### PR TITLE
[dynamicIO] update controller to be non-optional

### DIFF
--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -265,9 +265,7 @@ function abortOnSynchronousDynamicDataAccess(
 
   const error = createPrerenderInterruptedError(reason)
 
-  if (prerenderStore.controller) {
-    prerenderStore.controller.abort(error)
-  }
+  prerenderStore.controller.abort(error)
 
   const dynamicTracking = prerenderStore.dynamicTracking
   if (dynamicTracking) {

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -67,22 +67,24 @@ export type RequestStore = {
 export type PrerenderStoreModern = {
   type: 'prerender'
   readonly implicitTags: string[]
+
   /**
-   * This is the AbortController passed to React. It can be used to abort the prerender
-   * if we encounter conditions that do not require further rendering
+   * This signal is aborted when the React render is complete. (i.e. it is the same signal passed to react)
    */
-  readonly controller: null | AbortController
+  readonly renderSignal: AbortSignal
+  /**
+   * This is the AbortController which represents the boundary between Prerender and dynamic. In some renders it is
+   * the same as the controller for the renderSignal but in others it is a separate controller. It should be aborted
+   * whenever the we are no longer in the prerender phase of rendering. Typically this is after one task or when you call
+   * a sync API which requires the prerender to end immediately
+   */
+  readonly controller: AbortController
 
   /**
    * when not null this signal is used to track cache reads during prerendering and
    * to await all cache reads completing before aborting the prerender.
    */
   readonly cacheSignal: null | CacheSignal
-
-  /**
-   * This signal is used to clean up the prerender once it is complete.
-   */
-  readonly renderSignal: AbortSignal
 
   /**
    * During some prerenders we want to track dynamic access.


### PR DESCRIPTION
Previously we used the controller a signal for whether the current dynamicIO prerender should abort early or not. Now we separate the controller which signals whether we've left the Prerneder phase from the signal that actually aborts the render in some cases. Now we can always scope a controller in the prerenderStore and depending on whether we are filling caches or not we will end the render early or let it continue.

With this change the controller is always provided so we can reflect this in the type