### PR TITLE
Ensure pages/500 handles cache-control as expected

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -3305,6 +3305,8 @@ export default abstract class Server<
         const notFoundRevalidate = getRequestMeta(req, 'notFoundRevalidate')
         revalidate =
           typeof notFoundRevalidate === 'undefined' ? 0 : notFoundRevalidate
+      } else if (is500Page) {
+        revalidate = 0
       }
 
       // If the cache entry has a revalidate value that's a number, use it.


### PR DESCRIPTION
When `pages/500` uses `getStaticProps` we can honor statically generating the page but we can't send a `Cache-Control` with `stale-while-revalidate` as we shouldn't be caching errored pages ever. This ensures we handle that case and add a regression test for it. 