### PR TITLE
Fix: Middleware does not match when use :path

### DIFF
--- a/packages/next/src/build/analysis/get-page-static-info.test.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.test.ts
@@ -8,7 +8,7 @@ describe('get-page-static-infos', () => {
         {
           originalSource: '/middleware/path',
           regexp:
-            '^(?:\\/(_next\\/data\\/[^/]{1,}))?\\/middleware\\/path(.json)?[\\/#\\?]?$',
+            '^(?:\\/(_next\\/data\\/[^/]{1,}))?\\/middleware\\/path(\\.json)?[\\/#\\?]?$',
         },
       ]
       const result = getMiddlewareMatchers(matchers, { i18n: undefined })
@@ -21,16 +21,25 @@ describe('get-page-static-infos', () => {
         {
           originalSource: '/middleware/path',
           regexp:
-            '^(?:\\/(_next\\/data\\/[^/]{1,}))?\\/middleware\\/path(.json)?[\\/#\\?]?$',
+            '^(?:\\/(_next\\/data\\/[^/]{1,}))?\\/middleware\\/path(\\.json)?[\\/#\\?]?$',
         },
         {
           originalSource: '/middleware/another-path',
           regexp:
-            '^(?:\\/(_next\\/data\\/[^/]{1,}))?\\/middleware\\/another-path(.json)?[\\/#\\?]?$',
+            '^(?:\\/(_next\\/data\\/[^/]{1,}))?\\/middleware\\/another-path(\\.json)?[\\/#\\?]?$',
         },
       ]
       const result = getMiddlewareMatchers(matchers, { i18n: undefined })
       expect(result).toStrictEqual(expected)
+    })
+
+    it('matches /:id and /:id.json', () => {
+      const matchers = ['/:id']
+      const result = getMiddlewareMatchers(matchers, { i18n: undefined })[0]
+        .regexp
+      const regex = new RegExp(result)
+      expect(regex.test('/apple')).toBe(true)
+      expect(regex.test('/apple.json')).toBe(true)
     })
   })
 })

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -346,7 +346,7 @@ export function getMiddlewareMatchers(
     source = `/:nextData(_next/data/[^/]{1,})?${source}${
       isRoot
         ? `(${nextConfig.i18n ? '|\\.json|' : ''}/?index|/?index\\.json)?`
-        : '(.json)?'
+        : '{(\\.json)}?'
     }`
 
     if (nextConfig.basePath) {

--- a/test/e2e/app-dir/middleware-matching/app/chat/id/page.js
+++ b/test/e2e/app-dir/middleware-matching/app/chat/id/page.js
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <p>Chat/ID</p>
+}

--- a/test/e2e/app-dir/middleware-matching/app/layout.jsx
+++ b/test/e2e/app-dir/middleware-matching/app/layout.jsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/middleware-matching/app/page.jsx
+++ b/test/e2e/app-dir/middleware-matching/app/page.jsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <p>Home</p>
+}

--- a/test/e2e/app-dir/middleware-matching/index.test.ts
+++ b/test/e2e/app-dir/middleware-matching/index.test.ts
@@ -1,0 +1,17 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('app dir - middleware with custom matcher', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should match /:id (without asterisk)', async () => {
+    const browser = await next.browser('/chat/123')
+    expect(await browser.elementByCss('p').text()).toBe('Home')
+  })
+})

--- a/test/e2e/app-dir/middleware-matching/middleware.js
+++ b/test/e2e/app-dir/middleware-matching/middleware.js
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+
+export default function middleware(req, res) {
+  const url = req.nextUrl.clone()
+  url.pathname = '/'
+  return NextResponse.rewrite(url)
+}
+
+export const config = {
+  matcher: ['/chat/:id'],
+}


### PR DESCRIPTION
For a given path expression, we want it to optionally match a `.json` suffix. However, the original implementation was flawed:

The path `/:id` was altered to `/:id(.json)?`, which then converted to the Regex pattern `^(?:\/(.json))?[\/#\?]?$`. This Regex incorrectly matched only `/` or `/_json` — clearly not the intended result.

The fix involved adjusting the way we append the `.json` suffix. Instead of `/:id(.json)?`, we now use `/:id{(\\.json)}?`, which converts to the Regex `^(?:\/([^\/#\?]+?))(\.json)?[\/#\?]?$`. This pattern correctly matches both cases, with or without the `.json` suffix.

See https://github.com/pillarjs/path-to-regexp?tab=readme-ov-file#optional

-----

Fixes https://github.com/vercel/next.js/issues/53840
Fixes https://github.com/vercel/next.js/issues/55558
Closes DX-2088