### PR TITLE
[Docs]: Clarify scroll bahavior and traversing DOM

### DIFF
--- a/docs/02-app/02-api-reference/02-components/link.mdx
+++ b/docs/02-app/02-api-reference/02-components/link.mdx
@@ -233,7 +233,6 @@ When `scroll = {false}`, Next.js will not attempt to scroll to the first Page el
 
 > **Good to know**: Next.js checks if `scroll: false` before managing scroll behavior. If scrolling is enabled, it identifies the relevant DOM node for navigation and inspects each top-level element. All non-scrollable elements and those without rendered HTML are bypassed, this includes sticky or fixed positioned elements, and non-visible elements such as those calculated with `getBoundingClientRect`. Next.js then continues through siblings until it identifies a scrollable element that is visible in the viewport.
 
-
 <AppOnly>
 
 ```tsx filename="app/page.tsx" switcher

--- a/docs/02-app/02-api-reference/02-components/link.mdx
+++ b/docs/02-app/02-api-reference/02-components/link.mdx
@@ -231,6 +231,9 @@ export default function Home() {
 
 When `scroll = {false}`, Next.js will not attempt to scroll to the first Page element.
 
+> **Good to know**: Next.js checks if `scroll: false` before managing scroll behavior. If scrolling is enabled, it identifies the relevant DOM node for navigation and inspects each top-level element. All non-scrollable elements and those without rendered HTML are bypassed, this includes sticky or fixed positioned elements, and non-visible elements such as those calculated with `getBoundingClientRect`. Next.js then continues through siblings until it identifies a scrollable element that is visible in the viewport.
+
+
 <AppOnly>
 
 ```tsx filename="app/page.tsx" switcher


### PR DESCRIPTION
This PR clarifies scroll behavior when components are added to a page that do not contain visible elements. This PR adds a note to the `Link` docs explaining how Next.js traverses the DOM and bypasses certain components looking for a scrollable element.

Fixes: https://linear.app/vercel/issue/DOC-3391/add-guidance-on-metadata-placement-and-page-scroll-with-link
