### PR TITLE
Allow next build to work with serializable config

### DIFF
--- a/packages/next/src/build/generate-build-id.ts
+++ b/packages/next/src/build/generate-build-id.ts
@@ -1,8 +1,11 @@
 export async function generateBuildId(
-  generate: () => string | null | Promise<string | null>,
-  fallback: () => string
+  fallback: () => string,
+  generate?: (() => string | null | Promise<string | null>)
 ): Promise<string> {
-  let buildId = await generate()
+  let buildId = null
+  if (typeof generate === 'function') {
+    buildId = await generate()
+  }
   // If there's no buildId defined we'll fall back
   if (buildId === null) {
     // We also create a new buildId if it contains the word `ad` to avoid false

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -741,7 +741,7 @@ async function getBuildId(
   }
   return await nextBuildSpan
     .traceChild('generate-buildid')
-    .traceAsyncFn(() => generateBuildId(config.generateBuildId, nanoid))
+    .traceAsyncFn(() => generateBuildId(nanoid, config.generateBuildId))
 }
 
 const IS_TURBOPACK_BUILD = process.env.TURBOPACK && process.env.TURBOPACK_BUILD

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -991,7 +991,7 @@ export const defaultConfig: NextConfig = {
   cacheMaxMemorySize: 50 * 1024 * 1024,
   configOrigin: 'default',
   useFileSystemPublicRoutes: true,
-  generateBuildId: () => null,
+  generateBuildId: undefined,
   generateEtags: true,
   pageExtensions: ['tsx', 'ts', 'jsx', 'js'],
   poweredByHeader: true,


### PR DESCRIPTION
### What?

The entire Next.js config, save for this one param is completely serializable. This means that one could feed the Next.js config through `__NEXT_PRIVATE_STANDALONE_CONFIG` to override reading the local config and have a customized build event go through.

This param is already optional in end-user config, so just changing the defaults here. I foresee there to be no downstream effects.

### Why?

This allows some creative build strategies downstream in which a `next.config.js` may be bypassed entirely (although I wouldn't recommend *most* end-users to do this, this is for specialized use cases only).

### How?

Didn't open an issue yet, since opening an issue and opening a PR is the same effort (as you can see from the small diff). Hoping to have a discussion for its usefulness (or lack thereof) in this PR.

Thank you for reading!

Edit: Rebased on latest canary