### PR TITLE
fix: handle logging cicurlar object

### DIFF
--- a/packages/next/src/lib/is-error.ts
+++ b/packages/next/src/lib/is-error.ts
@@ -19,6 +19,21 @@ export default function isError(err: unknown): err is NextError {
   )
 }
 
+function safeStringify(obj: any) {
+  const seen = new WeakSet()
+
+  return JSON.stringify(obj, (_key, value) => {
+    // If value is an object and already seen, replace with "[Circular]"
+    if (typeof value === 'object' && value !== null) {
+      if (seen.has(value)) {
+        return '[Circular]'
+      }
+      seen.add(value)
+    }
+    return value
+  })
+}
+
 export function getProperError(err: unknown): Error {
   if (isError(err)) {
     return err
@@ -42,5 +57,5 @@ export function getProperError(err: unknown): Error {
     }
   }
 
-  return new Error(isPlainObject(err) ? JSON.stringify(err) : err + '')
+  return new Error(isPlainObject(err) ? safeStringify(err) : err + '')
 }

--- a/test/development/app-dir/serialize-circular-error/app/client/page.tsx
+++ b/test/development/app-dir/serialize-circular-error/app/client/page.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+class C {
+  other: D | null
+  constructor() {
+    this.other = null
+  }
+}
+
+class D {
+  a: C
+  constructor(a: C) {
+    this.a = a
+    a.other = this
+  }
+}
+
+const objC = new C()
+const objD = new D(objC)
+
+export default function Page() {
+  // eslint-disable-next-line no-throw-literal
+  throw { objC, objD }
+}

--- a/test/development/app-dir/serialize-circular-error/app/layout.tsx
+++ b/test/development/app-dir/serialize-circular-error/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/serialize-circular-error/app/page.tsx
+++ b/test/development/app-dir/serialize-circular-error/app/page.tsx
@@ -1,0 +1,22 @@
+class A {
+  other: B | null
+  constructor() {
+    this.other = null
+  }
+}
+
+class B {
+  a: A
+  constructor(a: A) {
+    this.a = a
+    a.other = this
+  }
+}
+
+const objA = new A()
+const objB = new B(objA)
+
+export default function Page() {
+  // eslint-disable-next-line no-throw-literal
+  throw { objA, objB }
+}

--- a/test/development/app-dir/serialize-circular-error/next.config.js
+++ b/test/development/app-dir/serialize-circular-error/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/development/app-dir/serialize-circular-error/serialize-circular-error.test.ts
+++ b/test/development/app-dir/serialize-circular-error/serialize-circular-error.test.ts
@@ -1,0 +1,46 @@
+import { nextTestSetup } from 'e2e-utils'
+import {
+  assertNoRedbox,
+  assertHasRedbox,
+  getRedboxDescription,
+} from 'next-test-utils'
+
+describe('serialize-circular-error', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should serialize the object from server component in console correctly', async () => {
+    const browser = await next.browser('/')
+    await assertHasRedbox(browser)
+
+    const description = await getRedboxDescription(browser)
+    // React cannot serialize thrown objects with circular references
+    expect(description).toBe(
+      '[ Server ] Error: An error occurred but serializing the error message failed.'
+    )
+
+    const output = next.cliOutput
+    expect(output).toContain(
+      'Error: {"objA":{"other":{"a":"[Circular]"}},"objB":"[Circular]"}'
+    )
+  })
+
+  it('should serialize the object from client component in console correctly', async () => {
+    const browser = await next.browser('/client')
+
+    // It's not a valid error object, it will display the global-error instead of the error overlay
+    // TODO: handle the error object in the client-side
+    await assertNoRedbox(browser)
+
+    const bodyText = await browser.elementByCss('body').text()
+    expect(bodyText).toContain(
+      'Application error: a client-side exception has occurred (see the browser console for more information).'
+    )
+
+    const output = next.cliOutput
+    expect(output).toContain(
+      'Error: {"objC":{"other":{"a":"[Circular]"}},"objD":"[Circular]"}'
+    )
+  })
+})


### PR DESCRIPTION
### What

Use a safe way to stringify the error on server side due to circular structure, looks like due to server replay that the log needs to be serialized on server side first then it will give a different error message like "failed to serialize", and then nextjs fail with the similar issue as well.


Now we add a safe stringify on Next.js side to avoid the circular structure get stringified directly, instead they're stingified into a string with showing which part is `*Circular*`

Fixes #72004 
Closes NDX-411