### PR TITLE
fix(node-environment-baseline): define `WebSocket` as configurable property

### DIFF
--- a/packages/next/src/server/node-environment-baseline.ts
+++ b/packages/next/src/server/node-environment-baseline.ts
@@ -12,5 +12,6 @@ if (typeof (globalThis as any).WebSocket !== 'function') {
     get() {
       return require('next/dist/compiled/ws').WebSocket
     },
+    configurable: true,
   })
 }

--- a/packages/next/src/server/node-environment-baseline.ts
+++ b/packages/next/src/server/node-environment-baseline.ts
@@ -12,6 +12,12 @@ if (typeof (globalThis as any).WebSocket !== 'function') {
     get() {
       return require('next/dist/compiled/ws').WebSocket
     },
-    configurable: true,
+    set(value) {
+      Object.defineProperty(globalThis, 'WebSocket', {
+        value,
+        configurable: true,
+        writable: true
+      })
+    },
   })
 }

--- a/packages/next/src/server/node-environment-baseline.ts
+++ b/packages/next/src/server/node-environment-baseline.ts
@@ -9,14 +9,15 @@ if (typeof (globalThis as any).AsyncLocalStorage !== 'function') {
 
 if (typeof (globalThis as any).WebSocket !== 'function') {
   Object.defineProperty(globalThis, 'WebSocket', {
+    configurable: true,
     get() {
       return require('next/dist/compiled/ws').WebSocket
     },
     set(value) {
       Object.defineProperty(globalThis, 'WebSocket', {
-        value,
         configurable: true,
-        writable: true
+        writable: true,
+        value,
       })
     },
   })


### PR DESCRIPTION

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

## What

The way Next.js re-defines a global `WebSocket` property makes it non-configurable. No other agents, such as API mocking libraries, are able to re-defined it. This [causes issues](https://github.com/mswjs/msw/issues/2339) for Next.js users.

# Why

Because the way the `WebSocket` property descriptor is set in Next.js doesn't allow that property to be configured anymore (and neither does it have a setter):

https://github.com/vercel/next.js/blob/de4f197e2fde19526ee019fbebb068e962b58fc0/packages/next/src/server/node-environment-baseline.ts#L11-L15

## How

This can be solved by setting `configurable: true` on the object descriptor. 

Generally, I'd advise against such restrictive descriptors for globals Next.js doesn't own, like fetch or WebSocket. Try adhering to how such globals are defined in Node.js—configurable and often with setters:

```
> Object.getOwnPropertyDescriptor(global, 'WebSocket')
{
  get: [Function: get WebSocket],
  set: [Function: set WebSocket],
  enumerable: false,
  configurable: true
}
```