### PR TITLE
fix /app-dir/middleware-matching turbopack test failure

### DIFF
--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -198,7 +198,7 @@ impl MiddlewareEndpoint {
                         }
                         source.push_str("/?index|/?index\\\\.json)?")
                     } else {
-                        source.push_str("(.json)?")
+                        source.push_str("{(\\\\.json)}?")
                     };
 
                     source.insert_str(0, "/:nextData(_next/data/[^/]{1,})?");

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -2268,15 +2268,6 @@
       "flakey": [],
       "runtimeError": false
     },
-    "test/e2e/app-dir/middleware-matching/index.test.ts": {
-      "passed": [],
-      "failed": [
-        "app dir - middleware with custom matcher should match /:id (without asterisk)"
-      ],
-      "pending": [],
-      "flakey": [],
-      "runtimeError": false
-    },
     "test/e2e/app-dir/middleware-sitemap/matcher-exclude-sitemap/index.test.ts": {
       "passed": [
         "middleware-sitemap should not be affected by middleware if sitemap.xml is excluded from the matcher"


### PR DESCRIPTION
Context
- I only fixed webpack codepath for https://github.com/vercel/next.js/pull/72056
- But we ended up merging it despite the fact the CI would fail due to Github incident https://www.githubstatus.com/incidents/9yk1fbk0qjjc

Notes
- `middleware.rs` only runs in build time for production turbopack build
- without this fix, the test would fail on 404 for prod mode, but would land on Chat page for dev mode