### PR TITLE
Support multiple tag arguments for `revalidateTag`

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/revalidateTag.mdx
+++ b/docs/02-app/02-api-reference/04-functions/revalidateTag.mdx
@@ -13,10 +13,10 @@ description: API Reference for the revalidateTag function.
 ## Parameters
 
 ```tsx
-revalidateTag(tag: string): void;
+revalidateTag(...tags: string[]): void;
 ```
 
-- `tag`: A string representing the cache tag associated with the data you want to revalidate. Must be less than or equal to 256 characters. This value is case-sensitive.
+- `tags`: One or more strings representing the cache tags associated with the data you want to revalidate. Each tag must be less than or equal to 256 characters. Tags are case-sensitive.
 
 You can add tags to `fetch` as follows:
 

--- a/packages/next/src/server/web/spec-extension/revalidate.ts
+++ b/packages/next/src/server/web/spec-extension/revalidate.ts
@@ -12,12 +12,12 @@ import { workUnitAsyncStorage } from '../../app-render/work-unit-async-storage.e
 import { DynamicServerError } from '../../../client/components/hooks-server-context'
 
 /**
- * This function allows you to purge [cached data](https://nextjs.org/docs/app/building-your-application/caching) on-demand for a specific cache tag.
+ * This function allows you to purge [cached data](https://nextjs.org/docs/app/building-your-application/caching) on-demand for specific cache tags.
  *
  * Read more: [Next.js Docs: `revalidateTag`](https://nextjs.org/docs/app/api-reference/functions/revalidateTag)
  */
-export function revalidateTag(tag: string) {
-  return revalidate(tag, `revalidateTag ${tag}`)
+export function revalidateTag(...tags: string[]) {
+  return revalidate(tags, `revalidateTag [${tags}]`)
 }
 
 /**
@@ -42,10 +42,10 @@ export function revalidatePath(originalPath: string, type?: 'layout' | 'page') {
       `Warning: a dynamic page path "${originalPath}" was passed to "revalidatePath", but the "type" parameter is missing. This has no effect by default, see more info here https://nextjs.org/docs/app/api-reference/functions/revalidatePath`
     )
   }
-  return revalidate(normalizedPath, `revalidatePath ${originalPath}`)
+  return revalidate([normalizedPath], `revalidatePath ${originalPath}`)
 }
 
-function revalidate(tag: string, expression: string) {
+function revalidate(tags: string[], expression: string) {
   const store = workAsyncStorage.getStore()
   if (!store || !store.incrementalCache) {
     throw new Error(
@@ -111,8 +111,10 @@ function revalidate(tag: string, expression: string) {
   if (!store.revalidatedTags) {
     store.revalidatedTags = []
   }
-  if (!store.revalidatedTags.includes(tag)) {
-    store.revalidatedTags.push(tag)
+  for (const tag of tags) {
+    if (!store.revalidatedTags.includes(tag)) {
+      store.revalidatedTags.push(tag)
+    }
   }
 
   // TODO: only revalidate if the path matches

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1322,6 +1322,27 @@ describe('app-dir action handling', () => {
       })
     })
 
+    it('should handle revalidateTag with multiple tags', async () => {
+      const browser = await next.browser('/revalidate-multiple')
+      const thankYouNext = await browser.elementByCss('#thankyounext').text()
+      const justPutIt = await browser.elementByCss('#justputit').text()
+      const youGotIt = await browser.elementByCss('#yougotit').text()
+
+      await browser.elementByCss('#revalidate').click()
+
+      await retry(async () => {
+        const newThankYouNext = await browser
+          .elementByCss('#thankyounext')
+          .text()
+        const newJustPutIt = await browser.elementByCss('#justputit').text()
+        const newYouGotIt = await browser.elementByCss('#yougotit').text()
+
+        expect(newThankYouNext).not.toBe(thankYouNext)
+        expect(newJustPutIt).not.toBe(justPutIt)
+        expect(newYouGotIt).toBe(youGotIt)
+      })
+    })
+
     // TODO: investigate flakey behavior with revalidate
     it.skip('should handle revalidateTag + redirect', async () => {
       const browser = await next.browser('/revalidate')

--- a/test/e2e/app-dir/actions/app/revalidate-multiple/page.js
+++ b/test/e2e/app-dir/actions/app/revalidate-multiple/page.js
@@ -4,14 +4,21 @@ export default async function Page() {
   const data1 = await fetch(
     'https://next-data-api-endpoint.vercel.app/api/random?a',
     {
-      next: { tags: ['thankyounext'] },
+      next: { revalidate: 3600, tags: ['thankyounext'] },
     }
   ).then((res) => res.text())
 
   const data2 = await fetch(
     'https://next-data-api-endpoint.vercel.app/api/random?b',
     {
-      next: { tags: ['justputit'] },
+      next: { revalidate: 3600, tags: ['justputit'] },
+    }
+  ).then((res) => res.text())
+
+  const data3 = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?c',
+    {
+      next: { revalidate: 3600, tags: ['yougotit'] },
     }
   ).then((res) => res.text())
 
@@ -24,16 +31,18 @@ export default async function Page() {
       <p>
         revalidate (tags: justputit): <span id="justputit">{data2}</span>
       </p>
+      <p>
+        revalidate (tags: yougotit): <span id="yougotit">{data3}</span>
+      </p>
       <form>
         <button
           id="revalidate"
           formAction={async () => {
             'use server'
-            revalidateTag('thankyounext')
-            revalidateTag('justputit')
+            revalidateTag('thankyounext', 'justputit')
           }}
         >
-          revalidate thankyounext
+          revalidate
         </button>
       </form>
     </>


### PR DESCRIPTION
### What?

 This commit changes `revalidateTag` to support multiple tag arguments.

### Why?

For parity with the new [`cacheTag` function](https://github.com/vercel/next.js/blob/eae26c7db2d0202e9253cee68cc35112a45426dd/packages/next/src/server/use-cache/cache-tag.ts#L4), which also supports multiple tag arguments. 
