### PR TITLE
update tag from latest -> next-14

### DIFF
--- a/scripts/publish-native.js
+++ b/scripts/publish-native.js
@@ -49,7 +49,9 @@ const cwd = process.cwd()
               `${path.join(nativePackagesDir, platform)}`,
               `--access`,
               `public`,
-              ...(version.includes('canary') ? ['--tag', 'canary'] : []),
+              ...(version.includes('canary')
+                ? ['--tag', 'canary']
+                : ['--tag', 'next-14']),
             ],
             { stdio: 'inherit' }
           )
@@ -107,7 +109,9 @@ const cwd = process.cwd()
               `${path.join(wasmDir, `pkg-${wasmTarget}`)}`,
               '--access',
               'public',
-              ...(version.includes('canary') ? ['--tag', 'canary'] : []),
+              ...(version.includes('canary')
+                ? ['--tag', 'canary']
+                : ['--tag', 'next-14']),
             ],
             { stdio: 'inherit' }
           )

--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -53,7 +53,7 @@ const cwd = process.cwd()
           '--access',
           'public',
           '--ignore-scripts',
-          ...(isCanary ? ['--tag', 'canary'] : []),
+          ...(isCanary ? ['--tag', 'canary'] : ['--tag', 'next-14']),
         ],
         { stdio: 'pipe' }
       )


### PR DESCRIPTION
This ensures we publish under separate tag for v14 backports. 