### PR TITLE
docs: typo useFormState import statement

### DIFF
--- a/docs/02-app/01-building-your-application/02-data-fetching/03-server-actions-and-mutations.mdx
+++ b/docs/02-app/01-building-your-application/02-data-fetching/03-server-actions-and-mutations.mdx
@@ -390,7 +390,7 @@ Then, you can pass your action to the `useFormState` hook and use the returned `
 ```tsx filename="app/ui/signup.tsx" highlight={11,18-20} switcher
 'use client'
 
-import { useFormState } from 'react'
+import { useFormState } from 'react-dom'
 import { createUser } from '@/app/actions'
 
 const initialState = {
@@ -415,7 +415,7 @@ export function Signup() {
 ```jsx filename="app/ui/signup.js" highlight={11,18-20} switcher
 'use client'
 
-import { useFormState } from 'react'
+import { useFormState } from 'react-dom'
 import { createUser } from '@/app/actions'
 
 const initialState = {


### PR DESCRIPTION
## Summary
Unlike [`useActionState`](https://react.dev/reference/react/useActionState), `useFormState` is imported from `react-dom`.

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide