### PR TITLE
fix: use `satisfies` operator instead of type in `tailwind.config.ts`

### DIFF
--- a/packages/create-next-app/templates/app-tw-empty/ts/tailwind.config.ts
+++ b/packages/create-next-app/templates/app-tw-empty/ts/tailwind.config.ts
@@ -1,8 +1,7 @@
 import type { Config } from "tailwindcss";
 
-const config: Config = {
+export default {
   content: ["./app/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: {},
   plugins: [],
-};
-export default config;
+} satisfies Config;

--- a/packages/create-next-app/templates/app-tw/ts/tailwind.config.ts
+++ b/packages/create-next-app/templates/app-tw/ts/tailwind.config.ts
@@ -1,6 +1,6 @@
 import type { Config } from "tailwindcss";
 
-const config: Config = {
+export default {
   content: [
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
@@ -15,5 +15,4 @@ const config: Config = {
     },
   },
   plugins: [],
-};
-export default config;
+} satisfies Config;

--- a/packages/create-next-app/templates/default-tw-empty/ts/tailwind.config.ts
+++ b/packages/create-next-app/templates/default-tw-empty/ts/tailwind.config.ts
@@ -1,8 +1,7 @@
 import type { Config } from "tailwindcss";
 
-const config: Config = {
+export default {
   content: ["./pages/**/*.{ts,tsx,mdx}"],
   theme: {},
   plugins: [],
-};
-export default config;
+} satisfies Config;

--- a/packages/create-next-app/templates/default-tw/ts/tailwind.config.ts
+++ b/packages/create-next-app/templates/default-tw/ts/tailwind.config.ts
@@ -1,6 +1,6 @@
 import type { Config } from "tailwindcss";
 
-const config: Config = {
+export default {
   content: [
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
@@ -15,5 +15,4 @@ const config: Config = {
     },
   },
   plugins: [],
-};
-export default config;
+} satisfies Config;


### PR DESCRIPTION
## Summary
Use [`satisfies`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#the-satisfies-operator) operator for reference tailwindcss configuration.

## Description
Tailwind provides a [`resolveConfig`](https://tailwindcss.com/docs/configuration#referencing-in-java-script) helper you can use to generate a fully merged version of your configuration object:
```ts
// type.ts
import type resolveConfig from "tailwindcss/resolveConfig";
import type config from "./tailwind.config";

type ResolveConfig = ReturnType<typeof resolveConfig<typeof config>>;

type ResolveConfigTheme = ResolveConfig["theme"];

type Color = keyof ResolveConfigTheme["colors"];
// type Color = "primary" | "secondary" | "tertiary" | keyof DefaultColors
// --- DefaultColors contain ... ---
// type Color = "primary" | "secondary" | "tertiary" | "inherit" | "current" |
//              "transparent" | "black" | "white" | "slate" | "gray" | "zinc" | 
//              "neutral" | "stone" | "red" | "orange" | ... 20 more

type FontSize = keyof ResolveConfigTheme["fontSize"];
// type FontSize = "xs" | "sm" | "base" | "lg" | "xl" | "2xl" | "3xl" | 
//                 "4xl" | "5xl" | "6xl" | "7xl" | "8xl" | "9xl"

type ZIndex = keyof ResolveConfigTheme["zIndex"];
// type ZIndex = "0" | "10" | "20" | "30" | "40" | "50" | "auto"
```

However, the type information cannot be successfully obtained by using `Config` types.

```ts
// tailwind.config.ts
import type { Config } from "tailwindcss";

// ❌ can't get type info
const config: Config = {
// ...
};

// ✔️ can get type info
const config = {
// ...
} satisfies Config;

export default config
```

That's why I introduced `satisfies` operator.
In addition, [official tailwind configuration](https://tailwindcss.com/docs/configuration#using-esm-or-type-script) uses `satisfies` operator.

```ts
// tailwind.config.ts
import type { Config } from 'tailwindcss'

export default {
  content: [],
  theme: {
    extend: {},
  },
  plugins: [],
} satisfies Config
```

Fix [referencing tailwind extended types in js with Nextjs framework](https://github.com/tailwindlabs/tailwindcss/issues/14212)