### PR TITLE
`@next/codemod`: Use `npm view` to support NPM registry mirrors

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -86,10 +86,14 @@ export async function runUpgrade(
     peerDependencies: Record<string, string>
   }
 
-  const res = await fetch(`https://registry.npmjs.org/next/${revision}`)
-  if (res.status === 200) {
-    targetNextPackageJson = await res.json()
-  }
+  try {
+    const targetNextPackage = execSync(
+      `npm --silent view "next@${revision}" --json`,
+      { encoding: 'utf-8' }
+    )
+    targetNextPackageJson = JSON.parse(targetNextPackage)
+  } catch {}
+
   const validRevision =
     targetNextPackageJson !== null &&
     typeof targetNextPackageJson === 'object' &&


### PR DESCRIPTION
This makes sure that NPM registry mirrors are supported, by using the `npm view` command instead of fetching from registry.npmjs.org.

I saw that there was another place the `npm view` command is already being utilized, so that why I'm assuming it's okay to use:

https://github.com/vercel/next.js/blob/382d16dd3cb608ca2185a7dc3d438f75d8fc8495/packages/next-codemod/bin/upgrade.ts#L40-L44

If there is anything not right with this PR, please let me know so I can fix it.

Fixes #72122.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
