### PR TITLE
Fix source mapping dev middlewares for Windows

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/get-source-map-from-file.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/get-source-map-from-file.ts
@@ -54,7 +54,10 @@ export async function getSourceMapFromFile(
     }
   }
 
-  const sourceMapFilename = path.resolve(path.dirname(filename), sourceUrl)
+  const sourceMapFilename = path.resolve(
+    path.dirname(filename),
+    decodeURIComponent(sourceUrl)
+  )
 
   try {
     const sourceMapContents = await fs.readFile(sourceMapFilename, 'utf-8')

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
@@ -17,6 +17,7 @@ import { launchEditor } from '../internal/helpers/launchEditor'
 import type { StackFrame } from 'next/dist/compiled/stacktrace-parser'
 import type { Project, TurbopackStackFrame } from '../../../../build/swc/types'
 import { getSourceMapFromFile } from '../internal/helpers/get-source-map-from-file'
+import { findSourceMap } from 'node:module'
 
 const currentSourcesByFile: Map<string, Promise<string | null>> = new Map()
 export async function batchedTraceSource(
@@ -174,6 +175,12 @@ export function getSourceMapMiddleware(project: Project, distDir: string) {
       filename.startsWith('webpack://') ||
       filename.startsWith('webpack-internal:///')
     ) {
+      const sourceMap = findSourceMap(filename)
+
+      if (sourceMap) {
+        return json(res, sourceMap.payload)
+      }
+
       return noContent(res)
     }
 

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware.ts
@@ -1,5 +1,6 @@
 import { constants as FS, promises as fs } from 'fs'
 import path from 'path'
+import url from 'url'
 import { SourceMapConsumer } from 'next/dist/compiled/source-map08'
 import type { StackFrame } from 'next/dist/compiled/stacktrace-parser'
 import { getSourceMapFromFile } from '../internal/helpers/get-source-map-from-file'
@@ -213,7 +214,11 @@ export async function getSource(
     filename = path.join(distDirectory, filename.replace(/^\/_next\//, ''))
   }
 
-  if (filename.startsWith('file:') || filename.startsWith(path.sep)) {
+  if (path.isAbsolute(filename)) {
+    filename = url.pathToFileURL(filename).href
+  }
+
+  if (filename.startsWith('file:')) {
     const sourceMap = await getSourceMapFromFile(filename)
 
     return sourceMap

--- a/packages/next/webpack.config.js
+++ b/packages/next/webpack.config.js
@@ -154,7 +154,6 @@ module.exports = ({ dev, turbo, bundleType, experimental }) => {
         experimental ? '-experimental' : ''
       }.runtime.${dev ? 'dev' : 'prod'}.js`,
       libraryTarget: 'commonjs2',
-      devtoolModuleFilenameTemplate: './[resource-path]',
     },
     devtool: process.env.NEXT_SERVER_EVAL_SOURCE_MAPS
       ? 'eval-source-map'


### PR DESCRIPTION
This fixes a couple of issues with `next dev` on Windows for resolving source maps, both for Turbopack and Webpack.

Unfortunately we still don't have a way to test this automatically. The devtools need to be open to trigger those source map requests, and [Playwright does not support that in headless mode](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-option-devtools).

So this change needs to be tested manually as described in [test/development/app-dir/source-mapping/README.md](https://github.com/vercel/next.js/blob/3551a583563e6528bdd9de34c4021dceabc54eaa/test/development/app-dir/source-mapping/README.md).

fixes #71854