### PR TITLE
chore(github): add dynamicIO label to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -82,6 +82,7 @@ body:
         - 'create-next-app'
         - 'Developer Experience'
         - 'Documentation'
+        - 'dynamicIO'
         - 'Lazy Loading'
         - 'Font (next/font)'
         - 'Image (next/image)'


### PR DESCRIPTION
## Why?

Add `dynamicIO` label to our issue template so we can start categorizing those issues.