### PR TITLE
Revert "unbreak canary (#72146)"

### DIFF
--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -174,8 +174,7 @@ export class NextInstance {
           // TODO: fix the TS error with the TS 5.6
           // x-ref: https://github.com/vercel/next.js/actions/runs/10777104696/job/29887663970?pr=69784
           typescript: '5.5.4',
-          // TODO: fix the TS error with 22.8.5
-          '@types/node': '22.8.4',
+          '@types/node': 'latest',
           ...this.dependencies,
           ...this.packageJson?.dependencies,
         }


### PR DESCRIPTION
This reverts commit 3650f478f341207119fba11a3a72231484cf7f67.

Breakage was fixed in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71054
