### PR TITLE
refactor: replace withWorkStore with createWorkStore and run

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -75,7 +75,7 @@ import { denormalizePagePath } from '../shared/lib/page-path/denormalize-page-pa
 import { normalizePagePath } from '../shared/lib/page-path/normalize-page-path'
 import { getRuntimeContext } from '../server/web/sandbox'
 import { isClientReference } from '../lib/client-reference'
-import { withWorkStore } from '../server/async-storage/with-work-store'
+import { createWorkStore } from '../server/async-storage/work-store'
 import type { CacheHandler } from '../server/lib/incremental-cache'
 import { IncrementalCache } from '../server/lib/incremental-cache'
 import { nodeFs } from '../server/lib/node-fs-methods'
@@ -1299,26 +1299,27 @@ export async function buildAppStaticPaths({
     }
   }
 
-  const routeParams = await withWorkStore(
-    ComponentMod.workAsyncStorage,
-    {
-      page,
-      // We're discovering the parameters here, so we don't have any unknown
-      // ones.
-      fallbackRouteParams: null,
-      renderOpts: {
-        incrementalCache,
-        cacheLifeProfiles,
-        supportsDynamicResponse: true,
-        isRevalidate: false,
-        experimental: {
-          after: false,
-          dynamicIO,
-        },
-        buildId,
+  const store = createWorkStore({
+    page,
+    // We're discovering the parameters here, so we don't have any unknown
+    // ones.
+    fallbackRouteParams: null,
+    renderOpts: {
+      incrementalCache,
+      cacheLifeProfiles,
+      supportsDynamicResponse: true,
+      isRevalidate: false,
+      experimental: {
+        after: false,
+        dynamicIO,
       },
+      buildId,
     },
-    async (store) => {
+  })
+
+  const routeParams = await ComponentMod.workAsyncStorage.run(
+    store,
+    async () => {
       async function builtRouteParams(
         parentsParams: Params[] = [],
         idx = 0

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -1,6 +1,4 @@
-import type { WithStore } from './with-store'
 import type { WorkStore } from '../app-render/work-async-storage.external'
-import type { AsyncLocalStorage } from 'async_hooks'
 import type { IncrementalCache } from '../lib/incremental-cache'
 import type { RenderOpts } from '../app-render/types'
 import type { FetchMetric } from '../base-http'
@@ -68,17 +66,13 @@ export type WorkStoreContext = {
     Partial<Pick<RenderOpts, 'reactLoadableManifest'>>
 }
 
-export const withWorkStore: WithStore<WorkStore, WorkStoreContext> = <Result>(
-  storage: AsyncLocalStorage<WorkStore>,
-  {
-    page,
-    fallbackRouteParams,
-    renderOpts,
-    requestEndedState,
-    isPrefetchRequest,
-  }: WorkStoreContext,
-  callback: (store: WorkStore) => Result
-): Result => {
+export function createWorkStore({
+  page,
+  fallbackRouteParams,
+  renderOpts,
+  requestEndedState,
+  isPrefetchRequest,
+}: WorkStoreContext): WorkStore {
   /**
    * Rules of Static & Dynamic HTML:
    *
@@ -130,7 +124,7 @@ export const withWorkStore: WithStore<WorkStore, WorkStoreContext> = <Result>(
   // TODO: remove this when we resolve accessing the store outside the execution context
   renderOpts.store = store
 
-  return storage.run(store, callback, store)
+  return store
 }
 
 function createAfterContext(

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -17,9 +17,9 @@ import { ensureInstrumentationRegistered } from './globals'
 import { createRequestStoreForAPI } from '../async-storage/request-store'
 import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
 import {
-  withWorkStore,
+  createWorkStore,
   type WorkStoreContext,
-} from '../async-storage/with-work-store'
+} from '../async-storage/work-store'
 import { workAsyncStorage } from '../app-render/work-async-storage.external'
 import { NEXT_ROUTER_PREFETCH_HEADER } from '../../client/components/app-router-headers'
 import { getTracer } from '../lib/trace/tracer'
@@ -261,38 +261,37 @@ export async function adapter(
               previewProps
             )
 
-            return await withWorkStore(
-              workAsyncStorage,
-              {
-                page: '/', // Fake Work
-                fallbackRouteParams: null,
-                renderOpts: {
-                  cacheLifeProfiles:
-                    params.request.nextConfig?.experimental?.cacheLife,
-                  experimental: {
-                    after: isAfterEnabled,
-                    isRoutePPREnabled: false,
-                    dynamicIO: false,
-                  },
-                  buildId: buildId ?? '',
-                  supportsDynamicResponse: true,
-                  waitUntil,
-                  onClose: closeController
-                    ? closeController.onClose.bind(closeController)
-                    : undefined,
+            const workStore = createWorkStore({
+              page: '/', // Fake Work
+              fallbackRouteParams: null,
+              renderOpts: {
+                cacheLifeProfiles:
+                  params.request.nextConfig?.experimental?.cacheLife,
+                experimental: {
+                  after: isAfterEnabled,
+                  isRoutePPREnabled: false,
+                  dynamicIO: false,
                 },
-                requestEndedState: { ended: false },
-                isPrefetchRequest: request.headers.has(
-                  NEXT_ROUTER_PREFETCH_HEADER
-                ),
+                buildId: buildId ?? '',
+                supportsDynamicResponse: true,
+                waitUntil,
+                onClose: closeController
+                  ? closeController.onClose.bind(closeController)
+                  : undefined,
               },
-              () =>
-                workUnitAsyncStorage.run(
-                  requestStore,
-                  params.handler,
-                  request,
-                  event
-                )
+              requestEndedState: { ended: false },
+              isPrefetchRequest: request.headers.has(
+                NEXT_ROUTER_PREFETCH_HEADER
+              ),
+            })
+
+            return await workAsyncStorage.run(workStore, () =>
+              workUnitAsyncStorage.run(
+                requestStore,
+                params.handler,
+                request,
+                event
+              )
             )
           } finally {
             // middleware cannot stream, so we can consider the response closed


### PR DESCRIPTION
This pull request refactors how work stores are created and used across various modules in the codebase, replacing the `withWorkStore` function with a new `createWorkStore` function. This change simplifies the code and improves readability by separating the creation and usage of work stores and aligns it with existing stores.