### PR TITLE
refactor: make metadata types explicit

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -18,7 +18,10 @@ import {
   isRedirectError,
   type RedirectType,
 } from '../../client/components/redirect'
-import RenderResult from '../render-result'
+import RenderResult, {
+  type AppPageRenderResultMetadata,
+  type StaticRenderResultMetadata,
+} from '../render-result'
 import type { WorkStore } from '../app-render/work-async-storage.external'
 import { FlightRenderResult } from './flight-render-result'
 import {
@@ -434,7 +437,10 @@ export async function handleAction({
     }
   | {
       type: 'done'
-      result: RenderResult | undefined
+      result:
+        | RenderResult<AppPageRenderResultMetadata>
+        | RenderResult<StaticRenderResultMetadata>
+        | undefined
       formState?: any
     }
 > {
@@ -583,7 +589,7 @@ export async function handleAction({
 
   const { actionAsyncStorage } = ComponentMod
 
-  let actionResult: RenderResult | undefined
+  let actionResult: RenderResult<AppPageRenderResultMetadata> | undefined
   let formState: any | undefined
   let actionModId: string | undefined
   const actionWasForwarded = Boolean(req.headers['x-action-forwarded'])

--- a/packages/next/src/server/app-render/flight-render-result.ts
+++ b/packages/next/src/server/app-render/flight-render-result.ts
@@ -1,13 +1,17 @@
 import { RSC_CONTENT_TYPE_HEADER } from '../../client/components/app-router-headers'
-import RenderResult, { type RenderResultMetadata } from '../render-result'
+import RenderResult, {
+  type AppPageRenderResultMetadata,
+} from '../render-result'
 
 /**
  * Flight Response is always set to RSC_CONTENT_TYPE_HEADER to ensure it does not get interpreted as HTML.
  */
-export class FlightRenderResult extends RenderResult {
+export class FlightRenderResult extends RenderResult<AppPageRenderResultMetadata> {
   constructor(
     response: string | ReadableStream<Uint8Array>,
-    metadata: RenderResultMetadata = {}
+    metadata: AppPageRenderResultMetadata = {
+      type: 'app',
+    }
   ) {
     super(response, { contentType: RSC_CONTENT_TYPE_HEADER, metadata })
   }

--- a/packages/next/src/server/render-result.ts
+++ b/packages/next/src/server/render-result.ts
@@ -14,6 +14,7 @@ import { isAbortError, pipeToNodeResponse } from './pipe-readable'
 type ContentTypeOption = string | undefined
 
 export type AppPageRenderResultMetadata = {
+  type: 'app'
   flightData?: Buffer
   revalidate?: Revalidate
   staticBailoutInfo?: {
@@ -37,6 +38,7 @@ export type AppPageRenderResultMetadata = {
 }
 
 export type PagesRenderResultMetadata = {
+  type: 'pages'
   pageData?: any
   revalidate?: Revalidate
   assetQueryString?: string
@@ -44,11 +46,14 @@ export type PagesRenderResultMetadata = {
   isRedirect?: boolean
 }
 
-export type StaticRenderResultMetadata = {}
+export type StaticRenderResultMetadata = {
+  type: 'static'
+}
 
-export type RenderResultMetadata = AppPageRenderResultMetadata &
-  PagesRenderResultMetadata &
-  StaticRenderResultMetadata
+export type RenderResultMetadata =
+  | AppPageRenderResultMetadata
+  | PagesRenderResultMetadata
+  | StaticRenderResultMetadata
 
 export type RenderResultResponse =
   | ReadableStream<Uint8Array>[]
@@ -95,7 +100,9 @@ export default class RenderResult<
    * @returns a new RenderResult instance
    */
   public static fromStatic(value: string | Buffer) {
-    return new RenderResult<StaticRenderResultMetadata>(value, { metadata: {} })
+    return new RenderResult<StaticRenderResultMetadata>(value, {
+      metadata: { type: 'static' },
+    })
   }
 
   private readonly waitUntil?: Promise<unknown>
@@ -108,10 +115,6 @@ export default class RenderResult<
     this.contentType = contentType
     this.metadata = metadata
     this.waitUntil = waitUntil
-  }
-
-  public assignMetadata(metadata: Metadata) {
-    Object.assign(this.metadata, metadata)
   }
 
   /**

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -407,11 +407,11 @@ export async function renderToHTMLImpl(
   query: NextParsedUrlQuery,
   renderOpts: Omit<RenderOpts, keyof RenderOptsExtra>,
   extra: RenderOptsExtra
-): Promise<RenderResult> {
+): Promise<RenderResult<PagesRenderResultMetadata>> {
   // Adds support for reading `cookies` in `getServerSideProps` when SSR.
   setLazyProp({ req: req as any }, 'cookies', getCookieParser(req.headers))
 
-  const metadata: PagesRenderResultMetadata = {}
+  const metadata: PagesRenderResultMetadata = { type: 'pages' }
 
   metadata.assetQueryString =
     (renderOpts.dev && renderOpts.assetQueryString) || ''
@@ -1567,7 +1567,7 @@ export type PagesRender = (
   pathname: string,
   query: NextParsedUrlQuery,
   renderOpts: RenderOpts
-) => Promise<RenderResult>
+) => Promise<RenderResult<PagesRenderResultMetadata>>
 
 export const renderToHTML: PagesRender = (
   req,

--- a/packages/next/src/server/route-modules/app-page/module.ts
+++ b/packages/next/src/server/route-modules/app-page/module.ts
@@ -14,6 +14,10 @@ import * as vendoredContexts from './vendored/contexts/entrypoints'
 import type { BaseNextRequest, BaseNextResponse } from '../../base-http'
 import type { ServerComponentsHmrCache } from '../../response-cache'
 import type { FallbackRouteParams } from '../../request/fallback-params'
+import type {
+  AppPageRenderResultMetadata,
+  StaticRenderResultMetadata,
+} from '../../render-result'
 
 let vendoredReactRSC
 let vendoredReactSSR
@@ -58,7 +62,10 @@ export class AppPageRouteModule extends RouteModule<
     req: BaseNextRequest,
     res: BaseNextResponse,
     context: AppPageRouteHandlerContext
-  ): Promise<RenderResult> {
+  ): Promise<
+    | RenderResult<AppPageRenderResultMetadata>
+    | RenderResult<StaticRenderResultMetadata>
+  > {
     return renderToHTMLOrFlight(
       req,
       res,

--- a/packages/next/src/server/route-modules/pages/module.ts
+++ b/packages/next/src/server/route-modules/pages/module.ts
@@ -19,6 +19,7 @@ import {
 } from '../route-module'
 import { renderToHTMLImpl, renderToHTML } from '../../render'
 import * as vendoredContexts from './vendored/contexts/entrypoints'
+import type { PagesRenderResultMetadata } from '../../render-result'
 
 /**
  * The PagesModule is the type of the module exported by the bundled pages
@@ -121,7 +122,7 @@ export class PagesRouteModule extends RouteModule<
     req: IncomingMessage,
     res: ServerResponse,
     context: PagesRouteHandlerContext
-  ): Promise<RenderResult> {
+  ): Promise<RenderResult<PagesRenderResultMetadata>> {
     return renderToHTMLImpl(
       req,
       res,


### PR DESCRIPTION
This pull request includes several changes to the `exportAppPage`, `exportPagesPage`, and `handleAction` functions, as well as updates to the `RenderResult` class and its usage across various files. The primary goal is to introduce metadata types for different render results and ensure that HTML is written to files correctly based on the metadata type.

Metadata handling and type updates:

* [`packages/next/src/export/routes/app-page.ts`](diffhunk://#diff-9c5ee2b00618f7eb86b6e26accb9f9cc2607eadf6fef1d95004ace4cecf398d4R139-R146): Added conditions to handle metadata of type 'app' and moved the static HTML file writing logic accordingly. [[1]](diffhunk://#diff-9c5ee2b00618f7eb86b6e26accb9f9cc2607eadf6fef1d95004ace4cecf398d4R139-R146) [[2]](diffhunk://#diff-9c5ee2b00618f7eb86b6e26accb9f9cc2607eadf6fef1d95004ace4cecf398d4L244-L251) [[3]](diffhunk://#diff-9c5ee2b00618f7eb86b6e26accb9f9cc2607eadf6fef1d95004ace4cecf398d4R278-R280) [[4]](diffhunk://#diff-9c5ee2b00618f7eb86b6e26accb9f9cc2607eadf6fef1d95004ace4cecf398d4R289-R298)
* [`packages/next/src/export/routes/pages.ts`](diffhunk://#diff-f36986c4b16ae0c7b0755a168d4504b54675ea518d2721c21dffb17775534ed7L7-R10): Updated `RenderResult` type annotations to include `PagesRenderResultMetadata` and `StaticRenderResultMetadata`. Added checks for metadata properties before accessing them. [[1]](diffhunk://#diff-f36986c4b16ae0c7b0755a168d4504b54675ea518d2721c21dffb17775534ed7L7-R10) [[2]](diffhunk://#diff-f36986c4b16ae0c7b0755a168d4504b54675ea518d2721c21dffb17775534ed7L84-R90) [[3]](diffhunk://#diff-f36986c4b16ae0c7b0755a168d4504b54675ea518d2721c21dffb17775534ed7L116-R125) [[4]](diffhunk://#diff-f36986c4b16ae0c7b0755a168d4504b54675ea518d2721c21dffb17775534ed7L144-R153) [[5]](diffhunk://#diff-f36986c4b16ae0c7b0755a168d4504b54675ea518d2721c21dffb17775534ed7L188-R201) [[6]](diffhunk://#diff-f36986c4b16ae0c7b0755a168d4504b54675ea518d2721c21dffb17775534ed7L219-R234)
* [`packages/next/src/server/app-render/action-handler.ts`](diffhunk://#diff-c809d50461027cdba7c092e564818b1172133d337abc5c513f829c94c8483dc6L21-R24): Updated `RenderResult` type annotations to include `AppPageRenderResultMetadata` and `StaticRenderResultMetadata`. [[1]](diffhunk://#diff-c809d50461027cdba7c092e564818b1172133d337abc5c513f829c94c8483dc6L21-R24) [[2]](diffhunk://#diff-c809d50461027cdba7c092e564818b1172133d337abc5c513f829c94c8483dc6L437-R443) [[3]](diffhunk://#diff-c809d50461027cdba7c092e564818b1172133d337abc5c513f829c94c8483dc6L586-R592)
* [`packages/next/src/server/app-render/app-render.tsx`](diffhunk://#diff-a3e2e024db1faa1b501e0dd6040eaaf0d931cb9878ae0fb0f4c3658daa982768R32): Updated various functions to use the new metadata types and added conditions to handle `AppPageRenderResultMetadata`. [[1]](diffhunk://#diff-a3e2e024db1faa1b501e0dd6040eaaf0d931cb9878ae0fb0f4c3658daa982768R32) [[2]](diffhunk://#diff-a3e2e024db1faa1b501e0dd6040eaaf0d931cb9878ae0fb0f4c3658daa982768L516-R517) [[3]](diffhunk://#diff-a3e2e024db1faa1b501e0dd6040eaaf0d931cb9878ae0fb0f4c3658daa982768R570) [[4]](diffhunk://#diff-a3e2e024db1faa1b501e0dd6040eaaf0d931cb9878ae0fb0f4c3658daa982768L589-R591) [[5]](diffhunk://#diff-a3e2e024db1faa1b501e0dd6040eaaf0d931cb9878ae0fb0f4c3658daa982768R634) [[6]](diffhunk://#diff-a3e2e024db1faa1b501e0dd6040eaaf0d931cb9878ae0fb0f4c3658daa982768L968-R974) [[7]](diffhunk://#diff-a3e2e024db1faa1b501e0dd6040eaaf0d931cb9878ae0fb0f4c3658daa982768L1063-R1071) [[8]](diffhunk://#diff-a3e2e024db1faa1b501e0dd6040eaaf0d931cb9878ae0fb0f4c3658daa982768L1208-R1216) [[9]](diffhunk://#diff-a3e2e024db1faa1b501e0dd6040eaaf0d931cb9878ae0fb0f4c3658daa982768L1335-R1345) [[10]](diffhunk://#diff-a3e2e024db1faa1b501e0dd6040eaaf0d931cb9878ae0fb0f4c3658daa982768L1344-R1354) [[11]](diffhunk://#diff-a3e2e024db1faa1b501e0dd6040eaaf0d931cb9878ae0fb0f4c3658daa982768L1387-R1400)
* [`packages/next/src/server/app-render/flight-render-result.ts`](diffhunk://#diff-19b6c39a9e42ce94f3e1db673c3a0c4a27544b83765e832823dea1c3ba250cf9L2-R14): Updated `FlightRenderResult` class to use `AppPageRenderResultMetadata`.

Other notable changes:

* [`packages/next/src/server/base-server.ts`](diffhunk://#diff-6f4291cc2bfc5073fdca12a014011769e840ee68583db1468acef075f037015aR2705): Added conditions to handle different metadata types and adjusted cache result handling based on metadata. [[1]](diffhunk://#diff-6f4291cc2bfc5073fdca12a014011769e840ee68583db1468acef075f037015aR2705) [[2]](diffhunk://#diff-6f4291cc2bfc5073fdca12a014011769e840ee68583db1468acef075f037015aR2718-R2724) [[3]](diffhunk://#diff-6f4291cc2bfc5073fdca12a014011769e840ee68583db1468acef075f037015aL2749-R2783) [[4]](diffhunk://#diff-6f4291cc2bfc5073fdca12a014011769e840ee68583db1468acef075f037015aR2794-R2820)
* [`packages/next/src/server/render-result.ts`](diffhunk://#diff-49d25e2bd9013aee7bf55c28709f5bc8fab098612a36435fd1a12ec9c9bb53cbR17): Introduced new metadata types `AppPageRenderResultMetadata`, `PagesRenderResultMetadata`, and `StaticRenderResultMetadata`. [[1]](diffhunk://#diff-49d25e2bd9013aee7bf55c28709f5bc8fab098612a36435fd1a12ec9c9bb53cbR17) [[2]](diffhunk://#diff-49d25e2bd9013aee7bf55c28709f5bc8fab098612a36435fd1a12ec9c9bb53cbR41-R56)