### PR TITLE
Snowflake backend for devlow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -194,6 +194,18 @@ jobs:
       stepName: 'devlow-bench-${{ matrix.mode }}-${{ matrix.selector }}'
     secrets: inherit
 
+  test-devlow:
+    name: test devlow package
+    needs: ['optimize-ci', 'changes']
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    strategy:
+      fail-fast: false
+    uses: ./.github/workflows/build_reusable.yml
+    with:
+      stepName: 'test-devlow'
+      afterBuild: pnpm install && pnpm run --filter=devlow-bench test
+    secrets: inherit
+
   test-turbopack-dev:
     name: test turbopack dev
     needs: ['optimize-ci', 'changes', 'build-next', 'build-native']

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1738,6 +1738,9 @@ importers:
       '@types/split2':
         specifier: ^4.2.0
         version: 4.2.3
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
 
   turbopack/packages/node-module-trace: {}
 
@@ -3460,6 +3463,150 @@ packages:
     resolution: {integrity: sha512-aKUhyn1QI5Ksbqcr3fFJj16p99QdjUxXAEuFst1Z47DRyoiMwivIH9MV/ARcJOCXVjPfjITciej8ZD2O/6qUmw==}
     engines: {node: '>=16'}
 
+  '@esbuild/aix-ppc64@0.23.1':
+    resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.23.1':
+    resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.23.1':
+    resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.23.1':
+    resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.23.1':
+    resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.23.1':
+    resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.23.1':
+    resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.23.1':
+    resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.23.1':
+    resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.23.1':
+    resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.23.1':
+    resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.23.1':
+    resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.23.1':
+    resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.23.1':
+    resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.23.1':
+    resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.23.1':
+    resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.23.1':
+    resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.23.1':
+    resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.23.1':
+    resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.23.1':
+    resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.23.1':
+    resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.23.1':
+    resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.23.1':
+    resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.23.1':
+    resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@eslint-community/eslint-utils@4.4.0':
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5070,9 +5217,6 @@ packages:
   '@types/babel__core@7.1.12':
     resolution: {integrity: sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==}
 
-  '@types/babel__core@7.1.14':
-    resolution: {integrity: sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==}
-
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -5828,10 +5972,6 @@ packages:
   ansi-escapes@3.2.0:
     resolution: {integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==}
     engines: {node: '>=4'}
-
-  ansi-escapes@4.3.0:
-    resolution: {integrity: sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==}
-    engines: {node: '>=8'}
 
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -7977,6 +8117,11 @@ packages:
 
   es6-symbol@3.1.3:
     resolution: {integrity: sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==}
+
+  esbuild@0.23.1:
+    resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -14381,6 +14526,11 @@ packages:
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
 
+  tsx@4.19.2:
+    resolution: {integrity: sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tty-browserify@0.0.1:
     resolution: {integrity: sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==}
 
@@ -15240,10 +15390,6 @@ packages:
     resolution: {integrity: sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==}
     engines: {node: '>=10'}
 
-  yargs-parser@21.0.1:
-    resolution: {integrity: sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==}
-    engines: {node: '>=12'}
-
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -15419,7 +15565,6 @@ snapshots:
     dependencies:
       '@babel/highlight': 7.25.7
       picocolors: 1.0.1
-    optional: true
 
   '@babel/compat-data@7.22.20': {}
 
@@ -15786,8 +15931,7 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.24.8': {}
 
-  '@babel/helper-plugin-utils@7.25.7':
-    optional: true
+  '@babel/helper-plugin-utils@7.25.7': {}
 
   '@babel/helper-remap-async-to-generator@7.22.20(@babel/core@7.22.5)':
     dependencies:
@@ -15914,8 +16058,7 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.24.7': {}
 
-  '@babel/helper-validator-identifier@7.25.7':
-    optional: true
+  '@babel/helper-validator-identifier@7.25.7': {}
 
   '@babel/helper-validator-option@7.21.0': {}
 
@@ -15968,7 +16111,6 @@ snapshots:
       chalk: 2.4.2
       js-tokens: 4.0.0
       picocolors: 1.0.1
-    optional: true
 
   '@babel/parser@7.22.5':
     dependencies:
@@ -16209,7 +16351,7 @@ snapshots:
   '@babel/plugin-syntax-typescript@7.25.4(@babel/core@7.22.5)':
     dependencies:
       '@babel/core': 7.22.5
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.25.7
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.22.5)':
     dependencies:
@@ -17299,7 +17441,6 @@ snapshots:
       '@babel/code-frame': 7.25.7
       '@babel/parser': 7.22.5
       '@babel/types': 7.22.5
-    optional: true
 
   '@babel/traverse@7.22.5':
     dependencies:
@@ -17519,6 +17660,78 @@ snapshots:
       comment-parser: 1.4.1
       esquery: 1.5.0
       jsdoc-type-pratt-parser: 4.0.0
+
+  '@esbuild/aix-ppc64@0.23.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/android-arm@0.23.1':
+    optional: true
+
+  '@esbuild/android-x64@0.23.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.23.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.23.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.23.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.23.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.23.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.23.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.23.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.23.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.23.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.23.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.23.1':
+    optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.56.0)':
     dependencies:
@@ -18035,7 +18248,7 @@ snapshots:
       jest-util: 29.7.0
       jest-validate: 29.7.0
       jest-watcher: 29.7.0
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-ansi: 6.0.0
@@ -18201,7 +18414,7 @@ snapshots:
       jest-regex-util: 27.5.1
       jest-util: 27.5.1
       micromatch: 4.0.8
-      pirates: 4.0.5
+      pirates: 4.0.6
       slash: 3.0.0
       source-map: 0.6.1
       write-file-atomic: 3.0.3
@@ -18242,7 +18455,7 @@ snapshots:
       jest-regex-util: 29.6.3
       jest-util: 29.7.0
       micromatch: 4.0.8
-      pirates: 4.0.5
+      pirates: 4.0.6
       slash: 3.0.0
       write-file-atomic: 4.0.2
     transitivePeerDependencies:
@@ -19760,14 +19973,6 @@ snapshots:
       '@types/babel__template': 7.4.0
       '@types/babel__traverse': 7.11.1
 
-  '@types/babel__core@7.1.14':
-    dependencies:
-      '@babel/parser': 7.22.5
-      '@babel/types': 7.22.5
-      '@types/babel__generator': 7.6.2
-      '@types/babel__template': 7.4.0
-      '@types/babel__traverse': 7.11.0
-
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.22.5
@@ -19775,7 +19980,6 @@ snapshots:
       '@types/babel__generator': 7.6.2
       '@types/babel__template': 7.4.0
       '@types/babel__traverse': 7.11.0
-    optional: true
 
   '@types/babel__generator@7.6.2':
     dependencies:
@@ -20714,10 +20918,6 @@ snapshots:
 
   ansi-escapes@3.2.0: {}
 
-  ansi-escapes@4.3.0:
-    dependencies:
-      type-fest: 0.8.1
-
   ansi-escapes@4.3.2:
     dependencies:
       type-fest: 0.21.3
@@ -20982,7 +21182,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.22.5
       '@jest/transform': 29.7.0
-      '@types/babel__core': 7.1.14
+      '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 6.1.1
       babel-preset-jest: 29.6.3(@babel/core@7.22.5)
       chalk: 4.1.2
@@ -21003,9 +21203,9 @@ snapshots:
 
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
-      '@babel/template': 7.24.7
+      '@babel/template': 7.25.7
       '@babel/types': 7.22.5
-      '@types/babel__core': 7.1.14
+      '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.11.0
 
   babel-plugin-macros@3.0.1:
@@ -23249,6 +23449,33 @@ snapshots:
       d: 1.0.1
       ext: 1.6.0
 
+  esbuild@0.23.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.23.1
+      '@esbuild/android-arm': 0.23.1
+      '@esbuild/android-arm64': 0.23.1
+      '@esbuild/android-x64': 0.23.1
+      '@esbuild/darwin-arm64': 0.23.1
+      '@esbuild/darwin-x64': 0.23.1
+      '@esbuild/freebsd-arm64': 0.23.1
+      '@esbuild/freebsd-x64': 0.23.1
+      '@esbuild/linux-arm': 0.23.1
+      '@esbuild/linux-arm64': 0.23.1
+      '@esbuild/linux-ia32': 0.23.1
+      '@esbuild/linux-loong64': 0.23.1
+      '@esbuild/linux-mips64el': 0.23.1
+      '@esbuild/linux-ppc64': 0.23.1
+      '@esbuild/linux-riscv64': 0.23.1
+      '@esbuild/linux-s390x': 0.23.1
+      '@esbuild/linux-x64': 0.23.1
+      '@esbuild/netbsd-x64': 0.23.1
+      '@esbuild/openbsd-arm64': 0.23.1
+      '@esbuild/openbsd-x64': 0.23.1
+      '@esbuild/sunos-x64': 0.23.1
+      '@esbuild/win32-arm64': 0.23.1
+      '@esbuild/win32-ia32': 0.23.1
+      '@esbuild/win32-x64': 0.23.1
+
   escalade@3.1.1: {}
 
   escape-goat@1.3.0: {}
@@ -25127,7 +25354,7 @@ snapshots:
 
   inquirer@7.3.3:
     dependencies:
-      ansi-escapes: 4.3.0
+      ansi-escapes: 4.3.2
       chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-width: 3.0.0
@@ -25708,7 +25935,7 @@ snapshots:
       jest-config: 29.7.0(@types/node@20.12.3)(babel-plugin-macros@3.1.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
-      yargs: 17.5.1
+      yargs: 17.7.2
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -25849,7 +26076,7 @@ snapshots:
       fb-watchman: 2.0.1
       graceful-fs: 4.2.11
       jest-regex-util: 29.4.3
-      jest-util: 29.5.0
+      jest-util: 29.7.0
       jest-worker: 29.7.0
       micromatch: 4.0.5
       walker: 1.0.8
@@ -26102,7 +26329,7 @@ snapshots:
       '@babel/core': 7.22.5
       '@babel/generator': 7.22.5
       '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.22.5)
-      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-syntax-typescript': 7.25.4(@babel/core@7.22.5)
       '@babel/types': 7.22.5
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
@@ -31285,6 +31512,13 @@ snapshots:
       tslib: 1.14.1
       typescript: 5.5.3
 
+  tsx@4.19.2:
+    dependencies:
+      esbuild: 0.23.1
+      get-tsconfig: 4.8.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tty-browserify@0.0.1: {}
 
   tunnel-agent@0.6.0:
@@ -32260,8 +32494,6 @@ snapshots:
 
   yargs-parser@20.2.4: {}
 
-  yargs-parser@21.0.1: {}
-
   yargs-parser@21.1.1: {}
 
   yargs@14.2.2:
@@ -32296,7 +32528,7 @@ snapshots:
       require-directory: 2.1.1
       string-width: 4.2.3
       y18n: 5.0.5
-      yargs-parser: 21.0.1
+      yargs-parser: 21.1.1
 
   yargs@17.7.2:
     dependencies:

--- a/turbopack/packages/devlow-bench/package.json
+++ b/turbopack/packages/devlow-bench/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "lint": "eslint src/",
     "prerelease": "pnpm run build",
+    "test": "node --import tsx --test src/**/*-test.ts",
     "build": "tsc"
   },
   "files": [
@@ -33,7 +34,8 @@
     "@types/inquirer": "^9.0.3",
     "@types/minimist": "^1.2.2",
     "@types/node": "^20.3.0",
-    "@types/split2": "^4.2.0"
+    "@types/split2": "^4.2.0",
+    "tsx": "4.19.2"
   },
   "dependencies": {
     "@datadog/datadog-api-client": "^1.13.0",

--- a/turbopack/packages/devlow-bench/src/cli.ts
+++ b/turbopack/packages/devlow-bench/src/cli.ts
@@ -13,6 +13,7 @@ import { pathToFileURL } from "url";
     "j",
     "console",
     "datadog",
+    "snowflake",
     "interactive",
     "i",
     "help",
@@ -54,6 +55,12 @@ import { pathToFileURL } from "url";
     );
     console.log(
       "                                     (requires DATADOG_API_KEY environment variables)"
+    );
+    console.log(
+      "  --snowflake[=<batch-uri>]          Upload the results to Snowflake"
+    );
+    console.log(
+      "                                     (requires SNOWFLAKE_TOPIC_NAME and SNOWFLAKE_SCHEMA_ID and environment variables)"
     );
     console.log("## Help");
     console.log("  --help, -h, -?                     Show this help");
@@ -104,6 +111,10 @@ import { pathToFileURL } from "url";
     args.datadog &&
       (await import("./interfaces/datadog.js")).default(
         typeof args.datadog === "string" ? { host: args.datadog } : undefined
+      ),
+    args.snowflake &&
+      (await import("./interfaces/snowflake.js")).default(
+        typeof args.snowflake === "string" ? { gatewayUri: args.snowflake } : undefined
       ),
     args.console !== false &&
       (await import("./interfaces/console.js")).default(),

--- a/turbopack/packages/devlow-bench/src/interfaces/constants.ts
+++ b/turbopack/packages/devlow-bench/src/interfaces/constants.ts
@@ -1,0 +1,33 @@
+import os from "node:os";
+import { command } from "../shell.js";
+
+export const UNIT_MAPPING: Record<string, string> = {
+  ms: "millisecond",
+  requests: "request",
+  bytes: "byte",
+};
+
+export const GIT_SHA =
+  process.env.GITHUB_SHA ??
+  (await (async () => {
+    const cmd = command("git", ["rev-parse", "HEAD"]);
+    await cmd.ok();
+    return cmd.output.trim();
+  })());
+
+export const GIT_BRANCH =
+  process.env.GITHUB_REF_NAME ??
+  (await (async () => {
+    const cmd = command("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+    await cmd.ok();
+    return cmd.output.trim();
+  })());
+
+export const IS_CI = Boolean(process.env.CI);
+export const OS = process.platform;
+export const OS_RELEASE = os.release();
+export const NUM_CPUS = os.cpus().length;
+export const CPU_MODEL = os.cpus()[0].model;
+export const USERNAME = os.userInfo().username;
+export const CPU_ARCH = os.arch();
+export const NODE_VERSION = process.version;

--- a/turbopack/packages/devlow-bench/src/interfaces/datadog.ts
+++ b/turbopack/packages/devlow-bench/src/interfaces/datadog.ts
@@ -5,7 +5,7 @@ import type {
 import type { Interface } from "../index.js";
 import datadogApiClient from "@datadog/datadog-api-client";
 import os from "os";
-import { command } from "../shell.js";
+import { CPU_ARCH, CPU_MODEL, GIT_BRANCH, GIT_SHA, IS_CI, NODE_VERSION, NUM_CPUS, OS, OS_RELEASE, USERNAME } from "./constants.js";
 
 function toIdentifier(str: string) {
   return str.replace(/\//g, ".").replace(/ /g, "_");
@@ -17,22 +17,6 @@ const UNIT_MAPPING: Record<string, string> = {
   bytes: "byte",
 };
 
-const GIT_SHA =
-  process.env.GITHUB_SHA ??
-  (await (async () => {
-    const cmd = command("git", ["rev-parse", "HEAD"]);
-    await cmd.ok();
-    return cmd.output.trim();
-  })());
-
-const GIT_BRANCH =
-  process.env.GITHUB_REF_NAME ??
-  (await (async () => {
-    const cmd = command("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
-    await cmd.ok();
-    return cmd.output.trim();
-  })());
-
 export default function createInterface({
   apiKey = process.env.DATADOG_API_KEY,
   appKey = process.env.DATADOG_APP_KEY,
@@ -41,15 +25,15 @@ export default function createInterface({
   if (!apiKey)
     throw new Error("Datadog API key is required (set DATADOG_API_KEY)");
   const commonTags = [
-    `ci:${!!process.env.CI || "false"}`,
-    `os:${process.platform}`,
-    `os_release:${os.release()}`,
-    `cpus:${os.cpus().length}`,
-    `cpu_model:${os.cpus()[0].model}`,
-    `user:${os.userInfo().username}`,
-    `arch:${os.arch()}`,
+    `ci:${IS_CI}`,
+    `os:${OS}`,
+    `os_release:${OS_RELEASE}`,
+    `cpus:${NUM_CPUS}`,
+    `cpu_model:${CPU_MODEL}`,
+    `user:${USERNAME}`,
+    `arch:${CPU_ARCH}`,
     `total_memory:${Math.round(os.totalmem() / 1024 / 1024 / 1024)}`,
-    `node_version:${process.version}`,
+    `node_version:${NODE_VERSION}`,
     `git_sha:${GIT_SHA}`,
     `git_branch:${GIT_BRANCH}`,
   ];

--- a/turbopack/packages/devlow-bench/src/interfaces/snowflake-test.ts
+++ b/turbopack/packages/devlow-bench/src/interfaces/snowflake-test.ts
@@ -1,0 +1,49 @@
+import assert from "assert";
+import createInterface from "./snowflake.js";
+import {mock, test} from "node:test"
+
+test('sending measurements to the batch endpoint', async () => {
+  const requests: Array<[string, RequestInit]> = [];
+
+  const fetchMock = mock.method(global, 'fetch', (req: string, options: RequestInit) => {
+    requests.push([req, options]);
+    return Promise.resolve(Response.json({}));
+  });
+
+  const iface = createInterface({
+    gatewayUri: 'http://127.0.0.1/v1/batch',
+    topicName: 'my-topic',
+    schemaId: 123,
+  });
+
+  assert(iface.measurement != null)
+  await iface.measurement('scenario', {myprop: 'foo'}, 'one', 42, 'ms');
+  await iface.measurement('scenario', {myprop: 'foo'}, 'two', 45, 'ms');
+  await iface.measurement('scenario', {myprop: 'foo'}, 'three', 38, 'ms');
+
+  assert(iface.end != null)
+  await iface.end('scenario', {myprop: 'foo'});
+
+  assert.equal(requests.length, 1);
+  const [url, options] = requests[0];
+  assert.equal(url, 'http://127.0.0.1/v1/batch');
+  assert(typeof options.body === 'string');
+  const body = JSON.parse(options.body);
+  assert.equal(body.schema_id, 123);
+  assert.equal(body.topic, 'my-topic');
+  assert(body.records.length === 3);
+  assert.equal(body.records[0].metric, 'one');
+  assert.equal(body.records[0].value, 42);
+  assert.equal(body.records[0].props_json, '{"myprop":"foo"}');
+  assert.equal(body.records[0].unit, 'ms');
+  assert.equal(body.records[1].metric, 'two');
+  assert.equal(body.records[1].value, 45);
+  assert.equal(body.records[1].props_json, '{"myprop":"foo"}');
+  assert.equal(body.records[1].unit, 'ms');
+  assert.equal(body.records[2].metric, 'three');
+  assert.equal(body.records[2].value, 38);
+  assert.equal(body.records[2].props_json, '{"myprop":"foo"}');
+  assert.equal(body.records[2].unit, 'ms');
+
+  fetchMock.mock.restore()
+});

--- a/turbopack/packages/devlow-bench/src/interfaces/snowflake.ts
+++ b/turbopack/packages/devlow-bench/src/interfaces/snowflake.ts
@@ -1,0 +1,117 @@
+import type { Interface } from "../index.js";
+import os from "os";
+import { CPU_ARCH, CPU_MODEL, GIT_BRANCH, GIT_SHA, IS_CI, NODE_VERSION, NUM_CPUS, OS, OS_RELEASE, USERNAME } from "./constants.js";
+import { randomUUID } from "crypto";
+
+type DevlowMetric = {
+  event_time: number;
+  scenario: string;
+  props: Record<string, string | number | boolean | null>;
+  metric: string;
+  value: number;
+  unit: string;
+  relative_to?: string;
+  is_ci: boolean;
+  os: string;
+  os_release: string;
+  cpus: number;
+  cpu_model: string;
+  user: string;
+  arch: string;
+  total_memory_bytes: number;
+  node_version: string;
+  git_sha: string;
+  git_branch: string;
+}
+
+export default function createInterface({
+  gatewayUri = process.env.SNOWFLAKE_BATCH_URI,
+  topicName = process.env.SNOWFLAKE_TOPIC_NAME,
+  schemaId = process.env.SNOWFLAKE_SCHEMA_ID ? parseInt(process.env.SNOWFLAKE_SCHEMA_ID, 10) : undefined,
+}: { gatewayUri?: string; topicName?: string, schemaId?: number } = {}): Interface {
+  if (!gatewayUri)
+    throw new Error("Snowflake gateway URI is required (set SNOWFLAKE_GATEWAY_URI)");
+  if (!topicName)
+    throw new Error("Snowflake topic name is required (set SNOWFLAKE_TOPIC_NAME)");
+  if (!schemaId)
+    throw new Error("Snowflake schema ID is required (set SNOWFLAKE_SCHEMA_ID to a valid integer)");
+
+  const records: DevlowMetric[] = []
+  const iface: Interface = {
+    measurement: async (scenario, props, name, value, unit, relativeTo) => {
+      const ts = Math.round(Date.now() / 1000);
+      records.push({
+        event_time: ts,
+        scenario,
+        props,
+        metric: name,
+        value,
+        unit,
+        relative_to: relativeTo,
+        is_ci: IS_CI,
+        os: OS,
+        os_release: OS_RELEASE,
+        cpus: NUM_CPUS,
+        cpu_model: CPU_MODEL,
+        user: USERNAME,
+        arch: CPU_ARCH,
+        total_memory_bytes: os.totalmem(),
+        node_version: NODE_VERSION,
+        git_sha: GIT_SHA,
+        git_branch: GIT_BRANCH,
+      })
+    },
+    end: async (scenario, props) => {
+      await trackAnalytics(gatewayUri, topicName, schemaId, records)
+    },
+  };
+  return iface;
+}
+
+async function trackAnalytics(
+  batchUri: string,
+  topic: string,
+  schemaId: number,
+  records: DevlowMetric[],
+): Promise<void> {
+  try {
+    const res = await fetch(batchUri, {
+      method: "POST",
+      headers: {
+        "Client-Id": "nextjs",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        schema_id: schemaId,
+        topic,
+        records: records.map((record) => omit({
+          ...record,
+          id: randomUUID(),
+          props_json: JSON.stringify(record.props),
+        }, ["props"])),
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(
+        `Unexpected HTTP response from reporting ${topic} event to Snowflake: ${res.status}. Body: ${await res.text()}`,
+      );
+    }
+  } catch (e) {
+    const wrappedError = new Error("Unexpected error tracking analytics event");
+    wrappedError.cause = e;
+    console.error(wrappedError);
+  }
+}
+
+export function omit<T extends { [key: string]: unknown }, K extends keyof T>(
+  object: T,
+  keys: K[]
+): Omit<T, K> {
+  const omitted: { [key: string]: unknown } = {}
+  Object.keys(object).forEach((key) => {
+    if (!keys.includes(key as K)) {
+      omitted[key] = object[key]
+    }
+  })
+  return omitted as Omit<T, K>
+}

--- a/turbopack/packages/devlow-bench/tsconfig.json
+++ b/turbopack/packages/devlow-bench/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "strict": true,
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "NodeNext",
     "types": ["node"],
     "outDir": "dist",


### PR DESCRIPTION
This adds a backend to devlow for Vercel’s HTTP data api for sending values to Snowflake. It requires the gateway’s batch uri endpoint, schema id, and topic name.

It collects the metrics and sends them as a batch, each with relevant metadata similar to the metadata collected by the Datadog backend.

Test Plan:

- [x] Manual test
- [x] Unit test


Closes PACK-3363