### PR TITLE
docs: fix code block extension for `cacheLife`

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/cacheLife.mdx
+++ b/docs/02-app/02-api-reference/04-functions/cacheLife.mdx
@@ -52,7 +52,7 @@ export default async function Page() {
 }
 ```
 
-```tsx filename="app/page.tsx" highlight={5} switcher
+```jsx filename="app/page.js" highlight={5} switcher
 'use cache'
 import { unstable_cacheLife as cacheLife } from 'next/cache'
 


### PR DESCRIPTION
This PR modifies the code block extension for [cacheLife](https://nextjs.org/docs/canary/app/api-reference/functions/cacheLife#usage).

As shown in the screenshot below, both code blocks were TSX (TypeScript), so I followed the guidelines [here](https://nextjs.org/docs/canary/community/contribution-guide#ts-and-js-switcher) and changed one of them to JSX (JavaScript).

![image](https://github.com/user-attachments/assets/590b2f82-a46d-4cc8-bb45-8a5262ac6dec)
