### PR TITLE
Document default values in cookies options

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/cookies.mdx
+++ b/docs/02-app/02-api-reference/04-functions/cookies.mdx
@@ -53,7 +53,7 @@ When setting a cookie, the following properties from the `options` object are su
 | `maxAge`          | Number                                 | Sets the cookie’s lifespan in seconds.                                             |
 | `domain`          | String                                 | Specifies the domain where the cookie is available.                                |
 | `path`            | String, default: `'/'`                 | Limits the cookie's scope to a specific path within the domain.                    |
-| `secure`          | Boolean,                               | Ensures the cookie is sent only over HTTPS connections for added security.         |
+| `secure`          | Boolean                                | Ensures the cookie is sent only over HTTPS connections for added security.         |
 | `httpOnly`        | Boolean                                | Restricts the cookie to HTTP requests, preventing client-side access.              |
 | `sameSite`        | Boolean, `'lax'`, `'strict'`, `'none'` | Controls the cookie's cross-site request behavior.                                 |
 | `priority`        | String (`"low"`, `"medium"`, `"high"`) | Specifies the cookie's priority                                                    |

--- a/docs/02-app/02-api-reference/04-functions/cookies.mdx
+++ b/docs/02-app/02-api-reference/04-functions/cookies.mdx
@@ -52,13 +52,15 @@ When setting a cookie, the following properties from the `options` object are su
 | `expires`         | Date                                   | Defines the exact date when the cookie will expire.                                |
 | `maxAge`          | Number                                 | Sets the cookie’s lifespan in seconds.                                             |
 | `domain`          | String                                 | Specifies the domain where the cookie is available.                                |
-| `path`            | String                                 | Limits the cookie's scope to a specific path within the domain.                    |
+| `path`            | String, default: `'/'`                 | Limits the cookie's scope to a specific path within the domain.                    |
 | `secure`          | Boolean,                               | Ensures the cookie is sent only over HTTPS connections for added security.         |
 | `httpOnly`        | Boolean                                | Restricts the cookie to HTTP requests, preventing client-side access.              |
 | `sameSite`        | Boolean, `'lax'`, `'strict'`, `'none'` | Controls the cookie's cross-site request behavior.                                 |
 | `priority`        | String (`"low"`, `"medium"`, `"high"`) | Specifies the cookie's priority                                                    |
 | `encode('value')` | Function                               | Specifies a function that will be used to encode a cookie's value.                 |
 | `partitioned`     | Boolean                                | Indicates whether the cookie is [partitioned](https://github.com/privacycg/CHIPS). |
+
+The only option with a default value is `path`.
 
 To learn more about these options, see the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies).
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

Document the default values for `cookies`, eg. used in `cookies().set()`, fix typo

### Why?

Default values are undocumented (probably because there are almost no default values)

![Screenshot 2024-11-01 at 16 20 57](https://github.com/user-attachments/assets/7de705f0-f0db-491d-9582-6f65f9688730)


### How?

1. Add a default annotation in the options table row for `path`, based on the `packages/next/src/compiled/@edge-runtime/cookies/index.js` code:
   https://github.com/vercel/next.js/blob/98fa0246d9d6f6adfcac91d8d9997672390cd051/packages/next/src/compiled/%40edge-runtime/cookies/index.js#L317-L328
2. Add a short paragraph about other options not having default values
3. Fix the extra `,` typo