### PR TITLE
skip seeding prefetch cache in development

### DIFF
--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -105,10 +105,13 @@ export function createInitialRouterState({
       null,
   }
 
-  if (location) {
+  if (process.env.NODE_ENV !== 'development' && location) {
     // Seed the prefetch cache with this page's data.
     // This is to prevent needlessly re-prefetching a page that is already reusable,
     // and will avoid triggering a loading state/data fetch stall when navigating back to the page.
+    // We don't currently do this in development because links aren't prefetched in development
+    // so having a mismatch between prefetch/no prefetch provides inconsistent behavior based on which page
+    // was loaded first.
     const url = new URL(
       `${location.pathname}${location.search}`,
       location.origin

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -192,12 +192,17 @@ describe('app dir - navigation', () => {
       await checkLink('top', 0)
       await checkLink('non-existent', 0)
 
-      // there should have been no RSC calls to fetch data
-      expect(hasRscRequest).toBe(false)
+      if (!isNextDev) {
+        // there should have been no RSC calls to fetch data
+        // this is skipped in development because there'll never be a prefetch cache
+        // entry for the loaded page and so every request will be a cache miss.
+        expect(hasRscRequest).toBe(false)
+      }
 
-      // There should be an RSC request if the query param is changed
       await checkLink('query-param', 2284)
       await browser.waitForIdleNetwork()
+
+      // There should be an RSC request if the query param is changed
       expect(hasRscRequest).toBe(true)
     })
 


### PR DESCRIPTION
Since prefetching is disabled in development, seeding the prefetch cache for the initially rendered page can lead to an inconsistent navigation experience, where the initially visited page won't behave the same as subsequent pages that you navigate to.

We should ultimately get to a place where the prefetch behavior is consistent between dev/start to keep the production behavior as consistent as possible with the development experience, but when we do so, we would want to enable it across the board.

This happens to fix a bug with dynamicIO because the server-patch action (which happens when data is missing for a rendered segment) was mismatching the router state tree, which triggers a hard navigation to recover. This happens to fix the issue because the router never hits the server patch case, which is when the hard navigation could occur. Separately, we're working to verify why the seeded prefetch entry might have caused this change in behavior only in dev.

Note: this modifies a navigation test that was asserting on RSC requests taking place, which will now happen in dev as there'll be no prefetch entry. 

Fixes #72150