### PR TITLE
refactor(turbopack-core): Migrate more resolve options structs to ResolvedVc

### DIFF
--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -38,7 +38,7 @@ pub struct InstrumentationEndpoint {
     source: Vc<Box<dyn Source>>,
     is_edge: bool,
 
-    app_dir: Option<Vc<FileSystemPath>>,
+    app_dir: Option<ResolvedVc<FileSystemPath>>,
     ecmascript_client_reference_transition_name: Option<Vc<RcStr>>,
 }
 
@@ -50,7 +50,7 @@ impl InstrumentationEndpoint {
         asset_context: Vc<Box<dyn AssetContext>>,
         source: Vc<Box<dyn Source>>,
         is_edge: bool,
-        app_dir: Option<Vc<FileSystemPath>>,
+        app_dir: Option<ResolvedVc<FileSystemPath>>,
         ecmascript_client_reference_transition_name: Option<Vc<RcStr>>,
     ) -> Vc<Self> {
         Self {

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -85,7 +85,7 @@ impl MiddlewareEndpoint {
 
         let mut evaluatable_assets = get_server_runtime_entries(
             Value::new(ServerContextType::Middleware {
-                app_dir: self.app_dir.as_deref().copied(),
+                app_dir: self.app_dir,
                 ecmascript_client_reference_transition_name: self
                     .ecmascript_client_reference_transition_name
                     .as_deref()

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -281,30 +281,30 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    fn client_module_options_context(self: Vc<Self>) -> Vc<ModuleOptionsContext> {
-        get_client_module_options_context(
+    async fn client_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
+        Ok(get_client_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
             self.project().client_compile_time_info().environment(),
             Value::new(ClientContextType::Pages {
-                pages_dir: self.pages_dir(),
+                pages_dir: self.pages_dir().to_resolved().await?,
             }),
             self.project().next_mode(),
             self.project().next_config(),
-        )
+        ))
     }
 
     #[turbo_tasks::function]
-    fn client_resolve_options_context(self: Vc<Self>) -> Vc<ResolveOptionsContext> {
-        get_client_resolve_options_context(
+    async fn client_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
+        Ok(get_client_resolve_options_context(
             self.project().project_path(),
             Value::new(ClientContextType::Pages {
-                pages_dir: self.pages_dir(),
+                pages_dir: self.pages_dir().to_resolved().await?,
             }),
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
-        )
+        ))
     }
 
     #[turbo_tasks::function]
@@ -387,153 +387,155 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    fn ssr_module_options_context(self: Vc<Self>) -> Vc<ModuleOptionsContext> {
-        get_server_module_options_context(
+    async fn ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
+        Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
             Value::new(ServerContextType::Pages {
-                pages_dir: self.pages_dir(),
+                pages_dir: self.pages_dir().to_resolved().await?,
             }),
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::NodeJs,
-        )
+        ))
     }
 
     #[turbo_tasks::function]
-    fn edge_ssr_module_options_context(self: Vc<Self>) -> Vc<ModuleOptionsContext> {
-        get_server_module_options_context(
+    async fn edge_ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
+        Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
             Value::new(ServerContextType::Pages {
-                pages_dir: self.pages_dir(),
+                pages_dir: self.pages_dir().to_resolved().await?,
             }),
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::Edge,
-        )
+        ))
     }
 
     #[turbo_tasks::function]
-    fn api_module_options_context(self: Vc<Self>) -> Vc<ModuleOptionsContext> {
-        get_server_module_options_context(
+    async fn api_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
+        Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
             Value::new(ServerContextType::PagesApi {
-                pages_dir: self.pages_dir(),
+                pages_dir: self.pages_dir().to_resolved().await?,
             }),
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::NodeJs,
-        )
+        ))
     }
 
     #[turbo_tasks::function]
-    fn edge_api_module_options_context(self: Vc<Self>) -> Vc<ModuleOptionsContext> {
-        get_server_module_options_context(
+    async fn edge_api_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
+        Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
             Value::new(ServerContextType::PagesApi {
-                pages_dir: self.pages_dir(),
+                pages_dir: self.pages_dir().to_resolved().await?,
             }),
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::Edge,
-        )
+        ))
     }
 
     #[turbo_tasks::function]
-    fn ssr_data_module_options_context(self: Vc<Self>) -> Vc<ModuleOptionsContext> {
-        get_server_module_options_context(
+    async fn ssr_data_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
+        Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
             Value::new(ServerContextType::PagesData {
-                pages_dir: self.pages_dir(),
+                pages_dir: self.pages_dir().to_resolved().await?,
             }),
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::NodeJs,
-        )
+        ))
     }
 
     #[turbo_tasks::function]
-    fn edge_ssr_data_module_options_context(self: Vc<Self>) -> Vc<ModuleOptionsContext> {
-        get_server_module_options_context(
+    async fn edge_ssr_data_module_options_context(
+        self: Vc<Self>,
+    ) -> Result<Vc<ModuleOptionsContext>> {
+        Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
             Value::new(ServerContextType::PagesData {
-                pages_dir: self.pages_dir(),
+                pages_dir: self.pages_dir().to_resolved().await?,
             }),
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::Edge,
-        )
+        ))
     }
 
     #[turbo_tasks::function]
-    fn ssr_resolve_options_context(self: Vc<Self>) -> Vc<ResolveOptionsContext> {
-        get_server_resolve_options_context(
+    async fn ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
+        Ok(get_server_resolve_options_context(
             self.project().project_path(),
             // NOTE(alexkirsz) This could be `PagesData` for the data endpoint, but it doesn't
             // matter (for now at least) because `get_server_resolve_options_context` doesn't
             // differentiate between the two.
             Value::new(ServerContextType::Pages {
-                pages_dir: self.pages_dir(),
+                pages_dir: self.pages_dir().to_resolved().await?,
             }),
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
-        )
+        ))
     }
 
     #[turbo_tasks::function]
-    fn edge_ssr_resolve_options_context(self: Vc<Self>) -> Vc<ResolveOptionsContext> {
-        get_edge_resolve_options_context(
+    async fn edge_ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
+        Ok(get_edge_resolve_options_context(
             self.project().project_path(),
             // NOTE(alexkirsz) This could be `PagesData` for the data endpoint, but it doesn't
             // matter (for now at least) because `get_server_resolve_options_context` doesn't
             // differentiate between the two.
             Value::new(ServerContextType::Pages {
-                pages_dir: self.pages_dir(),
+                pages_dir: self.pages_dir().to_resolved().await?,
             }),
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
-        )
+        ))
     }
 
     #[turbo_tasks::function]
-    fn client_runtime_entries(self: Vc<Self>) -> Vc<EvaluatableAssets> {
+    async fn client_runtime_entries(self: Vc<Self>) -> Result<Vc<EvaluatableAssets>> {
         let client_runtime_entries = get_client_runtime_entries(
             self.project().project_path(),
             Value::new(ClientContextType::Pages {
-                pages_dir: self.pages_dir(),
+                pages_dir: self.pages_dir().to_resolved().await?,
             }),
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
         );
-        client_runtime_entries.resolve_entries(self.client_module_context())
+        Ok(client_runtime_entries.resolve_entries(self.client_module_context()))
     }
 
     #[turbo_tasks::function]
-    fn runtime_entries(self: Vc<Self>) -> Vc<RuntimeEntries> {
-        get_server_runtime_entries(
+    async fn runtime_entries(self: Vc<Self>) -> Result<Vc<RuntimeEntries>> {
+        Ok(get_server_runtime_entries(
             Value::new(ServerContextType::Pages {
-                pages_dir: self.pages_dir(),
+                pages_dir: self.pages_dir().to_resolved().await?,
             }),
             self.project().next_mode(),
-        )
+        ))
     }
 
     #[turbo_tasks::function]
-    fn data_runtime_entries(self: Vc<Self>) -> Vc<RuntimeEntries> {
-        get_server_runtime_entries(
+    async fn data_runtime_entries(self: Vc<Self>) -> Result<Vc<RuntimeEntries>> {
+        Ok(get_server_runtime_entries(
             Value::new(ServerContextType::PagesData {
-                pages_dir: self.pages_dir(),
+                pages_dir: self.pages_dir().to_resolved().await?,
             }),
             self.project().next_mode(),
-        )
+        ))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -529,7 +529,7 @@ impl Project {
         let app_dir = find_app_dir(self.project_path()).await?;
 
         Ok(Vc::cell(
-            app_dir.map(|app_dir| AppProject::new(self, app_dir)),
+            app_dir.map(|app_dir| AppProject::new(self, *app_dir)),
         ))
     }
 
@@ -1001,7 +1001,7 @@ impl Project {
             self,
             middleware_asset_context,
             source,
-            app_dir,
+            app_dir.as_deref().copied(),
             ecmascript_client_reference_transition_name,
         )))
     }
@@ -1140,7 +1140,7 @@ impl Project {
             instrumentation_asset_context,
             source,
             is_edge,
-            app_dir,
+            app_dir.as_deref().copied(),
             ecmascript_client_reference_transition_name,
         )))
     }

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -230,7 +230,7 @@ impl DirectoryTree {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct OptionAppDir(Option<Vc<FileSystemPath>>);
+pub struct OptionAppDir(Option<ResolvedVc<FileSystemPath>>);
 
 /// Finds and returns the [DirectoryTree] of the app directory if existing.
 #[turbo_tasks::function]
@@ -244,7 +244,7 @@ pub async fn find_app_dir(project_path: Vc<FileSystemPath>) -> Result<Vc<OptionA
     } else {
         return Ok(Vc::cell(None));
     }
-    .resolve()
+    .to_resolved()
     .await?;
 
     Ok(Vc::cell(Some(app_dir)))

--- a/crates/next-core/src/next_build.rs
+++ b/crates/next-core/src/next_build.rs
@@ -1,19 +1,24 @@
 use anyhow::Result;
-use turbo_tasks::{RcStr, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::resolve::{options::ImportMapping, ExternalType};
 
 use crate::next_import_map::get_next_package;
 
 #[turbo_tasks::function]
-pub async fn get_postcss_package_mapping(project_path: Vc<FileSystemPath>) -> Vc<ImportMapping> {
-    ImportMapping::Alternatives(vec![
+pub async fn get_postcss_package_mapping(
+    project_path: ResolvedVc<FileSystemPath>,
+) -> Result<Vc<ImportMapping>> {
+    Ok(ImportMapping::Alternatives(vec![
         // Prefer the local installed version over the next.js version
-        ImportMapping::PrimaryAlternative("postcss".into(), Some(project_path)).cell(),
-        ImportMapping::PrimaryAlternative("postcss".into(), Some(get_next_package(project_path)))
-            .cell(),
+        ImportMapping::PrimaryAlternative("postcss".into(), Some(project_path)).resolved_cell(),
+        ImportMapping::PrimaryAlternative(
+            "postcss".into(),
+            Some(get_next_package(*project_path).to_resolved().await?),
+        )
+        .resolved_cell(),
     ])
-    .cell()
+    .cell())
 }
 
 #[turbo_tasks::function]
@@ -24,6 +29,6 @@ pub async fn get_external_next_compiled_package_mapping(
         Some(format!("next/dist/compiled/{}", &*package_name.await?).into()),
         ExternalType::CommonJs,
     )
-    .into()])
+    .resolved_cell()])
     .cell())
 }

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -127,11 +127,15 @@ pub fn get_client_compile_time_info(
     .cell()
 }
 
-#[turbo_tasks::value(serialization = "auto_for_input")]
+#[turbo_tasks::value(shared, serialization = "auto_for_input")]
 #[derive(Debug, Copy, Clone, Hash)]
 pub enum ClientContextType {
-    Pages { pages_dir: Vc<FileSystemPath> },
-    App { app_dir: Vc<FileSystemPath> },
+    Pages {
+        pages_dir: ResolvedVc<FileSystemPath>,
+    },
+    App {
+        app_dir: ResolvedVc<FileSystemPath>,
+    },
     Fallback,
     Other,
 }

--- a/crates/next-core/src/next_client/transforms.rs
+++ b/crates/next-core/src/next_client/transforms.rs
@@ -50,7 +50,7 @@ pub async fn get_next_client_transforms_rules(
             if !foreign_code {
                 rules.push(
                     get_next_pages_transforms_rule(
-                        pages_dir,
+                        *pages_dir,
                         ExportFilter::StripDataExports,
                         enable_mdx_rs,
                     )

--- a/crates/next-core/src/next_edge/unsupported.rs
+++ b/crates/next-core/src/next_edge/unsupported.rs
@@ -43,7 +43,7 @@ impl NextEdgeUnsupportedModuleReplacer {
 impl ImportMappingReplacement for NextEdgeUnsupportedModuleReplacer {
     #[turbo_tasks::function]
     fn replace(&self, _capture: Vc<Pattern>) -> Vc<ReplacedImportMapping> {
-        ReplacedImportMapping::Ignore.into()
+        ReplacedImportMapping::Ignore.cell()
     }
 
     #[turbo_tasks::function]
@@ -63,11 +63,12 @@ impl ImportMappingReplacement for NextEdgeUnsupportedModuleReplacer {
             };
             let content = AssetContent::file(File::from(code).into());
             let source = VirtualSource::new(root_path, content);
-            return Ok(
-                ImportMapResult::Result(ResolveResult::source(Vc::upcast(source)).into()).into(),
-            );
+            return Ok(ImportMapResult::Result(
+                ResolveResult::source(Vc::upcast(source)).resolved_cell(),
+            )
+            .cell());
         };
 
-        Ok(ImportMapResult::NoEntry.into())
+        Ok(ImportMapResult::NoEntry.cell())
     }
 }

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 
 use anyhow::{Context, Result};
-use turbo_tasks::{fxindexmap, FxIndexMap, RcStr, Value, Vc};
+use turbo_tasks::{fxindexmap, FxIndexMap, RcStr, ResolvedVc, Value, Vc};
 use turbo_tasks_fs::{FileSystem, FileSystemPath};
 use turbopack_core::{
     reference_type::{CommonJsReferenceSubType, ReferenceType},
@@ -87,7 +87,7 @@ const EDGE_UNSUPPORTED_NODE_INTERNALS: [&str; 44] = [
 /// Computes the Next-specific client import map.
 #[turbo_tasks::function]
 pub async fn get_next_client_import_map(
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
     ty: Value<ClientContextType>,
     next_config: Vc<NextConfig>,
     execution_context: Vc<ExecutionContext>,
@@ -167,7 +167,7 @@ pub async fn get_next_client_import_map(
                     "next/dist/compiled/react-dom-experimental/static.browser",
                 ),
             );
-            let react_client_package = get_react_client_package(&next_config).await?;
+            let react_client_package = get_react_client_package(next_config).await?;
             import_map.insert_exact_alias(
                 "react-dom/client",
                 request_to_import_mapping(
@@ -232,40 +232,43 @@ pub async fn get_next_client_import_map(
         ClientContextType::Other => {}
     }
 
-    insert_turbopack_dev_alias(&mut import_map);
+    insert_turbopack_dev_alias(&mut import_map).await?;
 
     Ok(import_map.cell())
 }
 
 /// Computes the Next-specific client import map.
 #[turbo_tasks::function]
-pub fn get_next_build_import_map() -> Vc<ImportMap> {
+pub async fn get_next_build_import_map() -> Result<Vc<ImportMap>> {
     let mut import_map = ImportMap::empty();
 
     insert_package_alias(
         &mut import_map,
         &format!("{VIRTUAL_PACKAGE_NAME}/"),
-        next_js_fs().root(),
+        next_js_fs().root().to_resolved().await?,
     );
 
-    let external = ImportMapping::External(None, ExternalType::CommonJs).cell();
+    let external = ImportMapping::External(None, ExternalType::CommonJs).resolved_cell();
 
     import_map.insert_exact_alias("next", external);
     import_map.insert_wildcard_alias("next/", external);
     import_map.insert_exact_alias("styled-jsx", external);
     import_map.insert_exact_alias(
         "styled-jsx/style",
-        ImportMapping::External(Some("styled-jsx/style.js".into()), ExternalType::CommonJs).cell(),
+        ImportMapping::External(Some("styled-jsx/style.js".into()), ExternalType::CommonJs)
+            .resolved_cell(),
     );
     import_map.insert_wildcard_alias("styled-jsx/", external);
 
-    import_map.cell()
+    Ok(import_map.cell())
 }
 
 /// Computes the Next-specific client fallback import map, which provides
 /// polyfills to Node.js externals.
 #[turbo_tasks::function]
-pub fn get_next_client_fallback_import_map(ty: Value<ClientContextType>) -> Vc<ImportMap> {
+pub async fn get_next_client_fallback_import_map(
+    ty: Value<ClientContextType>,
+) -> Result<Vc<ImportMap>> {
     let mut import_map = ImportMap::empty();
 
     match ty.into_value() {
@@ -284,15 +287,15 @@ pub fn get_next_client_fallback_import_map(ty: Value<ClientContextType>) -> Vc<I
         ClientContextType::Other => {}
     }
 
-    insert_turbopack_dev_alias(&mut import_map);
+    insert_turbopack_dev_alias(&mut import_map).await?;
 
-    import_map.cell()
+    Ok(import_map.cell())
 }
 
 /// Computes the Next-specific server-side import map.
 #[turbo_tasks::function]
 pub async fn get_next_server_import_map(
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
     ty: Value<ServerContextType>,
     next_config: Vc<NextConfig>,
     execution_context: Vc<ExecutionContext>,
@@ -318,7 +321,7 @@ pub async fn get_next_server_import_map(
 
     let ty = ty.into_value();
 
-    let external: Vc<ImportMapping> = ImportMapping::External(None, ExternalType::CommonJs).cell();
+    let external = ImportMapping::External(None, ExternalType::CommonJs).resolved_cell();
 
     import_map.insert_exact_alias("next/dist/server/require-hook", external);
     match ty {
@@ -334,7 +337,7 @@ pub async fn get_next_server_import_map(
             import_map.insert_exact_alias(
                 "styled-jsx/style",
                 ImportMapping::External(Some("styled-jsx/style.js".into()), ExternalType::CommonJs)
-                    .cell(),
+                    .resolved_cell(),
             );
             import_map.insert_wildcard_alias("styled-jsx/", external);
             // TODO: we should not bundle next/dist/build/utils in the pages renderer at all
@@ -370,7 +373,7 @@ pub async fn get_next_server_import_map(
 /// Computes the Next-specific edge-side import map.
 #[turbo_tasks::function]
 pub async fn get_next_edge_import_map(
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
     ty: Value<ServerContextType>,
     next_config: Vc<NextConfig>,
     execution_context: Vc<ExecutionContext>,
@@ -480,9 +483,10 @@ pub async fn get_next_edge_import_map(
         | ServerContextType::PagesApi { .. } => {
             insert_unsupported_node_internal_aliases(
                 &mut import_map,
-                project_path,
+                *project_path,
                 execution_context,
-            );
+            )
+            .await?;
         }
     }
 
@@ -492,19 +496,22 @@ pub async fn get_next_edge_import_map(
 /// Insert default aliases for the node.js's internal to raise unsupported
 /// runtime errors. User may provide polyfills for their own by setting user
 /// config's alias.
-fn insert_unsupported_node_internal_aliases(
+async fn insert_unsupported_node_internal_aliases(
     import_map: &mut ImportMap,
     project_path: Vc<FileSystemPath>,
     execution_context: Vc<ExecutionContext>,
-) {
-    let unsupported_replacer = ImportMapping::Dynamic(Vc::upcast(
-        NextEdgeUnsupportedModuleReplacer::new(project_path, execution_context),
+) -> Result<()> {
+    let unsupported_replacer = ImportMapping::Dynamic(ResolvedVc::upcast(
+        NextEdgeUnsupportedModuleReplacer::new(project_path, execution_context)
+            .to_resolved()
+            .await?,
     ))
-    .into();
+    .resolved_cell();
 
     EDGE_UNSUPPORTED_NODE_INTERNALS.iter().for_each(|module| {
         import_map.insert_alias(AliasPattern::exact(*module), unsupported_replacer);
     });
+    Ok(())
 }
 
 pub fn get_next_client_resolved_map(
@@ -547,19 +554,21 @@ static NEXT_ALIASES: [(&str, &str); 23] = [
 
 async fn insert_next_server_special_aliases(
     import_map: &mut ImportMap,
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
     ty: ServerContextType,
     runtime: NextRuntime,
     next_config: Vc<NextConfig>,
 ) -> Result<()> {
-    let external_cjs_if_node = move |context_dir: Vc<FileSystemPath>, request: &str| match runtime {
-        NextRuntime::Edge => request_to_import_mapping(context_dir, request),
-        NextRuntime::NodeJs => external_request_to_cjs_import_mapping(request),
-    };
-    let external_esm_if_node = move |context_dir: Vc<FileSystemPath>, request: &str| match runtime {
-        NextRuntime::Edge => request_to_import_mapping(context_dir, request),
-        NextRuntime::NodeJs => external_request_to_esm_import_mapping(request),
-    };
+    let external_cjs_if_node =
+        move |context_dir: ResolvedVc<FileSystemPath>, request: &str| match runtime {
+            NextRuntime::Edge => request_to_import_mapping(context_dir, request),
+            NextRuntime::NodeJs => external_request_to_cjs_import_mapping(request),
+        };
+    let external_esm_if_node =
+        move |context_dir: ResolvedVc<FileSystemPath>, request: &str| match runtime {
+            NextRuntime::Edge => request_to_import_mapping(context_dir, request),
+            NextRuntime::NodeJs => external_request_to_esm_import_mapping(request),
+        };
 
     import_map.insert_exact_alias(
         "next/dist/compiled/@vercel/og/index.node.js",
@@ -572,7 +581,7 @@ async fn insert_next_server_special_aliases(
             request_to_import_mapping(project_path, "react-dom/server.edge"),
             request_to_import_mapping(project_path, "react-dom/server.browser"),
         ])
-        .cell(),
+        .resolved_cell(),
     );
 
     import_map.insert_exact_alias(
@@ -582,7 +591,7 @@ async fn insert_next_server_special_aliases(
             external_cjs_if_node(project_path, "@opentelemetry/api"),
             external_cjs_if_node(project_path, "next/dist/compiled/@opentelemetry/api"),
         ])
-        .cell(),
+        .resolved_cell(),
     );
 
     match ty {
@@ -592,13 +601,14 @@ async fn insert_next_server_special_aliases(
         ServerContextType::AppSSR { app_dir }
         | ServerContextType::AppRSC { app_dir, .. }
         | ServerContextType::AppRoute { app_dir, .. } => {
+            let next_package = get_next_package(*app_dir).to_resolved().await?;
             import_map.insert_exact_alias(
                 "styled-jsx",
-                request_to_import_mapping(get_next_package(app_dir), "styled-jsx"),
+                request_to_import_mapping(next_package, "styled-jsx"),
             );
             import_map.insert_wildcard_alias(
                 "styled-jsx/",
-                request_to_import_mapping(get_next_package(app_dir), "styled-jsx/*"),
+                request_to_import_mapping(next_package, "styled-jsx/*"),
             );
 
             rsc_aliases(import_map, project_path, ty, runtime, next_config).await?;
@@ -665,7 +675,7 @@ async fn insert_next_server_special_aliases(
     Ok(())
 }
 
-async fn get_react_client_package(&next_config: &Vc<NextConfig>) -> Result<&'static str> {
+async fn get_react_client_package(next_config: Vc<NextConfig>) -> Result<&'static str> {
     let react_production_profiling = *next_config.enable_react_production_profiling().await?;
     let react_client_package = if react_production_profiling {
         "profiling"
@@ -678,7 +688,7 @@ async fn get_react_client_package(&next_config: &Vc<NextConfig>) -> Result<&'sta
 
 async fn rsc_aliases(
     import_map: &mut ImportMap,
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
     ty: ServerContextType,
     runtime: NextRuntime,
     next_config: Vc<NextConfig>,
@@ -691,7 +701,7 @@ async fn rsc_aliases(
     } else {
         ""
     };
-    let react_client_package = get_react_client_package(&next_config).await?;
+    let react_client_package = get_react_client_package(next_config).await?;
 
     let mut alias = FxIndexMap::default();
     if matches!(
@@ -800,7 +810,7 @@ pub fn mdx_import_source_file() -> RcStr {
 // Keep in sync with getOptimizedModuleAliases in webpack-config.ts
 async fn insert_optimized_module_aliases(
     import_map: &mut ImportMap,
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
 ) -> Result<()> {
     insert_exact_alias_map(
         import_map,
@@ -824,12 +834,12 @@ async fn insert_optimized_module_aliases(
 // Make sure to not add any external requests here.
 async fn insert_next_shared_aliases(
     import_map: &mut ImportMap,
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
     execution_context: Vc<ExecutionContext>,
     next_config: Vc<NextConfig>,
     is_runtime_edge: bool,
 ) -> Result<()> {
-    let package_root = next_js_fs().root();
+    let package_root = next_js_fs().root().to_resolved().await?;
 
     insert_alias_to_alternatives(
         import_map,
@@ -852,41 +862,52 @@ async fn insert_next_shared_aliases(
     //
     // TODO: Add BeforeResolve plugins for `@next/font/google`
 
+    let next_font_google_replacer_mapping = ImportMapping::Dynamic(ResolvedVc::upcast(
+        NextFontGoogleReplacer::new(*project_path)
+            .to_resolved()
+            .await?,
+    ))
+    .resolved_cell();
+
     import_map.insert_alias(
         // Request path from js via next-font swc transform
         AliasPattern::exact("next/font/google/target.css"),
-        ImportMapping::Dynamic(Vc::upcast(NextFontGoogleReplacer::new(project_path))).into(),
+        next_font_google_replacer_mapping,
     );
 
     import_map.insert_alias(
         // Request path from js via next-font swc transform
         AliasPattern::exact("@next/font/google/target.css"),
-        ImportMapping::Dynamic(Vc::upcast(NextFontGoogleReplacer::new(project_path))).into(),
+        next_font_google_replacer_mapping,
     );
 
     import_map.insert_alias(
         AliasPattern::exact("@vercel/turbopack-next/internal/font/google/cssmodule.module.css"),
-        ImportMapping::Dynamic(Vc::upcast(NextFontGoogleCssModuleReplacer::new(
-            project_path,
-            execution_context,
-        )))
-        .into(),
+        ImportMapping::Dynamic(ResolvedVc::upcast(
+            NextFontGoogleCssModuleReplacer::new(*project_path, execution_context)
+                .to_resolved()
+                .await?,
+        ))
+        .resolved_cell(),
     );
 
     import_map.insert_alias(
         AliasPattern::exact(GOOGLE_FONTS_INTERNAL_PREFIX),
-        ImportMapping::Dynamic(Vc::upcast(NextFontGoogleFontFileReplacer::new(
-            project_path,
-        )))
-        .into(),
+        ImportMapping::Dynamic(ResolvedVc::upcast(
+            NextFontGoogleFontFileReplacer::new(*project_path)
+                .to_resolved()
+                .await?,
+        ))
+        .resolved_cell(),
     );
 
-    import_map.insert_singleton_alias("@swc/helpers", get_next_package(project_path));
-    import_map.insert_singleton_alias("styled-jsx", get_next_package(project_path));
+    let next_package = get_next_package(*project_path).to_resolved().await?;
+    import_map.insert_singleton_alias("@swc/helpers", next_package);
+    import_map.insert_singleton_alias("styled-jsx", next_package);
     import_map.insert_singleton_alias("next", project_path);
     import_map.insert_singleton_alias("react", project_path);
     import_map.insert_singleton_alias("react-dom", project_path);
-    let react_client_package = get_react_client_package(&next_config).await?;
+    let react_client_package = get_react_client_package(next_config).await?;
     import_map.insert_exact_alias(
         "react-dom/client",
         request_to_import_mapping(project_path, &format!("react-dom/{react_client_package}")),
@@ -896,7 +917,7 @@ async fn insert_next_shared_aliases(
         // Make sure you can't import custom server as it'll cause all Next.js internals to be
         // bundled which doesn't work.
         AliasPattern::exact("next"),
-        ImportMapping::Empty.into(),
+        ImportMapping::Empty.resolved_cell(),
     );
 
     //https://github.com/vercel/next.js/blob/f94d4f93e4802f951063cfa3351dd5a2325724b3/packages/next/src/build/webpack-config.ts#L1196
@@ -938,11 +959,14 @@ async fn insert_next_shared_aliases(
         ),
     );
 
-    insert_turbopack_dev_alias(import_map);
+    insert_turbopack_dev_alias(import_map).await?;
     insert_package_alias(
         import_map,
         "@vercel/turbopack-node/",
-        turbopack_node::embed_js::embed_fs().root(),
+        turbopack_node::embed_js::embed_fs()
+            .root()
+            .to_resolved()
+            .await?,
     );
 
     let image_config = next_config.image_config().await?;
@@ -980,7 +1004,7 @@ pub async fn get_next_package(context_directory: Vc<FileSystemPath>) -> Result<V
 
 pub async fn insert_alias_option<const N: usize>(
     import_map: &mut ImportMap,
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
     alias_options: Vc<ResolveAliasMap>,
     conditions: [&'static str; N],
 ) -> Result<()> {
@@ -996,8 +1020,8 @@ pub async fn insert_alias_option<const N: usize>(
 fn export_value_to_import_mapping(
     value: &SubpathValue,
     conditions: &BTreeMap<RcStr, ConditionValue>,
-    project_path: Vc<FileSystemPath>,
-) -> Option<Vc<ImportMapping>> {
+    project_path: ResolvedVc<FileSystemPath>,
+) -> Option<ResolvedVc<ImportMapping>> {
     let mut result = Vec::new();
     value.add_results(
         conditions,
@@ -1009,24 +1033,26 @@ fn export_value_to_import_mapping(
         None
     } else {
         Some(if result.len() == 1 {
-            ImportMapping::PrimaryAlternative(result[0].0.into(), Some(project_path)).cell()
+            ImportMapping::PrimaryAlternative(result[0].0.into(), Some(project_path))
+                .resolved_cell()
         } else {
             ImportMapping::Alternatives(
                 result
                     .iter()
                     .map(|(m, _)| {
-                        ImportMapping::PrimaryAlternative((*m).into(), Some(project_path)).cell()
+                        ImportMapping::PrimaryAlternative((*m).into(), Some(project_path))
+                            .resolved_cell()
                     })
                     .collect(),
             )
-            .cell()
+            .resolved_cell()
         })
     }
 }
 
 fn insert_exact_alias_map(
     import_map: &mut ImportMap,
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
     map: FxIndexMap<&'static str, String>,
 ) {
     for (pattern, request) in map {
@@ -1036,7 +1062,7 @@ fn insert_exact_alias_map(
 
 fn insert_wildcard_alias_map(
     import_map: &mut ImportMap,
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
     map: FxIndexMap<&'static str, String>,
 ) {
     for (pattern, request) in map {
@@ -1049,11 +1075,11 @@ fn insert_wildcard_alias_map(
 fn insert_alias_to_alternatives<'a>(
     import_map: &mut ImportMap,
     alias: impl Into<String> + 'a,
-    alternatives: Vec<Vc<ImportMapping>>,
+    alternatives: Vec<ResolvedVc<ImportMapping>>,
 ) {
     import_map.insert_exact_alias(
         alias.into(),
-        ImportMapping::Alternatives(alternatives).into(),
+        ImportMapping::Alternatives(alternatives).resolved_cell(),
     );
 }
 
@@ -1061,37 +1087,44 @@ fn insert_alias_to_alternatives<'a>(
 fn insert_package_alias(
     import_map: &mut ImportMap,
     prefix: &str,
-    package_root: Vc<FileSystemPath>,
+    package_root: ResolvedVc<FileSystemPath>,
 ) {
     import_map.insert_wildcard_alias(
         prefix,
-        ImportMapping::PrimaryAlternative("./*".into(), Some(package_root)).cell(),
+        ImportMapping::PrimaryAlternative("./*".into(), Some(package_root)).resolved_cell(),
     );
 }
 
 /// Inserts an alias to @vercel/turbopack-dev into an import map.
-fn insert_turbopack_dev_alias(import_map: &mut ImportMap) {
+async fn insert_turbopack_dev_alias(import_map: &mut ImportMap) -> Result<()> {
     insert_package_alias(
         import_map,
         "@vercel/turbopack-ecmascript-runtime/",
-        turbopack_ecmascript_runtime::embed_fs().root(),
+        turbopack_ecmascript_runtime::embed_fs()
+            .root()
+            .to_resolved()
+            .await?,
     );
+    Ok(())
 }
 
 /// Creates a direct import mapping to the result of resolving a request
 /// in a context.
-fn request_to_import_mapping(context_path: Vc<FileSystemPath>, request: &str) -> Vc<ImportMapping> {
-    ImportMapping::PrimaryAlternative(request.into(), Some(context_path)).cell()
+fn request_to_import_mapping(
+    context_path: ResolvedVc<FileSystemPath>,
+    request: &str,
+) -> ResolvedVc<ImportMapping> {
+    ImportMapping::PrimaryAlternative(request.into(), Some(context_path)).resolved_cell()
 }
 
 /// Creates a direct import mapping to the result of resolving an external
 /// request.
-fn external_request_to_cjs_import_mapping(request: &str) -> Vc<ImportMapping> {
-    ImportMapping::External(Some(request.into()), ExternalType::CommonJs).into()
+fn external_request_to_cjs_import_mapping(request: &str) -> ResolvedVc<ImportMapping> {
+    ImportMapping::External(Some(request.into()), ExternalType::CommonJs).resolved_cell()
 }
 
 /// Creates a direct import mapping to the result of resolving an external
 /// request.
-fn external_request_to_esm_import_mapping(request: &str) -> Vc<ImportMapping> {
-    ImportMapping::External(Some(request.into()), ExternalType::EcmaScriptModule).into()
+fn external_request_to_esm_import_mapping(request: &str) -> ResolvedVc<ImportMapping> {
+    ImportMapping::External(Some(request.into()), ExternalType::EcmaScriptModule).resolved_cell()
 }

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -72,36 +72,36 @@ use crate::{
     },
 };
 
-#[turbo_tasks::value(serialization = "auto_for_input")]
+#[turbo_tasks::value(shared, serialization = "auto_for_input")]
 #[derive(Debug, Copy, Clone, Hash)]
 pub enum ServerContextType {
     Pages {
-        pages_dir: Vc<FileSystemPath>,
+        pages_dir: ResolvedVc<FileSystemPath>,
     },
     PagesApi {
-        pages_dir: Vc<FileSystemPath>,
+        pages_dir: ResolvedVc<FileSystemPath>,
     },
     PagesData {
-        pages_dir: Vc<FileSystemPath>,
+        pages_dir: ResolvedVc<FileSystemPath>,
     },
     AppSSR {
-        app_dir: Vc<FileSystemPath>,
+        app_dir: ResolvedVc<FileSystemPath>,
     },
     AppRSC {
-        app_dir: Vc<FileSystemPath>,
+        app_dir: ResolvedVc<FileSystemPath>,
         ecmascript_client_reference_transition_name: Option<Vc<RcStr>>,
         client_transition: Option<Vc<Box<dyn Transition>>>,
     },
     AppRoute {
-        app_dir: Vc<FileSystemPath>,
+        app_dir: ResolvedVc<FileSystemPath>,
         ecmascript_client_reference_transition_name: Option<Vc<RcStr>>,
     },
     Middleware {
-        app_dir: Option<Vc<FileSystemPath>>,
+        app_dir: Option<ResolvedVc<FileSystemPath>>,
         ecmascript_client_reference_transition_name: Option<Vc<RcStr>>,
     },
     Instrumentation {
-        app_dir: Option<Vc<FileSystemPath>>,
+        app_dir: Option<ResolvedVc<FileSystemPath>>,
         ecmascript_client_reference_transition_name: Option<Vc<RcStr>>,
     },
 }
@@ -622,7 +622,7 @@ pub async fn get_server_module_options_context(
             foreign_next_server_rules.extend(internal_custom_rules);
 
             custom_source_transform_rules.push(
-                get_next_react_server_components_transform_rule(next_config, false, Some(app_dir))
+                get_next_react_server_components_transform_rule(next_config, false, Some(*app_dir))
                     .await?,
             );
 
@@ -701,7 +701,7 @@ pub async fn get_server_module_options_context(
             foreign_next_server_rules.extend(internal_custom_rules);
 
             custom_source_transform_rules.push(
-                get_next_react_server_components_transform_rule(next_config, true, Some(app_dir))
+                get_next_react_server_components_transform_rule(next_config, true, Some(*app_dir))
                     .await?,
             );
 
@@ -755,7 +755,7 @@ pub async fn get_server_module_options_context(
             next_server_rules.extend(source_transform_rules);
 
             let mut common_next_server_rules = vec![
-                get_next_react_server_components_transform_rule(next_config, true, Some(app_dir))
+                get_next_react_server_components_transform_rule(next_config, true, Some(*app_dir))
                     .await?,
             ];
 
@@ -856,7 +856,12 @@ pub async fn get_server_module_options_context(
             }
 
             custom_source_transform_rules.push(
-                get_next_react_server_components_transform_rule(next_config, true, app_dir).await?,
+                get_next_react_server_components_transform_rule(
+                    next_config,
+                    true,
+                    app_dir.as_deref().copied(),
+                )
+                .await?,
             );
 
             internal_custom_rules.extend(custom_source_transform_rules.iter().cloned());

--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -70,7 +70,7 @@ pub async fn get_next_server_transforms_rules(
             if !foreign_code {
                 rules.push(
                     get_next_pages_transforms_rule(
-                        pages_dir,
+                        *pages_dir,
                         ExportFilter::StripDefaultExport,
                         mdx_rs,
                     )

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -50,7 +50,9 @@ async fn foreign_code_context_condition() -> Result<ContextCondition> {
 }
 
 #[turbo_tasks::function]
-pub fn get_client_import_map(project_path: Vc<FileSystemPath>) -> Vc<ImportMap> {
+pub async fn get_client_import_map(
+    project_path: ResolvedVc<FileSystemPath>,
+) -> Result<Vc<ImportMap>> {
     let mut import_map = ImportMap::empty();
 
     import_map.insert_singleton_alias("@swc/helpers", project_path);
@@ -62,12 +64,17 @@ pub fn get_client_import_map(project_path: Vc<FileSystemPath>) -> Vc<ImportMap> 
         "@vercel/turbopack-ecmascript-runtime/",
         ImportMapping::PrimaryAlternative(
             "./*".into(),
-            Some(turbopack_ecmascript_runtime::embed_fs().root()),
+            Some(
+                turbopack_ecmascript_runtime::embed_fs()
+                    .root()
+                    .to_resolved()
+                    .await?,
+            ),
         )
-        .cell(),
+        .resolved_cell(),
     );
 
-    import_map.cell()
+    Ok(import_map.cell())
 }
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -2506,7 +2506,7 @@ async fn resolve_import_map_result(
     query: Vc<RcStr>,
 ) -> Result<Option<Vc<ResolveResult>>> {
     Ok(match result {
-        ImportMapResult::Result(result) => Some(*result),
+        ImportMapResult::Result(result) => Some(**result),
         ImportMapResult::Alias(request, alias_lookup_path) => {
             let request = *request;
             let lookup_path = match alias_lookup_path {

--- a/turbopack/crates/turbopack-resolve/src/resolve.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve.rs
@@ -106,11 +106,11 @@ async fn base_resolve_options(
         for req in NODE_EXTERNALS {
             direct_mappings.insert(
                 AliasPattern::exact(req),
-                ImportMapping::External(None, ExternalType::CommonJs).into(),
+                ImportMapping::External(None, ExternalType::CommonJs).resolved_cell(),
             );
             direct_mappings.insert(
                 AliasPattern::exact(format!("node:{req}")),
-                ImportMapping::External(None, ExternalType::CommonJs).into(),
+                ImportMapping::External(None, ExternalType::CommonJs).resolved_cell(),
             );
         }
     }
@@ -119,11 +119,11 @@ async fn base_resolve_options(
             direct_mappings.insert(
                 AliasPattern::exact(req),
                 ImportMapping::External(Some(format!("node:{req}").into()), ExternalType::CommonJs)
-                    .into(),
+                    .resolved_cell(),
             );
             direct_mappings.insert(
                 AliasPattern::exact(format!("node:{req}")),
-                ImportMapping::External(None, ExternalType::CommonJs).into(),
+                ImportMapping::External(None, ExternalType::CommonJs).resolved_cell(),
             );
         }
     }

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -271,6 +271,7 @@ pub async fn tsconfig_resolve_options(
                         context_dir = *new_context;
                     }
                 };
+                let context_dir = context_dir.to_resolved().await?;
                 for (key, value) in paths.iter() {
                     if let JsonValue::Array(vec) = value {
                         let entries = vec
@@ -319,7 +320,7 @@ pub async fn tsconfig_resolve_options(
     let import_map = if !all_paths.is_empty() {
         let mut import_map = ImportMap::empty();
         for (key, value) in all_paths {
-            import_map.insert_alias(AliasPattern::parse(key), value.into());
+            import_map.insert_alias(AliasPattern::parse(key), value.resolved_cell());
         }
         Some(import_map.resolved_cell())
     } else {
@@ -360,9 +361,9 @@ pub async fn apply_tsconfig_resolve_options(
         resolve_options.modules.insert(
             0,
             ResolveModules::Path {
-                dir: *base_url,
+                dir: base_url,
                 // tsconfig basepath doesn't apply to json requests
-                excluded_extensions: Vc::cell(fxindexset![".json".into()]),
+                excluded_extensions: ResolvedVc::cell(fxindexset![".json".into()]),
             },
         );
     }

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -274,7 +274,7 @@ async fn run_test(prepared_test: Vc<PreparedTest>) -> Result<Vc<RunTestResult>> 
     let mut import_map = ImportMap::empty();
     import_map.insert_wildcard_alias(
         "esm-external/",
-        ImportMapping::External(Some("*".into()), ExternalType::EcmaScriptModule).cell(),
+        ImportMapping::External(Some("*".into()), ExternalType::EcmaScriptModule).resolved_cell(),
     );
 
     let asset_context: Vc<Box<dyn AssetContext>> = Vc::upcast(ModuleAssetContext::new(

--- a/turbopack/crates/turbopack/src/evaluate_context.rs
+++ b/turbopack/crates/turbopack/src/evaluate_context.rs
@@ -44,9 +44,14 @@ pub async fn node_evaluate_asset_context(
         "@vercel/turbopack-node/",
         ImportMapping::PrimaryAlternative(
             "./*".into(),
-            Some(turbopack_node::embed_js::embed_fs().root()),
+            Some(
+                turbopack_node::embed_js::embed_fs()
+                    .root()
+                    .to_resolved()
+                    .await?,
+            ),
         )
-        .cell(),
+        .resolved_cell(),
     );
     let import_map = import_map.resolved_cell();
     let node_env: RcStr =

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -10,7 +10,7 @@ pub use custom_module_type::CustomModuleType;
 pub use module_options_context::*;
 pub use module_rule::*;
 pub use rule_condition::*;
-use turbo_tasks::{RcStr, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, Vc};
 use turbo_tasks_fs::{glob::Glob, FileSystemPath};
 use turbopack_core::{
     reference_type::{CssReferenceSubType, ReferenceType, UrlReferenceSubType},
@@ -29,7 +29,7 @@ use crate::{
 #[turbo_tasks::function]
 async fn package_import_map_from_import_mapping(
     package_name: RcStr,
-    package_mapping: Vc<ImportMapping>,
+    package_mapping: ResolvedVc<ImportMapping>,
 ) -> Vc<ImportMap> {
     let mut import_map = ImportMap::default();
     import_map.insert_exact_alias(
@@ -42,12 +42,12 @@ async fn package_import_map_from_import_mapping(
 #[turbo_tasks::function]
 async fn package_import_map_from_context(
     package_name: RcStr,
-    context_path: Vc<FileSystemPath>,
+    context_path: ResolvedVc<FileSystemPath>,
 ) -> Vc<ImportMap> {
     let mut import_map = ImportMap::default();
     import_map.insert_exact_alias(
         format!("@vercel/turbopack/{}", package_name),
-        ImportMapping::PrimaryAlternative(package_name, Some(context_path)).cell(),
+        ImportMapping::PrimaryAlternative(package_name, Some(context_path)).resolved_cell(),
     );
     import_map.cell()
 }


### PR DESCRIPTION
A hand refactor of all the remaining struct fields from `Vc` to `ResolvedVc`, to unblock local tasks.

This is similar to #71948, as there's a focus on resolve options.

Note: "resolve" in this context means two different things. `turbopack-resolve` is about resolving module locations on disk. `ResolvedVc` is about resolving "cells" representing incremental computations.

Closes PACK-3369