### PR TITLE
Refactor prerender phase assignment

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2293,8 +2293,6 @@ async function prerenderToStream(
   tree: LoaderTree,
   implicitTags: Array<string>
 ): Promise<PrerenderToStreamResult> {
-  ctx.requestStore.phase = 'render'
-
   // When prerendering formState is always null. We still include it
   // because some shared APIs expect a formState value and this is slightly
   // more explicit than making it an optional function argument


### PR DESCRIPTION
When prerendering there really shouldn't be a requestStore at all. I will be removing it but in this change I am specifically removing the assignment of the render phase in the prerender function. This isn't needed because the phase is render by default anyway and all relevant rendering must be scoped inside a prerenderStore which precludes a requestStore anyway. This is part of a larger refactor to remove requestStore from shadowing prerenders.

This change should not alter any program semantics

stacked on #72205 