### PR TITLE
Refactor prerender cookies

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3640,13 +3640,6 @@ async function prerenderToStream(
         renderOpts.basePath
       )
 
-      // If there were mutable cookies set, we need to set them on the
-      // response.
-      const headers = new Headers()
-      if (appendMutableCookies(headers, ctx.requestStore.mutableCookies)) {
-        setHeader('set-cookie', Array.from(headers.values()))
-      }
-
       setHeader('location', redirectUrl)
     } else if (!shouldBailoutToCSR) {
       res.statusCode = 500


### PR DESCRIPTION
the prerender pathway had carryover logic from a prior refactor that checks if any cookies were modified during the prerender before encoding a redirect. This is non necessary because prerenders by definition have no mutable cookies. This is part of a larger refactor to eliminate the requestStore that scopes renderToHTML... including when prerendering. This shouldn't be necessary and if it is we have not factored the program sufficiently.

Stacked on #72207 