### PR TITLE
Refactor: move url to app context to avoid passing requestStore 

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -468,6 +468,7 @@ export async function handleAction({
     // We want the render to see any cookie writes that we performed during the action,
     // so we need to update the immutable cookies to reflect the changes.
     synchronizeMutableCookies(requestStore)
+    requestStore.phase = 'render'
     return generateFlight(...args)
   }
 
@@ -994,6 +995,7 @@ export async function handleAction({
         // swallow error, it's gonna be handled on the client
       }
 
+      requestStore.phase = 'render'
       return {
         type: 'done',
         result: await generateFlight(req, ctx, {


### PR DESCRIPTION
requestStore is set on the app context but this store doens't make sense to scope for all renders, in particular prerenders so we need to extract the necessary information that is actually globally available and carry that around on the app context instead. This change updates app context to carry the url object and it updates reads of the url to use app context instead of requestStore. Now nothing is reading requestStore from the context so I removed it.

This update is part of a larger refactor to eliminate the requestStore that shadows prerendering. It should not alter any program semantics.

stacked on #72211 