### PR TITLE
docs(draft-mode): fix missing `switcher` for TS and JS codeblock

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/draft-mode.mdx
+++ b/docs/02-app/02-api-reference/04-functions/draft-mode.mdx
@@ -10,7 +10,7 @@ related:
 
 `draftMode` is an **async** function allows you to enable and disable [Draft Mode](/docs/app/building-your-application/configuring/draft-mode), as well as check if Draft Mode is enabled in a [Server Component](/docs/app/building-your-application/rendering/server-components).
 
-```tsx filename="app/page.ts"
+```tsx filename="app/page.ts" switcher
 import { draftMode } from 'next/headers'
 
 export default async function Page() {
@@ -18,7 +18,7 @@ export default async function Page() {
 }
 ```
 
-```jsx filename="app/page.js"
+```jsx filename="app/page.js" switcher
 import { draftMode } from 'next/headers'
 
 export default async function Page() {
@@ -101,7 +101,7 @@ Then, send a request to invoke the Route Handler. If calling the route using the
 
 You can check if Draft Mode is enabled in a Server Component with the `isEnabled` property:
 
-```tsx filename="app/page.ts"
+```tsx filename="app/page.ts" switcher
 import { draftMode } from 'next/headers'
 
 export default async function Page() {
@@ -115,7 +115,7 @@ export default async function Page() {
 }
 ```
 
-```jsx filename="app/page.js"
+```jsx filename="app/page.js" switcher
 import { draftMode } from 'next/headers'
 
 export default async function Page() {


### PR DESCRIPTION
The same codeblock is displayed twice.


![image](https://github.com/user-attachments/assets/01da38e1-4437-4b0a-a08e-a911bf9fea94)

![image](https://github.com/user-attachments/assets/5194faf6-7d5f-44aa-a445-21e02e635809)

