### PR TITLE
docs(cacheLife): fix incorrect highlight and missing `switcher`

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/cacheLife.mdx
+++ b/docs/02-app/02-api-reference/04-functions/cacheLife.mdx
@@ -142,7 +142,7 @@ module.exports = nextConfig
 
 The example above caches for 14 days, checks for updates daily, and expires the cache after 14 days. You can then reference this profile throughout your application by its name:
 
-```tsx filename="app/page.tsx" highlight={4}
+```tsx filename="app/page.tsx" highlight={5}
 'use cache'
 import { unstable_cacheLife as cacheLife } from 'next/cache'
 
@@ -181,7 +181,7 @@ module.exports = nextConfig
 
 For specific use cases, you can set a custom cache profile by passing an object to the `cacheLife` function:
 
-```tsx filename="app/page.tsx" highlight={5-9}
+```tsx filename="app/page.tsx" highlight={5-9} switcher
 'use cache'
 import { unstable_cacheLife as cacheLife } from 'next/cache'
 
@@ -196,7 +196,7 @@ export default async function Page() {
 }
 ```
 
-```jsx filename="app/page.js" highlight={5-9}
+```jsx filename="app/page.js" highlight={5-9} switcher
 'use cache'
 import { unstable_cacheLife as cacheLife } from 'next/cache'
 


### PR DESCRIPTION
This PR fixes two issues on the [cacheLife](https://nextjs.org/docs/canary/app/api-reference/functions/cacheLife) documentation page:

1. Incorrect highlight for `biweekly` in [Defining reusable cache profiles](https://nextjs.org/docs/canary/app/api-reference/functions/cacheLife#defining-reusable-cache-profiles) section. It should highlight `biweekly` but not `export default async function Page()`

   ![image](https://github.com/user-attachments/assets/f5b331cf-a5eb-41b0-8cba-08b2a2ff836d)

2. Missing `switcher` for TS and JS codeblock in [Defining cache profiles inline](https://nextjs.org/docs/canary/app/api-reference/functions/cacheLife#defining-cache-profiles-inline) section. Codeblock is displayed twice

   ![image](https://github.com/user-attachments/assets/e618f806-674f-4c21-8e02-8c90dd2308a5)
