### PR TITLE
docs(cacheTag): remove unused `cacheLife` import and add missing `switcher`

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/cacheTag.mdx
+++ b/docs/02-app/02-api-reference/04-functions/cacheTag.mdx
@@ -143,11 +143,8 @@ export async function Bookings({ type = 'haircut' }) {
 
 You can use the data returned from an async function to tag the cache entry.
 
-```tsx filename="app/components/bookings.tsx"
-import {
-  unstable_cacheTag as cacheTag,
-  unstable_cacheLife as cacheLife,
-} from 'next/cache'
+```tsx filename="app/components/bookings.tsx" switcher
+import { unstable_cacheTag as cacheTag } from 'next/cache'
 
 interface BookingsProps {
   type: string
@@ -182,7 +179,7 @@ export async function Bookings({ type = 'haircut' }) {
 
 Using [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag), you can invalidate the cache for a specific tag when needed:
 
-```tsx filename="app/actions.ts"
+```tsx filename="app/actions.ts" switcher
 'use server'
 
 import { revalidateTag } from 'next/cache'


### PR DESCRIPTION
This PR fixes two issues on the [cacheTag](https://nextjs.org/docs/canary/app/api-reference/functions/cacheTag) documentation page:

1. Remove the unused `unstable_cacheLife` import in the TypeScript codeblock of [Creating tags from external data](https://nextjs.org/docs/canary/app/api-reference/functions/cacheTag#creating-tags-from-external-data) section:

   ![image](https://github.com/user-attachments/assets/db401635-f07b-4e48-bd39-9a21adedce41)


2. Missing `switcher` for TS codeblock in [Creating tags from external data](https://nextjs.org/docs/canary/app/api-reference/functions/cacheTag#creating-tags-from-external-data) and [Invalidating tagged cache](https://nextjs.org/docs/canary/app/api-reference/functions/cacheTag#invalidating-tagged-cache) sections. We already have the corresponding JS codeblock in the Markdown.

   ![image](https://github.com/user-attachments/assets/33a36ac4-d936-47dd-8e96-df9e67366680)

   ![image](https://github.com/user-attachments/assets/2f91f7de-f440-439c-9cce-1749e9645516)
