### PR TITLE
docs(server-actions-mutations): Add missing TS/JS switcher to `Passing Additional Arguments` section in `Server Actions and Mutations` docs

### DIFF
--- a/docs/02-app/01-building-your-application/02-data-fetching/03-server-actions-and-mutations.mdx
+++ b/docs/02-app/01-building-your-application/02-data-fetching/03-server-actions-and-mutations.mdx
@@ -219,7 +219,13 @@ export function UserProfile({ userId }) {
 
 The Server Action will receive the `userId` argument, in addition to the form data:
 
-```js filename="app/actions.js"
+```ts filename="app/actions.ts" switcher
+'use server'
+
+export async function updateUser(userId: string, formData: FormData) {}
+```
+
+```js filename="app/actions.js" switcher
 'use server'
 
 export async function updateUser(userId, formData) {}


### PR DESCRIPTION
 This PR adds a missing TypeScript/JavaScript code switcher to the [Passing Additional Arguments](https://nextjs.org/docs/canary/app/building-your-application/data-fetching/server-actions-and-mutations#passing-additional-arguments) section in the [Server Actions and Mutations](https://nextjs.org/docs/canary/app/building-your-application/data-fetching/server-actions-and-mutations) documentation. This enhancement improves accessibility for users by providing both TypeScript and JavaScript code examples, making it easier for developers to follow along in their preferred language.

![image](https://github.com/user-attachments/assets/d8225abc-c1d0-478f-afc1-6830f83587c4)

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
