### PR TITLE
fix loading bailout condition & server patch mismatch tolerance

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -12,7 +12,6 @@ import { applyFlightData } from '../apply-flight-data'
 import { handleMutable } from '../handle-mutable'
 import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
 import { createEmptyCacheNode } from '../../app-router'
-import { handleSegmentMismatch } from '../handle-segment-mismatch'
 
 export function serverPatchReducer(
   state: ReadonlyReducerState,
@@ -51,8 +50,13 @@ export function serverPatchReducer(
       state.canonicalUrl
     )
 
+    // `applyRouterStatePatchToTree` returns `null` when it determined that the server response is not applicable to the current tree.
+    // In other words, the server responded with a tree that doesn't match what the client is currently rendering.
+    // This can happen if the server patch action took longer to resolve than a subsequent navigation which would have changed the tree.
+    // Previously this case triggered an MPA navigation but it should be safe to simply discard the server response rather than forcing
+    // the entire page to reload.
     if (newTree === null) {
-      return handleSegmentMismatch(state, action, treePatch)
+      return state
     }
 
     if (isNavigatingToNewRootLayout(currentTree, newTree)) {

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -62,7 +62,6 @@ export async function walkTreeWithFlightRouterState({
     query,
     isPrefetch,
     getDynamicParamFromSegment,
-    componentMod: { tree: loaderTree },
   } = ctx
 
   const [segment, parallelRoutes, modules] = loaderTreeToFilter
@@ -118,7 +117,7 @@ export async function walkTreeWithFlightRouterState({
     !experimental.isRoutePPREnabled &&
     isPrefetch &&
     !Boolean(modules.loading) &&
-    !hasLoadingComponentInTree(loaderTree)
+    !hasLoadingComponentInTree(loaderTreeToFilter)
 
   if (!parentRendered && renderComponentsOnThisLevel) {
     const overriddenSegment =

--- a/test/e2e/app-dir/app-prefetch/prefetching.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.test.ts
@@ -232,7 +232,7 @@ describe('app dir - prefetching', () => {
     })
 
     const prefetchResponse = await response.text()
-    expect(prefetchResponse).toContain('Page Data!')
+    expect(prefetchResponse).not.toContain('Page Data!')
     expect(prefetchResponse).not.toContain('Layout Data!')
     expect(prefetchResponse).not.toContain('Loading Prefetch Auto')
   })


### PR DESCRIPTION
Pre-PPR on client navigations, we are currently determining whether or not to render the underlying React components based on the presence (or lack thereof) of `loading.js`. We'll render components up to the first segment containing `loading.js`, and then stop at that level. 

Similarly, if there's no `loading.js` in the tree at all, we'll return a mostly empty prefetch. The underlying reason for this is that we cannot assume a particular tree/subtree doesn't contain expensive invocations: `loading.js` is a signal we use to detect where some sort of dynamic call will happen. This heuristic is largely improved with PPR + DIO but we still need to support this case. 

Currently there's a bug that will lead to overfetching. When determining if we should skip the component tree, we check the presence of loading at that level, as well as the entire tree. This means that during partial navigations when the server starts rendering deeper within the tree rather than starting from the root, the presence of `loading.js` in an earlier segment would incorrectly tell the router it should render the page. 

This updates the handling to check for a loading segment only within the partial tree that's being diffed. That way when we recursively call this, it won't look at earlier segments when deciding if there's a loading segment deeper in the tree. 

This PR also adjusts the server-patch reducer to be more resilient to mismatching trees. Previously we triggered a hard navigation but this actually can become a fairly common case if the RSC response doesn't return initial bytes quickly enough, such as in `dynamicIO` when we're warming the dev caches prior to a navigation. Instead we'll return the state in-place and effectively discard the patch because the assumption is the tree was patched elsewhere. 