### PR TITLE
Revert "docs: change `NextAuth.js` to `Auth.js`"

### DIFF
--- a/docs/02-app/01-building-your-application/09-authentication/index.mdx
+++ b/docs/02-app/01-building-your-application/09-authentication/index.mdx
@@ -1642,10 +1642,10 @@ Now that you've learned about authentication in Next.js, here are Next.js-compat
 
 ### Auth Libraries
 
-- [Auth.js](https://authjs.dev/getting-started/installation?framework=next.js)
 - [Auth0](https://auth0.com/docs/quickstart/webapp/nextjs/01-login)
 - [Clerk](https://clerk.com/docs/quickstarts/nextjs)
 - [Kinde](https://kinde.com/docs/developer-tools/nextjs-sdk)
+- [NextAuth.js](https://authjs.dev/getting-started/installation?framework=next.js)
 - [Ory](https://www.ory.sh/docs/getting-started/integrate-auth/nextjs)
 - [Stack Auth](https://docs.stack-auth.com/getting-started/setup)
 - [Supabase](https://supabase.com/docs/guides/getting-started/quickstarts/nextjs)

--- a/docs/02-app/index.mdx
+++ b/docs/02-app/index.mdx
@@ -35,7 +35,7 @@ You can use [`redirect`](/docs/app/api-reference/functions/redirect) to redirect
 
 Here are some common authentication solutions that support the App Router:
 
-- [NextAuth.js](https://next-auth.js.org/configuration/nextjs#in-app-router)
+- [NextAuth.js](https://authjs.dev/getting-started/installation?framework=next.js)
 - [Clerk](https://clerk.com/docs/quickstarts/nextjs)
 - [Stack Auth](https://docs.stack-auth.com/getting-started/setup)
 - [Auth0](https://github.com/auth0/nextjs-auth0#app-router)

--- a/docs/02-app/index.mdx
+++ b/docs/02-app/index.mdx
@@ -35,7 +35,7 @@ You can use [`redirect`](/docs/app/api-reference/functions/redirect) to redirect
 
 Here are some common authentication solutions that support the App Router:
 
-- [Auth.js](https://authjs.dev/getting-started/installation?framework=Next.js)
+- [NextAuth.js](https://next-auth.js.org/configuration/nextjs#in-app-router)
 - [Clerk](https://clerk.com/docs/quickstarts/nextjs)
 - [Stack Auth](https://docs.stack-auth.com/getting-started/setup)
 - [Auth0](https://github.com/auth0/nextjs-auth0#app-router)

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -1,6 +1,6 @@
 # Authentication
 
-This is an example using [Auth.js](https://authjs.dev/) for authentication.
+This is an example using NextAuth.js for authentication.
 
 ## Deploy your own
 

--- a/examples/auth/app/layout.tsx
+++ b/examples/auth/app/layout.tsx
@@ -2,7 +2,7 @@ import "./globals.css";
 
 export const metadata = {
   title: "Next.js Authentication",
-  description: "Example using Auth.js",
+  description: "Example using NextAuth.js",
 };
 
 export default function RootLayout({


### PR DESCRIPTION
Reverts vercel/next.js#72201

Correction. As far as Next.js is concerned, it is still called NextAuth.js. :)

Auth.js is the framework agnostic core library/ecosystem description.

The Next.js integration will continue to be called NextAuth.js.

More info here: https://authjs.dev/contributors#history