### PR TITLE
Strip `assetPrefix` when resolving external source maps of client chunks

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
@@ -153,7 +153,10 @@ export function getOverlayMiddleware(project: Project) {
   }
 }
 
-export function getSourceMapMiddleware(project: Project, distDir: string) {
+export function getSourceMapMiddleware(
+  project: Project,
+  options: { assetPrefix: string; distDir: string }
+) {
   return async function (
     req: IncomingMessage,
     res: ServerResponse,
@@ -185,8 +188,13 @@ export function getSourceMapMiddleware(project: Project, distDir: string) {
     }
 
     try {
-      if (filename.startsWith('/_next/static')) {
-        filename = path.join(distDir, filename.replace(/^\/_next\//, ''))
+      const { assetPrefix, distDir } = options
+
+      if (filename.startsWith(`${assetPrefix}/_next/static`)) {
+        filename = path.join(
+          distDir,
+          filename.replace(new RegExp(`^${assetPrefix}/_next/`), '')
+        )
       }
 
       // Turbopack chunk filenames might be URL-encoded.

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware.ts
@@ -204,14 +204,20 @@ export async function getSourceMapFromCompilation(
 export async function getSource(
   filename: string,
   options: {
+    assetPrefix: string
     distDirectory: string
     getCompilations: () => webpack.Compilation[]
   }
 ): Promise<Source | undefined> {
-  const { distDirectory, getCompilations } = options
+  const { assetPrefix, distDirectory, getCompilations } = options
 
-  if (filename.startsWith('/_next/static')) {
-    filename = path.join(distDirectory, filename.replace(/^\/_next\//, ''))
+  // With Webpack, this branch can only be hit when manually changing from
+  // `eval-source-map` to `source-map` for testing purposes.
+  if (filename.startsWith(`${assetPrefix}/_next/static`)) {
+    filename = path.join(
+      distDirectory,
+      filename.replace(new RegExp(`^${assetPrefix}/_next/`), '')
+    )
   }
 
   if (path.isAbsolute(filename)) {
@@ -256,6 +262,7 @@ export async function getSource(
 }
 
 export function getOverlayMiddleware(options: {
+  assetPrefix: string
   distDirectory: string
   rootDirectory: string
   clientStats: () => webpack.Stats | null
@@ -263,6 +270,7 @@ export function getOverlayMiddleware(options: {
   edgeServerStats: () => webpack.Stats | null
 }) {
   const {
+    assetPrefix,
     distDirectory,
     rootDirectory,
     clientStats,
@@ -309,6 +317,7 @@ export function getOverlayMiddleware(options: {
 
       try {
         source = await getSource(frame.file, {
+          assetPrefix,
           distDirectory,
           getCompilations: () => {
             const compilations: webpack.Compilation[] = []
@@ -410,12 +419,19 @@ export function getOverlayMiddleware(options: {
 }
 
 export function getSourceMapMiddleware(options: {
+  assetPrefix: string
   distDirectory: string
   clientStats: () => webpack.Stats | null
   serverStats: () => webpack.Stats | null
   edgeServerStats: () => webpack.Stats | null
 }) {
-  const { distDirectory, clientStats, serverStats, edgeServerStats } = options
+  const {
+    assetPrefix,
+    distDirectory,
+    clientStats,
+    serverStats,
+    edgeServerStats,
+  } = options
 
   return async function (
     req: IncomingMessage,
@@ -438,6 +454,7 @@ export function getSourceMapMiddleware(options: {
 
     try {
       source = await getSource(filename, {
+        assetPrefix,
         distDirectory,
         getCompilations: () => {
           const compilations: webpack.Compilation[] = []

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -569,7 +569,10 @@ export async function createHotReloaderTurbopack(
 
   const middlewares = [
     getOverlayMiddleware(project),
-    getSourceMapMiddleware(project, distDir),
+    getSourceMapMiddleware(project, {
+      assetPrefix: nextConfig.assetPrefix.replace(/\/$/, ''),
+      distDir,
+    }),
   ]
 
   const versionInfoPromise = getVersionInfo(

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -1507,8 +1507,11 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       }),
     })
 
+    const assetPrefix = this.config.assetPrefix.replace(/\/$/, '')
+
     this.middlewares = [
       getOverlayMiddleware({
+        assetPrefix,
         distDirectory: this.distDir,
         rootDirectory: this.dir,
         clientStats: () => this.clientStats,
@@ -1516,6 +1519,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
         edgeServerStats: () => this.edgeServerStats,
       }),
       getSourceMapMiddleware({
+        assetPrefix,
         distDirectory: this.distDir,
         clientStats: () => this.clientStats,
         serverStats: () => this.serverStats,

--- a/test/development/app-dir/source-mapping/next.config.js
+++ b/test/development/app-dir/source-mapping/next.config.js
@@ -3,6 +3,17 @@
  */
 
 const nextConfig = {
+  assetPrefix: '/assets/', // intentional trailing slash to ensure we handle this as well
+  rewrites() {
+    return {
+      beforeFiles: [
+        {
+          source: '/assets/:path*',
+          destination: '/:path*',
+        },
+      ],
+    }
+  },
   experimental: {
     ppr: true,
   },


### PR DESCRIPTION
When using Turbopack, and importing a server action into a client component, the source map for the client chunk will be requested if devtools are open. The filename for this source map request might be `/_next/static/chunks/[project]__800ed2._.js`, for example. This scenario was already handled by the dev middleware. 

However, it didn't consider that there might also be an `assetPrefix` defined in the `next.config.js`. In this case, the filename would be `/some-asset-prefix/_next/static/chunks/[project]__800ed2._.js`. When resolving the external source map for this file, we need to strip the asset prefix.

Again, this can only be tested manually.