### PR TITLE
docs: add missing before section name

### DIFF
--- a/errors/next-prerender-current-time.mdx
+++ b/errors/next-prerender-current-time.mdx
@@ -153,6 +153,8 @@ export default async function Page() {
 
 If you want the current time to represent the time of a user Request, add `await connection()` before you read the current time. This instructs Next.js that everything after the `await connection()` requires there to be a user Request before it can run. If you add `await connection()` you will also need to ensure there is a Suspense boundary somewhere above the waiting component that describes a fallback UI React can use. The Suspense can be anywhere in the parent component stack but it is shown here above the waiting component for demonstration purposes.
 
+Before:
+
 ```jsx filename="app/page.js"
 export default async function Page() {
   const currentTime = Date.now()


### PR DESCRIPTION
## Summary
Only exist `after` directive at [next-prerender-current-time error page](https://nextjs.org/docs/messages/next-prerender-current-time).
Then add `before` section name.

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide