### PR TITLE
test: fix snapshots in next build and lint test

### DIFF
--- a/test/production/eslint/test/__snapshots__/next-build-and-lint.test.ts.snap
+++ b/test/production/eslint/test/__snapshots__/next-build-and-lint.test.ts.snap
@@ -594,6 +594,9 @@ exports[`Next Build production mode first time setup with TypeScript - ESLint v8
     "no-array-constructor": [
       "off",
     ],
+    "no-class-assign": [
+      "off",
+    ],
     "no-const-assign": [
       "off",
     ],
@@ -925,6 +928,9 @@ exports[`Next Build production mode first time setup with TypeScript - ESLint v9
       "warn",
     ],
     "no-array-constructor": [
+      "off",
+    ],
+    "no-class-assign": [
       "off",
     ],
     "no-const-assign": [


### PR DESCRIPTION
Update the snapshot to avoid failing. Would be good to lock the behavior later if possible. Tried locking the version but didn't help

x-ref: https://github.com/vercel/next.js/actions/runs/11669088907/job/32492379010
x-ref: https://github.com/vercel/next.js/actions/runs/11669714862/job/32494053281
x-ref: https://github.com/vercel/next.js/actions/runs/11669655913/job/32494187134