### PR TITLE
docs(use-cache): fix typo and link

### DIFF
--- a/docs/02-app/02-api-reference/01-directives/use-cache.mdx
+++ b/docs/02-app/02-api-reference/01-directives/use-cache.mdx
@@ -127,7 +127,7 @@ export default Page() {
 }
 ```
 
-> This is recommended for applications that previously used the [`export const dynamic = "force-cache"`](/docs/app/building-your-application/caching#opting-out-1) option, and will ensure the entire route is prerendered.
+> This is recommended for applications that previously used the [`export const dynamic = "force-static"`](/docs/app/api-reference/file-conventions/route-segment-config#dynamic) option, and will ensure the entire route is prerendered.
 
 ### Caching component output with `use cache`
 


### PR DESCRIPTION
## Why?

We have a typo and incorrect link.

- Fixes https://github.com/vercel/next.js/issues/72266