### PR TITLE
app build: don't merge dynamic params with query params

### DIFF
--- a/packages/next/src/export/routes/pages.ts
+++ b/packages/next/src/export/routes/pages.ts
@@ -3,6 +3,7 @@ import type { RenderOpts } from '../../server/render'
 import type { LoadComponentsReturnType } from '../../server/load-components'
 import type { AmpValidation } from '../types'
 import type { NextParsedUrlQuery } from '../../server/request-meta'
+import type { Params } from '../../server/request/params'
 
 import RenderResult from '../../server/render-result'
 import { join } from 'path'
@@ -36,6 +37,7 @@ export async function exportPagesPage(
   path: string,
   page: string,
   query: NextParsedUrlQuery,
+  params: Params | undefined,
   htmlFilepath: string,
   htmlFilename: string,
   ampPath: string,
@@ -75,6 +77,15 @@ export async function exportPagesPage(
     return
   }
 
+  // Pages router merges page params (e.g. [lang]) with query params
+  // primarily to support them both being accessible on `useRouter().query`.
+  // If we extracted dynamic params from the path, we need to merge them
+  // back into the query object.
+  const searchAndDynamicParams = {
+    ...query,
+    ...params,
+  }
+
   if (components.getStaticProps && !htmlFilepath.endsWith('.html')) {
     // make sure it ends with .html if the name contains a dot
     htmlFilepath += '.html'
@@ -105,7 +116,7 @@ export async function exportPagesPage(
         req,
         res,
         page,
-        query,
+        searchAndDynamicParams,
         renderOpts
       )
     } catch (err) {
@@ -161,7 +172,7 @@ export async function exportPagesPage(
           req,
           res,
           page,
-          { ...query, amp: '1' },
+          { ...searchAndDynamicParams, amp: '1' },
           renderOpts
         )
       } catch (err) {

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -158,12 +158,6 @@ async function exportPageImpl(
     const normalizedPage = isAppDir ? normalizeAppPath(page) : page
 
     params = getParams(normalizedPage, updatedPath)
-    if (params) {
-      query = {
-        ...query,
-        ...params,
-      }
-    }
   }
 
   const { req, res } = createRequestResponseMocks({ url: updatedPath })
@@ -315,6 +309,7 @@ async function exportPageImpl(
     path,
     page,
     query,
+    params,
     htmlFilepath,
     htmlFilename,
     ampPath,

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -844,9 +844,7 @@ export async function renderToHTMLImpl(
         },
         () =>
           getStaticProps({
-            ...(pageIsDynamic
-              ? { params: query as ParsedUrlQuery }
-              : undefined),
+            ...(pageIsDynamic ? { params } : undefined),
             ...(isPreview
               ? { draftMode: true, preview: true, previewData: previewData }
               : undefined),
@@ -1069,9 +1067,7 @@ export async function renderToHTMLImpl(
             res: resOrProxy,
             query,
             resolvedUrl: renderOpts.resolvedUrl as string,
-            ...(pageIsDynamic
-              ? { params: params as ParsedUrlQuery }
-              : undefined),
+            ...(pageIsDynamic ? { params } : undefined),
             ...(previewData !== false
               ? { draftMode: true, preview: true, previewData: previewData }
               : undefined),

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -742,6 +742,19 @@ describe('app-dir static/dynamic handling', () => {
   })
 
   if (isNextStart) {
+    it('should not encode dynamic parameters as search parameters in RSC data', async () => {
+      const data = process.env.__NEXT_EXPERIMENTAL_PPR
+        ? await next.readFile('.next/server/app/blog/seb.prefetch.rsc')
+        : await next.readFile('.next/server/app/blog/seb.rsc')
+
+      // During SSG, pages that correspond with dynamic routes shouldn't have any search
+      // parameters in the `__PAGE__` segment string. The only time we expect to see
+      // search parameters in the `__PAGE__` segment string is when the RSC data is
+      // requested from the client with search parameters.
+      expect(data).not.toContain('__PAGE__?')
+      expect(data).toContain('__PAGE__')
+    })
+
     it('should output HTML/RSC files for static paths', async () => {
       const files = (
         await glob('**/*', {


### PR DESCRIPTION
At build time we merge dynamic params (e.g. `[lang]`) with search params into the same object used as part of the pages/app renders. This is semantically incorrect and has led to some unexpected downstream behavior (such as dynamic params showing up as cache keys in flight data for app router). Pages router seems to rely on this behavior (for ex, `useRouter().query` combines both dynamic params with search params).

This avoids mutating `query` and instead combines them specifically in the pages export case. This also fixes an inconsistency in where we're reading params in pages render, specifically `getStaticProps` now reads params from `params` rather than `query` to align with `getServerSideProps` and not rely on the fact that we happen to merge them. 