### PR TITLE
docs(fetch): update fetch example to v15

### DIFF
--- a/docs/02-app/01-building-your-application/02-data-fetching/01-fetching.mdx
+++ b/docs/02-app/01-building-your-application/02-data-fetching/01-fetching.mdx
@@ -57,7 +57,7 @@ This example demonstrates a basic server-side data fetch using the `fetch` API i
 
 ### Fetching data on the server with the `fetch` API
 
-This component will fetch and display a list of blog posts. The response from `fetch` will be automatically cached.
+This component will fetch and display a list of blog posts. The response from `fetch` is not cached by default.
 
 ```tsx filename="app/page.tsx" switcher
 export default async function Page() {
@@ -89,11 +89,13 @@ export default async function Page() {
 
 If you are not using any [Dynamic APIs](/docs/app/building-your-application/rendering/server-components#dynamic-rendering) anywhere else in this route, it will be prerendered during `next build` to a static page. The data can then be updated using [Incremental Static Regeneration](/docs/app/building-your-application/data-fetching/incremental-static-regeneration).
 
-If you do _not_ want to cache the response from `fetch`, you can do the following:
+To prevent the page from prerendering, you can add the following to your file:
 
 ```js
-let data = await fetch('https://api.vercel.app/blog', { cache: 'no-store' })
+export const dynamic = 'force-dynamic'
 ```
+
+However, you will commonly use functions like `cookies`, `headers`, or reading the incoming `searchParams` from the page props, which will automatically make the page render dynamically. In this case, you do _not_ need to explicitly use `force-dynamic`.
 
 ### Fetching data on the server with an ORM or database
 


### PR DESCRIPTION
## Why?

The default cache config for fetch is `{ cache: 'no-store' }` with v15.

- Fixes https://github.com/vercel/next.js/issues/72213