### PR TITLE
feat(turbopack): Switch `turbo-tasks-memory/print_task_invalidation` compile-time feature to an environment variable

### DIFF
--- a/crates/napi/src/next_api/utils.rs
+++ b/crates/napi/src/next_api/utils.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap, future::Future, ops::Deref, path::PathBuf, sync::Arc, time::Duration,
+    collections::HashMap, env, future::Future, ops::Deref, path::PathBuf, sync::Arc, time::Duration,
 };
 
 use anyhow::{anyhow, Context, Result};
@@ -133,9 +133,11 @@ pub fn create_turbo_tasks(
             )?),
         ))
     } else {
-        NextTurboTasks::Memory(TurboTasks::new(turbo_tasks_memory::MemoryBackend::new(
-            memory_limit,
-        )))
+        let mut backend = turbo_tasks_memory::MemoryBackend::new(memory_limit);
+        if env::var_os("NEXT_TURBOPACK_PRINT_TASK_INVALIDATION").is_some() {
+            backend.print_task_invalidation(true);
+        }
+        NextTurboTasks::Memory(TurboTasks::new(backend))
     })
 }
 

--- a/turbopack/crates/turbo-tasks-memory/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-memory/Cargo.toml
@@ -48,7 +48,6 @@ turbo-tasks-build = { workspace = true }
 
 [features]
 track_unfinished = []
-print_task_invalidation = []
 default = []
 
 [[bench]]

--- a/turbopack/crates/turbo-tasks-memory/src/task.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/task.rs
@@ -894,9 +894,7 @@ impl Task {
             InProgress(..) => match result {
                 Ok(Ok(result)) => {
                     if state.output != result {
-                        if cfg!(feature = "print_task_invalidation")
-                            && state.output.content.is_some()
-                        {
+                        if backend.print_task_invalidation && state.output.content.is_some() {
                             println!(
                                 "Task {{ id: {}, name: {} }} invalidates:",
                                 *self.id, self.ty
@@ -1146,7 +1144,7 @@ impl Task {
                         drop(state);
                         change_job.apply(&aggregation_context);
 
-                        if cfg!(feature = "print_task_invalidation") {
+                        if backend.print_task_invalidation {
                             println!("invalidated Task {{ id: {}, name: {} }}", *self.id, self.ty);
                         }
                         turbo_tasks.schedule(self.id);


### PR DESCRIPTION
With this PR, `turbo-tasks-memory` (the new backend doesn't support this yet) can print invalidation information (basically just function names) to stdout when run with the following environment variable:

```
NEXT_TURBOPACK_PRINT_TASK_INVALIDATION=1
```

![Screenshot 2024-11-04 at 5.05.10 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/3d334ef6-184c-40df-9769-fd0373de00fb.png)

This was previously behind a compilation feature flag, however:

- We have to generate all the support code regardless of if the flag is set, so it doesn't seem like it would save us anything on binary size.
- The branch should be pretty cheap to check (and probably easy for the CPU to predict), so runtime performance when this flag isn't set should be negligible.
- It's a pretty big lift to ask users to try custom builds.

**Why?** The hope is that this can help debug cases where users get stuck in a fast refresh update loop: https://vercel.slack.com/archives/C03S8ED1DKM/p1730737898652749

This is similar to #72300, except that prints the *reason*, this prints the *tasks* that were actually invalidated. Printing the tasks works even if no reason was supplied, so it can probably be helpful in debugging those cases.

Closes PACK-3375