### PR TITLE
docs: add `legacy` version tag to `exportPathMap` docs

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/exportPathMap.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/exportPathMap.mdx
@@ -1,19 +1,12 @@
 ---
-title: exportPathMap (Deprecated)
-nav_title: exportPathMap
+title: exportPathMap
 description: Customize the pages that will be exported as HTML files when using `next export`.
+version: legacy
 ---
 
 {/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
 
 > This feature is exclusive to `next export` and currently **deprecated** in favor of `getStaticPaths` with `pages` or `generateStaticParams` with `app`.
-
-<details>
-  <summary>Examples</summary>
-
-- [Static Export](https://github.com/vercel/next.js/tree/canary/examples/with-static-export)
-
-</details>
 
 `exportPathMap` allows you to specify a mapping of request paths to page destinations, to be used during export. Paths defined in `exportPathMap` will also be available when using [`next dev`](/docs/app/api-reference/cli/next#next-dev-options).
 


### PR DESCRIPTION
## Description
At #71964, Legacy tag was introduced.
Then add that to `exportPathMap` docs instead of `deprecated` title name.

In addition, remove [Static Export](https://github.com/vercel/next.js/tree/canary/examples/with-static-export) example because it's no more use `exportPathMap`.

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide