### PR TITLE
docs: fix compatibility typo

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/10-dynamic-routes.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/10-dynamic-routes.mdx
@@ -50,7 +50,7 @@ See the [generateStaticParams()](#generating-static-params) page to learn how to
 ## Good to know
 
 - Since the `params` prop is a promise. You must use async/await or React's use function to access the values.
-  - In version 14 and earlier, `params` was a synchronous prop. To help with backwards compatability, you can still access it synchronously in Next.js 15, but this behavior will be deprecated in the future.
+  - In version 14 and earlier, `params` was a synchronous prop. To help with backwards compatibility, you can still access it synchronously in Next.js 15, but this behavior will be deprecated in the future.
 - Dynamic Segments are equivalent to [Dynamic Routes](/docs/pages/building-your-application/routing/dynamic-routes) in the `pages` directory.
 
 ## Generating Static Params


### PR DESCRIPTION
### Improving Documentation

- fix typo 

`compatability` -> `compatibility`