### PR TITLE
docs: fix typo

### DIFF
--- a/docs/02-app/01-building-your-application/10-deploying/03-multi-zones.mdx
+++ b/docs/02-app/01-building-your-application/10-deploying/03-multi-zones.mdx
@@ -100,7 +100,7 @@ Routing requests through [`rewrites`](/docs/app/api-reference/next-config-js/rew
 ```js filename="middleware.js"
 export async function middleware(request) {
   const { pathname, search } = req.nextUrl;
-  if (pathname === '/your-path' && myFeaturFlag.isEnabled()) {
+  if (pathname === '/your-path' && myFeatureFlag.isEnabled()) {
     return NextResponse.rewrite(`${rewriteDomain}${pathname}${search});
   }
 }


### PR DESCRIPTION
### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

fix typo

myFeaturFlag.isEnabled() -> myFeatureFlag.isEnabled()