### PR TITLE
docs: fix intented typo

### DIFF
--- a/docs/02-app/01-building-your-application/11-upgrading/04-app-router-migration.mdx
+++ b/docs/02-app/01-building-your-application/11-upgrading/04-app-router-migration.mdx
@@ -481,7 +481,7 @@ In addition, the new `useRouter` hook has the following changes:
 #### Sharing components between `pages` and `app`
 
 To keep components compatible between the `pages` and `app` routers, refer to the [`useRouter` hook from `next/compat/router`](/docs/pages/api-reference/functions/use-router#the-nextcompatrouter-export).
-This is the `useRouter` hook from the `pages` directory, but intented to be used while sharing components between routers. Once you are ready to use it only on the `app` router, update to the new [`useRouter` from `next/navigation`](/docs/app/api-reference/functions/use-router).
+This is the `useRouter` hook from the `pages` directory, but intended to be used while sharing components between routers. Once you are ready to use it only on the `app` router, update to the new [`useRouter` from `next/navigation`](/docs/app/api-reference/functions/use-router).
 
 ### Step 6: Migrating Data Fetching Methods
 


### PR DESCRIPTION
### Improving Documentation
- fix typo

`intented` -> `intended`