### PR TITLE
Refactor: scope requestStore to dynamic renders only

### DIFF
--- a/packages/next/src/server/async-storage/request-store.ts
+++ b/packages/next/src/server/async-storage/request-store.ts
@@ -108,10 +108,10 @@ export function createRequestStoreForRender(
   url: RequestContext['url'],
   implicitTags: RequestContext['implicitTags'],
   onUpdateCookies: RenderOpts['onUpdateCookies'],
-  renderResumeDataCache: RenderResumeDataCache | undefined,
   previewProps: WrapperRenderOpts['previewProps'],
   isHmrRefresh: RequestContext['isHmrRefresh'],
-  serverComponentsHmrCache: RequestContext['serverComponentsHmrCache']
+  serverComponentsHmrCache: RequestContext['serverComponentsHmrCache'],
+  renderResumeDataCache: RenderResumeDataCache | undefined
 ): RequestStore {
   return createRequestStoreImpl(
     // Pages start in render phase by default


### PR DESCRIPTION
This completes the refactor to eliminate a requestStore scoped around prerenders. Now we only scope requestStore around dynamic renders. If you are prerendering then the workUnitAsyncStorage will only have a prerender store or undefined. While it is possible to shadow stores because you can enter a cache scope from a render or prerender it generally should never be the case that you enter a prerender from a request or enter a request from a prerender. These are effectively top level scopes.

This should not change any program behavior

stacked on #72212