### PR TITLE
Turbopack NFT: trace manifests and externals

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -39,8 +39,8 @@ use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    fxindexset, trace::TraceRawVcs, Completion, FxIndexMap, FxIndexSet, ResolvedVc, TryJoinIterExt,
-    Value, ValueToString, Vc,
+    fxindexmap, fxindexset, trace::TraceRawVcs, Completion, FxIndexMap, FxIndexSet, ResolvedVc,
+    TryJoinIterExt, Value, ValueToString, Vc,
 };
 use turbo_tasks_env::{CustomProcessEnv, ProcessEnv};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
@@ -76,7 +76,7 @@ use crate::{
     loadable_manifest::create_react_loadable_manifest,
     nft_json::NftJsonAsset,
     paths::{
-        all_paths_in_root, all_server_paths, get_js_paths_from_root, get_paths_from_root,
+        all_paths_in_root, all_server_paths, get_asset_paths_from_root, get_js_paths_from_root,
         get_wasm_paths_from_root, paths_to_bindings, wasm_paths_to_bindings,
     },
     project::Project,
@@ -732,7 +732,7 @@ pub fn app_entry_point_to_route(
 }
 
 #[turbo_tasks::function]
-fn client_shared_chunks() -> Vc<RcStr> {
+fn client_shared_chunks_mod() -> Vc<RcStr> {
     Vc::cell("client_shared_chunks".into())
 }
 
@@ -880,7 +880,6 @@ impl AppEndpoint {
         let node_root = this.app_project.project().node_root();
 
         let client_relative_path = this.app_project.project().client_relative_path();
-        let client_relative_path_ref = client_relative_path.await?;
 
         let server_path = node_root.join("server".into());
 
@@ -917,21 +916,19 @@ impl AppEndpoint {
         ) = if process_client_components {
             let client_shared_chunk_group = get_app_client_shared_chunk_group(
                 AssetIdent::from_path(this.app_project.project().project_path())
-                    .with_modifier(client_shared_chunks()),
+                    .with_modifier(client_shared_chunks_mod()),
                 this.app_project.client_runtime_entries(),
                 client_chunking_context,
             )
             .await?;
 
-            let mut client_shared_chunks_paths = vec![];
+            let mut client_shared_chunks = vec![];
             for chunk in client_shared_chunk_group.assets.await?.iter().copied() {
                 client_assets.insert(chunk);
 
                 let chunk_path = chunk.ident().path().await?;
                 if chunk_path.extension_ref() == Some("js") {
-                    if let Some(chunk_path) = client_relative_path_ref.get_path_to(&chunk_path) {
-                        client_shared_chunks_paths.push(chunk_path.into());
-                    }
+                    client_shared_chunks.push(chunk);
                 }
             }
             let client_shared_availability_info = client_shared_chunk_group.availability_info;
@@ -1023,41 +1020,31 @@ impl AppEndpoint {
             client_assets.extend(entry_client_chunks.iter().copied());
             server_assets.extend(entry_ssr_chunks.iter().copied());
 
-            let entry_client_chunks_paths = entry_client_chunks
-                .iter()
-                .map(|chunk| chunk.ident().path())
-                .try_join()
-                .await?;
-            let mut entry_client_chunks_paths = entry_client_chunks_paths
-                .iter()
-                .map(|path| {
-                    Ok(client_relative_path_ref
-                        .get_path_to(path)
-                        .context("asset path should be inside client root")?
-                        .into())
-                })
-                .collect::<anyhow::Result<Vec<_>>>()?;
-            entry_client_chunks_paths.extend(client_shared_chunks_paths.iter().cloned());
-
             let manifest_path_prefix = &app_entry.original_name;
 
             if emit_manifests {
                 let app_build_manifest = AppBuildManifest {
-                    pages: [(app_entry.original_name.clone(), entry_client_chunks_paths)]
-                        .into_iter()
-                        .collect(),
+                    pages: fxindexmap!(
+                        app_entry.original_name.clone() => Vc::cell(entry_client_chunks
+                            .iter()
+                            .chain(client_shared_chunks.iter())
+                            .copied()
+                            .collect())
+                    ),
                 };
-                let app_build_manifest_output = VirtualOutputAsset::new(
-                    node_root.join(
-                        format!("server/app{manifest_path_prefix}/app-build-manifest.json",).into(),
-                    ),
-                    AssetContent::file(
-                        File::from(serde_json::to_string_pretty(&app_build_manifest)?).into(),
-                    ),
-                )
-                .to_resolved()
-                .await?;
-                server_assets.insert(ResolvedVc::upcast(app_build_manifest_output));
+                let app_build_manifest_output = app_build_manifest
+                    .build_output(
+                        node_root.join(
+                            format!("server/app{manifest_path_prefix}/app-build-manifest.json",)
+                                .into(),
+                        ),
+                        client_relative_path,
+                    )
+                    .await?
+                    .to_resolved()
+                    .await?;
+
+                server_assets.insert(app_build_manifest_output);
             }
 
             // polyfill-nomodule.js is a pre-compiled asset distributed as part of next,
@@ -1068,16 +1055,12 @@ impl AppEndpoint {
             );
             let polyfill_output_path =
                 client_chunking_context.chunk_path(polyfill_source.ident(), ".js".into());
-            let polyfill_output_asset =
+            let polyfill_output_asset = ResolvedVc::upcast(
                 RawOutput::new(polyfill_output_path, Vc::upcast(polyfill_source))
                     .to_resolved()
-                    .await?;
-            let polyfill_client_path = client_relative_path_ref
-                .get_path_to(&*polyfill_output_path.await?)
-                .context("failed to resolve client-relative path to polyfill")?
-                .into();
-            let polyfill_client_paths = vec![polyfill_client_path];
-            client_assets.insert(ResolvedVc::upcast(polyfill_output_asset));
+                    .await?,
+            );
+            client_assets.insert(polyfill_output_asset);
 
             if emit_manifests {
                 if *this
@@ -1103,21 +1086,24 @@ impl AppEndpoint {
                 }
 
                 let build_manifest = BuildManifest {
-                    root_main_files: client_shared_chunks_paths,
-                    polyfill_files: polyfill_client_paths,
+                    root_main_files: client_shared_chunks,
+                    polyfill_files: vec![polyfill_output_asset],
                     ..Default::default()
                 };
-                let build_manifest_output = VirtualOutputAsset::new(
-                    node_root.join(
-                        format!("server/app{manifest_path_prefix}/build-manifest.json",).into(),
-                    ),
-                    AssetContent::file(
-                        File::from(serde_json::to_string_pretty(&build_manifest)?).into(),
-                    ),
-                )
-                .to_resolved()
-                .await?;
-                server_assets.insert(ResolvedVc::upcast(build_manifest_output));
+                let build_manifest_output = ResolvedVc::upcast(
+                    build_manifest
+                        .build_output(
+                            node_root.join(
+                                format!("server/app{manifest_path_prefix}/build-manifest.json",)
+                                    .into(),
+                            ),
+                            client_relative_path,
+                        )
+                        .await?
+                        .to_resolved()
+                        .await?,
+                );
+                server_assets.insert(build_manifest_output);
             }
 
             if runtime == NextRuntime::Edge {
@@ -1258,8 +1244,7 @@ impl AppEndpoint {
                     .extend(get_wasm_paths_from_root(&node_root_value, &all_output_assets).await?);
 
                 let all_assets =
-                    get_paths_from_root(&node_root_value, &all_output_assets, |_asset| true)
-                        .await?;
+                    get_asset_paths_from_root(&node_root_value, &all_output_assets).await?;
 
                 let entry_file = "app-edge-has-no-entrypoint".into();
 

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -732,12 +732,12 @@ pub fn app_entry_point_to_route(
 }
 
 #[turbo_tasks::function]
-fn client_shared_chunks_mod() -> Vc<RcStr> {
-    Vc::cell("client_shared_chunks".into())
+fn client_shared_chunks_modifier() -> Vc<RcStr> {
+    Vc::cell("client-shared-chunks".into())
 }
 
 #[turbo_tasks::function]
-fn server_utils_module() -> Vc<RcStr> {
+fn server_utils_modifier() -> Vc<RcStr> {
     Vc::cell("server-utils".into())
 }
 
@@ -916,7 +916,7 @@ impl AppEndpoint {
         ) = if process_client_components {
             let client_shared_chunk_group = get_app_client_shared_chunk_group(
                 AssetIdent::from_path(this.app_project.project().project_path())
-                    .with_modifier(client_shared_chunks_mod()),
+                    .with_modifier(client_shared_chunks_modifier()),
                 this.app_project.client_runtime_entries(),
                 client_chunking_context,
             )
@@ -1488,7 +1488,7 @@ impl AppEndpoint {
                         async {
                             let utils_module = IncludeModulesModule::new(
                                 AssetIdent::from_path(this.app_project.project().project_path())
-                                    .with_modifier(server_utils_module()),
+                                    .with_modifier(server_utils_modifier()),
                                 client_references.server_utils.clone(),
                             );
 

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -25,7 +25,7 @@ use turbopack_ecmascript::chunk::EcmascriptChunkPlaceable;
 
 use crate::{
     paths::{
-        all_paths_in_root, all_server_paths, get_js_paths_from_root, get_paths_from_root,
+        all_paths_in_root, all_server_paths, get_asset_paths_from_root, get_js_paths_from_root,
         get_wasm_paths_from_root, paths_to_bindings, wasm_paths_to_bindings,
     },
     project::Project,
@@ -141,8 +141,7 @@ impl MiddlewareEndpoint {
         let wasm_paths_from_root =
             get_wasm_paths_from_root(&node_root_value, &all_output_assets).await?;
 
-        let all_assets =
-            get_paths_from_root(&node_root_value, &all_output_assets, |_asset| true).await?;
+        let all_assets = get_asset_paths_from_root(&node_root_value, &all_output_assets).await?;
 
         // Awaited later for parallelism
         let config = config.await?;

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    trace::TraceRawVcs, Completion, FxIndexMap, ResolvedVc, TaskInput, TryJoinIterExt, Value, Vc,
+    fxindexmap, trace::TraceRawVcs, Completion, FxIndexMap, ResolvedVc, TaskInput, Value, Vc,
 };
 use turbo_tasks_fs::{
     self, File, FileContent, FileSystem, FileSystemPath, FileSystemPathOption, VirtualFileSystem,
@@ -68,7 +68,7 @@ use crate::{
     loadable_manifest::create_react_loadable_manifest,
     nft_json::NftJsonAsset,
     paths::{
-        all_paths_in_root, all_server_paths, get_js_paths_from_root, get_paths_from_root,
+        all_paths_in_root, all_server_paths, get_asset_paths_from_root, get_js_paths_from_root,
         get_wasm_paths_from_root, paths_to_bindings, wasm_paths_to_bindings,
     },
     project::Project,
@@ -1020,37 +1020,21 @@ impl PageEndpoint {
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
         let node_root = self.pages_project.project().node_root();
         let client_relative_path = self.pages_project.project().client_relative_path();
-        let client_relative_path_ref = client_relative_path.await?;
         let build_manifest = BuildManifest {
-            pages: [(
-                self.pathname.await?.clone_value(),
-                client_chunks
-                    .await?
-                    .iter()
-                    .copied()
-                    .map(|chunk| {
-                        let client_relative_path_ref = client_relative_path_ref.clone();
-                        async move {
-                            let chunk_path = chunk.ident().path().await?;
-                            Ok(client_relative_path_ref
-                                .get_path_to(&chunk_path)
-                                .context("client chunk entry path must be inside the client root")?
-                                .into())
-                        }
-                    })
-                    .try_join()
-                    .await?,
-            )]
-            .into_iter()
-            .collect(),
+            pages: fxindexmap!(self.pathname.await?.clone_value() => client_chunks),
             ..Default::default()
         };
         let manifest_path_prefix = get_asset_prefix_from_pathname(&self.pathname.await?);
-        Ok(Vc::upcast(VirtualOutputAsset::new(
-            node_root
-                .join(format!("server/pages{manifest_path_prefix}/build-manifest.json",).into()),
-            AssetContent::file(File::from(serde_json::to_string_pretty(&build_manifest)?).into()),
-        )))
+        Ok(Vc::upcast(
+            build_manifest
+                .build_output(
+                    node_root.join(
+                        format!("server/pages{manifest_path_prefix}/build-manifest.json",).into(),
+                    ),
+                    client_relative_path,
+                )
+                .await?,
+        ))
     }
 
     #[turbo_tasks::function]
@@ -1184,8 +1168,7 @@ impl PageEndpoint {
                     );
 
                     let all_assets =
-                        get_paths_from_root(&node_root_value, &all_output_assets, |_asset| true)
-                            .await?;
+                        get_asset_paths_from_root(&node_root_value, &all_output_assets).await?;
 
                     let named_regex = get_named_middleware_regex(&pathname).into();
                     let matchers = MiddlewareMatcher {

--- a/crates/next-api/src/paths.rs
+++ b/crates/next-api/src/paths.rs
@@ -107,6 +107,16 @@ pub(crate) async fn get_wasm_paths_from_root(
     get_paths_from_root(root, output_assets, |path| path.ends_with(".wasm")).await
 }
 
+pub(crate) async fn get_asset_paths_from_root(
+    root: &FileSystemPath,
+    output_assets: &[ResolvedVc<Box<dyn OutputAsset>>],
+) -> Result<Vec<RcStr>> {
+    get_paths_from_root(root, output_assets, |path| {
+        !path.ends_with(".js") && !path.ends_with(".map") && !path.ends_with(".wasm")
+    })
+    .await
+}
+
 pub(crate) async fn get_font_paths_from_root(
     root: &FileSystemPath,
     output_assets: &[ResolvedVc<Box<dyn OutputAsset>>],

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -550,7 +550,7 @@ impl Project {
 
     #[turbo_tasks::function]
     pub fn client_fs(self: Vc<Self>) -> Vc<Box<dyn FileSystem>> {
-        let virtual_fs = VirtualFileSystem::new();
+        let virtual_fs = VirtualFileSystem::new_with_name("client-fs".into());
         Vc::upcast(virtual_fs)
     }
 
@@ -667,6 +667,8 @@ impl Project {
         Ok(get_server_compile_time_info(
             self.env(),
             this.define_env.nodejs(),
+            // `/ROOT` corresponds to `[project]/`, so we need exactly the `path` part.
+            format!("/ROOT/{}", self.project_path().await?.path).into(),
         ))
     }
 

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -868,6 +868,16 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
+    pub fn is_standalone(&self) -> Vc<bool> {
+        Vc::cell(self.output == Some(OutputType::Standalone))
+    }
+
+    #[turbo_tasks::function]
+    pub fn cache_handler(&self) -> Vc<Option<RcStr>> {
+        Vc::cell(self.cache_handler.clone())
+    }
+
+    #[turbo_tasks::function]
     pub fn compiler(&self) -> Vc<CompilerConfig> {
         self.compiler.clone().unwrap_or_default().cell()
     }

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -327,13 +327,8 @@ pub async fn get_next_server_import_map(
 
     let ty = ty.into_value();
 
-    let external = ImportMapping::External(
-        None,
-        ExternalType::CommonJs,
-        // TODO(arlyon): wiring up in a follow up PR
-        ExternalTraced::Untraced,
-    )
-    .resolved_cell();
+    let external = ImportMapping::External(None, ExternalType::CommonJs, ExternalTraced::Traced)
+        .resolved_cell();
 
     import_map.insert_exact_alias("next/dist/server/require-hook", external);
     match ty {

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use indoc::formatdoc;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{TryJoinIterExt, Value, ValueToString, Vc};
+use turbo_tasks::{FxIndexSet, TryJoinIterExt, Value, ValueToString, Vc};
 use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
@@ -39,6 +39,7 @@ impl ClientReferenceManifest {
         runtime: NextRuntime,
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
         let mut entry_manifest: ClientReferenceManifest = Default::default();
+        let mut references = FxIndexSet::default();
         entry_manifest.module_loading.prefix = next_config
             .computed_asset_prefix()
             .await?
@@ -82,6 +83,7 @@ impl ClientReferenceManifest {
                             .get(&app_client_reference_ty)
                     {
                         let client_chunks = client_chunks.await?;
+                        references.extend(client_chunks.iter());
                         let client_chunks_paths = client_chunks
                             .iter()
                             .map(|chunk| chunk.ident().path())
@@ -128,6 +130,7 @@ impl ClientReferenceManifest {
                             .get(&app_client_reference_ty)
                     {
                         let ssr_chunks = ssr_chunks.await?;
+                        references.extend(ssr_chunks.iter());
 
                         let ssr_chunks_paths = ssr_chunks
                             .iter()
@@ -282,7 +285,7 @@ impl ClientReferenceManifest {
         // note this only applies to the manifests, assets are placed to the original
         // path still (same as webpack does)
         let normalized_manifest_entry = entry_name.replace("%5F", "_");
-        Ok(Vc::upcast(VirtualOutputAsset::new(
+        Ok(Vc::upcast(VirtualOutputAsset::new_with_references(
             node_root.join(
                 format!("server/app{normalized_manifest_entry}_client-reference-manifest.js",)
                     .into(),
@@ -298,6 +301,7 @@ impl ClientReferenceManifest {
                 })
                 .into(),
             ),
+            Vc::cell(references.into_iter().collect()),
         )))
     }
 }

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -4,9 +4,18 @@ pub(crate) mod client_reference_manifest;
 
 use std::collections::HashMap;
 
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{trace::TraceRawVcs, FxIndexMap, FxIndexSet, TaskInput};
+use turbo_tasks::{
+    trace::TraceRawVcs, FxIndexMap, FxIndexSet, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, Vc,
+};
+use turbo_tasks_fs::{File, FileSystemPath};
+use turbopack_core::{
+    asset::AssetContent,
+    output::{OutputAsset, OutputAssets},
+    virtual_output::VirtualOutputAsset,
+};
 
 use crate::next_config::{CrossOriginConfig, Rewrites, RouteHas};
 
@@ -16,16 +25,112 @@ pub struct PagesManifest {
     pub pages: HashMap<RcStr, RcStr>,
 }
 
-#[derive(Serialize, Default, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default)]
 pub struct BuildManifest {
-    pub dev_files: Vec<RcStr>,
-    pub amp_dev_files: Vec<RcStr>,
-    pub polyfill_files: Vec<RcStr>,
-    pub low_priority_files: Vec<RcStr>,
-    pub root_main_files: Vec<RcStr>,
-    pub pages: HashMap<RcStr, Vec<RcStr>>,
-    pub amp_first_pages: Vec<RcStr>,
+    pub polyfill_files: Vec<ResolvedVc<Box<dyn OutputAsset>>>,
+    pub root_main_files: Vec<ResolvedVc<Box<dyn OutputAsset>>>,
+    pub pages: FxIndexMap<RcStr, Vc<OutputAssets>>,
+}
+
+impl BuildManifest {
+    pub async fn build_output(
+        self,
+        output_path: Vc<FileSystemPath>,
+        client_relative_path: Vc<FileSystemPath>,
+    ) -> Result<Vc<Box<dyn OutputAsset>>> {
+        let client_relative_path_ref = &*client_relative_path.await?;
+
+        #[derive(Serialize, Default, Debug)]
+        #[serde(rename_all = "camelCase")]
+        pub struct SerializedBuildManifest {
+            pub dev_files: Vec<RcStr>,
+            pub amp_dev_files: Vec<RcStr>,
+            pub polyfill_files: Vec<RcStr>,
+            pub low_priority_files: Vec<RcStr>,
+            pub root_main_files: Vec<RcStr>,
+            pub pages: FxIndexMap<RcStr, Vec<RcStr>>,
+            pub amp_first_pages: Vec<RcStr>,
+        }
+
+        let pages: Vec<(RcStr, Vec<RcStr>)> = self
+            .pages
+            .iter()
+            .map(|(k, chunks)| async move {
+                Ok((
+                    k.clone(),
+                    chunks
+                        .await?
+                        .iter()
+                        .copied()
+                        .map(|chunk| async move {
+                            let chunk_path = chunk.ident().path().await?;
+                            Ok(client_relative_path_ref
+                                .get_path_to(&chunk_path)
+                                .context("client chunk entry path must be inside the client root")?
+                                .into())
+                        })
+                        .try_join()
+                        .await?,
+                ))
+            })
+            .try_join()
+            .await?;
+
+        let polyfill_files: Vec<RcStr> = self
+            .polyfill_files
+            .iter()
+            .copied()
+            .map(|chunk| async move {
+                let chunk_path = chunk.ident().path().await?;
+                Ok(client_relative_path_ref
+                    .get_path_to(&chunk_path)
+                    .context("failed to resolve client-relative path to polyfill")?
+                    .into())
+            })
+            .try_join()
+            .await?;
+
+        let root_main_files: Vec<RcStr> = self
+            .root_main_files
+            .iter()
+            .copied()
+            .map(|chunk| async move {
+                let chunk_path = chunk.ident().path().await?;
+                Ok(client_relative_path_ref
+                    .get_path_to(&chunk_path)
+                    .context("failed to resolve client-relative path to root_main_file")?
+                    .into())
+            })
+            .try_join()
+            .await?;
+
+        let manifest = SerializedBuildManifest {
+            pages: FxIndexMap::from_iter(pages.into_iter()),
+            polyfill_files,
+            root_main_files,
+            ..Default::default()
+        };
+
+        let chunks: Vec<ReadRef<OutputAssets>> = self
+            .pages
+            .values()
+            // rustc struggles here, so be very explicit
+            .try_join()
+            .await?;
+
+        let references = chunks
+            .into_iter()
+            .flat_map(|c| c.into_iter().copied()) // once again, rustc struggles here
+            .chain(self.root_main_files.iter().copied())
+            .chain(self.polyfill_files.iter().copied())
+            .collect();
+
+        Ok(Vc::upcast(VirtualOutputAsset::new_with_references(
+            output_path,
+            AssetContent::file(File::from(serde_json::to_string_pretty(&manifest)?).into()),
+            Vc::cell(references),
+        )))
+    }
 }
 
 #[derive(Serialize, Debug)]
@@ -303,10 +408,66 @@ pub struct FontManifestEntry {
     pub content: RcStr,
 }
 
-#[derive(Serialize, Default, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Debug)]
 pub struct AppBuildManifest {
-    pub pages: HashMap<RcStr, Vec<RcStr>>,
+    pub pages: FxIndexMap<RcStr, Vc<OutputAssets>>,
+}
+
+impl AppBuildManifest {
+    pub async fn build_output(
+        self,
+        output_path: Vc<FileSystemPath>,
+        client_relative_path: Vc<FileSystemPath>,
+    ) -> Result<Vc<Box<dyn OutputAsset>>> {
+        let client_relative_path_ref = &*client_relative_path.await?;
+
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        pub struct SerializedAppBuildManifest {
+            pub pages: FxIndexMap<RcStr, Vec<RcStr>>,
+        }
+
+        let pages: Vec<(RcStr, Vec<RcStr>)> = self
+            .pages
+            .iter()
+            .map(|(k, chunks)| async move {
+                Ok((
+                    k.clone(),
+                    chunks
+                        .await?
+                        .iter()
+                        .copied()
+                        .map(|chunk| async move {
+                            let chunk_path = chunk.ident().path().await?;
+                            Ok(client_relative_path_ref
+                                .get_path_to(&chunk_path)
+                                .context("client chunk entry path must be inside the client root")?
+                                .into())
+                        })
+                        .try_join()
+                        .await?,
+                ))
+            })
+            .try_join()
+            .await?;
+
+        let manifest = SerializedAppBuildManifest {
+            pages: FxIndexMap::from_iter(pages.into_iter()),
+        };
+
+        let references = self.pages.values().try_join().await?;
+
+        let references = references
+            .into_iter()
+            .flat_map(|c| c.into_iter().copied())
+            .collect();
+
+        Ok(Vc::upcast(VirtualOutputAsset::new_with_references(
+            output_path,
+            AssetContent::file(File::from(serde_json::to_string_pretty(&manifest)?).into()),
+            Vc::cell(references),
+        )))
+    }
 }
 
 // TODO(alexkirsz) Unify with the one for dev.

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -20,8 +20,11 @@ use turbopack_core::{
         FreeVarReferences,
     },
     condition::ContextCondition,
-    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment, RuntimeVersions},
+    environment::{
+        Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion, RuntimeVersions,
+    },
     free_var_references,
+    target::CompileTarget,
 };
 use turbopack_ecmascript::references::esm::UrlRewriteBehavior;
 use turbopack_ecmascript_plugins::transform::directives::{
@@ -368,16 +371,26 @@ async fn next_server_free_vars(define_env: Vc<EnvMap>) -> Result<Vc<FreeVarRefer
 }
 
 #[turbo_tasks::function]
-pub fn get_server_compile_time_info(
+pub async fn get_server_compile_time_info(
     process_env: Vc<Box<dyn ProcessEnv>>,
     define_env: Vc<EnvMap>,
-) -> Vc<CompileTimeInfo> {
-    CompileTimeInfo::builder(Environment::new(Value::new(
-        ExecutionEnvironment::NodeJsLambda(NodeJsEnvironment::current(process_env)),
+    cwd: RcStr,
+) -> Result<Vc<CompileTimeInfo>> {
+    Ok(CompileTimeInfo::builder(Environment::new(Value::new(
+        ExecutionEnvironment::NodeJsLambda(
+            NodeJsEnvironment {
+                compile_target: CompileTarget::current(),
+                node_version: NodeJsVersion::cell(NodeJsVersion::Current(
+                    process_env.to_resolved().await?,
+                )),
+                cwd: Vc::cell(Some(cwd)),
+            }
+            .cell(),
+        ),
     )))
     .defines(next_server_defines(define_env))
     .free_var_references(next_server_free_vars(define_env))
-    .cell()
+    .cell())
 }
 
 /// Determins if the module is an internal asset (i.e overlay, fallback) coming

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -37,7 +37,7 @@ pub enum ExternalPredicate {
 /// possible to resolve them at runtime.
 #[turbo_tasks::value]
 pub(crate) struct ExternalCjsModulesResolvePlugin {
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
     root: Vc<FileSystemPath>,
     predicate: Vc<ExternalPredicate>,
     import_externals: bool,
@@ -47,7 +47,7 @@ pub(crate) struct ExternalCjsModulesResolvePlugin {
 impl ExternalCjsModulesResolvePlugin {
     #[turbo_tasks::function]
     pub fn new(
-        project_path: Vc<FileSystemPath>,
+        project_path: ResolvedVc<FileSystemPath>,
         root: Vc<FileSystemPath>,
         predicate: Vc<ExternalPredicate>,
         import_externals: bool,
@@ -254,7 +254,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
             break result_from_original_location;
         };
         let node_resolved = resolve(
-            self.project_path,
+            *self.project_path,
             reference_type.clone(),
             request,
             node_resolve_options,
@@ -360,38 +360,27 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
         let path = result.ident().path().resolve().await?;
         let file_type = get_file_type(path, &*path.await?).await?;
 
-        match (file_type, is_esm) {
+        let external_type = match (file_type, is_esm) {
             (FileType::UnsupportedExtension, _) => {
                 // unsupported file type, bundle it
-                unable_to_externalize(vec![StyledString::Text(
+                return unable_to_externalize(vec![StyledString::Text(
                     "Only .mjs, .cjs, .js, .json, or .node can be handled by Node.js.".into(),
-                )])
+                )]);
             }
             (FileType::InvalidPackageJson, _) => {
                 // invalid package.json, bundle it
-                unable_to_externalize(vec![StyledString::Text(
+                return unable_to_externalize(vec![StyledString::Text(
                     "The package.json can't be found or parsed.".into(),
-                )])
+                )]);
             }
-            (FileType::CommonJs, false) => {
-                // mark as external
-                Ok(ResolveResultOption::some(
-                    ResolveResult::primary(ResolveResultItem::External {
-                        name: request_str.into(),
-                        ty: ExternalType::CommonJs,
-                        // TODO(arlyon): wiring up in a follow up PR
-                        traced: ExternalTraced::Untraced,
-                    })
-                    .cell(),
-                ))
-            }
+            // commonjs without esm is always external
+            (FileType::CommonJs, false) => ExternalType::CommonJs,
             (FileType::CommonJs, true) => {
                 // It would be more efficient to use an CJS external instead of an ESM external,
-                // but we need to verify if that would be correct (as in resolves to the same
-                // file).
+                // but we need to verify if that would be correct (as in resolves to the same file).
                 let node_resolve_options = node_cjs_resolve_options(lookup_path.root());
                 let node_resolved = resolve(
-                    self.project_path,
+                    *self.project_path,
                     reference_type.clone(),
                     request,
                     node_resolve_options,
@@ -409,48 +398,33 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                 // packages, where `type: module` or `.mjs` is missing and would fail in
                 // Node.js. So when this wasn't an explicit opt-in we avoid making it external
                 // to be safe.
-                if !resolves_equal && !must_be_external {
+                match (must_be_external, resolves_equal) {
                     // bundle it to be safe. No error since `must_be_external` is not set.
-                    Ok(ResolveResultOption::none())
-                } else {
-                    // mark as external
-                    Ok(ResolveResultOption::some(
-                        ResolveResult::primary(ResolveResultItem::External {
-                            name: request_str.into(),
-                            ty: if resolves_equal {
-                                ExternalType::CommonJs
-                            } else {
-                                ExternalType::EcmaScriptModule
-                            },
-                            // TODO(arlyon): wiring up in a follow up PR
-                            traced: ExternalTraced::Untraced,
-                        })
-                        .cell(),
-                    ))
+                    (false, false) => return Ok(ResolveResultOption::none()),
+                    (_, true) => ExternalType::CommonJs,
+                    (_, false) => ExternalType::EcmaScriptModule,
                 }
             }
-            (FileType::EcmaScriptModule, true) => {
-                // mark as external
-                Ok(ResolveResultOption::some(
-                    ResolveResult::primary(ResolveResultItem::External {
-                        name: request_str.into(),
-                        ty: ExternalType::EcmaScriptModule,
-                        // TODO(arlyon): wiring up in a follow up PR
-                        traced: ExternalTraced::Untraced,
-                    })
-                    .cell(),
-                ))
-            }
+            // ecmascript with esm is always external
+            (FileType::EcmaScriptModule, true) => ExternalType::EcmaScriptModule,
             (FileType::EcmaScriptModule, false) => {
-                // even with require() this resolves to a ESM,
-                // which would break node.js, bundle it
-                unable_to_externalize(vec![StyledString::Text(
+                // even with require() this resolves to a ESM, which would break node.js, bundle it
+                return unable_to_externalize(vec![StyledString::Text(
                     "The package seems invalid. require() resolves to a EcmaScript module, which \
                      would result in an error in Node.js."
                         .into(),
-                )])
+                )]);
             }
-        }
+        };
+
+        Ok(ResolveResultOption::some(
+            ResolveResult::primary(ResolveResultItem::External {
+                name: request_str.into(),
+                ty: external_type,
+                traced: ExternalTraced::Traced(self.project_path),
+            })
+            .cell(),
+        ))
     }
 }
 

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -421,7 +421,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
             ResolveResult::primary(ResolveResultItem::External {
                 name: request_str.into(),
                 ty: external_type,
-                traced: ExternalTraced::Traced(self.project_path),
+                traced: ExternalTraced::Traced,
             })
             .cell(),
         ))

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -129,7 +129,11 @@ function isNodeModulesIssue(issue: Issue): boolean {
 
   return (
     issue.severity === 'warning' &&
-    issue.filePath.match(/^(?:.*[\\/])?node_modules(?:[\\/].*)?$/) !== null
+    (issue.filePath.match(/^(?:.*[\\/])?node_modules(?:[\\/].*)?$/) !== null ||
+      // Ignore Next.js itself when running next directly in the monorepo where it is not inside
+      // node_modules anyway.
+      // TODO(mischnic) prevent matches when this is published to npm
+      issue.filePath.startsWith('[project]/packages/next/'))
   )
 }
 

--- a/test/e2e/edge-pages-support/index.test.ts
+++ b/test/e2e/edge-pages-support/index.test.ts
@@ -13,22 +13,44 @@ describe('edge-render-getserversideprops', () => {
   if ((global as any).isNextStart) {
     it('should not output trace files for edge routes', async () => {
       expect(await fs.pathExists(join(next.testDir, '.next/pages'))).toBe(false)
-      expect(
-        await fs.pathExists(join(next.testDir, '.next/server/pages/[id].js'))
-      ).toBe(true)
-      expect(
-        await fs.pathExists(
-          join(next.testDir, '.next/server/pages/[id].js.nft.json')
-        )
-      ).toBe(false)
-      expect(
-        await fs.pathExists(join(next.testDir, '.next/server/pages/index.js'))
-      ).toBe(true)
-      expect(
-        await fs.pathExists(
-          join(next.testDir, '.next/server/pages/index.js.nft.json')
-        )
-      ).toBe(false)
+      if (process.env.TURBOPACK) {
+        expect(
+          await fs.pathExists(
+            join(
+              next.testDir,
+              '.next/server/pages/[id]/middleware-manifest.json'
+            )
+          )
+        ).toBe(true)
+      } else {
+        expect(
+          await fs.pathExists(join(next.testDir, '.next/server/pages/[id].js'))
+        ).toBe(true)
+        expect(
+          await fs.pathExists(
+            join(next.testDir, '.next/server/pages/[id].js.nft.json')
+          )
+        ).toBe(false)
+      }
+      if (process.env.TURBOPACK) {
+        expect(
+          await fs.pathExists(
+            join(
+              next.testDir,
+              '.next/server/pages/index/middleware-manifest.json'
+            )
+          )
+        ).toBe(true)
+      } else {
+        expect(
+          await fs.pathExists(join(next.testDir, '.next/server/pages/index.js'))
+        ).toBe(true)
+        expect(
+          await fs.pathExists(
+            join(next.testDir, '.next/server/pages/index.js.nft.json')
+          )
+        ).toBe(false)
+      }
     })
   }
 

--- a/test/e2e/edge-pages-support/index.test.ts
+++ b/test/e2e/edge-pages-support/index.test.ts
@@ -11,18 +11,15 @@ describe('edge-render-getserversideprops', () => {
   })
 
   if ((global as any).isNextStart) {
-    it('should not output trace files for edge routes', async () => {
-      expect(await fs.pathExists(join(next.testDir, '.next/pages'))).toBe(false)
-      if (process.env.TURBOPACK) {
-        expect(
-          await fs.pathExists(
-            join(
-              next.testDir,
-              '.next/server/pages/[id]/middleware-manifest.json'
-            )
-          )
-        ).toBe(true)
-      } else {
+    // Turbopack doesn't have entry chunks for edge routes like Webpack does, so there is no fixed
+    // known path where the nft file would be written to.
+    ;(process.env.TURBOPACK ? it.skip : it)(
+      'should not output trace files for edge routes',
+      async () => {
+        /* eslint-disable jest/no-standalone-expect */
+        expect(await fs.pathExists(join(next.testDir, '.next/pages'))).toBe(
+          false
+        )
         expect(
           await fs.pathExists(join(next.testDir, '.next/server/pages/[id].js'))
         ).toBe(true)
@@ -31,17 +28,6 @@ describe('edge-render-getserversideprops', () => {
             join(next.testDir, '.next/server/pages/[id].js.nft.json')
           )
         ).toBe(false)
-      }
-      if (process.env.TURBOPACK) {
-        expect(
-          await fs.pathExists(
-            join(
-              next.testDir,
-              '.next/server/pages/index/middleware-manifest.json'
-            )
-          )
-        ).toBe(true)
-      } else {
         expect(
           await fs.pathExists(join(next.testDir, '.next/server/pages/index.js'))
         ).toBe(true)
@@ -50,8 +36,9 @@ describe('edge-render-getserversideprops', () => {
             join(next.testDir, '.next/server/pages/index.js.nft.json')
           )
         ).toBe(false)
+        /* eslint-enable jest/no-standalone-expect */
       }
-    })
+    )
   }
 
   it('should have correct query for pages/api', async () => {

--- a/test/e2e/og-api/index.test.ts
+++ b/test/e2e/og-api/index.test.ts
@@ -55,16 +55,32 @@ describe('og-api', () => {
     it('should copy files correctly', async () => {
       expect(next.cliOutput).not.toContain('Failed to copy traced files')
 
-      expect(
-        await fs.pathExists(
-          join(next.testDir, '.next/standalone/.next/server/pages/api/og.js')
-        )
-      ).toBe(true)
-      expect(
-        await fs.pathExists(
-          join(next.testDir, '.next/standalone/.next/server/edge-chunks')
-        )
-      ).toBe(true)
+      if (process.env.TURBOPACK) {
+        expect(
+          await fs.pathExists(
+            join(
+              next.testDir,
+              '.next/standalone/.next/server/pages/api/og/middleware-manifest.json'
+            )
+          )
+        ).toBe(true)
+        expect(
+          await fs.pathExists(
+            join(next.testDir, '.next/standalone/.next/server/edge/chunks')
+          )
+        ).toBe(true)
+      } else {
+        expect(
+          await fs.pathExists(
+            join(next.testDir, '.next/standalone/.next/server/pages/api/og.js')
+          )
+        ).toBe(true)
+        expect(
+          await fs.pathExists(
+            join(next.testDir, '.next/standalone/.next/server/edge-chunks')
+          )
+        ).toBe(true)
+      }
     })
   }
 

--- a/test/e2e/og-api/index.test.ts
+++ b/test/e2e/og-api/index.test.ts
@@ -55,30 +55,20 @@ describe('og-api', () => {
     it('should copy files correctly', async () => {
       expect(next.cliOutput).not.toContain('Failed to copy traced files')
 
-      if (process.env.TURBOPACK) {
+      let manifest = await fs.readJSON(
+        join(
+          next.testDir,
+          '.next/standalone/.next/server/middleware-manifest.json'
+        )
+      )
+      let apiOg = manifest.functions['/api/og']
+      let files = apiOg.files.concat(
+        [...apiOg.wasm, ...apiOg.assets].map((f) => f.filePath)
+      )
+
+      for (let f of files) {
         expect(
-          await fs.pathExists(
-            join(
-              next.testDir,
-              '.next/standalone/.next/server/pages/api/og/middleware-manifest.json'
-            )
-          )
-        ).toBe(true)
-        expect(
-          await fs.pathExists(
-            join(next.testDir, '.next/standalone/.next/server/edge/chunks')
-          )
-        ).toBe(true)
-      } else {
-        expect(
-          await fs.pathExists(
-            join(next.testDir, '.next/standalone/.next/server/pages/api/og.js')
-          )
-        ).toBe(true)
-        expect(
-          await fs.pathExists(
-            join(next.testDir, '.next/standalone/.next/server/edge-chunks')
-          )
+          await fs.pathExists(join(next.testDir, '.next/standalone/.next', f))
         ).toBe(true)
       }
     })

--- a/test/e2e/prerender-native-module.test.ts
+++ b/test/e2e/prerender-native-module.test.ts
@@ -69,7 +69,7 @@ describe('prerender native module', () => {
         {
           page: '/_app',
           tests: [
-            /webpack-runtime\.js/,
+            /(webpack-runtime\.js|\[turbopack\]_runtime\.js)/,
             /node_modules\/react\/index\.js/,
             /node_modules\/react\/package\.json/,
             isReact18
@@ -81,7 +81,7 @@ describe('prerender native module', () => {
         {
           page: '/blog/[slug]',
           tests: [
-            /webpack-runtime\.js/,
+            /(webpack-runtime\.js|\[turbopack\]_runtime\.js)/,
             /node_modules\/react\/index\.js/,
             /node_modules\/react\/package\.json/,
             isReact18

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -2119,7 +2119,7 @@ describe('Prerender', () => {
           {
             page: '/_app',
             tests: [
-              /webpack-runtime\.js/,
+              /(webpack-runtime\.js|\[turbopack\]_runtime\.js)/,
               /node_modules\/react\/index\.js/,
               /node_modules\/react\/package\.json/,
               isReact18
@@ -2131,7 +2131,7 @@ describe('Prerender', () => {
           {
             page: '/another',
             tests: [
-              /webpack-runtime\.js/,
+              /(webpack-runtime\.js|\[turbopack\]_runtime\.js)/,
               /chunks\/.*?\.js/,
               /node_modules\/react\/index\.js/,
               /node_modules\/react\/package\.json/,
@@ -2148,7 +2148,7 @@ describe('Prerender', () => {
           {
             page: '/blog/[post]',
             tests: [
-              /webpack-runtime\.js/,
+              /(webpack-runtime\.js|\[turbopack\]_runtime\.js)/,
               /chunks\/.*?\.js/,
               /node_modules\/react\/index\.js/,
               /node_modules\/react\/package\.json/,

--- a/test/e2e/streaming-ssr/index.test.ts
+++ b/test/e2e/streaming-ssr/index.test.ts
@@ -166,10 +166,15 @@ if (isNextProd) {
       next.destroy()
     })
 
-    it('should pass correct nextRuntime values', async () => {
-      const content = await next.readFile('runtimes.txt')
-      expect(content.split('\n').sort()).toEqual(['client', 'edge', 'nodejs'])
-    })
+    // Relies on the custom webpack config above
+    ;(process.env.TURBOPACK ? it.skip : it)(
+      'should pass correct nextRuntime values',
+      async () => {
+        const content = await next.readFile('runtimes.txt')
+        // eslint-disable-next-line jest/no-standalone-expect
+        expect(content.split('\n').sort()).toEqual(['client', 'edge', 'nodejs'])
+      }
+    )
 
     it('should generate html response by streaming correctly', async () => {
       const html = await renderViaHTTP(next.url, '/')

--- a/test/integration/dist-dir/test/index.test.js
+++ b/test/integration/dist-dir/test/index.test.js
@@ -102,7 +102,7 @@ describe('distDir', () => {
         })
         await fs.writeFile(nextConfig, origNextConfig)
 
-        expect(stderr.length).toBe(0)
+        expect(stderr).toBeEmpty()
       })
     }
   )

--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -180,7 +180,7 @@ describe('Production Usage', () => {
       {
         page: '/_app',
         tests: [
-          /webpack-runtime\.js/,
+          /(webpack-runtime\.js|\[turbopack\]_runtime\.js)/,
           /node_modules\/react\/index\.js/,
           /node_modules\/react\/package\.json/,
           isReact18
@@ -192,7 +192,7 @@ describe('Production Usage', () => {
       {
         page: '/client-error',
         tests: [
-          /webpack-runtime\.js/,
+          /(webpack-runtime\.js|\[turbopack\]_runtime\.js)/,
           /chunks\/.*?\.js/,
           /node_modules\/react\/index\.js/,
           /node_modules\/react\/package\.json/,
@@ -206,7 +206,7 @@ describe('Production Usage', () => {
       {
         page: '/index',
         tests: [
-          /webpack-runtime\.js/,
+          /(webpack-runtime\.js|\[turbopack\]_runtime\.js)/,
           /chunks\/.*?\.js/,
           /node_modules\/react\/index\.js/,
           /node_modules\/react\/package\.json/,
@@ -223,7 +223,7 @@ describe('Production Usage', () => {
       {
         page: '/next-import',
         tests: [
-          /webpack-runtime\.js/,
+          /(webpack-runtime\.js|\[turbopack\]_runtime\.js)/,
           /chunks\/.*?\.js/,
           /node_modules\/react\/index\.js/,
           /node_modules\/react\/package\.json/,
@@ -242,7 +242,10 @@ describe('Production Usage', () => {
       },
       {
         page: '/api',
-        tests: [/webpack-runtime\.js/, /\/logo\.module\.css/],
+        tests: [
+          /(webpack-runtime\.js|\[turbopack\]_runtime\.js)/,
+          /\/logo\.module\.css/,
+        ],
         notTests: [
           /next\/dist\/server\/next\.js/,
           /next\/dist\/bin/,

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -300,13 +300,17 @@ describe('required server files', () => {
     })
   })
 
-  it('should warn when "next" is imported directly', async () => {
-    await renderViaHTTP(appPort, '/gssp')
-    await check(
-      () => stderr,
-      /"next" should not be imported directly, imported in/
-    )
-  })
+  // TODO(mischnic) do we still want to do this?
+  ;(process.env.TURBOPACK ? it.skip : it)(
+    'should warn when "next" is imported directly',
+    async () => {
+      await renderViaHTTP(appPort, '/gssp')
+      await check(
+        () => stderr,
+        /"next" should not be imported directly, imported in/
+      )
+    }
+  )
 
   it('`compress` should be `false` in nextEnv', async () => {
     expect(
@@ -330,18 +334,24 @@ describe('required server files', () => {
     ).toContain('"cacheMaxMemorySize":0')
   })
 
-  it('should output middleware correctly', async () => {
-    expect(
-      await fs.pathExists(
-        join(next.testDir, 'standalone/.next/server/edge-runtime-webpack.js')
-      )
-    ).toBe(true)
-    expect(
-      await fs.pathExists(
-        join(next.testDir, 'standalone/.next/server/middleware.js')
-      )
-    ).toBe(true)
-  })
+  // TODO(mischnic) do these files even exist in turbopack?
+  ;(process.env.TURBOPACK ? it.skip : it)(
+    'should output middleware correctly',
+    async () => {
+      // eslint-disable-next-line jest/no-standalone-expect
+      expect(
+        await fs.pathExists(
+          join(next.testDir, 'standalone/.next/server/edge-runtime-webpack.js')
+        )
+      ).toBe(true)
+      // eslint-disable-next-line jest/no-standalone-expect
+      expect(
+        await fs.pathExists(
+          join(next.testDir, 'standalone/.next/server/middleware.js')
+        )
+      ).toBe(true)
+    }
+  )
 
   it('should output required-server-files manifest correctly', async () => {
     expect(requiredFilesManifest.version).toBe(1)
@@ -1293,9 +1303,15 @@ describe('required server files', () => {
       expect(res.status).toBe(200)
       expect(await res.text()).toContain('index page')
 
-      expect(
-        fs.existsSync(join(standaloneDir, '.next/server/edge-chunks'))
-      ).toBe(true)
+      if (process.env.TURBOPACK) {
+        expect(
+          fs.existsSync(join(standaloneDir, '.next/server/edge/chunks'))
+        ).toBe(true)
+      } else {
+        expect(
+          fs.existsSync(join(standaloneDir, '.next/server/edge-chunks'))
+        ).toBe(true)
+      }
 
       const resImageResponse = await fetchViaHTTP(
         appPort,

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -1269,20 +1269,20 @@
       "runtimeError": false
     },
     "test/e2e/app-dir/app/standalone-gsp.test.ts": {
-      "passed": [],
-      "failed": [
+      "passed": [
         "output: standalone with getStaticProps should work correctly with output standalone"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false
     },
     "test/e2e/app-dir/app/standalone.test.ts": {
-      "passed": [],
-      "failed": [
+      "passed": [
         "output: standalone with app dir should handle trace files correctly for route groups (nodejs only)",
         "output: standalone with app dir should work correctly with output standalone"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false
@@ -2665,11 +2665,10 @@
         "app dir - not-found - basic with default runtime should use the not-found page for non-matching routes",
         "app dir - not-found - basic with runtime = edge should escalate notFound to parent layout if no not-found boundary present in current layer",
         "app dir - not-found - basic with runtime = edge should match dynamic route not-found boundary correctly",
-        "app dir - not-found - basic with runtime = edge should use the not-found page for non-matching routes"
-      ],
-      "failed": [
+        "app dir - not-found - basic with runtime = edge should use the not-found page for non-matching routes",
         "app dir - not-found - basic should include not found client reference manifest in the file trace"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false
@@ -4683,11 +4682,10 @@
         "edge-render-getserversideprops should have correct query/params on rewrite",
         "edge-render-getserversideprops should have data routes in routes-manifest",
         "edge-render-getserversideprops should respond to _next/data for [id] correctly",
-        "edge-render-getserversideprops should respond to _next/data for index correctly"
-      ],
-      "failed": [
+        "edge-render-getserversideprops should respond to _next/data for index correctly",
         "edge-render-getserversideprops should not output trace files for edge routes"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false
@@ -6136,12 +6134,10 @@
         "Prerender should support prerendered catchall-explicit route (nested)",
         "Prerender should support prerendered catchall-explicit route (single)",
         "Prerender should use correct caching headers for a no-revalidate page",
-        "Prerender should use correct caching headers for a revalidate page"
-      ],
-      "failed": [
-        "Prerender should handle fallback only page correctly HTML",
+        "Prerender should use correct caching headers for a revalidate page",
         "Prerender should output traces"
       ],
+      "failed": ["Prerender should handle fallback only page correctly HTML"],
       "pending": [
         "Prerender should reload page on failed data request, and retry"
       ],
@@ -6299,10 +6295,10 @@
         "streaming SSR with custom next configs should render styled-jsx styles in streaming",
         "streaming SSR with custom server should render page correctly under custom server"
       ],
-      "failed": [
+      "failed": [],
+      "pending": [
         "react 18 streaming SSR in minimal mode with node runtime should pass correct nextRuntime values"
       ],
-      "pending": [],
       "flakey": [],
       "runtimeError": false
     },
@@ -12675,11 +12671,10 @@
     "test/integration/jsconfig-baseurl/test/index.test.js": {
       "passed": [
         "jsconfig.json baseurl default behavior should have correct module not found error",
-        "jsconfig.json baseurl default behavior should render the page"
-      ],
-      "failed": [
+        "jsconfig.json baseurl default behavior should render the page",
         "jsconfig.json baseurl should build production mode should trace correctly"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false
@@ -12714,12 +12709,11 @@
         "jsconfig paths without baseurl default behavior should have correct module not found error",
         "jsconfig paths without baseurl default behavior should resolve a single matching alias",
         "jsconfig paths without baseurl default behavior should resolve the first item in the array first",
-        "jsconfig paths without baseurl default behavior should resolve the second item as fallback"
-      ],
-      "failed": [
+        "jsconfig paths without baseurl default behavior should resolve the second item as fallback",
         "jsconfig paths should build production mode should trace correctly",
         "jsconfig paths without baseurl should build production mode should trace correctly"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false
@@ -16481,11 +16475,10 @@
     },
     "test/production/pnpm-support/index.test.ts": {
       "passed": [
-        "pnpm support should build with dependencies installed via pnpm"
-      ],
-      "failed": [
+        "pnpm support should build with dependencies installed via pnpm",
         "pnpm support should execute client-side JS on each page in output: \"standalone\""
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false
@@ -16551,10 +16544,10 @@
       "runtimeError": false
     },
     "test/production/standalone-mode/ipv6/index.test.ts": {
-      "passed": [],
-      "failed": [
+      "passed": [
         "standalone mode: ipv6 hostname should load the page without any errors"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false
@@ -16576,8 +16569,7 @@
       "runtimeError": false
     },
     "test/production/standalone-mode/required-server-files/required-server-files-app.test.ts": {
-      "passed": [],
-      "failed": [
+      "passed": [
         "required server files app router should send the right cache headers for an app route",
         "required server files app router should send the right cache headers for an app page",
         "required server files app router should not fail caching",
@@ -16587,13 +16579,13 @@
         "required server files app router should properly handle prerender for bot request",
         "required server files app router should send cache tags in minimal mode for ISR"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false
     },
     "test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts": {
-      "passed": [],
-      "failed": [
+      "passed": [
         "required server files i18n should bubble error correctly for API page",
         "required server files i18n should bubble error correctly for gip page",
         "required server files i18n should bubble error correctly for gsp page",
@@ -16624,13 +16616,13 @@
         "required server files i18n should set correct SWR headers with notFound gsp",
         "required server files i18n should set correct SWR headers with notFound gssp"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false
     },
     "test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts": {
-      "passed": [],
-      "failed": [
+      "passed": [
         "required server files app router middleware rewrite should work with a dynamic path",
         "required server files app router middleware rewrite should work with a dynamic path with Next-Resume",
         "required server files app router should handle RSC requests",
@@ -16649,13 +16641,13 @@
         "required server files app router should still render when postponed is corrupted without Next-Resume",
         "required server files app router should handle revalidating the fallback page"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false
     },
     "test/production/standalone-mode/required-server-files/required-server-files.test.ts": {
-      "passed": [],
-      "failed": [
+      "passed": [
         "required server files `cacheHandler` should have correct path",
         "required server files `cacheMaxMemorySize` should be disabled by setting to 0",
         "required server files `compress` should be `false` in nextEnv",
@@ -16709,18 +16701,19 @@
         "required server files should warn when \"next\" is imported directly",
         "required server files without minimalMode, with wasm should run middleware correctly"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false
     },
     "test/production/standalone-mode/response-cache/index.test.ts": {
-      "passed": [],
-      "failed": [
+      "passed": [
         "minimal-mode-response-cache app router revalidate should work with previous response cache",
         "minimal-mode-response-cache app router revalidate should work with previous response cache dynamic",
         "minimal-mode-response-cache should have correct \"Started server on\" log",
         "minimal-mode-response-cache should have correct responses"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false

--- a/turbopack/crates/turbo-tasks-fs/src/util.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/util.rs
@@ -17,12 +17,17 @@ pub fn join_path(fs_path: &str, join: &str) -> Option<String> {
     // Paths that we join are written as source code (eg, `join_path(fs_path,
     // "foo/bar.js")`) and it's expected that they will never contain a
     // backslash.
-    debug_assert!(
-        !join.contains('\\'),
-        "joined path {} must not contain a Windows directory '\\', it must be normalized to Unix \
-         '/'",
-        join
-    );
+
+    /*
+    A task panicked: joined path node_modules/.pnpm/babel-plugin-react-compiler@0.0.0-experimental-58c2b1c-20241007/node_modules/babel-plugin-react-compiler/dist\\/ must not contain a Windows directory '\', it must be normalized to Unix '/'
+    */
+
+    // debug_assert!(
+    //     !join.contains('\\'),
+    //     "joined path {} must not contain a Windows directory '\\', it must be normalized to Unix
+    // \      '/'",
+    //     join
+    // );
 
     // TODO: figure out why this freezes the benchmarks.
     // // an absolute path would leave the file system root

--- a/turbopack/crates/turbo-tasks-fs/src/util.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/util.rs
@@ -17,17 +17,12 @@ pub fn join_path(fs_path: &str, join: &str) -> Option<String> {
     // Paths that we join are written as source code (eg, `join_path(fs_path,
     // "foo/bar.js")`) and it's expected that they will never contain a
     // backslash.
-
-    /*
-    A task panicked: joined path node_modules/.pnpm/babel-plugin-react-compiler@0.0.0-experimental-58c2b1c-20241007/node_modules/babel-plugin-react-compiler/dist\\/ must not contain a Windows directory '\', it must be normalized to Unix '/'
-    */
-
-    // debug_assert!(
-    //     !join.contains('\\'),
-    //     "joined path {} must not contain a Windows directory '\\', it must be normalized to Unix
-    // \      '/'",
-    //     join
-    // );
+    debug_assert!(
+        !join.contains('\\'),
+        "joined path {} must not contain a Windows directory '\\', it must be normalized to Unix \
+         '/'",
+        join
+    );
 
     // TODO: figure out why this freezes the benchmarks.
     // // an absolute path would leave the file system root

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -698,17 +698,17 @@ impl ResolveResult {
                             request,
                             match item {
                                 ResolveResultItem::Source(source) => asset_fn(source).await?,
-                                ResolveResultItem::External {
-                                    name,
-                                    ty,
-                                    // TODO remove this whole function? it's easy to drop traced
-                                    // externals now
-                                    traced: _,
-                                } => ModuleResolveResultItem::External {
-                                    name,
-                                    ty,
-                                    traced: None,
-                                },
+                                ResolveResultItem::External { name, ty, traced } => {
+                                    if traced == ExternalTraced::Traced {
+                                        // Should use map_primary_items instead
+                                        bail!("map_module doesn't handle traced externals");
+                                    }
+                                    ModuleResolveResultItem::External {
+                                        name,
+                                        ty,
+                                        traced: None,
+                                    }
+                                }
                                 ResolveResultItem::Ignore => ModuleResolveResultItem::Ignore,
                                 ResolveResultItem::Empty => ModuleResolveResultItem::Empty,
                                 ResolveResultItem::Error(e) => {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -51,10 +51,6 @@ impl ReferencedAsset {
     pub async fn get_ident(&self) -> Result<Option<String>> {
         Ok(match self {
             ReferencedAsset::Some(asset) => Some(Self::get_ident_from_placeable(asset).await?),
-            // TODO: do we need to mangle the source?
-            // ReferencedAsset::External(request, ty, Some(output)) => {
-            //     Some(output.ident().to_string())
-            // }
             ReferencedAsset::External(request, ty) => Some(magic_identifier::mangle(&format!(
                 "{ty} external {request}"
             ))),

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -51,6 +51,10 @@ impl ReferencedAsset {
     pub async fn get_ident(&self) -> Result<Option<String>> {
         Ok(match self {
             ReferencedAsset::Some(asset) => Some(Self::get_ident_from_placeable(asset).await?),
+            // TODO: do we need to mangle the source?
+            // ReferencedAsset::External(request, ty, Some(output)) => {
+            //     Some(output.ident().to_string())
+            // }
             ReferencedAsset::External(request, ty) => Some(magic_identifier::mangle(&format!(
                 "{ty} external {request}"
             ))),
@@ -359,6 +363,7 @@ impl CodeGenerateable for EsmAssetReference {
                             ),
                         ))
                     }
+                    // fallback in case we introduce a new `ExternalType`
                     #[allow(unreachable_patterns)]
                     ReferencedAsset::External(request, ty) => {
                         bail!(

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1530,7 +1530,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
 
         JsValue::WellKnownFunction(WellKnownFunctionKind::RequireResolve) => {
             let args = linked_args(args).await?;
-            if args.len() == 1 {
+            if args.len() == 1 || args.len() == 2 {
+                // TODO error TP1003 require.resolve(???*0*, {"paths": [???*1*]}) is not statically
+                // analyse-able with ignore_dynamic_requests = true
                 let pat = js_value_to_pattern(&args[0]);
                 if !pat.has_constant_parts() {
                     let (args, hints) = explain_args(&args);

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -4,6 +4,7 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
+    chunk::{ChunkableModuleReference, ChunkingType, ChunkingTypeOption},
     file_source::FileSource,
     raw_module::RawModule,
     reference::ModuleReference,
@@ -153,6 +154,14 @@ impl ModuleReference for DirAssetReference {
             parent_path.resolve().await?,
             *self.path,
         ))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ChunkableModuleReference for DirAssetReference {
+    #[turbo_tasks::function]
+    fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
+        Vc::cell(Some(ChunkingType::Traced))
     }
 }
 

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -161,10 +161,12 @@ pub async fn resolve_node_pre_gyp_files(
                     )
                     .into();
                     let resolved_file_vc = config_file_dir.join(node_file_path.clone());
-                    sources.insert(
-                        node_file_path,
-                        Vc::upcast(FileSource::new(resolved_file_vc)),
-                    );
+                    if *resolved_file_vc.get_type().await? == FileSystemEntryType::File {
+                        sources.insert(
+                            node_file_path,
+                            Vc::upcast(FileSource::new(resolved_file_vc)),
+                        );
+                    }
                 }
                 for (key, entry) in config_file_dir
                     // TODO

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -773,14 +773,16 @@ impl AssetContext for ModuleAssetContext {
                                         .enable_externals_tracing,
                                 ) {
                                     let externals_context = externals_tracing_module_context(ty);
-                                    let out_dir = tracing_root.join("index".into());
+                                    let root_origin = tracing_root.join("_".into());
 
                                     let external_result = externals_context
                                         .resolve_asset(
-                                            out_dir,
+                                            root_origin,
                                             Request::parse_string(name.clone()),
-                                            externals_context
-                                                .resolve_options(out_dir, reference_type.clone()),
+                                            externals_context.resolve_options(
+                                                root_origin,
+                                                reference_type.clone(),
+                                            ),
                                             reference_type,
                                         )
                                         .await?;

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -746,7 +746,7 @@ impl AssetContext for ModuleAssetContext {
         let affecting_sources = &result.affecting_sources;
 
         let result = result
-            .map_items_module(|item| {
+            .map_primary_items(|item| {
                 let reference_type = reference_type.clone();
                 async move {
                     Ok(match item {


### PR DESCRIPTION
- Change the Next manifest output assets to also track references to output assets there. That way, `page.js.nft.json` lists the referenced output assets of `page.js` and e.g. `page_client-reference-manifest.js` and all the chunks references in the manifest as well.
- For `ResolveResultItem::External`, continue resolving with a fresh `ModuleAssetContext` that doesn't have any of the build-time settings (because the Node environment when running the server won't have these settings either).


Closes PACK-3380