### PR TITLE
[Turbopack] add stack traces of turbo tasks functions

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
@@ -88,13 +88,20 @@ impl UpdateOutputOperation {
             }
             Ok(Err(err)) => {
                 task.insert(CachedDataItem::Error {
-                    value: SharedError::new(err),
+                    value: SharedError::new(err.context(format!(
+                        "Execution of {} failed",
+                        ctx.get_task_description(task_id)
+                    ))),
                 });
                 OutputValue::Error
             }
             Err(panic) => {
                 task.insert(CachedDataItem::Error {
-                    value: SharedError::new(anyhow!("Panic: {:?}", panic)),
+                    value: SharedError::new(anyhow!(
+                        "Panic in {}: {:?}",
+                        ctx.get_task_description(task_id),
+                        panic
+                    )),
                 });
                 OutputValue::Panic
             }


### PR DESCRIPTION
### What?

add stack traces to error in the new backend similar to the old backend

Closes PACK-3386