### PR TITLE
test opt out waitForChange

### DIFF
--- a/test/development/acceptance-app/app-hmr-changes.test.ts
+++ b/test/development/acceptance-app/app-hmr-changes.test.ts
@@ -41,21 +41,35 @@ describe('Error overlay - RSC build errors', () => {
 
         const break1 = originalPage.replace('break 1', '<Figure>')
 
-        await session.patch(pagePath, break1)
+        await session.patch(pagePath, break1, {
+          skipWaitForChanges: true,
+        })
 
         const break2 = break1.replace('{/* break point 2 */}', '<Figure />')
 
-        await session.patch(pagePath, break2)
+        await session.patch(pagePath, break2, {
+          skipWaitForChanges: true,
+        })
 
         for (let i = 0; i < 5; i++) {
-          await session.patch(pagePath, break2.replace('break 3', '<Hello />'))
+          await session.patch(
+            pagePath,
+            break2.replace('break 3', '<Hello />'),
+            { skipWaitForChanges: true }
+          )
 
-          await session.patch(pagePath, break2)
+          await session.patch(pagePath, break2, {
+            skipWaitForChanges: true,
+          })
           await session.assertHasRedbox()
 
-          await session.patch(pagePath, break1)
+          await session.patch(pagePath, break1, {
+            skipWaitForChanges: true,
+          })
 
-          await session.patch(pagePath, originalPage)
+          await session.patch(pagePath, originalPage, {
+            skipWaitForChanges: true,
+          })
           await session.assertNoRedbox()
         }
 

--- a/test/development/acceptance-app/editor-links.test.ts
+++ b/test/development/acceptance-app/editor-links.test.ts
@@ -62,7 +62,10 @@ describe('Error overlay - editor links', () => {
       outdent`
         import { useState } from 'react'
         export default () => 'hello world'
-      `
+      `,
+      {
+        skipWaitForChanges: true,
+      }
     )
 
     await session.assertHasRedbox()
@@ -107,7 +110,10 @@ describe('Error overlay - editor links', () => {
           outdent`
         import './mod1' 
         export default () => 'hello world'
-      `
+      `,
+          {
+            skipWaitForChanges: true,
+          }
         )
 
         await session.assertHasRedbox()
@@ -150,7 +156,8 @@ describe('Error overlay - editor links', () => {
           outdent`
         import './mod1' 
         export default () => 'hello world'
-      `
+      `,
+          { skipWaitForChanges: true }
         )
 
         await session.assertHasRedbox()

--- a/test/development/acceptance-app/invalid-imports.test.ts
+++ b/test/development/acceptance-app/invalid-imports.test.ts
@@ -227,7 +227,9 @@ describe('Error Overlay invalid imports', () => {
 
     const file = 'app/page.js'
     const content = await next.readFile(file)
-    await session.patch(file, "'use client'\n" + content)
+    await session.patch(file, "'use client'\n" + content, {
+      skipWaitForChanges: !!process.env.TURBOPACK, // TODO: server console did not show errors in turbopack, remove this flag when fixed
+    })
 
     await session.assertHasRedbox()
     if (process.env.TURBOPACK) {

--- a/test/development/acceptance-app/rsc-runtime-errors.test.ts
+++ b/test/development/acceptance-app/rsc-runtime-errors.test.ts
@@ -22,7 +22,10 @@ describe('Error overlay - RSC runtime errors', () => {
         callClientApi()
         return 'page'
       }
-    `
+    `,
+      {
+        skipWaitForChanges: true,
+      }
     )
 
     const browser = await next.browser('/server')
@@ -45,7 +48,10 @@ describe('Error overlay - RSC runtime errors', () => {
         callServerApi()
         return 'page'
       }
-    `
+    `,
+      {
+        skipWaitForChanges: true,
+      }
     )
 
     const browser = await next.browser('/client')
@@ -65,7 +71,10 @@ describe('Error overlay - RSC runtime errors', () => {
         export default function Page() {
           return <div>{alert('warn')}</div>
         }
-      `
+      `,
+      {
+        skipWaitForChanges: true,
+      }
     )
 
     const browser = await next.browser('/server')
@@ -84,7 +93,10 @@ describe('Error overlay - RSC runtime errors', () => {
           await fetch('http://locahost:3000/xxxx')
           return 'page'
         }
-        `
+        `,
+      {
+        skipWaitForChanges: true,
+      }
     )
     const browser = await next.browser('/server')
     await assertHasRedbox(browser)
@@ -102,7 +114,8 @@ describe('Error overlay - RSC runtime errors', () => {
         export default function Page() {
           throw new Error('test')
         }
-        `
+        `,
+      { skipWaitForChanges: true }
     )
     const browser = await next.browser('/server')
 
@@ -118,7 +131,8 @@ describe('Error overlay - RSC runtime errors', () => {
         export default function Page() {
           throw new Error('test')
         }
-        `
+        `,
+      { skipWaitForChanges: true }
     )
     const browser = await next.browser('/server')
 

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -29,7 +29,8 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
             </main>
           )
         }
-      `
+      `,
+      { skipWaitForChanges: true }
     )
 
     await session.evaluate(() => document.querySelector('button').click())
@@ -37,7 +38,9 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
       await session.evaluate(() => document.querySelector('p').textContent)
     ).toBe('1')
 
-    await session.patch('index.js', `export default () => <div/`)
+    await session.patch('index.js', `export default () => <div/`, {
+      skipWaitForChanges: true,
+    })
 
     await session.assertHasRedbox()
     expect(await session.getRedboxSource()).toInclude(
@@ -59,7 +62,8 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
             </main>
           )
         }
-      `
+      `,
+      { skipWaitForChanges: true }
     )
 
     await check(

--- a/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
+++ b/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
@@ -99,7 +99,8 @@ describe('Error Overlay for server components compiler errors in pages', () => {
         export default function Page() {
           return 'hello world'
         }
-      `
+      `,
+      { skipWaitForChanges: true }
     )
 
     await session.assertHasRedbox()
@@ -156,7 +157,8 @@ describe('Error Overlay for server components compiler errors in pages', () => {
         export default function Page() {
           return 'hello world'
         }
-      `
+      `,
+      { skipWaitForChanges: true }
     )
 
     await session.assertHasRedbox()

--- a/test/development/app-dir/server-components-hmr-cache/server-components-hmr-cache.test.ts
+++ b/test/development/app-dir/server-components-hmr-cache/server-components-hmr-cache.test.ts
@@ -25,15 +25,17 @@ describe('server-components-hmr-cache', () => {
       await next.patchFile(
         'components/shared-page.tsx',
         (content) => content.replace('foo', 'bar'),
-        async () => {
-          await retry(async () => {
-            const updatedContent = await browser.elementById('content').text()
-            expect(updatedContent).toBe('bar')
-            // TODO: remove custom duration in case we increase the default.
-          }, 5000)
+        {
+          runWithTempContent: async () => {
+            await retry(async () => {
+              const updatedContent = await browser.elementById('content').text()
+              expect(updatedContent).toBe('bar')
+              // TODO: remove custom duration in case we increase the default.
+            }, 5000)
 
-          const valueAfterPatch = await browser.elementById('value').text()
-          expect(valueBeforePatch).toEqual(valueAfterPatch)
+            const valueAfterPatch = await browser.elementById('value').text()
+            expect(valueBeforePatch).toEqual(valueAfterPatch)
+          },
         }
       )
     })
@@ -63,15 +65,19 @@ describe('server-components-hmr-cache', () => {
         await next.patchFile(
           'components/shared-page.tsx',
           (content) => content.replace('foo', 'bar'),
-          async () => {
-            await retry(async () => {
-              const updatedContent = await browser.elementById('content').text()
-              expect(updatedContent).toBe('bar')
-              // TODO: remove custom duration in case we increase the default.
-            }, 5000)
+          {
+            runWithTempContent: async () => {
+              await retry(async () => {
+                const updatedContent = await browser
+                  .elementById('content')
+                  .text()
+                expect(updatedContent).toBe('bar')
+                // TODO: remove custom duration in case we increase the default.
+              }, 5000)
 
-            const valueAfterPatch = getLoggedAfterValue()
-            expect(valueBeforePatch).toEqual(valueAfterPatch)
+              const valueAfterPatch = getLoggedAfterValue()
+              expect(valueBeforePatch).toEqual(valueAfterPatch)
+            },
           }
         )
       })
@@ -117,15 +123,19 @@ describe('server-components-hmr-cache', () => {
         await next.patchFile(
           'components/shared-page.tsx',
           (content) => content.replace('foo', 'bar'),
-          async () => {
-            await retry(async () => {
-              const updatedContent = await browser.elementById('content').text()
-              expect(updatedContent).toBe('bar')
-              // TODO: remove custom duration in case we increase the default.
-            }, 5000)
+          {
+            runWithTempContent: async () => {
+              await retry(async () => {
+                const updatedContent = await browser
+                  .elementById('content')
+                  .text()
+                expect(updatedContent).toBe('bar')
+                // TODO: remove custom duration in case we increase the default.
+              }, 5000)
 
-            const valueAfterPatch = await browser.elementById('value').text()
-            expect(valueBeforePatch).not.toEqual(valueAfterPatch)
+              const valueAfterPatch = await browser.elementById('value').text()
+              expect(valueBeforePatch).not.toEqual(valueAfterPatch)
+            },
           }
         )
       })
@@ -143,17 +153,19 @@ describe('server-components-hmr-cache', () => {
           await next.patchFile(
             'components/shared-page.tsx',
             (content) => content.replace('foo', 'bar'),
-            async () => {
-              await retry(async () => {
-                const updatedContent = await browser
-                  .elementById('content')
-                  .text()
-                expect(updatedContent).toBe('bar')
-                // TODO: remove custom duration in case we increase the default.
-              }, 5000)
+            {
+              runWithTempContent: async () => {
+                await retry(async () => {
+                  const updatedContent = await browser
+                    .elementById('content')
+                    .text()
+                  expect(updatedContent).toBe('bar')
+                  // TODO: remove custom duration in case we increase the default.
+                }, 5000)
 
-              const valueAfterPatch = await retry(() => getLoggedAfterValue())
-              expect(valueBeforePatch).not.toEqual(valueAfterPatch)
+                const valueAfterPatch = await retry(() => getLoggedAfterValue())
+                expect(valueBeforePatch).not.toEqual(valueAfterPatch)
+              },
             }
           )
         })

--- a/test/development/jsconfig-path-reloading/index.test.ts
+++ b/test/development/jsconfig-path-reloading/index.test.ts
@@ -43,7 +43,9 @@ describe('jsconfig-path-reloading', () => {
       })
 
       if (addAfterStart) {
-        await next.patchFile(tsConfigFile, tsConfigContent)
+        await next.patchFile(tsConfigFile, tsConfigContent, {
+          skipWaitForChanges: true,
+        })
       }
     })
     afterAll(() => next.destroy())
@@ -79,7 +81,8 @@ describe('jsconfig-path-reloading', () => {
           `import {secondData} from "@lib/second-data"\n${indexContent.replace(
             '</p>',
             `</p><p id="second-data">{JSON.stringify(secondData)}</p>`
-          )}`
+          )}`,
+          { skipWaitForChanges: true }
         )
 
         await assertHasRedbox(browser)
@@ -100,7 +103,8 @@ describe('jsconfig-path-reloading', () => {
             },
             null,
             2
-          )
+          ),
+          { skipWaitForChanges: true }
         )
 
         await assertNoRedbox(browser)
@@ -111,8 +115,12 @@ describe('jsconfig-path-reloading', () => {
         expect(html2).toContain('first-data')
         expect(html2).toContain('second-data')
       } finally {
-        await next.patchFile(indexPage, indexContent)
-        await next.patchFile(tsConfigFile, tsconfigContent)
+        await next.patchFile(indexPage, indexContent, {
+          skipWaitForChanges: true,
+        })
+        await next.patchFile(tsConfigFile, tsconfigContent, {
+          skipWaitForChanges: true,
+        })
         await check(async () => {
           const html3 = await browser.eval('document.documentElement.innerHTML')
           return html3.includes('id="first-data"') &&
@@ -151,11 +159,13 @@ describe('jsconfig-path-reloading', () => {
             },
             null,
             2
-          )
+          ),
+          { skipWaitForChanges: true }
         )
         await next.patchFile(
           indexPage,
-          indexContent.replace('@mybutton', '@myotherbutton')
+          indexContent.replace('@mybutton', '@myotherbutton'),
+          { skipWaitForChanges: true }
         )
 
         await assertNoRedbox(browser)
@@ -169,8 +179,12 @@ describe('jsconfig-path-reloading', () => {
           return 'success'
         }, 'success')
       } finally {
-        await next.patchFile(indexPage, indexContent)
-        await next.patchFile(tsConfigFile, tsconfigContent)
+        await next.patchFile(indexPage, indexContent, {
+          skipWaitForChanges: true,
+        })
+        await next.patchFile(tsConfigFile, tsconfigContent, {
+          skipWaitForChanges: true,
+        })
         await check(async () => {
           const html3 = await browser.eval('document.documentElement.innerHTML')
           return html3.includes('first button') &&

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -24,7 +24,10 @@ describe('middleware - development errors', () => {
         `
       export default function () {
         throw new Error('boom')
-      }`
+      }`,
+        {
+          skipWaitForChanges: true,
+        }
       )
 
       await next.start()
@@ -54,7 +57,9 @@ describe('middleware - development errors', () => {
     it('renders the error correctly and recovers', async () => {
       const browser = await next.browser('/')
       await assertHasRedbox(browser)
-      await next.patchFile('middleware.js', `export default function () {}`)
+      await next.patchFile('middleware.js', `export default function () {}`, {
+        skipWaitForChanges: true,
+      })
       await assertNoRedbox(browser)
     })
   })
@@ -71,7 +76,10 @@ describe('middleware - development errors', () => {
       export default function () {
         throwError()
         return NextResponse.next()
-      }`
+      }`,
+        {
+          skipWaitForChanges: true,
+        }
       )
 
       await next.start()
@@ -111,7 +119,10 @@ describe('middleware - development errors', () => {
       export default function () {
         eval('test')
         return NextResponse.next()
-      }`
+      }`,
+        {
+          skipWaitForChanges: true,
+        }
       )
 
       await next.start()
@@ -159,7 +170,9 @@ describe('middleware - development errors', () => {
       const browser = await next.browser('/')
       await assertHasRedbox(browser)
       expect(await getRedboxSource(browser)).toContain(`eval('test')`)
-      await next.patchFile('middleware.js', `export default function () {}`)
+      await next.patchFile('middleware.js', `export default function () {}`, {
+        skipWaitForChanges: true,
+      })
       await assertNoRedbox(browser)
     })
   })
@@ -173,7 +186,10 @@ describe('middleware - development errors', () => {
       throw new Error('booooom!')
       export default function () {
         return NextResponse.next()
-      }`
+      }`,
+        {
+          skipWaitForChanges: true,
+        }
       )
       await next.start()
     })
@@ -206,7 +222,9 @@ describe('middleware - development errors', () => {
       expect(source).toContain(`throw new Error('booooom!')`)
       expect(source).toContain('middleware.js')
       expect(source).not.toContain('//middleware.js')
-      await next.patchFile('middleware.js', `export default function () {}`)
+      await next.patchFile('middleware.js', `export default function () {}`, {
+        skipWaitForChanges: true,
+      })
       await assertNoRedbox(browser)
     })
   })
@@ -223,7 +241,10 @@ describe('middleware - development errors', () => {
 
       export default function () {
         return NextResponse.next()
-      }`
+      }`,
+        {
+          skipWaitForChanges: true,
+        }
       )
 
       await next.start()
@@ -257,7 +278,10 @@ describe('middleware - development errors', () => {
 
       export default function () {
         return NextResponse.next()
-      }`
+      }`,
+        {
+          skipWaitForChanges: true,
+        }
       )
 
       await next.start()
@@ -287,7 +311,9 @@ describe('middleware - development errors', () => {
 
   describe('when there is a compilation error from boot', () => {
     beforeEach(async () => {
-      await next.patchFile('middleware.js', `export default function () }`)
+      await next.patchFile('middleware.js', `export default function () }`, {
+        skipWaitForChanges: true,
+      })
 
       await next.start()
     })
@@ -310,7 +336,9 @@ describe('middleware - development errors', () => {
       expect(
         await browser.elementByCss('#nextjs__container_errors_desc').text()
       ).toEqual('Failed to compile')
-      await next.patchFile('middleware.js', `export default function () {}`)
+      await next.patchFile('middleware.js', `export default function () {}`, {
+        skipWaitForChanges: true,
+      })
       await assertNoRedbox(browser)
       expect(await browser.elementByCss('#page-title')).toBeTruthy()
     })
@@ -318,13 +346,17 @@ describe('middleware - development errors', () => {
 
   describe('when there is a compilation error after boot', () => {
     beforeEach(async () => {
-      await next.patchFile('middleware.js', `export default function () {}`)
+      await next.patchFile('middleware.js', `export default function () {}`, {
+        skipWaitForChanges: true,
+      })
 
       await next.start()
     })
 
     it('logs the error correctly', async () => {
-      await next.patchFile('middleware.js', `export default function () }`)
+      await next.patchFile('middleware.js', `export default function () }`, {
+        skipWaitForChanges: true,
+      })
       await next.fetch('/')
 
       await check(() => {
@@ -339,9 +371,13 @@ describe('middleware - development errors', () => {
     it('renders the error correctly and recovers', async () => {
       const browser = await next.browser('/')
       await assertNoRedbox(browser)
-      await next.patchFile('middleware.js', `export default function () }`)
+      await next.patchFile('middleware.js', `export default function () }`, {
+        skipWaitForChanges: true,
+      })
       await assertHasRedbox(browser)
-      await next.patchFile('middleware.js', `export default function () {}`)
+      await next.patchFile('middleware.js', `export default function () {}`, {
+        skipWaitForChanges: true,
+      })
       await assertNoRedbox(browser)
       expect(await browser.elementByCss('#page-title')).toBeTruthy()
     })

--- a/test/development/tsconfig-path-reloading/index.test.ts
+++ b/test/development/tsconfig-path-reloading/index.test.ts
@@ -43,7 +43,9 @@ describe('tsconfig-path-reloading', () => {
       })
 
       if (addAfterStart) {
-        await next.patchFile(tsConfigFile, tsConfigContent)
+        await next.patchFile(tsConfigFile, tsConfigContent, {
+          skipWaitForChanges: true,
+        })
       }
     })
     afterAll(() => next.destroy())
@@ -79,7 +81,8 @@ describe('tsconfig-path-reloading', () => {
           `import {secondData} from "@lib/second-data"\n${indexContent.replace(
             '</p>',
             `</p><p id="second-data">{JSON.stringify(secondData)}</p>`
-          )}`
+          )}`,
+          { skipWaitForChanges: true }
         )
 
         await assertHasRedbox(browser)
@@ -100,7 +103,8 @@ describe('tsconfig-path-reloading', () => {
             },
             null,
             2
-          )
+          ),
+          { skipWaitForChanges: true }
         )
 
         await assertNoRedbox(browser)
@@ -111,8 +115,12 @@ describe('tsconfig-path-reloading', () => {
         expect(html2).toContain('first-data')
         expect(html2).toContain('second-data')
       } finally {
-        await next.patchFile(indexPage, indexContent)
-        await next.patchFile(tsConfigFile, tsconfigContent)
+        await next.patchFile(indexPage, indexContent, {
+          skipWaitForChanges: true,
+        })
+        await next.patchFile(tsConfigFile, tsconfigContent, {
+          skipWaitForChanges: true,
+        })
         await check(async () => {
           const html3 = await browser.eval('document.documentElement.innerHTML')
           return html3.includes('id="first-data"') &&
@@ -151,11 +159,15 @@ describe('tsconfig-path-reloading', () => {
             },
             null,
             2
-          )
+          ),
+          {
+            skipWaitForChanges: true,
+          }
         )
         await next.patchFile(
           indexPage,
-          indexContent.replace('@mybutton', '@myotherbutton')
+          indexContent.replace('@mybutton', '@myotherbutton'),
+          { skipWaitForChanges: true }
         )
 
         await assertNoRedbox(browser)
@@ -169,8 +181,12 @@ describe('tsconfig-path-reloading', () => {
           return 'success'
         }, 'success')
       } finally {
-        await next.patchFile(indexPage, indexContent)
-        await next.patchFile(tsConfigFile, tsconfigContent)
+        await next.patchFile(indexPage, indexContent, {
+          skipWaitForChanges: true,
+        })
+        await next.patchFile(tsConfigFile, tsconfigContent, {
+          skipWaitForChanges: true,
+        })
         await check(async () => {
           const html3 = await browser.eval('document.documentElement.innerHTML')
           return html3.includes('first button') &&

--- a/test/e2e/app-dir/app-compilation/index.test.ts
+++ b/test/e2e/app-dir/app-compilation/index.test.ts
@@ -48,12 +48,14 @@ describe('app dir', () => {
           'app/page-with-loading/page.js',
           (content) =>
             content.replace('hello from slow page', 'hello from new page'),
-          async () =>
-            retry(async () => {
-              const headline = await browser.elementByCss('h1').text()
-              expect(headline).toBe('hello from new page')
-              await browser.close()
-            })
+          {
+            runWithTempContent: async () =>
+              retry(async () => {
+                const headline = await browser.elementByCss('h1').text()
+                expect(headline).toBe('hello from new page')
+                await browser.close()
+              }),
+          }
         )
       })
     })

--- a/test/e2e/app-dir/app-css/index.test.ts
+++ b/test/e2e/app-dir/app-css/index.test.ts
@@ -339,7 +339,8 @@ describe('app dir - css', () => {
         try {
           await next.patchFile(
             filePath,
-            origContent.replace('<h1>Hello</h1>', '<h1>Hello!</h1>')
+            origContent.replace('<h1>Hello</h1>', '<h1>Hello!</h1>'),
+            { skipWaitForChanges: true }
           )
 
           // Wait for HMR to trigger

--- a/test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts
+++ b/test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts
@@ -78,7 +78,8 @@ describe('app-fetch-deduping', () => {
             const time = await getTime()
           
             return <h1>{time}</h1>
-          }`
+          }`,
+          { skipWaitForChanges: true }
         )
 
         await next.render('/test')
@@ -104,7 +105,8 @@ describe('app-fetch-deduping', () => {
             const time = await getTime()
           
             return <h1>{time}</h1>
-          }`
+          }`,
+          { skipWaitForChanges: true }
         )
 
         await next.render('/test')

--- a/test/e2e/app-dir/app-invalid-revalidate/app-invalid-revalidate.test.ts
+++ b/test/e2e/app-dir/app-invalid-revalidate/app-invalid-revalidate.test.ts
@@ -19,8 +19,12 @@ describe('app-invalid-revalidate', () => {
     try {
       await next.patchFile(
         'app/layout.tsx',
-        origText.replace('// export', 'export')
+        origText.replace('// export', 'export'),
+        {
+          skipWaitForChanges: true,
+        }
       )
+
       await next.start().catch(() => {})
 
       await check(async () => {
@@ -30,7 +34,9 @@ describe('app-invalid-revalidate', () => {
         return next.cliOutput
       }, /Invalid revalidate value "1" on "\/", must be a non-negative number or false/)
     } finally {
-      await next.patchFile('app/layout.tsx', origText)
+      await next.patchFile('app/layout.tsx', origText, {
+        skipWaitForChanges: true,
+      })
     }
   })
 
@@ -41,7 +47,8 @@ describe('app-invalid-revalidate', () => {
     try {
       await next.patchFile(
         'app/page.tsx',
-        origText.replace('// export', 'export')
+        origText.replace('// export', 'export'),
+        { skipWaitForChanges: true }
       )
       await next.start().catch(() => {})
 
@@ -52,7 +59,9 @@ describe('app-invalid-revalidate', () => {
         return next.cliOutput
       }, /Invalid revalidate value "1" on "\/", must be a non-negative number or false/)
     } finally {
-      await next.patchFile('app/page.tsx', origText)
+      await next.patchFile('app/page.tsx', origText, {
+        skipWaitForChanges: true,
+      })
     }
   })
 
@@ -63,7 +72,8 @@ describe('app-invalid-revalidate', () => {
     try {
       await next.patchFile(
         'app/page.tsx',
-        origText.replace('// await', 'await')
+        origText.replace('// await', 'await'),
+        { skipWaitForChanges: true }
       )
       await next.start().catch(() => {})
 
@@ -74,7 +84,9 @@ describe('app-invalid-revalidate', () => {
         return next.cliOutput
       }, /Invalid revalidate value "1" on "\/", must be a non-negative number or false/)
     } finally {
-      await next.patchFile('app/page.tsx', origText)
+      await next.patchFile('app/page.tsx', origText, {
+        skipWaitForChanges: true,
+      })
     }
   })
 
@@ -85,7 +97,8 @@ describe('app-invalid-revalidate', () => {
     try {
       await next.patchFile(
         'app/page.tsx',
-        origText.replace('// await unstable', 'await unstable')
+        origText.replace('// await unstable', 'await unstable'),
+        { skipWaitForChanges: true }
       )
       await next.start().catch(() => {})
 
@@ -96,7 +109,9 @@ describe('app-invalid-revalidate', () => {
         return next.cliOutput
       }, /Invalid revalidate value "1" on "unstable_cache/)
     } finally {
-      await next.patchFile('app/page.tsx', origText)
+      await next.patchFile('app/page.tsx', origText, {
+        skipWaitForChanges: true,
+      })
     }
   })
 })

--- a/test/e2e/app-dir/dynamic/dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic/dynamic.test.ts
@@ -69,7 +69,10 @@ describe('app dir - next/dynamic', () => {
       const page = await next.readFile(pagePath)
       await next.patchFile(
         pagePath,
-        page.replace('const isDevTest = false', 'const isDevTest = true')
+        page.replace('const isDevTest = false', 'const isDevTest = true'),
+        {
+          skipWaitForChanges: true,
+        }
       )
       await retry(async () => {
         const { status } = await next.fetch('/default-loading')

--- a/test/e2e/app-dir/error-on-next-codemod-comment/error-on-next-codemod-comment.test.ts
+++ b/test/e2e/app-dir/error-on-next-codemod-comment/error-on-next-codemod-comment.test.ts
@@ -57,20 +57,26 @@ describe('app-dir - error-on-next-codemod-comment', () => {
 
     it('should error with inline comment as well', async () => {
       let originFileContent
-      await next.patchFile('app/page.tsx', (code) => {
-        originFileContent = code
-        return code.replace(
-          '// @next-codemod-error remove jsx of next line',
-          '/* @next-codemod-error remove jsx of next line */'
-        )
-      })
+      await next.patchFile(
+        'app/page.tsx',
+        (code) => {
+          originFileContent = code
+          return code.replace(
+            '// @next-codemod-error remove jsx of next line',
+            '/* @next-codemod-error remove jsx of next line */'
+          )
+        },
+        { skipWaitForChanges: true }
+      )
 
       const browser = await next.browser('/')
 
       await assertHasRedbox(browser)
 
       // Recover the original file content
-      await next.patchFile('app/page.tsx', originFileContent)
+      await next.patchFile('app/page.tsx', originFileContent, {
+        skipWaitForChanges: true,
+      })
     })
 
     it('should disappear the error when you rre the codemod comment', async () => {
@@ -79,20 +85,26 @@ describe('app-dir - error-on-next-codemod-comment', () => {
       await assertHasRedbox(browser)
 
       let originFileContent
-      await next.patchFile('app/page.tsx', (code) => {
-        originFileContent = code
-        return code.replace(
-          '// @next-codemod-error remove jsx of next line',
-          ''
-        )
-      })
+      await next.patchFile(
+        'app/page.tsx',
+        (code) => {
+          originFileContent = code
+          return code.replace(
+            '// @next-codemod-error remove jsx of next line',
+            ''
+          )
+        },
+        { skipWaitForChanges: true }
+      )
 
       await retry(async () => {
         await assertNoRedbox(browser)
       })
 
       // Recover the original file content
-      await next.patchFile('app/page.tsx', originFileContent)
+      await next.patchFile('app/page.tsx', originFileContent, {
+        skipWaitForChanges: true,
+      })
     })
 
     it('should disappear the error when you replace with bypass comment', async () => {
@@ -101,17 +113,23 @@ describe('app-dir - error-on-next-codemod-comment', () => {
       await assertHasRedbox(browser)
 
       let originFileContent
-      await next.patchFile('app/page.tsx', (code) => {
-        originFileContent = code
-        return code.replace('@next-codemod-error', '@next-codemod-bypass')
-      })
+      await next.patchFile(
+        'app/page.tsx',
+        (code) => {
+          originFileContent = code
+          return code.replace('@next-codemod-error', '@next-codemod-bypass')
+        },
+        { skipWaitForChanges: true }
+      )
 
       await retry(async () => {
         await assertNoRedbox(browser)
       })
 
       // Recover the original file content
-      await next.patchFile('app/page.tsx', originFileContent)
+      await next.patchFile('app/page.tsx', originFileContent, {
+        skipWaitForChanges: true,
+      })
     })
   } else {
     it('should fail the build with next build', async () => {

--- a/test/e2e/app-dir/logging/fetch-logging.test.ts
+++ b/test/e2e/app-dir/logging/fetch-logging.test.ts
@@ -235,15 +235,18 @@ describe('app-dir - logging', () => {
           await next.patchFile(
             'app/fetch-no-store/page.js',
             (content) => content.replace('Hello World!', 'Hello Test!'),
-            async () =>
-              retry(async () => {
-                headline = await browser.waitForElementByCss('h1').text()
-                expect(headline).toBe('Hello Test!')
-                const logs = stripAnsi(next.cliOutput.slice(outputIndex))
-                expect(logs).toInclude(' GET /fetch-no-store')
-                expect(logs).not.toInclude(` │ GET `)
-                // TODO: remove custom duration in case we increase the default.
-              }, 5000)
+            {
+              runWithTempContent: async () => {
+                await retry(async () => {
+                  headline = await browser.waitForElementByCss('h1').text()
+                  expect(headline).toBe('Hello Test!')
+                  const logs = stripAnsi(next.cliOutput.slice(outputIndex))
+                  expect(logs).toInclude(' GET /fetch-no-store')
+                  expect(logs).not.toInclude(` │ GET `)
+                  // TODO: remove custom duration in case we increase the default.
+                }, 5000)
+              },
+            }
           )
         })
 
@@ -269,25 +272,27 @@ describe('app-dir - logging', () => {
             await next.patchFile(
               'app/fetch-no-store/page.js',
               (content) => content.replace('Hello World!', 'Hello Test!'),
-              async () => {
-                const expectedUrl = withFullUrlFetches
-                  ? 'https://next-data-api-endpoint.vercel.app/api/random'
-                  : 'https://next-data-api-en../api/random'
+              {
+                runWithTempContent: async () => {
+                  const expectedUrl = withFullUrlFetches
+                    ? 'https://next-data-api-endpoint.vercel.app/api/random'
+                    : 'https://next-data-api-en../api/random'
 
-                return retry(async () => {
-                  headline = await browser.waitForElementByCss('h1').text()
-                  expect(headline).toBe('Hello Test!')
+                  return retry(async () => {
+                    headline = await browser.waitForElementByCss('h1').text()
+                    expect(headline).toBe('Hello Test!')
 
-                  const logs = stripAnsi(
-                    next.cliOutput.slice(outputIndex)
-                  ).replace(/\d+ms/g, '1ms')
+                    const logs = stripAnsi(
+                      next.cliOutput.slice(outputIndex)
+                    ).replace(/\d+ms/g, '1ms')
 
-                  expect(logs).toInclude(' GET /fetch-no-store')
-                  expect(logs).toInclude(
-                    ` │ GET ${expectedUrl}?request-input 200 in 1ms (HMR cache)`
-                  )
-                  // TODO: remove custom duration in case we increase the default.
-                }, 5000)
+                    expect(logs).toInclude(' GET /fetch-no-store')
+                    expect(logs).toInclude(
+                      ` │ GET ${expectedUrl}?request-input 200 in 1ms (HMR cache)`
+                    )
+                    // TODO: remove custom duration in case we increase the default.
+                  }, 5000)
+                },
               }
             )
           })

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -656,7 +656,8 @@ describe('app dir - rsc basics', () => {
         fileContent.replace(
           `import { renderToStaticMarkup } from 'react-dom/server'`,
           `import { renderToStaticMarkup } from 'react-dom/server.browser'`
-        )
+        ),
+        { skipWaitForChanges: true }
       )
 
       const browser = await next.browser('/app-react')
@@ -667,7 +668,7 @@ describe('app dir - rsc basics', () => {
         '<div class="react-static-markup">React Static Markup</div>'
       )
 
-      await next.patchFile(filePath, fileContent)
+      await next.patchFile(filePath, fileContent, { skipWaitForChanges: true })
     }
   })
 
@@ -724,44 +725,47 @@ describe('app dir - rsc basics', () => {
             }
           }
           `,
-          async () => {
-            await next.start()
-            const resPages$ = await next.render$('/app-react')
-            const [
-              ssrReact,
-              ssrReactDOM,
-              ssrClientReact,
-              ssrClientReactDOM,
-              ssrClientReactDOMServer,
-            ] = [
-              resPages$('#react').text(),
-              resPages$('#react-dom').text(),
-              resPages$('#client-react').text(),
-              resPages$('#client-react-dom').text(),
-              resPages$('#client-react-dom-server').text(),
-            ]
-            expect({
-              ssrReact,
-              ssrReactDOM,
-              ssrClientReact,
-              ssrClientReactDOM,
-              ssrClientReactDOMServer,
-            }).toEqual({
-              ssrReact: expect.stringMatching('-experimental-'),
-              ssrReactDOM: expect.stringMatching('-experimental-'),
-              ssrClientReact: expect.stringMatching('-experimental-'),
-              ssrClientReactDOM: expect.stringMatching('-experimental-'),
-              ssrClientReactDOMServer: expect.stringMatching('-experimental-'),
-            })
+          {
+            skipWaitForChanges: true,
+            runWithTempContent: async () => {
+              await next.start()
+              const resPages$ = await next.render$('/app-react')
+              const [
+                ssrReact,
+                ssrReactDOM,
+                ssrClientReact,
+                ssrClientReactDOM,
+                ssrClientReactDOMServer,
+              ] = [
+                resPages$('#react').text(),
+                resPages$('#react-dom').text(),
+                resPages$('#client-react').text(),
+                resPages$('#client-react-dom').text(),
+                resPages$('#client-react-dom-server').text(),
+              ]
+              expect({
+                ssrReact,
+                ssrReactDOM,
+                ssrClientReact,
+                ssrClientReactDOM,
+                ssrClientReactDOMServer,
+              }).toEqual({
+                ssrReact: expect.stringMatching('-experimental-'),
+                ssrReactDOM: expect.stringMatching('-experimental-'),
+                ssrClientReact: expect.stringMatching('-experimental-'),
+                ssrClientReactDOM: expect.stringMatching('-experimental-'),
+                ssrClientReactDOMServer:
+                  expect.stringMatching('-experimental-'),
+              })
 
-            const browser = await next.browser('/app-react')
-            const [
-              browserReact,
-              browserReactDOM,
-              browserClientReact,
-              browserClientReactDOM,
-              browserClientReactDOMServer,
-            ] = await browser.eval(`
+              const browser = await next.browser('/app-react')
+              const [
+                browserReact,
+                browserReactDOM,
+                browserClientReact,
+                browserClientReactDOM,
+                browserClientReactDOMServer,
+              ] = await browser.eval(`
               [
                 document.querySelector('#react').innerText,
                 document.querySelector('#react-dom').innerText,
@@ -770,20 +774,21 @@ describe('app dir - rsc basics', () => {
                 document.querySelector('#client-react-dom-server').innerText,
               ]
             `)
-            expect({
-              browserReact,
-              browserReactDOM,
-              browserClientReact,
-              browserClientReactDOM,
-              browserClientReactDOMServer,
-            }).toEqual({
-              browserReact: expect.stringMatching('-experimental-'),
-              browserReactDOM: expect.stringMatching('-experimental-'),
-              browserClientReact: expect.stringMatching('-experimental-'),
-              browserClientReactDOM: expect.stringMatching('-experimental-'),
-              browserClientReactDOMServer:
-                expect.stringMatching('-experimental-'),
-            })
+              expect({
+                browserReact,
+                browserReactDOM,
+                browserClientReact,
+                browserClientReactDOM,
+                browserClientReactDOMServer,
+              }).toEqual({
+                browserReact: expect.stringMatching('-experimental-'),
+                browserReactDOM: expect.stringMatching('-experimental-'),
+                browserClientReact: expect.stringMatching('-experimental-'),
+                browserClientReactDOM: expect.stringMatching('-experimental-'),
+                browserClientReactDOMServer:
+                  expect.stringMatching('-experimental-'),
+              })
+            },
           }
         )
       }

--- a/test/e2e/app-dir/scss/unused/unused.test.ts
+++ b/test/e2e/app-dir/scss/unused/unused.test.ts
@@ -40,9 +40,13 @@ describe.each([
 
     ;(isNextDev ? describe : describe.skip)('development only', () => {
       it('should have body visible', async () => {
-        await next.patchFile('pages/index.js', (contents) => {
-          return contents.replace('<div />', '<div>')
-        })
+        await next.patchFile(
+          'pages/index.js',
+          (contents) => {
+            return contents.replace('<div />', '<div>')
+          },
+          { skipWaitForChanges: true }
+        )
 
         const browser = await next.browser('/')
         const currentDisplay = await browser.eval(

--- a/test/e2e/type-module-interop/index.test.ts
+++ b/test/e2e/type-module-interop/index.test.ts
@@ -77,7 +77,10 @@ describe('Type module interop', () => {
         JSON.stringify({
           ...pkg,
           type: 'module',
-        })
+        }),
+        {
+          skipWaitForChanges: true,
+        }
       )
     }
   })

--- a/test/lib/development-sandbox.ts
+++ b/test/lib/development-sandbox.ts
@@ -14,8 +14,8 @@ import {
   getRedboxErrorLink,
 } from './next-test-utils'
 import webdriver, { WebdriverOptions } from './next-webdriver'
-import { NextInstance } from './next-modes/base'
 import { BrowserInterface } from './browsers/base'
+import { NextInstance } from './next-modes/base'
 
 export function waitForHydration(browser: BrowserInterface): Promise<void> {
   return browser.evalAsync(function () {
@@ -52,11 +52,18 @@ export async function sandbox(
   return {
     browser,
     session: {
-      async write(filename, content) {
-        // Update the file on filesystem
-        await next.patchFile(filename, content)
+      async write(
+        filename,
+        content,
+        config?: { skipWaitForChanges?: boolean }
+      ) {
+        await next.patchFile(filename, content, config)
       },
-      async patch(filename, content) {
+      async patch(
+        filename,
+        content,
+        config?: { skipWaitForChanges?: boolean }
+      ) {
         // Register an event for HMR completion
         await browser.eval(function () {
           ;(window as any).__HMR_STATE = 'pending'
@@ -70,7 +77,7 @@ export async function sandbox(
           }
         })
 
-        await this.write(filename, content)
+        await this.write(filename, content, config)
 
         for (;;) {
           const status = await browser.eval(() => (window as any).__HMR_STATE)

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -74,7 +74,7 @@ export class NextInstance {
   public forcedPort?: string
   public dirSuffix: string = ''
   public serverReadyPattern?: RegExp = / ✓ Ready in /
-  public serverCompiledPattern?: RegExp = / ✓ Compiled /
+  public serverCompiledPattern?: RegExp = /✓|⨯|Reload env/
 
   constructor(opts: NextInstanceOpts) {
     this.env = {}
@@ -501,7 +501,10 @@ export class NextInstance {
   public async patchFile(
     filename: string,
     content: string | ((content: string) => string),
-    runWithTempContent?: (context: { newFile: boolean }) => Promise<void>
+    config?: {
+      runWithTempContent?: (context: { newFile: boolean }) => Promise<void>
+      skipWaitForChanges?: boolean
+    }
   ): Promise<{ newFile: boolean }> {
     const outputPath = path.join(this.testDir, filename)
     const newFile = !existsSync(outputPath)
@@ -513,6 +516,7 @@ export class NextInstance {
       typeof content === 'function' ? content(previousContent) : content
     )
 
+    const runWithTempContent = config?.runWithTempContent
     if (runWithTempContent) {
       try {
         await runWithTempContent({ newFile })


### PR DESCRIPTION

- By default, tests await dev server to respond with special symbols like `✓`, `⨯`, `Reload env` after a file is patched. This allows us to minimize test duration and flakiness.
- However, in some scenarios, a file patch does not yield the server to respond. In which case, it requires an explicit opt-out for the await check, i.e., set `skipWaitForChanges` to true.
- Since `patchFile` had a third optional param, adding a fourth one could make the syntax cumbersome, so refactored the last 2 params into a config object.
- Note that the explicitness of `skipWaitForChanges` has additional benefits: (1) when a test fails, we can locate whether `patchFile` could be causing flakiness. (2) `skipWaitForChanges` exposed flaws of CLI experience -- some tests patched a broken file, but the CLI did not output an error message