### PR TITLE
examples: `check-examples.sh` considers `src/app` as Pages Router

### DIFF
--- a/examples/api-routes/.gitignore
+++ b/examples/api-routes/.gitignore
@@ -1,0 +1,40 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# env files (can opt-in for commiting if needed)
+.env*
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/blog-starter/next-env.d.ts
+++ b/examples/blog-starter/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/examples/cms-wordpress/next-env.d.ts
+++ b/examples/cms-wordpress/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/examples/with-zustand/next-env.d.ts
+++ b/examples/with-zustand/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -8,7 +8,7 @@ for folder in examples/* ; do
     ' | sponge $folder/package.json
   fi
   if [ -f "$folder/tsconfig.json" ]; then
-    if [ -d "$folder/app" ]; then
+    if [ -d "$folder/app" ] || [ -d "$folder/src/app" ]; then
       cp packages/create-next-app/templates/app/ts/next-env.d.ts $folder/next-env.d.ts
     else
       cp packages/create-next-app/templates/default/ts/next-env.d.ts $folder/next-env.d.ts


### PR DESCRIPTION
### Why?

When running `check-examples.sh`, it maps `next-env.d.ts` and `.gitignore` from the CNA templates. Previously, it was looking for `examples/*/app` only, therefore when the app had `src/app`, it was considered as Pages Router.