### PR TITLE
Show readable hook names in stack frames

### DIFF
--- a/crates/next-core/src/next_client/transforms.rs
+++ b/crates/next-core/src/next_client/transforms.rs
@@ -8,10 +8,10 @@ use crate::{
     next_client::context::ClientContextType,
     next_config::NextConfig,
     next_shared::transforms::{
-        get_next_dynamic_transform_rule, get_next_font_transform_rule, get_next_image_rule,
-        get_next_lint_transform_rule, get_next_modularize_imports_rule,
-        get_next_pages_transforms_rule, get_server_actions_transform_rule,
-        next_amp_attributes::get_next_amp_attr_rule,
+        debug_fn_name::get_debug_fn_name_rule, get_next_dynamic_transform_rule,
+        get_next_font_transform_rule, get_next_image_rule, get_next_lint_transform_rule,
+        get_next_modularize_imports_rule, get_next_pages_transforms_rule,
+        get_server_actions_transform_rule, next_amp_attributes::get_next_amp_attr_rule,
         next_cjs_optimizer::get_next_cjs_optimizer_rule,
         next_disallow_re_export_all_in_page::get_next_disallow_export_all_in_page_rule,
         next_page_config::get_next_page_config_rule,
@@ -42,6 +42,10 @@ pub async fn get_next_client_transforms_rules(
     }
 
     rules.push(get_next_font_transform_rule(enable_mdx_rs));
+
+    if mode.await?.is_development() {
+        rules.push(get_debug_fn_name_rule(enable_mdx_rs));
+    }
 
     let mut is_app_dir = false;
 

--- a/crates/next-core/src/next_shared/transforms/debug_fn_name.rs
+++ b/crates/next-core/src/next_shared/transforms/debug_fn_name.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use next_custom_transforms::transforms::debug_fn_name::debug_fn_name;
+use swc_core::ecma::{ast::Program, visit::VisitMutWith};
+use turbo_tasks::Vc;
+use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
+use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
+
+use super::module_rule_match_js_no_url;
+
+pub fn get_debug_fn_name_rule(enable_mdx_rs: bool) -> ModuleRule {
+    let debug_fn_name_transform =
+        EcmascriptInputTransform::Plugin(Vc::cell(Box::new(DebugFnNameTransformer {}) as _));
+
+    ModuleRule::new(
+        module_rule_match_js_no_url(enable_mdx_rs),
+        vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
+            prepend: Vc::cell(vec![]),
+            append: Vc::cell(vec![debug_fn_name_transform]),
+        }],
+    )
+}
+
+#[derive(Debug)]
+struct DebugFnNameTransformer {}
+
+#[async_trait]
+impl CustomTransformer for DebugFnNameTransformer {
+    #[tracing::instrument(level = tracing::Level::TRACE, name = "debug_fn_name", skip_all)]
+    async fn transform(&self, program: &mut Program, _ctx: &TransformContext<'_>) -> Result<()> {
+        program.visit_mut_with(&mut debug_fn_name());
+        Ok(())
+    }
+}

--- a/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/crates/next-core/src/next_shared/transforms/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod debug_fn_name;
 pub(crate) mod emotion;
 pub(crate) mod modularize_imports;
 pub(crate) mod next_amp_attributes;

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -219,6 +219,7 @@ function getBaseSWCOptions({
     // On server side of pages router we prefer CJS.
     preferEsm: esm,
     lintCodemodComments: true,
+    debugFunctionName: development,
   }
 }
 

--- a/test/development/acceptance-app/error-recovery.test.ts
+++ b/test/development/acceptance-app/error-recovery.test.ts
@@ -141,7 +141,7 @@ describe.each(['default', 'turbo'])('Error recovery app %s', () => {
     await session.waitForAndOpenRuntimeError()
 
     expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
-      "index.js (7:11) @ eval
+      "index.js (7:11) @ Index.useCallback[increment]
 
          5 |   const increment = useCallback(() => {
          6 |     setCount(c => c + 1)

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -107,7 +107,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     await session.assertHasRedbox()
     if (isTurbopack) {
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
-        "index.js (7:11) @ <unknown>
+        "index.js (7:11) @ Index.useCallback[increment]
 
            5 |   const increment = useCallback(() => {
            6 |     setCount(c => c + 1)

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -119,7 +119,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
       `)
     } else {
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
-        "index.js (7:11) @ eval
+        "index.js (7:11) @ Index.useCallback[increment]
 
            5 |   const increment = useCallback(() => {
            6 |     setCount(c => c + 1)

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -127,7 +127,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
             <AppContainer>
               <Container fn={function fn}>
                 <ReactDevOverlay>
-                  <ErrorBoundary globalOverlay={undefined} isMounted={false} onError={function}>
+                  <ErrorBoundary globalOverlay={undefined} isMounted={false} ...>
                     <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                       <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                         <Mismatch>
@@ -222,7 +222,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
             <AppContainer>
               <Container fn={function fn}>
                 <ReactDevOverlay>
-                  <ErrorBoundary globalOverlay={undefined} isMounted={false} onError={function}>
+                  <ErrorBoundary globalOverlay={undefined} isMounted={false} ...>
                     <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                       <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                         <Mismatch>
@@ -312,7 +312,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
             <AppContainer>
               <Container fn={function fn}>
                 <ReactDevOverlay>
-                  <ErrorBoundary globalOverlay={undefined} isMounted={false} onError={function}>
+                  <ErrorBoundary globalOverlay={undefined} isMounted={false} ...>
                     <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                       <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                         <Mismatch>
@@ -388,7 +388,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
             <AppContainer>
               <Container fn={function fn}>
                 <ReactDevOverlay>
-                  <ErrorBoundary globalOverlay={undefined} isMounted={false} onError={function}>
+                  <ErrorBoundary globalOverlay={undefined} isMounted={false} ...>
                     <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                       <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                         <Mismatch>
@@ -474,7 +474,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
             <AppContainer>
               <Container fn={function fn}>
                 <ReactDevOverlay>
-                  <ErrorBoundary globalOverlay={undefined} isMounted={false} onError={function}>
+                  <ErrorBoundary globalOverlay={undefined} isMounted={false} ...>
                     <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                       <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                         <Mismatch>
@@ -561,7 +561,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
             <AppContainer>
               <Container fn={function fn}>
                 <ReactDevOverlay>
-                  <ErrorBoundary globalOverlay={undefined} isMounted={false} onError={function}>
+                  <ErrorBoundary globalOverlay={undefined} isMounted={false} ...>
                     <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                       <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                         <Page>

--- a/test/development/app-dir/hook-function-names/app/button/page.tsx
+++ b/test/development/app-dir/hook-function-names/app/button/page.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { useCallback } from 'react'
+
+const Button = ({ message }: { message: string }) => {
+  const handleClick = useCallback(() => {
+    throw new Error(message)
+  }, [message])
+
+  return (
+    <button type="button" onClick={handleClick}>
+      Click me
+    </button>
+  )
+}
+
+export default function Page() {
+  return <Button message="Kaputt!" />
+}

--- a/test/development/app-dir/hook-function-names/app/layout.tsx
+++ b/test/development/app-dir/hook-function-names/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/hook-function-names/app/page.tsx
+++ b/test/development/app-dir/hook-function-names/app/page.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export default function Page() {
+  useEffect(() => {
+    throw new Error('error in useEffect')
+  }, [])
+
+  return <p>Hello world!</p>
+}

--- a/test/development/app-dir/hook-function-names/hook-function-names.test.ts
+++ b/test/development/app-dir/hook-function-names/hook-function-names.test.ts
@@ -1,0 +1,50 @@
+import { nextTestSetup } from 'e2e-utils'
+import {
+  assertHasRedbox,
+  getRedboxSource,
+  waitForAndOpenRuntimeError,
+} from 'next-test-utils'
+
+describe('hook-function-names', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should show readable hook names in stacks', async () => {
+    const browser = await next.browser('/button')
+
+    await browser.elementByCss('button').click()
+
+    await waitForAndOpenRuntimeError(browser)
+
+    expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
+      "app/button/page.tsx (7:11) @ eval
+
+         5 | const Button = ({ message }: { message: string }) => {
+         6 |   const handleClick = useCallback(() => {
+      >  7 |     throw new Error(message)
+           |           ^
+         8 |   }, [message])
+         9 |
+        10 |   return ("
+    `)
+  })
+
+  it('should show readable hook names in stacks for default-exported components', async () => {
+    const browser = await next.browser('/')
+
+    await assertHasRedbox(browser)
+
+    expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
+      "app/page.tsx (7:11) @ eval
+
+         5 | export default function Page() {
+         6 |   useEffect(() => {
+      >  7 |     throw new Error('error in useEffect')
+           |           ^
+         8 |   }, [])
+         9 |
+        10 |   return <p>Hello world!</p>"
+    `)
+  })
+})

--- a/test/development/app-dir/hook-function-names/hook-function-names.test.ts
+++ b/test/development/app-dir/hook-function-names/hook-function-names.test.ts
@@ -18,7 +18,7 @@ describe('hook-function-names', () => {
     await waitForAndOpenRuntimeError(browser)
 
     expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-      "app/button/page.tsx (7:11) @ eval
+      "app/button/page.tsx (7:11) @ Button.useCallback[handleClick]
 
          5 | const Button = ({ message }: { message: string }) => {
          6 |   const handleClick = useCallback(() => {
@@ -36,7 +36,7 @@ describe('hook-function-names', () => {
     await assertHasRedbox(browser)
 
     expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-      "app/page.tsx (7:11) @ eval
+      "app/page.tsx (7:11) @ Page.useEffect
 
          5 | export default function Page() {
          6 |   useEffect(() => {

--- a/test/development/app-dir/hook-function-names/hook-function-names.test.ts
+++ b/test/development/app-dir/hook-function-names/hook-function-names.test.ts
@@ -6,7 +6,7 @@ import {
 } from 'next-test-utils'
 
 describe('hook-function-names', () => {
-  const { next } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
   })
 
@@ -17,17 +17,31 @@ describe('hook-function-names', () => {
 
     await waitForAndOpenRuntimeError(browser)
 
-    expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-      "app/button/page.tsx (7:11) @ Button.useCallback[handleClick]
+    if (isTurbopack) {
+      expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
+        "app/button/page.tsx (7:11) @ Button.useCallback[handleClick]
 
-         5 | const Button = ({ message }: { message: string }) => {
-         6 |   const handleClick = useCallback(() => {
-      >  7 |     throw new Error(message)
-           |           ^
-         8 |   }, [message])
-         9 |
-        10 |   return ("
-    `)
+           5 | const Button = ({ message }: { message: string }) => {
+           6 |   const handleClick = useCallback(() => {
+        >  7 |     throw new Error(message)
+             |           ^
+           8 |   }, [message])
+           9 |
+          10 |   return ("
+      `)
+    } else {
+      expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
+            "app/button/page.tsx (7:11) @ Button.useCallback[handleClick]
+
+               5 | const Button = ({ message }: { message: string }) => {
+               6 |   const handleClick = useCallback(() => {
+            >  7 |     throw new Error(message)
+                 |           ^
+               8 |   }, [message])
+               9 |
+              10 |   return ("
+        `)
+    }
   })
 
   it('should show readable hook names in stacks for default-exported components', async () => {
@@ -35,16 +49,30 @@ describe('hook-function-names', () => {
 
     await assertHasRedbox(browser)
 
-    expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-      "app/page.tsx (7:11) @ Page.useEffect
+    if (isTurbopack) {
+      expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
+        "app/page.tsx (7:11) @ Page.useEffect
 
-         5 | export default function Page() {
-         6 |   useEffect(() => {
-      >  7 |     throw new Error('error in useEffect')
-           |           ^
-         8 |   }, [])
-         9 |
-        10 |   return <p>Hello world!</p>"
-    `)
+           5 | export default function Page() {
+           6 |   useEffect(() => {
+        >  7 |     throw new Error('error in useEffect')
+             |           ^
+           8 |   }, [])
+           9 |
+          10 |   return <p>Hello world!</p>"
+      `)
+    } else {
+      expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
+              "app/page.tsx (7:11) @ Page.useEffect
+
+                 5 | export default function Page() {
+                 6 |   useEffect(() => {
+              >  7 |     throw new Error('error in useEffect')
+                   |           ^
+                 8 |   }, [])
+                 9 |
+                10 |   return <p>Hello world!</p>"
+          `)
+    }
   })
 })

--- a/test/development/app-dir/hook-function-names/next.config.js
+++ b/test/development/app-dir/hook-function-names/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/integration/config-devtool-dev/test/index.test.js
+++ b/test/integration/config-devtool-dev/test/index.test.js
@@ -38,7 +38,7 @@ const appDir = join(__dirname, '../')
         // TODO: add win32 snapshot
       } else {
         expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-          "pages/index.js (5:11) @ eval
+          "pages/index.js (5:11) @ Index.useEffect
 
             3 | export default function Index(props) {
             4 |   useEffect(() => {


### PR DESCRIPTION
With this PR, we are enabling the SWC config `debugFunctionName` (introduced in #68056) to show readable React hook names in stack frames for errors and warnings in dev mode.

For example, for the following component:

```tsx
'use client'

import { useEffect } from 'react'

export default function Page() {
  useEffect(() => {
    throw new Error('Kaputt!')
  }, [])

  return <p>Hello world!</p>
}
```

We were showing this stack (abbreviated) before:

```
Error: Kaputt!
     at eval (page.tsx:7:11)
```

And now, we're showing this:

```
Error: Kaputt!
     at Page.useEffect (page.tsx:7:11)
```