### PR TITLE
[Per-Segment Prefetch] Add Route Tree prefetch

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2763,6 +2763,7 @@ async function prerenderToStream(
         metadata.segmentFlightData = await collectSegmentData(
           finalAttemptRSCPayload,
           flightData,
+          finalRenderPrerenderStore,
           ComponentMod,
           renderOpts
         )
@@ -3229,6 +3230,7 @@ async function prerenderToStream(
         metadata.segmentFlightData = await collectSegmentData(
           finalServerPayload,
           flightData,
+          finalClientPrerenderStore,
           ComponentMod,
           renderOpts
         )
@@ -3361,6 +3363,7 @@ async function prerenderToStream(
         metadata.segmentFlightData = await collectSegmentData(
           RSCPayload,
           flightData,
+          ssrPrerenderStore,
           ComponentMod,
           renderOpts
         )
@@ -3553,6 +3556,7 @@ async function prerenderToStream(
         metadata.segmentFlightData = await collectSegmentData(
           RSCPayload,
           flightData,
+          prerenderLegacyStore,
           ComponentMod,
           renderOpts
         )
@@ -3714,6 +3718,7 @@ async function prerenderToStream(
         metadata.segmentFlightData = await collectSegmentData(
           errorRSCPayload,
           flightData,
+          prerenderLegacyStore,
           ComponentMod,
           renderOpts
         )
@@ -3847,6 +3852,7 @@ const getGlobalErrorStyles = async (
 async function collectSegmentData(
   rscPayload: InitialRSCPayload,
   fullPageDataBuffer: Buffer,
+  prerenderStore: PrerenderStore,
   ComponentMod: AppPageModule,
   renderOpts: RenderOpts
 ): Promise<Map<string, Buffer> | undefined> {
@@ -3896,9 +3902,11 @@ async function collectSegmentData(
     serverModuleMap: null,
   }
 
+  const staleTime = prerenderStore.stale
   return await ComponentMod.collectSegmentData(
     routeTree,
     fullPageDataBuffer,
+    staleTime,
     clientReferenceManifest.clientModules as ManifestNode,
     serverConsumerManifest
   )

--- a/test/e2e/app-dir/ppr-navigations/simple/per-segment-prefetching.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/simple/per-segment-prefetching.test.ts
@@ -14,6 +14,21 @@ describe('per segment prefetching', () => {
   // these types of requests. This tests that the server responds correctly.
   // TODO: Replace with e2e tests once more is implemented.
 
+  it('prefetch a route tree', async () => {
+    const response = await next.fetch('/en', {
+      headers: {
+        RSC: '1',
+        'Next-Router-Prefetch': '1',
+        'Next-Router-Segment-Prefetch': '/_tree',
+      },
+    })
+    expect(response.status).toBe(200)
+    const responseText = await response.text()
+    // This is a basic check to ensure that the name of an expected field is
+    // somewhere in the Flight stream.
+    expect(responseText).toInclude('"staleTime"')
+  })
+
   it('prefetch an individual segment', async () => {
     const response = await next.fetch('/en', {
       headers: {


### PR DESCRIPTION
In the new design for prefetching, instead of prefetching all the data for a page in a single request, the client issues a separate request for each segment. The benefit of using separate requests is that the responses can be separately cached. For example, when prefetching multiple pages that share the same layout, the layout data only needs to be fetched once. Simlarly, when revalidating a tag, only segments that access that tag need to be refetched.

The client needs to know about the structure of the route tree in order to determine which segments can be reused. So, before it prefetches any actual segment data for a page, it will first fetch information about the route tree. The route tree contains the necessary data for sending and caching prefetch requests.

This PR updates the server to respond to route tree prefetches. To prefetch the route tree, the client sets the
`Next-Router-Segment-Prefetch` to `/_tree`.