### PR TITLE
bugfix: revalidate + force-cache should work

### DIFF
--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -298,31 +298,54 @@ export function createPatchedFetcher(
           typeof currentFetchCacheConfig === 'string' &&
           typeof currentFetchRevalidate !== 'undefined'
         ) {
-          // when providing fetch with a Request input, it'll automatically set a cache value of 'default'
-          // we only want to warn if the user is explicitly setting a cache value
-          if (!(isRequestInput && currentFetchCacheConfig === 'default')) {
+          // If the revalidate value conflicts with the cache value, we should warn the user and unset the conflicting values.
+          const isConflictingRevalidate =
+            // revalidate: 0 and cache: force-cache
+            (currentFetchCacheConfig === 'force-cache' &&
+              currentFetchRevalidate === 0) ||
+            // revalidate: >0 or revalidate: false and cache: no-store
+            (currentFetchCacheConfig === 'no-store' &&
+              (currentFetchRevalidate > 0 || currentFetchRevalidate === false))
+
+          if (isConflictingRevalidate) {
             cacheWarning = `Specified "cache: ${currentFetchCacheConfig}" and "revalidate: ${currentFetchRevalidate}", only one should be specified.`
+            currentFetchCacheConfig = undefined
+            currentFetchRevalidate = undefined
           }
-          currentFetchCacheConfig = undefined
         }
 
-        if (currentFetchCacheConfig === 'force-cache') {
+        const hasExplicitFetchCacheOptOut =
+          // fetch config itself signals not to cache
+          currentFetchCacheConfig === 'no-cache' ||
+          currentFetchCacheConfig === 'no-store' ||
+          // the fetch isn't explicitly caching and the segment level cache config signals not to cache
+          // note: `pageFetchCacheMode` is also set by being in an unstable_cache context.
+          pageFetchCacheMode === 'force-no-store' ||
+          pageFetchCacheMode === 'only-no-store'
+
+        // If no explicit fetch cache mode is set, but dynamic = `force-dynamic` is set,
+        // we shouldn't consider caching the fetch. This is because the `dynamic` cache
+        // is considered a "top-level" cache mode, whereas something like `fetchCache` is more
+        // fine-grained. Top-level modes are responsible for setting reasonable defaults for the
+        // other configurations.
+        const noFetchConfigAndForceDynamic =
+          !pageFetchCacheMode &&
+          !currentFetchCacheConfig &&
+          workStore.forceDynamic
+
+        if (
+          // force-cache was specified without a revalidate value. We set the revalidate value to false
+          // which will signal the cache to not revalidate
+          currentFetchCacheConfig === 'force-cache' &&
+          typeof currentFetchRevalidate === 'undefined'
+        ) {
           currentFetchRevalidate = false
         } else if (
           // if we are inside of "use cache"/"unstable_cache"
           // we shouldn't set the revalidate to 0 as it's overridden
           // by the cache context
           workUnitStore?.type !== 'cache' &&
-          (currentFetchCacheConfig === 'no-cache' ||
-            currentFetchCacheConfig === 'no-store' ||
-            pageFetchCacheMode === 'force-no-store' ||
-            pageFetchCacheMode === 'only-no-store' ||
-            // If no explicit fetch cache mode is set, but dynamic = `force-dynamic` is set,
-            // we shouldn't consider caching the fetch. This is because the `dynamic` cache
-            // is considered a "top-level" cache mode, whereas something like `fetchCache` is more
-            // fine-grained. Top-level modes are responsible for setting reasonable defaults for the
-            // other configurations.
-            (!pageFetchCacheMode && workStore.forceDynamic))
+          (hasExplicitFetchCacheOptOut || noFetchConfigAndForceDynamic)
         ) {
           currentFetchRevalidate = 0
         }

--- a/test/e2e/app-dir/app-static/app/force-cache-revalidate/page.js
+++ b/test/e2e/app-dir/app-static/app/force-cache-revalidate/page.js
@@ -1,0 +1,23 @@
+// we want to bail out of ISR, but still leverage fetch caching
+export const dynamic = 'force-dynamic'
+
+export default async function Page() {
+  const dataForceCache = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?b2',
+    {
+      cache: 'force-cache',
+      next: {
+        revalidate: 3,
+      },
+    }
+  ).then((res) => res.text())
+
+  return (
+    <>
+      <p>/force-cache-revalidate</p>
+      <p id="data-force-cache">
+        "cache: no-cache, revalidate: 3" {dataForceCache}
+      </p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/logging/app/cache-revalidate/page.js
+++ b/test/e2e/app-dir/logging/app/cache-revalidate/page.js
@@ -7,7 +7,7 @@ export default async function Page() {
     ),
     {
       next: {
-        revalidate: 3,
+        revalidate: 0,
       },
     }
   )
@@ -21,7 +21,7 @@ export default async function Page() {
     ),
     {
       next: {
-        revalidate: 3,
+        revalidate: 0,
       },
     }
   )
@@ -30,9 +30,33 @@ export default async function Page() {
     'https://next-data-api-endpoint.vercel.app/api/random?request-string',
     {
       next: {
-        revalidate: 3,
+        revalidate: 0,
       },
       cache: 'force-cache',
+    }
+  )
+
+  await fetch(
+    new Request(
+      'https://next-data-api-endpoint.vercel.app/api/random?no-store-request-input-cache-override',
+      {
+        cache: 'no-store',
+      }
+    ),
+    {
+      next: {
+        revalidate: 3,
+      },
+    }
+  )
+
+  await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?no-store-request-string',
+    {
+      next: {
+        revalidate: 3,
+      },
+      cache: 'no-store',
     }
   )
 

--- a/test/e2e/app-dir/logging/fetch-warning.test.ts
+++ b/test/e2e/app-dir/logging/fetch-warning.test.ts
@@ -21,27 +21,47 @@ describe('app-dir - fetch warnings', () => {
   })
 
   if (isNextDev) {
-    it('should log when request input is a string', async () => {
-      await retry(() => {
-        expect(next.cliOutput).toInclude(`
+    describe('force-cache and revalidate: 0', () => {
+      it('should log when request input is a string', async () => {
+        await retry(() => {
+          expect(next.cliOutput).toInclude(`
  │ GET https://next-data-api-endpoint.vercel.app/api/random?request-string
- │ │ ⚠ Specified "cache: force-cache" and "revalidate: 3", only one should be specified.`)
+ │ │ ⚠ Specified "cache: force-cache" and "revalidate: 0", only one should be specified.`)
+        })
       })
-    })
 
-    it('should log when request input is a Request instance', async () => {
-      await retry(() => {
-        expect(next.cliOutput).toInclude(`
+      it('should log when request input is a Request instance', async () => {
+        await retry(() => {
+          expect(next.cliOutput).toInclude(`
  │ GET https://next-data-api-endpoint.vercel.app/api/random?request-input-cache-override
- │ │ ⚠ Specified "cache: force-cache" and "revalidate: 3", only one should be specified.`)
+ │ │ ⚠ Specified "cache: force-cache" and "revalidate: 0", only one should be specified.`)
+        })
+      })
+
+      it('should not log when not overriding cache within the Request object', async () => {
+        await retry(() => {
+          expect(next.cliOutput).not.toInclude(`
+ │ GET https://next-data-api-endpoint.vercel.app/api/random?request-input
+ │ │ ⚠ Specified "cache:`)
+        })
       })
     })
 
-    it('should not log when overriding cache within the Request object', async () => {
-      await retry(() => {
-        expect(next.cliOutput).not.toInclude(`
- │ GET https://next-data-api-endpoint.vercel.app/api/random?request-input
- │ │ ⚠ Specified "cache: force-cache" and "revalidate: 3", only one should be specified.`)
+    describe('no-store and revalidate > 0', () => {
+      it('should log when request input is a string', async () => {
+        await retry(() => {
+          expect(next.cliOutput).toInclude(`
+ │ GET https://next-data-api-endpoint.vercel.app/api/random?no-store-request-string
+ │ │ ⚠ Specified "cache: no-store" and "revalidate: 3", only one should be specified.`)
+        })
+      })
+
+      it('should log when request input is a Request instance', async () => {
+        await retry(() => {
+          expect(next.cliOutput).toInclude(`
+ │ GET https://next-data-api-endpoint.vercel.app/api/random?no-store-request-input-cache-override
+ │ │ ⚠ Specified "cache: no-store" and "revalidate: 3", only one should be specified.`)
+        })
       })
     })
   } else {


### PR DESCRIPTION
When using `fetch('', { cache: 'force-cache', { next: { revalidate: 5 } })` on a page that bailed out of ISR, we were effectively ignoring both values and treating the fetch as uncacheable, for several reasons:

- When `cache` and `revalidate` are both specified, we were assuming any combination of the two values is invalid, and we'd unset both the revalidate & fetch configs. In actuality these two properties are only problematic when they convey different caching semantics. This check was modified to instead only warn & unset on conflicting values, specifically `cache: 'no-store` and `revalidate: >0` as well as `cache: 'force-cache'` and `revalidate: 0`.
- When `force-dynamic` was set, we'd opt into no-store behavior on the fetch even if the fetch had an explicit cache config, which is incorrect.

Fixes #71881
Fixes https://linear.app/vercel/issue/NEXT-3843