### PR TITLE
fetch cache: revalidate should take precedence over force-dynamic

### DIFF
--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -331,6 +331,7 @@ export function createPatchedFetcher(
         const noFetchConfigAndForceDynamic =
           !pageFetchCacheMode &&
           !currentFetchCacheConfig &&
+          !currentFetchRevalidate &&
           workStore.forceDynamic
 
         if (

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -211,6 +211,29 @@ describe('app-dir static/dynamic handling', () => {
       })
     })
 
+    it('should infer a fetch cache of "force-cache" when force-dynamic is used on a fetch with revalidate', async () => {
+      let currentData: string | undefined
+      await retry(async () => {
+        const $ = await next.render$('/force-dynamic-fetch-cache/revalidate')
+        const initialData = $('#data').text()
+        expect($('#data').text()).toBeTruthy()
+
+        const $2 = await next.render$('/force-dynamic-fetch-cache/revalidate')
+        currentData = $2('#data').text()
+        expect(currentData).toBeTruthy()
+        expect(currentData).toBe(initialData)
+      })
+
+      // wait for revalidation
+      await waitFor(3000)
+      await retry(async () => {
+        const $3 = await next.render$('/force-dynamic-fetch-cache/revalidate')
+        const finalValue = $3('#data').text()
+        expect(finalValue).toBeTruthy()
+        expect(finalValue).not.toBe(currentData)
+      })
+    })
+
     it('force-dynamic should supercede a "default" cache value', async () => {
       const $ = await next.render$('/force-dynamic-fetch-cache/default-cache')
       const initData = $('#data').text()
@@ -857,6 +880,8 @@ describe('app-dir static/dynamic handling', () => {
           "force-dynamic-fetch-cache/no-fetch-cache/page_client-reference-manifest.js",
           "force-dynamic-fetch-cache/no-fetch-cache/route/route.js",
           "force-dynamic-fetch-cache/no-fetch-cache/route/route_client-reference-manifest.js",
+          "force-dynamic-fetch-cache/revalidate/page.js",
+          "force-dynamic-fetch-cache/revalidate/page_client-reference-manifest.js",
           "force-dynamic-fetch-cache/with-fetch-cache/page.js",
           "force-dynamic-fetch-cache/with-fetch-cache/page_client-reference-manifest.js",
           "force-dynamic-fetch-cache/with-fetch-cache/route/route.js",

--- a/test/e2e/app-dir/app-static/app/force-dynamic-fetch-cache/revalidate/page.js
+++ b/test/e2e/app-dir/app-static/app/force-dynamic-fetch-cache/revalidate/page.js
@@ -1,0 +1,19 @@
+export const dynamic = 'force-dynamic'
+
+export default async function Page() {
+  const data = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random',
+    {
+      next: {
+        revalidate: 3,
+      },
+    }
+  ).then((res) => res.text())
+
+  return (
+    <>
+      <p id="page">/force-dynamic-fetch-cache/revalidate</p>
+      <p id="data">{data}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/logging/app/cache-revalidate/force-dynamic/page.js
+++ b/test/e2e/app-dir/logging/app/cache-revalidate/force-dynamic/page.js
@@ -1,0 +1,14 @@
+export const dynamic = 'force-dynamic'
+
+export default async function Page() {
+  const data = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?revalidate-3',
+    {
+      next: {
+        revalidate: 3,
+      },
+    }
+  ).then((res) => res.text())
+
+  return <div>Hello World! {data}</div>
+}


### PR DESCRIPTION
`force-dynamic` will automatically disable caching on a fetch. If `force-dynamic` is set, and there's a `revalidate` value on the fetch, the revalidate value will be a no-op unless you explicitly opt into caching via `cache: 'force-cache'`. This changes the behavior to favor a positive revalidate value over `force-dynamic` when deciding to cache the fetch.