### PR TITLE
fix(next-flight-loader): add `export` only if `ref` is truthy

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
@@ -124,7 +124,7 @@ rendered as a Component or passed to props of a Client Component.`)}); },
 ${stringifiedResourceKey},
 "default",
 );\n`
-        } else {
+        } else if (ref) {
           esmSource += `export const ${ref} = registerClientReference(
 function() { throw new Error(${JSON.stringify(`Attempted to call ${ref}() from \
 the server but ${ref} is on the client. It's not possible to invoke a client \


### PR DESCRIPTION
### What?

It is possible that `next-flight-loader` produces a module that is not valid JS if a module inside a `node_modules` has a module without `export` or with `export {}` statement.

### Why?

If an original module has no exports, the `ref` will be empty and the following code will be produced

```js
export const  = // ...
```

Notice that the variable name is missing.

### How?

Add guard that will check if `ref` is valid

Fixes #72358

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
