### PR TITLE
Publish misc. Turbopack packages

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -556,6 +556,34 @@ jobs:
           name: npm-publish-logs
           path: /home/runner/.npm/_logs/*
 
+  publish-turbopack-npm-packages:
+    # Matches the commit message written by turbopack/xtask/src/publish.rs:377
+    if: "${{(github.ref == 'refs/heads/canary') && startsWith(github.event.head_commit.message, 'chore: release turbopack npm packages')}}"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_LTS_VERSION }}
+          check-latest: true
+      - run: corepack enable
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpx turbo@canary run build --only --filter='./turbopack/packages/*'
+
+      - name: Write NPM_TOKEN
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN_ELEVATED }}" > ~/.npmrc
+
+      - name: Publish
+        run: cargo xtask workspace --publish
+
   deployExamples:
     if: ${{ needs.deploy-target.outputs.value != 'automated-preview' }}
     name: Deploy examples

--- a/turbopack/xtask/src/publish.rs
+++ b/turbopack/xtask/src/publish.rs
@@ -374,7 +374,7 @@ pub fn run_bump(names: HashSet<String>, dry_run: bool) {
         .args([
             "commit",
             "-m",
-            "chore: release npm packages",
+            "chore: release turbopack npm packages",
             "-m",
             tags_message.as_str(),
         ])


### PR DESCRIPTION
The `turbopack/` directory includes miscellaneous JavaScript packages that should be published to npm. This was handled in https://github.com/vercel/turbo/tree/5fc75a38477e9f810bc4ee8aba4c741425fe2342 before Turbopack moved to the Next.js repo.

Test Plan: Run workflow manually or with this PR and verify the publish xtask is run.


Closes PACK-3390