### PR TITLE
docs: Fix typo in closing tag of sample code

### DIFF
--- a/docs/02-app/02-api-reference/03-file-conventions/layout.mdx
+++ b/docs/02-app/02-api-reference/03-file-conventions/layout.mdx
@@ -158,7 +158,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       <ClientComponent />
       {/* Other Layout UI */}
       <main>{children}</main>
-    <>
+    </>
   )
 }
 ```
@@ -172,7 +172,7 @@ export default function Layout({ children }) {
       <ClientComponent />
       {/* Other Layout UI */}
       <main>{children}</main>
-    <>
+    </>
   )
 }
 ```


### PR DESCRIPTION
Hello! Thank you as always 🫶 
I'd like to contribute to the following points:

### Improving Documentation

- fix typo in closing tag
  - `<>` -> `</>`

---
👇 Now

<img width="362" alt="image" src="https://github.com/user-attachments/assets/fbb29a76-e1b8-467b-8453-46e5e1548db1">

in: [File Conventions: layout.js | Next.js](https://nextjs.org/docs/app/api-reference/file-conventions/layout)

---

Thank you for reading! I look forward to working together.