### PR TITLE
docs(testing): update cypress note (v14 now supported)

### DIFF
--- a/docs/02-app/01-building-your-application/08-testing/04-cypress.mdx
+++ b/docs/02-app/01-building-your-application/08-testing/04-cypress.mdx
@@ -8,7 +8,6 @@ description: Learn how to set up Cypress with Next.js for End-to-End (E2E) and C
 
 > **Warning:**
 >
-> - For **Component Testing**, Cypress currently does not support [Next.js version 14](https://github.com/cypress-io/cypress/issues/28185) and `async` Server Components. These issues are being tracked. For now, Component Testing works with Next.js version 13, and we recommend E2E testing for `async` Server Components.
 > - Cypress versions below 13.6.3 do not support [TypeScript version 5](https://github.com/cypress-io/cypress/issues/27731) with `moduleResolution:"bundler"`. However, this issue has been resolved in Cypress version 13.6.3 and later. [cypress v13.6.3](https://docs.cypress.io/guides/references/changelog#13-6-3)
 
 <AppOnly>


### PR DESCRIPTION
## Why?

Cypress has supported v14 for a while.

- Fixes https://github.com/vercel/next.js/issues/72325