### PR TITLE
[Prefetching] Move resource hints to tree prefetch

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3880,6 +3880,7 @@ async function collectSegmentData(
     return
   }
   const routeTree: FlightRouterState = flightDataPaths[0][0]
+  const seedData: CacheNodeSeedData = flightDataPaths[0][1]
 
   // Manifest passed to the Flight client for reading the full-page Flight
   // stream. Based off similar code in use-cache-wrapper.ts.
@@ -3898,6 +3899,7 @@ async function collectSegmentData(
   const staleTime = prerenderStore.stale
   return await ComponentMod.collectSegmentData(
     routeTree,
+    seedData,
     fullPageDataBuffer,
     staleTime,
     clientReferenceManifest.clientModules as ManifestNode,

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -1,9 +1,4 @@
-import type {
-  CacheNodeSeedData,
-  FlightRouterState,
-  InitialRSCPayload,
-  Segment,
-} from './types'
+import type { CacheNodeSeedData, FlightRouterState, Segment } from './types'
 import type { ManifestNode } from '../../build/webpack/plugins/flight-manifest-plugin'
 
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -59,14 +54,13 @@ type SegmentPrefetch = {
 
 export async function collectSegmentData(
   flightRouterState: FlightRouterState,
+  seedData: CacheNodeSeedData,
   fullPageDataBuffer: Buffer,
   staleTime: number,
   clientModules: ManifestNode,
   serverConsumerManifest: any
 ): Promise<Map<string, Buffer>> {
-  // Traverse the router tree. For each segment, decode the Flight stream for
-  // the page, pick out its segment data, and re-encode it to a new Flight
-  // stream. This will be served when performing a client-side prefetch.
+  // Traverse the router tree and generate a prefetch response for each segment.
 
   // Before we start, warm up the module cache by decoding the page data once.
   // Then we can assume that any remaining async tasks that occur the next time
@@ -86,10 +80,10 @@ export async function collectSegmentData(
 
   const tree = await collectSegmentDataImpl(
     flightRouterState,
+    seedData,
     fullPageDataBuffer,
     clientModules,
     serverConsumerManifest,
-    [],
     '',
     '',
     resultMap
@@ -100,20 +94,40 @@ export async function collectSegmentData(
     tree,
     staleTime,
   }
-  const treeStream = renderToReadableStream(treePrefetch, clientModules)
-  const routeBuffer = await streamToBuffer(treeStream)
-
-  resultMap.set('/_tree', routeBuffer)
+  const treeStream = await renderToReadableStream(
+    // SegmentPrefetch is not a valid return type for a React component, but
+    // we need to use a component so that when we decode the original stream
+    // inside of it, the side effects are transferred to the new stream.
+    // @ts-expect-error
+    <PrefetchTreeData
+      fullPageDataBuffer={fullPageDataBuffer}
+      serverConsumerManifest={serverConsumerManifest}
+      treePrefetch={treePrefetch}
+    />,
+    clientModules,
+    {
+      // Unlike when rendering the segment streams, we do not pass an abort
+      // controller here. There's nothing dynamic in the prefetch metadata; we
+      // will always render the result. We do still have to account for hanging
+      // promises, but we use a different strategy. See PrefetchTreeData.
+      onError() {
+        // Ignore any errors. These would have already been reported when
+        // we created the full page data.
+      },
+    }
+  )
+  const treeBuffer = await streamToBuffer(treeStream)
+  resultMap.set('/_tree', treeBuffer)
 
   return resultMap
 }
 
 async function collectSegmentDataImpl(
   route: FlightRouterState,
+  seedData: CacheNodeSeedData,
   fullPageDataBuffer: Buffer,
   clientModules: ManifestNode,
   serverConsumerManifest: any,
-  segmentPath: Array<[string, Segment]>,
   segmentPathStr: string,
   accessToken: string,
   segmentBufferMap: Map<string, Buffer>
@@ -127,12 +141,15 @@ async function collectSegmentDataImpl(
   let childAccessTokens: { [parallelRouteKey: string]: string } | null = null
 
   const children = route[1]
+  const seedDataChildren = seedData[2]
   for (const parallelRouteKey in children) {
     const childRoute = children[parallelRouteKey]
     const childSegment = childRoute[0]
-    const childSegmentPath = segmentPath.concat([
-      [parallelRouteKey, childSegment],
-    ])
+    const childSeedData = seedDataChildren[parallelRouteKey]
+    if (!childSeedData) {
+      // No corresponding seed data for this segment.
+      continue
+    }
     const childSegmentPathStr =
       segmentPathStr +
       '/' +
@@ -145,10 +162,10 @@ async function collectSegmentDataImpl(
     )
     const childTree = await collectSegmentDataImpl(
       childRoute,
+      seedData,
       fullPageDataBuffer,
       clientModules,
       serverConsumerManifest,
-      childSegmentPath,
       childSegmentPathStr,
       childAccessToken,
       segmentBufferMap
@@ -165,16 +182,46 @@ async function collectSegmentDataImpl(
   }
 
   // Render the segment data to a stream.
-  await renderSegmentDataToStream(
-    fullPageDataBuffer,
+  // In the future, this is where we can include additional metadata, like the
+  // stale time and cache tags.
+  const rsc = seedData[1]
+  const loading = seedData[3]
+  const segmentPrefetch: SegmentPrefetch = {
+    rsc,
+    loading,
+    slots: childAccessTokens,
+  }
+  // Since all we're doing is decoding and re-encoding a cached prerender, if
+  // it takes longer than a microtask, it must because of hanging promises
+  // caused by dynamic data. Abort the stream at the end of the current task.
+  const abortController = new AbortController()
+  waitAtLeastOneReactRenderTask().then(() => abortController.abort())
+  const segmentStream = await renderToReadableStream(
+    segmentPrefetch,
     clientModules,
-    serverConsumerManifest,
-    segmentPath,
-    segmentPathStr,
-    accessToken,
-    childAccessTokens,
-    segmentBufferMap
+    {
+      signal: abortController.signal,
+      onError() {
+        // Ignore any errors. These would have already been reported when
+        // we created the full page data.
+      },
+    }
   )
+  const segmentBuffer = await streamToBuffer(segmentStream)
+  // Add the buffer to the result map.
+  if (segmentPathStr === '') {
+    segmentBufferMap.set('/', segmentBuffer)
+  } else {
+    // The access token is appended to the end of the segment name. To request
+    // a segment, the client sends a header like:
+    //
+    //   Next-Router-Segment-Prefetch: /path/to/segment.accesstoken
+    //
+    // The segment path is provided by the tree prefetch, and the access
+    // token is provided in the parent layout's data.
+    const fullPath = `${segmentPathStr}.${accessToken}`
+    segmentBufferMap.set(fullPath, segmentBuffer)
+  }
 
   // Metadata about the segment. Sent to the client as part of the
   // tree prefetch.
@@ -187,138 +234,39 @@ async function collectSegmentDataImpl(
   }
 }
 
-async function renderSegmentDataToStream(
-  fullPageDataBuffer: Buffer,
-  clientModules: ManifestNode,
-  serverConsumerManifest: any,
-  segmentPath: Array<[string, Segment]>,
-  segmentPathStr: string,
-  accessToken: string,
-  childAccessTokens: { [parallelRouteKey: string]: string } | null,
-  segmentBufferMap: Map<string, Buffer>
-) {
-  // Create a new Flight response that contains data only for this segment.
-  try {
-    // Since all we're doing is decoding and re-encoding a cached prerender, if
-    // it takes longer than a microtask, it must because of hanging promises
-    // caused by dynamic data. Abort the stream at the end of the current task.
-    const abortController = new AbortController()
-    waitAtLeastOneReactRenderTask().then(() => abortController.abort())
-
-    const segmentStream = renderToReadableStream(
-      // SegmentPrefetch is not a valid return type for a React component, but
-      // we need to use a component so that when we decode the original stream
-      // inside of it, the side effects are transferred to the new stream.
-      // @ts-expect-error
-      <PickSegment
-        fullPageDataBuffer={fullPageDataBuffer}
-        serverConsumerManifest={serverConsumerManifest}
-        segmentPath={segmentPath}
-        childAccessTokens={childAccessTokens}
-      />,
-      clientModules,
-      {
-        signal: abortController.signal,
-        onError() {
-          // Ignore any errors. These would have already been reported when
-          // we created the full page data.
-        },
-      }
-    )
-    const segmentBuffer = await streamToBuffer(segmentStream)
-    // Add the buffer to the result map.
-    if (segmentPathStr === '') {
-      segmentBufferMap.set('/', segmentBuffer)
-    } else {
-      // The access token is appended to the end of the segment name. To request
-      // a segment, the client sends a header like:
-      //
-      //   Next-Router-Segment-Prefetch: /path/to/segment.accesstoken
-      //
-      // The segment path is provided by the tree prefetch, and the access
-      // token is provided in the parent layout's data.
-      const fullPath = `${segmentPathStr}.${accessToken}`
-      segmentBufferMap.set(fullPath, segmentBuffer)
-    }
-  } catch {
-    // If there are any errors, then we skip the segment. The effect is that
-    // a prefetch for this segment will 404.
-  }
-}
-
-async function PickSegment({
+async function PrefetchTreeData({
   fullPageDataBuffer,
   serverConsumerManifest,
-  segmentPath,
-  childAccessTokens,
+  treePrefetch,
 }: {
   fullPageDataBuffer: Buffer
   serverConsumerManifest: any
-  segmentPath: Array<[string, Segment]>
-  childAccessTokens: { [parallelRouteKey: string]: string } | null
-}): Promise<SegmentPrefetch | null> {
-  // We're currently rendering a Flight response for a segment prefetch.
-  // Decode the Flight stream for the whole page, then pick out the data for the
-  // segment at the given path. This ends up happening once per segment. Not
-  // ideal, but we do it this way so that that we can transfer the side effects
-  // from the original Flight stream (e.g. Float preloads) onto the Flight
-  // stream for each segment's prefetch.
-  //
-  // This does mean that a prefetch for an individual segment will include the
-  // resources for the entire page it belongs to, but this is a reasonable
-  // trade-off for now. The main downside is a bit of extra bandwidth.
+  treePrefetch: RootTreePrefetch
+}): Promise<RootTreePrefetch | null> {
+  // We're currently rendering a Flight response for a segment prefetch. Inside
+  // this component, decode the Flight stream for the whole page. This is a hack
+  // to transfer the side effects from the original Flight stream (e.g. Float
+  // preloads) onto the Flight stream for the tree prefetch.
+  // TODO: React needs a better way to do this. Needed for Server Actions, too.
+
   const replayConsoleLogs = true
-  const rscPayload: InitialRSCPayload = await createFromReadableStream(
-    streamFromBuffer(fullPageDataBuffer),
-    {
+  await Promise.race([
+    createFromReadableStream(streamFromBuffer(fullPageDataBuffer), {
       serverConsumerManifest,
       replayConsoleLogs,
-    }
-  )
+    }),
 
-  // FlightDataPaths is an unsound type, hence the additional checks.
-  const flightDataPaths = rscPayload.f
-  if (flightDataPaths.length !== 1 && flightDataPaths[0].length !== 3) {
-    console.error(
-      'Internal Next.js error: InitialRSCPayload does not match the expected ' +
-        'shape for a prerendered page during segment prefetch generation.'
-    )
-    return null
-  }
+    // If the page contains dynamic data, the stream will hang indefinitely. So,
+    // at the end of the current task, stop waiting and proceed rendering. This
+    // is similar to the AbortSignal strategy we use for generating segment
+    // data, except we don't actually want or need to abort the outer stream in
+    // this case.
+    waitAtLeastOneReactRenderTask(),
+  ])
 
-  // This starts out as the data for the whole page. Use the segment path to
-  // find the data for the desired segment.
-  let seedData: CacheNodeSeedData = flightDataPaths[0][1]
-  for (const [parallelRouteKey] of segmentPath) {
-    // Normally when traversing a route tree we would compare the segments to
-    // confirm that they match (i.e. are representations of the same tree),
-    // but we don't bother to do that here because because the path was
-    // generated from the same data tree that we're currently traversing.
-    const children = seedData[2]
-    const child = children[parallelRouteKey]
-    if (!child) {
-      // No child found for this segment path. Exit. Again, this should be
-      // unreachable because the segment path was computed using the same
-      // source as the page data, but the type system doesn't know that.
-      return null
-    } else {
-      // Keep traversing down the segment path
-      seedData = child
-    }
-  }
-
-  // We've reached the end of the segment path. seedData now represents the
-  // correct segment.
-  //
-  // In the future, this is where we can include additional metadata, like the
-  // stale time and cache tags.
-  const rsc = seedData[1]
-  const loading = seedData[3]
-  return {
-    rsc,
-    loading,
-    slots: childAccessTokens,
-  }
+  // By this point the side effects have been transfered and we can render the
+  // tree metadata.
+  return treePrefetch
 }
 
 // TODO: Consider updating or unifying this encoding logic for segments with


### PR DESCRIPTION
Based on:
- #72348

---


When prefetching a segment, the response currently includes all the side effects (e.g. resource hints and console.logs) for the entire page, not just the segment being requested. This is mostly the result of implementation limitations, since React does not currently give us a good way to extract side effects from an existing Flight response. We cheat by decoding the original stream inside a new Flight render, which has the effect of  transferring all the side effects from the original stream onto the new one.

This is mostly fine, except 1) every segment contains the entire page's resource hints, and 2) we have to decode the original stream once per segment.

But since all route prefetches must start with a prefetch of the route tree metadata, we can instead put the hints in that response only. Not the segment prefetches. That way we only have to decode the original stream once.

This saves CPU cycles and should result in fewer bytes over the wire, since we'll only load the resource hints once per page.