### PR TITLE
chore: add `syntax` parser directive to Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker.io/docker/dockerfile:1
+
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
 ARG VARIANT=20-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}

--- a/.devcontainer/base.Dockerfile
+++ b/.devcontainer/base.Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker.io/docker/dockerfile:1
+
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
 ARG VARIANT=20-bullseye
 FROM node:${VARIANT}

--- a/.github/actions/next-stats-action/Dockerfile
+++ b/.github/actions/next-stats-action/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker.io/docker/dockerfile:1
+
 FROM ubuntu:22.04
 
 LABEL com.github.actions.name="Next.js PR Stats"

--- a/examples/with-docker-compose/next-app/dev.Dockerfile
+++ b/examples/with-docker-compose/next-app/dev.Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker.io/docker/dockerfile:1
+
 FROM node:18-alpine
 
 WORKDIR /app

--- a/examples/with-docker-compose/next-app/prod-without-multistage.Dockerfile
+++ b/examples/with-docker-compose/next-app/prod-without-multistage.Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker.io/docker/dockerfile:1
+
 FROM node:18-alpine
 
 WORKDIR /app

--- a/examples/with-docker-compose/next-app/prod.Dockerfile
+++ b/examples/with-docker-compose/next-app/prod.Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker.io/docker/dockerfile:1
+
 FROM node:18-alpine AS base
 
 # Step 1. Rebuild the source code only when needed

--- a/examples/with-docker-multi-env/docker/development/Dockerfile
+++ b/examples/with-docker-multi-env/docker/development/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker.io/docker/dockerfile:1
+
 FROM node:18-alpine AS base
 
 # 1. Install dependencies only when needed

--- a/examples/with-docker-multi-env/docker/production/Dockerfile
+++ b/examples/with-docker-multi-env/docker/production/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker.io/docker/dockerfile:1
+
 FROM node:18-alpine AS base
 
 # 1. Install dependencies only when needed

--- a/examples/with-docker-multi-env/docker/staging/Dockerfile
+++ b/examples/with-docker-multi-env/docker/staging/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker.io/docker/dockerfile:1
+
 FROM node:18-alpine AS base
 
 # 1. Install dependencies only when needed

--- a/examples/with-docker/Dockerfile
+++ b/examples/with-docker/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker.io/docker/dockerfile:1
+
 FROM node:18-alpine AS base
 
 # Install dependencies only when needed


### PR DESCRIPTION
## What?
Add [`syntax`](https://docs.docker.com/reference/dockerfile/#syntax) parser directive to the first line of the [Dockerfile](https://docs.docker.com/reference/dockerfile/).

## Why?
To declare the Dockerfile syntax version to use for the build.
If unspecified, [BuildKit](https://docs.docker.com/build/buildkit/) uses a bundled version of the Dockerfile frontend. 

## How?
Append `# syntax=docker.io/docker/dockerfile:1` to the top of the [Dockerfile](https://docs.docker.com/reference/dockerfile/).