### PR TITLE
refactor(turbopack-core): Migrate `Sources` type (and related types) to `ResolvedVc`

### DIFF
--- a/crates/next-core/src/next_edge/unsupported.rs
+++ b/crates/next-core/src/next_edge/unsupported.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use indoc::formatdoc;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
@@ -62,9 +62,9 @@ impl ImportMappingReplacement for NextEdgeUnsupportedModuleReplacer {
               "#
             };
             let content = AssetContent::file(File::from(code).into());
-            let source = VirtualSource::new(root_path, content);
+            let source = VirtualSource::new(root_path, content).to_resolved().await?;
             return Ok(ImportMapResult::Result(
-                ResolveResult::source(Vc::upcast(source)).resolved_cell(),
+                ResolveResult::source(ResolvedVc::upcast(source)).resolved_cell(),
             )
             .cell());
         };

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -133,11 +133,11 @@ impl NextFontGoogleReplacer {
                 .into(),
             )
             .cell()),
-        );
-        Ok(
-            ImportMapResult::Result(ResolveResult::source(Vc::upcast(js_asset)).resolved_cell())
-                .cell(),
+        ).to_resolved().await?;
+        Ok(ImportMapResult::Result(
+            ResolveResult::source(ResolvedVc::upcast(js_asset)).resolved_cell(),
         )
+        .cell())
     }
 }
 
@@ -267,7 +267,7 @@ impl NextFontGoogleCssModuleReplacer {
         .await?;
 
         Ok(ImportMapResult::Result(
-            ResolveResult::source(*ResolvedVc::upcast(css_asset)).resolved_cell(),
+            ResolveResult::source(ResolvedVc::upcast(css_asset)).resolved_cell(),
         )
         .cell())
     }
@@ -386,12 +386,14 @@ impl ImportMappingReplacement for NextFontGoogleFontFileReplacer {
         let font_source = VirtualSource::new(
             font_virtual_path,
             AssetContent::file(FileContent::Content(font.await?.0.as_slice().into()).cell()),
-        );
-
-        Ok(
-            ImportMapResult::Result(ResolveResult::source(Vc::upcast(font_source)).resolved_cell())
-                .cell(),
         )
+        .to_resolved()
+        .await?;
+
+        Ok(ImportMapResult::Result(
+            ResolveResult::source(ResolvedVc::upcast(font_source)).resolved_cell(),
+        )
+        .cell())
     }
 }
 

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Context, Result};
 use indoc::formatdoc;
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{RcStr, Value, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, Value, Vc};
 use turbo_tasks_fs::{
     glob::Glob, json::parse_json_with_source_context, FileContent, FileSystemPath,
 };
@@ -174,10 +174,12 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                         .into(),
                     ),
                     AssetContent::file(FileContent::Content(file_content.into()).into()),
-                );
+                )
+                .to_resolved()
+                .await?;
 
                 Ok(ResolveResultOption::some(
-                    ResolveResult::source(Vc::upcast(js_asset)).into(),
+                    ResolveResult::source(ResolvedVc::upcast(js_asset)).cell(),
                 ))
             }
             "@vercel/turbopack-next/internal/font/local/cssmodule.module.css" => {
@@ -202,11 +204,13 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
 
                 let css_asset = VirtualSource::new(
                     css_virtual_path,
-                    AssetContent::file(FileContent::Content(stylesheet.into()).into()),
-                );
+                    AssetContent::file(FileContent::Content(stylesheet.into()).cell()),
+                )
+                .to_resolved()
+                .await?;
 
                 Ok(ResolveResultOption::some(
-                    ResolveResult::source(Vc::upcast(css_asset)).into(),
+                    ResolveResult::source(ResolvedVc::upcast(css_asset)).cell(),
                 ))
             }
             "@vercel/turbopack-next/internal/font/local/font" => {
@@ -233,10 +237,12 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                 let font_file = lookup_path.join(path.clone()).read();
 
                 let font_source =
-                    VirtualSource::new(font_virtual_path, AssetContent::file(font_file));
+                    VirtualSource::new(font_virtual_path, AssetContent::file(font_file))
+                        .to_resolved()
+                        .await?;
 
                 Ok(ResolveResultOption::some(
-                    ResolveResult::source(Vc::upcast(font_source)).into(),
+                    ResolveResult::source(ResolvedVc::upcast(font_source)).cell(),
                 ))
             }
             _ => Ok(ResolveResultOption::none()),

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 use lazy_static::lazy_static;
-use turbo_tasks::{RcStr, Value, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, Value, Vc};
 use turbo_tasks_fs::{glob::Glob, FileSystemPath};
 use turbopack_core::{
     diagnostics::DiagnosticExt,
@@ -319,7 +319,10 @@ impl AfterResolvePlugin for NextNodeSharedRuntimeResolvePlugin {
             .join(format!("{base}/{resource_request}").into());
 
         Ok(Vc::cell(Some(
-            ResolveResult::source(Vc::upcast(FileSource::new(new_path))).into(),
+            ResolveResult::source(ResolvedVc::upcast(
+                FileSource::new(new_path).to_resolved().await?,
+            ))
+            .cell(),
         )))
     }
 }
@@ -418,7 +421,10 @@ impl AfterResolvePlugin for NextSharedRuntimeResolvePlugin {
         let modified_path = raw_fs_path.path.replace("next/dist/esm/", "next/dist/");
         let new_path = fs_path.root().join(modified_path.into());
         Ok(Vc::cell(Some(
-            ResolveResult::source(Vc::upcast(FileSource::new(new_path))).into(),
+            ResolveResult::source(ResolvedVc::upcast(
+                FileSource::new(new_path).to_resolved().await?,
+            ))
+            .cell(),
         )))
     }
 }

--- a/crates/next-core/src/transform_options.rs
+++ b/crates/next-core/src/transform_options.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{self, FileJsonContent, FileSystemPath};
 use turbopack::{
     module_options::{
@@ -19,20 +19,18 @@ use crate::{mode::NextMode, next_config::NextConfig};
 
 async fn get_typescript_options(
     project_path: Vc<FileSystemPath>,
-) -> Option<Vec<(Vc<FileJsonContent>, Vc<Box<dyn Source>>)>> {
+) -> Result<Option<Vec<(Vc<FileJsonContent>, ResolvedVc<Box<dyn Source>>)>>> {
     let tsconfig = find_context_file(project_path, tsconfig());
-    match *tsconfig.await.ok()? {
-        FindContextFileResult::Found(path, _) => Some(
-            read_tsconfigs(
-                path.read(),
-                Vc::upcast(FileSource::new(*path)),
-                node_cjs_resolve_options(path.root()),
-            )
-            .await
-            .ok()?,
-        ),
-        FindContextFileResult::NotFound(_) => None,
-    }
+    Ok(match tsconfig.await.ok().as_deref() {
+        Some(FindContextFileResult::Found(path, _)) => read_tsconfigs(
+            path.read(),
+            ResolvedVc::upcast(FileSource::new(**path).to_resolved().await?),
+            node_cjs_resolve_options(path.root()),
+        )
+        .await
+        .ok(),
+        Some(FindContextFileResult::NotFound(_)) | None => None,
+    })
 }
 
 /// Build the transform options for specifically for the typescript's runtime
@@ -41,7 +39,7 @@ async fn get_typescript_options(
 pub async fn get_typescript_transform_options(
     project_path: Vc<FileSystemPath>,
 ) -> Result<Vc<TypescriptTransformOptions>> {
-    let tsconfig = get_typescript_options(project_path).await;
+    let tsconfig = get_typescript_options(project_path).await?;
 
     let use_define_for_class_fields = if let Some(tsconfig) = tsconfig {
         read_from_tsconfigs(&tsconfig, |json, _| {
@@ -66,7 +64,7 @@ pub async fn get_typescript_transform_options(
 pub async fn get_decorators_transform_options(
     project_path: Vc<FileSystemPath>,
 ) -> Result<Vc<DecoratorsOptions>> {
-    let tsconfig = get_typescript_options(project_path).await;
+    let tsconfig = get_typescript_options(project_path).await?;
 
     let decorators_transform_options = if let Some(tsconfig) = tsconfig {
         read_from_tsconfigs(&tsconfig, |json, _| {
@@ -126,7 +124,7 @@ pub async fn get_jsx_transform_options(
     is_rsc_context: bool,
     next_config: Vc<NextConfig>,
 ) -> Result<Vc<JsxTransformOptions>> {
-    let tsconfig = get_typescript_options(project_path).await;
+    let tsconfig = get_typescript_options(project_path).await?;
 
     let enable_react_refresh = if let Some(resolve_options_context) = resolve_options_context {
         assert_can_resolve_react_refresh(project_path, resolve_options_context)

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -145,7 +145,7 @@ pub async fn referenced_modules_and_affecting_sources(
                 .affecting_sources_iter()
                 .map(|source| async move {
                     Ok(ResolvedVc::upcast(
-                        RawModule::new(source).to_resolved().await?,
+                        RawModule::new(*source).to_resolved().await?,
                     ))
                 })
                 .try_join()

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -76,7 +76,7 @@ pub enum ModuleResolveResultItem {
 #[derive(Clone, Debug)]
 pub struct ModuleResolveResult {
     pub primary: FxIndexMap<RequestKey, ModuleResolveResultItem>,
-    pub affecting_sources: Vec<Vc<Box<dyn Source>>>,
+    pub affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
 }
 
 impl Default for ModuleResolveResult {
@@ -94,7 +94,7 @@ impl ModuleResolveResult {
     }
 
     pub fn unresolvable_with_affecting_sources(
-        affecting_sources: Vec<Vc<Box<dyn Source>>>,
+        affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> ModuleResolveResult {
         ModuleResolveResult {
             primary: FxIndexMap::default(),
@@ -140,7 +140,7 @@ impl ModuleResolveResult {
 
     pub fn modules_with_affecting_sources(
         modules: impl IntoIterator<Item = (RequestKey, ResolvedVc<Box<dyn Module>>)>,
-        affecting_sources: Vec<Vc<Box<dyn Source>>>,
+        affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> ModuleResolveResult {
         ModuleResolveResult {
             primary: modules
@@ -158,17 +158,17 @@ impl ModuleResolveResult {
         })
     }
 
-    pub fn add_affecting_source_ref(&mut self, source: Vc<Box<dyn Source>>) {
+    pub fn add_affecting_source_ref(&mut self, source: ResolvedVc<Box<dyn Source>>) {
         self.affecting_sources.push(source);
     }
 
-    pub fn affecting_sources_iter(&self) -> impl Iterator<Item = Vc<Box<dyn Source>>> + '_ {
+    pub fn affecting_sources_iter(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Source>>> + '_ {
         self.affecting_sources.iter().copied()
     }
 
     fn clone_with_affecting_sources(
         &self,
-        affecting_sources: Vec<Vc<Box<dyn Source>>>,
+        affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> ModuleResolveResult {
         ModuleResolveResult {
             primary: self.primary.clone(),
@@ -206,7 +206,7 @@ impl ModuleResolveResult {
     #[turbo_tasks::function]
     pub async fn with_affecting_source(
         self: Vc<Self>,
-        source: Vc<Box<dyn Source>>,
+        source: ResolvedVc<Box<dyn Source>>,
     ) -> Result<Vc<Self>> {
         let mut this = self.await?.clone_value();
         this.add_affecting_source_ref(source);
@@ -216,7 +216,7 @@ impl ModuleResolveResult {
     #[turbo_tasks::function]
     pub async fn with_affecting_sources(
         self: Vc<Self>,
-        sources: Vec<Vc<Box<dyn Source>>>,
+        sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> Result<Vc<Self>> {
         let mut this = self.await?.clone_value();
         for source in sources {
@@ -267,7 +267,7 @@ impl ModuleResolveResult {
     #[turbo_tasks::function]
     pub async fn alternatives_with_affecting_sources(
         results: Vec<Vc<ModuleResolveResult>>,
-        affecting_sources: Vec<Vc<Box<dyn Source>>>,
+        affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> Result<Vc<Self>> {
         if affecting_sources.is_empty() {
             return Ok(Self::alternatives(results));
@@ -277,7 +277,7 @@ impl ModuleResolveResult {
                 .into_iter()
                 .next()
                 .unwrap()
-                .with_affecting_sources(affecting_sources));
+                .with_affecting_sources(affecting_sources.into_iter().map(|src| *src).collect()));
         }
         let mut iter = results.into_iter().try_join().await?.into_iter();
         if let Some(current) = iter.next() {
@@ -372,7 +372,7 @@ impl Display for ExternalType {
 #[turbo_tasks::value(shared)]
 #[derive(Clone, Debug)]
 pub enum ResolveResultItem {
-    Source(Vc<Box<dyn Source>>),
+    Source(ResolvedVc<Box<dyn Source>>),
     External(RcStr, ExternalType),
     Ignore,
     Error(Vc<RcStr>),
@@ -427,7 +427,7 @@ impl RequestKey {
 #[derive(Clone, Debug)]
 pub struct ResolveResult {
     pub primary: FxIndexMap<RequestKey, ResolveResultItem>,
-    pub affecting_sources: Vec<Vc<Box<dyn Source>>>,
+    pub affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
 }
 
 impl Default for ResolveResult {
@@ -496,7 +496,7 @@ impl ResolveResult {
     }
 
     pub fn unresolvable_with_affecting_sources(
-        affecting_sources: Vec<Vc<Box<dyn Source>>>,
+        affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> ResolveResult {
         ResolveResult {
             primary: FxIndexMap::default(),
@@ -518,7 +518,7 @@ impl ResolveResult {
     pub fn primary_with_affecting_sources(
         request_key: RequestKey,
         result: ResolveResultItem,
-        affecting_sources: Vec<Vc<Box<dyn Source>>>,
+        affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> ResolveResult {
         let mut primary = FxIndexMap::with_capacity_and_hasher(1, Default::default());
         primary.insert(request_key, result);
@@ -528,11 +528,14 @@ impl ResolveResult {
         }
     }
 
-    pub fn source(source: Vc<Box<dyn Source>>) -> ResolveResult {
+    pub fn source(source: ResolvedVc<Box<dyn Source>>) -> ResolveResult {
         Self::source_with_key(RequestKey::default(), source)
     }
 
-    pub fn source_with_key(request_key: RequestKey, source: Vc<Box<dyn Source>>) -> ResolveResult {
+    pub fn source_with_key(
+        request_key: RequestKey,
+        source: ResolvedVc<Box<dyn Source>>,
+    ) -> ResolveResult {
         let mut primary = FxIndexMap::with_capacity_and_hasher(1, Default::default());
         primary.insert(request_key, ResolveResultItem::Source(source));
         ResolveResult {
@@ -543,8 +546,8 @@ impl ResolveResult {
 
     pub fn source_with_affecting_sources(
         request_key: RequestKey,
-        source: Vc<Box<dyn Source>>,
-        affecting_sources: Vec<Vc<Box<dyn Source>>>,
+        source: ResolvedVc<Box<dyn Source>>,
+        affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> ResolveResult {
         let mut primary = FxIndexMap::with_capacity_and_hasher(1, Default::default());
         primary.insert(request_key, ResolveResultItem::Source(source));
@@ -554,17 +557,17 @@ impl ResolveResult {
         }
     }
 
-    pub fn add_affecting_source_ref(&mut self, reference: Vc<Box<dyn Source>>) {
+    pub fn add_affecting_source_ref(&mut self, reference: ResolvedVc<Box<dyn Source>>) {
         self.affecting_sources.push(reference);
     }
 
-    pub fn get_affecting_sources(&self) -> impl Iterator<Item = Vc<Box<dyn Source>>> + '_ {
+    pub fn get_affecting_sources(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Source>>> + '_ {
         self.affecting_sources.iter().copied()
     }
 
     fn clone_with_affecting_sources(
         &self,
-        affecting_sources: Vec<Vc<Box<dyn Source>>>,
+        affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> ResolveResult {
         ResolveResult {
             primary: self.primary.clone(),
@@ -598,10 +601,10 @@ impl ResolveResult {
 
     pub async fn map<A, AF, R, RF>(&self, source_fn: A, affecting_source_fn: R) -> Result<Self>
     where
-        A: Fn(Vc<Box<dyn Source>>) -> AF,
-        AF: Future<Output = Result<Vc<Box<dyn Source>>>>,
-        R: Fn(Vc<Box<dyn Source>>) -> RF,
-        RF: Future<Output = Result<Vc<Box<dyn Source>>>>,
+        A: Fn(ResolvedVc<Box<dyn Source>>) -> AF,
+        AF: Future<Output = Result<ResolvedVc<Box<dyn Source>>>>,
+        R: Fn(ResolvedVc<Box<dyn Source>>) -> RF,
+        RF: Future<Output = Result<ResolvedVc<Box<dyn Source>>>>,
     {
         Ok(Self {
             primary: self
@@ -635,7 +638,7 @@ impl ResolveResult {
 
     pub async fn map_module<A, AF>(&self, source_fn: A) -> Result<ModuleResolveResult>
     where
-        A: Fn(Vc<Box<dyn Source>>) -> AF,
+        A: Fn(ResolvedVc<Box<dyn Source>>) -> AF,
         AF: Future<Output = Result<ModuleResolveResultItem>>,
     {
         Ok(ModuleResolveResult {
@@ -716,7 +719,7 @@ impl ResolveResult {
         Ok(self
             .map_module(|asset| async move {
                 Ok(ModuleResolveResultItem::Module(ResolvedVc::upcast(
-                    RawModule::new(asset).to_resolved().await?,
+                    RawModule::new(*asset).to_resolved().await?,
                 )))
             })
             .await?
@@ -726,7 +729,7 @@ impl ResolveResult {
     #[turbo_tasks::function]
     pub async fn with_affecting_source(
         self: Vc<Self>,
-        affecting_source: Vc<Box<dyn Source>>,
+        affecting_source: ResolvedVc<Box<dyn Source>>,
     ) -> Result<Vc<Self>> {
         let mut this = self.await?.clone_value();
         this.add_affecting_source_ref(affecting_source);
@@ -736,7 +739,7 @@ impl ResolveResult {
     #[turbo_tasks::function]
     pub async fn with_affecting_sources(
         self: Vc<Self>,
-        affecting_sources: Vec<Vc<Box<dyn Source>>>,
+        affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> Result<Vc<Self>> {
         let mut this = self.await?.clone_value();
         for affecting_source in affecting_sources {
@@ -787,7 +790,7 @@ impl ResolveResult {
     #[turbo_tasks::function]
     pub async fn alternatives_with_affecting_sources(
         results: Vec<Vc<ResolveResult>>,
-        affecting_sources: Vec<Vc<Box<dyn Source>>>,
+        affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> Result<Vc<Self>> {
         if affecting_sources.is_empty() {
             return Ok(Self::alternatives(results));
@@ -797,7 +800,7 @@ impl ResolveResult {
                 .into_iter()
                 .next()
                 .unwrap()
-                .with_affecting_sources(affecting_sources));
+                .with_affecting_sources(affecting_sources.into_iter().map(|src| *src).collect()));
         }
         let mut iter = results.into_iter().try_join().await?.into_iter();
         if let Some(current) = iter.next() {
@@ -963,30 +966,32 @@ impl ResolveResultOption {
 
 async fn exists(
     fs_path: Vc<FileSystemPath>,
-    refs: &mut Vec<Vc<Box<dyn Source>>>,
-) -> Result<Option<Vc<FileSystemPath>>> {
+    refs: &mut Vec<ResolvedVc<Box<dyn Source>>>,
+) -> Result<Option<ResolvedVc<FileSystemPath>>> {
     type_exists(fs_path, FileSystemEntryType::File, refs).await
 }
 
 async fn dir_exists(
     fs_path: Vc<FileSystemPath>,
-    refs: &mut Vec<Vc<Box<dyn Source>>>,
-) -> Result<Option<Vc<FileSystemPath>>> {
+    refs: &mut Vec<ResolvedVc<Box<dyn Source>>>,
+) -> Result<Option<ResolvedVc<FileSystemPath>>> {
     type_exists(fs_path, FileSystemEntryType::Directory, refs).await
 }
 
 async fn type_exists(
     fs_path: Vc<FileSystemPath>,
     ty: FileSystemEntryType,
-    refs: &mut Vec<Vc<Box<dyn Source>>>,
-) -> Result<Option<Vc<FileSystemPath>>> {
+    refs: &mut Vec<ResolvedVc<Box<dyn Source>>>,
+) -> Result<Option<ResolvedVc<FileSystemPath>>> {
     let result = fs_path.resolve().await?.realpath_with_links().await?;
     for path in result.symlinks.iter() {
-        refs.push(Vc::upcast(FileSource::new(**path)));
+        refs.push(ResolvedVc::upcast(
+            FileSource::new(**path).to_resolved().await?,
+        ));
     }
     let path = result.path;
     Ok(if *path.get_type().await? == ty {
-        Some(*path)
+        Some(path)
     } else {
         None
     })
@@ -994,11 +999,13 @@ async fn type_exists(
 
 async fn any_exists(
     fs_path: Vc<FileSystemPath>,
-    refs: &mut Vec<Vc<Box<dyn Source>>>,
+    refs: &mut Vec<ResolvedVc<Box<dyn Source>>>,
 ) -> Result<Option<(FileSystemEntryType, Vc<FileSystemPath>)>> {
     let result = fs_path.resolve().await?.realpath_with_links().await?;
     for path in result.symlinks.iter() {
-        refs.push(Vc::upcast(FileSource::new(**path)));
+        refs.push(ResolvedVc::upcast(
+            FileSource::new(**path).to_resolved().await?,
+        ));
     }
     let path = result.path;
     let ty = *path.get_type().await?;
@@ -1095,8 +1102,8 @@ pub fn package_json() -> Vc<Vec<RcStr>> {
 
 #[turbo_tasks::value(shared)]
 pub enum FindContextFileResult {
-    Found(ResolvedVc<FileSystemPath>, Vec<Vc<Box<dyn Source>>>),
-    NotFound(Vec<Vc<Box<dyn Source>>>),
+    Found(ResolvedVc<FileSystemPath>, Vec<ResolvedVc<Box<dyn Source>>>),
+    NotFound(Vec<ResolvedVc<Box<dyn Source>>>),
 }
 
 #[turbo_tasks::function]
@@ -1108,11 +1115,11 @@ pub async fn find_context_file(
     for name in &*names.await? {
         let fs_path = lookup_path.join(name.clone());
         if let Some(fs_path) = exists(fs_path, &mut refs).await? {
-            return Ok(FindContextFileResult::Found(fs_path.to_resolved().await?, refs).into());
+            return Ok(FindContextFileResult::Found(fs_path.to_resolved().await?, refs).cell());
         }
     }
     if lookup_path.await?.is_root() {
-        return Ok(FindContextFileResult::NotFound(refs).into());
+        return Ok(FindContextFileResult::NotFound(refs).cell());
     }
     if refs.is_empty() {
         // Tailcall
@@ -1148,7 +1155,7 @@ pub async fn find_context_file_or_package_key(
     let mut refs = Vec::new();
     let package_json_path = lookup_path.join("package.json".into());
     if let Some(package_json_path) = exists(package_json_path, &mut refs).await? {
-        if let Some(json) = &*read_package_json(package_json_path).await? {
+        if let Some(json) = &*read_package_json(*package_json_path).await? {
             if json.get(&**package_key).is_some() {
                 return Ok(FindContextFileResult::Found(
                     package_json_path.to_resolved().await?,
@@ -1198,7 +1205,7 @@ enum FindPackageItem {
 #[turbo_tasks::value]
 struct FindPackageResult {
     packages: Vec<FindPackageItem>,
-    affecting_sources: Vec<Vc<Box<dyn Source>>>,
+    affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
 }
 
 #[turbo_tasks::function]
@@ -1293,19 +1300,22 @@ fn merge_results(results: Vec<Vc<ResolveResult>>) -> Vc<ResolveResult> {
 
 fn merge_results_with_affecting_sources(
     results: Vec<Vc<ResolveResult>>,
-    affecting_sources: Vec<Vc<Box<dyn Source>>>,
+    affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
 ) -> Vc<ResolveResult> {
     if affecting_sources.is_empty() {
         return merge_results(results);
     }
     match results.len() {
-        0 => ResolveResult::unresolvable_with_affecting_sources(affecting_sources).into(),
+        0 => ResolveResult::unresolvable_with_affecting_sources(affecting_sources).cell(),
         1 => results
             .into_iter()
             .next()
             .unwrap()
-            .with_affecting_sources(affecting_sources),
-        _ => ResolveResult::alternatives_with_affecting_sources(results, affecting_sources),
+            .with_affecting_sources(affecting_sources.into_iter().map(|src| *src).collect()),
+        _ => ResolveResult::alternatives_with_affecting_sources(
+            results,
+            affecting_sources.into_iter().map(|src| *src).collect(),
+        ),
     }
 }
 
@@ -1319,13 +1329,16 @@ pub async fn resolve_raw(
         let RealPathResult { path, symlinks } = &*path.realpath_with_links().await?;
         Ok(ResolveResult::source_with_affecting_sources(
             RequestKey::new(request.into()),
-            Vc::upcast(FileSource::new(**path)),
+            ResolvedVc::upcast(FileSource::new(**path).to_resolved().await?),
             symlinks
                 .iter()
-                .map(|symlink| **symlink)
-                .map(FileSource::new)
-                .map(Vc::upcast)
-                .collect(),
+                .map(|symlink| async move {
+                    anyhow::Ok(ResolvedVc::upcast(
+                        FileSource::new(**symlink).to_resolved().await?,
+                    ))
+                })
+                .try_join()
+                .await?,
         )
         .cell())
     }
@@ -1451,7 +1464,13 @@ pub async fn url_resolve(
             request,
             resolve_options,
         )
-        .with_affecting_sources(rel_result.await?.get_affecting_sources().collect())
+        .with_affecting_sources(
+            rel_result
+                .await?
+                .get_affecting_sources()
+                .map(|src| *src)
+                .collect(),
+        )
     } else {
         rel_result
     };
@@ -1911,10 +1930,10 @@ async fn resolve_into_folder(
                         // we continue to try other alternatives
                         if !result.is_unresolvable_ref() {
                             let mut result = result.with_request_ref(".".into());
-                            result.add_affecting_source_ref(Vc::upcast(FileSource::new(
-                                package_json_path,
-                            )));
-                            return Ok(result.into());
+                            result.add_affecting_source_ref(ResolvedVc::upcast(
+                                FileSource::new(package_json_path).to_resolved().await?,
+                            ));
+                            return Ok(result.cell());
                         }
                     }
                 };
@@ -1924,12 +1943,12 @@ async fn resolve_into_folder(
     }
 
     if options_value.fully_specified {
-        return Ok(ResolveResult::unresolvable().into());
+        return Ok(ResolveResult::unresolvable().cell());
     }
 
     // fall back to dir/index.[js,ts,...]
     let pattern = match &options_value.default_files[..] {
-        [] => return Ok(ResolveResult::unresolvable().into()),
+        [] => return Ok(ResolveResult::unresolvable().cell()),
         [file] => Pattern::Constant(format!("./{file}").into()),
         files => Pattern::Alternatives(
             files
@@ -2234,7 +2253,7 @@ async fn apply_in_package(
                     options,
                 )
                 .with_replaced_request_key(value.into(), Value::new(request_key))
-                .with_affecting_sources(refs),
+                .with_affecting_sources(refs.into_iter().map(|src| *src).collect()),
             ));
         }
 
@@ -2596,15 +2615,22 @@ async fn resolved(
 
     Ok(ResolveResult::source_with_affecting_sources(
         request_key,
-        Vc::upcast(FileSource::new_with_query(**path, query)),
+        ResolvedVc::upcast(
+            FileSource::new_with_query(**path, query)
+                .to_resolved()
+                .await?,
+        ),
         symlinks
             .iter()
-            .map(|symlink| **symlink)
-            .map(FileSource::new)
-            .map(Vc::upcast)
-            .collect(),
+            .map(|symlink| async move {
+                anyhow::Ok(ResolvedVc::upcast(
+                    FileSource::new(**symlink).to_resolved().await?,
+                ))
+            })
+            .try_join()
+            .await?,
     )
-    .into())
+    .cell())
 }
 
 async fn handle_exports_imports_field(
@@ -2664,7 +2690,9 @@ async fn handle_exports_imports_field(
     // other options do not apply anymore when an exports field exist
     Ok(merge_results_with_affecting_sources(
         resolved_results,
-        vec![Vc::upcast(FileSource::new(package_json_path))],
+        vec![ResolvedVc::upcast(
+            FileSource::new(package_json_path).to_resolved().await?,
+        )],
     ))
 }
 

--- a/turbopack/crates/turbopack-core/src/source.rs
+++ b/turbopack/crates/turbopack-core/src/source.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 
 use crate::{asset::Asset, ident::AssetIdent};
 
@@ -12,9 +12,9 @@ pub trait Source: Asset {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct OptionSource(Option<Vc<Box<dyn Source>>>);
+pub struct OptionSource(Option<ResolvedVc<Box<dyn Source>>>);
 
 #[turbo_tasks::value(transparent)]
-pub struct Sources(Vec<Vc<Box<dyn Source>>>);
+pub struct Sources(Vec<ResolvedVc<Box<dyn Source>>>);
 
 // TODO All Vc::try_resolve_downcast::<Box<dyn Source>> calls should be removed

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -3067,7 +3067,7 @@ async fn resolve_as_webpack_runtime(
     );
 
     if let Some(source) = *resolved.first_source().await? {
-        Ok(webpack_runtime(source, transforms))
+        Ok(webpack_runtime(*source, transforms))
     } else {
         Ok(WebpackRuntime::None.into())
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -124,7 +124,9 @@ async fn resolve_reference_from_dir(
             PatternMatch::File(matched_path, file) => {
                 let realpath = file.realpath_with_links().await?;
                 for &symlink in &realpath.symlinks {
-                    affecting_sources.push(Vc::upcast(FileSource::new(*symlink)));
+                    affecting_sources.push(ResolvedVc::upcast(
+                        FileSource::new(*symlink).to_resolved().await?,
+                    ));
                 }
                 results.push((
                     RequestKey::new(matched_path.clone()),

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -180,7 +180,7 @@ impl ModuleReference for WebpackRuntimeAssetReference {
             .await?
             .map_module(|source| async move {
                 Ok(ModuleResolveResultItem::Module(ResolvedVc::upcast(
-                    WebpackModuleAsset::new(source, self.runtime, self.transforms)
+                    WebpackModuleAsset::new(*source, self.runtime, self.transforms)
                         .to_resolved()
                         .await?,
                 )))

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -209,8 +209,11 @@ pub async fn resolve_node_pre_gyp_files(
                         .await?,
                     affecting_paths
                         .into_iter()
-                        .map(|p| Vc::upcast(FileSource::new(p)))
-                        .collect(),
+                        .map(|p| async move {
+                            anyhow::Ok(ResolvedVc::upcast(FileSource::new(p).to_resolved().await?))
+                        })
+                        .try_join()
+                        .await?,
                 )
                 .cell());
             }

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -729,9 +729,9 @@ impl AssetContext for ModuleAssetContext {
                 let reference_type = reference_type.clone();
                 async move {
                     let process_result = if let Some(transition) = transition {
-                        transition.process(source, self, reference_type)
+                        transition.process(*source, self, reference_type)
                     } else {
-                        self.process_with_transition_rules(source, reference_type)
+                        self.process_with_transition_rules(*source, reference_type)
                     };
                     Ok(match *process_result.await? {
                         ProcessResult::Module(m) => {


### PR DESCRIPTION
A hand refactor of some struct fields from `Vc` to `ResolvedVc` to unblock local tasks.

Closes PACK-3392