### PR TITLE
Handle empty ESM client modules

### DIFF
--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -135,10 +135,13 @@ export function getRSCModuleInformation(
     }
   }
 
-  const clientRefs = clientInfoMatch?.[1]?.split(',')
-  const clientEntryType = clientInfoMatch?.[2] as 'cjs' | 'auto'
+  const clientRefsString = clientInfoMatch?.[1]
+  const clientRefs = clientRefsString ? clientRefsString.split(',') : []
+  const clientEntryType = clientInfoMatch?.[2] as 'cjs' | 'auto' | undefined
 
-  const type = clientRefs ? RSC_MODULE_TYPES.client : RSC_MODULE_TYPES.server
+  const type = clientInfoMatch
+    ? RSC_MODULE_TYPES.client
+    : RSC_MODULE_TYPES.server
 
   return {
     type,

--- a/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
@@ -34,10 +34,7 @@ export function getAssumedSourceType(
 
   if (sourceType === 'auto') {
     if (detectedClientEntryType === 'auto') {
-      if (
-        clientRefs.length === 0 ||
-        (clientRefs.length === 1 && clientRefs[0] === '')
-      ) {
+      if (clientRefs.length === 0) {
         // If there's zero export detected in the client boundary, and it's the
         // `auto` type, we can safely assume it's a CJS module because it doesn't
         // have ESM exports.
@@ -102,6 +99,10 @@ export default function transformSource(
     const stringifiedResourceKey = JSON.stringify(resourceKey)
 
     if (assumedSourceType === 'module') {
+      if (clientRefs.length === 0) {
+        return this.callback(null, 'export {}')
+      }
+
       if (clientRefs.includes('*')) {
         this.callback(
           new Error(

--- a/test/e2e/app-dir/esm-client-module-without-exports/app/layout.tsx
+++ b/test/e2e/app-dir/esm-client-module-without-exports/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/esm-client-module-without-exports/app/page.tsx
+++ b/test/e2e/app-dir/esm-client-module-without-exports/app/page.tsx
@@ -1,0 +1,5 @@
+import 'lib'
+
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/esm-client-module-without-exports/esm-client-module-without-exports.test.ts
+++ b/test/e2e/app-dir/esm-client-module-without-exports/esm-client-module-without-exports.test.ts
@@ -1,0 +1,12 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('esm-client-module-without-exports', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should render without errors', async () => {
+    const html = await next.render('/')
+    expect(html).toContain('hello world')
+  })
+})

--- a/test/e2e/app-dir/esm-client-module-without-exports/next.config.js
+++ b/test/e2e/app-dir/esm-client-module-without-exports/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/esm-client-module-without-exports/node_modules/lib/index.mjs
+++ b/test/e2e/app-dir/esm-client-module-without-exports/node_modules/lib/index.mjs
@@ -1,0 +1,1 @@
+'use client'

--- a/test/e2e/app-dir/esm-client-module-without-exports/node_modules/lib/package.json
+++ b/test/e2e/app-dir/esm-client-module-without-exports/node_modules/lib/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "lib",
+  "exports": {
+    ".": "./index.mjs"
+  }
+}


### PR DESCRIPTION
If an ESM module only includes a `'use client'` directive and no exports, which is the case for one of the modules that are included in `@chakra-ui/system` for example, we must not try to add `registerClientReference` statements for this module. This is a regression from #71968.

fixes #72358
closes #72359