### PR TITLE
improve `no-img-element` lint error message

### DIFF
--- a/errors/no-img-element.mdx
+++ b/errors/no-img-element.mdx
@@ -68,8 +68,20 @@ function Home() {
 }
 ```
 
+4. You can use a [custom image loader](/docs/pages/building-your-application/optimizing/images#loaders) to optimize images. Set [loaderFile](/docs/pages/api-reference/components/image#loaderfile) to the path of your custom loader.
+
+```js filename="next.config.js"
+module.exports = {
+  images: {
+    loader: 'custom',
+    loaderFile: './my/image/loader.js',
+  },
+}
+```
+
 ## Useful Links
 
 - [Image Component and Image Optimization](/docs/pages/building-your-application/optimizing/images)
 - [next/image API Reference](/docs/pages/api-reference/components/image)
 - [Largest Contentful Paint (LCP)](/learn/seo/web-performance/lcp)
+- [Next.js config loaderFile option](/docs/pages/api-reference/components/image#loaderfile)

--- a/packages/eslint-plugin-next/src/rules/no-img-element.ts
+++ b/packages/eslint-plugin-next/src/rules/no-img-element.ts
@@ -31,7 +31,7 @@ export = defineRule({
 
         context.report({
           node,
-          message: `Using \`<img>\` could result in slower LCP and higher bandwidth. Consider using \`<Image />\` from \`next/image\` to automatically optimize images. This may incur additional usage or cost from your provider. See: ${url}`,
+          message: `Using \`<img>\` could result in slower LCP and higher bandwidth. Consider using \`<Image />\` from \`next/image\` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: ${url}`,
         })
       },
     }

--- a/test/development/next-lint-eslint-formatter-compact/index.test.ts
+++ b/test/development/next-lint-eslint-formatter-compact/index.test.ts
@@ -29,7 +29,7 @@ describe('next-lint-eslint-formatter-compact', () => {
       'img elements must have an alt prop, either with meaningful text, or an empty string for decorative images.'
     )
     expect(fileOutput).toContain(
-      'Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element'
+      'Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element'
     )
 
     expect(fileOutput).toContain(`${next.testDir}/pages/index.js`)

--- a/test/integration/eslint/test/next-build.test.js
+++ b/test/integration/eslint/test/next-build.test.js
@@ -66,7 +66,7 @@ describe('Next Build', () => {
           'Error: `next/head` should not be imported in `pages/_document.js`. Use `<Head />` from `next/document` instead'
         )
         expect(output).toContain(
-          'Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images.'
+          'Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images.'
         )
         expect(output).toContain('Warning: Do not include stylesheets manually')
         expect(output).toContain(

--- a/test/integration/eslint/test/next-lint.test.js
+++ b/test/integration/eslint/test/next-lint.test.js
@@ -253,7 +253,7 @@ describe('Next Lint', () => {
       'Error: `next/head` should not be imported in `pages/_document.js`. Use `<Head />` from `next/document` instead'
     )
     expect(output).toContain(
-      'Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images.'
+      'Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images.'
     )
     expect(output).toContain('Warning: Do not include stylesheets manually')
     expect(output).toContain('Warning: Synchronous scripts should not be used')
@@ -277,7 +277,7 @@ describe('Next Lint', () => {
 
     const output = stdout + stderr
     expect(output).toContain(
-      'Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images.'
+      'Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images.'
     )
     expect(output).toContain('Error: Synchronous scripts should not be used.')
   })
@@ -307,7 +307,7 @@ describe('Next Lint', () => {
 
     const output = stdout + stderr
     expect(output).toContain(
-      'Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images.'
+      'Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images.'
     )
     expect(output).toContain('Error: Synchronous scripts should not be used.')
   })
@@ -497,7 +497,7 @@ describe('Next Lint', () => {
 
     expect(output).toContain('pages/bar.js')
     expect(output).toContain(
-      'Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images.'
+      'Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images.'
     )
 
     expect(output).not.toContain('pages/index.js')
@@ -540,7 +540,7 @@ describe('Next Lint', () => {
           }),
           expect.objectContaining({
             message:
-              'Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element',
+              'Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element',
           }),
         ])
       )
@@ -569,7 +569,7 @@ describe('Next Lint', () => {
       'img elements must have an alt prop, either with meaningful text, or an empty string for decorative images.'
     )
     expect(output).toContain(
-      'Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element'
+      'Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element'
     )
 
     expect(output).toContain('pages/index.cjs')

--- a/test/unit/eslint-plugin-next/no-img-element.test.ts
+++ b/test/unit/eslint-plugin-next/no-img-element.test.ts
@@ -5,7 +5,7 @@ import { rules } from '@next/eslint-plugin-next'
 const NextESLintRule = rules['no-img-element']
 
 const message =
-  'Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element'
+  'Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element'
 
 const tests = {
   valid: [


### PR DESCRIPTION
### Why?

To customize Image Optimation, the user can use a custom loader, but that information was out from the related lint error message.

Closes NDX-181