### PR TITLE
feat: add experimental `imgOptSequentialRead` config

### DIFF
--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -317,6 +317,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         imgOptConcurrency: z.number().int().optional().nullable(),
         imgOptTimeoutInSeconds: z.number().int().optional(),
         imgOptMaxInputPixels: z.number().int().optional(),
+        imgOptSequentialRead: z.boolean().optional().nullable(),
         internal_disableSyncDynamicAPIWarnings: z.boolean().optional(),
         isrFlushToDisk: z.boolean().optional(),
         largePageDataBytes: z.number().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -289,6 +289,7 @@ export interface ExperimentalConfig {
   imgOptConcurrency?: number | null
   imgOptTimeoutInSeconds?: number
   imgOptMaxInputPixels?: number
+  imgOptSequentialRead?: boolean | null
   optimisticClientCache?: boolean
   /**
    * @deprecated use config.expireTime instead
@@ -1101,6 +1102,7 @@ export const defaultConfig: NextConfig = {
     imgOptConcurrency: null,
     imgOptTimeoutInSeconds: 7,
     imgOptMaxInputPixels: 268_402_689, // https://sharp.pixelplumbing.com/api-constructor#:~:text=%5Boptions.limitInputPixels%5D
+    imgOptSequentialRead: null,
     isrFlushToDisk: true,
     workerThreads: false,
     proxyTimeout: undefined,

--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -514,6 +514,7 @@ export async function optimizeImage({
   height,
   concurrency,
   limitInputPixels,
+  sequentialRead,
   timeoutInSeconds,
 }: {
   buffer: Buffer
@@ -523,11 +524,13 @@ export async function optimizeImage({
   height?: number
   concurrency?: number | null
   limitInputPixels?: number
+  sequentialRead?: boolean | null
   timeoutInSeconds?: number
 }): Promise<Buffer> {
   const sharp = getSharp(concurrency)
   const transformer = sharp(buffer, {
     limitInputPixels,
+    sequentialRead: sequentialRead ?? undefined,
   })
     .timeout({
       seconds: timeoutInSeconds ?? 7,
@@ -645,7 +648,10 @@ export async function imageOptimizer(
   nextConfig: {
     experimental: Pick<
       NextConfigComplete['experimental'],
-      'imgOptConcurrency' | 'imgOptMaxInputPixels' | 'imgOptTimeoutInSeconds'
+      | 'imgOptConcurrency'
+      | 'imgOptMaxInputPixels'
+      | 'imgOptSequentialRead'
+      | 'imgOptTimeoutInSeconds'
     >
     images: Pick<
       NextConfigComplete['images'],
@@ -753,6 +759,7 @@ export async function imageOptimizer(
       width,
       concurrency: nextConfig.experimental.imgOptConcurrency,
       limitInputPixels: nextConfig.experimental.imgOptMaxInputPixels,
+      sequentialRead: nextConfig.experimental.imgOptSequentialRead,
       timeoutInSeconds: nextConfig.experimental.imgOptTimeoutInSeconds,
     })
     if (optimizedBuffer) {


### PR DESCRIPTION
This setting was originally added in PR https://github.com/vercel/next.js/pull/44881 and then removed in PR https://github.com/vercel/next.js/pull/65846 however it seems like it may still be useful in some cases. 

The [sharp docs](https://sharp.pixelplumbing.com/api-constructor) are not very clear:

> false to use random access, true to use sequential reads. Some operations will do this automatically.

Let's add it back as an experimental setting so we can measure performance.