### PR TITLE
Ignore error pages for cache revalidate

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1931,9 +1931,11 @@ export default abstract class Server<
     if (pathname === UNDERSCORE_NOT_FOUND_ROUTE) {
       pathname = '/404'
     }
-    const is404Page = pathname === '/404'
-
-    const is500Page = pathname === '/500'
+    const isErrorPathname = pathname === '/_error'
+    const is404Page =
+      pathname === '/404' || (isErrorPathname && res.statusCode === 404)
+    const is500Page =
+      pathname === '/500' || (isErrorPathname && res.statusCode === 500)
     const isAppPath = components.isAppPath === true
 
     const hasServerProps = !!components.getServerSideProps

--- a/test/production/empty-ssg-fallback/empty-ssg-fallback.test.ts
+++ b/test/production/empty-ssg-fallback/empty-ssg-fallback.test.ts
@@ -1,0 +1,12 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('empty-ssg-fallback', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should not cache 404 error page', async () => {
+    const res = await next.fetch('/any-non-existed')
+    expect(res.status).toBe(404)
+  })
+})

--- a/test/production/empty-ssg-fallback/pages/[...slug].tsx
+++ b/test/production/empty-ssg-fallback/pages/[...slug].tsx
@@ -1,0 +1,15 @@
+export const getStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: 'blocking',
+  }
+}
+export const getStaticProps = async () => {
+  return {
+    notFound: true,
+  }
+}
+
+export default function Page() {
+  return <p>slug</p>
+}

--- a/test/production/empty-ssg-fallback/pages/_error.tsx
+++ b/test/production/empty-ssg-fallback/pages/_error.tsx
@@ -1,0 +1,12 @@
+import { GetServerSidePropsContext } from 'next'
+
+function Error({ statusCode }: { statusCode: number }) {
+  return <p>{statusCode ? `${statusCode} error` : '500 error'}</p>
+}
+
+export async function getServerSideProps({ res }: GetServerSidePropsContext) {
+  const statusCode = res ? res.statusCode : 404
+  return { props: { statusCode } }
+}
+
+export default Error


### PR DESCRIPTION
### What

This is a case where the error page not being handled correctly, for SSG content when it's using `fallback: 'blocking'` and using `getStaticProps` to return `notFound: true`, the 404 page will return 500 on vercel deployment. Starting seeing it after [this change](https://github.com/vercel/next.js/pull/69990).

After investigation we found it's the `cacheEnrty.revalidate` [check is failing](https://github.com/vercel/next.js/blob/3170124cff8b35bf5ec642976b29e59f76931071/packages/next/src/server/base-server.ts#L3284-L3287). But for error pages they shouldn't enter that condition, but enter other 404/500 checks.

This PR fixes the condition of checking the error pages

### Test

Manually verified the deployment test since it's not running on the PR

#### With the Fix

Passed

```
NEXT_TEST_VERSION=https://files-n4ywuj310-huozhis-projects.vercel.app/next-15.0.3-canary.7.tgz p test-deploy test/production/empty-ssg-fallback/empty-ssg-fallback.test.ts
```

<img width="400" src="https://github.com/user-attachments/assets/aaf4c925-1e37-4993-864c-3ca6ade89380">


#### Without the Fix

Failing

<img width="400" src="https://github.com/user-attachments/assets/e7541ca5-cfbc-4b4b-b43f-759d6d89eb3b">


Closes NEXT-3857