### PR TITLE
Revert "feat(turbopack): Add an env var to debug-print the fast refresh invalidation reason (#72296)"

### DIFF
--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -246,12 +246,6 @@ export interface NapiUpdateMessage {
 export interface NapiUpdateInfo {
   duration: number
   tasks: number
-  /**
-   * A human-readable list of invalidation reasons (typically changed file paths) if known. Will
-   * be `None` if [`NapiUpdateInfoOpts::include_reasons`] is `false` or if no reason was
-   * specified (not every invalidation includes a reason).
-   */
-  reasons?: string
 }
 /**
  * Subscribes to lifecycle events of the compilation.
@@ -269,7 +263,6 @@ export interface NapiUpdateInfo {
 export function projectUpdateInfoSubscribe(
   project: { __napiType: 'Project' },
   aggregationMs: number,
-  includeReasons: boolean,
   func: (...args: any[]) => any
 ): void
 export interface StackFrame {

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -40,7 +40,6 @@ import type {
   TurbopackResult,
   TurbopackStackFrame,
   Update,
-  UpdateInfoOpts,
   UpdateMessage,
   WrittenEndpoint,
 } from './types'
@@ -762,12 +761,11 @@ function bindingToApi(
       return binding.projectGetSourceMap(this._nativeProject, filePath)
     }
 
-    updateInfoSubscribe(opts: UpdateInfoOpts) {
+    updateInfoSubscribe(aggregationMs: number) {
       return subscribe<TurbopackResult<UpdateMessage>>(true, async (callback) =>
         binding.projectUpdateInfoSubscribe(
           this._nativeProject,
-          opts.aggregationMs,
-          opts.includeReasons ?? false,
+          aggregationMs,
           callback
         )
       )

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -4,10 +4,7 @@ import type {
   ExternalObject,
   NextTurboTasks,
   RefCell,
-  NapiUpdateInfo as UpdateInfo,
 } from './generated-native'
-
-export type { NapiUpdateInfo as UpdateInfo } from './generated-native'
 
 export interface Binding {
   isWasm: boolean
@@ -198,9 +195,9 @@ export type UpdateMessage =
       value: UpdateInfo
     }
 
-export interface UpdateInfoOpts {
-  aggregationMs: number
-  includeReasons?: boolean
+export interface UpdateInfo {
+  duration: number
+  tasks: number
 }
 
 export interface Project {
@@ -223,7 +220,7 @@ export interface Project {
   ): Promise<TurbopackStackFrame | null>
 
   updateInfoSubscribe(
-    opts?: UpdateInfoOpts
+    aggregationMs: number
   ): AsyncIterableIterator<TurbopackResult<UpdateMessage>>
 
   shutdown(): Promise<void>

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -93,7 +93,6 @@ const isTestMode = !!(
   process.env.__NEXT_TEST_MODE ||
   process.env.DEBUG
 )
-const includeUpdateReasons = !!process.env.NEXT_TURBOPACK_INCLUDE_UPDATE_REASONS
 
 const sessionId = Math.floor(Number.MAX_SAFE_INTEGER * Math.random())
 
@@ -1019,21 +1018,13 @@ export async function createHotReloaderTurbopack(
   })
 
   async function handleProjectUpdates() {
-    for await (const updateMessage of project.updateInfoSubscribe({
-      aggregationMs: 30,
-      includeReasons: includeUpdateReasons,
-    })) {
+    for await (const updateMessage of project.updateInfoSubscribe(30)) {
       switch (updateMessage.updateType) {
         case 'start': {
           hotReloader.send({ action: HMR_ACTIONS_SENT_TO_BROWSER.BUILDING })
           break
         }
         case 'end': {
-          if (updateMessage.value.reasons) {
-            // debug: only populated when `process.env.NEXT_TURBOPACK_INCLUDE_UPDATE_REASONS` is set
-            // and a reason was supplied when the invalidation happened (not always true)
-            console.log('[Update Reasons]', updateMessage.value.reasons)
-          }
           sendEnqueuedMessages()
 
           function addErrors(

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -231,7 +231,7 @@ describe('next.rs api', () => {
       browserslistQuery: 'last 2 versions',
     })
     projectUpdateSubscription = filterMapAsyncIterator(
-      project.updateInfoSubscribe({ aggregationMs: 1000 }),
+      project.updateInfoSubscribe(1000),
       (update) => (update.updateType === 'end' ? update.value : undefined)
     )
   })


### PR DESCRIPTION
Not sure why this is happening, but @kdy1 bisected this commit to a null pointer assertion error in napi: https://vercel.slack.com/archives/C03EWR7LGEN/p1730901839682439?thread_ts=1730899709.760659&cid=C03EWR7LGEN

Reverting until I can repro and root cause.

Closes PACK-3402