### PR TITLE
[Turbopack] add BackendOptions and allow to disable dependencies, children and storage

### DIFF
--- a/crates/napi/src/next_api/utils.rs
+++ b/crates/napi/src/next_api/utils.rs
@@ -128,9 +128,14 @@ pub fn create_turbo_tasks(
 ) -> Result<NextTurboTasks> {
     Ok(if persistent_caching {
         NextTurboTasks::PersistentCaching(TurboTasks::new(
-            turbo_tasks_backend::TurboTasksBackend::new(default_backing_storage(
-                &output_path.join("cache/turbopack"),
-            )?),
+            turbo_tasks_backend::TurboTasksBackend::new(
+                turbo_tasks_backend::BackendOptions {
+                    dependency_tracking: true,
+                    children_tracking: true,
+                    storage_mode: Some(turbo_tasks_backend::StorageMode::ReadWrite),
+                },
+                default_backing_storage(&output_path.join("cache/turbopack"))?,
+            ),
         ))
     } else {
         let mut backend = turbo_tasks_memory::MemoryBackend::new(memory_limit);

--- a/crates/napi/src/next_api/utils.rs
+++ b/crates/napi/src/next_api/utils.rs
@@ -129,11 +129,7 @@ pub fn create_turbo_tasks(
     Ok(if persistent_caching {
         NextTurboTasks::PersistentCaching(TurboTasks::new(
             turbo_tasks_backend::TurboTasksBackend::new(
-                turbo_tasks_backend::BackendOptions {
-                    dependency_tracking: true,
-                    children_tracking: true,
-                    storage_mode: Some(turbo_tasks_backend::StorageMode::ReadWrite),
-                },
+                turbo_tasks_backend::BackendOptions::default(),
                 default_backing_storage(&output_path.join("cache/turbopack"))?,
             ),
         ))

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -120,6 +120,16 @@ pub struct BackendOptions {
     pub storage_mode: Option<StorageMode>,
 }
 
+impl Default for BackendOptions {
+    fn default() -> Self {
+        Self {
+            dependency_tracking: true,
+            children_tracking: true,
+            storage_mode: Some(StorageMode::ReadWrite),
+        }
+    }
+}
+
 pub struct TurboTasksBackend<B: BackingStorage>(Arc<TurboTasksBackendInner<B>>);
 
 struct TurboTasksBackendInner<B: BackingStorage> {
@@ -871,6 +881,9 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         task_id: TaskId,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) {
+        if !self.should_track_dependencies() {
+            panic!("Dependency tracking is disabled so invalidation is not allowed");
+        }
         operation::InvalidateOperation::run(
             smallvec![task_id],
             TaskDirtyCause::Unknown,
@@ -883,6 +896,9 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         tasks: &[TaskId],
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) {
+        if !self.should_track_dependencies() {
+            panic!("Dependency tracking is disabled so invalidation is not allowed");
+        }
         operation::InvalidateOperation::run(
             tasks.iter().copied().collect(),
             TaskDirtyCause::Unknown,
@@ -895,6 +911,9 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         tasks: &AutoSet<TaskId, BuildHasherDefault<FxHasher>, 2>,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) {
+        if !self.should_track_dependencies() {
+            panic!("Dependency tracking is disabled so invalidation is not allowed");
+        }
         operation::InvalidateOperation::run(
             tasks.iter().copied().collect(),
             TaskDirtyCause::Unknown,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -132,6 +132,9 @@ impl Default for BackendOptions {
 
 pub struct TurboTasksBackend<B: BackingStorage>(Arc<TurboTasksBackendInner<B>>);
 
+type TaskCacheLog = Sharded<ChunkedVec<(Arc<CachedTaskType>, TaskId)>>;
+type StorageLog = Sharded<ChunkedVec<CachedDataUpdate>>;
+
 struct TurboTasksBackendInner<B: BackingStorage> {
     options: BackendOptions,
 
@@ -141,12 +144,12 @@ struct TurboTasksBackendInner<B: BackingStorage> {
     persisted_task_id_factory: IdFactoryWithReuse<TaskId>,
     transient_task_id_factory: IdFactoryWithReuse<TaskId>,
 
-    persisted_task_cache_log: Option<Sharded<ChunkedVec<(Arc<CachedTaskType>, TaskId)>>>,
+    persisted_task_cache_log: Option<TaskCacheLog>,
     task_cache: BiMap<Arc<CachedTaskType>, TaskId>,
     transient_tasks: DashMap<TaskId, Arc<TransientTask>, BuildHasherDefault<FxHasher>>,
 
-    persisted_storage_data_log: Option<Sharded<ChunkedVec<CachedDataUpdate>>>,
-    persisted_storage_meta_log: Option<Sharded<ChunkedVec<CachedDataUpdate>>>,
+    persisted_storage_data_log: Option<StorageLog>,
+    persisted_storage_meta_log: Option<StorageLog>,
     storage: Storage<TaskId, CachedDataItem>,
 
     /// Number of executing operations + Highest bit is set when snapshot is

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -552,6 +552,7 @@ impl AggregationUpdateQueue {
     }
 
     pub fn run(job: AggregationUpdateJob, ctx: &mut impl ExecuteContext) {
+        debug_assert!(ctx.should_track_children());
         let mut queue = Self::new();
         queue.push(job);
         queue.execute(ctx);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
@@ -176,23 +176,30 @@ pub fn make_task_dirty_internal(
         }
         _ => unreachable!(),
     };
+
     let _span = tracing::trace_span!(
         "make task dirty",
         name = ctx.get_task_description(task_id),
         cause = cause.to_string()
     )
     .entered();
-    let aggregated_update = dirty_container.update_with_dirty_state(&DirtyState {
-        clean_in_session: None,
-    });
-    if !aggregated_update.is_zero() {
-        queue.extend(AggregationUpdateJob::data_update(
-            task,
-            AggregatedDataUpdate::new().dirty_container_update(task_id, aggregated_update),
-        ));
-    }
-    let root = task.has_key(&CachedDataItemKey::AggregateRoot {});
-    if root {
+
+    let should_schedule = if ctx.should_track_children() {
+        let aggregated_update = dirty_container.update_with_dirty_state(&DirtyState {
+            clean_in_session: None,
+        });
+        if !aggregated_update.is_zero() {
+            queue.extend(AggregationUpdateJob::data_update(
+                task,
+                AggregatedDataUpdate::new().dirty_container_update(task_id, aggregated_update),
+            ));
+        }
+        task.has_key(&CachedDataItemKey::AggregateRoot {})
+    } else {
+        true
+    };
+
+    if should_schedule {
         let description = ctx.get_task_desc_fn(task_id);
         if task.add(CachedDataItem::new_scheduled(description)) {
             ctx.schedule(task_id);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
@@ -28,11 +28,11 @@ impl UpdateCellOperation {
         }
 
         let recomputed = old_content.is_none() && !task.has_key(&CachedDataItemKey::Dirty {});
+        // recomputed means task wasn't invalidated, so we just recompute, so the content has not
+        // actually changed (At least we have to assume that tasks are deterministic and
+        // pure).
 
-        if recomputed {
-            // Task wasn't invalidated, so we just recompute, so the content has not actually
-            // changed (At least we have to assume that tasks are deterministic and
-            // pure).
+        if recomputed || !ctx.should_track_dependencies() {
             drop(task);
             drop(old_content);
             return;

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_collectible.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_collectible.rs
@@ -23,6 +23,10 @@ impl UpdateCollectibleOperation {
         count: i32,
         mut ctx: impl ExecuteContext,
     ) {
+        if !ctx.should_track_children() {
+            // Collectibles are not supported without children tracking
+            return;
+        }
         let mut queue = AggregationUpdateQueue::new();
         let mut task = ctx.task(task_id, TaskDataCategory::All);
         let outdated = get!(task, OutdatedCollectible { collectible }).copied();

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
@@ -110,8 +110,14 @@ impl UpdateOutputOperation {
             value: output_value,
         });
 
-        let dependent_tasks = get_many!(task, OutputDependent { task } => *task);
-        let children = get_many!(task, Child { task } => *task);
+        let dependent_tasks = ctx
+            .should_track_dependencies()
+            .then(|| get_many!(task, OutputDependent { task } => *task))
+            .unwrap_or_default();
+        let children = ctx
+            .should_track_children()
+            .then(|| get_many!(task, Child { task } => *task))
+            .unwrap_or_default();
 
         let mut queue = AggregationUpdateQueue::new();
 

--- a/turbopack/crates/turbo-tasks-backend/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/lib.rs
@@ -11,7 +11,10 @@ use std::path::Path;
 
 use anyhow::Result;
 
-pub use self::{backend::TurboTasksBackend, kv_backing_storage::KeyValueDatabaseBackingStorage};
+pub use self::{
+    backend::{BackendOptions, StorageMode, TurboTasksBackend},
+    kv_backing_storage::KeyValueDatabaseBackingStorage,
+};
 use crate::database::{
     handle_db_versioning, is_fresh, lmdb::LmbdKeyValueDatabase, FreshDbOptimization, NoopKvDb,
     ReadTransactionCache, StartupCacheLayer,

--- a/turbopack/crates/turbo-tasks-backend/tests/test_config.trs
+++ b/turbopack/crates/turbo-tasks-backend/tests/test_config.trs
@@ -9,6 +9,7 @@
   std::fs::create_dir_all(&path).unwrap();
   turbo_tasks::TurboTasks::new(
     turbo_tasks_backend::TurboTasksBackend::new(
+      turbo_tasks_backend::BackendOptions::default(),
       turbo_tasks_backend::default_backing_storage(
         path.as_path()
       ).unwrap()


### PR DESCRIPTION
### What?

Add options for the new backend to disable certain features.

* Storage can be disabled to avoid capturing change log data.
* Dependency tracking can be disabled when no changes are expected and no persistence is used
* Children tracking can be disabled for testing purposes.


Closes PACK-3405