### PR TITLE
chore(turbopack): Update indexmap dependency from 1.x to 2.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,7 +839,7 @@ dependencies = [
  "ahash 0.8.11",
  "chrono",
  "either",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itertools 0.13.0",
  "nom",
  "once_cell",
@@ -2550,7 +2550,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.11",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2997,9 +2997,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -3966,7 +3966,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "futures",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "next-core",
  "regex",
  "serde",
@@ -4042,7 +4042,7 @@ dependencies = [
  "auto-hash-map",
  "base64 0.21.4",
  "futures",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "indoc",
  "lazy-regex",
  "lazy_static",
@@ -4126,7 +4126,7 @@ dependencies = [
  "fxhash",
  "getrandom",
  "iana-time-zone",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "lightningcss-napi",
  "mdxjs",
  "napi",
@@ -5801,7 +5801,7 @@ version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itoa",
  "ryu",
  "serde",
@@ -5913,7 +5913,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itoa",
  "ryu",
  "serde",
@@ -6315,7 +6315,7 @@ dependencies = [
  "base64 0.21.4",
  "dashmap 5.5.3",
  "either",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "jsonc-parser",
  "lru",
  "napi",
@@ -6407,7 +6407,7 @@ dependencies = [
  "anyhow",
  "crc",
  "dashmap 5.5.3",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "is-macro",
  "once_cell",
  "parking_lot",
@@ -6512,7 +6512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aa30931f9b26af8edcb4cce605909d15dcfd7577220b22c50a2988f2a53c4c1"
 dependencies = [
  "anyhow",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "serde",
  "serde_json",
  "sourcemap",
@@ -6811,7 +6811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27be5007d501b111706bb5e055a57388aeda89b5b13613831a285e4571575400"
 dependencies = [
  "arrayvec 0.7.4",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "is-macro",
  "rustc-hash 1.1.0",
  "serde",
@@ -7032,7 +7032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba0fa4819b1353cbe5e15fabbc1618e0da6c51404214042457d3dd7a60e14960"
 dependencies = [
  "arrayvec 0.7.4",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "num-bigint",
  "num_cpus",
  "once_cell",
@@ -7091,7 +7091,7 @@ checksum = "536d242fcc9ae6dfcb3bf0fb1a0b087b20feca33e070aa51d585acbf8ac1ba5d"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "once_cell",
  "preset_env_base",
  "rustc-hash 1.1.0",
@@ -7166,7 +7166,7 @@ checksum = "f0a2438f61a45819b5adf0c338c92c07d83306d630fb2e6dc261c60fb75653d7"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.5.0",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "once_cell",
  "phf",
  "rayon",
@@ -7203,7 +7203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ca64973f33eb69cc29b9d1a432e6eebfbffa281be128318f8754013557a69e"
 dependencies = [
  "arrayvec 0.7.4",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "is-macro",
  "num-bigint",
  "rayon",
@@ -7254,7 +7254,7 @@ dependencies = [
  "Inflector",
  "anyhow",
  "bitflags 2.5.0",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "is-macro",
  "path-clean 1.0.1",
  "pathdiff",
@@ -7279,7 +7279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63d691ccea03a8eb25f37c7498e7609ad76ca3dc2070b630596e49f0b8fd1f4"
 dependencies = [
  "dashmap 5.5.3",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "once_cell",
  "petgraph",
  "rayon",
@@ -7325,7 +7325,7 @@ checksum = "90002fdbe17f10c84cb29a102154a30ee5ad3e7165f0610d18ba8aa3a592924c"
 dependencies = [
  "base64 0.21.4",
  "dashmap 5.5.3",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "once_cell",
  "rayon",
  "serde",
@@ -7392,7 +7392,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89892c33cf84806957c34539cb84a26c69f6d2c7c8d9ae3131113105852f1d60"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "rustc-hash 1.1.0",
  "swc_atoms",
  "swc_common",
@@ -7409,7 +7409,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "024a9ee9a19f448b31af002b90c43b9dfdb4e1fad23c76c21fe26a7c6e0f78a7"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "num_cpus",
  "once_cell",
  "rayon",
@@ -7493,7 +7493,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f65856acf41991a43d47d19ca947ee34f1152fccc42f048063c64eaf45a8e26"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "petgraph",
  "rustc-hash 1.1.0",
  "swc_common",
@@ -8113,7 +8113,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -8126,7 +8126,7 @@ version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -8423,7 +8423,7 @@ dependencies = [
  "erased-serde",
  "event-listener 2.5.3",
  "futures",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "mopa",
  "once_cell",
  "parking_lot",
@@ -8458,7 +8458,7 @@ dependencies = [
  "dashmap 5.5.3",
  "either",
  "hashbrown 0.14.5",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "lmdb-rkv",
  "once_cell",
  "parking_lot",
@@ -8514,7 +8514,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dotenvs",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "serde",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -8553,7 +8553,7 @@ dependencies = [
  "futures",
  "futures-retry",
  "include_dir",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "jsonc-parser",
  "mime",
  "notify",
@@ -8638,7 +8638,7 @@ dependencies = [
  "criterion",
  "dashmap 5.5.3",
  "either",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "loom",
  "num_cpus",
  "once_cell",
@@ -8681,7 +8681,7 @@ dependencies = [
  "criterion",
  "difference",
  "futures",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "lazy_static",
  "regex",
  "rstest",
@@ -8738,7 +8738,7 @@ name = "turbopack-browser"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "indoc",
  "serde",
  "serde_json",
@@ -8819,7 +8819,7 @@ dependencies = [
  "auto-hash-map",
  "browserslist-rs",
  "futures",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "lazy_static",
  "once_cell",
  "patricia_tree",
@@ -8857,7 +8857,7 @@ name = "turbopack-css"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "indoc",
  "lightningcss",
  "once_cell",
@@ -8888,7 +8888,7 @@ dependencies = [
  "futures",
  "hyper",
  "hyper-tungstenite",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "mime",
  "mime_guess",
  "parking_lot",
@@ -8921,7 +8921,7 @@ dependencies = [
  "async-trait",
  "criterion",
  "either",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "indoc",
  "lazy_static",
  "num-bigint",
@@ -8967,7 +8967,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "lightningcss",
  "modularize_imports",
  "serde",
@@ -9005,7 +9005,7 @@ name = "turbopack-env"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "serde",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -9073,7 +9073,7 @@ dependencies = [
  "either",
  "futures",
  "futures-retry",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "indoc",
  "mime",
  "once_cell",
@@ -9102,7 +9102,7 @@ name = "turbopack-nodejs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "indoc",
  "serde",
  "tracing",
@@ -9121,7 +9121,7 @@ name = "turbopack-resolve"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "lazy_static",
  "regex",
  "serde",
@@ -9182,7 +9182,7 @@ dependencies = [
  "anyhow",
  "dunce",
  "futures",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "once_cell",
  "serde",
  "serde_json",
@@ -9214,7 +9214,7 @@ dependencies = [
  "anyhow",
  "either",
  "flate2",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "itertools 0.10.5",
  "postcard",
  "rayon",
@@ -9247,7 +9247,7 @@ name = "turbopack-wasm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "indoc",
  "serde",
  "turbo-tasks",
@@ -9943,7 +9943,7 @@ dependencies = [
  "ciborium",
  "derive_builder 0.12.0",
  "hex",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "schemars",
  "semver 1.0.23",
  "serde",
@@ -10143,7 +10143,7 @@ version = "0.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dfcdb72d96f01e6c85b6bf20102e7423bdbaad5c337301bab2bbf253d26413c"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "semver 1.0.23",
 ]
 
@@ -10154,7 +10154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
 dependencies = [
  "bitflags 2.5.0",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "semver 1.0.23",
 ]
 
@@ -10724,7 +10724,7 @@ dependencies = [
  "cargo-lock",
  "chrono",
  "clap 4.5.2",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "inquire",
  "num-format",
  "owo-colors 3.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ futures-retry = "0.6.0"
 hashbrown = "0.14.5"
 httpmock = { version = "0.6.8", default-features = false }
 image = { version = "0.25.0", default-features = false }
-indexmap = "1.9.2"
+indexmap = "2.5.0"
 indicatif = "0.17.3"
 indoc = "2.0.0"
 itertools = "0.10.5"

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -135,7 +135,7 @@ impl VersionedContentMap {
                     .get_mut(k)
                     // guaranteed
                     .unwrap()
-                    .remove(&assets);
+                    .swap_remove(&assets);
                 changed = changed || res
             }
             changed

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/update.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/update.rs
@@ -104,7 +104,7 @@ pub(super) async fn update_chunk_list(
     let mut chunks = FxIndexMap::<_, _>::default();
 
     for (chunk_path, from_chunk_version) in &from.by_path {
-        if let Some(chunk_content) = by_path.remove(chunk_path) {
+        if let Some(chunk_content) = by_path.swap_remove(chunk_path) {
             let chunk_update = chunk_content
                 .update(TraitRef::cell(from_chunk_version.clone()))
                 .await?;

--- a/turbopack/crates/turbopack-browser/src/ecmascript/merged/update.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/merged/update.rs
@@ -195,7 +195,7 @@ pub(super) async fn update_ecmascript_merged_chunk(
         };
 
         let chunk_update = if let Some(from_version) =
-            from_versions_by_chunk_path.remove(chunk_path)
+            from_versions_by_chunk_path.swap_remove(chunk_path)
         {
             // The chunk was present in the previous version, so we must update it.
             let update = update_ecmascript_chunk(*content, from_version).await?;

--- a/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
@@ -151,7 +151,7 @@ impl RouteTree {
             self.not_found_sources
                 .extend(other.not_found_sources.iter().copied());
             for (key, value) in other.static_segments.iter() {
-                if let Some((key, self_value)) = self.static_segments.remove_entry(key) {
+                if let Some((key, self_value)) = self.static_segments.swap_remove_entry(key) {
                     static_segments.insert(key, vec![self_value, *value]);
                 } else if let Some(list) = static_segments.get_mut(key) {
                     list.push(*value);

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -342,7 +342,7 @@ impl DepGraph {
                 let data = data.get(id).unwrap();
 
                 for var in data.var_decls.iter() {
-                    required_vars.remove(var);
+                    required_vars.swap_remove(var);
                 }
 
                 // Depend on import statements from 'ImportBinding'
@@ -462,7 +462,7 @@ impl DepGraph {
                                 is_type_only: false,
                             });
 
-                            required_vars.remove(export);
+                            required_vars.swap_remove(export);
 
                             deps.push(PartId::Export(export.0.as_str().into()));
 
@@ -944,7 +944,7 @@ impl DepGraph {
                                     &top_level_vars,
                                 )
                             };
-                            used_ids.read.remove(&default_var.to_id());
+                            used_ids.read.swap_remove(&default_var.to_id());
                             used_ids.write.insert(default_var.to_id());
                             let mut captured_ids = if export.decl.is_fn_expr() {
                                 ids_captured_by(
@@ -956,7 +956,7 @@ impl DepGraph {
                             } else {
                                 Vars::default()
                             };
-                            captured_ids.read.remove(&default_var.to_id());
+                            captured_ids.read.swap_remove(&default_var.to_id());
 
                             let data = ItemData {
                                 read_vars: used_ids.read,

--- a/turbopack/crates/turbopack-trace-server/src/reader/turbopack.rs
+++ b/turbopack/crates/turbopack-trace-server/src/reader/turbopack.rs
@@ -182,11 +182,11 @@ impl TurbopackFormat {
                 };
                 let mut values = values.into_iter().collect::<FxIndexMap<_, _>>();
                 let duration = values
-                    .remove("duration")
+                    .swap_remove("duration")
                     .and_then(|v| v.as_u64())
                     .unwrap_or(0);
                 let name = values
-                    .remove("name")
+                    .swap_remove("name")
                     .and_then(|v| v.as_str().map(|s| s.to_string()))
                     .unwrap_or("event".into());
 


### PR DESCRIPTION
I noticed we were using a pretty old version of indexmap, this updates that.

`indexmap 1.9.3` still exists in the lockfile as there are some other dependencies we have (mostly `wasmer`) that pull it, but as those dependencies are updated, we'll get rid of it.

I specified the lower version range bound as `2.5.0` instead of `2.6.0` because I wanted to avoid introducing [yet another minor version of hashbrown](https://github.com/indexmap-rs/indexmap/blob/master/RELEASES.md), which might *slightly* help with compilation times. This is just a lower bound, so eventually we'll end up on `2.6.0` (or a later version) if dependency asks for it.

Closes PACK-3406