### PR TITLE
test slightly reduce runtime

### DIFF
--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -182,7 +182,7 @@ export class NextDevInstance extends NextInstance {
               if (!this.serverCompiledPattern.test(cliOutput)) {
                 throw new Error('Server has not finished restarting.')
               }
-            }, 5000)
+            })
           } catch (e) {
             /** Fail silently because not all change will be reflected in the server output */
           }
@@ -198,7 +198,7 @@ export class NextDevInstance extends NextInstance {
     }
 
     const { newFile } = await super.patchFile(filename, content)
-    await retry(() => waitForChanges({ newFile }))
+    await waitForChanges({ newFile })
 
     return { newFile }
   }


### PR DESCRIPTION
Our patchFile buffer was overly pessimistic. Striking a better balance of runtime and flakiness.