### PR TITLE
Turbopack: Commit changed generated bindings types

### DIFF
--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -370,15 +370,6 @@ export interface NapiRewrite {
   has?: Array<NapiRouteHas>
   missing?: Array<NapiRouteHas>
 }
-export function createTurboTasks(
-  outputPath: string,
-  persistentCaching: boolean,
-  memoryLimit?: number | undefined | null
-): ExternalObject<NextTurboTasks>
-export function runTurboTracing(
-  options: Buffer,
-  turboTasks: ExternalObject<NextTurboTasks>
-): Promise<Array<string>>
 export function getTargetTriple(): string
 export function initHeapProfiler(): ExternalObject<RefCell>
 export function teardownHeapProfiler(

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -23,10 +23,8 @@ import {
 import { getReactCompilerLoader } from '../get-babel-loader-config'
 import { TurbopackInternalError } from '../../server/dev/turbopack-utils'
 import type {
-  ExternalObject,
   NapiPartialProjectOptions,
   NapiProjectOptions,
-  NextTurboTasks,
 } from './generated-native'
 import type {
   Binding,
@@ -1054,18 +1052,6 @@ async function loadWasm(importPath = '') {
           return undefined
         },
         turbo: {
-          startTrace() {
-            Log.error('Wasm binding does not support trace yet')
-          },
-          createTurboTasks: function (
-            _outputPath: string,
-            _persistentCaching: boolean,
-            _memoryLimit?: number | undefined
-          ): ExternalObject<NextTurboTasks> {
-            throw new Error(
-              '`turbo.createTurboTasks` is not supported by the wasm bindings.'
-            )
-          },
           createProject: function (
             _options: ProjectOptions,
             _turboEngineOptions?: TurboEngineOptions | undefined
@@ -1233,24 +1219,6 @@ function loadNative(importPath?: string) {
       initHeapProfiler: bindings.initHeapProfiler,
       teardownHeapProfiler: bindings.teardownHeapProfiler,
       turbo: {
-        startTrace(options = {}, turboTasks: ExternalObject<NextTurboTasks>) {
-          initHeapProfiler()
-          return (customBindings ?? bindings).runTurboTracing(
-            toBuffer({ exact: true, ...options }),
-            turboTasks
-          )
-        },
-        createTurboTasks(
-          outputPath: string,
-          persistentCaching: boolean,
-          memoryLimit?: number
-        ): ExternalObject<NextTurboTasks> {
-          return bindings.createTurboTasks(
-            outputPath,
-            persistentCaching,
-            memoryLimit
-          )
-        },
         createProject: bindingToApi(customBindings ?? bindings, false),
         startTurbopackTraceServer(traceFilePath) {
           Log.warn(

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -1,20 +1,10 @@
 import type { NextConfigComplete } from '../../server/config-shared'
 import type { __ApiPreviewProps } from '../../server/api-utils'
-import type {
-  ExternalObject,
-  NextTurboTasks,
-  RefCell,
-} from './generated-native'
+import type { ExternalObject, RefCell } from './generated-native'
 
 export interface Binding {
   isWasm: boolean
   turbo: {
-    startTrace(options: any, turboTasks: ExternalObject<NextTurboTasks>): any
-    createTurboTasks(
-      outputPath: string,
-      persistentCaching: boolean,
-      memoryLimit?: number
-    ): ExternalObject<NextTurboTasks>
     createProject(
       options: ProjectOptions,
       turboEngineOptions?: TurboEngineOptions


### PR DESCRIPTION
This should have been part of #70998 when the Rust NAPI function were removed


Closes PACK-3415