### PR TITLE
Add missing closing `</AppOnly>`

### DIFF
--- a/docs/01-app/01-getting-started/02-project-structure.mdx
+++ b/docs/01-app/01-getting-started/02-project-structure.mdx
@@ -311,3 +311,5 @@ This strategy stores globally shared application code in the root `app` director
   width="1600"
   height="1011"
 />
+
+</AppOnly>


### PR DESCRIPTION
The MDX was invalid after https://github.com/vercel/next.js/pull/72399 causing next-site deploy failures

(I'm not entirely sure if this is where the `</AppOnly>` should go, feel free to correct that)

Closes PACK-3416