### PR TITLE
Correct reason for Turbopack incompat, remove inaccurate "good to know"

### DIFF
--- a/docs/01-app/02-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/02-building-your-application/07-configuring/05-mdx.mdx
@@ -649,7 +649,7 @@ export default withMDX(nextConfig)
 
 > **Good to know**:
 >
-> remark and rehype plugins cannot be used with [Turbopack](/docs/architecture/turbopack), due to lack of plugins support in [`mdxRs`](#using-the-rust-based-mdx-compiler-experimental)
+> remark and rehype plugins cannot be used with [Turbopack](/docs/architecture/turbopack), due to [inability to pass JavaScript functions to Rust](https://github.com/vercel/next.js/issues/71819#issuecomment-2461802968)
 
 ## Remote MDX
 
@@ -785,10 +785,6 @@ module.exports = withMDX({
   },
 })
 ```
-
-> **Good to know**:
->
-> This option is required when processing markdown and MDX while using [Turbopack](/docs/architecture/turbopack) (`next dev --turbopack`).
 
 ## Helpful Links
 

--- a/docs/01-app/02-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/02-building-your-application/07-configuring/05-mdx.mdx
@@ -649,7 +649,7 @@ export default withMDX(nextConfig)
 
 > **Good to know**:
 >
-> remark and rehype plugins cannot be used with [Turbopack](/docs/architecture/turbopack), due to [inability to pass JavaScript functions to Rust](https://github.com/vercel/next.js/issues/71819#issuecomment-2461802968)
+> remark and rehype plugins cannot be used with [Turbopack](/docs/architecture/turbopack) yet, due to [inability to pass JavaScript functions to Rust](https://github.com/vercel/next.js/issues/71819#issuecomment-2461802968)
 
 ## Remote MDX
 


### PR DESCRIPTION

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

1. Fix the incorrect statement added in #72241, as per @timneutkens' comment here:
   - https://github.com/vercel/next.js/pull/72241#discussion_r1832894901
2. Remove the outdated "good to know" section stating that Turbopack requires `mdxjs-rs` and is not compatible with `@next/mdx`

### Why?

The docs are currently incorrect

### How?

Edit [remark and rehype plugins](https://nextjs.org/docs/app/building-your-application/configuring/mdx#remark-and-rehype-plugins) section on docs page