### PR TITLE
[dynamicIO] abort warmup after caches are complete

### DIFF
--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -189,7 +189,7 @@ export interface RenderOptsPartial {
    * The resume data cache that was generated for this partially prerendered
    * page during dev warmup.
    */
-  devWarmupRenderResumeDataCache?: RenderResumeDataCache
+  devRenderResumeDataCache?: RenderResumeDataCache
 
   /**
    * When true, only the static shell of the page will be rendered. This will

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -61,11 +61,6 @@ export type RequestStore = {
   // DEV-only
   usedDynamic?: boolean
   prerenderPhase?: boolean
-
-  /**
-   * The resume data cache for this request. This will be a mutable cache.
-   */
-  devWarmupPrerenderResumeDataCache: PrerenderResumeDataCache | null
 } & PhasePartial
 
 /**
@@ -220,14 +215,9 @@ export function getPrerenderResumeDataCache(
   workUnitStore: WorkUnitStore
 ): PrerenderResumeDataCache | null {
   if (
-    workUnitStore.type !== 'prerender-legacy' &&
-    workUnitStore.type !== 'cache' &&
-    workUnitStore.type !== 'unstable-cache'
+    workUnitStore.type === 'prerender' ||
+    workUnitStore.type === 'prerender-ppr'
   ) {
-    if (workUnitStore.type === 'request') {
-      return workUnitStore.devWarmupPrerenderResumeDataCache
-    }
-
     return workUnitStore.prerenderResumeDataCache
   }
 

--- a/packages/next/src/server/async-storage/request-store.ts
+++ b/packages/next/src/server/async-storage/request-store.ts
@@ -248,7 +248,6 @@ function createRequestStoreImpl(
       return cache.draftMode
     },
     renderResumeDataCache: renderResumeDataCache ?? null,
-    devWarmupPrerenderResumeDataCache: null,
     isHmrRefresh,
     serverComponentsHmrCache:
       serverComponentsHmrCache ||

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -175,7 +175,6 @@ import type { RouteModule } from './route-modules/route-module'
 import { FallbackMode, parseFallbackField } from '../lib/fallback'
 import { toResponseCacheEntry } from './response-cache/utils'
 import { scheduleOnNextTick } from '../lib/scheduler'
-import { createRenderResumeDataCache } from './resume-data-cache/resume-data-cache'
 
 export type FindComponentsResult = {
   components: LoadComponentsReturnType
@@ -2654,11 +2653,9 @@ export default abstract class Server<
 
               // If the warmup is successful, we should use the resume data
               // cache from the warmup.
-              if (warmup.metadata.devWarmupPrerenderResumeDataCache) {
-                renderOpts.devWarmupRenderResumeDataCache =
-                  createRenderResumeDataCache(
-                    warmup.metadata.devWarmupPrerenderResumeDataCache
-                  )
+              if (warmup.metadata.devRenderResumeDataCache) {
+                renderOpts.devRenderResumeDataCache =
+                  warmup.metadata.devRenderResumeDataCache
               }
             }
 

--- a/packages/next/src/server/render-result.ts
+++ b/packages/next/src/server/render-result.ts
@@ -10,7 +10,7 @@ import {
   streamToString,
 } from './stream-utils/node-web-streams-helper'
 import { isAbortError, pipeToNodeResponse } from './pipe-readable'
-import type { PrerenderResumeDataCache } from './resume-data-cache/resume-data-cache'
+import type { RenderResumeDataCache } from './resume-data-cache/resume-data-cache'
 
 type ContentTypeOption = string | undefined
 
@@ -40,7 +40,7 @@ export type AppPageRenderResultMetadata = {
    * In development, the cache is warmed up before the render. This is attached
    * to the metadata so that it can be used during the render.
    */
-  devWarmupPrerenderResumeDataCache?: PrerenderResumeDataCache
+  devRenderResumeDataCache?: RenderResumeDataCache
 }
 
 export type PagesRenderResultMetadata = {


### PR DESCRIPTION
When we warmup we are trying to fill caches so the actual dev dynamic render can have the right environment for logs to help with debugging. If we have no inflight cache reads/fills happening there is no reason to continue the warmup.

This change updates the warmup function to wait for the cacheSignal to indicate it is complete before aborting. This should not alter any program behavior but is observable if you contrive a very slow prefetch request like awaiting a setTimeout inside loading.tsx

This allows us to remove the dev only property tracking the prerenderResumeCache in the request store type. I also moved the prerender->render cache conversion into the warmup function since it leaks less about the implementation generatlized the name since it being a cache from a warmup is sort of an implementation detail from the render interface perspective so we'll just call it a  devRenderResumeCache. still quite the mouthful