### PR TITLE
Add provenance to Turbopack misc. packages

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -560,6 +560,9 @@ jobs:
     # Matches the commit message written by turbopack/xtask/src/publish.rs:377
     if: "${{(github.ref == 'refs/heads/canary') && startsWith(github.event.head_commit.message, 'chore: release turbopack npm packages')}}"
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v3
 

--- a/turbopack/packages/devlow-bench/package.json
+++ b/turbopack/packages/devlow-bench/package.json
@@ -2,6 +2,11 @@
   "name": "@vercel/devlow-bench",
   "version": "0.3.3",
   "description": "Benchmarking tool for the developer workflow",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/next.js",
+    "directory": "turbopack/packages/devlow-bench"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Following #72360, this adds the necessary options in GitHub Actions to allow npm to publish the packages with provenance (authenticity/signing).


Closes PACK-3419