### PR TITLE
chore: update eslint document path

### DIFF
--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -8,7 +8,7 @@
     "url": "vercel/next.js",
     "directory": "packages/eslint-config-next"
   },
-  "homepage": "https://nextjs.org/docs/app/building-your-application/configuring/eslint#eslint-config",
+  "homepage": "https://nextjs.org/docs/app/api-reference/config/eslint#eslint-config",
   "dependencies": {
     "@next/eslint-plugin-next": "15.0.3",
     "@rushstack/eslint-patch": "^1.10.3",

--- a/packages/eslint-plugin-next/README.md
+++ b/packages/eslint-plugin-next/README.md
@@ -1,4 +1,4 @@
 # `@next/eslint-plugin-next`
 
 Documentation for `@next/eslint-plugin-next` can be found at:
-https://nextjs.org/docs/app/building-your-application/configuring/eslint#eslint-plugin
+https://nextjs.org/docs/app/api-reference/config/eslint#eslint-plugin

--- a/packages/next/src/lib/eslint/customFormatter.ts
+++ b/packages/next/src/lib/eslint/customFormatter.ts
@@ -131,7 +131,7 @@ export async function formatResults(
         ? output +
           `\n\n${cyan(
             'info'
-          )}  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/building-your-application/configuring/eslint#disabling-rules`
+          )}  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules`
         : '',
     totalNextPluginErrorCount,
     totalNextPluginWarningCount,

--- a/packages/next/src/lib/eslint/runLintCheck.ts
+++ b/packages/next/src/lib/eslint/runLintCheck.ts
@@ -52,7 +52,7 @@ async function cliPrompt(cwd: string): Promise<{ config?: any }> {
     bold(
       `${cyan(
         '?'
-      )} How would you like to configure ESLint? https://nextjs.org/docs/app/building-your-application/configuring/eslint`
+      )} How would you like to configure ESLint? https://nextjs.org/docs/app/api-reference/config/eslint`
     )
   )
 
@@ -263,7 +263,7 @@ async function lint(
     } else {
       Log.warn('')
       Log.warn(
-        'The Next.js plugin was not detected in your ESLint configuration. See https://nextjs.org/docs/app/building-your-application/configuring/eslint#migrating-existing-config'
+        'The Next.js plugin was not detected in your ESLint configuration. See https://nextjs.org/docs/app/api-reference/config/eslint#migrating-existing-config'
       )
     }
 
@@ -423,7 +423,7 @@ export async function runLintCheck(
         if (selectedConfig == null) {
           // Show a warning if no option is selected in prompt
           Log.warn(
-            'If you set up ESLint yourself, we recommend adding the Next.js ESLint plugin. See https://nextjs.org/docs/app/building-your-application/configuring/eslint#migrating-existing-config'
+            'If you set up ESLint yourself, we recommend adding the Next.js ESLint plugin. See https://nextjs.org/docs/app/api-reference/config/eslint#migrating-existing-config'
           )
           return null
         } else {

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -631,7 +631,7 @@ export interface NextConfig extends Record<string, any> {
 
   /**
    * @since version 11
-   * @see [ESLint configuration](https://nextjs.org/docs/app/building-your-application/configuring/eslint)
+   * @see [ESLint configuration](https://nextjs.org/docs/app/api-reference/config/eslint)
    */
   eslint?: ESLintConfig
 


### PR DESCRIPTION
## Description
At #72178, [ESLint](https://nextjs.org/docs/app/api-reference/config/eslint) docs was moved.
So update the old URLs.

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide