### PR TITLE
codemod(turbopack): Replace `return Err(anyhow!())` with `anyhow::bail!()`

### DIFF
--- a/crates/next-core/src/next_font/google/options.rs
+++ b/crates/next-core/src/next_font/google/options.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{fxindexset, trace::TraceRawVcs, FxIndexMap, FxIndexSet, RcStr, Value, Vc};
 

--- a/crates/next-core/src/next_font/google/options.rs
+++ b/crates/next-core/src/next_font/google/options.rs
@@ -72,9 +72,7 @@ pub(super) fn options_from_request(
     data: &FxIndexMap<RcStr, FontDataEntry>,
 ) -> Result<NextFontGoogleOptions> {
     if request.arguments.len() > 1 {
-        return Err(anyhow!(
-            "Only zero or one arguments to font functions are currently supported"
-        ));
+        anyhow::bail!("Only zero or one arguments to font functions are currently supported")
     }
     // Invariant enforced above: either None or Some(the only item in the vec)
     let argument = request.arguments.last().cloned().unwrap_or_default();
@@ -102,33 +100,33 @@ pub(super) fn options_from_request(
     let supports_variable_weight = font_data.weights.iter().any(|el| el == "variable");
     let weights = if requested_weights.is_empty() {
         if !supports_variable_weight {
-            return Err(anyhow!(
+            anyhow::bail!(
                 "Missing weight for {}. Available weights: {}",
                 font_family,
                 font_data.weights.join(", ")
-            ));
+            )
         }
 
         FontWeights::Variable
     } else if requested_weights.contains("variable") {
         if requested_weights.len() > 1 {
-            return Err(anyhow!(
+            anyhow::bail!(
                 "Unexpected `variable` in weight array for font {}. You only need `variable`, it \
                  includes all available weights.",
                 font_family
-            ));
+            )
         }
 
         FontWeights::Variable
     } else {
         for requested_weight in &requested_weights {
             if !font_data.weights.contains(requested_weight) {
-                return Err(anyhow!(
+                anyhow::bail!(
                     "Unknown weight {} for font {}.\nAvailable weights: {}",
                     requested_weight,
                     font_family,
                     font_data.weights.join(", ")
-                ));
+                )
             }
         }
 
@@ -150,37 +148,37 @@ pub(super) fn options_from_request(
 
     for requested_style in &styles {
         if !font_data.styles.contains(requested_style) {
-            return Err(anyhow!(
+            anyhow::bail!(
                 "Unknown style {} for font {}.\nAvailable styles: {}",
                 requested_style,
                 font_family,
                 font_data.styles.join(", ")
-            ));
+            )
         }
     }
 
     let display = argument.display.unwrap_or_else(|| "swap".into());
 
     if !ALLOWED_DISPLAY_VALUES.contains(&display.as_str()) {
-        return Err(anyhow!(
+        anyhow::bail!(
             "Invalid display value {} for font {}.\nAvailable display values: {}",
             display,
             font_family,
             ALLOWED_DISPLAY_VALUES.join(", ")
-        ));
+        )
     }
 
     if let Some(axes) = argument.axes.as_ref() {
         if !axes.is_empty() {
             if !supports_variable_weight {
-                return Err(anyhow!("Axes can only be defined for variable fonts."));
+                anyhow::bail!("Axes can only be defined for variable fonts.")
             }
 
             if weights != FontWeights::Variable {
-                return Err(anyhow!(
+                anyhow::bail!(
                     "Axes can only be defined for variable fonts when the weight property is \
                      nonexistent or set to `variable`."
-                ));
+                )
             }
         }
     }

--- a/crates/next-core/src/next_font/google/util.rs
+++ b/crates/next-core/src/next_font/google/util.rs
@@ -1,6 +1,6 @@
 use std::{cmp::Ordering, collections::BTreeSet};
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Context, Result};
 use turbo_tasks::{FxIndexSet, RcStr};
 
 use super::options::{FontData, FontWeights};
@@ -72,7 +72,7 @@ pub(super) fn get_font_axes(
 
                 for tag in selected_variable_axes {
                     if !definable_axes_tags.contains(tag) {
-                        anyhow::bail!(
+                        bail!(
                             "Invalid axes value {} for font {}.\nAvailable axes: {}",
                             tag,
                             font_family,

--- a/crates/next-core/src/next_font/google/util.rs
+++ b/crates/next-core/src/next_font/google/util.rs
@@ -72,12 +72,12 @@ pub(super) fn get_font_axes(
 
                 for tag in selected_variable_axes {
                     if !definable_axes_tags.contains(tag) {
-                        return Err(anyhow!(
+                        anyhow::bail!(
                             "Invalid axes value {} for font {}.\nAvailable axes: {}",
                             tag,
                             font_family,
                             definable_axes_tags.join(", ")
-                        ));
+                        )
                     }
                 }
             }

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -851,7 +851,7 @@ impl FileSystem for DiskFileSystem {
                 .with_context(|| format!("create symlink to {}", target))?;
             }
             LinkContent::Invalid => {
-                return Err(anyhow!("invalid symlink target: {}", full_path.display()));
+                anyhow::bail!("invalid symlink target: {}", full_path.display())
             }
             LinkContent::NotFound => {
                 retry_future(|| fs::remove_file(&full_path))

--- a/turbopack/crates/turbo-tasks-testing/tests/all_in_one.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/all_in_one.rs
@@ -2,7 +2,7 @@
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use turbo_tasks::{RcStr, ResolvedVc, Value, ValueToString, Vc};
 use turbo_tasks_testing::{register, run, Registration};
 
@@ -143,7 +143,7 @@ trait MyTrait: ValueToString {
     // TODO #[turbo_tasks::function]
     async fn my_trait_function(self: Vc<Self>) -> Result<Vc<RcStr>> {
         if *self.to_string().await? != "42" {
-            anyhow::bail!("my_trait_function must only be called with 42 as value")
+            bail!("my_trait_function must only be called with 42 as value")
         }
         // Calling a function twice
         Ok(self.to_string())

--- a/turbopack/crates/turbo-tasks-testing/tests/all_in_one.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/all_in_one.rs
@@ -143,9 +143,7 @@ trait MyTrait: ValueToString {
     // TODO #[turbo_tasks::function]
     async fn my_trait_function(self: Vc<Self>) -> Result<Vc<RcStr>> {
         if *self.to_string().await? != "42" {
-            return Err(anyhow!(
-                "my_trait_function must only be called with 42 as value"
-            ));
+            anyhow::bail!("my_trait_function must only be called with 42 as value")
         }
         // Calling a function twice
         Ok(self.to_string())

--- a/turbopack/crates/turbopack-bench/src/lib.rs
+++ b/turbopack/crates/turbopack-bench/src/lib.rs
@@ -256,10 +256,10 @@ fn bench_hmr_internal(
                                             hmr_warmup_dropped += 1;
 
                                             if hmr_warmup_dropped >= hmr_warmup {
-                                                return Err(anyhow!(
+                                                anyhow::bail!(
                                                     "failed to make warmup change {} times",
                                                     hmr_warmup_dropped
-                                                ));
+                                                )
                                             }
                                         }
                                         Ok(_) => {

--- a/turbopack/crates/turbopack-bench/src/util/npm.rs
+++ b/turbopack/crates/turbopack-bench/src/util/npm.rs
@@ -69,7 +69,7 @@ pub fn install(install_dir: &Path, packages: &[NpmPackage<'_>]) -> Result<()> {
     if !npm.status.success() {
         io::stdout().write_all(&npm.stdout)?;
         io::stderr().write_all(&npm.stderr)?;
-        return Err(anyhow!("npm install failed. See above."));
+        anyhow::bail!("npm install failed. See above.")
     }
 
     Ok(())

--- a/turbopack/crates/turbopack-bench/src/util/npm.rs
+++ b/turbopack/crates/turbopack-bench/src/util/npm.rs
@@ -8,7 +8,7 @@ use std::{
     path::Path,
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use serde_json::json;
 
 use crate::util::command;

--- a/turbopack/crates/turbopack-bench/src/util/page_guard.rs
+++ b/turbopack/crates/turbopack-bench/src/util/page_guard.rs
@@ -70,10 +70,7 @@ impl<'a> PageGuard<'a> {
                     }
                 }
                 Event::EventExceptionThrown(event) => {
-                    return Err(anyhow!(
-                        "Exception throw in page: {}",
-                        event.exception_details
-                    ));
+                    anyhow::bail!("Exception throw in page: {}", event.exception_details)
                 }
             }
         }

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use mime_guess::mime::TEXT_HTML_UTF_8;
 use turbo_tasks::{RcStr, ReadRef, ResolvedVc, TryJoinIterExt, Value, Vc};
 use turbo_tasks_fs::{File, FileSystemPath};

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -191,7 +191,7 @@ impl DevHtmlAssetContent {
                     relative_path
                 ));
             } else {
-                return Err(anyhow!("chunk with unknown asset type: {}", relative_path));
+                anyhow::bail!("chunk with unknown asset type: {}", relative_path)
             }
         }
 

--- a/turbopack/crates/turbopack-node/src/render/node_api_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/node_api_source.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use serde_json::Value as JsonValue;
 use turbo_tasks::{FxIndexSet, RcStr, ResolvedVc, Value, Vc};
 use turbo_tasks_env::ProcessEnv;

--- a/turbopack/crates/turbopack-node/src/render/node_api_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/node_api_source.rs
@@ -112,7 +112,7 @@ impl GetContentSourceContent for NodeApiContentSource {
         data: Value<ContentSourceData>,
     ) -> Result<Vc<ContentSourceContent>> {
         let Some(params) = &*self.route_match.params(path.clone()).await? else {
-            return Err(anyhow!("Non matching path provided"));
+            anyhow::bail!("Non matching path provided")
         };
         let ContentSourceData {
             method: Some(method),
@@ -124,7 +124,7 @@ impl GetContentSourceContent for NodeApiContentSource {
             ..
         } = &*data
         else {
-            return Err(anyhow!("Missing request data"));
+            anyhow::bail!("Missing request data")
         };
         let entry = (*self.entry).entry(data.clone()).await?;
         Ok(ContentSourceContent::HttpProxy(

--- a/turbopack/crates/turbopack-node/src/render/rendered_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/rendered_source.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use serde_json::Value as JsonValue;
 use turbo_tasks::{FxIndexSet, RcStr, ResolvedVc, Value, Vc};
 use turbo_tasks_env::ProcessEnv;

--- a/turbopack/crates/turbopack-node/src/render/rendered_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/rendered_source.rs
@@ -171,11 +171,7 @@ impl GetContentSourceContent for NodeRenderContentSource {
     ) -> Result<Vc<ContentSourceContent>> {
         let pathname = self.pathname.await?;
         let Some(params) = &*self.route_match.params(path.clone()).await? else {
-            return Err(anyhow!(
-                "Non matching path ({}) provided for {}",
-                path,
-                pathname
-            ));
+            anyhow::bail!("Non matching path ({}) provided for {}", path, pathname)
         };
         let ContentSourceData {
             method: Some(method),
@@ -186,7 +182,7 @@ impl GetContentSourceContent for NodeRenderContentSource {
             ..
         } = &*data
         else {
-            return Err(anyhow!("Missing request data"));
+            anyhow::bail!("Missing request data")
         };
         let entry = (*self.entry).entry(data.clone()).await?;
         let result = render_static(

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -279,7 +279,7 @@ impl Asset for JsonSource {
                 let value = match &*self.key.await? {
                     Some(key) => {
                         let Some(value) = json.get(&**key) else {
-                            return Err(anyhow::anyhow!("Invalid file type {:?}", file_type));
+                            anyhow::bail!("Invalid file type {:?}", file_type)
                         };
                         value
                     }

--- a/turbopack/crates/turbopack-static/src/output_asset.rs
+++ b/turbopack/crates/turbopack-static/src/output_asset.rs
@@ -37,10 +37,10 @@ impl OutputAsset for StaticAsset {
             if let FileContent::Content(file) = &*file.await? {
                 turbo_tasks_hash::hash_xxh3_hash64(file.content())
             } else {
-                return Err(anyhow!("StaticAsset::path: not found"));
+                anyhow::bail!("StaticAsset::path: not found")
             }
         } else {
-            return Err(anyhow!("StaticAsset::path: unsupported file content"));
+            anyhow::bail!("StaticAsset::path: unsupported file content")
         };
         let content_hash_b16 = turbo_tasks_hash::encode_hex(content_hash);
         let asset_path = self

--- a/turbopack/crates/turbopack-static/src/output_asset.rs
+++ b/turbopack/crates/turbopack-static/src/output_asset.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use turbo_tasks::Vc;
 use turbo_tasks_fs::FileContent;
 use turbopack_core::{


### PR DESCRIPTION
Early returns should use `anyhow::bail!()`.

Ran ast-grep with

```bash
sg run --lang rust --pattern 'return Err(anyhow!($$$ARGS));' --rewrite 'anyhow::bail!($$$ARGS)' --update-all && sg run --lang rust --pattern 'return Err(anyhow::anyhow!($$$ARGS));' --rewrite 'anyhow::bail!($$$ARGS)' --update-all && cargo fmt
```

Manually cleaned up unused import warnings (second commit) because `cargo fix` hangs (idle, no CPU usage) about halfway through our build, and I'm not sure why. I tested the latest nightly, and it hangs too.

Closes PACK-3437