### PR TITLE
docs(turbopack): Document build dependency on clang for rocksdb

### DIFF
--- a/contributing/core/developing.md
+++ b/contributing/core/developing.md
@@ -12,9 +12,9 @@
   ```
   corepack enable pnpm
   ```
-- (Linux) Install LLD, the LLVM linker:
+- (Linux) Install LLD (the LLVM linker) and Clang (used by `rust-rocksdb`):
   ```
-  sudo apt install lld
+  sudo apt install lld clang
   ```
 
 ## Local Development


### PR DESCRIPTION
Noticed this after rebuilding on top of #71688 

Most Linux distributions default to `gcc` for their default `cc` implementation (e.g. via Debian's `build-essential` meta-package, which we can probably implicitly assume is installed), which means that they won't typically have `clang` installed.

`librocksdb-sys` seems to always depend on `clang` on Linux. It looks like this might be a consequence of using [rust-bindgen](https://github.com/rust-lang/rust-bindgen) (though I'm confused why this didn't come up earlier), as it looks like rocksdb can otherwise build with gcc.

This shouldn't be an issue for macos, since `clang` is the default `cc` on that platform.

Closes PACK-3492