### PR TITLE
Skip canary checks during internal development with VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -58,6 +58,7 @@
         // "TURBOPACK_DEV": "1",
         // "TURBOPACK_BUILD": "1",
         "NEXT_PRIVATE_LOCAL_WEBPACK": "1",
+        "NEXT_PRIVATE_SKIP_CANARY_CHECK": "1",
         "NEXT_TELEMETRY_DISABLED": "1"
       }
     },
@@ -89,6 +90,7 @@
       },
       "env": {
         "NEXT_PRIVATE_LOCAL_WEBPACK": "1",
+        "NEXT_PRIVATE_SKIP_CANARY_CHECK": "1",
         "NEXT_TELEMETRY_DISABLED": "1"
       }
     },


### PR DESCRIPTION
https://github.com/vercel/next.js/pull/72464 for `launch.json`