### PR TITLE
[Turbopack] fix bug where task was not recomputed when stale

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1358,7 +1358,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         let InProgressState::InProgress {
             done_event,
             once_task: _,
-            stale: _,
+            stale,
             session_dependent,
         } = in_progress
         else {


### PR DESCRIPTION
### What?

typo that took me long to find.

We want to check stale flag again when the task lock is acquired again


Closes PACK-3451