### PR TITLE
[Turbopack] add logical value mode for tracing

### DIFF
--- a/turbopack/crates/turbopack-trace-server/src/span.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span.rs
@@ -35,6 +35,7 @@ pub struct Span {
 
     // More nested fields, but memory lazily allocated
     pub time_data: OnceLock<Box<SpanTimeData>>,
+    pub logical_data: OnceLock<Box<SpanLogicalData>>,
     pub extra: OnceLock<Box<SpanExtra>>,
     pub names: OnceLock<Box<SpanNames>>,
 }
@@ -55,6 +56,11 @@ pub struct SpanTimeData {
     pub total_time: OnceLock<u64>,
     pub corrected_self_time: OnceLock<u64>,
     pub corrected_total_time: OnceLock<u64>,
+}
+
+#[derive(Default)]
+pub struct SpanLogicalData {
+    pub needed_space: OnceLock<u64>,
 }
 
 #[derive(Default)]
@@ -85,6 +91,10 @@ impl Span {
     pub fn time_data_mut(&mut self) -> &mut SpanTimeData {
         self.time_data();
         self.time_data.get_mut().unwrap()
+    }
+
+    pub fn logical_data(&self) -> &SpanLogicalData {
+        self.logical_data.get_or_init(Default::default)
     }
 
     pub fn extra(&self) -> &SpanExtra {
@@ -135,6 +145,7 @@ pub struct SpanGraph {
     pub total_span_count: OnceLock<u64>,
     pub corrected_self_time: OnceLock<u64>,
     pub corrected_total_time: OnceLock<u64>,
+    pub logical_needed_space: OnceLock<u64>,
     pub bottom_up: OnceLock<Vec<Arc<SpanBottomUp>>>,
 }
 

--- a/turbopack/crates/turbopack-trace-server/src/store.rs
+++ b/turbopack/crates/turbopack-trace-server/src/store.rs
@@ -6,6 +6,8 @@ use std::{
     sync::{atomic::AtomicU64, OnceLock},
 };
 
+use indexmap::IndexMap;
+
 use crate::{
     self_time_tree::SelfTimeTree,
     span::{Span, SpanEvent, SpanIndex},
@@ -43,6 +45,7 @@ fn new_root_span() -> Span {
         total_allocation_count: OnceLock::new(),
         total_span_count: OnceLock::new(),
         time_data: OnceLock::new(),
+        logical_data: OnceLock::new(),
         extra: OnceLock::new(),
         names: OnceLock::new(),
     }
@@ -98,6 +101,7 @@ impl Store {
             total_allocation_count: OnceLock::new(),
             total_span_count: OnceLock::new(),
             time_data: OnceLock::new(),
+            logical_data: OnceLock::new(),
             extra: OnceLock::new(),
             names: OnceLock::new(),
         });
@@ -124,7 +128,9 @@ impl Store {
         outdated_spans: &mut HashSet<SpanIndex>,
     ) {
         let span = &mut self.spans[span_index.get()];
-        span.args.extend(args);
+        let mut map = span.args.drain(..).collect::<IndexMap<_, _>>();
+        map.extend(args);
+        span.args.extend(map.into_iter());
         outdated_spans.insert(span_index);
     }
 
@@ -319,6 +325,7 @@ impl Store {
             span.total_allocation_count.take();
             span.total_span_count.take();
             span.extra.take();
+            span.logical_data.take();
         }
 
         for id in outdated_spans.iter() {


### PR DESCRIPTION
### What?

Add a mode to the trace server which makes every child large enough to be visible. This allows to navigate the trace data logically without time info.


Closes PACK-4391