### PR TITLE
Turbopack: NFT followups

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1403,7 +1403,7 @@ impl AppEndpoint {
                             *rsc_chunk,
                             this.app_project.project().output_fs().root(),
                             this.app_project.project().project_fs().root(),
-                            this.app_project.project().client_fs(),
+                            this.app_project.project().client_fs().root(),
                             client_reference_manifest.iter().map(|m| **m).collect(),
                         )
                         .to_resolved()

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -43,7 +43,7 @@ use turbo_tasks::{
     TryJoinIterExt, Value, ValueToString, Vc,
 };
 use turbo_tasks_env::{CustomProcessEnv, ProcessEnv};
-use turbo_tasks_fs::{File, FileContent, FileSystemPath};
+use turbo_tasks_fs::{File, FileContent, FileSystem, FileSystemPath};
 use turbopack::{
     module_options::{transition_rule::TransitionRule, ModuleOptionsContext, RuleCondition},
     resolve_options_context::ResolveOptionsContext,
@@ -1401,8 +1401,8 @@ impl AppEndpoint {
                     server_assets.insert(ResolvedVc::upcast(
                         NftJsonAsset::new(
                             *rsc_chunk,
-                            this.app_project.project().output_fs(),
-                            this.app_project.project().project_fs(),
+                            this.app_project.project().output_fs().root(),
+                            this.app_project.project().project_fs().root(),
                             this.app_project.project().client_fs(),
                             client_reference_manifest.iter().map(|m| **m).collect(),
                         )

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -43,7 +43,7 @@ use turbo_tasks::{
     TryJoinIterExt, Value, ValueToString, Vc,
 };
 use turbo_tasks_env::{CustomProcessEnv, ProcessEnv};
-use turbo_tasks_fs::{File, FileContent, FileSystem, FileSystemPath};
+use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack::{
     module_options::{transition_rule::TransitionRule, ModuleOptionsContext, RuleCondition},
     resolve_options_context::ResolveOptionsContext,
@@ -1400,10 +1400,8 @@ impl AppEndpoint {
                 {
                     server_assets.insert(ResolvedVc::upcast(
                         NftJsonAsset::new(
+                            this.app_project.project(),
                             *rsc_chunk,
-                            this.app_project.project().output_fs().root(),
-                            this.app_project.project().project_fs().root(),
-                            this.app_project.project().client_fs().root(),
                             client_reference_manifest.iter().map(|m| **m).collect(),
                         )
                         .to_resolved()

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -8,7 +8,7 @@ use next_core::{
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{Completion, ResolvedVc, Value, Vc};
-use turbo_tasks_fs::{File, FileContent, FileSystem, FileSystemPath};
+use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
     chunk::{
@@ -225,15 +225,9 @@ impl InstrumentationEndpoint {
             let mut output_assets = vec![chunk];
             if this.project.next_mode().await?.is_production() {
                 output_assets.push(ResolvedVc::upcast(
-                    NftJsonAsset::new(
-                        *chunk,
-                        this.project.output_fs().root(),
-                        this.project.project_fs().root(),
-                        this.project.client_fs().root(),
-                        vec![],
-                    )
-                    .to_resolved()
-                    .await?,
+                    NftJsonAsset::new(this.project, *chunk, vec![])
+                        .to_resolved()
+                        .await?,
                 ));
             }
             Ok(Vc::cell(output_assets))

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -8,7 +8,7 @@ use next_core::{
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{Completion, ResolvedVc, Value, Vc};
-use turbo_tasks_fs::{File, FileContent, FileSystemPath};
+use turbo_tasks_fs::{File, FileContent, FileSystem, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
     chunk::{
@@ -227,8 +227,8 @@ impl InstrumentationEndpoint {
                 output_assets.push(ResolvedVc::upcast(
                     NftJsonAsset::new(
                         *chunk,
-                        this.project.output_fs(),
-                        this.project.project_fs(),
+                        this.project.output_fs().root(),
+                        this.project.project_fs().root(),
                         this.project.client_fs(),
                         vec![],
                     )

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -229,7 +229,7 @@ impl InstrumentationEndpoint {
                         *chunk,
                         this.project.output_fs().root(),
                         this.project.project_fs().root(),
-                        this.project.client_fs(),
+                        this.project.client_fs().root(),
                         vec![],
                     )
                     .to_resolved()

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Result};
 use serde_json::json;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
-use turbo_tasks_fs::{File, FileSystem, FileSystemPath, VirtualFileSystem};
+use turbo_tasks_fs::{File, FileSystem, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     ident::AssetIdent,
@@ -129,20 +129,6 @@ impl NftJsonAsset {
                     .replace("/_next/", "/.next/")
                     .into(),
             )));
-        }
-
-        // items that are on the externals file system
-        if let Some(path_fs) = Vc::try_resolve_downcast_type::<VirtualFileSystem>(*path_fs).await? {
-            if path_fs.await?.name == "traced" {
-                return Ok(Vc::cell(Some(
-                    self.ident_in_project_fs()
-                        .await?
-                        .get_relative_path_to(
-                            &*this.project_root.root().join(path_ref.path.clone()).await?,
-                        )
-                        .unwrap(),
-                )));
-            }
         }
 
         // Make this an error for now, this should effectively be unreachable

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -133,7 +133,7 @@ impl NftJsonAsset {
 
         // items that are on the externals file system
         if let Some(path_fs) = Vc::try_resolve_downcast_type::<VirtualFileSystem>(*path_fs).await? {
-            if path_fs.await?.name == "externals" {
+            if path_fs.await?.name == "traced" {
                 return Ok(Vc::cell(Some(
                     self.ident_in_project_fs()
                         .await?

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use anyhow::{bail, Result};
 use serde_json::json;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{File, FileSystem, FileSystemPath, VirtualFileSystem};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -145,7 +145,11 @@ impl NftJsonAsset {
             }
         }
 
-        Ok(Vc::cell(None))
+        // Make this an error for now, this should effectively be unreachable
+        bail!(
+            "NftJsonAsset: cannot handle filepath {}",
+            path.to_string().await?
+        );
     }
 }
 

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -68,6 +68,13 @@ impl NftJsonAsset {
     fn project_path(&self) -> Vc<FileSystemPath> {
         self.project.project_path()
     }
+
+    #[turbo_tasks::function]
+    async fn dist_dir(&self) -> Result<Vc<RcStr>> {
+        Ok(Vc::cell(
+            format!("/{}/", self.project.dist_dir().await?).into(),
+        ))
+    }
 }
 
 #[turbo_tasks::value(transparent)]
@@ -128,7 +135,7 @@ impl NftJsonAsset {
                     .await?
                     .get_relative_path_to(&path_ref)
                     .unwrap()
-                    .replace("/_next/", "/.next/")
+                    .replace("/_next/", &self.dist_dir().await?)
                     .into(),
             )));
         }

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -63,6 +63,11 @@ impl NftJsonAsset {
     fn client_root(&self) -> Vc<FileSystemPath> {
         self.project.client_fs().root()
     }
+
+    #[turbo_tasks::function]
+    fn project_path(&self) -> Vc<FileSystemPath> {
+        self.project.project_path()
+    }
 }
 
 #[turbo_tasks::value(transparent)]
@@ -71,13 +76,6 @@ pub struct OutputSpecifier(Option<RcStr>);
 #[turbo_tasks::value_impl]
 impl NftJsonAsset {
     #[turbo_tasks::function]
-    async fn output_root_in_project_fs(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
-        Ok(self
-            .project_root()
-            .join(self.await?.project.project_path().await?.path.clone()))
-    }
-
-    #[turbo_tasks::function]
     async fn ident_folder(self: Vc<Self>) -> Vc<FileSystemPath> {
         self.ident().path().parent()
     }
@@ -85,7 +83,7 @@ impl NftJsonAsset {
     #[turbo_tasks::function]
     async fn ident_folder_in_project_fs(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
         Ok(self
-            .output_root_in_project_fs()
+            .project_path()
             .join(self.ident_folder().await?.path.clone()))
     }
 

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -882,7 +882,7 @@ impl PageEndpoint {
                 )
                 .await?;
 
-                let nft = if this
+                let server_asset_trace_file = if this
                     .pages_project
                     .project()
                     .next_mode()
@@ -892,8 +892,8 @@ impl PageEndpoint {
                     ResolvedVc::cell(Some(ResolvedVc::upcast(
                         NftJsonAsset::new(
                             *ssr_entry_chunk,
-                            this.pages_project.project().output_fs(),
-                            this.pages_project.project().project_fs(),
+                            this.pages_project.project().output_fs().root(),
+                            this.pages_project.project().project_fs().root(),
                             this.pages_project.project().client_fs(),
                             vec![],
                         )
@@ -907,7 +907,7 @@ impl PageEndpoint {
                 Ok(SsrChunk::NodeJs {
                     entry: ssr_entry_chunk,
                     dynamic_import_entries,
-                    nft,
+                    server_asset_trace_file,
                 }
                 .cell())
             }
@@ -1109,11 +1109,11 @@ impl PageEndpoint {
             SsrChunk::NodeJs {
                 entry,
                 dynamic_import_entries,
-                nft,
+                server_asset_trace_file,
             } => {
                 server_assets.push(entry);
-                if let Some(nft) = &*nft.await? {
-                    server_assets.push(*nft);
+                if let Some(server_asset_trace_file) = &*server_asset_trace_file.await? {
+                    server_assets.push(*server_asset_trace_file);
                 }
 
                 if emit_manifests {
@@ -1396,7 +1396,7 @@ pub enum SsrChunk {
     NodeJs {
         entry: ResolvedVc<Box<dyn OutputAsset>>,
         dynamic_import_entries: Vc<DynamicImportedChunks>,
-        nft: ResolvedVc<OptionOutputAsset>,
+        server_asset_trace_file: ResolvedVc<OptionOutputAsset>,
     },
     Edge {
         files: Vc<OutputAssets>,

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -894,7 +894,7 @@ impl PageEndpoint {
                             *ssr_entry_chunk,
                             this.pages_project.project().output_fs().root(),
                             this.pages_project.project().project_fs().root(),
-                            this.pages_project.project().client_fs(),
+                            this.pages_project.project().client_fs().root(),
                             vec![],
                         )
                         .to_resolved()

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -890,15 +890,9 @@ impl PageEndpoint {
                     .is_production()
                 {
                     ResolvedVc::cell(Some(ResolvedVc::upcast(
-                        NftJsonAsset::new(
-                            *ssr_entry_chunk,
-                            this.pages_project.project().output_fs().root(),
-                            this.pages_project.project().project_fs().root(),
-                            this.pages_project.project().client_fs().root(),
-                            vec![],
-                        )
-                        .to_resolved()
-                        .await?,
+                        NftJsonAsset::new(this.pages_project.project(), *ssr_entry_chunk, vec![])
+                            .to_resolved()
+                            .await?,
                     )))
                 } else {
                     ResolvedVc::cell(None)


### PR DESCRIPTION
Closes PACK-3421

Address PR feedback from https://github.com/vercel/next.js/pull/72305

When working on this, I uncovered another bug which will be handled in a different PR.

Changes:
- Don't rely on `DiskFileSystem` but only via file paths and `is_inside()`
- Put the `RebasedAsset` for externals on the `[project]/` fs (this way, they aren't emitted either), i.e. don't perform any rebasing at all and just reference the files where they are