### PR TITLE
docs(turbopack): Better document the Vc type, with references to ResolvedVc and VcOperation

### DIFF
--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -2,25 +2,29 @@
 //! execution.
 //!
 //! It defines 4 primitives:
-//! - functions: Unit of execution, invalidation and reexecution.
-//! - values: Data created, stored and returned by functions.
-//! - traits: Traits that define a set of functions on values.
-//! - collectibles: Values emitted in functions that bubble up the call graph and can be collected
-//!   in parent functions.
+//! - **[Functions][macro@crate::function]:** Units of execution, invalidation, and reexecution.
+//! - **[Values][macro@crate::value]:** Data created, stored, and returned by functions.
+//! - **[Traits][macro@crate::value_trait]:** Traits that define a set of functions on values.
+//! - **[Collectibles][crate::TurboTasks::emit_collectible]:** Values emitted in functions that
+//!   bubble up the call graph and can be collected in parent functions.
 //!
 //! It also defines some derived elements from that:
-//! - cells: The locations in functions where values are stored. The content of a cell can change
-//!   after the reexecution of a function.
-//! - Vcs: A reference to a cell in a function or a return value of a function.
-//! - task: An instance of a function together with its arguments.
+//! - **[Tasks][book-tasks]:** An instance of a function together with its arguments.
+//! - **[Cells][book-cells]:** The locations associated with tasks where values are stored. The
+//!   contents of a cell can change after the reexecution of a function.
+//! - **[`Vc`s ("Value Cells")][Vc]:** A reference to a cell or a return value of a function.
 //!
-//! A Vc can be read to get a read-only reference to the stored data.
+//! A [`Vc`] can be read to get [a read-only reference][ReadRef] to the stored data, representing a
+//! snapshot of that cell at that point in time.
 //!
-//! On execution of functions, turbo-tasks will track which Vcs are read. Once
-//! any of these change, turbo-tasks will invalidate the task created from the
-//! function's execution and it will eventually be scheduled and reexecuted.
+//! On execution of functions, `turbo-tasks` will track which [`Vc`]s are read. Once any of these
+//! change, `turbo-tasks` will invalidate the task created from the function's execution and it will
+//! eventually be scheduled and reexecuted.
 //!
 //! Collectibles go through a similar process.
+//!
+//! [book-cells]: https://turbopack-rust-docs.vercel.sh/turbo-engine/cells.html
+//! [book-tasks]: https://turbopack-rust-docs.vercel.sh/turbo-engine/tasks.html
 
 #![feature(trivial_bounds)]
 #![feature(min_specialization)]

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -66,7 +66,7 @@ macro_rules! stringify_path {
 /// implement [`ShrinkToFit`].
 ///
 /// This is used by the derive macro for [`ShrinkToFit`], which is called by the
-/// [turbo_tasks::value][crate::value] macro.
+/// [turbo_tasks::value][macro@crate::value] macro.
 ///
 /// [autoderef]: http://lukaskalbertodt.github.io/2019/12/05/generalized-autoref-based-specialization.html
 pub struct ShrinkToFitDerefSpecialization<'a, T> {

--- a/turbopack/crates/turbo-tasks/src/raw_vc.rs
+++ b/turbopack/crates/turbo-tasks/src/raw_vc.rs
@@ -54,6 +54,15 @@ impl Display for CellId {
     }
 }
 
+/// A type-erased representation of [`Vc`].
+///
+/// Type erasure reduces the [monomorphization] (and therefore binary size and compilation time)
+/// required to support `Vc`.
+///
+/// This type is heavily used within the [`Backend`][crate::backend::Backend] trait, but should
+/// otherwise be treated as an internal implementation detail of `turbo-tasks`.
+///
+/// [monomorphization]: https://doc.rust-lang.org/book/ch10-01-syntax.html#performance-of-code-using-generics
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum RawVc {
     TaskOutput(TaskId),

--- a/turbopack/crates/turbo-tasks/src/state.rs
+++ b/turbopack/crates/turbo-tasks/src/state.rs
@@ -96,6 +96,25 @@ impl<T> Drop for StateRef<'_, T> {
     }
 }
 
+/// An [internally-mutable] type, similar to [`RefCell`][std::cell::RefCell] or [`Mutex`] that can
+/// be stored inside a [`VcValueType`].
+///
+/// **[`State`] should only be used with [`OperationVc`] and types that implement
+/// [`OperationValue`]**.
+///
+/// Setting values inside a [`State`] bypasses the normal argument and return value tracking
+/// that's tracks child function calls and re-runs tasks until their values settled. That system is
+/// needed for [strong consistency]. [`OperationVc`] ensures that function calls are reconnected
+/// with the parent/child call graph.
+///
+/// When reading a `State` with [`State::get`], the state itself (though not any values inside of
+/// it) is marked as a dependency of the current task.
+///
+/// [internally-mutable]: https://doc.rust-lang.org/book/ch15-05-interior-mutability.html
+/// [`VcValueType`]: crate::VcValueType
+/// [strong consistency]: crate::Vc::strongly_consistent
+/// [`OperationVc`]: crate::OperationVc
+/// [`OperationValue`]: crate::OperationValue
 #[derive(Serialize, Deserialize)]
 pub struct State<T> {
     serialization_invalidator: SerializationInvalidator,


### PR DESCRIPTION
![Screenshot 2024-11-25 at 16-42-42 Vc in turbo_tasks - Rust.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/759f1e16-90b0-45e1-bfbf-19cbfd238748.png)

![Screenshot 2024-11-25 at 16-43-09 OperationVc in turbo_tasks - Rust.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/6b36e3aa-6fa2-4a9d-baf9-7f24987acf9f.png)

![Screenshot 2024-11-25 at 16-43-25 ResolvedVc in turbo_tasks - Rust.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/ed5794bb-0f5b-491e-ae6e-9ccf9878e609.png)

![Screenshot 2024-11-25 at 16-43-41 State in turbo_tasks - Rust.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/4a79d97f-f33b-44ca-b26e-930c2352089f.png)



Closes PACK-3638