### PR TITLE
chore(turbopack): Centralize reqwest TLS feature configs in turbo-tasks-fetch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ turbo-tasks-backend = { path = "turbopack/crates/turbo-tasks-backend" }
 turbo-tasks-build = { path = "turbopack/crates/turbo-tasks-build" }
 turbo-tasks-bytes = { path = "turbopack/crates/turbo-tasks-bytes" }
 turbo-tasks-env = { path = "turbopack/crates/turbo-tasks-env" }
-turbo-tasks-fetch = { path = "turbopack/crates/turbo-tasks-fetch", default-features = false }
+turbo-tasks-fetch = { path = "turbopack/crates/turbo-tasks-fetch" }
 turbo-tasks-fs = { path = "turbopack/crates/turbo-tasks-fs" }
 turbo-tasks-hash = { path = "turbopack/crates/turbo-tasks-hash" }
 turbo-tasks-macros = { path = "turbopack/crates/turbo-tasks-macros" }
@@ -102,13 +102,6 @@ swc_emotion = { version = "0.72.28" }
 swc_relay = { version = "0.44.30" }
 
 # General Deps
-
-# Be careful when selecting tls backend, including change default tls backend.
-# If you changed, must verify with ALL build targets with next-swc to ensure
-# it works. next-swc have various platforms, some doesn't support native (using openssl-sys)
-# and some aren't buildable with rustls.
-reqwest = { version = "=0.11.17", default-features = false }
-
 chromiumoxide = { version = "0.5.4", features = [
   "tokio-runtime",
 ], default-features = false }
@@ -180,6 +173,7 @@ quote = "1.0.23"
 rand = "0.8.5"
 rayon = "1.10.0"
 regex = "1.10.6"
+reqwest = { version = "=0.11.17", default-features = false }
 rstest = "0.16.0"
 rustc-hash = "1.1.0"
 semver = "1.0.16"

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -37,13 +37,6 @@ __internal_dhat-heap = ["dhat"]
 # effectively does nothing.
 __internal_dhat-ad-hoc = ["dhat"]
 
-# Enable specific tls features per-target.
-[target.'cfg(all(target_os = "windows", target_arch = "aarch64"))'.dependencies]
-next-core = { workspace = true, features = ["native-tls"] }
-
-[target.'cfg(not(any(all(target_os = "windows", target_arch = "aarch64"), target_arch="wasm32")))'.dependencies]
-next-core = { workspace = true, features = ["rustls-tls"] }
-
 [lints]
 workspace = true
 

--- a/crates/next-build-test/Cargo.toml
+++ b/crates/next-build-test/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 anyhow = { workspace = true }
 futures-util = "0.3.30"
 next-api = { workspace = true }
+next-core = { workspace = true }
 num_cpus = "1.16.0"
 rand = { workspace = true, features = ["small_rng"] }
 serde_json = { workspace = true }
@@ -35,13 +36,6 @@ turbopack-env = { workspace = true }
 turbopack-node = { workspace = true }
 turbopack-nodejs = { workspace = true }
 turbopack-trace-utils = { workspace = true }
-
-# Enable specific tls features per-target.
-[target.'cfg(all(target_os = "windows", target_arch = "aarch64"))'.dependencies]
-next-core = { workspace = true, features = ["native-tls"] }
-
-[target.'cfg(not(any(all(target_os = "windows", target_arch = "aarch64"), target_arch="wasm32")))'.dependencies]
-next-core = { workspace = true, features = ["rustls-tls"] }
 
 [build-dependencies]
 turbo-tasks-build = { workspace = true }

--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -82,8 +82,6 @@ turbo-tasks-build = { workspace = true }
 
 [features]
 next-font-local = []
-native-tls = ["turbo-tasks-fetch/native-tls"]
-rustls-tls = ["turbo-tasks-fetch/rustls-tls"]
 plugin = [
   "swc_core/plugin_transform_host_native",
   "turbopack-ecmascript-plugins/swc_ecma_transform_plugin",

--- a/crates/next-core/src/lib.rs
+++ b/crates/next-core/src/lib.rs
@@ -65,9 +65,3 @@ pub fn register() {
     turbopack_ecmascript_plugins::register();
     include!(concat!(env!("OUT_DIR"), "/register.rs"));
 }
-
-#[cfg(all(feature = "native-tls", feature = "rustls-tls"))]
-compile_error!("You can't enable both `native-tls` and `rustls-tls`");
-
-#[cfg(all(not(feature = "native-tls"), not(feature = "rustls-tls")))]
-compile_error!("You have to enable one of the TLS backends: `native-tls` or `rustls-tls`");

--- a/packages/next-swc/README.md
+++ b/packages/next-swc/README.md
@@ -36,16 +36,15 @@ pnpm build-wasm
 Due to platform differences napi bindings selectively enables supported features.
 See below tables for the currently enabled features.
 
-| arch\platform | Linux(gnu) | Linux(musl) | Darwin    | Win32     |
+| arch\platform | Linux(gnu) | Linux(musl) | Darwin    | Windows   |
 | ------------- | ---------- | ----------- | --------- | --------- |
-| ia32          |            |             |           | a,b,d,e   |
 | x64           | a,b,d,e,f  | a,b,d,e,f   | a,b,d,e,f | a,b,d,e,f |
 | aarch64       | a,d,e,f    | a,d,e,f     | a,b,d,e,f | a,b,c,e   |
 
-- a: `turbo_tasks_malloc`,
-- b: `turbo_tasks_malloc_custom_allocator`,
-- c: `native-tls`,
-- d: `rustls-tls`,
+- a: `turbo_tasks_malloc`
+- b: `turbo_tasks_malloc_custom_allocator`
+- c: `native-tls` (via `turbo-tasks-fetch`)
+- d: `rustls-tls` (via `turbo-tasks-fetch`)
 - e: `image-extended` (webp)
 - f: `plugin`
 

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -13,8 +13,8 @@
     "cache-build-native": "[ -d native ] && echo $(ls native)",
     "rust-check-fmt": "cd ../..; cargo fmt -- --check",
     "rust-check-clippy": "cargo clippy --workspace --all-targets -- -D warnings -A deprecated",
-    "rust-check-napi-rustls": "cargo check -p next-swc-napi",
-    "test-cargo-unit": "cargo nextest run --workspace --exclude next-swc-napi --release --no-fail-fast --features rustls-tls"
+    "rust-check-napi": "cargo check -p next-swc-napi",
+    "test-cargo-unit": "cargo nextest run --workspace --exclude next-swc-napi --release --no-fail-fast"
   },
   "napi": {
     "name": "next-swc",

--- a/packages/next-swc/turbo.json
+++ b/packages/next-swc/turbo.json
@@ -87,11 +87,7 @@
       "outputs": ["native/*.node"]
     },
     "rust-check": {
-      "dependsOn": [
-        "rust-check-fmt",
-        "rust-check-clippy",
-        "rust-check-napi-rustls"
-      ]
+      "dependsOn": ["rust-check-fmt", "rust-check-clippy", "rust-check-napi"]
     },
     "rust-check-fmt": {
       "inputs": [
@@ -116,7 +112,7 @@
         "../../rust-toolchain"
       ]
     },
-    "rust-check-napi-rustls": {
+    "rust-check-napi": {
       "inputs": [
         "../../.cargo/**",
         "../../crates/**",

--- a/turbopack/crates/turbo-tasks-fetch/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fetch/Cargo.toml
@@ -8,15 +8,20 @@ edition = "2021"
 [lib]
 bench = false
 
-[features]
-default = ["native-tls"]
-# Allow to configure specific tls backend for reqwest.
-# See top level Cargo.toml for more details.
-native-tls = ["reqwest/native-tls"]
-rustls-tls = ["reqwest/rustls-tls"]
-
 [lints]
 workspace = true
+
+# Enable specific tls features per-target.
+#
+# Be careful when selecting tls backend, including change default tls backend.
+# If you changed, must verify with ALL build targets with next-swc to ensure
+# it works. next-swc have various platforms, some doesn't support native (using openssl-sys)
+# and some aren't buildable with rustls.
+[target.'cfg(all(target_os = "windows", target_arch = "aarch64"))'.dependencies]
+reqwest = { workspace = true, features = ["native-tls"] }
+
+[target.'cfg(not(any(all(target_os = "windows", target_arch = "aarch64"), target_arch="wasm32")))'.dependencies]
+reqwest = { workspace = true, features = ["rustls-tls"] }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/turbopack/crates/turbo-tasks-fetch/build.rs
+++ b/turbopack/crates/turbo-tasks-fetch/build.rs
@@ -1,19 +1,5 @@
 use turbo_tasks_build::generate_register;
 
-#[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
-fn check_tls_config() {
-    // do nothing
-}
-#[cfg(not(any(feature = "native-tls", feature = "rustls-tls")))]
-fn check_tls_config() {
-    panic!("You must enable one of the TLS features: native-tls or rustls-tls");
-}
-
 fn main() {
     generate_register();
-
-    // Check if tls feature for reqwest is properly configured.
-    // Technically reqwest falls back to non-tls http request if none of the tls
-    // features are enabled, But we won't allow it.
-    check_tls_config();
 }

--- a/turbopack/crates/turbopack-cli/Cargo.toml
+++ b/turbopack/crates/turbopack-cli/Cargo.toml
@@ -19,11 +19,7 @@ name = "mod"
 harness = false
 
 [features]
-# By default, we enable native-tls for reqwest via downstream transitive features.
-# This is for the convenience of running daily dev workflows, i.e running
-# `cargo xxx` without explicitly specifying features, not that we want to
-# promote this as default backend. Actual configuration is done when building turbopack-cli.
-default = ["custom_allocator", "native-tls"]
+default = ["custom_allocator"]
 serializable = []
 tokio_console = [
   "dep:console-subscriber",
@@ -32,8 +28,6 @@ tokio_console = [
 ]
 profile = []
 custom_allocator = ["turbo-tasks-malloc/custom_allocator"]
-native-tls = ["turbo-tasks-fetch/native-tls"]
-rustls-tls = ["turbo-tasks-fetch/rustls-tls"]
 
 [lints]
 workspace = true
@@ -51,7 +45,7 @@ tokio = { workspace = true, features = ["full"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 turbo-tasks = { workspace = true }
 turbo-tasks-env = { workspace = true }
-turbo-tasks-fetch = { workspace = true, default-features = false }
+turbo-tasks-fetch = { workspace = true }
 turbo-tasks-fs = { workspace = true }
 turbo-tasks-malloc = { workspace = true, default-features = false }
 turbo-tasks-memory = { workspace = true }


### PR DESCRIPTION
Noticed this mess while working with @samcx on #72442 where we had to run:

```
cargo nextest r --features next-core/native-tls -p next-core
```

This PR makes `turbo-tasks-fetch` responsible for setting the `reqwest` TLS features, rather than trying to pass that feature flag down.

After this PR, running tests on `next-core` works with just:

```
cargo nextest r -p next-core
```

## Why?

- The feature flag logic was getting duplicated in multiple top-level targets.
- Packages that depended on `turbo-tasks-fetch` (directly *or transitively*) had to specify a default feature and make sure that default feature was disabled in the workspace's dependency list so that `cargo test -p package-name` would work
- ... or you had to specify a flag when compiling, like `--features next-core/native-tls`.

Technically this change gives us less flexibility. We can't produce multiple binaries for the same platform target with different TLS stacks. But I don't think we would've ever used that flexibility anyways.

Closes PACK-3469