### PR TITLE
Fix the path to the next/experimental/testing/server export

### DIFF
--- a/packages/next/experimental/testing/server.d.ts
+++ b/packages/next/experimental/testing/server.d.ts
@@ -1,1 +1,1 @@
-export * from '../dist/experimental/testing/server'
+export * from '../../dist/experimental/testing/server'

--- a/packages/next/experimental/testing/server.js
+++ b/packages/next/experimental/testing/server.js
@@ -1,1 +1,1 @@
-module.exports = require('../dist/experimental/testing/server')
+module.exports = require('../../dist/experimental/testing/server')


### PR DESCRIPTION
The path to the export from the `dist` directory currently doesn't resolve.