### PR TITLE
chore(deps): use pnpm 9.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,7 +257,7 @@
   },
   "engines": {
     "node": ">=18.18.0",
-    "pnpm": "9.6.0"
+    "pnpm": "~9.12.0"
   },
   "packageManager": "pnpm@9.6.0",
   "pnpm": {


### PR DESCRIPTION
### What?

Bump pnpm to 9.12+

### Why?

I have 9.12.2 installed and it did not allow me to use it.

### How?
 

