### PR TITLE
refactor(turbopack): Use `ResolvedVc` for `turbopack-ecmascript`

### DIFF
--- a/crates/next-core/src/next_shared/transforms/debug_fn_name.rs
+++ b/crates/next-core/src/next_shared/transforms/debug_fn_name.rs
@@ -9,8 +9,9 @@ use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, Transfor
 use super::module_rule_match_js_no_url;
 
 pub fn get_debug_fn_name_rule(enable_mdx_rs: bool) -> ModuleRule {
-    let debug_fn_name_transform =
-        EcmascriptInputTransform::Plugin(Vc::cell(Box::new(DebugFnNameTransformer {}) as _));
+    let debug_fn_name_transform = EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(
+        DebugFnNameTransformer {},
+    ) as _));
 
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),

--- a/crates/next-core/src/next_shared/transforms/debug_fn_name.rs
+++ b/crates/next-core/src/next_shared/transforms/debug_fn_name.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::debug_fn_name::debug_fn_name;
 use swc_core::ecma::{ast::Program, visit::VisitMutWith};
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::ResolvedVc;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 

--- a/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/crates/next-core/src/next_shared/transforms/mod.rs
@@ -31,7 +31,7 @@ pub use next_font::get_next_font_transform_rule;
 pub use next_lint::get_next_lint_transform_rule;
 pub use next_strip_page_exports::get_next_pages_transforms_rule;
 pub use server_actions::get_server_actions_transform_rule;
-use turbo_tasks::{ReadRef, ResolvedVc, Value, Vc};
+use turbo_tasks::{ReadRef, ResolvedVc, Value};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect, ModuleType, RuleCondition};
 use turbopack_core::reference_type::{ReferenceType, UrlReferenceSubType};

--- a/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/crates/next-core/src/next_shared/transforms/mod.rs
@@ -136,7 +136,7 @@ pub(crate) fn get_ecma_transform_rule(
     enable_mdx_rs: bool,
     prepend: bool,
 ) -> ModuleRule {
-    let transformer = EcmascriptInputTransform::Plugin(Vc::cell(transformer as _));
+    let transformer = EcmascriptInputTransform::Plugin(ResolvedVc::cell(transformer as _));
     let (prepend, append) = if prepend {
         (
             ResolvedVc::cell(vec![transformer]),

--- a/crates/next-core/src/next_shared/transforms/modularize_imports.rs
+++ b/crates/next-core/src/next_shared/transforms/modularize_imports.rs
@@ -35,7 +35,7 @@ pub fn get_next_modularize_imports_rule(
     modularize_imports_config: &FxIndexMap<String, ModularizeImportPackageConfig>,
     enable_mdx_rs: bool,
 ) -> ModuleRule {
-    let transformer = EcmascriptInputTransform::Plugin(Vc::cell(Box::new(
+    let transformer = EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(
         ModularizeImportsTransformer::new(modularize_imports_config),
     ) as _));
     ModuleRule::new(

--- a/crates/next-core/src/next_shared/transforms/modularize_imports.rs
+++ b/crates/next-core/src/next_shared/transforms/modularize_imports.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use modularize_imports::{modularize_imports, PackageConfig};
 use serde::{Deserialize, Serialize};
 use swc_core::ecma::ast::Program;
-use turbo_tasks::{trace::TraceRawVcs, FxIndexMap, ResolvedVc, Vc};
+use turbo_tasks::{trace::TraceRawVcs, FxIndexMap, ResolvedVc};
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 

--- a/crates/next-core/src/next_shared/transforms/next_amp_attributes.rs
+++ b/crates/next-core/src/next_shared/transforms/next_amp_attributes.rs
@@ -10,7 +10,7 @@ use super::module_rule_match_js_no_url;
 
 pub fn get_next_amp_attr_rule(enable_mdx_rs: bool) -> ModuleRule {
     let transformer =
-        EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextAmpAttributes {}) as _));
+        EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(NextAmpAttributes {}) as _));
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {

--- a/crates/next-core/src/next_shared/transforms/next_amp_attributes.rs
+++ b/crates/next-core/src/next_shared/transforms/next_amp_attributes.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::amp_attributes::amp_attributes;
 use swc_core::ecma::ast::*;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::ResolvedVc;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 

--- a/crates/next-core/src/next_shared/transforms/next_cjs_optimizer.rs
+++ b/crates/next-core/src/next_shared/transforms/next_cjs_optimizer.rs
@@ -6,7 +6,7 @@ use swc_core::{
     common::SyntaxContext,
     ecma::{ast::*, visit::VisitMutWith},
 };
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::ResolvedVc;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 

--- a/crates/next-core/src/next_shared/transforms/next_cjs_optimizer.rs
+++ b/crates/next-core/src/next_shared/transforms/next_cjs_optimizer.rs
@@ -47,8 +47,9 @@ pub fn get_next_cjs_optimizer_rule(enable_mdx_rs: bool) -> ModuleRule {
         )]),
     };
 
-    let transformer =
-        EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextCjsOptimizer { config }) as _));
+    let transformer = EcmascriptInputTransform::Plugin(ResolvedVc::cell(
+        Box::new(NextCjsOptimizer { config }) as _,
+    ));
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {

--- a/crates/next-core/src/next_shared/transforms/next_disallow_re_export_all_in_page.rs
+++ b/crates/next-core/src/next_shared/transforms/next_disallow_re_export_all_in_page.rs
@@ -13,8 +13,9 @@ pub fn get_next_disallow_export_all_in_page_rule(
     enable_mdx_rs: bool,
     pages_dir: ReadRef<FileSystemPath>,
 ) -> ModuleRule {
-    let transformer =
-        EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextDisallowReExportAllInPage) as _));
+    let transformer = EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(
+        NextDisallowReExportAllInPage,
+    ) as _));
     ModuleRule::new(
         module_rule_match_pages_page_file(enable_mdx_rs, pages_dir),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {

--- a/crates/next-core/src/next_shared/transforms/next_disallow_re_export_all_in_page.rs
+++ b/crates/next-core/src/next_shared/transforms/next_disallow_re_export_all_in_page.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::disallow_re_export_all_in_page::disallow_re_export_all_in_page;
 use swc_core::ecma::ast::*;
-use turbo_tasks::{ReadRef, ResolvedVc, Vc};
+use turbo_tasks::{ReadRef, ResolvedVc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};

--- a/crates/next-core/src/next_shared/transforms/next_dynamic.rs
+++ b/crates/next-core/src/next_shared/transforms/next_dynamic.rs
@@ -17,12 +17,13 @@ pub async fn get_next_dynamic_transform_rule(
     mode: Vc<NextMode>,
     enable_mdx_rs: bool,
 ) -> Result<ModuleRule> {
-    let dynamic_transform = EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextJsDynamic {
-        is_server_compiler,
-        is_react_server_layer,
-        is_app_dir,
-        mode: *mode.await?,
-    }) as _));
+    let dynamic_transform =
+        EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(NextJsDynamic {
+            is_server_compiler,
+            is_react_server_layer,
+            is_app_dir,
+            mode: *mode.await?,
+        }) as _));
     Ok(ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {

--- a/crates/next-core/src/next_shared/transforms/next_edge_node_api_assert.rs
+++ b/crates/next-core/src/next_shared/transforms/next_edge_node_api_assert.rs
@@ -16,10 +16,11 @@ pub fn next_edge_node_api_assert(
     should_error_for_node_apis: bool,
     is_production: bool,
 ) -> ModuleRule {
-    let transformer = EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextEdgeNodeApiAssert {
-        should_error_for_node_apis,
-        is_production,
-    }) as _));
+    let transformer =
+        EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(NextEdgeNodeApiAssert {
+            should_error_for_node_apis,
+            is_production,
+        }) as _));
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {

--- a/crates/next-core/src/next_shared/transforms/next_edge_node_api_assert.rs
+++ b/crates/next-core/src/next_shared/transforms/next_edge_node_api_assert.rs
@@ -5,7 +5,7 @@ use swc_core::{
     common::SyntaxContext,
     ecma::{ast::*, utils::ExprCtx, visit::VisitWith},
 };
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::ResolvedVc;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 

--- a/crates/next-core/src/next_shared/transforms/next_font.rs
+++ b/crates/next-core/src/next_shared/transforms/next_font.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::fonts::*;
 use swc_core::ecma::{ast::Program, atoms::JsWord, visit::VisitMutWith};
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::ResolvedVc;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 

--- a/crates/next-core/src/next_shared/transforms/next_font.rs
+++ b/crates/next-core/src/next_shared/transforms/next_font.rs
@@ -18,7 +18,9 @@ pub fn get_next_font_transform_rule(enable_mdx_rs: bool) -> ModuleRule {
     ];
 
     let transformer =
-        EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextJsFont { font_loaders }) as _));
+        EcmascriptInputTransform::Plugin(ResolvedVc::cell(
+            Box::new(NextJsFont { font_loaders }) as _
+        ));
     ModuleRule::new(
         // TODO: Only match in pages (not pages/api), app/, etc.
         module_rule_match_js_no_url(enable_mdx_rs),

--- a/crates/next-core/src/next_shared/transforms/next_middleware_dynamic_assert.rs
+++ b/crates/next-core/src/next_shared/transforms/next_middleware_dynamic_assert.rs
@@ -9,8 +9,9 @@ use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, Transfor
 use super::module_rule_match_js_no_url;
 
 pub fn get_middleware_dynamic_assert_rule(enable_mdx_rs: bool) -> ModuleRule {
-    let transformer =
-        EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextMiddlewareDynamicAssert {}) as _));
+    let transformer = EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(
+        NextMiddlewareDynamicAssert {},
+    ) as _));
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {

--- a/crates/next-core/src/next_shared/transforms/next_middleware_dynamic_assert.rs
+++ b/crates/next-core/src/next_shared/transforms/next_middleware_dynamic_assert.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::middleware_dynamic::next_middleware_dynamic;
 use swc_core::ecma::{ast::*, visit::VisitMutWith};
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::ResolvedVc;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 

--- a/crates/next-core/src/next_shared/transforms/next_optimize_server_react.rs
+++ b/crates/next-core/src/next_shared/transforms/next_optimize_server_react.rs
@@ -14,7 +14,7 @@ pub fn get_next_optimize_server_react_rule(
     optimize_use_state: bool,
 ) -> ModuleRule {
     let transformer =
-        EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextOptimizeServerReact {
+        EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(NextOptimizeServerReact {
             optimize_use_state,
         }) as _));
     ModuleRule::new(

--- a/crates/next-core/src/next_shared/transforms/next_optimize_server_react.rs
+++ b/crates/next-core/src/next_shared/transforms/next_optimize_server_react.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::optimize_server_react::{optimize_server_react, Config};
 use swc_core::ecma::ast::*;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::ResolvedVc;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 

--- a/crates/next-core/src/next_shared/transforms/next_page_config.rs
+++ b/crates/next-core/src/next_shared/transforms/next_page_config.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::page_config::page_config;
 use swc_core::ecma::ast::*;
-use turbo_tasks::{ReadRef, ResolvedVc, Vc};
+use turbo_tasks::{ReadRef, ResolvedVc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};

--- a/crates/next-core/src/next_shared/transforms/next_page_config.rs
+++ b/crates/next-core/src/next_shared/transforms/next_page_config.rs
@@ -13,7 +13,7 @@ pub fn get_next_page_config_rule(
     enable_mdx_rs: bool,
     pages_dir: ReadRef<FileSystemPath>,
 ) -> ModuleRule {
-    let transformer = EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextPageConfig {
+    let transformer = EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(NextPageConfig {
         // [TODO]: update once turbopack build works
         is_development: true,
     }) as _));

--- a/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
+++ b/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
@@ -101,7 +101,7 @@ impl CustomTransformer for NextPageStaticInfo {
                     messages.push("Visit https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config for more information.".to_string());
 
                     PageStaticInfoIssue {
-                        file_path: *ctx.file_path,
+                        file_path: ctx.file_path,
                         messages,
                         severity: IssueSeverity::Warning,
                     }
@@ -115,7 +115,7 @@ impl CustomTransformer for NextPageStaticInfo {
                 && is_app_page
             {
                 PageStaticInfoIssue {
-                    file_path:* ctx.file_path,
+                    file_path: ctx.file_path,
                     messages: vec![format!(r#"Page "{}" cannot use both "use client" and export function "generateStaticParams()"."#, ctx.file_path_str)],
                     severity: IssueSeverity::Error,
                 }
@@ -130,7 +130,7 @@ impl CustomTransformer for NextPageStaticInfo {
 
 #[turbo_tasks::value(shared)]
 pub struct PageStaticInfoIssue {
-    pub file_path: Vc<FileSystemPath>,
+    pub file_path: ResolvedVc<FileSystemPath>,
     pub messages: Vec<String>,
     pub severity: IssueSeverity,
 }
@@ -154,7 +154,7 @@ impl Issue for PageStaticInfoIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        self.file_path
+        *self.file_path
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
+++ b/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
@@ -25,10 +25,11 @@ pub fn get_next_page_static_info_assert_rule(
     server_context: Option<ServerContextType>,
     client_context: Option<ClientContextType>,
 ) -> ModuleRule {
-    let transformer = EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextPageStaticInfo {
-        server_context,
-        client_context,
-    }) as _));
+    let transformer =
+        EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(NextPageStaticInfo {
+            server_context,
+            client_context,
+        }) as _));
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
@@ -100,7 +101,7 @@ impl CustomTransformer for NextPageStaticInfo {
                     messages.push("Visit https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config for more information.".to_string());
 
                     PageStaticInfoIssue {
-                        file_path: ctx.file_path,
+                        file_path: *ctx.file_path,
                         messages,
                         severity: IssueSeverity::Warning,
                     }
@@ -114,7 +115,7 @@ impl CustomTransformer for NextPageStaticInfo {
                 && is_app_page
             {
                 PageStaticInfoIssue {
-                    file_path: ctx.file_path,
+                    file_path:* ctx.file_path,
                     messages: vec![format!(r#"Page "{}" cannot use both "use client" and export function "generateStaticParams()"."#, ctx.file_path_str)],
                     severity: IssueSeverity::Error,
                 }

--- a/crates/next-core/src/next_shared/transforms/next_pure.rs
+++ b/crates/next-core/src/next_shared/transforms/next_pure.rs
@@ -9,7 +9,8 @@ use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, Transfor
 use super::module_rule_match_js_no_url;
 
 pub fn get_next_pure_rule(enable_mdx_rs: bool) -> ModuleRule {
-    let transformer = EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextPure {}) as _));
+    let transformer =
+        EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(NextPure {}) as _));
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {

--- a/crates/next-core/src/next_shared/transforms/next_pure.rs
+++ b/crates/next-core/src/next_shared/transforms/next_pure.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::pure::pure_magic;
 use swc_core::ecma::{ast::*, visit::VisitMutWith};
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::ResolvedVc;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 

--- a/crates/next-core/src/next_shared/transforms/next_shake_exports.rs
+++ b/crates/next-core/src/next_shared/transforms/next_shake_exports.rs
@@ -10,8 +10,9 @@ use super::module_rule_match_js_no_url;
 
 #[allow(dead_code)]
 pub fn get_next_shake_exports_rule(enable_mdx_rs: bool, ignore: Vec<String>) -> ModuleRule {
-    let transformer =
-        EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextShakeExports { ignore }) as _));
+    let transformer = EcmascriptInputTransform::Plugin(ResolvedVc::cell(
+        Box::new(NextShakeExports { ignore }) as _,
+    ));
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {

--- a/crates/next-core/src/next_shared/transforms/next_shake_exports.rs
+++ b/crates/next-core/src/next_shared/transforms/next_shake_exports.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::shake_exports::{shake_exports, Config};
 use swc_core::ecma::ast::*;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::ResolvedVc;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 

--- a/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
+++ b/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
@@ -18,9 +18,10 @@ pub async fn get_next_pages_transforms_rule(
     enable_mdx_rs: bool,
 ) -> Result<ModuleRule> {
     // Apply the Next SSG transform to all pages.
-    let strip_transform = EcmascriptInputTransform::Plugin(Vc::cell(Box::new(
-        NextJsStripPageExports { export_filter },
-    ) as _));
+    let strip_transform =
+        EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(NextJsStripPageExports {
+            export_filter,
+        }) as _));
     Ok(ModuleRule::new(
         RuleCondition::all(vec![
             RuleCondition::all(vec![

--- a/crates/next-core/src/next_shared/transforms/server_actions.rs
+++ b/crates/next-core/src/next_shared/transforms/server_actions.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::server_actions::{server_actions, Config};
 use swc_core::{common::FileName, ecma::ast::Program};
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::ResolvedVc;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 

--- a/crates/next-core/src/next_shared/transforms/server_actions.rs
+++ b/crates/next-core/src/next_shared/transforms/server_actions.rs
@@ -20,10 +20,11 @@ pub fn get_server_actions_transform_rule(
     enable_mdx_rs: bool,
     dynamic_io_enabled: bool,
 ) -> ModuleRule {
-    let transformer = EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextServerActions {
-        transform,
-        dynamic_io_enabled,
-    }) as _));
+    let transformer =
+        EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(NextServerActions {
+            transform,
+            dynamic_io_enabled,
+        }) as _));
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -145,16 +145,16 @@ async fn get_client_module_options_context(
         conditions,
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
             prepend: ResolvedVc::cell(vec![
-                EcmascriptInputTransform::Plugin(Vc::cell(Box::new(
+                EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(
                     EmotionTransformer::new(&EmotionTransformConfig::default())
                         .expect("Should be able to create emotion transformer"),
                 ) as _)),
-                EcmascriptInputTransform::Plugin(Vc::cell(Box::new(
+                EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(
                     StyledComponentsTransformer::new(&StyledComponentsTransformConfig::default()),
                 ) as _)),
-                EcmascriptInputTransform::Plugin(Vc::cell(Box::new(StyledJsxTransformer::new(
-                    versions,
-                )) as _)),
+                EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(
+                    StyledJsxTransformer::new(versions),
+                ) as _)),
             ]),
             append: ResolvedVc::cell(vec![]),
         }],

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -140,7 +140,7 @@ pub async fn make_chunk_group(
         .await?;
     let async_loader_external_module_references = async_loader_references
         .iter()
-        .flat_map(|references| references.iter().copied())
+        .flat_map(|references| references.iter().map(|&reference| *reference))
         .collect();
 
     // Pass chunk items to chunking algorithm

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -140,7 +140,7 @@ pub async fn make_chunk_group(
         .await?;
     let async_loader_external_module_references = async_loader_references
         .iter()
-        .flat_map(|references| references.iter().map(|&reference| *reference))
+        .flat_map(|references| references.iter().copied())
         .collect();
 
     // Pass chunk items to chunking algorithm

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -343,7 +343,7 @@ async fn graph_node_to_referenced_nodes(
         .map(|reference| async {
             let reference = *reference;
             let Some(chunkable_module_reference) =
-                ResolvedVc::try_downcast::<Box<dyn ChunkableModuleReference>>(reference).await?
+                Vc::try_resolve_downcast::<Box<dyn ChunkableModuleReference>>(reference).await?
             else {
                 return Ok(vec![ChunkGraphEdge {
                     key: None,

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -343,7 +343,7 @@ async fn graph_node_to_referenced_nodes(
         .map(|reference| async {
             let reference = *reference;
             let Some(chunkable_module_reference) =
-                Vc::try_resolve_downcast::<Box<dyn ChunkableModuleReference>>(reference).await?
+                ResolvedVc::try_downcast::<Box<dyn ChunkableModuleReference>>(reference).await?
             else {
                 return Ok(vec![ChunkGraphEdge {
                     key: None,

--- a/turbopack/crates/turbopack-core/src/introspect/utils.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/utils.rs
@@ -64,10 +64,10 @@ pub async fn children_from_module_references(
     let key = reference_ty();
     let mut children = FxIndexSet::default();
     let references = references.await?;
-    for reference in &*references {
+    for &reference in &*references {
         let mut key = key;
         if let Some(chunkable) =
-            Vc::try_resolve_downcast::<Box<dyn ChunkableModuleReference>>(*reference).await?
+            ResolvedVc::try_downcast::<Box<dyn ChunkableModuleReference>>(reference).await?
         {
             match &*chunkable.chunking_type().await? {
                 None => {}

--- a/turbopack/crates/turbopack-core/src/introspect/utils.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/utils.rs
@@ -67,7 +67,7 @@ pub async fn children_from_module_references(
     for &reference in &*references {
         let mut key = key;
         if let Some(chunkable) =
-            ResolvedVc::try_downcast::<Box<dyn ChunkableModuleReference>>(reference).await?
+            Vc::try_resolve_downcast::<Box<dyn ChunkableModuleReference>>(reference).await?
         {
             match &*chunkable.chunking_type().await? {
                 None => {}

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -34,7 +34,7 @@ pub trait ModuleReference: ValueToString {
 
 /// Multiple [ModuleReference]s
 #[turbo_tasks::value(transparent)]
-pub struct ModuleReferences(Vec<Vc<Box<dyn ModuleReference>>>);
+pub struct ModuleReferences(Vec<ResolvedVc<Box<dyn ModuleReference>>>);
 
 #[turbo_tasks::value_impl]
 impl ModuleReferences {

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -34,7 +34,7 @@ pub trait ModuleReference: ValueToString {
 
 /// Multiple [ModuleReference]s
 #[turbo_tasks::value(transparent)]
-pub struct ModuleReferences(Vec<ResolvedVc<Box<dyn ModuleReference>>>);
+pub struct ModuleReferences(Vec<Vc<Box<dyn ModuleReference>>>);
 
 #[turbo_tasks::value_impl]
 impl ModuleReferences {

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use swc_core::ecma::ast::Program;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString};
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
@@ -49,7 +49,7 @@ impl SwcPluginModule {
 
 #[turbo_tasks::value(shared)]
 struct UnsupportedSwcEcmaTransformPluginsIssue {
-    pub file_path: Vc<FileSystemPath>,
+    pub file_path: ResolvedVc<FileSystemPath>,
 }
 
 #[turbo_tasks::value_impl]
@@ -72,7 +72,7 @@ impl Issue for UnsupportedSwcEcmaTransformPluginsIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        self.file_path
+        *self.file_path
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -13,7 +13,7 @@ use swc_core::{
     },
 };
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc, Vc};
+use turbo_tasks::{FxIndexMap, FxIndexSet, Vc};
 use turbopack_core::{issue::IssueSource, source::Source};
 
 use super::{top_level_await::has_top_level_await, JsValue, ModuleValue};

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known.rs
@@ -1,7 +1,7 @@
 use std::mem::take;
 
 use anyhow::Result;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::compile_time_info::CompileTimeInfo;
 use url::Url;
 
@@ -64,13 +64,13 @@ pub async fn well_known_function_call(
         ),
         WellKnownFunctionKind::Require => require(args),
         WellKnownFunctionKind::RequireContextRequire(value) => {
-            require_context_require(*value, args).await?
+            require_context_require(value, args).await?
         }
         WellKnownFunctionKind::RequireContextRequireKeys(value) => {
-            require_context_require_keys(*value, args).await?
+            require_context_require_keys(value, args).await?
         }
         WellKnownFunctionKind::RequireContextRequireResolve(value) => {
-            require_context_require_resolve(*value, args).await?
+            require_context_require_resolve(value, args).await?
         }
         WellKnownFunctionKind::PathToFileUrl => path_to_file_url(args),
         WellKnownFunctionKind::OsArch => compile_time_info
@@ -354,15 +354,15 @@ pub fn require(args: Vec<JsValue>) -> JsValue {
 }
 
 /// (try to) statically evaluate `require.context(...)()`
-pub async fn require_context_require(
-    val: Vc<RequireContextValue>,
+async fn require_context_require(
+    val: ResolvedVc<RequireContextValue>,
     args: Vec<JsValue>,
 ) -> Result<JsValue> {
     if args.is_empty() {
         return Ok(JsValue::unknown(
             JsValue::call(
                 Box::new(JsValue::WellKnownFunction(
-                    WellKnownFunctionKind::RequireContextRequire(val.to_resolved().await?),
+                    WellKnownFunctionKind::RequireContextRequire(val),
                 )),
                 args,
             ),
@@ -375,7 +375,7 @@ pub async fn require_context_require(
         return Ok(JsValue::unknown(
             JsValue::call(
                 Box::new(JsValue::WellKnownFunction(
-                    WellKnownFunctionKind::RequireContextRequire(val.to_resolved().await?),
+                    WellKnownFunctionKind::RequireContextRequire(val),
                 )),
                 args,
             ),
@@ -389,7 +389,7 @@ pub async fn require_context_require(
         return Ok(JsValue::unknown(
             JsValue::call(
                 Box::new(JsValue::WellKnownFunction(
-                    WellKnownFunctionKind::RequireContextRequire(val.to_resolved().await?),
+                    WellKnownFunctionKind::RequireContextRequire(val),
                 )),
                 args,
             ),
@@ -406,8 +406,8 @@ pub async fn require_context_require(
 }
 
 /// (try to) statically evaluate `require.context(...).keys()`
-pub async fn require_context_require_keys(
-    val: Vc<RequireContextValue>,
+async fn require_context_require_keys(
+    val: ResolvedVc<RequireContextValue>,
     args: Vec<JsValue>,
 ) -> Result<JsValue> {
     Ok(if args.is_empty() {
@@ -417,7 +417,7 @@ pub async fn require_context_require_keys(
         JsValue::unknown(
             JsValue::call(
                 Box::new(JsValue::WellKnownFunction(
-                    WellKnownFunctionKind::RequireContextRequireKeys(val.to_resolved().await?),
+                    WellKnownFunctionKind::RequireContextRequireKeys(val),
                 )),
                 args,
             ),
@@ -428,15 +428,15 @@ pub async fn require_context_require_keys(
 }
 
 /// (try to) statically evaluate `require.context(...).resolve()`
-pub async fn require_context_require_resolve(
-    val: Vc<RequireContextValue>,
+async fn require_context_require_resolve(
+    val: ResolvedVc<RequireContextValue>,
     args: Vec<JsValue>,
 ) -> Result<JsValue> {
     if args.len() != 1 {
         return Ok(JsValue::unknown(
             JsValue::call(
                 Box::new(JsValue::WellKnownFunction(
-                    WellKnownFunctionKind::RequireContextRequireResolve(val.to_resolved().await?),
+                    WellKnownFunctionKind::RequireContextRequireResolve(val),
                 )),
                 args,
             ),
@@ -449,7 +449,7 @@ pub async fn require_context_require_resolve(
         return Ok(JsValue::unknown(
             JsValue::call(
                 Box::new(JsValue::WellKnownFunction(
-                    WellKnownFunctionKind::RequireContextRequireResolve(val.to_resolved().await?),
+                    WellKnownFunctionKind::RequireContextRequireResolve(val),
                 )),
                 args,
             ),
@@ -463,7 +463,7 @@ pub async fn require_context_require_resolve(
         return Ok(JsValue::unknown(
             JsValue::call(
                 Box::new(JsValue::WellKnownFunction(
-                    WellKnownFunctionKind::RequireContextRequireResolve(val.to_resolved().await?),
+                    WellKnownFunctionKind::RequireContextRequireResolve(val),
                 )),
                 args,
             ),

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
@@ -28,16 +28,16 @@ pub struct AsyncLoaderModule {
 #[turbo_tasks::value_impl]
 impl AsyncLoaderModule {
     #[turbo_tasks::function]
-    pub async fn new(
-        module: Vc<Box<dyn ChunkableModule>>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
+    pub fn new(
+        module: ResolvedVc<Box<dyn ChunkableModule>>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
         availability_info: Value<AvailabilityInfo>,
-    ) -> Result<Vc<Self>> {
-        Ok(Self::cell(AsyncLoaderModule {
-            inner: module.to_resolved().await?,
-            chunking_context: chunking_context.to_resolved().await?,
+    ) -> Vc<Self> {
+        Self::cell(AsyncLoaderModule {
+            inner: module,
+            chunking_context,
             availability_info: availability_info.into_value(),
-        }))
+        })
     }
 
     #[turbo_tasks::function]
@@ -79,15 +79,15 @@ impl Asset for AsyncLoaderModule {
 impl ChunkableModule for AsyncLoaderModule {
     #[turbo_tasks::function]
     async fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
-        Ok(Vc::upcast(
+        self: ResolvedVc<Self>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        Vc::upcast(
             AsyncLoaderChunkItem {
-                chunking_context: chunking_context.to_resolved().await?,
-                module: self.to_resolved().await?,
+                chunking_context,
+                module: self,
             }
             .cell(),
-        ))
+        )
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -22,7 +22,7 @@ use crate::{
 #[derive(Default, Clone)]
 pub struct EcmascriptChunkItemContent {
     pub inner_code: Rope,
-    pub source_map: Option<ResolvedVc<Box<dyn GenerateSourceMap>>>,
+    pub source_map: Option<Vc<Box<dyn GenerateSourceMap>>>,
     pub options: EcmascriptChunkItemOptions,
     pub rewrite_source_path: Option<ResolvedVc<FileSystemPath>>,
     pub placeholder_for_future_extensions: (),
@@ -159,7 +159,7 @@ impl EcmascriptChunkItemContent {
                 None => None,
             }
         } else {
-            self.source_map.map(|v| *v)
+            self.source_map
         };
 
         code.push_source(&self.inner_code, source_map);

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -43,15 +43,15 @@ pub struct EcmascriptChunk {
 #[turbo_tasks::value_impl]
 impl EcmascriptChunk {
     #[turbo_tasks::function]
-    pub async fn new(
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-        content: Vc<EcmascriptChunkContent>,
-    ) -> Result<Vc<Self>> {
-        Ok(EcmascriptChunk {
-            chunking_context: chunking_context.to_resolved().await?,
-            content: content.to_resolved().await?,
+    pub fn new(
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+        content: ResolvedVc<EcmascriptChunkContent>,
+    ) -> Vc<Self> {
+        EcmascriptChunk {
+            chunking_context,
+            content,
         }
-        .cell())
+        .cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -38,7 +38,7 @@ enum SideEffectsValue {
 
 #[turbo_tasks::function]
 async fn side_effects_from_package_json(
-    package_json: Vc<FileSystemPath>,
+    package_json: ResolvedVc<FileSystemPath>,
 ) -> Result<Vc<SideEffectsValue>> {
     if let FileJsonContent::Content(content) = &*package_json.read_json().await? {
         if let Some(side_effects) = content.get("sideEffects") {
@@ -56,7 +56,7 @@ async fn side_effects_from_package_json(
                             }
                         } else {
                             SideEffectsInPackageJsonIssue {
-                                path: package_json.to_resolved().await?,
+                                path: package_json,
                                 description: Some(
                                     StyledString::Text(
                                         format!(
@@ -126,7 +126,7 @@ async fn side_effects_from_package_json(
 
 #[turbo_tasks::value]
 struct SideEffectsInPackageJsonIssue {
-    path: Vc<FileSystemPath>,
+    path: ResolvedVc<FileSystemPath>,
     description: Option<ResolvedVc<StyledString>>,
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -144,7 +144,7 @@ impl Issue for SideEffectsInPackageJsonIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        self.path
+        *self.path
     }
 
     #[turbo_tasks::function]
@@ -154,7 +154,7 @@ impl Issue for SideEffectsInPackageJsonIssue {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(self.description)
+        *ResolvedVc::cell(self.description)
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -154,7 +154,7 @@ impl Issue for SideEffectsInPackageJsonIssue {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        *ResolvedVc::cell(self.description)
+        Vc::cell(self.description.map(|v| *v))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
@@ -91,15 +91,15 @@ impl Asset for ChunkGroupFilesAsset {
 impl ChunkableModule for ChunkGroupFilesAsset {
     #[turbo_tasks::function]
     async fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
+        self: ResolvedVc<Self>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
         let this = self.await?;
         Ok(Vc::upcast(
             ChunkGroupFilesChunkItem {
-                chunking_context: chunking_context.to_resolved().await?,
+                chunking_context,
                 client_root: this.client_root,
-                inner: self.to_resolved().await?,
+                inner: self,
             }
             .cell(),
         ))

--- a/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
@@ -108,8 +108,8 @@ pub trait CodeGenerateableWithAsyncModuleInfo {
 
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat)]
 pub enum CodeGen {
-    CodeGenerateable(ResolvedVc<Box<dyn CodeGenerateable>>),
-    CodeGenerateableWithAsyncModuleInfo(ResolvedVc<Box<dyn CodeGenerateableWithAsyncModuleInfo>>),
+    CodeGenerateable(Vc<Box<dyn CodeGenerateable>>),
+    CodeGenerateableWithAsyncModuleInfo(Vc<Box<dyn CodeGenerateableWithAsyncModuleInfo>>),
 }
 
 #[turbo_tasks::value(transparent)]

--- a/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
@@ -109,7 +109,7 @@ pub trait CodeGenerateableWithAsyncModuleInfo {
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat)]
 pub enum CodeGen {
     CodeGenerateable(Vc<Box<dyn CodeGenerateable>>),
-    CodeGenerateableWithAsyncModuleInfo(Vc<Box<dyn CodeGenerateableWithAsyncModuleInfo>>),
+    CodeGenerateableWithAsyncModuleInfo(ResolvedVc<Box<dyn CodeGenerateableWithAsyncModuleInfo>>),
 }
 
 #[turbo_tasks::value(transparent)]

--- a/turbopack/crates/turbopack-ecmascript/src/global_module_id_strategy.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/global_module_id_strategy.rs
@@ -86,7 +86,7 @@ async fn referenced_modules(module: Vc<Box<dyn Module>>) -> Result<Vc<Referenced
     for (module_list, async_loader) in modules_and_async_loaders {
         for module in module_list {
             if set.insert(module) {
-                modules.push(ReferencedModule::Module(*module).resolved_cell());
+                modules.push(ReferencedModule::Module(module).resolved_cell());
             }
         }
         if let Some(async_loader_module) = async_loader {
@@ -106,7 +106,7 @@ pub async fn get_children_modules(
     let parent_module = parent.await?.module();
     let mut modules = referenced_modules(parent_module).await?.clone_value();
     for module in parent_module.additional_layers_modules().await? {
-        modules.push(ReferencedModule::Module(**module).resolved_cell());
+        modules.push(ReferencedModule::Module(*module).resolved_cell());
     }
     Ok(modules.into_iter())
 }
@@ -125,7 +125,7 @@ pub async fn children_modules_idents(
             root_modules
                 .await?
                 .iter()
-                .map(|module| ReferencedModule::Module(**module).resolved_cell())
+                .map(|module| ReferencedModule::Module(*module).resolved_cell())
                 .collect::<Vec<_>>(),
             get_children_modules,
         )

--- a/turbopack/crates/turbopack-ecmascript/src/global_module_id_strategy.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/global_module_id_strategy.rs
@@ -31,7 +31,7 @@ pub enum ReferencedModule {
 impl ReferencedModule {
     fn module(&self) -> Vc<Box<dyn Module>> {
         match *self {
-            ReferencedModule::Module(module) => module,
+            ReferencedModule::Module(module) => *module,
             ReferencedModule::AsyncLoaderModule(module) => *module,
         }
     }

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -721,7 +721,7 @@ impl EcmascriptModuleContent {
         references: Vc<ModuleReferences>,
         code_generation: Vc<CodeGenerateables>,
         async_module: Vc<OptionAsyncModule>,
-        source_map: Vc<OptionSourceMap>,
+        source_map: ResolvedVc<OptionSourceMap>,
         exports: Vc<EcmascriptExports>,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<Self>> {

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -465,7 +465,7 @@ impl EcmascriptModuleAsset {
 
     #[turbo_tasks::function]
     pub fn parse(&self) -> Vc<ParseResult> {
-        parse(*self.source, Value::new(self.ty), *self.transforms)
+        parse(self.source, Value::new(self.ty), self.transforms)
     }
 
     #[turbo_tasks::function]
@@ -834,7 +834,7 @@ async fn gen_content_with_code_gens(
 
             Ok(EcmascriptModuleContent {
                 inner_code: bytes.into(),
-                source_map: Some(Vc::upcast(srcmap)),
+                source_map: Some(ResolvedVc::upcast(srcmap.to_resolved().await?)),
                 is_esm: eval_context.is_esm(specified_module_type),
             }
             .cell())

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -394,7 +394,7 @@ impl EcmascriptAnalyzable for EcmascriptModuleAsset {
             *analyze.references,
             *analyze.code_generation,
             *analyze.async_module,
-            *analyze.source_map,
+            analyze.source_map,
             *analyze.exports,
             async_module_info,
         ))

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -704,7 +704,7 @@ impl EcmascriptChunkItem for ModuleChunkItem {
 #[turbo_tasks::value]
 pub struct EcmascriptModuleContent {
     pub inner_code: Rope,
-    pub source_map: Option<ResolvedVc<Box<dyn GenerateSourceMap>>>,
+    pub source_map: Option<Vc<Box<dyn GenerateSourceMap>>>,
     pub is_esm: bool,
     // pub refresh: bool,
 }
@@ -721,7 +721,7 @@ impl EcmascriptModuleContent {
         references: Vc<ModuleReferences>,
         code_generation: Vc<CodeGenerateables>,
         async_module: Vc<OptionAsyncModule>,
-        source_map: ResolvedVc<OptionSourceMap>,
+        source_map: Vc<OptionSourceMap>,
         exports: Vc<EcmascriptExports>,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<Self>> {
@@ -779,7 +779,7 @@ impl EcmascriptModuleContent {
             ident,
             specified_module_type,
             &[],
-            OptionSourceMap::none().to_resolved().await?,
+            OptionSourceMap::none(),
         )
         .await
     }
@@ -790,7 +790,7 @@ async fn gen_content_with_code_gens(
     ident: Vc<AssetIdent>,
     specified_module_type: SpecifiedModuleType,
     code_gens: &[&CodeGeneration],
-    original_src_map: ResolvedVc<OptionSourceMap>,
+    original_src_map: Vc<OptionSourceMap>,
 ) -> Result<Vc<EcmascriptModuleContent>> {
     let parsed = parsed.await?;
 

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -192,7 +192,7 @@ fn modifier() -> Vc<RcStr> {
 #[derive(Clone)]
 pub struct EcmascriptModuleAssetBuilder {
     source: ResolvedVc<Box<dyn Source>>,
-    asset_context: ResolvedVc<Box<dyn AssetContext>>,
+    asset_context: Vc<Box<dyn AssetContext>>,
     ty: EcmascriptModuleAssetType,
     transforms: ResolvedVc<EcmascriptInputTransforms>,
     options: ResolvedVc<EcmascriptOptions>,
@@ -215,7 +215,7 @@ impl EcmascriptModuleAssetBuilder {
         if let Some(inner_assets) = self.inner_assets {
             EcmascriptModuleAsset::new_with_inner_assets(
                 *self.source,
-                *self.asset_context,
+                self.asset_context,
                 Value::new(self.ty),
                 *self.transforms,
                 *self.options,
@@ -225,7 +225,7 @@ impl EcmascriptModuleAssetBuilder {
         } else {
             EcmascriptModuleAsset::new(
                 *self.source,
-                *self.asset_context,
+                self.asset_context,
                 Value::new(self.ty),
                 *self.transforms,
                 *self.options,
@@ -276,7 +276,7 @@ pub trait EcmascriptAnalyzable {
 impl EcmascriptModuleAsset {
     pub fn builder(
         source: ResolvedVc<Box<dyn Source>>,
-        asset_context: ResolvedVc<Box<dyn AssetContext>>,
+        asset_context: Vc<Box<dyn AssetContext>>,
         transforms: ResolvedVc<EcmascriptInputTransforms>,
         options: ResolvedVc<EcmascriptOptions>,
         compile_time_info: ResolvedVc<CompileTimeInfo>,

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -721,7 +721,7 @@ impl EcmascriptModuleContent {
         references: Vc<ModuleReferences>,
         code_generation: Vc<CodeGenerateables>,
         async_module: Vc<OptionAsyncModule>,
-        source_map: Vc<OptionSourceMap>,
+        source_map: ResolvedVc<OptionSourceMap>,
         exports: Vc<EcmascriptExports>,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<Self>> {
@@ -790,7 +790,7 @@ async fn gen_content_with_code_gens(
     ident: Vc<AssetIdent>,
     specified_module_type: SpecifiedModuleType,
     code_gens: &[&CodeGeneration],
-    original_src_map: Vc<OptionSourceMap>,
+    original_src_map: ResolvedVc<OptionSourceMap>,
 ) -> Result<Vc<EcmascriptModuleContent>> {
     let parsed = parsed.await?;
 

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -214,22 +214,22 @@ impl EcmascriptModuleAssetBuilder {
     pub fn build(self) -> Vc<EcmascriptModuleAsset> {
         if let Some(inner_assets) = self.inner_assets {
             EcmascriptModuleAsset::new_with_inner_assets(
-                self.source,
-                self.asset_context,
+                *self.source,
+                *self.asset_context,
                 Value::new(self.ty),
-                self.transforms,
-                self.options,
-                self.compile_time_info,
+                *self.transforms,
+                *self.options,
+                *self.compile_time_info,
                 *inner_assets,
             )
         } else {
             EcmascriptModuleAsset::new(
-                self.source,
-                self.asset_context,
+                *self.source,
+                *self.asset_context,
                 Value::new(self.ty),
-                self.transforms,
-                self.options,
-                self.compile_time_info,
+                *self.transforms,
+                *self.options,
+                *self.compile_time_info,
             )
         }
     }
@@ -391,11 +391,11 @@ impl EcmascriptAnalyzable for EcmascriptModuleAsset {
             self.ident(),
             module_type_result.module_type,
             chunking_context,
-            analyze.references,
-            analyze.code_generation,
-            analyze.async_module,
-            analyze.source_map,
-            analyze.exports,
+            *analyze.references,
+            *analyze.code_generation,
+            *analyze.async_module,
+            *analyze.source_map,
+            *analyze.exports,
             async_module_info,
         ))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -714,15 +714,15 @@ impl EcmascriptModuleContent {
     /// Creates a new [`Vc<EcmascriptModuleContent>`].
     #[turbo_tasks::function]
     pub async fn new(
-        parsed: ResolvedVc<ParseResult>,
-        ident: ResolvedVc<AssetIdent>,
+        parsed: Vc<ParseResult>,
+        ident: Vc<AssetIdent>,
         specified_module_type: SpecifiedModuleType,
-        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
-        references: ResolvedVc<ModuleReferences>,
-        code_generation: ResolvedVc<CodeGenerateables>,
-        async_module: ResolvedVc<OptionAsyncModule>,
-        source_map: ResolvedVc<OptionSourceMap>,
-        exports: ResolvedVc<EcmascriptExports>,
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+        references: Vc<ModuleReferences>,
+        code_generation: Vc<CodeGenerateables>,
+        async_module: Vc<OptionAsyncModule>,
+        source_map: Vc<OptionSourceMap>,
+        exports: Vc<EcmascriptExports>,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<Self>> {
         let mut code_gens = Vec::new();
@@ -765,10 +765,10 @@ impl EcmascriptModuleContent {
 
         gen_content_with_code_gens(
             parsed.to_resolved().await?,
-            ident,
+            *ident,
             specified_module_type,
             &code_gens,
-            source_map,
+            *source_map,
         )
         .await
     }

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -560,14 +560,14 @@ impl Asset for EcmascriptModuleAsset {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for EcmascriptModuleAsset {
     #[turbo_tasks::function]
-    async fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<Box<dyn ChunkItem>>> {
-        Ok(Vc::upcast(ModuleChunkItem::cell(ModuleChunkItem {
-            module: self.to_resolved().await?,
-            chunking_context: chunking_context.to_resolved().await?,
-        })))
+    fn as_chunk_item(
+        self: ResolvedVc<Self>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Box<dyn ChunkItem>> {
+        Vc::upcast(ModuleChunkItem::cell(ModuleChunkItem {
+            module: self,
+            chunking_context,
+        }))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -763,8 +763,14 @@ impl EcmascriptModuleContent {
         let code_gens = code_gens.into_iter().try_join().await?;
         let code_gens = code_gens.iter().map(|cg| &**cg).collect::<Vec<_>>();
 
-        gen_content_with_code_gens(parsed, ident, specified_module_type, &code_gens, source_map)
-            .await
+        gen_content_with_code_gens(
+            parsed.to_resolved().await?,
+            ident,
+            specified_module_type,
+            &code_gens,
+            source_map,
+        )
+        .await
     }
 
     /// Creates a new [`Vc<EcmascriptModuleContent>`] without an analysis pass.
@@ -775,7 +781,7 @@ impl EcmascriptModuleContent {
         specified_module_type: SpecifiedModuleType,
     ) -> Result<Vc<Self>> {
         gen_content_with_code_gens(
-            parsed,
+            parsed.to_resolved().await?,
             ident,
             specified_module_type,
             &[],

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -779,7 +779,7 @@ impl EcmascriptModuleContent {
             ident,
             specified_module_type,
             &[],
-            OptionSourceMap::none(),
+            OptionSourceMap::none().to_resolved().await?,
         )
         .await
     }

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -191,12 +191,12 @@ fn modifier() -> Vc<RcStr> {
 
 #[derive(Clone)]
 pub struct EcmascriptModuleAssetBuilder {
-    source: ResolvedVc<Box<dyn Source>>,
+    source: Vc<Box<dyn Source>>,
     asset_context: Vc<Box<dyn AssetContext>>,
     ty: EcmascriptModuleAssetType,
-    transforms: ResolvedVc<EcmascriptInputTransforms>,
-    options: ResolvedVc<EcmascriptOptions>,
-    compile_time_info: ResolvedVc<CompileTimeInfo>,
+    transforms: Vc<EcmascriptInputTransforms>,
+    options: Vc<EcmascriptOptions>,
+    compile_time_info: Vc<CompileTimeInfo>,
     inner_assets: Option<ResolvedVc<InnerAssets>>,
 }
 
@@ -214,22 +214,22 @@ impl EcmascriptModuleAssetBuilder {
     pub fn build(self) -> Vc<EcmascriptModuleAsset> {
         if let Some(inner_assets) = self.inner_assets {
             EcmascriptModuleAsset::new_with_inner_assets(
-                *self.source,
+                self.source,
                 self.asset_context,
                 Value::new(self.ty),
-                *self.transforms,
-                *self.options,
-                *self.compile_time_info,
+                self.transforms,
+                self.options,
+                self.compile_time_info,
                 *inner_assets,
             )
         } else {
             EcmascriptModuleAsset::new(
-                *self.source,
+                self.source,
                 self.asset_context,
                 Value::new(self.ty),
-                *self.transforms,
-                *self.options,
-                *self.compile_time_info,
+                self.transforms,
+                self.options,
+                self.compile_time_info,
             )
         }
     }
@@ -275,11 +275,11 @@ pub trait EcmascriptAnalyzable {
 
 impl EcmascriptModuleAsset {
     pub fn builder(
-        source: ResolvedVc<Box<dyn Source>>,
+        source: Vc<Box<dyn Source>>,
         asset_context: Vc<Box<dyn AssetContext>>,
-        transforms: ResolvedVc<EcmascriptInputTransforms>,
-        options: ResolvedVc<EcmascriptOptions>,
-        compile_time_info: ResolvedVc<CompileTimeInfo>,
+        transforms: Vc<EcmascriptInputTransforms>,
+        options: Vc<EcmascriptOptions>,
+        compile_time_info: Vc<CompileTimeInfo>,
     ) -> EcmascriptModuleAssetBuilder {
         EcmascriptModuleAssetBuilder {
             source,

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -645,7 +645,7 @@ impl ChunkItem for ModuleChunkItem {
 
     #[turbo_tasks::function]
     fn module(&self) -> Vc<Box<dyn Module>> {
-        Vc::upcast(self.module)
+        *ResolvedVc::upcast(self.module)
     }
 
     #[turbo_tasks::function]
@@ -689,11 +689,11 @@ impl EcmascriptChunkItem for ModuleChunkItem {
         // TODO check if we need to pass async_module_info at all
         let content = this
             .module
-            .module_content(this.chunking_context, async_module_info);
+            .module_content(*this.chunking_context, async_module_info);
 
         Ok(EcmascriptChunkItemContent::new(
             content,
-            this.chunking_context,
+            *this.chunking_context,
             this.module.options(),
             async_module_options,
         ))
@@ -786,7 +786,7 @@ impl EcmascriptModuleContent {
 }
 
 async fn gen_content_with_code_gens(
-    parsed: Vc<ParseResult>,
+    parsed: ResolvedVc<ParseResult>,
     ident: Vc<AssetIdent>,
     specified_module_type: SpecifiedModuleType,
     code_gens: &[&CodeGeneration],

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -834,7 +834,7 @@ async fn gen_content_with_code_gens(
 
             Ok(EcmascriptModuleContent {
                 inner_code: bytes.into(),
-                source_map: Some(ResolvedVc::upcast(srcmap.to_resolved().await?)),
+                source_map: Some(Vc::upcast(srcmap)),
                 is_esm: eval_context.is_esm(specified_module_type),
             }
             .cell())

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -721,7 +721,7 @@ impl EcmascriptModuleContent {
         references: Vc<ModuleReferences>,
         code_generation: Vc<CodeGenerateables>,
         async_module: Vc<OptionAsyncModule>,
-        source_map: ResolvedVc<OptionSourceMap>,
+        source_map: Vc<OptionSourceMap>,
         exports: Vc<EcmascriptExports>,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<Self>> {

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -596,7 +596,7 @@ impl ResolveOrigin for EcmascriptModuleAsset {
 
     #[turbo_tasks::function]
     fn asset_context(&self) -> Vc<Box<dyn AssetContext>> {
-        self.asset_context
+        *self.asset_context
     }
 
     #[turbo_tasks::function]
@@ -651,7 +651,7 @@ impl ChunkItem for ModuleChunkItem {
     #[turbo_tasks::function]
     async fn is_self_async(&self) -> Result<Vc<bool>> {
         if let Some(async_module) = *self.module.get_async_module().await? {
-            Ok(async_module.is_self_async(self.module.analyze().await?.references))
+            Ok(async_module.is_self_async(*self.module.analyze().await?.references))
         } else {
             Ok(Vc::cell(false))
         }

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -142,17 +142,17 @@ impl Asset for ManifestAsyncModule {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for ManifestAsyncModule {
     #[turbo_tasks::function]
-    fn as_chunk_item(
+    async fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
-        Vc::upcast(
+    ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
+        Ok(Vc::upcast(
             ManifestChunkItem {
                 chunking_context: chunking_context.to_resolved().await?,
                 manifest: self.to_resolved().await?,
             }
             .cell(),
-        )
+        ))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -143,16 +143,16 @@ impl Asset for ManifestAsyncModule {
 impl ChunkableModule for ManifestAsyncModule {
     #[turbo_tasks::function]
     async fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
-        Ok(Vc::upcast(
+        self: ResolvedVc<Self>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        Vc::upcast(
             ManifestChunkItem {
-                chunking_context: chunking_context.to_resolved().await?,
-                manifest: self.to_resolved().await?,
+                chunking_context,
+                manifest: self,
             }
             .cell(),
-        ))
+        )
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -148,8 +148,8 @@ impl ChunkableModule for ManifestAsyncModule {
     ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
         Vc::upcast(
             ManifestChunkItem {
-                chunking_context,
-                manifest: self,
+                chunking_context: chunking_context.to_resolved().await?,
+                manifest: self.to_resolved().await?,
             }
             .cell(),
         )

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -41,16 +41,16 @@ pub struct ManifestAsyncModule {
 #[turbo_tasks::value_impl]
 impl ManifestAsyncModule {
     #[turbo_tasks::function]
-    pub fn new(
+    pub async fn new(
         module: Vc<Box<dyn ChunkableModule>>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
         availability_info: Value<AvailabilityInfo>,
-    ) -> Vc<Self> {
-        Self::cell(ManifestAsyncModule {
+    ) -> Result<Vc<Self>> {
+        Ok(Self::cell(ManifestAsyncModule {
             inner: module.to_resolved().await?,
             chunking_context: chunking_context.to_resolved().await?,
             availability_info: availability_info.into_value(),
-        })
+        }))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -42,15 +42,15 @@ pub struct ManifestAsyncModule {
 impl ManifestAsyncModule {
     #[turbo_tasks::function]
     pub async fn new(
-        module: Vc<Box<dyn ChunkableModule>>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
+        module: ResolvedVc<Box<dyn ChunkableModule>>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
         availability_info: Value<AvailabilityInfo>,
-    ) -> Result<Vc<Self>> {
-        Ok(Self::cell(ManifestAsyncModule {
-            inner: module.to_resolved().await?,
-            chunking_context: chunking_context.to_resolved().await?,
+    ) -> Vc<Self> {
+        Self::cell(ManifestAsyncModule {
+            inner: module,
+            chunking_context,
             availability_info: availability_info.into_value(),
-        }))
+        })
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -55,8 +55,10 @@ impl ManifestAsyncModule {
 
     #[turbo_tasks::function]
     pub(super) fn chunks(&self) -> Vc<OutputAssets> {
-        self.chunking_context
-            .chunk_group_assets(Vc::upcast(self.inner), Value::new(self.availability_info))
+        self.chunking_context.chunk_group_assets(
+            *ResolvedVc::upcast(self.inner),
+            Value::new(self.availability_info),
+        )
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
@@ -95,7 +95,7 @@ impl ChunkItem for ManifestChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        Vc::upcast(self.chunking_context)
+        *ResolvedVc::upcast(self.chunking_context)
     }
 
     #[turbo_tasks::function]
@@ -107,6 +107,6 @@ impl ChunkItem for ManifestChunkItem {
 
     #[turbo_tasks::function]
     fn module(&self) -> Vc<Box<dyn Module>> {
-        Vc::upcast(self.manifest)
+        *ResolvedVc::upcast(self.manifest)
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
@@ -50,14 +50,14 @@ pub struct ManifestLoaderChunkItem {
 #[turbo_tasks::value_impl]
 impl ManifestLoaderChunkItem {
     #[turbo_tasks::function]
-    pub fn new(
+    pub async fn new(
         manifest: Vc<ManifestAsyncModule>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Vc<Self> {
-        Self::cell(ManifestLoaderChunkItem {
-            manifest,
-            chunking_context,
-        })
+    ) -> Result<Vc<Self>> {
+        Ok(Self::cell(ManifestLoaderChunkItem {
+            manifest: manifest.to_resolved().await?,
+            chunking_context: chunking_context.to_resolved().await?,
+        }))
     }
 
     #[turbo_tasks::function]
@@ -125,7 +125,7 @@ impl ChunkItem for ManifestLoaderChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        Vc::upcast(self.chunking_context)
+        *ResolvedVc::upcast(self.chunking_context)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
@@ -50,14 +50,14 @@ pub struct ManifestLoaderChunkItem {
 #[turbo_tasks::value_impl]
 impl ManifestLoaderChunkItem {
     #[turbo_tasks::function]
-    pub async fn new(
-        manifest: Vc<ManifestAsyncModule>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<Self>> {
-        Ok(Self::cell(ManifestLoaderChunkItem {
-            manifest: manifest.to_resolved().await?,
-            chunking_context: chunking_context.to_resolved().await?,
-        }))
+    pub fn new(
+        manifest: ResolvedVc<ManifestAsyncModule>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Self> {
+        Self::cell(ManifestLoaderChunkItem {
+            manifest,
+            chunking_context,
+        })
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
@@ -137,7 +137,7 @@ impl ChunkItem for ManifestLoaderChunkItem {
 
     #[turbo_tasks::function]
     fn module(&self) -> Vc<Box<dyn Module>> {
-        Vc::upcast(self.manifest)
+        *ResolvedVc::upcast(self.manifest)
     }
 }
 
@@ -145,7 +145,7 @@ impl ChunkItem for ManifestLoaderChunkItem {
 impl EcmascriptChunkItem for ManifestLoaderChunkItem {
     #[turbo_tasks::function]
     async fn chunking_context(&self) -> Result<Vc<Box<dyn ChunkingContext>>> {
-        Ok(self.manifest.await?.chunking_context)
+        Ok(*self.manifest.await?.chunking_context)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -31,7 +31,7 @@ use crate::ParseResultSourceMap;
 #[turbo_tasks::function]
 pub async fn minify(path: Vc<FileSystemPath>, code: Vc<Code>) -> Result<Vc<Code>> {
     let path = path.await?;
-    let original_map = code.generate_source_map();
+    let original_map = code.generate_source_map().to_resolved().await?;
     let code = code.await?;
 
     let cm = Arc::new(SwcSourceMap::new(FilePathMapping::empty()));

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -31,7 +31,7 @@ use crate::ParseResultSourceMap;
 #[turbo_tasks::function]
 pub async fn minify(path: Vc<FileSystemPath>, code: Vc<Code>) -> Result<Vc<Code>> {
     let path = path.await?;
-    let original_map = code.generate_source_map().to_resolved().await?;
+    let original_map = code.generate_source_map();
     let code = code.await?;
 
     let cm = Arc::new(SwcSourceMap::new(FilePathMapping::empty()));

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -87,7 +87,7 @@ pub struct ParseResultSourceMap {
 
     /// An input's original source map, if one exists. This will be used to
     /// trace locations back to the input's pre-transformed sources.
-    original_source_map: ResolvedVc<OptionSourceMap>,
+    original_source_map: Vc<OptionSourceMap>,
 }
 
 impl PartialEq for ParseResultSourceMap {
@@ -100,7 +100,7 @@ impl ParseResultSourceMap {
     pub fn new(
         files_map: Arc<swc_core::common::SourceMap>,
         mappings: Vec<(BytePos, LineCol)>,
-        original_source_map: ResolvedVc<OptionSourceMap>,
+        original_source_map: Vc<OptionSourceMap>,
     ) -> Self {
         ParseResultSourceMap {
             files_map,

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -100,7 +100,7 @@ impl ParseResultSourceMap {
     pub fn new(
         files_map: Arc<swc_core::common::SourceMap>,
         mappings: Vec<(BytePos, LineCol)>,
-        original_source_map: Vc<OptionSourceMap>,
+        original_source_map: ResolvedVc<OptionSourceMap>,
     ) -> Self {
         ParseResultSourceMap {
             files_map,

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -213,7 +213,7 @@ async fn parse_internal(
                         fs_path,
                         ident,
                         file_path_hash,
-                        *source,
+                        source,
                         ty,
                         transforms,
                     )
@@ -253,7 +253,7 @@ async fn parse_file_content(
     fs_path: &FileSystemPath,
     ident: &str,
     file_path_hash: u128,
-    source: Vc<Box<dyn Source>>,
+    source: ResolvedVc<Box<dyn Source>>,
     ty: EcmascriptModuleAssetType,
     transforms: &[EcmascriptInputTransform],
 ) -> Result<Vc<ParseResult>> {
@@ -262,14 +262,14 @@ async fn parse_file_content(
         true,
         false,
         Box::new(IssueEmitter::new(
-            source,
+            *source,
             source_map.clone(),
             Some("Ecmascript file had an error".into()),
         )),
     );
 
     let emitter = Box::new(IssueEmitter::new(
-        source,
+        *source,
         source_map.clone(),
         Some("Parsing ecmascript source code failed".into()),
     ));
@@ -435,7 +435,7 @@ async fn parse_file_content(
                 unresolved_mark,
                 top_level_mark,
                 Some(&comments),
-                Some(source),
+                Some(*source),
             );
 
             Ok::<ParseResult, anyhow::Error>(ParseResult::Ok {

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -189,7 +189,7 @@ async fn parse_internal(
         Err(error) => {
             let error: RcStr = PrettyPrintError(&error).to_string().into();
             ReadSourceIssue {
-                source,
+                source: source.to_resolved().await?,
                 error: error.clone(),
             }
             .cell()
@@ -231,7 +231,7 @@ async fn parse_internal(
                 Err(error) => {
                     let error: RcStr = PrettyPrintError(&error).to_string().into();
                     ReadSourceIssue {
-                        source,
+                        source: source.to_resolved().await?,
                         error: error.clone(),
                     }
                     .cell()

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -396,7 +396,7 @@ async fn parse_file_content(
                 file_path_str: &fs_path.path,
                 file_name_str: fs_path.file_name(),
                 file_name_hash: file_path_hash,
-                file_path: fs_path_vc,
+                file_path: fs_path_vc.to_resolved().await?,
             };
             let span = tracing::trace_span!("transforms");
             async {

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -155,7 +155,7 @@ impl SourceMapGenConfig for InlineSourcesContentConfig {
 
 #[turbo_tasks::function]
 pub async fn parse(
-    source: Vc<Box<dyn Source>>,
+    source: ResolvedVc<Box<dyn Source>>,
     ty: Value<EcmascriptModuleAssetType>,
     transforms: Vc<EcmascriptInputTransforms>,
 ) -> Result<Vc<ParseResult>> {
@@ -174,7 +174,7 @@ pub async fn parse(
 }
 
 async fn parse_internal(
-    source: Vc<Box<dyn Source>>,
+    source: ResolvedVc<Box<dyn Source>>,
     ty: Value<EcmascriptModuleAssetType>,
     transforms: Vc<EcmascriptInputTransforms>,
 ) -> Result<Vc<ParseResult>> {
@@ -189,7 +189,7 @@ async fn parse_internal(
         Err(error) => {
             let error: RcStr = PrettyPrintError(&error).to_string().into();
             ReadSourceIssue {
-                source: source.to_resolved().await?,
+                source,
                 error: error.clone(),
             }
             .cell()
@@ -213,7 +213,7 @@ async fn parse_internal(
                         fs_path,
                         ident,
                         file_path_hash,
-                        source,
+                        *source,
                         ty,
                         transforms,
                     )
@@ -231,7 +231,7 @@ async fn parse_internal(
                 Err(error) => {
                     let error: RcStr = PrettyPrintError(&error).to_string().into();
                     ReadSourceIssue {
-                        source: source.to_resolved().await?,
+                        source,
                         error: error.clone(),
                     }
                     .cell()

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -42,18 +42,18 @@ pub struct AmdDefineAssetReference {
 #[turbo_tasks::value_impl]
 impl AmdDefineAssetReference {
     #[turbo_tasks::function]
-    pub async fn new(
-        origin: Vc<Box<dyn ResolveOrigin>>,
-        request: Vc<Request>,
-        issue_source: Vc<IssueSource>,
+    pub fn new(
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        request: ResolvedVc<Request>,
+        issue_source: ResolvedVc<IssueSource>,
         in_try: bool,
-    ) -> Result<Vc<Self>> {
-        Ok(Self::cell(AmdDefineAssetReference {
-            origin: origin.to_resolved().await?,
-            request: request.to_resolved().await?,
-            issue_source: issue_source.to_resolved().await?,
+    ) -> Vc<Self> {
+        Self::cell(AmdDefineAssetReference {
+            origin,
+            request,
+            issue_source,
             in_try,
-        }))
+        })
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -154,7 +154,7 @@ impl CodeGenerateable for AmdDefineWithDependenciesCodeGen {
                     } => ResolvedElement::PatternMapping {
                         pattern_mapping: PatternMapping::resolve_request(
                             **request,
-                            self.origin,
+                            *self.origin,
                             Vc::upcast(chunking_context),
                             cjs_resolve(
                                 *self.origin,

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -153,15 +153,10 @@ impl CodeGenerateable for AmdDefineWithDependenciesCodeGen {
                         request_str,
                     } => ResolvedElement::PatternMapping {
                         pattern_mapping: PatternMapping::resolve_request(
-                            **request,
+                            request,
                             self.origin,
                             Vc::upcast(chunking_context),
-                            cjs_resolve(
-                                self.origin,
-                                **request,
-                                Some(self.issue_source),
-                                self.in_try,
-                            ),
+                            cjs_resolve(self.origin, request, Some(self.issue_source), self.in_try),
                             Value::new(ChunkItem),
                         )
                         .await?,

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -117,10 +117,10 @@ pub struct AmdDefineWithDependenciesCodeGen {
 impl AmdDefineWithDependenciesCodeGen {
     pub fn new(
         dependencies_requests: Vec<AmdDefineDependencyElement>,
-        origin: Vc<Box<dyn ResolveOrigin>>,
-        path: Vc<AstPath>,
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        path: ResolvedVc<AstPath>,
         factory_type: AmdDefineFactoryType,
-        issue_source: Vc<IssueSource>,
+        issue_source: ResolvedVc<IssueSource>,
         in_try: bool,
     ) -> Vc<Self> {
         Self::cell(AmdDefineWithDependenciesCodeGen {

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -110,7 +110,7 @@ pub struct AmdDefineWithDependenciesCodeGen {
     origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     path: ResolvedVc<AstPath>,
     factory_type: AmdDefineFactoryType,
-    issue_source: ResolvedVc<IssueSource>,
+    issue_source: Vc<IssueSource>,
     in_try: bool,
 }
 
@@ -120,7 +120,7 @@ impl AmdDefineWithDependenciesCodeGen {
         origin: ResolvedVc<Box<dyn ResolveOrigin>>,
         path: ResolvedVc<AstPath>,
         factory_type: AmdDefineFactoryType,
-        issue_source: ResolvedVc<IssueSource>,
+        issue_source: Vc<IssueSource>,
         in_try: bool,
     ) -> Vc<Self> {
         Self::cell(AmdDefineWithDependenciesCodeGen {

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -107,7 +107,7 @@ pub enum AmdDefineFactoryType {
 #[derive(Debug)]
 pub struct AmdDefineWithDependenciesCodeGen {
     dependencies_requests: Vec<AmdDefineDependencyElement>,
-    origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+    origin: Vc<Box<dyn ResolveOrigin>>,
     path: ResolvedVc<AstPath>,
     factory_type: AmdDefineFactoryType,
     issue_source: Vc<IssueSource>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -86,7 +86,7 @@ impl ChunkableModuleReference for AmdDefineAssetReference {}
 #[derive(ValueDebugFormat, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, Clone)]
 pub enum AmdDefineDependencyElement {
     Request {
-        request: ResolvedVc<Request>,
+        request: Vc<Request>,
         request_str: String,
     },
     Exports,

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -153,10 +153,15 @@ impl CodeGenerateable for AmdDefineWithDependenciesCodeGen {
                         request_str,
                     } => ResolvedElement::PatternMapping {
                         pattern_mapping: PatternMapping::resolve_request(
-                            request,
+                            *request,
                             self.origin,
                             Vc::upcast(chunking_context),
-                            cjs_resolve(self.origin, request, Some(self.issue_source), self.in_try),
+                            cjs_resolve(
+                                self.origin,
+                                *request,
+                                Some(self.issue_source),
+                                self.in_try,
+                            ),
                             Value::new(ChunkItem),
                         )
                         .await?,

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -117,7 +117,7 @@ pub struct AmdDefineWithDependenciesCodeGen {
 impl AmdDefineWithDependenciesCodeGen {
     pub fn new(
         dependencies_requests: Vec<AmdDefineDependencyElement>,
-        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        origin: Vc<Box<dyn ResolveOrigin>>,
         path: ResolvedVc<AstPath>,
         factory_type: AmdDefineFactoryType,
         issue_source: Vc<IssueSource>,
@@ -154,10 +154,10 @@ impl CodeGenerateable for AmdDefineWithDependenciesCodeGen {
                     } => ResolvedElement::PatternMapping {
                         pattern_mapping: PatternMapping::resolve_request(
                             **request,
-                            *self.origin,
+                            self.origin,
                             Vc::upcast(chunking_context),
                             cjs_resolve(
-                                *self.origin,
+                                self.origin,
                                 **request,
                                 Some(self.issue_source),
                                 self.in_try,

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -159,7 +159,7 @@ impl CodeGenerateable for AmdDefineWithDependenciesCodeGen {
                             cjs_resolve(
                                 *self.origin,
                                 **request,
-                                Some(*self.issue_source),
+                                Some(self.issue_source),
                                 self.in_try,
                             ),
                             Value::new(ChunkItem),

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -42,18 +42,18 @@ pub struct AmdDefineAssetReference {
 #[turbo_tasks::value_impl]
 impl AmdDefineAssetReference {
     #[turbo_tasks::function]
-    pub fn new(
+    pub async fn new(
         origin: Vc<Box<dyn ResolveOrigin>>,
         request: Vc<Request>,
         issue_source: Vc<IssueSource>,
         in_try: bool,
-    ) -> Vc<Self> {
-        Self::cell(AmdDefineAssetReference {
-            origin,
-            request,
-            issue_source,
+    ) -> Result<Vc<Self>> {
+        Ok(Self::cell(AmdDefineAssetReference {
+            origin: origin.to_resolved().await?,
+            request: request.to_resolved().await?,
+            issue_source: issue_source.to_resolved().await?,
             in_try,
-        })
+        }))
     }
 }
 
@@ -62,9 +62,9 @@ impl ModuleReference for AmdDefineAssetReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         cjs_resolve(
-            self.origin,
-            self.request,
-            Some(self.issue_source),
+            *self.origin,
+            *self.request,
+            Some(*self.issue_source),
             self.in_try,
         )
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
@@ -6,7 +6,7 @@ use swc_core::{
     quote,
 };
 use turbo_tasks::{
-    trace::TraceRawVcs, FxIndexSet, ReadRef, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Vc,
+    trace::TraceRawVcs, FxIndexSet, ReadRef, TryFlatJoinIterExt, TryJoinIterExt, Vc,
 };
 use turbopack_core::{
     chunk::{
@@ -51,7 +51,7 @@ pub struct AsyncModule {
 
 /// Option<[AsyncModule]>.
 #[turbo_tasks::value(transparent)]
-pub struct OptionAsyncModule(Option<ResolvedVc<AsyncModule>>);
+pub struct OptionAsyncModule(Option<Vc<AsyncModule>>);
 
 #[turbo_tasks::value_impl]
 impl OptionAsyncModule {

--- a/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
@@ -78,9 +78,9 @@ impl OptionAsyncModule {
 struct AsyncModuleIdents(FxIndexSet<String>);
 
 async fn get_inherit_async_referenced_asset(
-    r: Vc<Box<dyn ModuleReference>>,
+    r: ResolvedVc<Box<dyn ModuleReference>>,
 ) -> Result<Option<ReadRef<ReferencedAsset>>> {
-    let Some(r) = Vc::try_resolve_downcast::<Box<dyn ChunkableModuleReference>>(r).await? else {
+    let Some(r) = ResolvedVc::try_downcast::<Box<dyn ChunkableModuleReference>>(r).await? else {
         return Ok(None);
     };
     let Some(ty) = *r.chunking_type().await? else {
@@ -109,7 +109,7 @@ impl AsyncModule {
             .await?
             .iter()
             .map(|r| async {
-                let Some(referenced_asset) = get_inherit_async_referenced_asset(*r).await? else {
+                let Some(referenced_asset) = get_inherit_async_referenced_asset(r).await? else {
                     return Ok(None);
                 };
                 Ok(match &*referenced_asset {
@@ -156,7 +156,7 @@ impl AsyncModule {
                     .await?
                     .iter()
                     .map(|r| async {
-                        let Some(referenced_asset) = get_inherit_async_referenced_asset(*r).await?
+                        let Some(referenced_asset) = get_inherit_async_referenced_asset(r).await?
                         else {
                             return Ok(false);
                         };

--- a/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
@@ -78,9 +78,9 @@ impl OptionAsyncModule {
 struct AsyncModuleIdents(FxIndexSet<String>);
 
 async fn get_inherit_async_referenced_asset(
-    r: ResolvedVc<Box<dyn ModuleReference>>,
+    r: Vc<Box<dyn ModuleReference>>,
 ) -> Result<Option<ReadRef<ReferencedAsset>>> {
-    let Some(r) = ResolvedVc::try_downcast::<Box<dyn ChunkableModuleReference>>(r).await? else {
+    let Some(r) = Vc::try_resolve_downcast::<Box<dyn ChunkableModuleReference>>(r).await? else {
         return Ok(None);
     };
     let Some(ty) = *r.chunking_type().await? else {
@@ -109,7 +109,7 @@ impl AsyncModule {
             .await?
             .iter()
             .map(|r| async {
-                let Some(referenced_asset) = get_inherit_async_referenced_asset(r).await? else {
+                let Some(referenced_asset) = get_inherit_async_referenced_asset(*r).await? else {
                     return Ok(None);
                 };
                 Ok(match &*referenced_asset {
@@ -156,7 +156,7 @@ impl AsyncModule {
                     .await?
                     .iter()
                     .map(|r| async {
-                        let Some(referenced_asset) = get_inherit_async_referenced_asset(r).await?
+                        let Some(referenced_asset) = get_inherit_async_referenced_asset(*r).await?
                         else {
                             return Ok(false);
                         };

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -53,9 +53,9 @@ impl ModuleReference for CjsAssetReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         cjs_resolve(
-            self.origin,
-            self.request,
-            Some(self.issue_source),
+            *self.origin,
+            *self.request,
+            Some(*self.issue_source),
             self.in_try,
         )
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -34,15 +34,15 @@ pub struct CjsAssetReference {
 impl CjsAssetReference {
     #[turbo_tasks::function]
     pub async fn new(
-        origin: Vc<Box<dyn ResolveOrigin>>,
-        request: Vc<Request>,
-        issue_source: Vc<IssueSource>,
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        request: ResolvedVc<Request>,
+        issue_source: ResolvedVc<IssueSource>,
         in_try: bool,
     ) -> Result<Vc<Self>> {
         Ok(Self::cell(CjsAssetReference {
-            origin: origin.to_resolved().await?,
-            request: request.to_resolved().await?,
-            issue_source: issue_source.to_resolved().await?,
+            origin,
+            request,
+            issue_source,
             in_try,
         }))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -33,18 +33,18 @@ pub struct CjsAssetReference {
 #[turbo_tasks::value_impl]
 impl CjsAssetReference {
     #[turbo_tasks::function]
-    pub fn new(
+    pub async fn new(
         origin: Vc<Box<dyn ResolveOrigin>>,
         request: Vc<Request>,
         issue_source: Vc<IssueSource>,
         in_try: bool,
-    ) -> Vc<Self> {
-        Self::cell(CjsAssetReference {
-            origin,
-            request,
-            issue_source,
+    ) -> Result<Vc<Self>> {
+        Ok(Self::cell(CjsAssetReference {
+            origin: origin.to_resolved().await?,
+            request: request.to_resolved().await?,
+            issue_source: issue_source.to_resolved().await?,
             in_try,
-        })
+        }))
     }
 }
 
@@ -138,9 +138,9 @@ impl CodeGenerateable for CjsRequireAssetReference {
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let pm = PatternMapping::resolve_request(
-            self.request,
-            self.origin,
-            *Vc::upcast(chunking_context),
+            *self.request,
+            *self.origin,
+            Vc::upcast(chunking_context),
             cjs_resolve(
                 *self.origin,
                 *self.request,

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -245,8 +245,8 @@ impl CodeGenerateable for CjsRequireResolveAssetReference {
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let pm = PatternMapping::resolve_request(
-            self.request,
-            self.origin,
+            *self.request,
+            *self.origin,
             Vc::upcast(chunking_context),
             cjs_resolve(
                 *self.origin,

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -216,9 +216,9 @@ impl ModuleReference for CjsRequireResolveAssetReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         cjs_resolve(
-            self.origin,
-            self.request,
-            Some(self.issue_source),
+            *self.origin,
+            *self.request,
+            Some(*self.issue_source),
             self.in_try,
         )
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -87,20 +87,20 @@ pub struct CjsRequireAssetReference {
 #[turbo_tasks::value_impl]
 impl CjsRequireAssetReference {
     #[turbo_tasks::function]
-    pub fn new(
+    pub async fn new(
         origin: Vc<Box<dyn ResolveOrigin>>,
         request: Vc<Request>,
         path: Vc<AstPath>,
         issue_source: Vc<IssueSource>,
         in_try: bool,
-    ) -> Vc<Self> {
-        Self::cell(CjsRequireAssetReference {
-            origin,
-            request,
-            path,
-            issue_source,
+    ) -> Result<Vc<Self>> {
+        Ok(Self::cell(CjsRequireAssetReference {
+            origin: origin.to_resolved().await?,
+            request: request.to_resolved().await?,
+            path: path.to_resolved().await?,
+            issue_source: issue_source.to_resolved().await?,
             in_try,
-        })
+        }))
     }
 }
 
@@ -109,9 +109,9 @@ impl ModuleReference for CjsRequireAssetReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         cjs_resolve(
-            self.origin,
-            self.request,
-            Some(self.issue_source),
+            *self.origin,
+            *self.request,
+            Some(*self.issue_source),
             self.in_try,
         )
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -87,20 +87,20 @@ pub struct CjsRequireAssetReference {
 #[turbo_tasks::value_impl]
 impl CjsRequireAssetReference {
     #[turbo_tasks::function]
-    pub async fn new(
-        origin: Vc<Box<dyn ResolveOrigin>>,
-        request: Vc<Request>,
-        path: Vc<AstPath>,
-        issue_source: Vc<IssueSource>,
+    pub fn new(
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        request: ResolvedVc<Request>,
+        path: ResolvedVc<AstPath>,
+        issue_source: ResolvedVc<IssueSource>,
         in_try: bool,
-    ) -> Result<Vc<Self>> {
-        Ok(Self::cell(CjsRequireAssetReference {
-            origin: origin.to_resolved().await?,
-            request: request.to_resolved().await?,
-            path: path.to_resolved().await?,
-            issue_source: issue_source.to_resolved().await?,
+    ) -> Vc<Self> {
+        Self::cell(CjsRequireAssetReference {
+            origin,
+            request,
+            path,
+            issue_source,
             in_try,
-        }))
+        })
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -195,10 +195,10 @@ pub struct CjsRequireResolveAssetReference {
 impl CjsRequireResolveAssetReference {
     #[turbo_tasks::function]
     pub fn new(
-        origin: Vc<Box<dyn ResolveOrigin>>,
-        request: Vc<Request>,
-        path: Vc<AstPath>,
-        issue_source: Vc<IssueSource>,
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        request: ResolvedVc<Request>,
+        path: ResolvedVc<AstPath>,
+        issue_source: ResolvedVc<IssueSource>,
         in_try: bool,
     ) -> Vc<Self> {
         Self::cell(CjsRequireResolveAssetReference {

--- a/turbopack/crates/turbopack-ecmascript/src/references/constant_condition.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/constant_condition.rs
@@ -26,7 +26,7 @@ pub struct ConstantCondition {
 #[turbo_tasks::value_impl]
 impl ConstantCondition {
     #[turbo_tasks::function]
-    pub fn new(value: Value<ConstantConditionValue>, path: Vc<AstPath>) -> Vc<Self> {
+    pub fn new(value: Value<ConstantConditionValue>, path: ResolvedVc<AstPath>) -> Vc<Self> {
         Self::cell(ConstantCondition {
             value: value.into_value(),
             path,

--- a/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
@@ -18,7 +18,7 @@ pub struct ConstantValue {
 #[turbo_tasks::value_impl]
 impl ConstantValue {
     #[turbo_tasks::function]
-    pub fn new(value: Value<CompileTimeDefineValue>, path: Vc<AstPath>) -> Vc<Self> {
+    pub fn new(value: Value<CompileTimeDefineValue>, path: ResolvedVc<AstPath>) -> Vc<Self> {
         Self::cell(ConstantValue {
             value: value.into_value(),
             path,

--- a/turbopack/crates/turbopack-ecmascript/src/references/dynamic_expression.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/dynamic_expression.rs
@@ -25,7 +25,7 @@ pub struct DynamicExpression {
 #[turbo_tasks::value_impl]
 impl DynamicExpression {
     #[turbo_tasks::function]
-    pub fn new(path: Vc<AstPath>) -> Vc<Self> {
+    pub fn new(path: ResolvedVc<AstPath>) -> Vc<Self> {
         Self::cell(DynamicExpression {
             path,
             ty: DynamicExpressionType::Normal,
@@ -33,7 +33,7 @@ impl DynamicExpression {
     }
 
     #[turbo_tasks::function]
-    pub fn new_promise(path: Vc<AstPath>) -> Vc<Self> {
+    pub fn new_promise(path: ResolvedVc<AstPath>) -> Vc<Self> {
         Self::cell(DynamicExpression {
             path,
             ty: DynamicExpressionType::Promise,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -124,9 +124,9 @@ impl EsmAssetReference {
 impl EsmAssetReference {
     #[turbo_tasks::function]
     pub fn new(
-        origin: Vc<Box<dyn ResolveOrigin>>,
-        request: Vc<Request>,
-        issue_source: Vc<IssueSource>,
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        request: ResolvedVc<Request>,
+        issue_source: ResolvedVc<IssueSource>,
         annotations: Value<ImportAnnotations>,
         export_name: Option<ResolvedVc<ModulePart>>,
         import_externals: bool,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -482,6 +482,6 @@ impl Issue for InvalidExport {
 
     #[turbo_tasks::function]
     fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(Some(self.source))
+        Vc::cell(Some(*self.source))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -41,7 +41,7 @@ use crate::{
 
 #[turbo_tasks::value]
 pub enum ReferencedAsset {
-    Some(Vc<Box<dyn EcmascriptChunkPlaceable>>),
+    Some(ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>),
     External(RcStr, ExternalType),
     None,
     Unresolvable,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -112,7 +112,7 @@ pub struct EsmAssetReference {
 
 impl EsmAssetReference {
     fn get_origin(&self) -> Vc<Box<dyn ResolveOrigin>> {
-        let mut origin = self.origin;
+        let mut origin = *self.origin;
         if let Some(transition) = self.annotations.transition() {
             origin = origin.with_transition(transition.into());
         }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -193,7 +193,7 @@ impl ModuleReference for EsmAssetReference {
                 for &module in result.primary_modules().await? {
                     if let Some(module) = ResolvedVc::try_downcast(module).await? {
                         let export = export_name.await?;
-                        if *is_export_missing(*module, export.clone_value()).await? {
+                        if is_export_missing(*module, export.clone_value()).await? {
                             InvalidExport {
                                 export: export_name,
                                 module,
@@ -427,7 +427,7 @@ impl Issue for InvalidExport {
     #[turbo_tasks::function]
     async fn description(&self) -> Result<Vc<OptionStyledString>> {
         let export = self.export.await?;
-        let export_names = all_known_export_names(self.module).await?;
+        let export_names = all_known_export_names(*self.module).await?;
         let did_you_mean = export_names
             .iter()
             .map(|s| (s, jaro(export.as_str(), s.as_str())))

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -88,7 +88,7 @@ impl ReferencedAsset {
                         ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(module)
                             .await?
                     {
-                        return Ok(ReferencedAsset::Some(*placeable).cell());
+                        return Ok(ReferencedAsset::Some(**placeable).cell());
                     }
                 }
                 // TODO ignore should probably be handled differently

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -88,7 +88,7 @@ impl ReferencedAsset {
                         ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(module)
                             .await?
                     {
-                        return Ok(ReferencedAsset::Some(placeable).cell());
+                        return Ok(ReferencedAsset::Some(*placeable).cell());
                     }
                 }
                 // TODO ignore should probably be handled differently

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -162,13 +162,13 @@ impl ModuleReference for EsmAssetReference {
         if let Request::Module { module, .. } = &*self.request.await? {
             if module == TURBOPACK_PART_IMPORT_SOURCE {
                 if let Some(part) = self.export_name {
-                    let module: Vc<crate::EcmascriptModuleAsset> =
-                        Vc::try_resolve_downcast_type(self.origin)
+                    let module: ResolvedVc<crate::EcmascriptModuleAsset> =
+                        ResolvedVc::try_downcast_type(self.origin)
                             .await?
                             .expect("EsmAssetReference origin should be a EcmascriptModuleAsset");
 
                     return Ok(ModuleResolveResult::module(
-                        EcmascriptModulePartAsset::select_part(module, *part)
+                        EcmascriptModulePartAsset::select_part(*module, *part)
                             .to_resolved()
                             .await?,
                     )

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -88,7 +88,7 @@ impl ReferencedAsset {
                         ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(module)
                             .await?
                     {
-                        return Ok(ReferencedAsset::Some(**placeable).cell());
+                        return Ok(ReferencedAsset::Some(placeable).cell());
                     }
                 }
                 // TODO ignore should probably be handled differently

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -41,7 +41,7 @@ use crate::{
 
 #[turbo_tasks::value]
 pub enum ReferencedAsset {
-    Some(ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>),
+    Some(Vc<Box<dyn EcmascriptChunkPlaceable>>),
     External(RcStr, ExternalType),
     None,
     Unresolvable,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -260,7 +260,7 @@ impl CodeGenerateable for EsmAssetReference {
             if let ReferencedAsset::Unresolvable = &*referenced_asset {
                 // Insert code that throws immediately at time of import if a request is
                 // unresolvable
-                let request = request_to_string(this.request).await?.to_string();
+                let request = request_to_string(*this.request).await?.to_string();
                 let stmt = Stmt::Expr(ExprStmt {
                     expr: Box::new(throw_module_not_found_expr(&request)),
                     span: DUMMY_SP,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -193,7 +193,7 @@ impl ModuleReference for EsmAssetReference {
                 for &module in result.primary_modules().await? {
                     if let Some(module) = ResolvedVc::try_downcast(module).await? {
                         let export = export_name.await?;
-                        if is_export_missing(*module, export.clone_value()).await? {
+                        if *is_export_missing(*module, export.clone_value()).await? {
                             InvalidExport {
                                 export: export_name,
                                 module,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -463,7 +463,7 @@ impl Issue for InvalidExport {
 
     #[turbo_tasks::function]
     async fn detail(&self) -> Result<Vc<OptionStyledString>> {
-        let export_names = all_known_export_names(self.module).await?;
+        let export_names = all_known_export_names(*self.module).await?;
         Ok(Vc::cell(Some(
             StyledString::Line(vec![
                 StyledString::Text("These are the exports of the module:\n".into()),

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
@@ -47,9 +47,9 @@ pub struct EsmBinding {
 
 impl EsmBinding {
     pub fn new(
-        reference: Vc<EsmAssetReference>,
+        reference: ResolvedVc<EsmAssetReference>,
         export: Option<RcStr>,
-        ast_path: Vc<AstPath>,
+        ast_path: ResolvedVc<AstPath>,
     ) -> Self {
         EsmBinding {
             reference,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
@@ -40,14 +40,14 @@ impl EsmBindings {
 
 #[derive(Hash, Clone, Debug, TaskInput, Serialize, Deserialize, PartialEq, Eq, TraceRawVcs)]
 pub struct EsmBinding {
-    pub reference: ResolvedVc<EsmAssetReference>,
+    pub reference: Vc<EsmAssetReference>,
     pub export: Option<RcStr>,
     pub ast_path: ResolvedVc<AstPath>,
 }
 
 impl EsmBinding {
     pub fn new(
-        reference: ResolvedVc<EsmAssetReference>,
+        reference: Vc<EsmAssetReference>,
         export: Option<RcStr>,
         ast_path: ResolvedVc<AstPath>,
     ) -> Self {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -65,7 +65,7 @@ impl ModuleReference for EsmAsyncAssetReference {
             self.request,
             Value::new(EcmaScriptModulesReferenceSubType::DynamicImport),
             self.in_try,
-            Some(self.issue_source),
+            Some(*self.issue_source),
         )
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -38,10 +38,10 @@ pub struct EsmAsyncAssetReference {
 impl EsmAsyncAssetReference {
     #[turbo_tasks::function]
     pub fn new(
-        origin: Vc<Box<dyn ResolveOrigin>>,
-        request: Vc<Request>,
-        path: Vc<AstPath>,
-        issue_source: Vc<IssueSource>,
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        request: ResolvedVc<Request>,
+        path: ResolvedVc<AstPath>,
+        issue_source: ResolvedVc<IssueSource>,
         in_try: bool,
         import_externals: bool,
     ) -> Vc<Self> {
@@ -61,8 +61,8 @@ impl ModuleReference for EsmAsyncAssetReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         esm_resolve(
-            self.origin,
-            self.request,
+            *self.origin,
+            *self.request,
             Value::new(EcmaScriptModulesReferenceSubType::DynamicImport),
             self.in_try,
             Some(*self.issue_source),

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -235,7 +235,7 @@ async fn handle_declared_export(
                 *ReferencedAsset::from_resolve_result(reference.resolve_reference()).await?
             {
                 return Ok(ControlFlow::Break(FollowExportsResult {
-                    module: *m,
+                    module: m,
                     export_name: None,
                     ty: FoundExportType::Found,
                 }));

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -416,7 +416,7 @@ fn emit_star_exports_issue(source_ident: Vc<AssetIdent>, message: RcStr) {
 #[derive(Hash, Debug)]
 pub struct EsmExports {
     pub exports: BTreeMap<RcStr, EsmExport>,
-    pub star_exports: Vec<ResolvedVc<Box<dyn ModuleReference>>>,
+    pub star_exports: Vec<Vc<Box<dyn ModuleReference>>>,
 }
 
 /// The expanded version of [EsmExports], the `exports` field here includes all
@@ -429,7 +429,7 @@ pub struct EsmExports {
 pub struct ExpandedExports {
     pub exports: BTreeMap<RcStr, EsmExport>,
     /// Modules we couldn't analyse all exports of.
-    pub dynamic_exports: Vec<ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>>,
+    pub dynamic_exports: Vec<Vc<Box<dyn EcmascriptChunkPlaceable>>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -439,7 +439,7 @@ impl EsmExports {
         let mut exports: BTreeMap<RcStr, EsmExport> = self.exports.clone();
         let mut dynamic_exports = vec![];
 
-        for esm_ref in self.star_exports.iter() {
+        for &esm_ref in self.star_exports.iter() {
             // TODO(PACK-2176): we probably need to handle re-exporting from external
             // modules.
             let ReferencedAsset::Some(asset) =
@@ -454,11 +454,7 @@ impl EsmExports {
                 if !exports.contains_key(export) {
                     exports.insert(
                         export.clone(),
-                        EsmExport::ImportedBinding(
-                            ResolvedVc::upcast(*esm_ref),
-                            export.clone(),
-                            false,
-                        ),
+                        EsmExport::ImportedBinding(Vc::upcast(esm_ref), export.clone(), false),
                     );
                 }
             }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -43,9 +43,9 @@ pub enum EsmExport {
     /// An imported binding that is exported (export { a as b } from "...")
     ///
     /// The last bool is true if the binding is a mutable binding
-    ImportedBinding(ResolvedVc<Box<dyn ModuleReference>>, RcStr, bool),
+    ImportedBinding(Vc<Box<dyn ModuleReference>>, RcStr, bool),
     /// An imported namespace that is exported (export * from "...")
-    ImportedNamespace(ResolvedVc<Box<dyn ModuleReference>>),
+    ImportedNamespace(Vc<Box<dyn ModuleReference>>),
     /// An error occurred while resolving the export
     Error,
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -221,12 +221,12 @@ async fn handle_declared_export(
                     .await?
                 {
                     return Ok(ControlFlow::Break(FollowExportsResult {
-                        module,
+                        module: *module,
                         export_name: Some(name.clone()),
                         ty: FoundExportType::SideEffects,
                     }));
                 }
-                return Ok(ControlFlow::Continue((module, name.clone())));
+                return Ok(ControlFlow::Continue((*module, name.clone())));
             }
         }
         EsmExport::ImportedNamespace(reference) => {
@@ -234,7 +234,7 @@ async fn handle_declared_export(
                 *ReferencedAsset::from_resolve_result(reference.resolve_reference()).await?
             {
                 return Ok(ControlFlow::Break(FollowExportsResult {
-                    module: m,
+                    module: *m,
                     export_name: None,
                     ty: FoundExportType::Found,
                 }));
@@ -293,7 +293,7 @@ async fn get_all_export_names(
                 if let ReferencedAsset::Some(m) =
                     *ReferencedAsset::from_resolve_result(esm_ref.resolve_reference()).await?
                 {
-                    Some(get_all_export_names(m))
+                    Some(get_all_export_names(*m))
                 } else {
                     None
                 },
@@ -344,8 +344,8 @@ pub async fn expand_star_exports(
                     if let ReferencedAsset::Some(asset) =
                         &*ReferencedAsset::from_resolve_result(esm_ref.resolve_reference()).await?
                     {
-                        if checked_modules.insert(*asset) {
-                            queue.push((*asset, asset.get_exports()));
+                        if checked_modules.insert(**asset) {
+                            queue.push((**asset, asset.get_exports()));
                         }
                     }
                 }
@@ -447,7 +447,7 @@ impl EsmExports {
                 continue;
             };
 
-            let export_info = expand_star_exports(*asset).await?;
+            let export_info = expand_star_exports(**asset).await?;
 
             for export in &export_info.star_exports {
                 if !exports.contains_key(export) {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -118,7 +118,7 @@ pub enum FoundExportType {
 
 #[turbo_tasks::value]
 pub struct FollowExportsResult {
-    pub module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
+    pub module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
     pub export_name: Option<RcStr>,
     pub ty: FoundExportType,
 }
@@ -264,8 +264,8 @@ async fn handle_declared_export(
 
 #[turbo_tasks::value]
 struct AllExportNamesResult {
-    esm_exports: FxIndexMap<RcStr, ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>>,
-    dynamic_exporting_modules: Vec<ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>>,
+    esm_exports: FxIndexMap<RcStr, Vc<Box<dyn EcmascriptChunkPlaceable>>>,
+    dynamic_exporting_modules: Vec<Vc<Box<dyn EcmascriptChunkPlaceable>>>,
 }
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -454,7 +454,11 @@ impl EsmExports {
                 if !exports.contains_key(export) {
                     exports.insert(
                         export.clone(),
-                        EsmExport::ImportedBinding(Vc::upcast(*esm_ref), export.clone(), false),
+                        EsmExport::ImportedBinding(
+                            ResolvedVc::upcast(*esm_ref),
+                            export.clone(),
+                            false,
+                        ),
                     );
                 }
             }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -52,7 +52,7 @@ pub enum EsmExport {
 
 #[turbo_tasks::function]
 pub async fn is_export_missing(
-    module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
+    module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
     export_name: RcStr,
 ) -> Result<Vc<bool>> {
     let exports = module.get_exports().await?;
@@ -271,7 +271,7 @@ struct AllExportNamesResult {
 
 #[turbo_tasks::function]
 async fn get_all_export_names(
-    module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
+    module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
 ) -> Result<Vc<AllExportNamesResult>> {
     let exports = module.get_exports().await?;
     let EcmascriptExports::EsmExports(exports) = &*exports else {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -125,7 +125,7 @@ pub struct FollowExportsResult {
 
 #[turbo_tasks::function]
 pub async fn follow_reexports(
-    module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
+    module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
     export_name: RcStr,
     side_effect_free_packages: Vc<Glob>,
 ) -> Result<Vc<FollowExportsResult>> {
@@ -170,7 +170,7 @@ pub async fn follow_reexports(
 
         // Try to find the export in the star exports
         if !exports_ref.star_exports.is_empty() && &*export_name != "default" {
-            let result = get_all_export_names(*module).await?;
+            let result = get_all_export_names(module).await?;
             if let Some(m) = result.esm_exports.get(&export_name) {
                 module = *m;
                 continue;
@@ -344,8 +344,8 @@ pub async fn expand_star_exports(
                     if let ReferencedAsset::Some(asset) =
                         &*ReferencedAsset::from_resolve_result(esm_ref.resolve_reference()).await?
                     {
-                        if checked_modules.insert(**asset) {
-                            queue.push((**asset, asset.get_exports()));
+                        if checked_modules.insert(*asset) {
+                            queue.push((*asset, asset.get_exports()));
                         }
                     }
                 }
@@ -447,7 +447,7 @@ impl EsmExports {
                 continue;
             };
 
-            let export_info = expand_star_exports(**asset).await?;
+            let export_info = expand_star_exports(*asset).await?;
 
             for export in &export_info.star_exports {
                 if !exports.contains_key(export) {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -206,12 +206,11 @@ pub async fn follow_reexports(
 }
 
 async fn handle_declared_export(
-    module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
+    module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
     export_name: RcStr,
     export: &EsmExport,
     side_effect_free_packages: Vc<Glob>,
-) -> Result<ControlFlow<FollowExportsResult, (ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>, RcStr)>>
-{
+) -> Result<ControlFlow<FollowExportsResult, (Vc<Box<dyn EcmascriptChunkPlaceable>>, RcStr)>> {
     match export {
         EsmExport::ImportedBinding(reference, name, _) => {
             if let ReferencedAsset::Some(module) =
@@ -271,7 +270,7 @@ struct AllExportNamesResult {
 
 #[turbo_tasks::function]
 async fn get_all_export_names(
-    module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
+    module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
 ) -> Result<Vc<AllExportNamesResult>> {
     let exports = module.get_exports().await?;
     let EcmascriptExports::EsmExports(exports) = &*exports else {
@@ -294,7 +293,7 @@ async fn get_all_export_names(
                 if let ReferencedAsset::Some(m) =
                     *ReferencedAsset::from_resolve_result(esm_ref.resolve_reference()).await?
                 {
-                    Some(get_all_export_names(*m))
+                    Some(get_all_export_names(m))
                 } else {
                     None
                 },

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -154,7 +154,7 @@ pub async fn follow_reexports(
         // Try to find the export in the local exports
         let exports_ref = exports.await?;
         if let Some(export) = exports_ref.exports.get(&export_name) {
-            match handle_declared_export(*module, export_name, export, side_effect_free_packages)
+            match handle_declared_export(module, export_name, export, side_effect_free_packages)
                 .await?
             {
                 ControlFlow::Continue((m, n)) => {
@@ -206,7 +206,7 @@ pub async fn follow_reexports(
 }
 
 async fn handle_declared_export(
-    module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
+    module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
     export_name: RcStr,
     export: &EsmExport,
     side_effect_free_packages: Vc<Glob>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -170,7 +170,7 @@ pub async fn follow_reexports(
 
         // Try to find the export in the star exports
         if !exports_ref.star_exports.is_empty() && &*export_name != "default" {
-            let result = get_all_export_names(module).await?;
+            let result = get_all_export_names(*module).await?;
             if let Some(m) = result.esm_exports.get(&export_name) {
                 module = *m;
                 continue;

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -77,7 +77,7 @@ pub async fn is_export_missing(
         return Ok(Vc::cell(true));
     }
 
-    let all_export_names = get_all_export_names(module).await?;
+    let all_export_names = get_all_export_names(*module).await?;
     if all_export_names.esm_exports.contains_key(&export_name) {
         return Ok(Vc::cell(false));
     }
@@ -227,7 +227,7 @@ async fn handle_declared_export(
                         ty: FoundExportType::SideEffects,
                     }));
                 }
-                return Ok(ControlFlow::Continue((*module, name.clone())));
+                return Ok(ControlFlow::Continue((module, name.clone())));
             }
         }
         EsmExport::ImportedNamespace(reference) => {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -428,7 +428,7 @@ pub struct EsmExports {
 pub struct ExpandedExports {
     pub exports: BTreeMap<RcStr, EsmExport>,
     /// Modules we couldn't analyse all exports of.
-    pub dynamic_exports: Vec<Vc<Box<dyn EcmascriptChunkPlaceable>>>,
+    pub dynamic_exports: Vec<ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
@@ -88,7 +88,7 @@ pub struct ImportMetaRef {
 #[turbo_tasks::value_impl]
 impl ImportMetaRef {
     #[turbo_tasks::function]
-    pub fn new(ast_path: Vc<AstPath>) -> Vc<Self> {
+    pub fn new(ast_path: ResolvedVc<AstPath>) -> Vc<Self> {
         ImportMetaRef { ast_path }.cell()
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
@@ -30,11 +30,8 @@ pub struct ImportMetaBinding {
 #[turbo_tasks::value_impl]
 impl ImportMetaBinding {
     #[turbo_tasks::function]
-    pub async fn new(path: Vc<FileSystemPath>) -> Result<Vc<Self>> {
-        Ok(ImportMetaBinding {
-            path: path.to_resolved().await?,
-        }
-        .cell())
+    pub fn new(path: ResolvedVc<FileSystemPath>) -> Vc<Self> {
+        ImportMetaBinding { path }.cell()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
@@ -29,7 +29,7 @@ pub struct EsmModuleIdAssetReference {
 #[turbo_tasks::value_impl]
 impl EsmModuleIdAssetReference {
     #[turbo_tasks::function]
-    pub fn new(inner: Vc<EsmAssetReference>, ast_path: Vc<AstPath>) -> Vc<Self> {
+    pub fn new(inner: ResolvedVc<EsmAssetReference>, ast_path: ResolvedVc<AstPath>) -> Vc<Self> {
         Self::cell(EsmModuleIdAssetReference { inner, ast_path })
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_item.rs
@@ -30,7 +30,7 @@ pub struct EsmModuleItem {
 #[turbo_tasks::value_impl]
 impl EsmModuleItem {
     #[turbo_tasks::function]
-    pub fn new(path: Vc<AstPath>) -> Vc<Self> {
+    pub fn new(path: ResolvedVc<AstPath>) -> Vc<Self> {
         Self::cell(EsmModuleItem { path })
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -92,10 +92,10 @@ impl ModuleReference for UrlAssetReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         url_resolve(
-            self.origin,
-            self.request,
+            *self.origin,
+            *self.request,
             Value::new(ReferenceType::Url(UrlReferenceSubType::EcmaScriptNewUrl)),
-            Some(self.issue_source),
+            Some(*self.issue_source),
             self.in_try,
         )
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -61,22 +61,22 @@ pub struct UrlAssetReference {
 impl UrlAssetReference {
     #[turbo_tasks::function]
     pub async fn new(
-        origin: Vc<Box<dyn ResolveOrigin>>,
-        request: Vc<Request>,
-        rendering: Vc<Rendering>,
-        ast_path: Vc<AstPath>,
-        issue_source: Vc<IssueSource>,
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        request: ResolvedVc<Request>,
+        rendering: ResolvedVc<Rendering>,
+        ast_path: ResolvedVc<AstPath>,
+        issue_source: ResolvedVc<IssueSource>,
         in_try: bool,
-        url_rewrite_behavior: Vc<UrlRewriteBehavior>,
+        url_rewrite_behavior: ResolvedVc<UrlRewriteBehavior>,
     ) -> Result<Vc<Self>> {
         Ok(UrlAssetReference {
-            origin: origin.to_resolved().await?,
-            request: request.to_resolved().await?,
-            rendering: rendering.to_resolved().await?,
-            ast_path: ast_path.to_resolved().await?,
-            issue_source: issue_source.to_resolved().await?,
+            origin,
+            request,
+            rendering,
+            ast_path,
+            issue_source,
             in_try,
-            url_rewrite_behavior: url_rewrite_behavior.to_resolved().await?,
+            url_rewrite_behavior,
         }
         .cell())
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -60,7 +60,7 @@ pub struct UrlAssetReference {
 #[turbo_tasks::value_impl]
 impl UrlAssetReference {
     #[turbo_tasks::function]
-    pub fn new(
+    pub async fn new(
         origin: Vc<Box<dyn ResolveOrigin>>,
         request: Vc<Request>,
         rendering: Vc<Rendering>,
@@ -68,17 +68,17 @@ impl UrlAssetReference {
         issue_source: Vc<IssueSource>,
         in_try: bool,
         url_rewrite_behavior: Vc<UrlRewriteBehavior>,
-    ) -> Vc<Self> {
-        UrlAssetReference {
-            origin,
-            request,
-            rendering,
-            ast_path,
-            issue_source,
+    ) -> Result<Vc<Self>> {
+        Ok(UrlAssetReference {
+            origin: origin.to_resolved().await?,
+            request: request.to_resolved().await?,
+            rendering: rendering.to_resolved().await?,
+            ast_path: ast_path.to_resolved().await?,
+            issue_source: issue_source.to_resolved().await?,
             in_try,
-            url_rewrite_behavior,
+            url_rewrite_behavior: url_rewrite_behavior.to_resolved().await?,
         }
-        .cell()
+        .cell())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -60,7 +60,7 @@ pub struct UrlAssetReference {
 #[turbo_tasks::value_impl]
 impl UrlAssetReference {
     #[turbo_tasks::function]
-    pub async fn new(
+    pub fn new(
         origin: ResolvedVc<Box<dyn ResolveOrigin>>,
         request: ResolvedVc<Request>,
         rendering: ResolvedVc<Rendering>,
@@ -68,8 +68,8 @@ impl UrlAssetReference {
         issue_source: ResolvedVc<IssueSource>,
         in_try: bool,
         url_rewrite_behavior: ResolvedVc<UrlRewriteBehavior>,
-    ) -> Result<Vc<Self>> {
-        Ok(UrlAssetReference {
+    ) -> Vc<Self> {
+        UrlAssetReference {
             origin,
             request,
             rendering,
@@ -78,7 +78,7 @@ impl UrlAssetReference {
             in_try,
             url_rewrite_behavior,
         }
-        .cell())
+        .cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -125,7 +125,7 @@ impl ChunkableModule for CachedExternalModule {
     #[turbo_tasks::function]
     fn as_chunk_item(
         self: ResolvedVc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn ChunkItem>> {
         Vc::upcast(
             CachedExternalModuleChunkItem {

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -219,7 +219,7 @@ impl ChunkItem for CachedExternalModuleChunkItem {
 impl EcmascriptChunkItem for CachedExternalModuleChunkItem {
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        self.chunking_context
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]
@@ -259,7 +259,7 @@ pub struct IncludeIdentModule {
 #[turbo_tasks::value_impl]
 impl IncludeIdentModule {
     #[turbo_tasks::function]
-    pub fn new(ident: Vc<AssetIdent>) -> Vc<Self> {
+    pub fn new(ident: ResolvedVc<AssetIdent>) -> Vc<Self> {
         Self { ident }.cell()
     }
 }
@@ -274,6 +274,6 @@ impl Asset for IncludeIdentModule {
 impl Module for IncludeIdentModule {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        self.ident
+        *self.ident
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -157,7 +157,7 @@ impl EcmascriptChunkPlaceable for CachedExternalModule {
                         has_top_level_await: true,
                         import_externals: true,
                     }
-                    .resolved_cell(),
+                    .cell(),
                 )
             } else {
                 None

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -239,7 +239,7 @@ impl EcmascriptChunkItem for CachedExternalModuleChunkItem {
 
         EcmascriptChunkItemContent::new(
             self.module.content(),
-            self.chunking_context,
+            *self.chunking_context,
             EcmascriptOptions::default().cell(),
             async_module_options,
         )

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -199,12 +199,12 @@ impl ChunkItem for CachedExternalModuleChunkItem {
 
     #[turbo_tasks::function]
     fn module(&self) -> Vc<Box<dyn Module>> {
-        Vc::upcast(self.module)
+        Vc::upcast(*self.module)
     }
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        self.chunking_context
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -124,7 +124,7 @@ impl Asset for CachedExternalModule {
 impl ChunkableModule for CachedExternalModule {
     #[turbo_tasks::function]
     fn as_chunk_item(
-        self: Vc<Self>,
+        self: ResolvedVc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn ChunkItem>> {
         Vc::upcast(

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -157,7 +157,7 @@ impl EcmascriptChunkPlaceable for CachedExternalModule {
                         has_top_level_await: true,
                         import_externals: true,
                     }
-                    .cell(),
+                    .resolved_cell(),
                 )
             } else {
                 None

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2348,7 +2348,7 @@ fn issue_source(source: Vc<Box<dyn Source>>, span: Span) -> Vc<IssueSource> {
 async fn analyze_amd_define(
     source: Vc<Box<dyn Source>>,
     analysis: &mut AnalyzeEcmascriptModuleResultBuilder,
-    origin: Vc<Box<dyn ResolveOrigin>>,
+    origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     handler: &Handler,
     span: Span,
     ast_path: &[AstParentKind],
@@ -2367,12 +2367,14 @@ async fn analyze_amd_define(
                 id.as_str(),
                 deps,
                 in_try,
-            );
+            )
+            .await?;
         }
         [JsValue::Array { items: deps, .. }, _] => {
             analyze_amd_define_with_deps(
                 source, analysis, origin, handler, span, ast_path, None, deps, in_try,
-            );
+            )
+            .await?;
         }
         [JsValue::Constant(id), JsValue::Function(..)] if id.as_str().is_some() => {
             analysis.add_code_gen(
@@ -2450,7 +2452,7 @@ async fn analyze_amd_define(
                         AmdDefineDependencyElement::Exports,
                         AmdDefineDependencyElement::Module,
                     ],
-                    *origin,
+                    origin,
                     ResolvedVc::cell(ast_path.to_vec()),
                     AmdDefineFactoryType::Unknown,
                     issue_source(source, span).to_resolved().await?,
@@ -2472,17 +2474,17 @@ async fn analyze_amd_define(
     Ok(())
 }
 
-fn analyze_amd_define_with_deps(
+async fn analyze_amd_define_with_deps(
     source: Vc<Box<dyn Source>>,
     analysis: &mut AnalyzeEcmascriptModuleResultBuilder,
-    origin: Vc<Box<dyn ResolveOrigin>>,
+    origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     handler: &Handler,
     span: Span,
     ast_path: &[AstParentKind],
     id: Option<&str>,
     deps: &[JsValue],
     in_try: bool,
-) {
+) -> Result<()> {
     let mut requests = Vec::new();
     for dep in deps {
         if let Some(dep) = dep.as_str() {
@@ -2504,7 +2506,7 @@ fn analyze_amd_define_with_deps(
                     requests.push(AmdDefineDependencyElement::Module);
                 }
                 _ => {
-                    let request = Request::parse_string(dep.into());
+                    let request = Request::parse_string(dep.into()).to_resolved().await?;
                     let reference = AmdDefineAssetReference::new(
                         origin,
                         request,
@@ -2537,14 +2539,20 @@ fn analyze_amd_define_with_deps(
         );
     }
 
-    analysis.add_code_gen(AmdDefineWithDependenciesCodeGen::new(
-        requests,
-        origin,
-        Vc::cell(ast_path.to_vec()),
-        AmdDefineFactoryType::Function,
-        issue_source(source, span),
-        in_try,
-    ));
+    analysis.add_code_gen(
+        AmdDefineWithDependenciesCodeGen::new(
+            requests,
+            origin,
+            Vc::cell(ast_path.to_vec()),
+            AmdDefineFactoryType::Function,
+            issue_source(source, span),
+            in_try,
+        )
+        .to_resolved()
+        .await?,
+    );
+
+    Ok(())
 }
 
 /// Used to generate the "root" path to a __filename/__dirname/import.meta.url

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -267,7 +267,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
 
     /// Sets the analysis result ES export.
     pub fn set_async_module(&mut self, async_module: ResolvedVc<AsyncModule>) {
-        self.async_module = ResolvedVcc::cell(Some(async_module));
+        self.async_module = ResolvedVc::cell(Some(async_module));
     }
 
     /// Sets whether the analysis was successful.
@@ -322,7 +322,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
                 reexport_references: ResolvedVc::cell(reexport_references),
                 evaluation_references: ResolvedVc::cell(evaluation_references),
                 code_generation: ResolvedVc::cell(self.code_gens),
-                exports: self.exports.into(),
+                exports: self.exports.resolved_cell(),
                 async_module: self.async_module,
                 successful: self.successful,
                 source_map,
@@ -779,7 +779,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
         match detect_dynamic_export(program) {
             DetectedDynamicExportType::CommonJs => {
                 SpecifiedModuleTypeIssue {
-                    path: source.ident().path(),
+                    path: source.ident().path().to_resolved().await?,
                     specified_type,
                 }
                 .cell()

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -507,14 +507,14 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                     if let Some(m) = REFERENCE_PATH.captures(text) {
                         let path = &m[1];
                         analysis.add_reference(
-                            TsReferencePathAssetReference::new(*origin, path.into())
+                            TsReferencePathAssetReference::new(origin, path.into())
                                 .to_resolved()
                                 .await?,
                         );
                     } else if let Some(m) = REFERENCE_TYPES.captures(text) {
                         let types = &m[1];
                         analysis.add_reference(
-                            TsReferenceTypeAssetReference::new(*origin, types.into())
+                            TsReferenceTypeAssetReference::new(origin, types.into())
                                 .to_resolved()
                                 .await?,
                         );

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1590,7 +1590,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 }
                 analysis.add_reference(
                     CjsRequireResolveAssetReference::new(
-                        origin,
+                        *origin,
                         Request::parse(Value::new(pat)),
                         Vc::cell(ast_path.to_vec()),
                         issue_source(*source, span),
@@ -1633,13 +1633,13 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
 
             analysis.add_reference(
                 RequireContextAssetReference::new(
-                    source,
-                    origin,
+                    *source,
+                    *origin,
                     options.dir,
                     options.include_subdirs,
                     Vc::cell(options.filter),
                     Vc::cell(ast_path.to_vec()),
-                    Some(issue_source(source, span)),
+                    Some(issue_source(*source, span)),
                     in_try,
                 )
                 .to_resolved()

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1592,7 +1592,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         origin,
                         Request::parse(Value::new(pat)),
                         Vc::cell(ast_path.to_vec()),
-                        issue_source(source, span),
+                        issue_source(*source, span),
                         in_try,
                     )
                     .to_resolved()

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2191,7 +2191,7 @@ async fn handle_free_var_reference(
             export,
         } => {
             let esm_reference = EsmAssetReference::new(
-                lookup_path.map_or(*state.origin, |lookup_path| {
+                lookup_path.map_or(state.origin, |lookup_path| {
                     Vc::upcast(PlainResolveOrigin::new(
                         state.origin.asset_context(),
                         *lookup_path,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1940,8 +1940,11 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     .link_value(args[0].clone(), ImportAttributes::empty_ref())
                     .await?;
                 if let Some(s) = first_arg.as_str() {
-                    analysis
-                        .add_reference(NodeBindingsReference::new(origin.origin_path(), s.into()));
+                    analysis.add_reference(
+                        NodeBindingsReference::new(origin.origin_path(), s.into())
+                            .to_resolved()
+                            .await?,
+                    );
                     return Ok(());
                 }
             }
@@ -2056,7 +2059,11 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         .await?;
                     js_value_to_pattern(&linked_func_call)
                 };
-                analysis.add_reference(DirAssetReference::new(source, Pattern::new(abs_pattern)));
+                analysis.add_reference(
+                    DirAssetReference::new(source, Pattern::new(abs_pattern))
+                        .to_resolved()
+                        .await?,
+                );
                 return Ok(());
             }
             let (args, hints) = explain_args(&args);

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2383,13 +2383,11 @@ async fn analyze_amd_define_with_deps(
                 _ => {
                     let request = Request::parse_string(dep.into()).to_resolved().await?;
                     let reference = AmdDefineAssetReference::new(
-                        origin,
-                        request,
+                        *origin,
+                        *request,
                         issue_source(source, span),
                         in_try,
-                    )
-                    .to_resolved()
-                    .await?;
+                    );
                     requests.push(AmdDefineDependencyElement::Request {
                         request,
                         request_str: dep.to_string(),

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -155,7 +155,7 @@ pub struct AnalyzeEcmascriptModuleResult {
     pub async_module: ResolvedVc<OptionAsyncModule>,
     /// `true` when the analysis was successful.
     pub successful: bool,
-    pub source_map: ResolvedVc<OptionSourceMap>,
+    pub source_map: Vc<OptionSourceMap>,
 }
 
 /// A temporary analysis result builder to pass around, to be turned into an
@@ -537,11 +537,10 @@ pub(crate) async fn analyse_ecmascript_module_internal(
             let reference = SourceMapReference::new(origin_path, source_map_origin);
             analysis.add_reference(reference);
             let source_map = reference.generate_source_map();
-            analysis.set_source_map(
-                convert_to_turbopack_source_map(source_map, source_map_origin)
-                    .to_resolved()
-                    .await?,
-            );
+            analysis.set_source_map(convert_to_turbopack_source_map(
+                source_map,
+                source_map_origin,
+            ));
             source_map_from_comment = true;
         } else if path.starts_with("data:application/json;base64,") {
             let source_map_origin = origin_path;

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -701,7 +701,9 @@ pub(crate) async fn analyse_ecmascript_module_internal(
     // Check if it was a webpack entry
     if let Some((request, span)) = webpack_runtime {
         let request = Request::parse(Value::new(request.into()));
-        let runtime = resolve_as_webpack_runtime(origin, request, transforms);
+        let runtime = resolve_as_webpack_runtime(origin, request, *transforms)
+            .to_resolved()
+            .await?;
 
         if let WebpackRuntime::Webpack5 { .. } = &*runtime.await? {
             ignore_effect_span = Some(span);

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2274,10 +2274,11 @@ async fn handle_free_var_reference(
         ),
 
         FreeVarReference::Value(value) => {
-            analysis.add_code_gen(ConstantValue::new(
-                Value::new(value.clone()),
-                Vc::cell(ast_path.to_vec()),
-            ));
+            analysis.add_code_gen(
+                ConstantValue::new(Value::new(value.clone()), Vc::cell(ast_path.to_vec()))
+                    .to_resolved()
+                    .await?,
+            );
         }
         FreeVarReference::EcmaScriptModule {
             request,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2128,7 +2128,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     {
                         analysis.add_reference(
                             DirAssetReference::new(
-                                source,
+                                *source,
                                 Pattern::new(Pattern::Constant(dir.into())),
                             )
                             .to_resolved()
@@ -2198,9 +2198,9 @@ async fn handle_member(
         ) if s.as_str() == Some("cache") => {
             analysis.add_code_gen(
                 CjsRequireCacheAccess {
-                    path: Vc::cell(ast_path.to_vec()),
+                    path: ResolvedVc::cell(ast_path.to_vec()),
                 }
-                .cell(),
+                .resolved_cell(),
             );
         }
         _ => {}

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2090,7 +2090,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     CjsAssetReference::new(
                         *origin,
                         Request::parse(Value::new(js_value_to_pattern(&args[1]))),
-                        issue_source(source, span),
+                        issue_source(*source, span),
                         in_try,
                     )
                     .to_resolved()
@@ -2402,7 +2402,7 @@ async fn analyze_amd_define(
                         AmdDefineDependencyElement::Exports,
                         AmdDefineDependencyElement::Module,
                     ],
-                    *origin,
+                    origin,
                     ResolvedVc::cell(ast_path.to_vec()),
                     AmdDefineFactoryType::Unknown,
                     issue_source(source, span).to_resolved().await?,
@@ -2420,7 +2420,7 @@ async fn analyze_amd_define(
                         AmdDefineDependencyElement::Exports,
                         AmdDefineDependencyElement::Module,
                     ],
-                    *origin,
+                    origin,
                     ResolvedVc::cell(ast_path.to_vec()),
                     AmdDefineFactoryType::Function,
                     issue_source(source, span).to_resolved().await?,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2324,7 +2324,7 @@ async fn handle_free_var_reference(
                 },
                 state.import_externals,
             )
-            .resolve()
+            .to_resolved()
             .await?;
             analysis.add_reference(esm_reference);
             analysis.add_binding(EsmBinding::new(

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2999,12 +2999,12 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
                                 let esm_ref = self.import_references[index];
                                 if let Some(export) = export {
                                     EsmExport::ImportedBinding(
-                                        Vc::upcast(esm_ref),
+                                        ResolvedVc::upcast(esm_ref),
                                         export,
                                         is_fake_esm,
                                     )
                                 } else {
-                                    EsmExport::ImportedNamespace(Vc::upcast(esm_ref))
+                                    EsmExport::ImportedNamespace(ResolvedVc::upcast(esm_ref))
                                 }
                             } else {
                                 EsmExport::LocalBinding(binding_name, is_fake_esm)

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -547,7 +547,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
         if path.ends_with(".map") {
             let source_map_origin = origin_path.parent().join(path.into());
             let reference = SourceMapReference::new(origin_path, source_map_origin);
-            analysis.add_reference(reference);
+            analysis.add_reference(reference.to_resolved().await?);
             let source_map = reference.generate_source_map();
             analysis.set_source_map(
                 convert_to_turbopack_source_map(source_map, source_map_origin)
@@ -568,7 +568,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
     }
     if !source_map_from_comment {
         if let Some(generate_source_map) =
-            Vc::try_resolve_sidecast::<Box<dyn GenerateSourceMap>>(source).await?
+            ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(source).await?
         {
             let source_map_origin = source.ident().path();
             analysis.set_source_map(
@@ -585,7 +585,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
     let handler = Handler::with_emitter(
         true,
         false,
-        Box::new(IssueEmitter::new(source, source_map.clone(), None)),
+        Box::new(IssueEmitter::new(*source, source_map.clone(), None)),
     );
 
     let mut var_graph =
@@ -598,7 +598,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
             origin,
             Request::parse(Value::new(RcStr::from(&*r.module_path).into())),
             r.issue_source
-                .unwrap_or_else(|| IssueSource::from_source_only(source)),
+                .unwrap_or_else(|| IssueSource::from_source_only(*source)),
             Value::new(r.annotations.clone()),
             match options.tree_shaking_mode {
                 Some(TreeShakingMode::ModuleFragments) => match &r.imported_symbol {
@@ -1178,8 +1178,11 @@ pub(crate) async fn analyse_ecmascript_module_internal(
             } => {
                 if let Some(r) = import_references.get(esm_reference_index) {
                     if let Some("__turbopack_module_id__") = export.as_deref() {
-                        analysis
-                            .add_reference(EsmModuleIdAssetReference::new(*r, Vc::cell(ast_path)))
+                        analysis.add_reference(
+                            EsmModuleIdAssetReference::new(*r, Vc::cell(ast_path))
+                                .to_resolved()
+                                .await?,
+                        )
                     } else {
                         analysis.add_local_reference(*r);
                         analysis.add_import_reference(*r);

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -281,9 +281,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
         mut self,
         track_reexport_references: bool,
     ) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
-        let bindings = EsmBindings::new(take(&mut self.bindings))
-            .to_resolved()
-            .await?;
+        let bindings = EsmBindings::new(take(&mut self.bindings));
         if !bindings.await?.bindings.is_empty() {
             self.add_code_gen(bindings);
         }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -708,7 +708,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
             ignore_effect_span = Some(span);
             analysis.add_reference(
                 WebpackRuntimeAssetReference {
-                    origin,
+                    origin: origin.to_resolved().await?,
                     request,
                     runtime,
                     transforms,
@@ -1966,11 +1966,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         .await?;
                     js_value_to_pattern(&linked_func_call)
                 };
-                analysis.add_reference(
-                    DirAssetReference::new(*source, Pattern::new(abs_pattern))
-                        .to_resolved()
-                        .await?,
-                );
+                analysis.add_reference(DirAssetReference::new(*source, Pattern::new(abs_pattern)));
                 return Ok(());
             }
             let (args, hints) = explain_args(&args);
@@ -2028,14 +2024,10 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                             })
                             .flatten()
                     {
-                        analysis.add_reference(
-                            DirAssetReference::new(
-                                *source,
-                                Pattern::new(Pattern::Constant(dir.into())),
-                            )
-                            .to_resolved()
-                            .await?,
-                        );
+                        analysis.add_reference(DirAssetReference::new(
+                            *source,
+                            Pattern::new(Pattern::Constant(dir.into())),
+                        ));
                     }
                     return Ok(());
                 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -169,7 +169,7 @@ pub struct AnalyzeEcmascriptModuleResultBuilder {
     exports: EcmascriptExports,
     async_module: ResolvedVc<OptionAsyncModule>,
     successful: bool,
-    source_map: Option<ResolvedVc<OptionSourceMap>>,
+    source_map: Option<Vc<OptionSourceMap>>,
     bindings: Vec<EsmBinding>,
 }
 
@@ -254,7 +254,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     }
 
     /// Sets the analysis result ES export.
-    pub fn set_source_map(&mut self, source_map: ResolvedVc<OptionSourceMap>) {
+    pub fn set_source_map(&mut self, source_map: Vc<OptionSourceMap>) {
         self.source_map = Some(source_map);
     }
 
@@ -264,8 +264,8 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     }
 
     /// Sets the analysis result ES export.
-    pub fn set_async_module(&mut self, async_module: ResolvedVc<AsyncModule>) {
-        self.async_module = ResolvedVc::cell(Some(async_module));
+    pub fn set_async_module(&mut self, async_module: Vc<AsyncModule>) {
+        self.async_module = Vc::cell(Some(async_module));
     }
 
     /// Sets whether the analysis was successful.

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1199,7 +1199,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                     analysis.add_code_gen(ImportMetaBinding::new(source.ident().path()));
                 }
 
-                analysis.add_code_gen(ImportMetaRef::new(Vc::cell(ast_path)).to_resolved().await?);
+                analysis.add_code_gen(ImportMetaRef::new(Vc::cell(ast_path)));
             }
         }
     }
@@ -1752,16 +1752,12 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         return Ok(());
                     }
                 }
-                analysis.add_reference(
-                    CjsAssetReference::new(
-                        *origin,
-                        Request::parse(Value::new(pat)),
-                        issue_source(*source, span),
-                        in_try,
-                    )
-                    .to_resolved()
-                    .await?,
-                );
+                analysis.add_reference(CjsAssetReference::new(
+                    *origin,
+                    Request::parse(Value::new(pat)),
+                    issue_source(*source, span),
+                    in_try,
+                ));
                 return Ok(());
             }
             let (args, hints) = explain_args(&args);
@@ -2290,22 +2286,18 @@ async fn analyze_amd_define(
             ));
         }
         [JsValue::Constant(id), _] if id.as_str().is_some() => {
-            analysis.add_code_gen(
-                AmdDefineWithDependenciesCodeGen::new(
-                    vec![
-                        AmdDefineDependencyElement::Require,
-                        AmdDefineDependencyElement::Exports,
-                        AmdDefineDependencyElement::Module,
-                    ],
-                    origin,
-                    ResolvedVc::cell(ast_path.to_vec()),
-                    AmdDefineFactoryType::Unknown,
-                    issue_source(source, span).to_resolved().await?,
-                    in_try,
-                )
-                .to_resolved()
-                .await?,
-            );
+            analysis.add_code_gen(AmdDefineWithDependenciesCodeGen::new(
+                vec![
+                    AmdDefineDependencyElement::Require,
+                    AmdDefineDependencyElement::Exports,
+                    AmdDefineDependencyElement::Module,
+                ],
+                origin,
+                ResolvedVc::cell(ast_path.to_vec()),
+                AmdDefineFactoryType::Unknown,
+                issue_source(source, span).to_resolved().await?,
+                in_try,
+            ));
         }
         [JsValue::Function(..)] => {
             analysis.add_code_gen(AmdDefineWithDependenciesCodeGen::new(

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1570,20 +1570,16 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 }
             };
 
-            analysis.add_reference(
-                RequireContextAssetReference::new(
-                    *source,
-                    *origin,
-                    options.dir,
-                    options.include_subdirs,
-                    Vc::cell(options.filter),
-                    Vc::cell(ast_path.to_vec()),
-                    Some(issue_source(*source, span)),
-                    in_try,
-                )
-                .to_resolved()
-                .await?,
-            );
+            analysis.add_reference(RequireContextAssetReference::new(
+                *source,
+                *origin,
+                options.dir,
+                options.include_subdirs,
+                Vc::cell(options.filter),
+                Vc::cell(ast_path.to_vec()),
+                Some(issue_source(*source, span)),
+                in_try,
+            ));
         }
 
         JsValue::WellKnownFunction(WellKnownFunctionKind::FsReadMethod(name)) => {
@@ -2291,22 +2287,18 @@ async fn analyze_amd_define(
             .await?;
         }
         [JsValue::Constant(id), JsValue::Function(..)] if id.as_str().is_some() => {
-            analysis.add_code_gen(
-                AmdDefineWithDependenciesCodeGen::new(
-                    vec![
-                        AmdDefineDependencyElement::Require,
-                        AmdDefineDependencyElement::Exports,
-                        AmdDefineDependencyElement::Module,
-                    ],
-                    origin,
-                    ResolvedVc::cell(ast_path.to_vec()),
-                    AmdDefineFactoryType::Function,
-                    issue_source(source, span).to_resolved().await?,
-                    in_try,
-                )
-                .to_resolved()
-                .await?,
-            );
+            analysis.add_code_gen(AmdDefineWithDependenciesCodeGen::new(
+                vec![
+                    AmdDefineDependencyElement::Require,
+                    AmdDefineDependencyElement::Exports,
+                    AmdDefineDependencyElement::Module,
+                ],
+                origin,
+                ResolvedVc::cell(ast_path.to_vec()),
+                AmdDefineFactoryType::Function,
+                issue_source(source, span).to_resolved().await?,
+                in_try,
+            ));
         }
         [JsValue::Constant(id), _] if id.as_str().is_some() => {
             analysis.add_code_gen(

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1371,11 +1371,11 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         }
                         analysis.add_reference(
                             UrlAssetReference::new(
-                                origin,
+                                *origin,
                                 Request::parse(Value::new(pat)),
                                 compile_time_info.environment().rendering(),
                                 Vc::cell(ast_path.to_vec()),
-                                issue_source(source, span),
+                                issue_source(*source, span),
                                 in_try,
                                 url_rewrite_behavior
                                     .unwrap_or(UrlRewriteBehavior::Relative)
@@ -1409,10 +1409,10 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     if *compile_time_info.environment().rendering().await? == Rendering::Client {
                         analysis.add_reference(
                             WorkerAssetReference::new(
-                                origin,
+                                *origin,
                                 Request::parse(Value::new(pat)),
                                 Vc::cell(ast_path.to_vec()),
-                                issue_source(source, span),
+                                issue_source(*source, span),
                                 in_try,
                             )
                             .to_resolved()
@@ -1797,7 +1797,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 }
                 if !dynamic || !ignore_dynamic_requests {
                     analysis.add_reference(
-                        FileSourceReference::new(source, Pattern::new(pat))
+                        FileSourceReference::new(*source, Pattern::new(pat))
                             .to_resolved()
                             .await?,
                     )
@@ -1843,9 +1843,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 }
                 analysis.add_reference(
                     CjsAssetReference::new(
-                        origin,
+                        *origin,
                         Request::parse(Value::new(pat)),
-                        issue_source(source, span),
+                        issue_source(*source, span),
                         in_try,
                     )
                     .to_resolved()

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -484,7 +484,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
     };
 
     let compile_time_info = compile_time_info_for_module_type(
-        raw_module.compile_time_info,
+        *raw_module.compile_time_info,
         eval_context.is_esm(specified_type),
     );
 
@@ -1179,7 +1179,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                 if let Some(r) = import_references.get(esm_reference_index) {
                     if let Some("__turbopack_module_id__") = export.as_deref() {
                         analysis.add_reference(
-                            EsmModuleIdAssetReference::new(*r, Vc::cell(ast_path))
+                            EsmModuleIdAssetReference::new(**r, Vc::cell(ast_path))
                                 .to_resolved()
                                 .await?,
                         )

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1496,17 +1496,25 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         ),
                     );
                     if ignore_dynamic_requests {
-                        analysis.add_code_gen(DynamicExpression::new(Vc::cell(ast_path.to_vec())));
+                        analysis.add_code_gen(
+                            DynamicExpression::new(Vc::cell(ast_path.to_vec()))
+                                .to_resolved()
+                                .await?,
+                        );
                         return Ok(());
                     }
                 }
-                analysis.add_reference(CjsRequireAssetReference::new(
-                    origin,
-                    Request::parse(Value::new(pat)),
-                    Vc::cell(ast_path.to_vec()),
-                    issue_source(source, span),
-                    in_try,
-                ));
+                analysis.add_reference(
+                    CjsRequireAssetReference::new(
+                        origin,
+                        Request::parse(Value::new(pat)),
+                        Vc::cell(ast_path.to_vec()),
+                        issue_source(source, span),
+                        in_try,
+                    )
+                    .to_resolved()
+                    .await?,
+                );
                 return Ok(());
             }
             let (args, hints) = explain_args(&args);

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -190,7 +190,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     }
 
     /// Adds an asset reference to the analysis result.
-    pub fn add_reference<R>(&mut self, reference: Vc<R>)
+    pub fn add_reference<R>(&mut self, reference: ResolvedVc<R>)
     where
         R: Upcast<Box<dyn ModuleReference>>,
     {
@@ -200,7 +200,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     }
 
     /// Adds an asset reference to the analysis result.
-    pub fn add_import_reference<R>(&mut self, reference: Vc<R>)
+    pub fn add_import_reference<R>(&mut self, reference: ResolvedVc<R>)
     where
         R: Upcast<Box<dyn ModuleReference>>,
     {
@@ -208,7 +208,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     }
 
     /// Adds an reexport reference to the analysis result.
-    pub fn add_local_reference<R>(&mut self, reference: Vc<R>)
+    pub fn add_local_reference<R>(&mut self, reference: ResolvedVc<R>)
     where
         R: Upcast<Box<dyn ModuleReference>>,
     {
@@ -216,7 +216,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     }
 
     /// Adds an reexport reference to the analysis result.
-    pub fn add_reexport_reference<R>(&mut self, reference: Vc<R>)
+    pub fn add_reexport_reference<R>(&mut self, reference: ResolvedVc<R>)
     where
         R: Upcast<Box<dyn ModuleReference>>,
     {
@@ -224,12 +224,12 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     }
 
     /// Adds an evaluation reference to the analysis result.
-    pub fn add_evaluation_reference(&mut self, reference: Vc<EsmAssetReference>) {
+    pub fn add_evaluation_reference(&mut self, reference: ResolvedVc<EsmAssetReference>) {
         self.evaluation_references.insert(Vc::upcast(reference));
     }
 
     /// Adds a codegen to the analysis result.
-    pub fn add_code_gen<C>(&mut self, code_gen: Vc<C>)
+    pub fn add_code_gen<C>(&mut self, code_gen: ResolvedVc<C>)
     where
         C: Upcast<Box<dyn CodeGenerateable>>,
     {
@@ -264,8 +264,8 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     }
 
     /// Sets the analysis result ES export.
-    pub fn set_async_module(&mut self, async_module: Vc<AsyncModule>) {
-        self.async_module = Vc::cell(Some(async_module));
+    pub fn set_async_module(&mut self, async_module: ResolvedVc<AsyncModule>) {
+        self.async_module = ResolvedVcc::cell(Some(async_module));
     }
 
     /// Sets whether the analysis was successful.

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1557,13 +1557,16 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         return Ok(());
                     }
                 }
-                analysis.add_reference(CjsRequireResolveAssetReference::new(
-                    origin,
-                    Request::parse(Value::new(pat)),
-                    Vc::cell(ast_path.to_vec()),
-                    issue_source(source, span),
-                    in_try,
-                ));
+                analysis
+                    .add_reference(CjsRequireResolveAssetReference::new(
+                        origin,
+                        Request::parse(Value::new(pat)),
+                        Vc::cell(ast_path.to_vec()),
+                        issue_source(source, span),
+                        in_try,
+                    ))
+                    .to_resolved()
+                    .await?;
                 return Ok(());
             }
             let (args, hints) = explain_args(&args);
@@ -1932,10 +1935,13 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                                         .await?;
                                     js_value_to_pattern(&linked_func_call)
                                 };
-                                analysis.add_reference(DirAssetReference::new(
-                                    source,
-                                    Pattern::new(abs_pattern),
-                                ));
+                                analysis
+                                    .add_reference(DirAssetReference::new(
+                                        source,
+                                        Pattern::new(abs_pattern),
+                                    ))
+                                    .to_resolved()
+                                    .await?;
                                 return Ok(());
                             }
                         }
@@ -1943,12 +1949,16 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                             if let Some(pkg) = pkg_or_dir.as_str() {
                                 if pkg != "html" {
                                     let pat = js_value_to_pattern(pkg_or_dir);
-                                    analysis.add_reference(CjsAssetReference::new(
-                                        origin,
-                                        Request::parse(Value::new(pat)),
-                                        issue_source(source, span),
-                                        in_try,
-                                    ));
+                                    analysis.add_reference(
+                                        CjsAssetReference::new(
+                                            origin,
+                                            Request::parse(Value::new(pat)),
+                                            issue_source(source, span),
+                                            in_try,
+                                        )
+                                        .to_resolved()
+                                        .await?,
+                                    );
                                 }
                                 return Ok(());
                             }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1443,7 +1443,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     }
                 }
                 analysis.add_reference(EsmAsyncAssetReference::new(
-                    *origin,
+                    origin,
                     Request::parse(Value::new(pat)),
                     Vc::cell(ast_path.to_vec()),
                     issue_source(*source, span),
@@ -1480,7 +1480,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     }
                 }
                 analysis.add_reference(CjsRequireAssetReference::new(
-                    *origin,
+                    origin,
                     Request::parse(Value::new(pat)),
                     Vc::cell(ast_path.to_vec()),
                     issue_source(*source, span),
@@ -1528,7 +1528,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     }
                 }
                 analysis.add_reference(CjsRequireResolveAssetReference::new(
-                    *origin,
+                    origin,
                     Request::parse(Value::new(pat)),
                     Vc::cell(ast_path.to_vec()),
                     issue_source(*source, span),
@@ -1568,7 +1568,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
 
             analysis.add_reference(RequireContextAssetReference::new(
                 *source,
-                *origin,
+                origin,
                 options.dir,
                 options.include_subdirs,
                 Vc::cell(options.filter),
@@ -1753,7 +1753,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     }
                 }
                 analysis.add_reference(CjsAssetReference::new(
-                    *origin,
+                    origin,
                     Request::parse(Value::new(pat)),
                     issue_source(*source, span),
                     in_try,
@@ -1848,11 +1848,8 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     .link_value(args[0].clone(), ImportAttributes::empty_ref())
                     .await?;
                 if let Some(s) = first_arg.as_str() {
-                    analysis.add_reference(
-                        NodeBindingsReference::new(origin.origin_path(), s.into())
-                            .to_resolved()
-                            .await?,
-                    );
+                    analysis
+                        .add_reference(NodeBindingsReference::new(origin.origin_path(), s.into()));
                     return Ok(());
                 }
             }
@@ -1981,7 +1978,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             let args = linked_args(args).await?;
             if args.len() == 2 && args.get(1).and_then(|arg| arg.as_str()).is_some() {
                 analysis.add_reference(CjsAssetReference::new(
-                    *origin,
+                    origin,
                     Request::parse(Value::new(js_value_to_pattern(&args[1]))),
                     issue_source(*source, span),
                     in_try,
@@ -2405,7 +2402,7 @@ async fn analyze_amd_define_with_deps(
     analysis.add_code_gen(AmdDefineWithDependenciesCodeGen::new(
         requests,
         origin,
-        Vc::cell(ast_path.to_vec()),
+        ResolvedVc::cell(ast_path.to_vec()),
         AmdDefineFactoryType::Function,
         issue_source(source, span),
         in_try,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2269,7 +2269,7 @@ async fn analyze_amd_define(
                 origin,
                 ResolvedVc::cell(ast_path.to_vec()),
                 AmdDefineFactoryType::Function,
-                issue_source(source, span).to_resolved().await?,
+                issue_source(source, span),
                 in_try,
             ));
         }
@@ -2283,7 +2283,7 @@ async fn analyze_amd_define(
                 origin,
                 ResolvedVc::cell(ast_path.to_vec()),
                 AmdDefineFactoryType::Unknown,
-                issue_source(source, span).to_resolved().await?,
+                issue_source(source, span),
                 in_try,
             ));
         }
@@ -2297,17 +2297,17 @@ async fn analyze_amd_define(
                 origin,
                 ResolvedVc::cell(ast_path.to_vec()),
                 AmdDefineFactoryType::Function,
-                issue_source(source, span).to_resolved().await?,
+                issue_source(source, span),
                 in_try,
             ));
         }
         [JsValue::Object { .. }] => {
             analysis.add_code_gen(AmdDefineWithDependenciesCodeGen::new(
                 vec![],
-                *origin,
+                origin,
                 ResolvedVc::cell(ast_path.to_vec()),
                 AmdDefineFactoryType::Value,
-                issue_source(source, span).to_resolved().await?,
+                issue_source(source, span),
                 in_try,
             ));
         }
@@ -2321,7 +2321,7 @@ async fn analyze_amd_define(
                 origin,
                 ResolvedVc::cell(ast_path.to_vec()),
                 AmdDefineFactoryType::Unknown,
-                issue_source(source, span).to_resolved().await?,
+                issue_source(source, span),
                 in_try,
             ));
         }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -698,7 +698,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
     // Check if it was a webpack entry
     if let Some((request, span)) = webpack_runtime {
         let request = Request::parse(Value::new(request.into()));
-        let runtime = resolve_as_webpack_runtime(origin, *request, *transforms);
+        let runtime = resolve_as_webpack_runtime(origin, request, *transforms);
 
         if let WebpackRuntime::Webpack5 { .. } = &*runtime.await? {
             ignore_effect_span = Some(span);
@@ -2362,10 +2362,10 @@ async fn analyze_amd_define_with_deps(
                     requests.push(AmdDefineDependencyElement::Module);
                 }
                 _ => {
-                    let request = Request::parse_string(dep.into()).to_resolved().await?;
+                    let request = Request::parse_string(dep.into());
                     let reference = AmdDefineAssetReference::new(
-                        *origin,
-                        *request,
+                        origin,
+                        request,
                         issue_source(source, span),
                         in_try,
                     );

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2382,10 +2382,10 @@ async fn analyze_amd_define(
                         AmdDefineDependencyElement::Exports,
                         AmdDefineDependencyElement::Module,
                     ],
-                    *origin,
+                    origin,
                     ResolvedVc::cell(ast_path.to_vec()),
                     AmdDefineFactoryType::Function,
-                    issue_source(source, span),
+                    issue_source(source, span).to_resolved().await?,
                     in_try,
                 )
                 .to_resolved()
@@ -2403,7 +2403,7 @@ async fn analyze_amd_define(
                     *origin,
                     ResolvedVc::cell(ast_path.to_vec()),
                     AmdDefineFactoryType::Unknown,
-                    issue_source(source, span),
+                    issue_source(source, span).to_resolved().await?,
                     in_try,
                 )
                 .to_resolved()
@@ -2421,7 +2421,7 @@ async fn analyze_amd_define(
                     *origin,
                     ResolvedVc::cell(ast_path.to_vec()),
                     AmdDefineFactoryType::Function,
-                    issue_source(source, span),
+                    issue_source(source, span).to_resolved().await?,
                     in_try,
                 )
                 .to_resolved()
@@ -2435,7 +2435,7 @@ async fn analyze_amd_define(
                     *origin,
                     ResolvedVc::cell(ast_path.to_vec()),
                     AmdDefineFactoryType::Value,
-                    issue_source(source, span),
+                    issue_source(source, span).to_resolved().await?,
                     in_try,
                 )
                 .to_resolved()
@@ -2453,7 +2453,7 @@ async fn analyze_amd_define(
                     *origin,
                     ResolvedVc::cell(ast_path.to_vec()),
                     AmdDefineFactoryType::Unknown,
-                    issue_source(source, span),
+                    issue_source(source, span).to_resolved().await?,
                     in_try,
                 )
                 .to_resolved()

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1169,8 +1169,8 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                         analysis
                             .add_reference(EsmModuleIdAssetReference::new(r, Vc::cell(ast_path)))
                     } else {
-                        analysis.add_local_reference(*r);
-                        analysis.add_import_reference(*r);
+                        analysis.add_local_reference(r);
+                        analysis.add_import_reference(r);
                         analysis.add_binding(EsmBinding::new(
                             r,
                             export,
@@ -1527,25 +1527,17 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         ),
                     );
                     if ignore_dynamic_requests {
-                        analysis.add_code_gen(
-                            DynamicExpression::new(Vc::cell(ast_path.to_vec()))
-                                .to_resolved()
-                                .await?,
-                        );
+                        analysis.add_code_gen(DynamicExpression::new(Vc::cell(ast_path.to_vec())));
                         return Ok(());
                     }
                 }
-                analysis.add_reference(
-                    CjsRequireResolveAssetReference::new(
-                        *origin,
-                        Request::parse(Value::new(pat)),
-                        Vc::cell(ast_path.to_vec()),
-                        issue_source(*source, span),
-                        in_try,
-                    )
-                    .to_resolved()
-                    .await?,
-                );
+                analysis.add_reference(CjsRequireResolveAssetReference::new(
+                    *origin,
+                    Request::parse(Value::new(pat)),
+                    Vc::cell(ast_path.to_vec()),
+                    issue_source(*source, span),
+                    in_try,
+                ));
                 return Ok(());
             }
             let (args, hints) = explain_args(&args);
@@ -1929,11 +1921,10 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                                         .await?;
                                     js_value_to_pattern(&linked_func_call)
                                 };
-                                analysis.add_reference(
-                                    DirAssetReference::new(*source, Pattern::new(abs_pattern))
-                                        .to_resolved()
-                                        .await?,
-                                );
+                                analysis.add_reference(DirAssetReference::new(
+                                    *source,
+                                    Pattern::new(abs_pattern),
+                                ));
                                 return Ok(());
                             }
                         }
@@ -1941,16 +1932,12 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                             if let Some(pkg) = pkg_or_dir.as_str() {
                                 if pkg != "html" {
                                     let pat = js_value_to_pattern(pkg_or_dir);
-                                    analysis.add_reference(
-                                        CjsAssetReference::new(
-                                            *origin,
-                                            Request::parse(Value::new(pat)),
-                                            issue_source(*source, span),
-                                            in_try,
-                                        )
-                                        .to_resolved()
-                                        .await?,
-                                    );
+                                    analysis.add_reference(CjsAssetReference::new(
+                                        *origin,
+                                        Request::parse(Value::new(pat)),
+                                        issue_source(*source, span),
+                                        in_try,
+                                    ));
                                 }
                                 return Ok(());
                             }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2826,10 +2826,10 @@ impl StaticAnalyser {
 struct ModuleReferencesVisitor<'a> {
     eval_context: &'a EvalContext,
     old_analyser: StaticAnalyser,
-    import_references: &'a [ResolvedVc<EsmAssetReference>],
+    import_references: &'a [Vc<EsmAssetReference>],
     analysis: &'a mut AnalyzeEcmascriptModuleResultBuilder,
     esm_exports: BTreeMap<RcStr, EsmExport>,
-    esm_star_exports: Vec<ResolvedVc<Box<dyn ModuleReference>>>,
+    esm_star_exports: Vec<Vc<Box<dyn ModuleReference>>>,
     webpack_runtime: Option<(RcStr, Span)>,
     webpack_entry: bool,
     webpack_chunks: Vec<Lit>,
@@ -2838,7 +2838,7 @@ struct ModuleReferencesVisitor<'a> {
 impl<'a> ModuleReferencesVisitor<'a> {
     fn new(
         eval_context: &'a EvalContext,
-        import_references: &'a [ResolvedVc<EsmAssetReference>],
+        import_references: &'a [Vc<EsmAssetReference>],
         analysis: &'a mut AnalyzeEcmascriptModuleResultBuilder,
     ) -> Self {
         Self {

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -712,7 +712,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                     runtime,
                     transforms,
                 }
-                .cell(),
+                .resolved_cell(),
             );
 
             if webpack_entry {
@@ -722,7 +722,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                         runtime,
                         transforms,
                     }
-                    .cell(),
+                    .resolved_cell(),
                 );
             }
 
@@ -733,7 +733,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                         runtime,
                         transforms,
                     }
-                    .cell(),
+                    .resolved_cell(),
                 );
             }
         }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2224,7 +2224,7 @@ fn issue_source(source: Vc<Box<dyn Source>>, span: Span) -> Vc<IssueSource> {
 async fn analyze_amd_define(
     source: Vc<Box<dyn Source>>,
     analysis: &mut AnalyzeEcmascriptModuleResultBuilder,
-    origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+    origin: Vc<Box<dyn ResolveOrigin>>,
     handler: &Handler,
     span: Span,
     ast_path: &[AstParentKind],

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1998,7 +1998,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                                     js_value_to_pattern(&linked_func_call)
                                 };
                                 analysis.add_reference(
-                                    DirAssetReference::new(source, Pattern::new(abs_pattern))
+                                    DirAssetReference::new(*source, Pattern::new(abs_pattern))
                                         .to_resolved()
                                         .await?,
                                 );
@@ -2060,7 +2060,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     js_value_to_pattern(&linked_func_call)
                 };
                 analysis.add_reference(
-                    DirAssetReference::new(source, Pattern::new(abs_pattern))
+                    DirAssetReference::new(*source, Pattern::new(abs_pattern))
                         .to_resolved()
                         .await?,
                 );

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2088,7 +2088,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             if args.len() == 2 && args.get(1).and_then(|arg| arg.as_str()).is_some() {
                 analysis.add_reference(
                     CjsAssetReference::new(
-                        origin,
+                        *origin,
                         Request::parse(Value::new(js_value_to_pattern(&args[1]))),
                         issue_source(source, span),
                         in_try,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2460,6 +2460,8 @@ async fn analyze_amd_define(
             );
         }
     }
+
+    Ok(())
 }
 
 fn analyze_amd_define_with_deps(

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -279,7 +279,9 @@ impl AnalyzeEcmascriptModuleResultBuilder {
         mut self,
         track_reexport_references: bool,
     ) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
-        let bindings = EsmBindings::new(take(&mut self.bindings));
+        let bindings = EsmBindings::new(take(&mut self.bindings))
+            .to_resolved()
+            .await?;
         if !bindings.await?.bindings.is_empty() {
             self.add_code_gen(bindings);
         }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1457,9 +1457,11 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         ),
                     );
                     if ignore_dynamic_requests {
-                        analysis.add_code_gen(DynamicExpression::new_promise(Vc::cell(
-                            ast_path.to_vec(),
-                        )));
+                        analysis.add_code_gen(
+                            DynamicExpression::new_promise(Vc::cell(ast_path.to_vec()))
+                                .to_resolved()
+                                .await?,
+                        );
                         return Ok(());
                     }
                 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2375,18 +2375,22 @@ async fn analyze_amd_define(
             );
         }
         [JsValue::Constant(id), JsValue::Function(..)] if id.as_str().is_some() => {
-            analysis.add_code_gen(AmdDefineWithDependenciesCodeGen::new(
-                vec![
-                    AmdDefineDependencyElement::Require,
-                    AmdDefineDependencyElement::Exports,
-                    AmdDefineDependencyElement::Module,
-                ],
-                origin,
-                Vc::cell(ast_path.to_vec()),
-                AmdDefineFactoryType::Function,
-                issue_source(source, span),
-                in_try,
-            ));
+            analysis.add_code_gen(
+                AmdDefineWithDependenciesCodeGen::new(
+                    vec![
+                        AmdDefineDependencyElement::Require,
+                        AmdDefineDependencyElement::Exports,
+                        AmdDefineDependencyElement::Module,
+                    ],
+                    *origin,
+                    ResolvedVc::cell(ast_path.to_vec()),
+                    AmdDefineFactoryType::Function,
+                    issue_source(source, span),
+                    in_try,
+                )
+                .to_resolved()
+                .await?,
+            );
         }
         [JsValue::Constant(id), _] if id.as_str().is_some() => {
             analysis.add_code_gen(
@@ -2396,8 +2400,8 @@ async fn analyze_amd_define(
                         AmdDefineDependencyElement::Exports,
                         AmdDefineDependencyElement::Module,
                     ],
-                    origin,
-                    Vc::cell(ast_path.to_vec()),
+                    *origin,
+                    ResolvedVc::cell(ast_path.to_vec()),
                     AmdDefineFactoryType::Unknown,
                     issue_source(source, span),
                     in_try,
@@ -2414,8 +2418,8 @@ async fn analyze_amd_define(
                         AmdDefineDependencyElement::Exports,
                         AmdDefineDependencyElement::Module,
                     ],
-                    origin,
-                    Vc::cell(ast_path.to_vec()),
+                    *origin,
+                    ResolvedVc::cell(ast_path.to_vec()),
                     AmdDefineFactoryType::Function,
                     issue_source(source, span),
                     in_try,
@@ -2428,8 +2432,8 @@ async fn analyze_amd_define(
             analysis.add_code_gen(
                 AmdDefineWithDependenciesCodeGen::new(
                     vec![],
-                    origin,
-                    Vc::cell(ast_path.to_vec()),
+                    *origin,
+                    ResolvedVc::cell(ast_path.to_vec()),
                     AmdDefineFactoryType::Value,
                     issue_source(source, span),
                     in_try,
@@ -2446,8 +2450,8 @@ async fn analyze_amd_define(
                         AmdDefineDependencyElement::Exports,
                         AmdDefineDependencyElement::Module,
                     ],
-                    origin,
-                    Vc::cell(ast_path.to_vec()),
+                    *origin,
+                    ResolvedVc::cell(ast_path.to_vec()),
                     AmdDefineFactoryType::Unknown,
                     issue_source(source, span),
                     in_try,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -718,7 +718,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
         let request = Request::parse(Value::new(request.into()))
             .to_resolved()
             .await?;
-        let runtime = resolve_as_webpack_runtime(origin, request, *transforms)
+        let runtime = resolve_as_webpack_runtime(origin, *request, *transforms)
             .to_resolved()
             .await?;
 
@@ -2676,7 +2676,11 @@ async fn require_context_visitor(
     );
 
     Ok(JsValue::WellKnownFunction(
-        WellKnownFunctionKind::RequireContextRequire(RequireContextValue::from_context_map(map)),
+        WellKnownFunctionKind::RequireContextRequire(
+            RequireContextValue::from_context_map(map)
+                .to_resolved()
+                .await?,
+        ),
     ))
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2333,7 +2333,7 @@ async fn analyze_amd_define(
 async fn analyze_amd_define_with_deps(
     source: Vc<Box<dyn Source>>,
     analysis: &mut AnalyzeEcmascriptModuleResultBuilder,
-    origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+    origin: Vc<Box<dyn ResolveOrigin>>,
     handler: &Handler,
     span: Span,
     ast_path: &[AstParentKind],

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1369,17 +1369,21 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                                 return Ok(());
                             }
                         }
-                        analysis.add_reference(UrlAssetReference::new(
-                            origin,
-                            Request::parse(Value::new(pat)),
-                            compile_time_info.environment().rendering(),
-                            Vc::cell(ast_path.to_vec()),
-                            issue_source(source, span),
-                            in_try,
-                            url_rewrite_behavior
-                                .unwrap_or(UrlRewriteBehavior::Relative)
-                                .cell(),
-                        ));
+                        analysis.add_reference(
+                            UrlAssetReference::new(
+                                origin,
+                                Request::parse(Value::new(pat)),
+                                compile_time_info.environment().rendering(),
+                                Vc::cell(ast_path.to_vec()),
+                                issue_source(source, span),
+                                in_try,
+                                url_rewrite_behavior
+                                    .unwrap_or(UrlRewriteBehavior::Relative)
+                                    .cell(),
+                            )
+                            .to_resolved()
+                            .await?,
+                        );
                     }
                 }
                 return Ok(());
@@ -1655,7 +1659,11 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         return Ok(());
                     }
                 }
-                analysis.add_reference(FileSourceReference::new(source, Pattern::new(pat)));
+                analysis.add_reference(
+                    FileSourceReference::new(source, Pattern::new(pat))
+                        .to_resolved()
+                        .await?,
+                );
                 return Ok(());
             }
             let (args, hints) = explain_args(&args);
@@ -1698,7 +1706,11 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     return Ok(());
                 }
             }
-            analysis.add_reference(FileSourceReference::new(source, Pattern::new(pat)));
+            analysis.add_reference(
+                FileSourceReference::new(source, Pattern::new(pat))
+                    .to_resolved()
+                    .await?,
+            );
             return Ok(());
         }
 
@@ -1732,7 +1744,11 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     return Ok(());
                 }
             }
-            analysis.add_reference(DirAssetReference::new(source, Pattern::new(pat)));
+            analysis.add_reference(
+                DirAssetReference::new(source, Pattern::new(pat))
+                    .to_resolved()
+                    .await?,
+            );
             return Ok(());
         }
         JsValue::WellKnownFunction(WellKnownFunctionKind::ChildProcessSpawnMethod(name)) => {

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -309,7 +309,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
         let source_map = if let Some(source_map) = self.source_map {
             source_map
         } else {
-            OptionSourceMap::none().to_resolved().await?
+            OptionSourceMap::none()
         };
         Ok(AnalyzeEcmascriptModuleResult::cell(
             AnalyzeEcmascriptModuleResult {
@@ -559,14 +559,10 @@ pub(crate) async fn analyse_ecmascript_module_internal(
             ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(source).await?
         {
             let source_map_origin = source.ident().path();
-            analysis.set_source_map(
-                convert_to_turbopack_source_map(
-                    generate_source_map.generate_source_map(),
-                    source_map_origin,
-                )
-                .to_resolved()
-                .await?,
-            );
+            analysis.set_source_map(convert_to_turbopack_source_map(
+                generate_source_map.generate_source_map(),
+                source_map_origin,
+            ));
         }
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -697,12 +697,8 @@ pub(crate) async fn analyse_ecmascript_module_internal(
     let mut ignore_effect_span = None;
     // Check if it was a webpack entry
     if let Some((request, span)) = webpack_runtime {
-        let request = Request::parse(Value::new(request.into()))
-            .to_resolved()
-            .await?;
-        let runtime = resolve_as_webpack_runtime(origin, *request, *transforms)
-            .to_resolved()
-            .await?;
+        let request = Request::parse(Value::new(request.into()));
+        let runtime = resolve_as_webpack_runtime(origin, *request, *transforms);
 
         if let WebpackRuntime::Webpack5 { .. } = &*runtime.await? {
             ignore_effect_span = Some(span);
@@ -1914,7 +1910,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                                 if pkg != "html" {
                                     let pat = js_value_to_pattern(pkg_or_dir);
                                     analysis.add_reference(CjsAssetReference::new(
-                                        *origin,
+                                        origin,
                                         Request::parse(Value::new(pat)),
                                         issue_source(*source, span),
                                         in_try,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1664,7 +1664,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     }
                 }
                 analysis.add_reference(
-                    FileSourceReference::new(source, Pattern::new(pat))
+                    FileSourceReference::new(*source, Pattern::new(pat))
                         .to_resolved()
                         .await?,
                 );
@@ -1711,7 +1711,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 }
             }
             analysis.add_reference(
-                FileSourceReference::new(source, Pattern::new(pat))
+                FileSourceReference::new(*source, Pattern::new(pat))
                     .to_resolved()
                     .await?,
             );
@@ -2297,14 +2297,18 @@ async fn handle_free_var_reference(
             export,
         } => {
             let esm_reference = EsmAssetReference::new(
-                lookup_path.map_or(state.origin, |lookup_path| {
+                lookup_path.map_or(*state.origin, |lookup_path| {
                     Vc::upcast(PlainResolveOrigin::new(
                         state.origin.asset_context(),
                         *lookup_path,
                     ))
                 }),
                 Request::parse(Value::new(request.clone().into())),
-                IssueSource::from_swc_offsets(state.source, span.lo.to_usize(), span.hi.to_usize()),
+                IssueSource::from_swc_offsets(
+                    *state.source,
+                    span.lo.to_usize(),
+                    span.hi.to_usize(),
+                ),
                 Default::default(),
                 match state.tree_shaking_mode {
                     Some(TreeShakingMode::ModuleFragments)

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -546,11 +546,10 @@ pub(crate) async fn analyse_ecmascript_module_internal(
         } else if path.starts_with("data:application/json;base64,") {
             let source_map_origin = origin_path;
             let source_map = maybe_decode_data_url(path.into());
-            analysis.set_source_map(
-                convert_to_turbopack_source_map(source_map, source_map_origin)
-                    .to_resolved()
-                    .await?,
-            );
+            analysis.set_source_map(convert_to_turbopack_source_map(
+                source_map,
+                source_map_origin,
+            ));
             source_map_from_comment = true;
         }
     }
@@ -703,7 +702,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                     origin: origin.to_resolved().await?,
                     request,
                     runtime,
-                    transforms: *transforms,
+                    transforms,
                 }
                 .cell(),
             );
@@ -713,7 +712,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                     WebpackEntryAssetReference {
                         source,
                         runtime,
-                        transforms: *transforms,
+                        transforms,
                     }
                     .cell(),
                 );
@@ -724,7 +723,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                     WebpackChunkAssetReference {
                         chunk_id: chunk,
                         runtime,
-                        transforms: *transforms,
+                        transforms,
                     }
                     .cell(),
                 );

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1198,7 +1198,11 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                     } else {
                         analysis.add_local_reference(*r);
                         analysis.add_import_reference(*r);
-                        analysis.add_binding(EsmBinding::new(*r, export, Vc::cell(ast_path)));
+                        analysis.add_binding(EsmBinding::new(
+                            *r,
+                            export,
+                            ResolvedVc::cell(ast_path),
+                        ));
                     }
                 }
             }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2512,7 +2512,9 @@ async fn analyze_amd_define_with_deps(
                         request,
                         issue_source(source, span),
                         in_try,
-                    );
+                    )
+                    .to_resolved()
+                    .await?;
                     requests.push(AmdDefineDependencyElement::Request {
                         request,
                         request_str: dep.to_string(),

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1575,17 +1575,25 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         ),
                     );
                     if ignore_dynamic_requests {
-                        analysis.add_code_gen(DynamicExpression::new(Vc::cell(ast_path.to_vec())));
+                        analysis.add_code_gen(
+                            DynamicExpression::new(Vc::cell(ast_path.to_vec()))
+                                .to_resolved()
+                                .await?,
+                        );
                         return Ok(());
                     }
                 }
-                analysis.add_reference(CjsRequireResolveAssetReference::new(
-                    origin,
-                    Request::parse(Value::new(pat)),
-                    Vc::cell(ast_path.to_vec()),
-                    issue_source(source, span),
-                    in_try,
-                ));
+                analysis.add_reference(
+                    CjsRequireResolveAssetReference::new(
+                        origin,
+                        Request::parse(Value::new(pat)),
+                        Vc::cell(ast_path.to_vec()),
+                        issue_source(source, span),
+                        in_try,
+                    )
+                    .to_resolved()
+                    .await?,
+                );
                 return Ok(());
             }
             let (args, hints) = explain_args(&args);
@@ -2078,10 +2086,14 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                             })
                             .flatten()
                     {
-                        analysis.add_reference(DirAssetReference::new(
-                            source,
-                            Pattern::new(Pattern::Constant(dir.into())),
-                        ));
+                        analysis.add_reference(
+                            DirAssetReference::new(
+                                source,
+                                Pattern::new(Pattern::Constant(dir.into())),
+                            )
+                            .to_resolved()
+                            .await?,
+                        );
                     }
                     return Ok(());
                 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -336,8 +336,8 @@ impl Default for AnalyzeEcmascriptModuleResultBuilder {
 struct AnalysisState<'a> {
     handler: &'a Handler,
     source: ResolvedVc<Box<dyn Source>>,
-    origin: ResolvedVc<Box<dyn ResolveOrigin>>,
-    compile_time_info: ResolvedVc<CompileTimeInfo>,
+    origin: Vc<Box<dyn ResolveOrigin>>,
+    compile_time_info: Vc<CompileTimeInfo>,
     var_graph: &'a VarGraph,
     /// This is the current state of known values of function
     /// arguments.

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -196,7 +196,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     {
         let r = ResolvedVc::upcast(reference);
         self.references.insert(r);
-        self.local_references.insert(Vc::upcast(reference));
+        self.local_references.insert(ResolvedVc::upcast(reference));
     }
 
     /// Adds an asset reference to the analysis result.
@@ -288,23 +288,26 @@ impl AnalyzeEcmascriptModuleResultBuilder {
             self.add_code_gen(bindings);
         }
 
-        let mut references: Vec<_> = self.references.into_iter().collect();
+        let mut references: Vec<_> = self.references.into_iter().map(|v| *v).collect();
         let mut local_references: Vec<_> = track_reexport_references
             .then(|| self.local_references.into_iter())
             .into_iter()
             .flatten()
+            .map(|v| *v)
             .collect();
 
         let mut reexport_references: Vec<_> = track_reexport_references
             .then(|| self.reexport_references.into_iter())
             .into_iter()
             .flatten()
+            .map(|v| *v)
             .collect();
 
         let mut evaluation_references: Vec<_> = track_reexport_references
             .then(|| self.evaluation_references.into_iter())
             .into_iter()
             .flatten()
+            .map(|v| *v)
             .collect();
 
         let source_map = if let Some(source_map) = self.source_map {
@@ -322,7 +325,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
                 exports: self.exports.into(),
                 async_module: self.async_module,
                 successful: self.successful,
-                source_map: *source_map,
+                source_map,
             },
         ))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -734,7 +734,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                         runtime,
                         transforms,
                     }
-                    .resolved_cell(),
+                    .cell(),
                 );
             }
         }
@@ -2416,18 +2416,14 @@ async fn analyze_amd_define_with_deps(
         );
     }
 
-    analysis.add_code_gen(
-        AmdDefineWithDependenciesCodeGen::new(
-            requests,
-            origin,
-            Vc::cell(ast_path.to_vec()),
-            AmdDefineFactoryType::Function,
-            issue_source(source, span),
-            in_try,
-        )
-        .to_resolved()
-        .await?,
-    );
+    analysis.add_code_gen(AmdDefineWithDependenciesCodeGen::new(
+        requests,
+        origin,
+        Vc::cell(ast_path.to_vec()),
+        AmdDefineFactoryType::Function,
+        issue_source(source, span),
+        in_try,
+    ));
 
     Ok(())
 }
@@ -2884,7 +2880,7 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
                                 let esm_ref = self.import_references[index];
                                 if let Some(export) = export {
                                     EsmExport::ImportedBinding(
-                                        ResolvedVc::upcast(esm_ref),
+                                        Vc::upcast(esm_ref),
                                         export,
                                         is_fake_esm,
                                     )

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1821,14 +1821,10 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         .origin_path()
                         .root()
                         .join(s.trim_start_matches("/ROOT/").into());
-                    analysis.add_reference(
-                        NodeGypBuildReference::new(
-                            current_context,
-                            compile_time_info.environment().compile_target(),
-                        )
-                        .to_resolved()
-                        .await?,
-                    );
+                    analysis.add_reference(NodeGypBuildReference::new(
+                        current_context,
+                        compile_time_info.environment().compile_target(),
+                    ));
                     return Ok(());
                 }
             }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -264,8 +264,8 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     }
 
     /// Sets the analysis result ES export.
-    pub fn set_async_module(&mut self, async_module: Vc<AsyncModule>) {
-        self.async_module = Vc::cell(Some(async_module));
+    pub fn set_async_module(&mut self, async_module: ResolvedVc<AsyncModule>) {
+        self.async_module = ResolvedVc::cell(Some(async_module));
     }
 
     /// Sets whether the analysis was successful.
@@ -707,7 +707,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                     origin: origin.to_resolved().await?,
                     request,
                     runtime,
-                    transforms,
+                    transforms: *transforms,
                 }
                 .cell(),
             );
@@ -717,7 +717,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                     WebpackEntryAssetReference {
                         source,
                         runtime,
-                        transforms,
+                        transforms: *transforms,
                     }
                     .cell(),
                 );
@@ -728,7 +728,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                     WebpackChunkAssetReference {
                         chunk_id: chunk,
                         runtime,
-                        transforms,
+                        transforms: *transforms,
                     }
                     .cell(),
                 );

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -288,22 +288,22 @@ impl AnalyzeEcmascriptModuleResultBuilder {
             self.add_code_gen(bindings);
         }
 
-        let mut references: Vec<_> = self.references.into_iter().map(|v| *v).collect();
-        let mut local_references: Vec<_> = track_reexport_references
+        let references: Vec<_> = self.references.into_iter().map(|v| *v).collect();
+        let local_references: Vec<_> = track_reexport_references
             .then(|| self.local_references.into_iter())
             .into_iter()
             .flatten()
             .map(|v| *v)
             .collect();
 
-        let mut reexport_references: Vec<_> = track_reexport_references
+        let reexport_references: Vec<_> = track_reexport_references
             .then(|| self.reexport_references.into_iter())
             .into_iter()
             .flatten()
             .map(|v| *v)
             .collect();
 
-        let mut evaluation_references: Vec<_> = track_reexport_references
+        let evaluation_references: Vec<_> = track_reexport_references
             .then(|| self.evaluation_references.into_iter())
             .into_iter()
             .flatten()

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1630,16 +1630,20 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 }
             };
 
-            analysis.add_reference(RequireContextAssetReference::new(
-                source,
-                origin,
-                options.dir,
-                options.include_subdirs,
-                Vc::cell(options.filter),
-                Vc::cell(ast_path.to_vec()),
-                Some(issue_source(source, span)),
-                in_try,
-            ));
+            analysis.add_reference(
+                RequireContextAssetReference::new(
+                    source,
+                    origin,
+                    options.dir,
+                    options.include_subdirs,
+                    Vc::cell(options.filter),
+                    Vc::cell(ast_path.to_vec()),
+                    Some(issue_source(source, span)),
+                    in_try,
+                )
+                .to_resolved()
+                .await?,
+            );
         }
 
         JsValue::WellKnownFunction(WellKnownFunctionKind::FsReadMethod(name)) => {
@@ -1745,7 +1749,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 }
             }
             analysis.add_reference(
-                DirAssetReference::new(source, Pattern::new(pat))
+                DirAssetReference::new(*source, Pattern::new(pat))
                     .to_resolved()
                     .await?,
             );
@@ -1778,7 +1782,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                             CjsAssetReference::new(
                                 *origin,
                                 Request::parse(Value::new(pat)),
-                                issue_source(source, span),
+                                issue_source(*source, span),
                                 in_try,
                             )
                             .to_resolved()

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -194,9 +194,9 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     where
         R: Upcast<Box<dyn ModuleReference>>,
     {
-        let r = ResolvedVc::upcast(reference);
+        let r = Vc::upcast(reference);
         self.references.insert(r);
-        self.local_references.insert(ResolvedVc::upcast(reference));
+        self.local_references.insert(r);
     }
 
     /// Adds an asset reference to the analysis result.
@@ -204,7 +204,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     where
         R: Upcast<Box<dyn ModuleReference>>,
     {
-        self.references.insert(ResolvedVc::upcast(reference));
+        self.references.insert(Vc::upcast(reference));
     }
 
     /// Adds an reexport reference to the analysis result.
@@ -212,7 +212,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     where
         R: Upcast<Box<dyn ModuleReference>>,
     {
-        self.local_references.insert(ResolvedVc::upcast(reference));
+        self.local_references.insert(Vc::upcast(reference));
     }
 
     /// Adds an reexport reference to the analysis result.
@@ -220,14 +220,12 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     where
         R: Upcast<Box<dyn ModuleReference>>,
     {
-        self.reexport_references
-            .insert(ResolvedVc::upcast(reference));
+        self.reexport_references.insert(Vc::upcast(reference));
     }
 
     /// Adds an evaluation reference to the analysis result.
     pub fn add_evaluation_reference(&mut self, reference: Vc<EsmAssetReference>) {
-        self.evaluation_references
-            .insert(ResolvedVc::upcast(reference));
+        self.evaluation_references.insert(Vc::upcast(reference));
     }
 
     /// Adds a codegen to the analysis result.
@@ -236,7 +234,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
         C: Upcast<Box<dyn CodeGenerateable>>,
     {
         self.code_gens
-            .push(CodeGen::CodeGenerateable(ResolvedVc::upcast(code_gen)));
+            .push(CodeGen::CodeGenerateable(Vc::upcast(code_gen)));
     }
 
     /// Adds a codegen to the analysis result.
@@ -246,9 +244,9 @@ impl AnalyzeEcmascriptModuleResultBuilder {
         C: Upcast<Box<dyn CodeGenerateableWithAsyncModuleInfo>>,
     {
         self.code_gens
-            .push(CodeGen::CodeGenerateableWithAsyncModuleInfo(
-                ResolvedVc::upcast(code_gen),
-            ));
+            .push(CodeGen::CodeGenerateableWithAsyncModuleInfo(Vc::upcast(
+                code_gen,
+            )));
     }
 
     pub fn add_binding(&mut self, binding: EsmBinding) {

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -435,7 +435,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
 
     let parsed = if let Some(part) = part {
         let parsed = parse(*source, ty, *transforms);
-        let split_data = split(source.ident(), source, parsed);
+        let split_data = split(source.ident(), *source, parsed);
         part_of_module(split_data, part)
     } else {
         module.failsafe_parse()

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -502,18 +502,14 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                     let text = &comment.text;
                     if let Some(m) = REFERENCE_PATH.captures(text) {
                         let path = &m[1];
-                        analysis.add_reference(
-                            TsReferencePathAssetReference::new(origin, path.into())
-                                .to_resolved()
-                                .await?,
-                        );
+                        analysis
+                            .add_reference(TsReferencePathAssetReference::new(origin, path.into()));
                     } else if let Some(m) = REFERENCE_TYPES.captures(text) {
                         let types = &m[1];
-                        analysis.add_reference(
-                            TsReferenceTypeAssetReference::new(origin, types.into())
-                                .to_resolved()
-                                .await?,
-                        );
+                        analysis.add_reference(TsReferenceTypeAssetReference::new(
+                            origin,
+                            types.into(),
+                        ));
                     }
                 }
             }
@@ -727,7 +723,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                     runtime,
                     transforms,
                 }
-                .resolved_cell(),
+                .cell(),
             );
 
             if webpack_entry {
@@ -737,7 +733,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                         runtime,
                         transforms,
                     }
-                    .resolved_cell(),
+                    .cell(),
                 );
             }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -361,9 +361,9 @@ impl<'a> AnalysisState<'a> {
             &early_value_visitor,
             &|value| {
                 value_visitor(
-                    *self.origin,
+                    self.origin,
                     value,
-                    *self.compile_time_info,
+                    self.compile_time_info,
                     self.var_graph,
                     attributes,
                 )
@@ -1335,7 +1335,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                             }
                         }
                         analysis.add_reference(UrlAssetReference::new(
-                            *origin,
+                            origin,
                             Request::parse(Value::new(pat)),
                             compile_time_info.environment().rendering(),
                             Vc::cell(ast_path.to_vec()),
@@ -1369,7 +1369,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
 
                     if *compile_time_info.environment().rendering().await? == Rendering::Client {
                         analysis.add_reference(WorkerAssetReference::new(
-                            *origin,
+                            origin,
                             Request::parse(Value::new(pat)),
                             Vc::cell(ast_path.to_vec()),
                             issue_source(*source, span),

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -640,14 +640,12 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                 let import_ref = import_references[i];
                 match reexport {
                     Reexport::Star => {
-                        visitor
-                            .esm_star_exports
-                            .push(ResolvedVc::upcast(import_ref));
+                        visitor.esm_star_exports.push(Vc::upcast(import_ref));
                     }
                     Reexport::Namespace { exported: n } => {
                         visitor.esm_exports.insert(
                             n.as_str().into(),
-                            EsmExport::ImportedNamespace(ResolvedVc::upcast(import_ref)),
+                            EsmExport::ImportedNamespace(Vc::upcast(import_ref)),
                         );
                     }
                     Reexport::Named {
@@ -657,7 +655,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                         visitor.esm_exports.insert(
                             e.as_str().into(),
                             EsmExport::ImportedBinding(
-                                ResolvedVc::upcast(import_ref),
+                                Vc::upcast(import_ref),
                                 i.to_string().into(),
                                 false,
                             ),
@@ -1166,18 +1164,15 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                 span: _,
                 in_try: _,
             } => {
-                if let Some(r) = import_references.get(esm_reference_index) {
+                if let Some(&r) = import_references.get(esm_reference_index) {
                     if let Some("__turbopack_module_id__") = export.as_deref() {
-                        analysis.add_reference(
-                            EsmModuleIdAssetReference::new(**r, Vc::cell(ast_path))
-                                .to_resolved()
-                                .await?,
-                        )
+                        analysis
+                            .add_reference(EsmModuleIdAssetReference::new(r, Vc::cell(ast_path)))
                     } else {
                         analysis.add_local_reference(*r);
                         analysis.add_import_reference(*r);
                         analysis.add_binding(EsmBinding::new(
-                            *r,
+                            r,
                             export,
                             ResolvedVc::cell(ast_path),
                         ));
@@ -1484,25 +1479,17 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         ),
                     );
                     if ignore_dynamic_requests {
-                        analysis.add_code_gen(
-                            DynamicExpression::new(Vc::cell(ast_path.to_vec()))
-                                .to_resolved()
-                                .await?,
-                        );
+                        analysis.add_code_gen(DynamicExpression::new(Vc::cell(ast_path.to_vec())));
                         return Ok(());
                     }
                 }
-                analysis.add_reference(
-                    CjsRequireAssetReference::new(
-                        *origin,
-                        Request::parse(Value::new(pat)),
-                        Vc::cell(ast_path.to_vec()),
-                        issue_source(*source, span),
-                        in_try,
-                    )
-                    .to_resolved()
-                    .await?,
-                );
+                analysis.add_reference(CjsRequireAssetReference::new(
+                    *origin,
+                    Request::parse(Value::new(pat)),
+                    Vc::cell(ast_path.to_vec()),
+                    issue_source(*source, span),
+                    in_try,
+                ));
                 return Ok(());
             }
             let (args, hints) = explain_args(&args);

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -443,21 +443,13 @@ pub(crate) async fn analyse_ecmascript_module_internal(
     } = *module.determine_module_type().await?;
 
     if let Some(package_json) = referenced_package_json {
-        analysis.add_reference(
-            PackageJsonReference::new(*package_json)
-                .to_resolved()
-                .await?,
-        );
+        analysis.add_reference(PackageJsonReference::new(*package_json));
     }
 
     if analyze_types {
         match &*find_context_file(path.parent(), tsconfig()).await? {
             FindContextFileResult::Found(tsconfig, _) => {
-                analysis.add_reference(
-                    TsConfigReference::new(origin, **tsconfig)
-                        .to_resolved()
-                        .await?,
-                );
+                analysis.add_reference(TsConfigReference::new(origin, **tsconfig));
             }
             FindContextFileResult::NotFound(_) => {}
         };
@@ -543,7 +535,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
         if path.ends_with(".map") {
             let source_map_origin = origin_path.parent().join(path.into());
             let reference = SourceMapReference::new(origin_path, source_map_origin);
-            analysis.add_reference(reference.to_resolved().await?);
+            analysis.add_reference(reference);
             let source_map = reference.generate_source_map();
             analysis.set_source_map(
                 convert_to_turbopack_source_map(source_map, source_map_origin)
@@ -629,7 +621,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
             import_externals,
         );
 
-        import_references.push(r.to_resolved().await?);
+        import_references.push(r);
     }
 
     for i in evaluation_references {
@@ -886,11 +878,9 @@ pub(crate) async fn analyse_ecmascript_module_internal(
 
         match effect {
             Effect::Unreachable { start_ast_path } => {
-                analysis.add_code_gen(
-                    Unreachable::new(AstPathRange::StartAfter(start_ast_path.to_vec()).cell())
-                        .to_resolved()
-                        .await?,
-                );
+                analysis.add_code_gen(Unreachable::new(
+                    AstPathRange::StartAfter(start_ast_path.to_vec()).cell(),
+                ));
             }
             Effect::Conditional {
                 condition,
@@ -905,23 +895,15 @@ pub(crate) async fn analyse_ecmascript_module_internal(
 
                 macro_rules! inactive {
                     ($block:ident) => {
-                        analysis.add_code_gen(
-                            Unreachable::new($block.range.clone().cell())
-                                .to_resolved()
-                                .await?,
-                        );
+                        analysis.add_code_gen(Unreachable::new($block.range.clone().cell()));
                     };
                 }
                 macro_rules! condition {
                     ($expr:expr) => {
-                        analysis.add_code_gen(
-                            ConstantCondition::new(
-                                Value::new($expr),
-                                Vc::cell(condition_ast_path.to_vec()),
-                            )
-                            .to_resolved()
-                            .await?,
-                        );
+                        analysis.add_code_gen(ConstantCondition::new(
+                            Value::new($expr),
+                            Vc::cell(condition_ast_path.to_vec()),
+                        ));
                     };
                 }
                 macro_rules! active {

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -358,9 +358,9 @@ impl<'a> AnalysisState<'a> {
             &early_value_visitor,
             &|value| {
                 value_visitor(
-                    self.origin,
+                    *self.origin,
                     value,
-                    self.compile_time_info,
+                    *self.compile_time_info,
                     self.var_graph,
                     attributes,
                 )
@@ -742,7 +742,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
     let exports = if !esm_exports.is_empty() || !esm_star_exports.is_empty() {
         if specified_type == SpecifiedModuleType::CommonJs {
             SpecifiedModuleTypeIssue {
-                path: source.ident().path(),
+                path: source.ident().path().to_resolved().await?,
                 specified_type,
             }
             .cell()

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1914,10 +1914,14 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         .origin_path()
                         .root()
                         .join(s.trim_start_matches("/ROOT/").into());
-                    analysis.add_reference(NodeGypBuildReference::new(
-                        current_context,
-                        compile_time_info.environment().compile_target(),
-                    ));
+                    analysis.add_reference(
+                        NodeGypBuildReference::new(
+                            current_context,
+                            compile_time_info.environment().compile_target(),
+                        )
+                        .to_resolved()
+                        .await?,
+                    );
                     return Ok(());
                 }
             }
@@ -2330,7 +2334,7 @@ async fn handle_free_var_reference(
             analysis.add_binding(EsmBinding::new(
                 esm_reference,
                 export.clone(),
-                Vc::cell(ast_path.to_vec()),
+                ResolvedVc::cell(ast_path.to_vec()),
             ));
         }
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1365,21 +1365,17 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                                 return Ok(());
                             }
                         }
-                        analysis.add_reference(
-                            UrlAssetReference::new(
-                                *origin,
-                                Request::parse(Value::new(pat)),
-                                compile_time_info.environment().rendering(),
-                                Vc::cell(ast_path.to_vec()),
-                                issue_source(*source, span),
-                                in_try,
-                                url_rewrite_behavior
-                                    .unwrap_or(UrlRewriteBehavior::Relative)
-                                    .cell(),
-                            )
-                            .to_resolved()
-                            .await?,
-                        );
+                        analysis.add_reference(UrlAssetReference::new(
+                            *origin,
+                            Request::parse(Value::new(pat)),
+                            compile_time_info.environment().rendering(),
+                            Vc::cell(ast_path.to_vec()),
+                            issue_source(*source, span),
+                            in_try,
+                            url_rewrite_behavior
+                                .unwrap_or(UrlRewriteBehavior::Relative)
+                                .cell(),
+                        ));
                     }
                 }
                 return Ok(());
@@ -1403,17 +1399,13 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     }
 
                     if *compile_time_info.environment().rendering().await? == Rendering::Client {
-                        analysis.add_reference(
-                            WorkerAssetReference::new(
-                                *origin,
-                                Request::parse(Value::new(pat)),
-                                Vc::cell(ast_path.to_vec()),
-                                issue_source(*source, span),
-                                in_try,
-                            )
-                            .to_resolved()
-                            .await?,
-                        );
+                        analysis.add_reference(WorkerAssetReference::new(
+                            *origin,
+                            Request::parse(Value::new(pat)),
+                            Vc::cell(ast_path.to_vec()),
+                            issue_source(*source, span),
+                            in_try,
+                        ));
                     }
 
                     return Ok(());
@@ -1475,26 +1467,20 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         ),
                     );
                     if ignore_dynamic_requests {
-                        analysis.add_code_gen(
-                            DynamicExpression::new_promise(Vc::cell(ast_path.to_vec()))
-                                .to_resolved()
-                                .await?,
-                        );
+                        analysis.add_code_gen(DynamicExpression::new_promise(Vc::cell(
+                            ast_path.to_vec(),
+                        )));
                         return Ok(());
                     }
                 }
-                analysis.add_reference(
-                    EsmAsyncAssetReference::new(
-                        *origin,
-                        Request::parse(Value::new(pat)),
-                        Vc::cell(ast_path.to_vec()),
-                        issue_source(*source, span),
-                        in_try,
-                        state.import_externals,
-                    )
-                    .to_resolved()
-                    .await?,
-                );
+                analysis.add_reference(EsmAsyncAssetReference::new(
+                    *origin,
+                    Request::parse(Value::new(pat)),
+                    Vc::cell(ast_path.to_vec()),
+                    issue_source(*source, span),
+                    in_try,
+                    state.import_externals,
+                ));
                 return Ok(());
             }
             let (args, hints) = explain_args(&args);
@@ -1660,11 +1646,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         return Ok(());
                     }
                 }
-                analysis.add_reference(
-                    FileSourceReference::new(*source, Pattern::new(pat))
-                        .to_resolved()
-                        .await?,
-                );
+                analysis.add_reference(FileSourceReference::new(*source, Pattern::new(pat)));
                 return Ok(());
             }
             let (args, hints) = explain_args(&args);
@@ -1707,11 +1689,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     return Ok(());
                 }
             }
-            analysis.add_reference(
-                FileSourceReference::new(*source, Pattern::new(pat))
-                    .to_resolved()
-                    .await?,
-            );
+            analysis.add_reference(FileSourceReference::new(*source, Pattern::new(pat)));
             return Ok(());
         }
 
@@ -1745,11 +1723,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     return Ok(());
                 }
             }
-            analysis.add_reference(
-                DirAssetReference::new(*source, Pattern::new(pat))
-                    .to_resolved()
-                    .await?,
-            );
+            analysis.add_reference(DirAssetReference::new(*source, Pattern::new(pat)));
             return Ok(());
         }
         JsValue::WellKnownFunction(WellKnownFunctionKind::ChildProcessSpawnMethod(name)) => {
@@ -1775,16 +1749,12 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         show_dynamic_warning = true;
                     }
                     if !dynamic || !ignore_dynamic_requests {
-                        analysis.add_reference(
-                            CjsAssetReference::new(
-                                *origin,
-                                Request::parse(Value::new(pat)),
-                                issue_source(*source, span),
-                                in_try,
-                            )
-                            .to_resolved()
-                            .await?,
-                        );
+                        analysis.add_reference(CjsAssetReference::new(
+                            *origin,
+                            Request::parse(Value::new(pat)),
+                            issue_source(*source, span),
+                            in_try,
+                        ));
                     }
                 }
                 let dynamic = !pat.has_constant_parts();
@@ -1792,11 +1762,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     show_dynamic_warning = true;
                 }
                 if !dynamic || !ignore_dynamic_requests {
-                    analysis.add_reference(
-                        FileSourceReference::new(*source, Pattern::new(pat))
-                            .to_resolved()
-                            .await?,
-                    )
+                    analysis.add_reference(FileSourceReference::new(*source, Pattern::new(pat)));
                 }
                 if show_dynamic_warning {
                     let (args, hints) = explain_args(&args);

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -506,14 +506,18 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                     let text = &comment.text;
                     if let Some(m) = REFERENCE_PATH.captures(text) {
                         let path = &m[1];
-                        analysis
-                            .add_reference(TsReferencePathAssetReference::new(origin, path.into()));
+                        analysis.add_reference(
+                            TsReferencePathAssetReference::new(*origin, path.into())
+                                .to_resolved()
+                                .await?,
+                        );
                     } else if let Some(m) = REFERENCE_TYPES.captures(text) {
                         let types = &m[1];
-                        analysis.add_reference(TsReferenceTypeAssetReference::new(
-                            origin,
-                            types.into(),
-                        ));
+                        analysis.add_reference(
+                            TsReferenceTypeAssetReference::new(*origin, types.into())
+                                .to_resolved()
+                                .await?,
+                        );
                     }
                 }
             }
@@ -888,9 +892,11 @@ pub(crate) async fn analyse_ecmascript_module_internal(
 
         match effect {
             Effect::Unreachable { start_ast_path } => {
-                analysis.add_code_gen(Unreachable::new(
-                    AstPathRange::StartAfter(start_ast_path.to_vec()).cell(),
-                ));
+                analysis.add_code_gen(
+                    Unreachable::new(AstPathRange::StartAfter(start_ast_path.to_vec()).cell())
+                        .to_resolved()
+                        .await?,
+                );
             }
             Effect::Conditional {
                 condition,
@@ -910,10 +916,14 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                 }
                 macro_rules! condition {
                     ($expr:expr) => {
-                        analysis.add_code_gen(ConstantCondition::new(
-                            Value::new($expr),
-                            Vc::cell(condition_ast_path.to_vec()),
-                        ));
+                        analysis.add_code_gen(
+                            ConstantCondition::new(
+                                Value::new($expr),
+                                Vc::cell(condition_ast_path.to_vec()),
+                            )
+                            .to_resolved()
+                            .await?,
+                        );
                     };
                 }
                 macro_rules! active {

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -161,10 +161,10 @@ pub struct AnalyzeEcmascriptModuleResult {
 /// A temporary analysis result builder to pass around, to be turned into an
 /// `Vc<AnalyzeEcmascriptModuleResult>` eventually.
 pub struct AnalyzeEcmascriptModuleResultBuilder {
-    references: FxIndexSet<ResolvedVc<Box<dyn ModuleReference>>>,
-    local_references: FxIndexSet<ResolvedVc<Box<dyn ModuleReference>>>,
-    reexport_references: FxIndexSet<ResolvedVc<Box<dyn ModuleReference>>>,
-    evaluation_references: FxIndexSet<ResolvedVc<Box<dyn ModuleReference>>>,
+    references: FxIndexSet<Vc<Box<dyn ModuleReference>>>,
+    local_references: FxIndexSet<Vc<Box<dyn ModuleReference>>>,
+    reexport_references: FxIndexSet<Vc<Box<dyn ModuleReference>>>,
+    evaluation_references: FxIndexSet<Vc<Box<dyn ModuleReference>>>,
     code_gens: Vec<CodeGen>,
     exports: EcmascriptExports,
     async_module: ResolvedVc<OptionAsyncModule>,
@@ -190,7 +190,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     }
 
     /// Adds an asset reference to the analysis result.
-    pub fn add_reference<R>(&mut self, reference: ResolvedVc<R>)
+    pub fn add_reference<R>(&mut self, reference: Vc<R>)
     where
         R: Upcast<Box<dyn ModuleReference>>,
     {
@@ -200,7 +200,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     }
 
     /// Adds an asset reference to the analysis result.
-    pub fn add_import_reference<R>(&mut self, reference: ResolvedVc<R>)
+    pub fn add_import_reference<R>(&mut self, reference: Vc<R>)
     where
         R: Upcast<Box<dyn ModuleReference>>,
     {
@@ -208,7 +208,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     }
 
     /// Adds an reexport reference to the analysis result.
-    pub fn add_local_reference<R>(&mut self, reference: ResolvedVc<R>)
+    pub fn add_local_reference<R>(&mut self, reference: Vc<R>)
     where
         R: Upcast<Box<dyn ModuleReference>>,
     {
@@ -216,7 +216,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     }
 
     /// Adds an reexport reference to the analysis result.
-    pub fn add_reexport_reference<R>(&mut self, reference: ResolvedVc<R>)
+    pub fn add_reexport_reference<R>(&mut self, reference: Vc<R>)
     where
         R: Upcast<Box<dyn ModuleReference>>,
     {
@@ -225,13 +225,13 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     }
 
     /// Adds an evaluation reference to the analysis result.
-    pub fn add_evaluation_reference(&mut self, reference: ResolvedVc<EsmAssetReference>) {
+    pub fn add_evaluation_reference(&mut self, reference: Vc<EsmAssetReference>) {
         self.evaluation_references
             .insert(ResolvedVc::upcast(reference));
     }
 
     /// Adds a codegen to the analysis result.
-    pub fn add_code_gen<C>(&mut self, code_gen: ResolvedVc<C>)
+    pub fn add_code_gen<C>(&mut self, code_gen: Vc<C>)
     where
         C: Upcast<Box<dyn CodeGenerateable>>,
     {
@@ -241,7 +241,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
 
     /// Adds a codegen to the analysis result.
     #[allow(dead_code)]
-    pub fn add_code_gen_with_availability_info<C>(&mut self, code_gen: ResolvedVc<C>)
+    pub fn add_code_gen_with_availability_info<C>(&mut self, code_gen: Vc<C>)
     where
         C: Upcast<Box<dyn CodeGenerateableWithAsyncModuleInfo>>,
     {

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1775,7 +1775,11 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     show_dynamic_warning = true;
                 }
                 if !dynamic || !ignore_dynamic_requests {
-                    analysis.add_reference(FileSourceReference::new(source, Pattern::new(pat)));
+                    analysis.add_reference(
+                        FileSourceReference::new(source, Pattern::new(pat))
+                            .to_resolved()
+                            .await?,
+                    )
                 }
                 if show_dynamic_warning {
                     let (args, hints) = explain_args(&args);
@@ -1816,12 +1820,16 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         return Ok(());
                     }
                 }
-                analysis.add_reference(CjsAssetReference::new(
-                    origin,
-                    Request::parse(Value::new(pat)),
-                    issue_source(source, span),
-                    in_try,
-                ));
+                analysis.add_reference(
+                    CjsAssetReference::new(
+                        origin,
+                        Request::parse(Value::new(pat)),
+                        issue_source(source, span),
+                        in_try,
+                    )
+                    .to_resolved()
+                    .await?,
+                );
                 return Ok(());
             }
             let (args, hints) = explain_args(&args);

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1506,10 +1506,10 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 }
                 analysis.add_reference(
                     CjsRequireAssetReference::new(
-                        origin,
+                        *origin,
                         Request::parse(Value::new(pat)),
                         Vc::cell(ast_path.to_vec()),
-                        issue_source(source, span),
+                        issue_source(*source, span),
                         in_try,
                     )
                     .to_resolved()
@@ -1526,9 +1526,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
         }
         JsValue::WellKnownFunction(WellKnownFunctionKind::Define) => {
             analyze_amd_define(
-                source,
+                *source,
                 analysis,
-                origin,
+                *origin,
                 handler,
                 span,
                 ast_path,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1695,7 +1695,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     }
                     if !dynamic || !ignore_dynamic_requests {
                         analysis.add_reference(CjsAssetReference::new(
-                            *origin,
+                            origin,
                             Request::parse(Value::new(pat)),
                             issue_source(*source, span),
                             in_try,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1776,7 +1776,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     if !dynamic || !ignore_dynamic_requests {
                         analysis.add_reference(
                             CjsAssetReference::new(
-                                origin,
+                                *origin,
                                 Request::parse(Value::new(pat)),
                                 issue_source(source, span),
                                 in_try,
@@ -2004,9 +2004,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                                     let pat = js_value_to_pattern(pkg_or_dir);
                                     analysis.add_reference(
                                         CjsAssetReference::new(
-                                            origin,
+                                            *origin,
                                             Request::parse(Value::new(pat)),
-                                            issue_source(source, span),
+                                            issue_source(*source, span),
                                             in_try,
                                         )
                                         .to_resolved()

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1454,10 +1454,10 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     }
                 }
                 analysis.add_reference(EsmAsyncAssetReference::new(
-                    origin,
+                    *origin,
                     Request::parse(Value::new(pat)),
                     Vc::cell(ast_path.to_vec()),
-                    issue_source(source, span),
+                    issue_source(*source, span),
                     in_try,
                     state.import_externals,
                 ));

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -151,7 +151,7 @@ impl ModuleReference for DirAssetReference {
         let parent_path = self.source.ident().path().parent();
         Ok(resolve_reference_from_dir(
             parent_path.resolve().await?,
-            self.path,
+            *self.path,
         ))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -61,7 +61,7 @@ pub struct DirAssetReference {
 #[turbo_tasks::value_impl]
 impl DirAssetReference {
     #[turbo_tasks::function]
-    pub fn new(source: Vc<Box<dyn Source>>, path: Vc<Pattern>) -> Vc<Self> {
+    pub fn new(source: ResolvedVc<Box<dyn Source>>, path: ResolvedVc<Pattern>) -> Vc<Self> {
         Self::cell(DirAssetReference { source, path })
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -23,7 +23,7 @@ pub struct PackageJsonReference {
 #[turbo_tasks::value_impl]
 impl PackageJsonReference {
     #[turbo_tasks::function]
-    pub fn new(package_json: Vc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(package_json: ResolvedVc<FileSystemPath>) -> Vc<Self> {
         Self::cell(PackageJsonReference { package_json })
     }
 }
@@ -33,7 +33,7 @@ impl ModuleReference for PackageJsonReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
         Ok(ModuleResolveResult::module(ResolvedVc::upcast(
-            RawModule::new(Vc::upcast(FileSource::new(self.package_json)))
+            RawModule::new(Vc::upcast(FileSource::new(*self.package_json)))
                 .to_resolved()
                 .await?,
         ))

--- a/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
@@ -17,7 +17,7 @@ pub struct FileSourceReference {
 #[turbo_tasks::value_impl]
 impl FileSourceReference {
     #[turbo_tasks::function]
-    pub fn new(source: Vc<Box<dyn Source>>, path: Vc<Pattern>) -> Vc<Self> {
+    pub fn new(source: ResolvedVc<Box<dyn Source>>, path: ResolvedVc<Pattern>) -> Vc<Self> {
         Self::cell(FileSourceReference { source, path })
     }
 }
@@ -28,7 +28,7 @@ impl ModuleReference for FileSourceReference {
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         let context_dir = self.source.ident().path().parent();
 
-        resolve_raw(context_dir, self.path, false).as_raw_module_result()
+        resolve_raw(context_dir, *self.path, false).as_raw_module_result()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -219,13 +219,13 @@ pub struct RequireContextAssetReference {
 impl RequireContextAssetReference {
     #[turbo_tasks::function]
     pub fn new(
-        source: Vc<Box<dyn Source>>,
-        origin: Vc<Box<dyn ResolveOrigin>>,
+        source: ResolvedVc<Box<dyn Source>>,
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
         dir: RcStr,
         include_subdirs: bool,
         filter: Vc<Regex>,
-        path: Vc<AstPath>,
-        issue_source: Option<Vc<IssueSource>>,
+        path: ResolvedVc<AstPath>,
+        issue_source: Option<ResolvedVc<IssueSource>>,
         in_try: bool,
     ) -> Vc<Self> {
         let map = RequireContextMap::generate(

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -233,7 +233,7 @@ impl RequireContextAssetReference {
             origin.origin_path().parent().join(dir.clone()),
             include_subdirs,
             filter,
-            issue_source,
+            issue_source.map(|v| *v),
             in_try,
         )
         .to_resolved()

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -218,7 +218,7 @@ pub struct RequireContextAssetReference {
 #[turbo_tasks::value_impl]
 impl RequireContextAssetReference {
     #[turbo_tasks::function]
-    pub fn new(
+    pub async fn new(
         source: ResolvedVc<Box<dyn Source>>,
         origin: ResolvedVc<Box<dyn ResolveOrigin>>,
         dir: RcStr,
@@ -227,7 +227,7 @@ impl RequireContextAssetReference {
         path: ResolvedVc<AstPath>,
         issue_source: Option<ResolvedVc<IssueSource>>,
         in_try: bool,
-    ) -> Vc<Self> {
+    ) -> Result<Vc<Self>> {
         let map = RequireContextMap::generate(
             origin,
             origin.origin_path().parent().join(dir.clone()),
@@ -235,7 +235,9 @@ impl RequireContextAssetReference {
             filter,
             issue_source,
             in_try,
-        );
+        )
+        .to_resolved()
+        .await?;
         let inner = RequireContextAsset {
             source,
             origin,
@@ -316,7 +318,7 @@ pub struct ResolvedModuleReference(ResolvedVc<ModuleResolveResult>);
 impl ModuleReference for ResolvedModuleReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        self.0
+        *self.0
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -177,8 +177,12 @@ impl RequireContextMap {
 
         for (context_relative, path) in list {
             if let Some(origin_relative) = origin_path.get_relative_path_to(&*path.await?) {
-                let request = Request::parse(Value::new(origin_relative.clone().into()));
-                let result = cjs_resolve(origin, request, issue_source, is_optional);
+                let request = Request::parse(Value::new(origin_relative.clone().into()))
+                    .to_resolved()
+                    .await?;
+                let result = cjs_resolve(origin, request, issue_source, is_optional)
+                    .to_resolved()
+                    .await?;
 
                 map.insert(
                     context_relative.clone(),

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -229,10 +229,10 @@ impl RequireContextAssetReference {
         in_try: bool,
     ) -> Result<Vc<Self>> {
         let map = RequireContextMap::generate(
-            origin,
+            *origin,
             origin.origin_path().parent().join(dir.clone()),
             include_subdirs,
-            filter,
+            *filter,
             issue_source,
             in_try,
         )

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -180,7 +180,7 @@ impl RequireContextMap {
                 let request = Request::parse(Value::new(origin_relative.clone().into()))
                     .to_resolved()
                     .await?;
-                let result = cjs_resolve(origin, request, issue_source, is_optional)
+                let result = cjs_resolve(origin, *request, issue_source, is_optional)
                     .to_resolved()
                     .await?;
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -439,10 +439,10 @@ impl EcmascriptChunkItem for RequireContextChunkItem {
 
         for (key, entry) in map {
             let pm = PatternMapping::resolve_request(
-                entry.request,
-                self.origin,
-                Vc::upcast(self.chunking_context),
-                entry.result,
+                *entry.request,
+                *self.origin,
+                *ResolvedVc::upcast(self.chunking_context),
+                *entry.result,
                 Value::new(ResolveType::ChunkItem),
             )
             .await?;

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -387,8 +387,8 @@ impl Asset for RequireContextAsset {
 impl ChunkableModule for RequireContextAsset {
     #[turbo_tasks::function]
     async fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
+        self: ResolvedVc<Self>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
         let this = self.await?;
         Ok(Vc::upcast(

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -122,7 +122,7 @@ impl DirList {
             for (k, entry) in &*dir {
                 match entry {
                     DirListEntry::File(path) => {
-                        list.insert(k.clone(), **path);
+                        list.insert(k.clone(), *path);
                     }
                     DirListEntry::Dir(d) => {
                         queue.push_back(d.await?);

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -427,7 +427,7 @@ pub struct RequireContextChunkItem {
 impl EcmascriptChunkItem for RequireContextChunkItem {
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        self.chunking_context
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -180,7 +180,7 @@ impl RequireContextMap {
                 let request = Request::parse(Value::new(origin_relative.clone().into()))
                     .to_resolved()
                     .await?;
-                let result = cjs_resolve(origin, *request, issue_source, is_optional)
+                let result = cjs_resolve(origin, *request, issue_source.map(|v| *v), is_optional)
                     .to_resolved()
                     .await?;
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -166,7 +166,7 @@ impl RequireContextMap {
         dir: Vc<FileSystemPath>,
         recursive: bool,
         filter: Vc<Regex>,
-        issue_source: Option<Vc<IssueSource>>,
+        issue_source: Option<ResolvedVc<IssueSource>>,
         is_optional: bool,
     ) -> Result<Vc<Self>> {
         let origin_path = &*origin.origin_path().parent().await?;
@@ -232,7 +232,7 @@ impl RequireContextAssetReference {
             *origin,
             origin.origin_path().parent().join(dir.clone()),
             include_subdirs,
-            *filter,
+            filter,
             issue_source,
             in_try,
         )

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -248,14 +248,14 @@ impl RequireContextAssetReference {
         }
         .resolved_cell();
 
-        Self::cell(RequireContextAssetReference {
+        Ok(Self::cell(RequireContextAssetReference {
             inner,
             dir,
             include_subdirs,
             path,
             issue_source,
             in_try,
-        })
+        }))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -518,7 +518,7 @@ impl ChunkItem for RequireContextChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        Vc::upcast(self.chunking_context)
+        *ResolvedVc::upcast(self.chunking_context)
     }
 
     #[turbo_tasks::function]
@@ -530,6 +530,6 @@ impl ChunkItem for RequireContextChunkItem {
 
     #[turbo_tasks::function]
     fn module(&self) -> Vc<Box<dyn Module>> {
-        Vc::upcast(self.inner)
+        *ResolvedVc::upcast(self.inner)
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/type_issue.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/type_issue.rs
@@ -14,7 +14,7 @@ pub struct SpecifiedModuleTypeIssue {
 impl Issue for SpecifiedModuleTypeIssue {
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        self.path
+        *self.path
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
@@ -64,7 +64,7 @@ pub struct TsReferencePathAssetReference {
 #[turbo_tasks::value_impl]
 impl TsReferencePathAssetReference {
     #[turbo_tasks::function]
-    pub fn new(origin: Vc<Box<dyn ResolveOrigin>>, path: RcStr) -> Vc<Self> {
+    pub fn new(origin: ResolvedVc<Box<dyn ResolveOrigin>>, path: RcStr) -> Vc<Self> {
         Self::cell(TsReferencePathAssetReference { origin, path })
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
@@ -33,7 +33,7 @@ impl ModuleReference for TsConfigReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
         Ok(ModuleResolveResult::module(ResolvedVc::upcast(
-            TsConfigModuleAsset::new(self.origin, Vc::upcast(FileSource::new(self.tsconfig)))
+            TsConfigModuleAsset::new(*self.origin, Vc::upcast(FileSource::new(*self.tsconfig)))
                 .to_resolved()
                 .await?,
         ))

--- a/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
@@ -23,7 +23,10 @@ pub struct TsConfigReference {
 #[turbo_tasks::value_impl]
 impl TsConfigReference {
     #[turbo_tasks::function]
-    pub fn new(origin: Vc<Box<dyn ResolveOrigin>>, tsconfig: Vc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        tsconfig: ResolvedVc<FileSystemPath>,
+    ) -> Vc<Self> {
         Self::cell(TsConfigReference { tsconfig, origin })
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
@@ -119,7 +119,7 @@ pub struct TsReferenceTypeAssetReference {
 #[turbo_tasks::value_impl]
 impl TsReferenceTypeAssetReference {
     #[turbo_tasks::function]
-    pub fn new(origin: Vc<Box<dyn ResolveOrigin>>, module: RcStr) -> Vc<Self> {
+    pub fn new(origin: ResolvedVc<Box<dyn ResolveOrigin>>, module: RcStr) -> Vc<Self> {
         Self::cell(TsReferenceTypeAssetReference { origin, module })
     }
 }
@@ -129,7 +129,7 @@ impl ModuleReference for TsReferenceTypeAssetReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         type_resolve(
-            self.origin,
+            *self.origin,
             Request::module(
                 self.module.clone(),
                 Value::new(RcStr::default().into()),

--- a/turbopack/crates/turbopack-ecmascript/src/references/unreachable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/unreachable.rs
@@ -33,7 +33,7 @@ pub struct Unreachable {
 #[turbo_tasks::value_impl]
 impl Unreachable {
     #[turbo_tasks::function]
-    pub fn new(range: Vc<AstPathRange>) -> Vc<Self> {
+    pub fn new(range: ResolvedVc<AstPathRange>) -> Vc<Self> {
         Self::cell(Unreachable { range })
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -56,11 +56,11 @@ impl WorkerAssetReference {
         self: &WorkerAssetReference,
     ) -> Result<Option<Vc<WorkerLoaderModule>>> {
         let module = url_resolve(
-            self.origin,
-            self.request,
+            *self.origin,
+            *self.request,
             // TODO support more worker types
             Value::new(ReferenceType::Worker(WorkerReferenceSubType::WebWorker)),
-            Some(self.issue_source),
+            Some(*self.issue_source),
             self.in_try,
         );
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -35,10 +35,10 @@ pub struct WorkerAssetReference {
 impl WorkerAssetReference {
     #[turbo_tasks::function]
     pub fn new(
-        origin: Vc<Box<dyn ResolveOrigin>>,
-        request: Vc<Request>,
-        path: Vc<AstPath>,
-        issue_source: Vc<IssueSource>,
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        request: ResolvedVc<Request>,
+        path: ResolvedVc<AstPath>,
+        issue_source: ResolvedVc<IssueSource>,
         in_try: bool,
     ) -> Vc<Self> {
         Self::cell(WorkerAssetReference {

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
@@ -142,7 +142,7 @@ impl ChunkItem for EcmascriptModuleFacadeChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        Vc::upcast(self.chunking_context)
+        *ResolvedVc::upcast(self.chunking_context)
     }
 
     #[turbo_tasks::function]
@@ -154,7 +154,7 @@ impl ChunkItem for EcmascriptModuleFacadeChunkItem {
 
     #[turbo_tasks::function]
     fn module(&self) -> Vc<Box<dyn Module>> {
-        Vc::upcast(self.module)
+        *ResolvedVc::upcast(self.module)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
@@ -74,19 +74,19 @@ impl EcmascriptChunkItem for EcmascriptModuleFacadeChunkItem {
             if let Some(code_gen) =
                 Vc::try_resolve_sidecast::<Box<dyn CodeGenerateableWithAsyncModuleInfo>>(r).await?
             {
-                code_gens.push(code_gen.code_generation(chunking_context, async_module_info));
+                code_gens.push(code_gen.code_generation(*chunking_context, async_module_info));
             } else if let Some(code_gen) =
                 Vc::try_resolve_sidecast::<Box<dyn CodeGenerateable>>(r).await?
             {
-                code_gens.push(code_gen.code_generation(chunking_context));
+                code_gens.push(code_gen.code_generation(*chunking_context));
             }
         }
         code_gens.push(self.module.async_module().code_generation(
-            chunking_context,
+            *chunking_context,
             async_module_info,
             references,
         ));
-        code_gens.push(exports.code_generation(chunking_context));
+        code_gens.push(exports.code_generation(*chunking_context));
         let code_gens = code_gens.into_iter().try_join().await?;
         let code_gens = code_gens.iter().map(|cg| &**cg).collect::<Vec<_>>();
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
@@ -124,7 +124,7 @@ impl EcmascriptChunkItem for EcmascriptModuleFacadeChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        self.chunking_context
+        *self.chunking_context
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -208,19 +208,24 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
                     exports.insert(
                         "default".into(),
                         EsmExport::ImportedBinding(
-                            Vc::upcast(EcmascriptModulePartReference::new_part(
-                                self.module,
-                                ModulePart::exports(),
-                            )),
+                            ResolvedVc::upcast(
+                                EcmascriptModulePartReference::new_part(
+                                    *self.module,
+                                    ModulePart::exports(),
+                                )
+                                .to_resolved()
+                                .await?,
+                            ),
                             "default".into(),
                             false,
                         ),
                     );
                 }
-                star_exports.push(Vc::upcast(EcmascriptModulePartReference::new_part(
-                    self.module,
-                    ModulePart::exports(),
-                )));
+                star_exports.push(ResolvedVc::upcast(
+                    EcmascriptModulePartReference::new_part(*self.module, ModulePart::exports())
+                        .to_resolved()
+                        .await?,
+                ));
             }
             ModulePart::RenamedExport {
                 original_export,

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -168,14 +168,10 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
                             exports.insert(
                                 name.clone(),
                                 EsmExport::ImportedBinding(
-                                    ResolvedVc::upcast(
-                                        EcmascriptModulePartReference::new_part(
-                                            *self.module,
-                                            ModulePart::locals(),
-                                        )
-                                        .to_resolved()
-                                        .await?,
-                                    ),
+                                    ResolvedVc::upcast(EcmascriptModulePartReference::new_part(
+                                        *self.module,
+                                        ModulePart::locals(),
+                                    )),
                                     name,
                                     *mutable,
                                 ),

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -83,14 +83,14 @@ impl Module for EcmascriptModuleFacadeModule {
                 let references = result.evaluation_references;
                 let mut references = references.await?.clone_value();
                 references.push(Vc::upcast(EcmascriptModulePartReference::new_part(
-                    self.module,
+                    *self.module,
                     ModulePart::locals(),
                 )));
                 references
             }
             ModulePart::Exports => {
                 let Some(module) =
-                    Vc::try_resolve_sidecast::<Box<dyn EcmascriptAnalyzable>>(self.module).await?
+                    ResolvedVc::try_sidecast::<Box<dyn EcmascriptAnalyzable>>(self.module).await?
                 else {
                     bail!(
                         "Expected EcmascriptModuleAsset for a EcmascriptModuleFacadeModule with \

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -168,7 +168,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
                             exports.insert(
                                 name.clone(),
                                 EsmExport::ImportedBinding(
-                                    ResolvedVc::upcast(EcmascriptModulePartReference::new_part(
+                                    Vc::upcast(EcmascriptModulePartReference::new_part(
                                         *self.module,
                                         ModulePart::locals(),
                                     )),
@@ -233,7 +233,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
                 exports.insert(
                     export.await?.clone_value(),
                     EsmExport::ImportedBinding(
-                        ResolvedVc::upcast(EcmascriptModulePartReference::new(*self.module)),
+                        Vc::upcast(EcmascriptModulePartReference::new(*self.module)),
                         original_export.clone_value(),
                         false,
                     ),
@@ -242,7 +242,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
             ModulePart::RenamedNamespace { export } => {
                 exports.insert(
                     export.await?.clone_value(),
-                    EsmExport::ImportedNamespace(ResolvedVc::upcast(
+                    EsmExport::ImportedNamespace(Vc::upcast(
                         EcmascriptModulePartReference::new(*self.module)
                             .to_resolved()
                             .await?,

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -242,11 +242,9 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
             ModulePart::RenamedNamespace { export } => {
                 exports.insert(
                     export.await?.clone_value(),
-                    EsmExport::ImportedNamespace(Vc::upcast(
-                        EcmascriptModulePartReference::new(*self.module)
-                            .to_resolved()
-                            .await?,
-                    )),
+                    EsmExport::ImportedNamespace(Vc::upcast(EcmascriptModulePartReference::new(
+                        *self.module,
+                    ))),
                 );
             }
             ModulePart::Evaluation => {

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -35,7 +35,10 @@ pub struct EcmascriptModuleFacadeModule {
 #[turbo_tasks::value_impl]
 impl EcmascriptModuleFacadeModule {
     #[turbo_tasks::function]
-    pub fn new(module: Vc<Box<dyn EcmascriptChunkPlaceable>>, ty: Vc<ModulePart>) -> Vc<Self> {
+    pub fn new(
+        module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
+        ty: ResolvedVc<ModulePart>,
+    ) -> Vc<Self> {
         EcmascriptModuleFacadeModule { module, ty }.cell()
     }
 
@@ -240,7 +243,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
                     export.await?.clone_value(),
                     EsmExport::ImportedBinding(
                         ResolvedVc::upcast(
-                            EcmascriptModulePartReference::new(self.module)
+                            EcmascriptModulePartReference::new(*self.module)
                                 .to_resolved()
                                 .await?,
                         ),
@@ -253,7 +256,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
                 exports.insert(
                     export.await?.clone_value(),
                     EsmExport::ImportedNamespace(ResolvedVc::upcast(
-                        EcmascriptModulePartReference::new(self.module)
+                        EcmascriptModulePartReference::new(*self.module)
                             .to_resolved()
                             .await?,
                     )),

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -75,7 +75,7 @@ impl Module for EcmascriptModuleFacadeModule {
         let references = match &*self.ty.await? {
             ModulePart::Evaluation => {
                 let Some(module) =
-                    Vc::try_resolve_sidecast::<Box<dyn EcmascriptAnalyzable>>(self.module).await?
+                    ResolvedVc::try_sidecast::<Box<dyn EcmascriptAnalyzable>>(self.module).await?
                 else {
                     bail!(
                         "Expected EcmascriptModuleAsset for a EcmascriptModuleFacadeModule with \

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -239,7 +239,11 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
                 exports.insert(
                     export.await?.clone_value(),
                     EsmExport::ImportedBinding(
-                        Vc::upcast(EcmascriptModulePartReference::new(self.module)),
+                        ResolvedVc::upcast(
+                            EcmascriptModulePartReference::new(self.module)
+                                .to_resolved()
+                                .await?,
+                        ),
                         original_export.clone_value(),
                         false,
                     ),
@@ -248,9 +252,11 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
             ModulePart::RenamedNamespace { export } => {
                 exports.insert(
                     export.await?.clone_value(),
-                    EsmExport::ImportedNamespace(Vc::upcast(EcmascriptModulePartReference::new(
-                        self.module,
-                    ))),
+                    EsmExport::ImportedNamespace(ResolvedVc::upcast(
+                        EcmascriptModulePartReference::new(self.module)
+                            .to_resolved()
+                            .await?,
+                    )),
                 );
             }
             ModulePart::Evaluation => {

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -101,7 +101,7 @@ impl Module for EcmascriptModuleFacadeModule {
                 let references = result.reexport_references;
                 let mut references = references.await?.clone_value();
                 references.push(Vc::upcast(EcmascriptModulePartReference::new_part(
-                    self.module,
+                    *self.module,
                     ModulePart::locals(),
                 )));
                 references
@@ -109,11 +109,11 @@ impl Module for EcmascriptModuleFacadeModule {
             ModulePart::Facade => {
                 vec![
                     Vc::upcast(EcmascriptModulePartReference::new_part(
-                        self.module,
+                        *self.module,
                         ModulePart::evaluation(),
                     )),
                     Vc::upcast(EcmascriptModulePartReference::new_part(
-                        self.module,
+                        *self.module,
                         ModulePart::exports(),
                     )),
                 ]

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -165,10 +165,14 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
                             exports.insert(
                                 name.clone(),
                                 EsmExport::ImportedBinding(
-                                    Vc::upcast(EcmascriptModulePartReference::new_part(
-                                        self.module,
-                                        ModulePart::locals(),
-                                    )),
+                                    ResolvedVc::upcast(
+                                        EcmascriptModulePartReference::new_part(
+                                            *self.module,
+                                            ModulePart::locals(),
+                                        )
+                                        .to_resolved()
+                                        .await?,
+                                    ),
                                     name,
                                     *mutable,
                                 ),

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -215,24 +215,19 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
                     exports.insert(
                         "default".into(),
                         EsmExport::ImportedBinding(
-                            ResolvedVc::upcast(
-                                EcmascriptModulePartReference::new_part(
-                                    *self.module,
-                                    ModulePart::exports(),
-                                )
-                                .to_resolved()
-                                .await?,
-                            ),
+                            Vc::upcast(EcmascriptModulePartReference::new_part(
+                                *self.module,
+                                ModulePart::exports(),
+                            )),
                             "default".into(),
                             false,
                         ),
                     );
                 }
-                star_exports.push(ResolvedVc::upcast(
-                    EcmascriptModulePartReference::new_part(*self.module, ModulePart::exports())
-                        .to_resolved()
-                        .await?,
-                ));
+                star_exports.push(Vc::upcast(EcmascriptModulePartReference::new_part(
+                    *self.module,
+                    ModulePart::exports(),
+                )));
             }
             ModulePart::RenamedExport {
                 original_export,
@@ -242,11 +237,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
                 exports.insert(
                     export.await?.clone_value(),
                     EsmExport::ImportedBinding(
-                        ResolvedVc::upcast(
-                            EcmascriptModulePartReference::new(*self.module)
-                                .to_resolved()
-                                .await?,
-                        ),
+                        ResolvedVc::upcast(EcmascriptModulePartReference::new(*self.module)),
                         original_export.clone_value(),
                         false,
                     ),

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -287,8 +287,8 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
 impl ChunkableModule for EcmascriptModuleFacadeModule {
     #[turbo_tasks::function]
     fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
+        self: ResolvedVc<Self>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
         Vc::upcast(
             EcmascriptModuleFacadeChunkItem {

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -64,7 +64,7 @@ impl Module for EcmascriptModuleFacadeModule {
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         let inner = self.module.ident();
 
-        Ok(inner.with_part(self.ty))
+        Ok(inner.with_part(*self.ty))
     }
 
     #[turbo_tasks::function]
@@ -119,10 +119,10 @@ impl Module for EcmascriptModuleFacadeModule {
                 ]
             }
             ModulePart::RenamedNamespace { .. } => {
-                vec![Vc::upcast(EcmascriptModulePartReference::new(self.module))]
+                vec![Vc::upcast(EcmascriptModulePartReference::new(*self.module))]
             }
             ModulePart::RenamedExport { .. } => {
-                vec![Vc::upcast(EcmascriptModulePartReference::new(self.module))]
+                vec![Vc::upcast(EcmascriptModulePartReference::new(*self.module))]
             }
             _ => {
                 bail!("Unexpected ModulePart for EcmascriptModuleFacadeModule");

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
@@ -71,7 +71,7 @@ impl EcmascriptChunkItem for EcmascriptModuleLocalsChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        self.chunking_context
+        *self.chunking_context
     }
 }
 
@@ -89,7 +89,7 @@ impl ChunkItem for EcmascriptModuleLocalsChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        Vc::upcast(self.chunking_context)
+        *ResolvedVc::upcast(self.chunking_context)
     }
 
     #[turbo_tasks::function]
@@ -101,7 +101,7 @@ impl ChunkItem for EcmascriptModuleLocalsChunkItem {
 
     #[turbo_tasks::function]
     fn module(&self) -> Vc<Box<dyn Module>> {
-        Vc::upcast(self.module)
+        *ResolvedVc::upcast(self.module)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
@@ -109,7 +109,7 @@ impl ChunkItem for EcmascriptModuleLocalsChunkItem {
         let module = self.module.await?;
         let analyze = module.module.analyze().await?;
         if let Some(async_module) = *analyze.async_module.await? {
-            let is_self_async = async_module.is_self_async(analyze.local_references);
+            let is_self_async = async_module.is_self_async(*analyze.local_references);
             Ok(is_self_async)
         } else {
             Ok(Vc::cell(false))

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
@@ -56,7 +56,7 @@ impl EcmascriptChunkItem for EcmascriptModuleLocalsChunkItem {
             *analyze_result.local_references,
             *analyze_result.code_generation,
             *analyze_result.async_module,
-            *analyze_result.source_map,
+            analyze_result.source_map,
             exports,
             async_module_info,
         );

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
@@ -52,21 +52,19 @@ impl EcmascriptChunkItem for EcmascriptModuleLocalsChunkItem {
             parsed,
             self.module.ident(),
             module_type_result.module_type,
-            chunking_context,
+            *chunking_context,
             *analyze_result.local_references,
             *analyze_result.code_generation,
             *analyze_result.async_module,
             *analyze_result.source_map,
             exports,
             async_module_info,
-        )
-        .to_resolved()
-        .await?;
+        );
 
         Ok(EcmascriptChunkItemContent::new(
             content,
-            self.chunking_context,
-            original_module.await?.options,
+            *chunking_context,
+            *original_module.await?.options,
             async_module_options,
         ))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
@@ -53,13 +53,15 @@ impl EcmascriptChunkItem for EcmascriptModuleLocalsChunkItem {
             self.module.ident(),
             module_type_result.module_type,
             chunking_context,
-            analyze_result.local_references,
-            analyze_result.code_generation,
-            analyze_result.async_module,
-            analyze_result.source_map,
+            *analyze_result.local_references,
+            *analyze_result.code_generation,
+            *analyze_result.async_module,
+            *analyze_result.source_map,
             exports,
             async_module_info,
-        );
+        )
+        .to_resolved()
+        .await?;
 
         Ok(EcmascriptChunkItemContent::new(
             content,

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -113,8 +113,8 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleLocalsModule {
 impl ChunkableModule for EcmascriptModuleLocalsModule {
     #[turbo_tasks::function]
     fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
+        self: ResolvedVc<Self>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
         Vc::upcast(
             EcmascriptModuleLocalsChunkItem {

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -50,7 +50,7 @@ impl Module for EcmascriptModuleLocalsModule {
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<ModuleReferences>> {
         let result = self.module.analyze().await?;
-        Ok(result.local_references)
+        Ok(*result.local_references)
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -33,7 +33,7 @@ pub struct EcmascriptModuleLocalsModule {
 #[turbo_tasks::value_impl]
 impl EcmascriptModuleLocalsModule {
     #[turbo_tasks::function]
-    pub fn new(module: Vc<EcmascriptModuleAsset>) -> Vc<Self> {
+    pub fn new(module: ResolvedVc<EcmascriptModuleAsset>) -> Vc<Self> {
         EcmascriptModuleLocalsModule { module }.cell()
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/static_code.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/static_code.rs
@@ -17,7 +17,7 @@ use crate::EcmascriptAnalyzable;
 #[turbo_tasks::value]
 pub struct StaticEcmascriptCode {
     asset_context: ResolvedVc<Box<dyn AssetContext>>,
-    asset: ResolvedVc<Box<dyn EcmascriptAnalyzable>>,
+    asset: Vc<Box<dyn EcmascriptAnalyzable>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -30,7 +30,7 @@ impl StaticEcmascriptCode {
     ) -> Result<Vc<Self>> {
         let module = asset_context
             .process(
-                Vc::upcast(FileSource::new(asset_path)),
+                Vc::upcast(FileSource::new(*asset_path)),
                 Value::new(ReferenceType::Runtime),
             )
             .module();

--- a/turbopack/crates/turbopack-ecmascript/src/static_code.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/static_code.rs
@@ -25,8 +25,8 @@ impl StaticEcmascriptCode {
     /// Creates a new [`Vc<StaticEcmascriptCode>`].
     #[turbo_tasks::function]
     pub async fn new(
-        asset_context: Vc<Box<dyn AssetContext>>,
-        asset_path: Vc<FileSystemPath>,
+        asset_context: ResolvedVc<Box<dyn AssetContext>>,
+        asset_path: ResolvedVc<FileSystemPath>,
     ) -> Result<Vc<Self>> {
         let module = asset_context
             .process(

--- a/turbopack/crates/turbopack-ecmascript/src/text/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/text/mod.rs
@@ -25,7 +25,7 @@ pub struct TextContentFileSource {
 #[turbo_tasks::value_impl]
 impl TextContentFileSource {
     #[turbo_tasks::function]
-    pub fn new(source: Vc<Box<dyn Source>>) -> Vc<Self> {
+    pub fn new(source: ResolvedVc<Box<dyn Source>>) -> Vc<Self> {
         TextContentFileSource { source }.cell()
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -325,7 +325,7 @@ impl Issue for UnsupportedServerActionIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        self.file_path
+        *self.file_path
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -104,7 +104,7 @@ impl EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     pub async fn is_async_module(self: Vc<Self>) -> Result<Vc<bool>> {
         let this = self.await?;
-        let result = analyze(this.full_module, this.part);
+        let result = analyze(*this.full_module, *this.part);
 
         if let Some(async_module) = *result.await?.async_module.await? {
             Ok(async_module.is_self_async(self.references()))

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -123,13 +123,13 @@ impl Module for EcmascriptModulePartAsset {
 
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<ModuleReferences>> {
-        let split_data = split_module(self.full_module).await?;
+        let split_data = split_module(*self.full_module).await?;
 
-        let analyze = analyze(self.full_module, self.part).await?;
+        let analyze = analyze(*self.full_module, *self.part).await?;
 
         let deps = match &*split_data {
             SplitResult::Ok { deps, .. } => deps,
-            SplitResult::Failed { .. } => return Ok(analyze.references),
+            SplitResult::Failed { .. } => return Ok(*analyze.references),
         };
 
         let part_dep = |part: Vc<ModulePart>| -> Vc<Box<dyn ModuleReference>> {

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -36,7 +36,7 @@ impl EcmascriptParsable for EcmascriptModulePartAsset {
     async fn failsafe_parse(&self) -> Result<Vc<ParseResult>> {
         let parsed = self.full_module.failsafe_parse();
         let split_data = split(self.full_module.ident(), self.full_module.source(), parsed);
-        Ok(part_of_module(split_data, self.part))
+        Ok(part_of_module(split_data, *self.part))
     }
     #[turbo_tasks::function]
     fn parse_original(&self) -> Vc<ParseResult> {
@@ -54,7 +54,7 @@ impl EcmascriptAnalyzable for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     fn analyze(&self) -> Vc<AnalyzeEcmascriptModuleResult> {
         let part = self.part;
-        analyse_ecmascript_module(self.full_module, Some(part))
+        analyse_ecmascript_module(*self.full_module, Some(*part))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -194,7 +194,7 @@ impl Asset for EcmascriptModulePartAsset {
 impl EcmascriptChunkPlaceable for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     async fn get_exports(self: Vc<Self>) -> Result<Vc<EcmascriptExports>> {
-        Ok(self.analyze().await?.exports)
+        Ok(*self.analyze().await?.exports)
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -79,7 +79,10 @@ impl EcmascriptModulePartAsset {
     /// of a pointer to the full module and the [ModulePart] pointing the part
     /// of the module.
     #[turbo_tasks::function]
-    pub fn new(module: Vc<EcmascriptModuleAsset>, part: Vc<ModulePart>) -> Vc<Self> {
+    pub fn new(
+        module: ResolvedVc<EcmascriptModuleAsset>,
+        part: ResolvedVc<ModulePart>,
+    ) -> Vc<Self> {
         EcmascriptModulePartAsset {
             full_module: module,
             part,

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -222,7 +222,7 @@ impl ChunkableModule for EcmascriptModulePartAsset {
 impl EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     pub(super) fn analyze(&self) -> Vc<AnalyzeEcmascriptModuleResult> {
-        analyze(self.full_module, self.part)
+        analyze(*self.full_module, *self.part)
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -202,8 +202,8 @@ impl EcmascriptChunkPlaceable for EcmascriptModulePartAsset {
 impl ChunkableModule for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
+        self: ResolvedVc<Self>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
         Vc::upcast(
             EcmascriptModulePartChunkItem {

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -118,7 +118,7 @@ impl EcmascriptModulePartAsset {
 impl Module for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        self.full_module.ident().with_part(self.part)
+        self.full_module.ident().with_part(*self.part)
     }
 
     #[turbo_tasks::function]
@@ -134,7 +134,7 @@ impl Module for EcmascriptModulePartAsset {
 
         let part_dep = |part: Vc<ModulePart>| -> Vc<Box<dyn ModuleReference>> {
             Vc::upcast(SingleModuleReference::new(
-                Vc::upcast(EcmascriptModulePartAsset::new(self.full_module, part)),
+                Vc::upcast(EcmascriptModulePartAsset::new(*self.full_module, part)),
                 Vc::cell("ecmascript module part".into()),
             ))
         };
@@ -149,7 +149,7 @@ impl Module for EcmascriptModulePartAsset {
         }
 
         let deps = {
-            let part_id = get_part_id(&split_data, self.part)
+            let part_id = get_part_id(&split_data, *self.part)
                 .await
                 .with_context(|| format!("part {:?} is not found in the module", self.part))?;
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
@@ -37,8 +37,8 @@ impl EcmascriptChunkItem for EcmascriptModulePartChunkItem {
     ) -> Result<Vc<EcmascriptChunkItemContent>> {
         let module = self.module.await?;
 
-        let split_data = split_module(module.full_module);
-        let parsed = part_of_module(split_data, module.part);
+        let split_data = split_module(*module.full_module);
+        let parsed = part_of_module(split_data, *module.part);
 
         let analyze = self.module.analyze().await?;
         let async_module_options = analyze.async_module.module_options(async_module_info);
@@ -50,25 +50,25 @@ impl EcmascriptChunkItem for EcmascriptModulePartChunkItem {
             module.full_module.ident(),
             module_type_result.module_type,
             *self.chunking_context,
-            analyze.references,
-            analyze.code_generation,
-            analyze.async_module,
-            analyze.source_map,
-            analyze.exports,
+            *analyze.references,
+            *analyze.code_generation,
+            *analyze.async_module,
+            *analyze.source_map,
+            *analyze.exports,
             async_module_info,
         );
 
         Ok(EcmascriptChunkItemContent::new(
             content,
             *self.chunking_context,
-            module.full_module.await?.options,
+            *module.full_module.await?.options,
             async_module_options,
         ))
     }
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        self.chunking_context
+        *self.chunking_context
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
@@ -86,7 +86,7 @@ impl ChunkItem for EcmascriptModulePartChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        Vc::upcast(self.chunking_context)
+        *ResolvedVc::upcast(self.chunking_context)
     }
 
     #[turbo_tasks::function]
@@ -98,7 +98,7 @@ impl ChunkItem for EcmascriptModulePartChunkItem {
 
     #[turbo_tasks::function]
     fn module(&self) -> Vc<Box<dyn Module>> {
-        Vc::upcast(self.module)
+        *ResolvedVc::upcast(self.module)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
@@ -53,7 +53,7 @@ impl EcmascriptChunkItem for EcmascriptModulePartChunkItem {
             *analyze.references,
             *analyze.code_generation,
             *analyze.async_module,
-            *analyze.source_map,
+            analyze.source_map,
             *analyze.exports,
             async_module_info,
         );

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
@@ -49,7 +49,7 @@ impl EcmascriptChunkItem for EcmascriptModulePartChunkItem {
             parsed,
             module.full_module.ident(),
             module_type_result.module_type,
-            self.chunking_context,
+            *self.chunking_context,
             analyze.references,
             analyze.code_generation,
             analyze.async_module,
@@ -60,7 +60,7 @@ impl EcmascriptChunkItem for EcmascriptModulePartChunkItem {
 
         Ok(EcmascriptChunkItemContent::new(
             content,
-            self.chunking_context,
+            *self.chunking_context,
             module.full_module.await?.options,
             async_module_options,
         ))

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -478,9 +478,9 @@ pub(super) async fn split_module(asset: Vc<EcmascriptModuleAsset>) -> Result<Vc<
 
 #[turbo_tasks::function]
 pub(super) async fn split(
-    ident: Vc<AssetIdent>,
+    ident: ResolvedVc<AssetIdent>,
     source: Vc<Box<dyn Source>>,
-    parsed: Vc<ParseResult>,
+    parsed: ResolvedVc<ParseResult>,
 ) -> Result<Vc<SplitResult>> {
     // Do not split already split module
     if !ident.await?.parts.is_empty() {
@@ -580,7 +580,7 @@ pub(super) async fn split(
                         Some(source),
                     );
 
-                    ParseResult::cell(ParseResult::Ok {
+                    ParseResult::resolved_cell(ParseResult::Ok {
                         program,
                         globals: globals.clone(),
                         comments: comments.clone(),

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -728,8 +728,8 @@ pub(crate) async fn part_of_module(
                 );
             }
 
-            Ok(modules[part_id as usize])
+            Ok(*modules[part_id as usize])
         }
-        SplitResult::Failed { parse_result } => Ok(*parse_result),
+        SplitResult::Failed { parse_result } => Ok(**parse_result),
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -250,7 +250,10 @@ pub struct TsNodeRequireReference {
 #[turbo_tasks::value_impl]
 impl TsNodeRequireReference {
     #[turbo_tasks::function]
-    pub fn new(origin: Vc<Box<dyn ResolveOrigin>>, request: Vc<Request>) -> Vc<Self> {
+    pub fn new(
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        request: ResolvedVc<Request>,
+    ) -> Vc<Self> {
         Self::cell(TsNodeRequireReference { origin, request })
     }
 }
@@ -259,7 +262,7 @@ impl TsNodeRequireReference {
 impl ModuleReference for TsNodeRequireReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        cjs_resolve(self.origin, self.request, None, false)
+        cjs_resolve(*self.origin, *self.request, None, false)
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -208,7 +208,7 @@ pub struct TsExtendsReference {
 #[turbo_tasks::value_impl]
 impl TsExtendsReference {
     #[turbo_tasks::function]
-    pub fn new(config: Vc<Box<dyn Source>>) -> Vc<Self> {
+    pub fn new(config: ResolvedVc<Box<dyn Source>>) -> Vc<Self> {
         Self::cell(TsExtendsReference { config })
     }
 }
@@ -218,7 +218,7 @@ impl ModuleReference for TsExtendsReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
         Ok(ModuleResolveResult::module(ResolvedVc::upcast(
-            RawModule::new(Vc::upcast(self.config))
+            RawModule::new(*ResolvedVc::upcast(self.config))
                 .to_resolved()
                 .await?,
         ))

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -290,7 +290,10 @@ pub struct TsConfigTypesReference {
 #[turbo_tasks::value_impl]
 impl TsConfigTypesReference {
     #[turbo_tasks::function]
-    pub fn new(origin: Vc<Box<dyn ResolveOrigin>>, request: Vc<Request>) -> Vc<Self> {
+    pub fn new(
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        request: ResolvedVc<Request>,
+    ) -> Vc<Self> {
         Self::cell(TsConfigTypesReference { origin, request })
     }
 }
@@ -299,7 +302,7 @@ impl TsConfigTypesReference {
 impl ModuleReference for TsConfigTypesReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        type_resolve(self.origin, self.request)
+        type_resolve(*self.origin, *self.request)
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -176,7 +176,10 @@ pub struct CompilerReference {
 #[turbo_tasks::value_impl]
 impl CompilerReference {
     #[turbo_tasks::function]
-    pub fn new(origin: Vc<Box<dyn ResolveOrigin>>, request: Vc<Request>) -> Vc<Self> {
+    pub fn new(
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        request: ResolvedVc<Request>,
+    ) -> Vc<Self> {
         Self::cell(CompilerReference { origin, request })
     }
 }
@@ -185,7 +188,7 @@ impl CompilerReference {
 impl ModuleReference for CompilerReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        cjs_resolve(self.origin, self.request, None, false)
+        cjs_resolve(*self.origin, *self.request, None, false)
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -40,9 +40,9 @@ pub struct WebpackModuleAsset {
 impl WebpackModuleAsset {
     #[turbo_tasks::function]
     pub fn new(
-        source: Vc<Box<dyn Source>>,
-        runtime: Vc<WebpackRuntime>,
-        transforms: Vc<EcmascriptInputTransforms>,
+        source: ResolvedVc<Box<dyn Source>>,
+        runtime: ResolvedVc<WebpackRuntime>,
+        transforms: ResolvedVc<EcmascriptInputTransforms>,
     ) -> Vc<Self> {
         Self::cell(WebpackModuleAsset {
             source,
@@ -136,12 +136,14 @@ pub struct WebpackEntryAssetReference {
 impl ModuleReference for WebpackEntryAssetReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
-        Ok(ModuleResolveResult::module(ResolvedVc::upcast(
-            WebpackModuleAsset::new(self.source, self.runtime, self.transforms)
-                .to_resolved()
-                .await?,
-        ))
-        .cell())
+        Ok(
+            ModuleResolveResult::module(ResolvedVc::upcast(WebpackModuleAsset::new(
+                *self.source,
+                *self.runtime,
+                *self.transforms,
+            )))
+            .cell(),
+        )
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -181,7 +181,7 @@ impl ModuleReference for WebpackRuntimeAssetReference {
             .await?
             .map_module(|source| async move {
                 Ok(ModuleResolveResultItem::Module(ResolvedVc::upcast(
-                    WebpackModuleAsset::new(*source, self.runtime, self.transforms)
+                    WebpackModuleAsset::new(*source, self.runtime, *self.transforms)
                         .to_resolved()
                         .await?,
                 )))

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -175,7 +175,7 @@ impl ModuleReference for WebpackRuntimeAssetReference {
         let resolved = resolve(
             self.origin.origin_path().parent().resolve().await?,
             Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
-            self.request,
+            *self.request,
             options,
         );
 
@@ -183,7 +183,9 @@ impl ModuleReference for WebpackRuntimeAssetReference {
             .await?
             .map_module(|source| async move {
                 Ok(ModuleResolveResultItem::Module(ResolvedVc::upcast(
-                    WebpackModuleAsset::new(*source, self.runtime, self.transforms),
+                    WebpackModuleAsset::new(*source, self.runtime, self.transforms)
+                        .to_resolved()
+                        .await?,
                 )))
             })
             .await?

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -78,7 +78,7 @@ pub struct WebpackChunkAssetReference {
     #[turbo_tasks(trace_ignore)]
     pub chunk_id: Lit,
     pub runtime: Vc<WebpackRuntime>,
-    pub transforms: Vc<EcmascriptInputTransforms>,
+    pub transforms: ResolvedVc<EcmascriptInputTransforms>,
 }
 
 #[turbo_tasks::value_impl]
@@ -101,7 +101,7 @@ impl ModuleReference for WebpackChunkAssetReference {
                 let source = Vc::upcast(FileSource::new(context_path.join(filename)));
 
                 ModuleResolveResult::module(ResolvedVc::upcast(
-                    WebpackModuleAsset::new(source, self.runtime, self.transforms)
+                    WebpackModuleAsset::new(source, self.runtime, *self.transforms)
                         .to_resolved()
                         .await?,
                 ))
@@ -158,7 +158,7 @@ pub struct WebpackRuntimeAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: Vc<Request>,
     pub runtime: Vc<WebpackRuntime>,
-    pub transforms: Vc<EcmascriptInputTransforms>,
+    pub transforms: ResolvedVc<EcmascriptInputTransforms>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -61,7 +61,7 @@ impl Module for WebpackModuleAsset {
 
     #[turbo_tasks::function]
     fn references(&self) -> Vc<ModuleReferences> {
-        module_references(self.source, self.runtime, self.transforms)
+        module_references(*self.source, *self.runtime, *self.transforms)
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -128,7 +128,7 @@ impl ValueToString for WebpackChunkAssetReference {
 #[turbo_tasks::value(shared)]
 pub struct WebpackEntryAssetReference {
     pub source: ResolvedVc<Box<dyn Source>>,
-    pub runtime: ResolvedVc<WebpackRuntime>,
+    pub runtime: Vc<WebpackRuntime>,
     pub transforms: ResolvedVc<EcmascriptInputTransforms>,
 }
 
@@ -137,7 +137,7 @@ impl ModuleReference for WebpackEntryAssetReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
         Ok(ModuleResolveResult::module(ResolvedVc::upcast(
-            WebpackModuleAsset::new(*self.source, *self.runtime, *self.transforms)
+            WebpackModuleAsset::new(*self.source, self.runtime, *self.transforms)
                 .to_resolved()
                 .await?,
         ))

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -100,11 +100,11 @@ impl ModuleReference for WebpackChunkAssetReference {
                 let filename = format!("./chunks/{}.js", chunk_id).into();
                 let source = Vc::upcast(FileSource::new(context_path.join(filename)));
 
-                ModuleResolveResult::module(ResolvedVc::upcast(
-                    WebpackModuleAsset::new(source, self.runtime, self.transforms)
-                        .to_resolved()
-                        .await?,
-                ))
+                ModuleResolveResult::module(ResolvedVc::upcast(WebpackModuleAsset::new(
+                    source,
+                    self.runtime,
+                    self.transforms,
+                )))
                 .cell()
             }
             WebpackRuntime::None => ModuleResolveResult::unresolvable().cell(),

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -136,14 +136,12 @@ pub struct WebpackEntryAssetReference {
 impl ModuleReference for WebpackEntryAssetReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
-        Ok(
-            ModuleResolveResult::module(ResolvedVc::upcast(WebpackModuleAsset::new(
-                *self.source,
-                *self.runtime,
-                *self.transforms,
-            )))
-            .cell(),
-        )
+        Ok(ModuleResolveResult::module(ResolvedVc::upcast(
+            WebpackModuleAsset::new(*self.source, *self.runtime, *self.transforms)
+                .to_resolved()
+                .await?,
+        ))
+        .cell())
     }
 }
 
@@ -183,7 +181,7 @@ impl ModuleReference for WebpackRuntimeAssetReference {
             .await?
             .map_module(|source| async move {
                 Ok(ModuleResolveResultItem::Module(ResolvedVc::upcast(
-                    WebpackModuleAsset::new(*source, self.runtime, self.transforms)
+                    WebpackModuleAsset::new(*source, *self.runtime, *self.transforms)
                         .to_resolved()
                         .await?,
                 )))

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -77,8 +77,8 @@ impl Asset for WebpackModuleAsset {
 pub struct WebpackChunkAssetReference {
     #[turbo_tasks(trace_ignore)]
     pub chunk_id: Lit,
-    pub runtime: ResolvedVc<WebpackRuntime>,
-    pub transforms: ResolvedVc<EcmascriptInputTransforms>,
+    pub runtime: Vc<WebpackRuntime>,
+    pub transforms: Vc<EcmascriptInputTransforms>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -156,9 +156,9 @@ impl ValueToString for WebpackEntryAssetReference {
 #[turbo_tasks::value(shared)]
 pub struct WebpackRuntimeAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
-    pub request: ResolvedVc<Request>,
-    pub runtime: ResolvedVc<WebpackRuntime>,
-    pub transforms: ResolvedVc<EcmascriptInputTransforms>,
+    pub request: Vc<Request>,
+    pub runtime: Vc<WebpackRuntime>,
+    pub transforms: Vc<EcmascriptInputTransforms>,
 }
 
 #[turbo_tasks::value_impl]
@@ -173,7 +173,7 @@ impl ModuleReference for WebpackRuntimeAssetReference {
         let resolved = resolve(
             self.origin.origin_path().parent().resolve().await?,
             Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
-            *self.request,
+            self.request,
             options,
         );
 
@@ -181,7 +181,7 @@ impl ModuleReference for WebpackRuntimeAssetReference {
             .await?
             .map_module(|source| async move {
                 Ok(ModuleResolveResultItem::Module(ResolvedVc::upcast(
-                    WebpackModuleAsset::new(*source, *self.runtime, *self.transforms)
+                    WebpackModuleAsset::new(source, self.runtime, self.transforms)
                         .to_resolved()
                         .await?,
                 )))

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -100,11 +100,11 @@ impl ModuleReference for WebpackChunkAssetReference {
                 let filename = format!("./chunks/{}.js", chunk_id).into();
                 let source = Vc::upcast(FileSource::new(context_path.join(filename)));
 
-                ModuleResolveResult::module(ResolvedVc::upcast(WebpackModuleAsset::new(
-                    source,
-                    self.runtime,
-                    self.transforms,
-                )))
+                ModuleResolveResult::module(ResolvedVc::upcast(
+                    WebpackModuleAsset::new(source, self.runtime, self.transforms)
+                        .to_resolved()
+                        .await?,
+                ))
                 .cell()
             }
             WebpackRuntime::None => ModuleResolveResult::unresolvable().cell(),

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -181,9 +181,7 @@ impl ModuleReference for WebpackRuntimeAssetReference {
             .await?
             .map_module(|source| async move {
                 Ok(ModuleResolveResultItem::Module(ResolvedVc::upcast(
-                    WebpackModuleAsset::new(*source, self.runtime, self.transforms)
-                        .to_resolved()
-                        .await?,
+                    WebpackModuleAsset::new(*source, self.runtime, self.transforms),
                 )))
             })
             .await?

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -181,7 +181,7 @@ impl ModuleReference for WebpackRuntimeAssetReference {
             .await?
             .map_module(|source| async move {
                 Ok(ModuleResolveResultItem::Module(ResolvedVc::upcast(
-                    WebpackModuleAsset::new(source, self.runtime, self.transforms)
+                    WebpackModuleAsset::new(*source, self.runtime, self.transforms)
                         .to_resolved()
                         .await?,
                 )))

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
@@ -232,7 +232,7 @@ pub async fn webpack_runtime(
 
                         return Ok(WebpackRuntime::Webpack5 {
                             chunk_request_expr: value,
-                            context_path: source.ident().path().parent().resolve().await?,
+                            context_path: source.ident().path().parent().to_resolved().await?,
                         }
                         .into());
                     }

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/references.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/references.rs
@@ -28,7 +28,7 @@ pub async fn module_references(
     let parsed = parse(
         source,
         Value::new(EcmascriptModuleAssetType::Ecmascript),
-        transforms,
+        *transforms,
     )
     .await?;
     match &*parsed {

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/references.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/references.rs
@@ -6,7 +6,7 @@ use swc_core::{
         visit::{Visit, VisitWith},
     },
 };
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{Value, Vc};
 use turbopack_core::{
     reference::{ModuleReference, ModuleReferences},
     source::Source,
@@ -62,9 +62,9 @@ pub async fn module_references(
 }
 
 struct ModuleReferencesVisitor<'a> {
-    runtime: ResolvedVc<WebpackRuntime>,
-    references: &'a mut Vec<ResolvedVc<Box<dyn ModuleReference>>>,
-    transforms: ResolvedVc<EcmascriptInputTransforms>,
+    runtime: Vc<WebpackRuntime>,
+    references: &'a mut Vec<Vc<Box<dyn ModuleReference>>>,
+    transforms: Vc<EcmascriptInputTransforms>,
 }
 
 impl Visit for ModuleReferencesVisitor<'_> {

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/references.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/references.rs
@@ -6,7 +6,7 @@ use swc_core::{
         visit::{Visit, VisitWith},
     },
 };
-use turbo_tasks::{Value, Vc};
+use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbopack_core::{
     reference::{ModuleReference, ModuleReferences},
     source::Source,
@@ -23,7 +23,7 @@ use crate::{
 pub async fn module_references(
     source: Vc<Box<dyn Source>>,
     runtime: Vc<WebpackRuntime>,
-    transforms: Vc<EcmascriptInputTransforms>,
+    transforms: ResolvedVc<EcmascriptInputTransforms>,
 ) -> Result<Vc<ModuleReferences>> {
     let parsed = parse(
         source,
@@ -64,7 +64,7 @@ pub async fn module_references(
 struct ModuleReferencesVisitor<'a> {
     runtime: Vc<WebpackRuntime>,
     references: &'a mut Vec<Vc<Box<dyn ModuleReference>>>,
-    transforms: Vc<EcmascriptInputTransforms>,
+    transforms: ResolvedVc<EcmascriptInputTransforms>,
 }
 
 impl Visit for ModuleReferencesVisitor<'_> {

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -54,7 +54,7 @@ impl WorkerLoaderChunkItem {
                     .chunk_path(module.inner.ident(), ".js".into()),
             )
             .with_modifier(worker_modifier()),
-            EvaluatableAssets::empty().with_entry(evaluatable),
+            EvaluatableAssets::empty().with_entry(*evaluatable),
             Value::new(AvailabilityInfo::Root),
         ))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -73,7 +73,7 @@ impl WorkerLoaderChunkItem {
 impl EcmascriptChunkItem for WorkerLoaderChunkItem {
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        self.chunking_context
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -138,7 +138,7 @@ impl ChunkItem for WorkerLoaderChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        Vc::upcast(self.chunking_context)
+        *ResolvedVc::upcast(self.chunking_context)
     }
 
     #[turbo_tasks::function]
@@ -150,6 +150,6 @@ impl ChunkItem for WorkerLoaderChunkItem {
 
     #[turbo_tasks::function]
     fn module(&self) -> Vc<Box<dyn Module>> {
-        Vc::upcast(self.module)
+        *ResolvedVc::upcast(self.module)
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -40,7 +40,7 @@ impl WorkerLoaderChunkItem {
         let module = self.module.await?;
 
         let Some(evaluatable) =
-            Vc::try_resolve_downcast::<Box<dyn EvaluatableAsset>>(module.inner).await?
+            ResolvedVc::try_downcast::<Box<dyn EvaluatableAsset>>(module.inner).await?
         else {
             bail!(
                 "{} is not evaluatable for Worker loader module",

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -26,7 +26,7 @@ pub struct WorkerLoaderModule {
 #[turbo_tasks::value_impl]
 impl WorkerLoaderModule {
     #[turbo_tasks::function]
-    pub fn new(module: Vc<Box<dyn ChunkableModule>>) -> Vc<Self> {
+    pub fn new(module: ResolvedVc<Box<dyn ChunkableModule>>) -> Vc<Self> {
         Self::cell(WorkerLoaderModule { inner: module })
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -69,8 +69,8 @@ impl Asset for WorkerLoaderModule {
 impl ChunkableModule for WorkerLoaderModule {
     #[turbo_tasks::function]
     fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
+        self: ResolvedVc<Self>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
         Vc::upcast(
             WorkerLoaderChunkItem {

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -45,13 +45,13 @@ fn inner_module_reference_description() -> Vc<RcStr> {
 impl Module for WorkerLoaderModule {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        Self::asset_ident_for(self.inner)
+        Self::asset_ident_for(*self.inner)
     }
 
     #[turbo_tasks::function]
     async fn references(self: Vc<Self>) -> Result<Vc<ModuleReferences>> {
         Ok(Vc::cell(vec![Vc::upcast(SingleModuleReference::new(
-            Vc::upcast(self.await?.inner),
+            *ResolvedVc::upcast(self.await?.inner),
             inner_module_reference_description(),
         ))]))
     }

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -249,11 +249,11 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         conditions,
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
             prepend: ResolvedVc::cell(vec![
-                EcmascriptInputTransform::Plugin(Vc::cell(Box::new(
+                EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(
                     EmotionTransformer::new(&EmotionTransformConfig::default())
                         .expect("Should be able to create emotion transformer"),
                 ) as _)),
-                EcmascriptInputTransform::Plugin(Vc::cell(Box::new(
+                EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(
                     StyledComponentsTransformer::new(&StyledComponentsTransformConfig::default()),
                 ) as _)),
             ]),

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -120,8 +120,8 @@ impl ModuleOptions {
             transforms.push(EcmascriptInputTransform::React {
                 development: jsx.development,
                 refresh: jsx.react_refresh,
-                import_source: Vc::cell(jsx.import_source.clone()),
-                runtime: Vc::cell(jsx.runtime.clone()),
+                import_source: ResolvedVc::cell(jsx.import_source.clone()),
+                runtime: ResolvedVc::cell(jsx.runtime.clone()),
             });
         }
 


### PR DESCRIPTION
### What?

Use `ResolvedVc` for struct fields in `turbopack-ecmascript` crate

### Why?

Follow-up of https://github.com/vercel/next.js/pull/72200, https://github.com/vercel/next.js/pull/72382, https://github.com/vercel/next.js/pull/72320

### How?

Closes PACK-3438