### PR TITLE
fix(turbopack): Depend on side effect from import binding

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -111,6 +111,11 @@ pub(crate) struct ItemData {
     ///
     /// Used to optimize `ImportBinding`.
     pub binding_source: Option<(Str, ImportSpecifier)>,
+
+    /// Explicit dependencies of this item.
+    ///
+    /// Used to depend from import binding to side-effect-import without additional analysis.
+    pub explicit_deps: Vec<ItemId>,
 }
 
 impl fmt::Debug for ItemData {
@@ -143,6 +148,7 @@ impl Default for ItemData {
             pure: Default::default(),
             export: Default::default(),
             binding_source: Default::default(),
+            explicit_deps: Default::default(),
         }
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -136,6 +136,7 @@ impl fmt::Debug for ItemData {
             .field("eventual_write_vars", &self.eventual_write_vars)
             .field("side_effects", &self.side_effects)
             .field("export", &self.export)
+            .field("explicit_deps", &self.explicit_deps)
             .finish()
     }
 }
@@ -471,6 +472,8 @@ impl DepGraph {
                         if let Some((module_specifier, import_specifier)) =
                             &dep_item_data.binding_source
                         {
+                            debug_assert!(!dep_item_data.explicit_deps.is_empty());
+
                             // Preserve the order of the side effects by importing the import
                             // binding fragment
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -79,6 +79,8 @@ impl Analyzer<'_> {
             vars: Default::default(),
         };
 
+        analyzer.handle_explicit_deps();
+
         let eventual_ids = analyzer.hoist_vars_and_bindings();
 
         analyzer.evaluate_immediate(module, &eventual_ids);
@@ -88,6 +90,16 @@ impl Analyzer<'_> {
         analyzer.handle_exports(module);
 
         (g, items)
+    }
+
+    fn handle_explicit_deps(&mut self) {
+        for item_id in self.item_ids.iter() {
+            if let Some(item) = self.items.get(item_id) {
+                if !item.explicit_deps.is_empty() {
+                    self.g.add_strong_deps(item_id, item.explicit_deps.iter());
+                }
+            }
+        }
     }
 
     /// Phase 1: Hoisted Variables and Bindings

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -79,8 +79,6 @@ impl Analyzer<'_> {
             vars: Default::default(),
         };
 
-        analyzer.handle_explicit_deps();
-
         let eventual_ids = analyzer.hoist_vars_and_bindings();
 
         analyzer.evaluate_immediate(module, &eventual_ids);
@@ -88,6 +86,8 @@ impl Analyzer<'_> {
         analyzer.evaluate_eventual(module);
 
         analyzer.handle_exports(module);
+
+        analyzer.handle_explicit_deps();
 
         (g, items)
     }

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/1/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/1/output.md
@@ -459,9 +459,6 @@ import "module";
 ```
 ## Part 6
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
 import { upper } from "module";
 export { upper as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -574,7 +571,7 @@ import { d as foobar } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -7
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: -6
 };
 import { upper } from "module";
 import "__TURBOPACK_PART__" assert {
@@ -720,9 +717,6 @@ import "module";
 ```
 ## Part 6
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
 import { upper } from "module";
 export { upper as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -817,7 +811,7 @@ import { d as foobar } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -7
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: -6
 };
 import { upper } from "module";
 import "__TURBOPACK_PART__" assert {

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/2/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/2/output.md
@@ -498,9 +498,6 @@ import "module";
 ```
 ## Part 7
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { upper } from "module";
 export { upper as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -613,7 +610,7 @@ import { d as foobar } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -8
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -7
 };
 import { upper } from "module";
 import "__TURBOPACK_PART__" assert {
@@ -767,9 +764,6 @@ import "module";
 ```
 ## Part 7
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { upper } from "module";
 export { upper as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -864,7 +858,7 @@ import { d as foobar } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -8
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -7
 };
 import { upper } from "module";
 import "__TURBOPACK_PART__" assert {

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/amphtml-document/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/amphtml-document/output.md
@@ -341,9 +341,6 @@ import "react/jsx-runtime";
 ```
 ## Part 3
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { jsx as _jsx } from "react/jsx-runtime";
 export { _jsx as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -352,9 +349,6 @@ export { _jsx as b } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 4
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { jsxs as _jsxs } from "react/jsx-runtime";
 export { _jsxs as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -363,9 +357,6 @@ export { _jsxs as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 5
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { Fragment as _Fragment } from "react/jsx-runtime";
 export { _Fragment as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -382,9 +373,6 @@ import 'next/document';
 ```
 ## Part 7
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import Document from 'next/document';
 export { Document as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -393,9 +381,6 @@ export { Document as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { Html } from 'next/document';
 export { Html as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -404,9 +389,6 @@ export { Html as f } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 9
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { Head } from 'next/document';
 export { Head as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -415,9 +397,6 @@ export { Head as g } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 10
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { Main } from 'next/document';
 export { Main as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -426,9 +405,6 @@ export { Main as h } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 11
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { NextScript } from 'next/document';
 export { NextScript as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -438,35 +414,35 @@ export { NextScript as i } from "__TURBOPACK_VAR__" assert {
 ## Part 12
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -7
 };
 import Document from 'next/document';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: -4
 };
 import { jsxs as _jsxs } from "react/jsx-runtime";
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: -5
 };
 import { Fragment as _Fragment } from "react/jsx-runtime";
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: -3
 };
 import { jsx as _jsx } from "react/jsx-runtime";
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -8
 };
 import { Html } from 'next/document';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -9
 };
 import { Head } from 'next/document';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -10
 };
 import { Main } from 'next/document';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -11
 };
 import { NextScript } from 'next/document';
 class MyDocument extends Document {
@@ -571,9 +547,6 @@ import "react/jsx-runtime";
 ```
 ## Part 3
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { jsx as _jsx } from "react/jsx-runtime";
 export { _jsx as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -582,9 +555,6 @@ export { _jsx as b } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 4
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { jsxs as _jsxs } from "react/jsx-runtime";
 export { _jsxs as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -593,9 +563,6 @@ export { _jsxs as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 5
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { Fragment as _Fragment } from "react/jsx-runtime";
 export { _Fragment as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -612,9 +579,6 @@ import 'next/document';
 ```
 ## Part 7
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import Document from 'next/document';
 export { Document as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -623,9 +587,6 @@ export { Document as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { Html } from 'next/document';
 export { Html as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -634,9 +595,6 @@ export { Html as f } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 9
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { Head } from 'next/document';
 export { Head as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -645,9 +603,6 @@ export { Head as g } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 10
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { Main } from 'next/document';
 export { Main as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -656,9 +611,6 @@ export { Main as h } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 11
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { NextScript } from 'next/document';
 export { NextScript as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -668,35 +620,35 @@ export { NextScript as i } from "__TURBOPACK_VAR__" assert {
 ## Part 12
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -7
 };
 import Document from 'next/document';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: -4
 };
 import { jsxs as _jsxs } from "react/jsx-runtime";
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: -5
 };
 import { Fragment as _Fragment } from "react/jsx-runtime";
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: -3
 };
 import { jsx as _jsx } from "react/jsx-runtime";
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -8
 };
 import { Html } from 'next/document';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -9
 };
 import { Head } from 'next/document';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -10
 };
 import { Main } from 'next/document';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -11
 };
 import { NextScript } from 'next/document';
 class MyDocument extends Document {

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/app-route/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/app-route/output.md
@@ -456,9 +456,6 @@ import '../../server/future/route-modules/app-route/module.compiled';
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
 import { AppRouteRouteModule } from '../../server/future/route-modules/app-route/module.compiled';
 export { AppRouteRouteModule as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -475,9 +472,6 @@ import '../../server/future/route-kind';
 ```
 ## Part 10
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
-};
 import { RouteKind } from '../../server/future/route-kind';
 export { RouteKind as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -494,9 +488,6 @@ import '../../server/lib/patch-fetch';
 ```
 ## Part 12
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
-};
 import { patchFetch as _patchFetch } from '../../server/lib/patch-fetch';
 export { _patchFetch as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -513,9 +504,6 @@ import 'VAR_USERLAND';
 ```
 ## Part 14
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
-};
 import * as userland from 'VAR_USERLAND';
 export { userland as j } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -525,15 +513,15 @@ export { userland as j } from "__TURBOPACK_VAR__" assert {
 ## Part 15
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
+    __turbopack_part__: -8
 };
 import { AppRouteRouteModule } from '../../server/future/route-modules/app-route/module.compiled';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
+    __turbopack_part__: -10
 };
 import { RouteKind } from '../../server/future/route-kind';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
+    __turbopack_part__: -14
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -590,7 +578,7 @@ import { f as workAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -16
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+    __turbopack_part__: -12
 };
 import { patchFetch as _patchFetch } from '../../server/lib/patch-fetch';
 import { e as serverHooks } from "__TURBOPACK_PART__" assert {
@@ -735,9 +723,6 @@ import '../../server/future/route-modules/app-route/module.compiled';
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
 import { AppRouteRouteModule } from '../../server/future/route-modules/app-route/module.compiled';
 export { AppRouteRouteModule as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -754,9 +739,6 @@ import '../../server/future/route-kind';
 ```
 ## Part 10
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
-};
 import { RouteKind } from '../../server/future/route-kind';
 export { RouteKind as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -773,9 +755,6 @@ import '../../server/lib/patch-fetch';
 ```
 ## Part 12
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
-};
 import { patchFetch as _patchFetch } from '../../server/lib/patch-fetch';
 export { _patchFetch as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -792,9 +771,6 @@ import 'VAR_USERLAND';
 ```
 ## Part 14
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
-};
 import * as userland from 'VAR_USERLAND';
 export { userland as j } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -804,15 +780,15 @@ export { userland as j } from "__TURBOPACK_VAR__" assert {
 ## Part 15
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
+    __turbopack_part__: -8
 };
 import { AppRouteRouteModule } from '../../server/future/route-modules/app-route/module.compiled';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
+    __turbopack_part__: -10
 };
 import { RouteKind } from '../../server/future/route-kind';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
+    __turbopack_part__: -14
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -866,7 +842,7 @@ import { f as workAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -16
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+    __turbopack_part__: -12
 };
 import { patchFetch as _patchFetch } from '../../server/lib/patch-fetch';
 import { e as serverHooks } from "__TURBOPACK_PART__" assert {

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/dce/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/dce/output.md
@@ -114,9 +114,6 @@ import './module';
 ```
 ## Part 2
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
 import { baz } from './module';
 export { baz as a } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -126,7 +123,7 @@ export { baz as a } from "__TURBOPACK_VAR__" assert {
 ## Part 3
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+    __turbopack_part__: -2
 };
 import { baz } from './module';
 import "__TURBOPACK_PART__" assert {
@@ -175,9 +172,6 @@ import './module';
 ```
 ## Part 2
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
 import { baz } from './module';
 export { baz as a } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -187,7 +181,7 @@ export { baz as a } from "__TURBOPACK_VAR__" assert {
 ## Part 3
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+    __turbopack_part__: -2
 };
 import { baz } from './module';
 import "__TURBOPACK_PART__" assert {

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/export-named/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/export-named/output.md
@@ -113,9 +113,6 @@ import "./lib";
 ```
 ## Part 3
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { cat as __TURBOPACK__reexport__cat__ } from "./lib";
 export { __TURBOPACK__reexport__cat__ as a } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -174,9 +171,6 @@ import "./lib";
 ```
 ## Part 3
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { cat as __TURBOPACK__reexport__cat__ } from "./lib";
 export { __TURBOPACK__reexport__cat__ as a } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-2/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-2/output.md
@@ -725,9 +725,6 @@ import 'react';
 ```
 ## Part 10
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
-};
 import React from 'react';
 export { React as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -744,9 +741,6 @@ import '../../client/components/hooks-server-context';
 ```
 ## Part 12
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
-};
 import { DynamicServerError } from '../../client/components/hooks-server-context';
 export { DynamicServerError as j } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -763,9 +757,6 @@ import '../../client/components/static-generation-bailout';
 ```
 ## Part 14
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
-};
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout';
 export { StaticGenBailoutError as k } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -782,9 +773,6 @@ import '../../lib/url';
 ```
 ## Part 16
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
-};
 import { getPathname } from '../../lib/url';
 export { getPathname as l } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -794,7 +782,7 @@ export { getPathname as l } from "__TURBOPACK_VAR__" assert {
 ## Part 17
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
+    __turbopack_part__: -10
 };
 import React from 'react';
 import "__TURBOPACK_PART__" assert {
@@ -851,15 +839,15 @@ export { createPrerenderState as c } from "__TURBOPACK_VAR__" assert {
 ## Part 19
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+    __turbopack_part__: -12
 };
 import { DynamicServerError } from '../../client/components/hooks-server-context';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+    __turbopack_part__: -16
 };
 import { getPathname } from '../../lib/url';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
+    __turbopack_part__: -14
 };
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout';
 import { n as postponeWithTracking } from "__TURBOPACK_PART__" assert {
@@ -891,15 +879,15 @@ export { markCurrentScopeAsDynamic as e } from "__TURBOPACK_VAR__" assert {
 ## Part 20
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+    __turbopack_part__: -12
 };
 import { DynamicServerError } from '../../client/components/hooks-server-context';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+    __turbopack_part__: -16
 };
 import { getPathname } from '../../lib/url';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
+    __turbopack_part__: -14
 };
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout';
 import { n as postponeWithTracking } from "__TURBOPACK_PART__" assert {
@@ -992,7 +980,7 @@ export { formatDynamicAPIAccesses as d } from "__TURBOPACK_VAR__" assert {
 ## Part 25
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
+    __turbopack_part__: -10
 };
 import React from 'react';
 import { o as assertPostpone } from "__TURBOPACK_PART__" assert {
@@ -1163,9 +1151,6 @@ import 'react';
 ```
 ## Part 10
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
-};
 import React from 'react';
 export { React as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1182,9 +1167,6 @@ import '../../client/components/hooks-server-context';
 ```
 ## Part 12
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
-};
 import { DynamicServerError } from '../../client/components/hooks-server-context';
 export { DynamicServerError as j } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1201,9 +1183,6 @@ import '../../client/components/static-generation-bailout';
 ```
 ## Part 14
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
-};
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout';
 export { StaticGenBailoutError as k } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1220,9 +1199,6 @@ import '../../lib/url';
 ```
 ## Part 16
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
-};
 import { getPathname } from '../../lib/url';
 export { getPathname as l } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1232,7 +1208,7 @@ export { getPathname as l } from "__TURBOPACK_VAR__" assert {
 ## Part 17
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
+    __turbopack_part__: -10
 };
 import React from 'react';
 import "__TURBOPACK_PART__" assert {
@@ -1260,15 +1236,15 @@ export { createPrerenderState as c } from "__TURBOPACK_VAR__" assert {
 ## Part 19
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+    __turbopack_part__: -12
 };
 import { DynamicServerError } from '../../client/components/hooks-server-context';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+    __turbopack_part__: -16
 };
 import { getPathname } from '../../lib/url';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
+    __turbopack_part__: -14
 };
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout';
 import { n as postponeWithTracking } from "__TURBOPACK_PART__" assert {
@@ -1300,15 +1276,15 @@ export { markCurrentScopeAsDynamic as e } from "__TURBOPACK_VAR__" assert {
 ## Part 20
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+    __turbopack_part__: -12
 };
 import { DynamicServerError } from '../../client/components/hooks-server-context';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+    __turbopack_part__: -16
 };
 import { getPathname } from '../../lib/url';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
+    __turbopack_part__: -14
 };
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout';
 import { n as postponeWithTracking } from "__TURBOPACK_PART__" assert {
@@ -1367,7 +1343,7 @@ export { trackDynamicFetch as g } from "__TURBOPACK_VAR__" assert {
 ## Part 23
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
+    __turbopack_part__: -10
 };
 import React from 'react';
 import { o as assertPostpone } from "__TURBOPACK_PART__" assert {
@@ -1442,7 +1418,7 @@ export { assertPostpone as o } from "__TURBOPACK_VAR__" assert {
 ## Part 27
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
+    __turbopack_part__: -10
 };
 import React from 'react';
 import { o as assertPostpone } from "__TURBOPACK_PART__" assert {

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-3/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-3/output.md
@@ -1176,9 +1176,6 @@ import "node:net";
 ```
 ## Part 4
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
-};
 import { createConnection } from "node:net";
 export { createConnection as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1195,9 +1192,6 @@ import "../compiled/stacktrace-parser";
 ```
 ## Part 6
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
 import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
 export { parseStackTrace as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1214,9 +1208,6 @@ import "./error";
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
 import { getProperError } from "./error";
 export { getProperError as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1226,11 +1217,11 @@ export { getProperError as e } from "__TURBOPACK_VAR__" assert {
 ## Part 9
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: -6
 };
 import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
+    __turbopack_part__: -8
 };
 import { getProperError } from "./error";
 function structuredError(e) {
@@ -1252,7 +1243,7 @@ import { b as structuredError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -9
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+    __turbopack_part__: -4
 };
 import { createConnection } from "node:net";
 function createIpc(port) {
@@ -1927,9 +1918,6 @@ import "node:net";
 ```
 ## Part 4
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
-};
 import { createConnection } from "node:net";
 export { createConnection as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1946,9 +1934,6 @@ import "../compiled/stacktrace-parser";
 ```
 ## Part 6
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
 import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
 export { parseStackTrace as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1965,9 +1950,6 @@ import "./error";
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
 import { getProperError } from "./error";
 export { getProperError as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1977,11 +1959,11 @@ export { getProperError as e } from "__TURBOPACK_VAR__" assert {
 ## Part 9
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: -6
 };
 import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
+    __turbopack_part__: -8
 };
 import { getProperError } from "./error";
 function structuredError(e) {
@@ -2003,7 +1985,7 @@ import { b as structuredError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -9
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+    __turbopack_part__: -4
 };
 import { createConnection } from "node:net";
 function createIpc(port) {

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/ipc-evaluate/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/ipc-evaluate/output.md
@@ -267,9 +267,6 @@ import "./index";
 ```
 ## Part 3
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { IPC } from "./index";
 export { IPC as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -279,7 +276,7 @@ export { IPC as b } from "__TURBOPACK_VAR__" assert {
 ## Part 4
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: -3
 };
 import { IPC } from "./index";
 const ipc = IPC;
@@ -455,9 +452,6 @@ import "./index";
 ```
 ## Part 3
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { IPC } from "./index";
 export { IPC as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -467,7 +461,7 @@ export { IPC as b } from "__TURBOPACK_VAR__" assert {
 ## Part 4
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: -3
 };
 import { IPC } from "./index";
 const ipc = IPC;

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/ipc-index/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/ipc-index/output.md
@@ -1176,9 +1176,6 @@ import "node:net";
 ```
 ## Part 4
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
-};
 import { createConnection } from "node:net";
 export { createConnection as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1195,9 +1192,6 @@ import "../compiled/stacktrace-parser";
 ```
 ## Part 6
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
 import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
 export { parseStackTrace as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1214,9 +1208,6 @@ import "./error";
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
 import { getProperError } from "./error";
 export { getProperError as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1226,11 +1217,11 @@ export { getProperError as e } from "__TURBOPACK_VAR__" assert {
 ## Part 9
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: -6
 };
 import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
+    __turbopack_part__: -8
 };
 import { getProperError } from "./error";
 function structuredError(e) {
@@ -1252,7 +1243,7 @@ import { b as structuredError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -9
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+    __turbopack_part__: -4
 };
 import { createConnection } from "node:net";
 function createIpc(port) {
@@ -1927,9 +1918,6 @@ import "node:net";
 ```
 ## Part 4
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
-};
 import { createConnection } from "node:net";
 export { createConnection as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1946,9 +1934,6 @@ import "../compiled/stacktrace-parser";
 ```
 ## Part 6
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
 import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
 export { parseStackTrace as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1965,9 +1950,6 @@ import "./error";
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
 import { getProperError } from "./error";
 export { getProperError as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1977,11 +1959,11 @@ export { getProperError as e } from "__TURBOPACK_VAR__" assert {
 ## Part 9
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: -6
 };
 import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
+    __turbopack_part__: -8
 };
 import { getProperError } from "./error";
 function structuredError(e) {
@@ -2003,7 +1985,7 @@ import { b as structuredError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -9
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+    __turbopack_part__: -4
 };
 import { createConnection } from "node:net";
 function createIpc(port) {

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/mui-sys/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/mui-sys/output.md
@@ -1201,9 +1201,6 @@ import './style';
 ```
 ## Part 15
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
 import style from './style';
 export { style as n } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1220,9 +1217,6 @@ import './compose';
 ```
 ## Part 17
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
-};
 import compose from './compose';
 export { compose as o } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1239,9 +1233,6 @@ import './spacing';
 ```
 ## Part 19
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
-};
 import { createUnaryUnit } from './spacing';
 export { createUnaryUnit as p } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1250,9 +1241,6 @@ export { createUnaryUnit as p } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 20
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
-};
 import { getValue } from './spacing';
 export { getValue as q } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1269,9 +1257,6 @@ import './breakpoints';
 ```
 ## Part 22
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
-};
 import { handleBreakpoints } from './breakpoints';
 export { handleBreakpoints as r } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1288,9 +1273,6 @@ import './responsivePropType';
 ```
 ## Part 24
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
-};
 import responsivePropType from './responsivePropType';
 export { responsivePropType as s } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1300,15 +1282,15 @@ export { responsivePropType as s } from "__TURBOPACK_VAR__" assert {
 ## Part 25
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+    __turbopack_part__: -19
 };
 import { createUnaryUnit } from './spacing';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+    __turbopack_part__: -20
 };
 import { getValue } from './spacing';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+    __turbopack_part__: -22
 };
 import { handleBreakpoints } from './breakpoints';
 import "__TURBOPACK_PART__" assert {
@@ -1335,7 +1317,7 @@ import { c as gap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -25
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import responsivePropType from './responsivePropType';
 gap.propTypes = process.env.NODE_ENV !== 'production' ? {
@@ -1359,15 +1341,15 @@ gap.filterProps = [
 ## Part 28
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+    __turbopack_part__: -19
 };
 import { createUnaryUnit } from './spacing';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+    __turbopack_part__: -20
 };
 import { getValue } from './spacing';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+    __turbopack_part__: -22
 };
 import { handleBreakpoints } from './breakpoints';
 import "__TURBOPACK_PART__" assert {
@@ -1394,7 +1376,7 @@ import { b as columnGap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -28
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import responsivePropType from './responsivePropType';
 columnGap.propTypes = process.env.NODE_ENV !== 'production' ? {
@@ -1418,15 +1400,15 @@ columnGap.filterProps = [
 ## Part 31
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+    __turbopack_part__: -19
 };
 import { createUnaryUnit } from './spacing';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+    __turbopack_part__: -20
 };
 import { getValue } from './spacing';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+    __turbopack_part__: -22
 };
 import { handleBreakpoints } from './breakpoints';
 import "__TURBOPACK_PART__" assert {
@@ -1453,7 +1435,7 @@ import { m as rowGap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -31
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import responsivePropType from './responsivePropType';
 rowGap.propTypes = process.env.NODE_ENV !== 'production' ? {
@@ -1477,7 +1459,7 @@ rowGap.filterProps = [
 ## Part 34
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+    __turbopack_part__: -15
 };
 import style from './style';
 import "__TURBOPACK_PART__" assert {
@@ -1494,7 +1476,7 @@ export { gridColumn as h } from "__TURBOPACK_VAR__" assert {
 ## Part 35
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+    __turbopack_part__: -15
 };
 import style from './style';
 import "__TURBOPACK_PART__" assert {
@@ -1511,7 +1493,7 @@ export { gridRow as i } from "__TURBOPACK_VAR__" assert {
 ## Part 36
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+    __turbopack_part__: -15
 };
 import style from './style';
 import "__TURBOPACK_PART__" assert {
@@ -1528,7 +1510,7 @@ export { gridAutoFlow as f } from "__TURBOPACK_VAR__" assert {
 ## Part 37
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+    __turbopack_part__: -15
 };
 import style from './style';
 import "__TURBOPACK_PART__" assert {
@@ -1545,7 +1527,7 @@ export { gridAutoColumns as e } from "__TURBOPACK_VAR__" assert {
 ## Part 38
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+    __turbopack_part__: -15
 };
 import style from './style';
 import "__TURBOPACK_PART__" assert {
@@ -1562,7 +1544,7 @@ export { gridAutoRows as g } from "__TURBOPACK_VAR__" assert {
 ## Part 39
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+    __turbopack_part__: -15
 };
 import style from './style';
 import "__TURBOPACK_PART__" assert {
@@ -1579,7 +1561,7 @@ export { gridTemplateColumns as k } from "__TURBOPACK_VAR__" assert {
 ## Part 40
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+    __turbopack_part__: -15
 };
 import style from './style';
 import "__TURBOPACK_PART__" assert {
@@ -1596,7 +1578,7 @@ export { gridTemplateRows as l } from "__TURBOPACK_VAR__" assert {
 ## Part 41
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+    __turbopack_part__: -15
 };
 import style from './style';
 import "__TURBOPACK_PART__" assert {
@@ -1613,7 +1595,7 @@ export { gridTemplateAreas as j } from "__TURBOPACK_VAR__" assert {
 ## Part 42
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+    __turbopack_part__: -15
 };
 import style from './style';
 import "__TURBOPACK_PART__" assert {
@@ -1630,7 +1612,7 @@ export { gridArea as d } from "__TURBOPACK_VAR__" assert {
 ## Part 43
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
+    __turbopack_part__: -17
 };
 import compose from './compose';
 import { c as gap } from "__TURBOPACK_PART__" assert {
@@ -1924,9 +1906,6 @@ import './style';
 ```
 ## Part 15
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
 import style from './style';
 export { style as n } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1943,9 +1922,6 @@ import './compose';
 ```
 ## Part 17
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
-};
 import compose from './compose';
 export { compose as o } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1962,9 +1938,6 @@ import './spacing';
 ```
 ## Part 19
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
-};
 import { createUnaryUnit } from './spacing';
 export { createUnaryUnit as p } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1973,9 +1946,6 @@ export { createUnaryUnit as p } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 20
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
-};
 import { getValue } from './spacing';
 export { getValue as q } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1992,9 +1962,6 @@ import './breakpoints';
 ```
 ## Part 22
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
-};
 import { handleBreakpoints } from './breakpoints';
 export { handleBreakpoints as r } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -2011,9 +1978,6 @@ import './responsivePropType';
 ```
 ## Part 24
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
-};
 import responsivePropType from './responsivePropType';
 export { responsivePropType as s } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -2023,15 +1987,15 @@ export { responsivePropType as s } from "__TURBOPACK_VAR__" assert {
 ## Part 25
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+    __turbopack_part__: -19
 };
 import { createUnaryUnit } from './spacing';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+    __turbopack_part__: -20
 };
 import { getValue } from './spacing';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+    __turbopack_part__: -22
 };
 import { handleBreakpoints } from './breakpoints';
 import "__TURBOPACK_PART__" assert {
@@ -2058,7 +2022,7 @@ import { c as gap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -25
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import responsivePropType from './responsivePropType';
 gap.propTypes = process.env.NODE_ENV !== 'production' ? {
@@ -2082,15 +2046,15 @@ gap.filterProps = [
 ## Part 28
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+    __turbopack_part__: -19
 };
 import { createUnaryUnit } from './spacing';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+    __turbopack_part__: -20
 };
 import { getValue } from './spacing';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+    __turbopack_part__: -22
 };
 import { handleBreakpoints } from './breakpoints';
 import "__TURBOPACK_PART__" assert {
@@ -2117,7 +2081,7 @@ import { b as columnGap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -28
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import responsivePropType from './responsivePropType';
 columnGap.propTypes = process.env.NODE_ENV !== 'production' ? {
@@ -2141,15 +2105,15 @@ columnGap.filterProps = [
 ## Part 31
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+    __turbopack_part__: -19
 };
 import { createUnaryUnit } from './spacing';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+    __turbopack_part__: -20
 };
 import { getValue } from './spacing';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+    __turbopack_part__: -22
 };
 import { handleBreakpoints } from './breakpoints';
 import "__TURBOPACK_PART__" assert {
@@ -2176,7 +2140,7 @@ import { m as rowGap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -31
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import responsivePropType from './responsivePropType';
 rowGap.propTypes = process.env.NODE_ENV !== 'production' ? {
@@ -2200,7 +2164,7 @@ rowGap.filterProps = [
 ## Part 34
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+    __turbopack_part__: -15
 };
 import style from './style';
 import "__TURBOPACK_PART__" assert {
@@ -2217,7 +2181,7 @@ export { gridColumn as h } from "__TURBOPACK_VAR__" assert {
 ## Part 35
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+    __turbopack_part__: -15
 };
 import style from './style';
 import "__TURBOPACK_PART__" assert {
@@ -2234,7 +2198,7 @@ export { gridRow as i } from "__TURBOPACK_VAR__" assert {
 ## Part 36
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+    __turbopack_part__: -15
 };
 import style from './style';
 import "__TURBOPACK_PART__" assert {
@@ -2251,7 +2215,7 @@ export { gridAutoFlow as f } from "__TURBOPACK_VAR__" assert {
 ## Part 37
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+    __turbopack_part__: -15
 };
 import style from './style';
 import "__TURBOPACK_PART__" assert {
@@ -2268,7 +2232,7 @@ export { gridAutoColumns as e } from "__TURBOPACK_VAR__" assert {
 ## Part 38
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+    __turbopack_part__: -15
 };
 import style from './style';
 import "__TURBOPACK_PART__" assert {
@@ -2285,7 +2249,7 @@ export { gridAutoRows as g } from "__TURBOPACK_VAR__" assert {
 ## Part 39
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+    __turbopack_part__: -15
 };
 import style from './style';
 import "__TURBOPACK_PART__" assert {
@@ -2302,7 +2266,7 @@ export { gridTemplateColumns as k } from "__TURBOPACK_VAR__" assert {
 ## Part 40
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+    __turbopack_part__: -15
 };
 import style from './style';
 import "__TURBOPACK_PART__" assert {
@@ -2319,7 +2283,7 @@ export { gridTemplateRows as l } from "__TURBOPACK_VAR__" assert {
 ## Part 41
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+    __turbopack_part__: -15
 };
 import style from './style';
 import "__TURBOPACK_PART__" assert {
@@ -2336,7 +2300,7 @@ export { gridTemplateAreas as j } from "__TURBOPACK_VAR__" assert {
 ## Part 42
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+    __turbopack_part__: -15
 };
 import style from './style';
 import "__TURBOPACK_PART__" assert {
@@ -2353,7 +2317,7 @@ export { gridArea as d } from "__TURBOPACK_VAR__" assert {
 ## Part 43
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
+    __turbopack_part__: -17
 };
 import compose from './compose';
 import { c as gap } from "__TURBOPACK_PART__" assert {

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nanoid/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nanoid/output.md
@@ -460,7 +460,7 @@ export { random };
 ## Part 5
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
+    __turbopack_part__: -9
 };
 import { urlAlphabet } from './url-alphabet/index.js';
 import "__TURBOPACK_PART__" assert {
@@ -476,9 +476,6 @@ import 'crypto';
 ```
 ## Part 7
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import crypto from 'crypto';
 export { crypto as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -495,9 +492,6 @@ import './url-alphabet/index.js';
 ```
 ## Part 9
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
-};
 import { urlAlphabet } from './url-alphabet/index.js';
 export { urlAlphabet as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -537,7 +531,7 @@ import { g as POOL_SIZE_MULTIPLIER } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -10
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -7
 };
 import crypto from 'crypto';
 import { i as poolOffset } from "__TURBOPACK_PART__" assert {
@@ -630,7 +624,7 @@ import { i as poolOffset } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -12
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
+    __turbopack_part__: -9
 };
 import { urlAlphabet } from './url-alphabet/index.js';
 import { h as pool } from "__TURBOPACK_PART__" assert {
@@ -748,7 +742,7 @@ export { random };
 ## Part 5
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
+    __turbopack_part__: -9
 };
 import { urlAlphabet } from './url-alphabet/index.js';
 import "__TURBOPACK_PART__" assert {
@@ -764,9 +758,6 @@ import 'crypto';
 ```
 ## Part 7
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import crypto from 'crypto';
 export { crypto as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -783,9 +774,6 @@ import './url-alphabet/index.js';
 ```
 ## Part 9
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
-};
 import { urlAlphabet } from './url-alphabet/index.js';
 export { urlAlphabet as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -825,7 +813,7 @@ import { g as POOL_SIZE_MULTIPLIER } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -10
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -7
 };
 import crypto from 'crypto';
 import { i as poolOffset } from "__TURBOPACK_PART__" assert {
@@ -918,7 +906,7 @@ import { i as poolOffset } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -12
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
+    __turbopack_part__: -9
 };
 import { urlAlphabet } from './url-alphabet/index.js';
 import { h as pool } from "__TURBOPACK_PART__" assert {

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/next-response/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/next-response/output.md
@@ -482,9 +482,6 @@ import '../../web/spec-extension/cookies';
 ```
 ## Part 3
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { stringifyCookie } from '../../web/spec-extension/cookies';
 export { stringifyCookie as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -501,9 +498,6 @@ import '../next-url';
 ```
 ## Part 5
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
 import { NextURL } from '../next-url';
 export { NextURL as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -520,9 +514,6 @@ import '../utils';
 ```
 ## Part 7
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { toNodeOutgoingHttpHeaders } from '../utils';
 export { toNodeOutgoingHttpHeaders as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -531,9 +522,6 @@ export { toNodeOutgoingHttpHeaders as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { validateURL } from '../utils';
 export { validateURL as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -550,9 +538,6 @@ import './adapters/reflect';
 ```
 ## Part 10
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
-};
 import { ReflectAdapter } from './adapters/reflect';
 export { ReflectAdapter as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -569,9 +554,6 @@ import './cookies';
 ```
 ## Part 12
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
-};
 import { ResponseCookies } from './cookies';
 export { ResponseCookies as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -630,33 +612,33 @@ export { handleMiddlewareField as j } from "__TURBOPACK_VAR__" assert {
 ## Part 16
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+    __turbopack_part__: -12
 };
 import { ResponseCookies } from './cookies';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: -3
 };
 import { stringifyCookie } from '../../web/spec-extension/cookies';
 import { j as handleMiddlewareField } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -15
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
+    __turbopack_part__: -10
 };
 import { ReflectAdapter } from './adapters/reflect';
 import { h as INTERNALS } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -13
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+    __turbopack_part__: -5
 };
 import { NextURL } from '../next-url';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -7
 };
 import { toNodeOutgoingHttpHeaders } from '../utils';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -8
 };
 import { validateURL } from '../utils';
 import { i as REDIRECTS } from "__TURBOPACK_PART__" assert {
@@ -807,9 +789,6 @@ import '../../web/spec-extension/cookies';
 ```
 ## Part 3
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { stringifyCookie } from '../../web/spec-extension/cookies';
 export { stringifyCookie as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -826,9 +805,6 @@ import '../next-url';
 ```
 ## Part 5
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
 import { NextURL } from '../next-url';
 export { NextURL as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -845,9 +821,6 @@ import '../utils';
 ```
 ## Part 7
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { toNodeOutgoingHttpHeaders } from '../utils';
 export { toNodeOutgoingHttpHeaders as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -856,9 +829,6 @@ export { toNodeOutgoingHttpHeaders as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { validateURL } from '../utils';
 export { validateURL as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -875,9 +845,6 @@ import './adapters/reflect';
 ```
 ## Part 10
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
-};
 import { ReflectAdapter } from './adapters/reflect';
 export { ReflectAdapter as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -894,9 +861,6 @@ import './cookies';
 ```
 ## Part 12
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
-};
 import { ResponseCookies } from './cookies';
 export { ResponseCookies as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -955,33 +919,33 @@ export { handleMiddlewareField as j } from "__TURBOPACK_VAR__" assert {
 ## Part 16
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+    __turbopack_part__: -12
 };
 import { ResponseCookies } from './cookies';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: -3
 };
 import { stringifyCookie } from '../../web/spec-extension/cookies';
 import { j as handleMiddlewareField } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -15
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
+    __turbopack_part__: -10
 };
 import { ReflectAdapter } from './adapters/reflect';
 import { h as INTERNALS } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -13
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+    __turbopack_part__: -5
 };
 import { NextURL } from '../next-url';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -7
 };
 import { toNodeOutgoingHttpHeaders } from '../utils';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -8
 };
 import { validateURL } from '../utils';
 import { i as REDIRECTS } from "__TURBOPACK_PART__" assert {

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nextjs-tracer/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nextjs-tracer/output.md
@@ -738,9 +738,6 @@ import './constants';
 ```
 ## Part 7
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { LogSpanAllowList } from './constants';
 export { LogSpanAllowList as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -749,9 +746,6 @@ export { LogSpanAllowList as f } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { NextVanillaSpanAllowlist } from './constants';
 export { NextVanillaSpanAllowlist as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -965,7 +959,7 @@ import { s as clientTraceDataSetter } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -20
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -8
 };
 import { NextVanillaSpanAllowlist } from './constants';
 import { l as ROOT_CONTEXT } from "__TURBOPACK_PART__" assert {
@@ -981,7 +975,7 @@ import { o as rootSpanAttributesStore } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -16
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -7
 };
 import { LogSpanAllowList } from './constants';
 import { n as closeSpanWithError } from "__TURBOPACK_PART__" assert {
@@ -1264,9 +1258,6 @@ import './constants';
 ```
 ## Part 7
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { LogSpanAllowList } from './constants';
 export { LogSpanAllowList as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1275,9 +1266,6 @@ export { LogSpanAllowList as f } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { NextVanillaSpanAllowlist } from './constants';
 export { NextVanillaSpanAllowlist as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1482,7 +1470,7 @@ import { s as clientTraceDataSetter } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -20
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -8
 };
 import { NextVanillaSpanAllowlist } from './constants';
 import { l as ROOT_CONTEXT } from "__TURBOPACK_PART__" assert {
@@ -1498,7 +1486,7 @@ import { o as rootSpanAttributesStore } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -16
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -7
 };
 import { LogSpanAllowList } from './constants';
 import { n as closeSpanWithError } from "__TURBOPACK_PART__" assert {

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/node-fetch/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/node-fetch/output.md
@@ -179,9 +179,6 @@ import 'node:stream';
 ```
 ## Part 3
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import Stream from 'node:stream';
 export { Stream as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -191,7 +188,7 @@ export { Stream as b } from "__TURBOPACK_VAR__" assert {
 ## Part 4
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: -3
 };
 import Stream from 'node:stream';
 import "__TURBOPACK_PART__" assert {
@@ -277,9 +274,6 @@ import 'node:stream';
 ```
 ## Part 3
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import Stream from 'node:stream';
 export { Stream as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -289,7 +283,7 @@ export { Stream as b } from "__TURBOPACK_VAR__" assert {
 ## Part 4
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: -3
 };
 import Stream from 'node:stream';
 import "__TURBOPACK_PART__" assert {

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/otel-core/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/otel-core/output.md
@@ -241,9 +241,6 @@ import '../../utils/environment';
 ```
 ## Part 4
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
-};
 import { DEFAULT_ENVIRONMENT } from '../../utils/environment';
 export { DEFAULT_ENVIRONMENT as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -252,9 +249,6 @@ export { DEFAULT_ENVIRONMENT as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 5
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
-};
 import { parseEnvironment } from '../../utils/environment';
 export { parseEnvironment as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -271,9 +265,6 @@ import './globalThis';
 ```
 ## Part 7
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { _globalThis } from './globalThis';
 export { _globalThis as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -283,15 +274,15 @@ export { _globalThis as e } from "__TURBOPACK_VAR__" assert {
 ## Part 8
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+    __turbopack_part__: -4
 };
 import { DEFAULT_ENVIRONMENT } from '../../utils/environment';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+    __turbopack_part__: -5
 };
 import { parseEnvironment } from '../../utils/environment';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -7
 };
 import { _globalThis } from './globalThis';
 function getEnv() {
@@ -306,11 +297,11 @@ export { getEnv as a } from "__TURBOPACK_VAR__" assert {
 ## Part 9
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -7
 };
 import { _globalThis } from './globalThis';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+    __turbopack_part__: -5
 };
 import { parseEnvironment } from '../../utils/environment';
 function getEnvWithoutDefaults() {
@@ -387,9 +378,6 @@ import '../../utils/environment';
 ```
 ## Part 4
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
-};
 import { DEFAULT_ENVIRONMENT } from '../../utils/environment';
 export { DEFAULT_ENVIRONMENT as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -398,9 +386,6 @@ export { DEFAULT_ENVIRONMENT as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 5
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
-};
 import { parseEnvironment } from '../../utils/environment';
 export { parseEnvironment as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -417,9 +402,6 @@ import './globalThis';
 ```
 ## Part 7
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { _globalThis } from './globalThis';
 export { _globalThis as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -429,15 +411,15 @@ export { _globalThis as e } from "__TURBOPACK_VAR__" assert {
 ## Part 8
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+    __turbopack_part__: -4
 };
 import { DEFAULT_ENVIRONMENT } from '../../utils/environment';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+    __turbopack_part__: -5
 };
 import { parseEnvironment } from '../../utils/environment';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -7
 };
 import { _globalThis } from './globalThis';
 function getEnv() {
@@ -452,11 +434,11 @@ export { getEnv as a } from "__TURBOPACK_VAR__" assert {
 ## Part 9
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -7
 };
 import { _globalThis } from './globalThis';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+    __turbopack_part__: -5
 };
 import { parseEnvironment } from '../../utils/environment';
 function getEnvWithoutDefaults() {

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/route-handler/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/route-handler/output.md
@@ -176,9 +176,6 @@ import "next/server";
 ```
 ## Part 4
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
-};
 import { NextResponse } from "next/server";
 export { NextResponse as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -188,7 +185,7 @@ export { NextResponse as c } from "__TURBOPACK_VAR__" assert {
 ## Part 5
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+    __turbopack_part__: -4
 };
 import { NextResponse } from "next/server";
 const GET = (req)=>{
@@ -275,9 +272,6 @@ import "next/server";
 ```
 ## Part 4
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
-};
 import { NextResponse } from "next/server";
 export { NextResponse as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -287,7 +281,7 @@ export { NextResponse as c } from "__TURBOPACK_VAR__" assert {
 ## Part 5
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+    __turbopack_part__: -4
 };
 import { NextResponse } from "next/server";
 const GET = (req)=>{

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/template-pages/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/template-pages/output.md
@@ -925,9 +925,6 @@ import '../../server/future/route-modules/pages/module.compiled';
 ```
 ## Part 14
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
-};
 import { PagesRouteModule } from '../../server/future/route-modules/pages/module.compiled';
 export { PagesRouteModule as m } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -944,9 +941,6 @@ import '../../server/future/route-kind';
 ```
 ## Part 16
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
-};
 import { RouteKind } from '../../server/future/route-kind';
 export { RouteKind as n } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -963,9 +957,6 @@ import './helpers';
 ```
 ## Part 18
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
-};
 import { hoist } from './helpers';
 export { hoist as o } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -982,9 +973,6 @@ import 'VAR_MODULE_DOCUMENT';
 ```
 ## Part 20
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 19
-};
 import Document from 'VAR_MODULE_DOCUMENT';
 export { Document as p } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1001,9 +989,6 @@ import 'VAR_MODULE_APP';
 ```
 ## Part 22
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
-};
 import App from 'VAR_MODULE_APP';
 export { App as q } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1020,9 +1005,6 @@ import 'VAR_USERLAND';
 ```
 ## Part 24
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
-};
 import * as userland from 'VAR_USERLAND';
 export { userland as r } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1032,11 +1014,11 @@ export { userland as r } from "__TURBOPACK_VAR__" assert {
 ## Part 25
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1051,11 +1033,11 @@ export { __TURBOPACK__default__export__ as a } from "__TURBOPACK_VAR__" assert {
 ## Part 26
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1070,11 +1052,11 @@ export { getStaticProps as e } from "__TURBOPACK_VAR__" assert {
 ## Part 27
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1089,11 +1071,11 @@ export { getStaticPaths as d } from "__TURBOPACK_VAR__" assert {
 ## Part 28
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1108,11 +1090,11 @@ export { getServerSideProps as c } from "__TURBOPACK_VAR__" assert {
 ## Part 29
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1127,11 +1109,11 @@ export { config as b } from "__TURBOPACK_VAR__" assert {
 ## Part 30
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1146,11 +1128,11 @@ export { reportWebVitals as f } from "__TURBOPACK_VAR__" assert {
 ## Part 31
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1165,11 +1147,11 @@ export { unstable_getStaticProps as l } from "__TURBOPACK_VAR__" assert {
 ## Part 32
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1184,11 +1166,11 @@ export { unstable_getStaticPaths as k } from "__TURBOPACK_VAR__" assert {
 ## Part 33
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1203,11 +1185,11 @@ export { unstable_getStaticParams as j } from "__TURBOPACK_VAR__" assert {
 ## Part 34
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1222,11 +1204,11 @@ export { unstable_getServerProps as h } from "__TURBOPACK_VAR__" assert {
 ## Part 35
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1241,23 +1223,23 @@ export { unstable_getServerSideProps as i } from "__TURBOPACK_VAR__" assert {
 ## Part 36
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
+    __turbopack_part__: -14
 };
 import { PagesRouteModule } from '../../server/future/route-modules/pages/module.compiled';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+    __turbopack_part__: -16
 };
 import { RouteKind } from '../../server/future/route-kind';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+    __turbopack_part__: -22
 };
 import App from 'VAR_MODULE_APP';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 19
+    __turbopack_part__: -20
 };
 import Document from 'VAR_MODULE_DOCUMENT';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1488,9 +1470,6 @@ import '../../server/future/route-modules/pages/module.compiled';
 ```
 ## Part 14
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
-};
 import { PagesRouteModule } from '../../server/future/route-modules/pages/module.compiled';
 export { PagesRouteModule as m } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1507,9 +1486,6 @@ import '../../server/future/route-kind';
 ```
 ## Part 16
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
-};
 import { RouteKind } from '../../server/future/route-kind';
 export { RouteKind as n } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1526,9 +1502,6 @@ import './helpers';
 ```
 ## Part 18
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
-};
 import { hoist } from './helpers';
 export { hoist as o } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1545,9 +1518,6 @@ import 'VAR_MODULE_DOCUMENT';
 ```
 ## Part 20
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 19
-};
 import Document from 'VAR_MODULE_DOCUMENT';
 export { Document as p } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1564,9 +1534,6 @@ import 'VAR_MODULE_APP';
 ```
 ## Part 22
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
-};
 import App from 'VAR_MODULE_APP';
 export { App as q } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1583,9 +1550,6 @@ import 'VAR_USERLAND';
 ```
 ## Part 24
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
-};
 import * as userland from 'VAR_USERLAND';
 export { userland as r } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1595,11 +1559,11 @@ export { userland as r } from "__TURBOPACK_VAR__" assert {
 ## Part 25
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1614,11 +1578,11 @@ export { __TURBOPACK__default__export__ as a } from "__TURBOPACK_VAR__" assert {
 ## Part 26
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1633,11 +1597,11 @@ export { getStaticProps as e } from "__TURBOPACK_VAR__" assert {
 ## Part 27
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1652,11 +1616,11 @@ export { getStaticPaths as d } from "__TURBOPACK_VAR__" assert {
 ## Part 28
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1671,11 +1635,11 @@ export { getServerSideProps as c } from "__TURBOPACK_VAR__" assert {
 ## Part 29
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1690,11 +1654,11 @@ export { config as b } from "__TURBOPACK_VAR__" assert {
 ## Part 30
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1709,11 +1673,11 @@ export { reportWebVitals as f } from "__TURBOPACK_VAR__" assert {
 ## Part 31
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1728,11 +1692,11 @@ export { unstable_getStaticProps as l } from "__TURBOPACK_VAR__" assert {
 ## Part 32
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1747,11 +1711,11 @@ export { unstable_getStaticPaths as k } from "__TURBOPACK_VAR__" assert {
 ## Part 33
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1766,11 +1730,11 @@ export { unstable_getStaticParams as j } from "__TURBOPACK_VAR__" assert {
 ## Part 34
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1785,11 +1749,11 @@ export { unstable_getServerProps as h } from "__TURBOPACK_VAR__" assert {
 ## Part 35
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: -18
 };
 import { hoist } from './helpers';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {
@@ -1804,23 +1768,23 @@ export { unstable_getServerSideProps as i } from "__TURBOPACK_VAR__" assert {
 ## Part 36
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
+    __turbopack_part__: -14
 };
 import { PagesRouteModule } from '../../server/future/route-modules/pages/module.compiled';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+    __turbopack_part__: -16
 };
 import { RouteKind } from '../../server/future/route-kind';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+    __turbopack_part__: -22
 };
 import App from 'VAR_MODULE_APP';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 19
+    __turbopack_part__: -20
 };
 import Document from 'VAR_MODULE_DOCUMENT';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: -24
 };
 import * as userland from 'VAR_USERLAND';
 import "__TURBOPACK_PART__" assert {

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/test-config-1/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/test-config-1/output.md
@@ -459,9 +459,6 @@ import "module";
 ```
 ## Part 6
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
 import { upper } from "module";
 export { upper as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -574,7 +571,7 @@ import { d as foobar } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -7
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: -6
 };
 import { upper } from "module";
 import "__TURBOPACK_PART__" assert {
@@ -720,9 +717,6 @@ import "module";
 ```
 ## Part 6
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
 import { upper } from "module";
 export { upper as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -817,7 +811,7 @@ import { d as foobar } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -7
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: -6
 };
 import { upper } from "module";
 import "__TURBOPACK_PART__" assert {

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/typeof-1/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/typeof-1/output.md
@@ -215,9 +215,6 @@ import 'next/server';
 ```
 ## Part 3
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { NextResponse } from 'next/server';
 export { NextResponse as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -234,9 +231,6 @@ import '../../ClientComponent';
 ```
 ## Part 5
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
 import { ClientComponent } from '../../ClientComponent';
 export { ClientComponent as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -253,9 +247,6 @@ import 'my-module/MyModuleClientComponent';
 ```
 ## Part 7
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { MyModuleClientComponent } from 'my-module/MyModuleClientComponent';
 export { MyModuleClientComponent as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -265,15 +256,15 @@ export { MyModuleClientComponent as d } from "__TURBOPACK_VAR__" assert {
 ## Part 8
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -7
 };
 import { MyModuleClientComponent } from 'my-module/MyModuleClientComponent';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: -3
 };
 import { NextResponse } from 'next/server';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+    __turbopack_part__: -5
 };
 import { ClientComponent } from '../../ClientComponent';
 function GET() {
@@ -339,9 +330,6 @@ import 'next/server';
 ```
 ## Part 3
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { NextResponse } from 'next/server';
 export { NextResponse as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -358,9 +346,6 @@ import '../../ClientComponent';
 ```
 ## Part 5
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
 import { ClientComponent } from '../../ClientComponent';
 export { ClientComponent as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -377,9 +362,6 @@ import 'my-module/MyModuleClientComponent';
 ```
 ## Part 7
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { MyModuleClientComponent } from 'my-module/MyModuleClientComponent';
 export { MyModuleClientComponent as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -389,15 +371,15 @@ export { MyModuleClientComponent as d } from "__TURBOPACK_VAR__" assert {
 ## Part 8
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: -7
 };
 import { MyModuleClientComponent } from 'my-module/MyModuleClientComponent';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: -3
 };
 import { NextResponse } from 'next/server';
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+    __turbopack_part__: -5
 };
 import { ClientComponent } from '../../ClientComponent';
 function GET() {


### PR DESCRIPTION
### What?

Use proper logic to depend on the side-effect-import node from the import-binding nodes.

### Why?

We previously used a workaround based on a hash map with the module specifier as the key, but as I'm going to optimize the graph, we need to store every dependency information in the graph so that the optimizer can use information.

The previous code does not work with graph optimizations because of the assumption it makes. It assumes that an import binding node is a single item entry 
 by checking `dep_item_ids.len() == 1`, but with graph optimization this may not be true anymore

### How?

Closes PACK-3444

