### PR TITLE
Bypass source map dev middleware for client chunks

### DIFF
--- a/packages/next/src/client/app-find-source-map-url.ts
+++ b/packages/next/src/client/app-find-source-map-url.ts
@@ -8,15 +8,22 @@ export const findSourceMapURL =
           return null
         }
 
-        const url = new URL(pathname, document.location.origin)
+        if (
+          filename.startsWith(document.location.origin) &&
+          filename.includes('/_next/static')
+        ) {
+          // This is a request for a client chunk. This can only happen when
+          // using Turbopack. In this case, since we control how those source
+          // maps are generated, we can safely assume that the sourceMappingURL
+          // is relative to the filename, with an added `.map` extension. The
+          // browser can just request this file, and it gets served through the
+          // normal dev server, without the need to route this through
+          // the `/__nextjs_source-map` dev middleware.
+          return `${filename}.map`
+        }
 
-        url.searchParams.set(
-          'filename',
-          filename.replace(
-            new RegExp(`^${document.location.origin}${basePath}`),
-            ''
-          )
-        )
+        const url = new URL(pathname, document.location.origin)
+        url.searchParams.set('filename', filename)
 
         return url.href
       }

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
@@ -153,10 +153,7 @@ export function getOverlayMiddleware(project: Project) {
   }
 }
 
-export function getSourceMapMiddleware(
-  project: Project,
-  options: { assetPrefix: string; distDir: string }
-) {
+export function getSourceMapMiddleware(project: Project) {
   return async function (
     req: IncomingMessage,
     res: ServerResponse,
@@ -188,15 +185,6 @@ export function getSourceMapMiddleware(
     }
 
     try {
-      const { assetPrefix, distDir } = options
-
-      if (filename.startsWith(`${assetPrefix}/_next/static`)) {
-        filename = path.join(
-          distDir,
-          filename.replace(new RegExp(`^${assetPrefix}/_next/`), '')
-        )
-      }
-
       // Turbopack chunk filenames might be URL-encoded.
       filename = decodeURI(filename)
 

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware.ts
@@ -204,21 +204,10 @@ export async function getSourceMapFromCompilation(
 export async function getSource(
   filename: string,
   options: {
-    assetPrefix: string
-    distDirectory: string
     getCompilations: () => webpack.Compilation[]
   }
 ): Promise<Source | undefined> {
-  const { assetPrefix, distDirectory, getCompilations } = options
-
-  // With Webpack, this branch can only be hit when manually changing from
-  // `eval-source-map` to `source-map` for testing purposes.
-  if (filename.startsWith(`${assetPrefix}/_next/static`)) {
-    filename = path.join(
-      distDirectory,
-      filename.replace(new RegExp(`^${assetPrefix}/_next/`), '')
-    )
-  }
+  const { getCompilations } = options
 
   if (path.isAbsolute(filename)) {
     filename = url.pathToFileURL(filename).href
@@ -262,21 +251,12 @@ export async function getSource(
 }
 
 export function getOverlayMiddleware(options: {
-  assetPrefix: string
-  distDirectory: string
   rootDirectory: string
   clientStats: () => webpack.Stats | null
   serverStats: () => webpack.Stats | null
   edgeServerStats: () => webpack.Stats | null
 }) {
-  const {
-    assetPrefix,
-    distDirectory,
-    rootDirectory,
-    clientStats,
-    serverStats,
-    edgeServerStats,
-  } = options
+  const { rootDirectory, clientStats, serverStats, edgeServerStats } = options
 
   return async function (
     req: IncomingMessage,
@@ -317,8 +297,6 @@ export function getOverlayMiddleware(options: {
 
       try {
         source = await getSource(frame.file, {
-          assetPrefix,
-          distDirectory,
           getCompilations: () => {
             const compilations: webpack.Compilation[] = []
 
@@ -419,19 +397,11 @@ export function getOverlayMiddleware(options: {
 }
 
 export function getSourceMapMiddleware(options: {
-  assetPrefix: string
-  distDirectory: string
   clientStats: () => webpack.Stats | null
   serverStats: () => webpack.Stats | null
   edgeServerStats: () => webpack.Stats | null
 }) {
-  const {
-    assetPrefix,
-    distDirectory,
-    clientStats,
-    serverStats,
-    edgeServerStats,
-  } = options
+  const { clientStats, serverStats, edgeServerStats } = options
 
   return async function (
     req: IncomingMessage,
@@ -454,8 +424,6 @@ export function getSourceMapMiddleware(options: {
 
     try {
       source = await getSource(filename, {
-        assetPrefix,
-        distDirectory,
         getCompilations: () => {
           const compilations: webpack.Compilation[] = []
 

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -569,10 +569,7 @@ export async function createHotReloaderTurbopack(
 
   const middlewares = [
     getOverlayMiddleware(project),
-    getSourceMapMiddleware(project, {
-      assetPrefix: nextConfig.assetPrefix.replace(/\/$/, ''),
-      distDir,
-    }),
+    getSourceMapMiddleware(project),
   ]
 
   const versionInfoPromise = getVersionInfo(

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -1507,20 +1507,14 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       }),
     })
 
-    const assetPrefix = this.config.assetPrefix.replace(/\/$/, '')
-
     this.middlewares = [
       getOverlayMiddleware({
-        assetPrefix,
-        distDirectory: this.distDir,
         rootDirectory: this.dir,
         clientStats: () => this.clientStats,
         serverStats: () => this.serverStats,
         edgeServerStats: () => this.edgeServerStats,
       }),
       getSourceMapMiddleware({
-        assetPrefix,
-        distDirectory: this.distDir,
         clientStats: () => this.clientStats,
         serverStats: () => this.serverStats,
         edgeServerStats: () => this.edgeServerStats,

--- a/test/development/app-dir/source-mapping/next.config.js
+++ b/test/development/app-dir/source-mapping/next.config.js
@@ -3,7 +3,7 @@
  */
 
 const nextConfig = {
-  assetPrefix: '/assets/', // intentional trailing slash to ensure we handle this as well
+  assetPrefix: '/assets',
   rewrites() {
     return {
       beforeFiles: [

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -107,6 +107,8 @@ impl EcmascriptDevChunkContent {
             let filename = chunk_path.file_name();
             write!(
                 code,
+                // findSourceMapURL assumes this co-located sourceMappingURL,
+                // and needs to be adjusted in case this is ever changed.
                 "\n\n//# sourceMappingURL={}.map",
                 urlencoding::encode(filename)
             )?;

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -168,6 +168,8 @@ impl EcmascriptDevEvaluateChunk {
             let filename = chunk_path.file_name();
             write!(
                 code,
+                // findSourceMapURL assumes this co-located sourceMappingURL,
+                // and needs to be adjusted in case this is ever changed.
                 "\n\n//# sourceMappingURL={}.map",
                 urlencoding::encode(filename)
             )?;

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -113,6 +113,8 @@ pub async fn minify(path: Vc<FileSystemPath>, code: Vc<Code>) -> Result<Vc<Code>
 
     write!(
         builder,
+        // findSourceMapURL assumes this co-located sourceMappingURL,
+        // and needs to be adjusted in case this is ever changed.
         "\n\n//# sourceMappingURL={}.map",
         urlencoding::encode(path.file_name())
     )?;


### PR DESCRIPTION
A multi-zone Next.js app might have complex rewrites for its client assets. For these apps, resolving a source map through the `/__nextjs_source-map` dev middleware might fail because the asset might belong to a different app.

Instead of trying to resolve those rewrites (i.e. using `fetch` instead of `fs`), we can just bypass the source map dev middleware for client chunks. Because we control how those source maps are generated, we can safely assume that the `sourceMappingURL` is relative to the filename, with an added `.map` extension. The browser can just request this file, and it gets served through the normal dev server, without the need to route this through the source map dev middleware.

reverts #72258