### PR TITLE
Do not log full error when source map can not be resolved

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
@@ -218,7 +218,13 @@ export function getSourceMapMiddleware(
         }
       }
     } catch (error) {
-      console.error('Failed to get source map:', error)
+      console.error(
+        `Failed to get source map for ${filename}. Please file a Next.js issue.`
+      )
+
+      if (process.env.__NEXT_VERBOSE_LOGGING) {
+        console.error(error)
+      }
     }
 
     noContent(res)

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware.ts
@@ -473,7 +473,13 @@ export function getSourceMapMiddleware(options: {
         },
       })
     } catch (error) {
-      console.error('Failed to get source map:', error)
+      console.error(
+        `Failed to get source map for ${filename}. Please file a Next.js issue.`
+      )
+
+      if (process.env.__NEXT_VERBOSE_LOGGING) {
+        console.error(error)
+      }
 
       return internalServerError(res)
     }


### PR DESCRIPTION
When a source map can't be resolved, logging the full error including the stack trace unnecessarily clutters the terminal. For Next.js users, this is a non-actionable exception. The only viable action is to report it as an issue. Next.js maintainers can use `__NEXT_VERBOSE_LOGGING` when investigating those issues.