### PR TITLE
refactor: remove unused asNotFound property

### DIFF
--- a/packages/next/src/client/components/not-found-boundary.tsx
+++ b/packages/next/src/client/components/not-found-boundary.tsx
@@ -9,7 +9,6 @@ import { MissingSlotContext } from '../../shared/lib/app-router-context.shared-r
 interface NotFoundBoundaryProps {
   notFound?: React.ReactNode
   notFoundStyles?: React.ReactNode
-  asNotFound?: boolean
   children: React.ReactNode
   missingSlots?: Set<string>
 }
@@ -31,7 +30,7 @@ class NotFoundErrorBoundary extends React.Component<
   constructor(props: NotFoundErrorBoundaryProps) {
     super(props)
     this.state = {
-      notFoundTriggered: !!props.asNotFound,
+      notFoundTriggered: false,
       previousPathname: props.pathname,
     }
   }
@@ -113,7 +112,6 @@ class NotFoundErrorBoundary extends React.Component<
 export function NotFoundBoundary({
   notFound,
   notFoundStyles,
-  asNotFound,
   children,
 }: NotFoundBoundaryProps) {
   // When we're rendering the missing params shell, this will return null. This
@@ -129,7 +127,6 @@ export function NotFoundBoundary({
         pathname={pathname}
         notFound={notFound}
         notFoundStyles={notFoundStyles}
-        asNotFound={asNotFound}
         missingSlots={missingSlots}
       >
         {children}

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -458,7 +458,7 @@ describe('Error overlay for hydration errors in App router', () => {
                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
                   <LoadingBoundary hasLoading={false} loading={undefined} loadingStyles={undefined} loadingScripts={undefined}>
                     <NotFoundBoundary notFound={[...]} notFoundStyles={[...]}>
-                      <NotFoundErrorBoundary pathname="/" notFound={[...]} notFoundStyles={[...]} asNotFound={undefined} ...>
+                      <NotFoundErrorBoundary pathname="/" notFound={[...]} notFoundStyles={[...]} missingSlots={Set}>
                         <RedirectBoundary>
                           <RedirectErrorBoundary router={{...}}>
                             <InnerLayoutRouter parallelRouterKey="children" url="/" tree={[...]} childNodes={Map} ...>
@@ -927,7 +927,7 @@ describe('Error overlay for hydration errors in App router', () => {
     if (isTurbopack) {
       expect(fullPseudoHtml).toMatchInlineSnapshot(`
         "...
-          <NotFoundErrorBoundary pathname="/" notFound={[...]} notFoundStyles={[...]} asNotFound={undefined} missingSlots={Set}>
+          <NotFoundErrorBoundary pathname="/" notFound={[...]} notFoundStyles={[...]} missingSlots={Set}>
             <RedirectBoundary>
               <RedirectErrorBoundary router={{...}}>
                 <InnerLayoutRouter parallelRouterKey="children" url="/" tree={[...]} childNodes={Map} segmentPath={[...]} ...>
@@ -947,7 +947,7 @@ describe('Error overlay for hydration errors in App router', () => {
     } else {
       expect(fullPseudoHtml).toMatchInlineSnapshot(`
         "...
-          <NotFoundErrorBoundary pathname="/" notFound={[...]} notFoundStyles={[...]} asNotFound={undefined} missingSlots={Set}>
+          <NotFoundErrorBoundary pathname="/" notFound={[...]} notFoundStyles={[...]} missingSlots={Set}>
             <RedirectBoundary>
               <RedirectErrorBoundary router={{...}}>
                 <InnerLayoutRouter parallelRouterKey="children" url="/" tree={[...]} childNodes={Map} segmentPath={[...]} ...>


### PR DESCRIPTION
### What

`asNotFound` property is not used, refactor to remove it