### PR TITLE
Combine bound `"use cache"` closure args into a single parameter

### DIFF
--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/39/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/39/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 2, async function fn($$ACTION_ARG_0, $$ACTION_ARG_1) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 2, async function fn([$$ACTION_ARG_0, $$ACTION_ARG_1]) {
     console.log($$ACTION_ARG_0);
     return {
         foo: $$ACTION_ARG_1

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/40/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/40/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91":"$$RSC_SERVER_ACTION_2","c03128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", 2, async function cache($$ACTION_ARG_0, $$ACTION_ARG_1, e) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", 2, async function cache([$$ACTION_ARG_0, $$ACTION_ARG_1], e) {
     const f = $$ACTION_ARG_0 + e;
     return [
         f,

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/42/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/42/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 2, async function($$ACTION_ARG_0, $$ACTION_ARG_1) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 2, async function([$$ACTION_ARG_0, $$ACTION_ARG_1]) {
     console.log($$ACTION_ARG_0);
     return {
         foo: $$ACTION_ARG_1

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -524,7 +524,7 @@ export function cache(
           )
         }
 
-        args.unshift(...boundArgs)
+        args.unshift(boundArgs)
       }
 
       const temporaryReferences = createClientTemporaryReferenceSet()


### PR DESCRIPTION
This is a pure refactoring without any behavioral changes. It will allow us to more easily incorporate the presence of the bound args param into the server reference information byte.