### PR TITLE
turbopack: short radix results in panic due to out of range error (fixes #71707)

### DIFF
--- a/crates/next-core/src/next_app/metadata/mod.rs
+++ b/crates/next-core/src/next_app/metadata/mod.rs
@@ -262,19 +262,22 @@ fn djb2_hash(str: &str) -> u32 {
 fn format_radix(mut x: u32, radix: u32) -> String {
     let mut result = vec![];
 
-    loop {
+    // Handle 0 specially since it won't enter the loop
+    if x == 0 {
+        result.push('0');
+    }
+
+    while x > 0 {
         let m = x % radix;
         x /= radix;
-
-        // will panic if you use a bad radix (< 2 or > 36).
         result.push(std::char::from_digit(m, radix).unwrap());
-        if x == 0 {
-            break;
-        }
     }
 
     result.reverse();
-    result[..6].iter().collect()
+    let s: String = result.iter().collect();
+    
+    // Take up to 6 chars, if string is shorter than 6 chars, return the whole string
+    s.chars().take(6).collect()
 }
 
 /// If there's special convention like (...) or @ in the page path,


### PR DESCRIPTION
I had the same issue as #71707 but can't provide a reproduction given it's production code. 

The modified function is emulating `toString(36).slice(0, 6)`. JS would return the entire string in this instance if the string is less than 6 letters long, but the current version panics because it was written assuming the string will always be > 6 characters long.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation befo- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md
re opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
