### PR TITLE
docs: remove unstable_after from Dynamic APIs

### DIFF
--- a/docs/01-app/02-building-your-application/03-rendering/01-server-components.mdx
+++ b/docs/01-app/02-building-your-application/03-rendering/01-server-components.mdx
@@ -105,7 +105,6 @@ Dynamic APIs rely on information that can only be known at request time (and not
 - [`draftMode`](/docs/app/api-reference/functions/draft-mode)
 - [`searchParams` prop](/docs/app/api-reference/file-conventions/page#searchparams-optional)
 - [`unstable_noStore`](/docs/app/api-reference/functions/unstable_noStore)
-- [`unstable_after`](/docs/app/api-reference/functions/unstable_after)
 
 ### Streaming
 


### PR DESCRIPTION
This pull request removes the unstable_after from the Dynamic APIs, as it does not cause a route to become dynamic.
