### PR TITLE
chore: update webpack loaders path on turbopack

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -134,14 +134,14 @@ export interface ExperimentalTurboOptions {
   /**
    * (`next --turbopack` only) A list of webpack loaders to apply when running with Turbopack.
    *
-   * @see [Turbopack Loaders](https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders)
+   * @see [Turbopack Loaders](https://nextjs.org/docs/app/api-reference/next-config-js/turbo#configuring-webpack-loaders)
    */
   loaders?: Record<string, TurboLoaderItem[]>
 
   /**
    * (`next --turbopack` only) A list of webpack loaders to apply when running with Turbopack.
    *
-   * @see [Turbopack Loaders](https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders)
+   * @see [Turbopack Loaders](https://nextjs.org/docs/app/api-reference/next-config-js/turbo#configuring-webpack-loaders)
    */
   rules?: Record<string, TurboRuleConfigItemOrShortcut>
 

--- a/test/development/basic/hmr/error-recovery.test.ts
+++ b/test/development/basic/hmr/error-recovery.test.ts
@@ -527,7 +527,7 @@ describe.each([
               Unknown module type
               This module doesn't have an associated type. Use a known file extension, or register a loader for it.
 
-              Read more: https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders"
+              Read more: https://nextjs.org/docs/app/api-reference/next-config-js/turbo#configuring-webpack-loaders"
             `)
         } else {
           expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`

--- a/turbopack/crates/turbopack-core/src/issue/module.rs
+++ b/turbopack/crates/turbopack-core/src/issue/module.rs
@@ -43,7 +43,7 @@ pub async fn emit_unknown_module_type_error(source: Vc<Box<dyn Source>>) -> Resu
         description: StyledString::Text(
             r"This module doesn't have an associated type. Use a known file extension, or register a loader for it.
 
-Read more: https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders".into(),
+Read more: https://nextjs.org/docs/app/api-reference/next-config-js/turbo#configuring-webpack-loaders".into(),
         )
         .resolved_cell(),
     }

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/dynamic-unrelated/issues/Unknown module type-5512c1.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/dynamic-unrelated/issues/Unknown module type-5512c1.txt
@@ -1,4 +1,4 @@
 error - [process module] [project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/dynamic-unrelated/input/sub/helper.txt  Unknown module type
   This module doesn't have an associated type. Use a known file extension, or register a loader for it.
   
-  Read more: https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders
+  Read more: https://nextjs.org/docs/app/api-reference/next-config-js/turbo#configuring-webpack-loaders

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/dynamic-unrelated/issues/Unknown module type-faeccc.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/dynamic-unrelated/issues/Unknown module type-faeccc.txt
@@ -1,4 +1,4 @@
 error - [process module] [project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/dynamic-unrelated/input/sub/README.md  Unknown module type
   This module doesn't have an associated type. Use a known file extension, or register a loader for it.
   
-  Read more: https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders
+  Read more: https://nextjs.org/docs/app/api-reference/next-config-js/turbo#configuring-webpack-loaders


### PR DESCRIPTION
## Summary

At #70031, [turbo docs](https://nextjs.org/docs/app/api-reference/next-config-js/turbo) was update.
Then I update the reference path to it.

### Before

https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders

### After

https://nextjs.org/docs/app/api-reference/next-config-js/turbo#configuring-webpack-loaders