### PR TITLE
fix(turbopack): Depend on side effect from import binding

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -111,6 +111,17 @@ pub(crate) struct ItemData {
     ///
     /// Used to optimize `ImportBinding`.
     pub binding_source: Option<(Str, ImportSpecifier)>,
+
+    /// Explicit dependencies of this item.
+    ///
+    /// Used to depend from import binding to side-effect-import without additional analysis.
+    ///
+    /// - Note: ImportBinding should depend on actual import statements because those imports may
+    ///   have side effects.
+    ///
+    /// See https://github.com/vercel/next.js/pull/71234#issuecomment-2409810084 for the problematic
+    /// test case.
+    pub explicit_deps: Vec<ItemId>,
 }
 
 impl fmt::Debug for ItemData {
@@ -125,6 +136,7 @@ impl fmt::Debug for ItemData {
             .field("eventual_write_vars", &self.eventual_write_vars)
             .field("side_effects", &self.side_effects)
             .field("export", &self.export)
+            .field("explicit_deps", &self.explicit_deps)
             .finish()
     }
 }
@@ -143,6 +155,7 @@ impl Default for ItemData {
             pure: Default::default(),
             export: Default::default(),
             binding_source: Default::default(),
+            explicit_deps: Default::default(),
         }
     }
 }
@@ -811,15 +824,15 @@ impl DepGraph {
                         _ => {}
                     },
                     ModuleDecl::ExportNamed(item) => {
-                        if let Some(src) = &item.src {
+                        let import_id = if let Some(src) = &item.src {
                             // One item for the import for re-export
-                            let id = ItemId::Item {
+                            let import_id = ItemId::Item {
                                 index,
                                 kind: ItemIdItemKind::ImportOfModule,
                             };
-                            ids.push(id.clone());
+                            ids.push(import_id.clone());
                             items.insert(
-                                id,
+                                import_id.clone(),
                                 ItemData {
                                     is_hoisted: true,
                                     side_effects: true,
@@ -833,7 +846,11 @@ impl DepGraph {
                                     ..Default::default()
                                 },
                             );
-                        }
+
+                            Some(import_id)
+                        } else {
+                            None
+                        };
 
                         for (si, s) in item.specifiers.iter().enumerate() {
                             let (orig, mut local, exported) = match s {
@@ -910,6 +927,7 @@ impl DepGraph {
                                                 phase: Default::default(),
                                             },
                                         )),
+                                        explicit_deps: vec![import_id.clone().unwrap()],
                                         ..Default::default()
                                     },
                                 );
@@ -1077,26 +1095,24 @@ impl DepGraph {
                 ModuleItem::ModuleDecl(ModuleDecl::Import(item)) => {
                     // We create multiple items for each import.
 
-                    {
-                        // One item for the import itself
-                        let id = ItemId::Item {
-                            index,
-                            kind: ItemIdItemKind::ImportOfModule,
-                        };
-                        ids.push(id.clone());
-                        items.insert(
-                            id,
-                            ItemData {
-                                is_hoisted: true,
-                                side_effects: true,
-                                content: ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
-                                    specifiers: Default::default(),
-                                    ..item.clone()
-                                })),
-                                ..Default::default()
-                            },
-                        );
-                    }
+                    // One item for the import itself
+                    let import_id = ItemId::Item {
+                        index,
+                        kind: ItemIdItemKind::ImportOfModule,
+                    };
+                    ids.push(import_id.clone());
+                    items.insert(
+                        import_id.clone(),
+                        ItemData {
+                            is_hoisted: true,
+                            side_effects: true,
+                            content: ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
+                                specifiers: Default::default(),
+                                ..item.clone()
+                            })),
+                            ..Default::default()
+                        },
+                    );
 
                     // One per binding
                     for (si, s) in item.specifiers.iter().enumerate() {
@@ -1122,6 +1138,7 @@ impl DepGraph {
                                 } else {
                                     None
                                 },
+                                explicit_deps: vec![import_id.clone()],
                                 ..Default::default()
                             },
                         );

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -87,7 +87,19 @@ impl Analyzer<'_> {
 
         analyzer.handle_exports(module);
 
+        analyzer.handle_explicit_deps();
+
         (g, items)
+    }
+
+    fn handle_explicit_deps(&mut self) {
+        for item_id in self.item_ids.iter() {
+            if let Some(item) = self.items.get(item_id) {
+                if !item.explicit_deps.is_empty() {
+                    self.g.add_strong_deps(item_id, item.explicit_deps.iter());
+                }
+            }
+        }
     }
 
     /// Phase 1: Hoisted Variables and Bindings

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/tests.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/tests.rs
@@ -161,6 +161,8 @@ fn run(input: PathBuf) {
         writeln!(s, "# Phase 4").unwrap();
         writeln!(s, "```mermaid\n{}```", render_graph(&item_ids, analyzer.g)).unwrap();
 
+        analyzer.handle_explicit_deps();
+
         let mut condensed = analyzer.g.finalize(analyzer.items);
 
         writeln!(s, "# Final").unwrap();

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/1/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/1/output.md
@@ -385,6 +385,7 @@ graph TD
     N17 -.-> N4;
     N17 --> N7;
     N0 --> N13;
+    N6 --> N5;
 ```
 # Entrypoints
 
@@ -459,6 +460,9 @@ import "module";
 ```
 ## Part 6
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
@@ -720,6 +724,9 @@ import "module";
 ```
 ## Part 6
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/2/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/2/output.md
@@ -405,6 +405,7 @@ graph TD
     N17 -.-> N4;
     N17 --> N8;
     N0 --> N14;
+    N7 --> N6;
 ```
 # Entrypoints
 
@@ -498,6 +499,9 @@ import "module";
 ```
 ## Part 7
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
@@ -767,6 +771,9 @@ import "module";
 ```
 ## Part 7
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/amphtml-document/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/amphtml-document/output.md
@@ -303,6 +303,14 @@ graph TD
     N13 --> N6;
     N1 --> N13;
     N0 --> N13;
+    N3 --> N2;
+    N4 --> N2;
+    N5 --> N2;
+    N7 --> N6;
+    N8 --> N6;
+    N9 --> N6;
+    N10 --> N6;
+    N11 --> N6;
 ```
 # Entrypoints
 
@@ -344,6 +352,9 @@ import "react/jsx-runtime";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
 import { jsx as _jsx } from "react/jsx-runtime";
 export { _jsx as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -355,6 +366,9 @@ export { _jsx as b } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
 import { jsxs as _jsxs } from "react/jsx-runtime";
 export { _jsxs as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -363,6 +377,9 @@ export { _jsxs as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 5
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
@@ -385,6 +402,9 @@ import 'next/document';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import Document from 'next/document';
 export { Document as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -393,6 +413,9 @@ export { Document as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
@@ -407,6 +430,9 @@ export { Html as f } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import { Head } from 'next/document';
 export { Head as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -418,6 +444,9 @@ export { Head as g } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import { Main } from 'next/document';
 export { Main as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -426,6 +455,9 @@ export { Main as h } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 11
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
@@ -574,6 +606,9 @@ import "react/jsx-runtime";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
 import { jsx as _jsx } from "react/jsx-runtime";
 export { _jsx as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -585,6 +620,9 @@ export { _jsx as b } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
 import { jsxs as _jsxs } from "react/jsx-runtime";
 export { _jsxs as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -593,6 +631,9 @@ export { _jsxs as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 5
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
@@ -615,6 +656,9 @@ import 'next/document';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import Document from 'next/document';
 export { Document as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -623,6 +667,9 @@ export { Document as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
@@ -637,6 +684,9 @@ export { Html as f } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import { Head } from 'next/document';
 export { Head as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -648,6 +698,9 @@ export { Head as g } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import { Main } from 'next/document';
 export { Main as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -656,6 +709,9 @@ export { Main as h } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 11
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/app-route/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/app-route/output.md
@@ -363,6 +363,10 @@ graph TD
     N18 -.-> N5;
     N18 -.-> N6;
     N0 --> N15;
+    N8 --> N7;
+    N10 --> N9;
+    N12 --> N11;
+    N14 --> N13;
 ```
 # Entrypoints
 
@@ -459,6 +463,9 @@ import '../../server/future/route-modules/app-route/module.compiled';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 7
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
 import { AppRouteRouteModule } from '../../server/future/route-modules/app-route/module.compiled';
 export { AppRouteRouteModule as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -475,6 +482,9 @@ import '../../server/future/route-kind';
 ```
 ## Part 10
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
@@ -497,6 +507,9 @@ import '../../server/lib/patch-fetch';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 11
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
 import { patchFetch as _patchFetch } from '../../server/lib/patch-fetch';
 export { _patchFetch as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -513,6 +526,9 @@ import 'VAR_USERLAND';
 ```
 ## Part 14
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
@@ -738,6 +754,9 @@ import '../../server/future/route-modules/app-route/module.compiled';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 7
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
 import { AppRouteRouteModule } from '../../server/future/route-modules/app-route/module.compiled';
 export { AppRouteRouteModule as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -754,6 +773,9 @@ import '../../server/future/route-kind';
 ```
 ## Part 10
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
@@ -776,6 +798,9 @@ import '../../server/lib/patch-fetch';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 11
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
 import { patchFetch as _patchFetch } from '../../server/lib/patch-fetch';
 export { _patchFetch as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -792,6 +817,9 @@ import 'VAR_USERLAND';
 ```
 ## Part 14
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/dce/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/dce/output.md
@@ -87,6 +87,7 @@ graph TD
     N3 --> N2;
     N3 --> N1;
     N0 --> N3;
+    N2 --> N1;
 ```
 # Entrypoints
 
@@ -114,6 +115,9 @@ import './module';
 ```
 ## Part 2
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
@@ -175,6 +179,9 @@ import './module';
 ```
 ## Part 2
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/export-named/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/export-named/output.md
@@ -75,6 +75,7 @@ graph TD
     N3["Items: [ItemId(0, ImportBinding(0))]"];
     N1 --> N3;
     N0 --> N2;
+    N3 --> N2;
 ```
 # Entrypoints
 
@@ -113,6 +114,9 @@ import "./lib";
 ```
 ## Part 3
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
@@ -174,6 +178,9 @@ import "./lib";
 ```
 ## Part 3
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-2/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-2/output.md
@@ -610,6 +610,10 @@ graph TD
     N25 --> N17;
     N25 --> N10;
     N0 --> N17;
+    N10 --> N9;
+    N12 --> N11;
+    N14 --> N13;
+    N16 --> N15;
 ```
 # Entrypoints
 
@@ -728,6 +732,9 @@ import 'react';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
 import React from 'react';
 export { React as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -744,6 +751,9 @@ import '../../client/components/hooks-server-context';
 ```
 ## Part 12
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 11
 };
@@ -766,6 +776,9 @@ import '../../client/components/static-generation-bailout';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout';
 export { StaticGenBailoutError as k } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -782,6 +795,9 @@ import '../../lib/url';
 ```
 ## Part 16
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 15
 };
@@ -1166,6 +1182,9 @@ import 'react';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
 import React from 'react';
 export { React as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1182,6 +1201,9 @@ import '../../client/components/hooks-server-context';
 ```
 ## Part 12
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 11
 };
@@ -1204,6 +1226,9 @@ import '../../client/components/static-generation-bailout';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout';
 export { StaticGenBailoutError as k } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1220,6 +1245,9 @@ import '../../lib/url';
 ```
 ## Part 16
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 15
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-3/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-3/output.md
@@ -1124,6 +1124,9 @@ graph TD
     N10 --> N4;
     N10 --> N9;
     N0 --> N30;
+    N4 --> N3;
+    N6 --> N5;
+    N8 --> N7;
 ```
 # Entrypoints
 
@@ -1179,6 +1182,9 @@ import "node:net";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
 import { createConnection } from "node:net";
 export { createConnection as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1198,6 +1204,9 @@ import "../compiled/stacktrace-parser";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
 import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
 export { parseStackTrace as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1214,6 +1223,9 @@ import "./error";
 ```
 ## Part 8
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 7
 };
@@ -1930,6 +1942,9 @@ import "node:net";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
 import { createConnection } from "node:net";
 export { createConnection as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1949,6 +1964,9 @@ import "../compiled/stacktrace-parser";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
 import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
 export { parseStackTrace as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1965,6 +1983,9 @@ import "./error";
 ```
 ## Part 8
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 7
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/ipc-evaluate/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/ipc-evaluate/output.md
@@ -229,6 +229,7 @@ graph TD
     N6 --> N2;
     N1 --> N6;
     N0 --> N6;
+    N3 --> N2;
 ```
 # Entrypoints
 
@@ -267,6 +268,9 @@ import "./index";
 ```
 ## Part 3
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
@@ -455,6 +459,9 @@ import "./index";
 ```
 ## Part 3
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/ipc-index/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/ipc-index/output.md
@@ -1124,6 +1124,9 @@ graph TD
     N10 --> N4;
     N10 --> N9;
     N0 --> N30;
+    N4 --> N3;
+    N6 --> N5;
+    N8 --> N7;
 ```
 # Entrypoints
 
@@ -1179,6 +1182,9 @@ import "node:net";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
 import { createConnection } from "node:net";
 export { createConnection as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1198,6 +1204,9 @@ import "../compiled/stacktrace-parser";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
 import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
 export { parseStackTrace as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1214,6 +1223,9 @@ import "./error";
 ```
 ## Part 8
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 7
 };
@@ -1930,6 +1942,9 @@ import "node:net";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
 import { createConnection } from "node:net";
 export { createConnection as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1949,6 +1964,9 @@ import "../compiled/stacktrace-parser";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
 import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
 export { parseStackTrace as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1965,6 +1983,9 @@ import "./error";
 ```
 ## Part 8
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 7
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/mui-sys/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/mui-sys/output.md
@@ -1022,6 +1022,12 @@ graph TD
     N4 --> N42;
     N1 --> N44;
     N0 --> N44;
+    N15 --> N14;
+    N17 --> N16;
+    N19 --> N18;
+    N20 --> N18;
+    N22 --> N21;
+    N24 --> N23;
 ```
 # Entrypoints
 
@@ -1204,6 +1210,9 @@ import './style';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
 import style from './style';
 export { style as n } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1220,6 +1229,9 @@ import './compose';
 ```
 ## Part 17
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
@@ -1242,6 +1254,9 @@ import './spacing';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
 import { createUnaryUnit } from './spacing';
 export { createUnaryUnit as p } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1250,6 +1265,9 @@ export { createUnaryUnit as p } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 20
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
@@ -1272,6 +1290,9 @@ import './breakpoints';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 21
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
 import { handleBreakpoints } from './breakpoints';
 export { handleBreakpoints as r } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1288,6 +1309,9 @@ import './responsivePropType';
 ```
 ## Part 24
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 23
 };
@@ -1927,6 +1951,9 @@ import './style';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
 import style from './style';
 export { style as n } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1943,6 +1970,9 @@ import './compose';
 ```
 ## Part 17
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
@@ -1965,6 +1995,9 @@ import './spacing';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
 import { createUnaryUnit } from './spacing';
 export { createUnaryUnit as p } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1973,6 +2006,9 @@ export { createUnaryUnit as p } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 20
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
@@ -1995,6 +2031,9 @@ import './breakpoints';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 21
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
 import { handleBreakpoints } from './breakpoints';
 export { handleBreakpoints as r } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -2011,6 +2050,9 @@ import './responsivePropType';
 ```
 ## Part 24
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 23
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nanoid/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nanoid/output.md
@@ -390,6 +390,8 @@ graph TD
     N5 --> N9;
     N4 --> N14;
     N0 --> N15;
+    N7 --> N6;
+    N9 --> N8;
 ```
 # Entrypoints
 
@@ -479,6 +481,9 @@ import 'crypto';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import crypto from 'crypto';
 export { crypto as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -495,6 +500,9 @@ import './url-alphabet/index.js';
 ```
 ## Part 9
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
@@ -767,6 +775,9 @@ import 'crypto';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import crypto from 'crypto';
 export { crypto as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -783,6 +794,9 @@ import './url-alphabet/index.js';
 ```
 ## Part 9
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/next-response/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/next-response/output.md
@@ -444,6 +444,12 @@ graph TD
     N16 --> N8;
     N1 --> N16;
     N0 --> N14;
+    N3 --> N2;
+    N5 --> N4;
+    N7 --> N6;
+    N8 --> N6;
+    N10 --> N9;
+    N12 --> N11;
 ```
 # Entrypoints
 
@@ -485,6 +491,9 @@ import '../../web/spec-extension/cookies';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
 import { stringifyCookie } from '../../web/spec-extension/cookies';
 export { stringifyCookie as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -501,6 +510,9 @@ import '../next-url';
 ```
 ## Part 5
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
@@ -523,6 +535,9 @@ import '../utils';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import { toNodeOutgoingHttpHeaders } from '../utils';
 export { toNodeOutgoingHttpHeaders as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -531,6 +546,9 @@ export { toNodeOutgoingHttpHeaders as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
@@ -553,6 +571,9 @@ import './adapters/reflect';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
 import { ReflectAdapter } from './adapters/reflect';
 export { ReflectAdapter as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -569,6 +590,9 @@ import './cookies';
 ```
 ## Part 12
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 11
 };
@@ -810,6 +834,9 @@ import '../../web/spec-extension/cookies';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
 import { stringifyCookie } from '../../web/spec-extension/cookies';
 export { stringifyCookie as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -826,6 +853,9 @@ import '../next-url';
 ```
 ## Part 5
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
@@ -848,6 +878,9 @@ import '../utils';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import { toNodeOutgoingHttpHeaders } from '../utils';
 export { toNodeOutgoingHttpHeaders as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -856,6 +889,9 @@ export { toNodeOutgoingHttpHeaders as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
@@ -878,6 +914,9 @@ import './adapters/reflect';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
 import { ReflectAdapter } from './adapters/reflect';
 export { ReflectAdapter as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -894,6 +933,9 @@ import './cookies';
 ```
 ## Part 12
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 11
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nextjs-tracer/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nextjs-tracer/output.md
@@ -653,6 +653,8 @@ graph TD
     N2 --> N11;
     N14 --> N13;
     N0 --> N22;
+    N7 --> N6;
+    N8 --> N6;
 ```
 # Entrypoints
 
@@ -741,6 +743,9 @@ import './constants';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import { LogSpanAllowList } from './constants';
 export { LogSpanAllowList as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -749,6 +754,9 @@ export { LogSpanAllowList as f } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
@@ -1267,6 +1275,9 @@ import './constants';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import { LogSpanAllowList } from './constants';
 export { LogSpanAllowList as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1275,6 +1286,9 @@ export { LogSpanAllowList as f } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/node-fetch/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/node-fetch/output.md
@@ -141,6 +141,7 @@ graph TD
     N6 --> N4;
     N1 --> N6;
     N0 --> N6;
+    N3 --> N2;
 ```
 # Entrypoints
 
@@ -179,6 +180,9 @@ import 'node:stream';
 ```
 ## Part 3
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
@@ -277,6 +281,9 @@ import 'node:stream';
 ```
 ## Part 3
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/otel-core/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/otel-core/output.md
@@ -192,6 +192,9 @@ graph TD
     N9 --> N5;
     N9 --> N7;
     N0 --> N6;
+    N4 --> N3;
+    N5 --> N3;
+    N7 --> N6;
 ```
 # Entrypoints
 
@@ -244,6 +247,9 @@ import '../../utils/environment';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
 import { DEFAULT_ENVIRONMENT } from '../../utils/environment';
 export { DEFAULT_ENVIRONMENT as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -252,6 +258,9 @@ export { DEFAULT_ENVIRONMENT as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 5
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
@@ -271,6 +280,9 @@ import './globalThis';
 ```
 ## Part 7
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
@@ -390,6 +402,9 @@ import '../../utils/environment';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
 import { DEFAULT_ENVIRONMENT } from '../../utils/environment';
 export { DEFAULT_ENVIRONMENT as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -398,6 +413,9 @@ export { DEFAULT_ENVIRONMENT as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 5
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
@@ -417,6 +435,9 @@ import './globalThis';
 ```
 ## Part 7
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/route-handler/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/route-handler/output.md
@@ -127,6 +127,7 @@ graph TD
     N1 --> N5;
     N2 --> N6;
     N0 --> N3;
+    N4 --> N3;
 ```
 # Entrypoints
 
@@ -176,6 +177,9 @@ import "next/server";
 ```
 ## Part 4
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
@@ -275,6 +279,9 @@ import "next/server";
 ```
 ## Part 4
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/template-pages/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/template-pages/output.md
@@ -766,6 +766,12 @@ graph TD
     N9 --> N35;
     N7 --> N36;
     N0 --> N36;
+    N14 --> N13;
+    N16 --> N15;
+    N18 --> N17;
+    N20 --> N19;
+    N22 --> N21;
+    N24 --> N23;
 ```
 # Entrypoints
 
@@ -928,6 +934,9 @@ import '../../server/future/route-modules/pages/module.compiled';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
 import { PagesRouteModule } from '../../server/future/route-modules/pages/module.compiled';
 export { PagesRouteModule as m } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -944,6 +953,9 @@ import '../../server/future/route-kind';
 ```
 ## Part 16
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 15
 };
@@ -966,6 +978,9 @@ import './helpers';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 17
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
 import { hoist } from './helpers';
 export { hoist as o } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -982,6 +997,9 @@ import 'VAR_MODULE_DOCUMENT';
 ```
 ## Part 20
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 19
 };
@@ -1004,6 +1022,9 @@ import 'VAR_MODULE_APP';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 21
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
 import App from 'VAR_MODULE_APP';
 export { App as q } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1020,6 +1041,9 @@ import 'VAR_USERLAND';
 ```
 ## Part 24
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 23
 };
@@ -1491,6 +1515,9 @@ import '../../server/future/route-modules/pages/module.compiled';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
 import { PagesRouteModule } from '../../server/future/route-modules/pages/module.compiled';
 export { PagesRouteModule as m } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1507,6 +1534,9 @@ import '../../server/future/route-kind';
 ```
 ## Part 16
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 15
 };
@@ -1529,6 +1559,9 @@ import './helpers';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 17
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
 import { hoist } from './helpers';
 export { hoist as o } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1545,6 +1578,9 @@ import 'VAR_MODULE_DOCUMENT';
 ```
 ## Part 20
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 19
 };
@@ -1567,6 +1603,9 @@ import 'VAR_MODULE_APP';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 21
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
 import App from 'VAR_MODULE_APP';
 export { App as q } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1583,6 +1622,9 @@ import 'VAR_USERLAND';
 ```
 ## Part 24
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 23
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/test-config-1/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/test-config-1/output.md
@@ -385,6 +385,7 @@ graph TD
     N17 -.-> N4;
     N17 --> N7;
     N0 --> N13;
+    N6 --> N5;
 ```
 # Entrypoints
 
@@ -459,6 +460,9 @@ import "module";
 ```
 ## Part 6
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
@@ -720,6 +724,9 @@ import "module";
 ```
 ## Part 6
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/typeof-1/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/typeof-1/output.md
@@ -177,6 +177,9 @@ graph TD
     N8 --> N5;
     N8 --> N7;
     N0 --> N6;
+    N3 --> N2;
+    N5 --> N4;
+    N7 --> N6;
 ```
 # Entrypoints
 
@@ -218,6 +221,9 @@ import 'next/server';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
 import { NextResponse } from 'next/server';
 export { NextResponse as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -237,6 +243,9 @@ import '../../ClientComponent';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
 import { ClientComponent } from '../../ClientComponent';
 export { ClientComponent as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -253,6 +262,9 @@ import 'my-module/MyModuleClientComponent';
 ```
 ## Part 7
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
@@ -342,6 +354,9 @@ import 'next/server';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
 import { NextResponse } from 'next/server';
 export { NextResponse as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -361,6 +376,9 @@ import '../../ClientComponent';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
 import { ClientComponent } from '../../ClientComponent';
 export { ClientComponent as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -377,6 +395,9 @@ import 'my-module/MyModuleClientComponent';
 ```
 ## Part 7
 ```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_df110c._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_df110c._.js
@@ -160,6 +160,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 ;
 ;
 ;
+;
 }}),
 "[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/module.js [test] (ecmascript) <export fakeCat>": ((__turbopack_context__) => {
 "use strict";

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_df110c._.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_df110c._.js.map
@@ -27,9 +27,9 @@
     {"offset": {"line": 138, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":""}},
     {"offset": {"line": 144, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
     {"offset": {"line": 150, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":""}},
-    {"offset": {"line": 162, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
-    {"offset": {"line": 168, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":""}},
-    {"offset": {"line": 174, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
-    {"offset": {"line": 180, "column": 0}, "map": {"version":3,"sources":["turbopack://[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/index.js"],"sourcesContent":["import { fakeCat } from \"./module\";\n\n\nconsole.log(fakeCat)\n"],"names":[],"mappings":";AAAA;AAAA;;AAGA,QAAQ,GAAG,CAAC,iPAAA,CAAA,UAAO"}},
-    {"offset": {"line": 185, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
+    {"offset": {"line": 163, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 169, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":""}},
+    {"offset": {"line": 175, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 181, "column": 0}, "map": {"version":3,"sources":["turbopack://[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/index.js"],"sourcesContent":["import { fakeCat } from \"./module\";\n\n\nconsole.log(fakeCat)\n"],"names":[],"mappings":";AAAA;AAAA;;AAGA,QAAQ,GAAG,CAAC,iPAAA,CAAA,UAAO"}},
+    {"offset": {"line": 186, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
 }

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-namespace_input_fa3563._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-namespace_input_fa3563._.js
@@ -315,6 +315,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 ;
 ;
 ;
+;
 }}),
 "[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/module.js [test] (ecmascript) <export lib>": ((__turbopack_context__) => {
 "use strict";

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-namespace_input_fa3563._.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-namespace_input_fa3563._.js.map
@@ -45,9 +45,9 @@
     {"offset": {"line": 288, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":""}},
     {"offset": {"line": 302, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
     {"offset": {"line": 308, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":""}},
-    {"offset": {"line": 317, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
-    {"offset": {"line": 323, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":""}},
-    {"offset": {"line": 329, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
-    {"offset": {"line": 335, "column": 0}, "map": {"version":3,"sources":["turbopack://[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/index.js"],"sourcesContent":["import {lib} from './module'\n\nconsole.log(lib.cat)\n"],"names":[],"mappings":";AAAA;AAAA;;AAEA,QAAQ,GAAG,CAAC,iPAAA,CAAA,MAAG,CAAC,GAAG"}},
-    {"offset": {"line": 340, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
+    {"offset": {"line": 318, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 324, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":""}},
+    {"offset": {"line": 330, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 336, "column": 0}, "map": {"version":3,"sources":["turbopack://[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/index.js"],"sourcesContent":["import {lib} from './module'\n\nconsole.log(lib.cat)\n"],"names":[],"mappings":";AAAA;AAAA;;AAEA,QAAQ,GAAG,CAAC,iPAAA,CAAA,MAAG,CAAC,GAAG"}},
+    {"offset": {"line": 341, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
 }


### PR DESCRIPTION
### What?

Use proper logic to depend on the side-effect-import node from the import-binding nodes in **graph construction phase**.

### Why?

We previously used a workaround based on a hash map with the module specifier as the key, but as I'm going to optimize the graph, we need to store every dependency information in the graph so that the optimizer can use information.

### How?

Closes PACK-3444

