### PR TITLE
fix(turbopack): Fix CSS Module renaming behavior for `@container`

### DIFF
--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -559,6 +559,7 @@ async fn process_content(
                 },
                 dashed_idents: false,
                 grid: false,
+                container: false,
                 ..Default::default()
             }),
 
@@ -1150,6 +1151,7 @@ mod tests {
                     pattern: Pattern::default(),
                     dashed_idents: false,
                     grid: false,
+                    container: false,
                     ..Default::default()
                 }),
                 ..Default::default()


### PR DESCRIPTION
### What?

Disable CSS Modules renaming for containers.

### Why?

We should match the behavior of webpack mode.

See: https://github.com/parcel-bundler/lightningcss/pull/835

### How?

 - Closes PACK-3315
 - Closes #71233

