### PR TITLE
CNA: prompt enable turbopack value to true

### DIFF
--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -233,7 +233,7 @@ async function run(): Promise<void> {
       importAlias: '@/*',
       customizeImportAlias: false,
       empty: false,
-      turbopack: false,
+      turbopack: true,
       disableGit: false,
     }
     const getPrefOrDefault = (field: string) =>


### PR DESCRIPTION
### Why?

Since Turbopack for dev is stable for v15, enable the prompt value to true.

Closes NDX-461
x-ref: [slack-thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1731083893866479)