### PR TITLE
docs(page): Add missing async to Page component for Promise-based params

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/page.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/page.mdx
@@ -6,7 +6,7 @@ description: API reference for the page.js file.
 The `page` file is used to define a page in your Next.js application.
 
 ```tsx filename="app/blog/[slug]/page.tsx" switcher
-export default function Page({
+export default async function Page({
   params,
   searchParams,
 }: {
@@ -158,7 +158,7 @@ To use `searchParams` and `params` in a Client Component (which cannot be `async
 
 import { use } from 'react'
 
-export function Page({
+export async function Page({
   params,
   searchParams,
 }: {
@@ -175,7 +175,7 @@ export function Page({
 
 import { use } from 'react'
 
-export function Page({ params, searchParams }) {
+export async function Page({ params, searchParams }) {
   const { slug } = use(params)
   const { query } = use(searchParams)
 }

--- a/docs/01-app/03-api-reference/03-file-conventions/page.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/page.mdx
@@ -158,7 +158,7 @@ To use `searchParams` and `params` in a Client Component (which cannot be `async
 
 import { use } from 'react'
 
-export async function Page({
+export default async function Page({
   params,
   searchParams,
 }: {
@@ -175,7 +175,7 @@ export async function Page({
 
 import { use } from 'react'
 
-export async function Page({ params, searchParams }) {
+export default async function Page({ params, searchParams }) {
   const { slug } = use(params)
   const { query } = use(searchParams)
 }


### PR DESCRIPTION
### Improving Documentation

This PR updates the examples in the documentation to include async in the Page component, aligning with the recent change where params now returns a Promise. :)