### PR TITLE
Bump the monorepo packages TypeScript to `5.6.3`

### DIFF
--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -24,6 +24,6 @@
     "@types/fontkit": "2.0.0",
     "@vercel/ncc": "0.34.0",
     "fontkit": "2.0.2",
-    "typescript": "5.5.3"
+    "typescript": "5.6.3"
   }
 }

--- a/packages/next-codemod/package.json
+++ b/packages/next-codemod/package.json
@@ -40,6 +40,6 @@
     "@types/jscodeshift": "0.11.0",
     "@types/prompts": "2.4.2",
     "@types/semver": "7.3.1",
-    "typescript": "5.5.3"
+    "typescript": "5.6.3"
   }
 }

--- a/packages/third-parties/package.json
+++ b/packages/third-parties/package.json
@@ -29,7 +29,7 @@
     "next": "15.0.4-canary.6",
     "outdent": "0.8.0",
     "prettier": "2.5.1",
-    "typescript": "5.5.3"
+    "typescript": "5.6.3"
   },
   "peerDependencies": {
     "next": "^13.0.0 || ^14.0.0 || ^15.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -853,8 +853,8 @@ importers:
         specifier: 2.0.2
         version: 2.0.2
       typescript:
-        specifier: 5.5.3
-        version: 5.5.3
+        specifier: 5.6.3
+        version: 5.6.3
 
   packages/next:
     dependencies:
@@ -1555,8 +1555,8 @@ importers:
         specifier: 7.3.1
         version: 7.3.1
       typescript:
-        specifier: 5.5.3
-        version: 5.5.3
+        specifier: 5.6.3
+        version: 5.6.3
 
   packages/next-env:
     devDependencies:
@@ -1642,8 +1642,8 @@ importers:
         specifier: 2.5.1
         version: 2.5.1
       typescript:
-        specifier: 5.5.3
-        version: 5.5.3
+        specifier: 5.6.3
+        version: 5.6.3
 
   turbopack/crates/turbopack-cli/js:
     dependencies:
@@ -14666,11 +14666,6 @@ packages:
   typescript@4.9.5:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
-    hasBin: true
-
-  typescript@5.5.3:
-    resolution: {integrity: sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==}
-    engines: {node: '>=14.17'}
     hasBin: true
 
   typescript@5.6.3:
@@ -31632,8 +31627,6 @@ snapshots:
       csstype: 3.1.2
 
   typescript@4.9.5: {}
-
-  typescript@5.5.3: {}
 
   typescript@5.6.3: {}
 


### PR DESCRIPTION
### Why?

PR #72311 bumped the repo's TS to 5.6.3 but missed out on the packages that added TypeScript to their own at #71256.