### PR TITLE
Fix static indicator with dynamicIO

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1301,7 +1301,8 @@ async function renderToHTMLOrFlightImpl(
       // The type check here ensures that `req` is correctly typed, and the
       // environment variable check provides dead code elimination.
       process.env.NEXT_RUNTIME !== 'edge' &&
-      isNodeNextRequest(req)
+      isNodeNextRequest(req) &&
+      !isDevWarmupRequest
     ) {
       const setAppIsrStatus = renderOpts.setAppIsrStatus
       req.originalRequest.on('end', () => {

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
@@ -1,5 +1,7 @@
 /* eslint-disable jest/no-standalone-expect */
 import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import { BrowserInterface } from 'next-webdriver'
 
 const WITH_PPR = !!process.env.__NEXT_EXPERIMENTAL_PPR
 
@@ -14,6 +16,43 @@ describe('dynamic-io', () => {
   }
 
   const itSkipTurbopack = isTurbopack ? it.skip : it
+
+  if (isNextDev && !WITH_PPR) {
+    async function hasStaticIndicator(browser: BrowserInterface) {
+      const staticIndicatorPresent = await browser.eval(() =>
+        Boolean(
+          document
+            .querySelector('nextjs-portal')
+            .shadowRoot.querySelector('.nextjs-static-indicator-toast-wrapper')
+        )
+      )
+      return staticIndicatorPresent
+    }
+
+    it('should not have static indicator on dynamic route', async () => {
+      const browser = await next.browser('/cases/dynamic_api_cookies')
+
+      await retry(async () => {
+        expect(await browser.eval('!!window.next.router ? "yes": "no"')).toBe(
+          'yes'
+        )
+      })
+
+      expect(await hasStaticIndicator(browser)).toBe(false)
+    })
+
+    it('should have static indicator on static route', async () => {
+      const browser = await next.browser('/cases/static')
+
+      await retry(async () => {
+        expect(await browser.eval('!!window.next.router ? "yes": "no"')).toBe(
+          'yes'
+        )
+      })
+
+      expect(await hasStaticIndicator(browser)).toBe(true)
+    })
+  }
 
   it('should not have route specific errors', async () => {
     expect(next.cliOutput).not.toMatch('Error: Route "/')


### PR DESCRIPTION
This ensures we don't incorrectly update the static indicator status during the dev warmup render which was causing it to show unexpectedly with dynamicIO enabled. 