### PR TITLE
silence sass `legacy-js-api` warning

### DIFF
--- a/crates/next-core/src/next_shared/webpack_rules/sass.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/sass.rs
@@ -12,9 +12,14 @@ pub async fn maybe_add_sass_loader(
     webpack_rules: Option<Vc<WebpackRules>>,
 ) -> Result<Vc<OptionWebpackRules>> {
     let sass_options = sass_options.await?;
-    let Some(sass_options) = sass_options.as_object() else {
+    let Some(mut sass_options) = sass_options.as_object().cloned() else {
         bail!("sass_options must be an object");
     };
+    // TODO: Remove this once we upgrade to sass-loader 16
+    sass_options.insert(
+        "silenceDeprecations".into(),
+        serde_json::json!(["legacy-js-api"]),
+    );
     let mut rules = if let Some(webpack_rules) = webpack_rules {
         webpack_rules.await?.clone_value()
     } else {

--- a/packages/next/src/build/webpack/config/blocks/css/index.ts
+++ b/packages/next/src/build/webpack/config/blocks/css/index.ts
@@ -181,6 +181,8 @@ export const css = curry(async function css(
           // Since it's optional and not required, we'll disable it by default
           // to avoid the confusion.
           fibers: false,
+          // TODO: Remove this once we upgrade to sass-loader 16
+          silenceDeprecations: ['legacy-js-api'],
           ...sassOptions,
         },
         additionalData: sassPrependData || sassAdditionalData,


### PR DESCRIPTION
### Why?

This PR silences `legacy-js-api` warning enabled from PR https://github.com/vercel/next.js/pull/70067 by updating the `sass-loader` to v15. Will follow up with adding an option to enable the sass-loader v16 by PR https://github.com/vercel/next.js/pull/72423.

x-ref: https://github.com/vercel/next.js/issues/71638