### PR TITLE
fix: update rsc error documentation links

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -249,10 +249,10 @@ fn report_error(app_dir: &Option<PathBuf>, filepath: &str, error_kind: RSCErrorK
         RSCErrorKind::NextRscErrServerImport((source, span)) => {
             let msg = match source.as_str() {
                 // If importing "react-dom/server", we should show a different error.
-                "react-dom/server" => "You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.\nLearn more: https://nextjs.org/docs/getting-started/react-essentials".to_string(),
+                "react-dom/server" => "You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering/server-components".to_string(),
                 // If importing "next/router", we should tell them to use "next/navigation".
                 "next/router" => r#"You have a Server Component that imports next/router. Use next/navigation instead.\nLearn more: https://nextjs.org/docs/app/api-reference/functions/use-router"#.to_string(),
-                _ => format!(r#"You're importing a component that imports {source}. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.\nLearn more: https://nextjs.org/docs/getting-started/react-essentials\n\n"#)
+                _ => format!(r#"You're importing a component that imports {source}. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering/client-components\n\n"#)
             };
 
             (msg, span)
@@ -270,15 +270,15 @@ fn report_error(app_dir: &Option<PathBuf>, filepath: &str, error_kind: RSCErrorK
                 .unwrap_or_default();
 
             let msg = if !is_app_dir {
-                format!("You're importing a component that needs \"{source}\". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/getting-started/react-essentials#server-components\n\n")
+                format!("You're importing a component that needs \"{source}\". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components\n\n")
             } else {
-                format!("You're importing a component that needs \"{source}\". That only works in a Server Component but one of its parents is marked with \"use client\", so it's a Client Component.\nLearn more: https://nextjs.org/docs/getting-started/react-essentials\n\n")
+                format!("You're importing a component that needs \"{source}\". That only works in a Server Component but one of its parents is marked with \"use client\", so it's a Client Component.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering/server-components\n\n")
             };
             (msg, span)
         }
         RSCErrorKind::NextRscErrReactApi((source, span)) => {
             let msg = if source == "Component" {
-                "You’re importing a class component. It only works in a Client Component but none of its parents are marked with \"use client\", so they're Server Components by default.\nLearn more: https://nextjs.org/docs/getting-started/react-essentials#client-components\n\n".to_string()
+                "You’re importing a class component. It only works in a Client Component but none of its parents are marked with \"use client\", so they're Server Components by default.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering/client-components\n\n".to_string()
             } else {
                 format!("You're importing a component that needs `{source}`. This React hook only works in a client component. To fix, mark the file (or its parent) with the `\"use client\"` directive.\n\n Learn more: https://nextjs.org/docs/app/building-your-application/rendering/client-components\n\n")
             };
@@ -287,12 +287,12 @@ fn report_error(app_dir: &Option<PathBuf>, filepath: &str, error_kind: RSCErrorK
         },
         RSCErrorKind::NextRscErrErrorFileServerComponent(span) => {
             (
-                format!("{filepath} must be a Client Component. Add the \"use client\" directive the top of the file to resolve this issue.\nLearn more: https://nextjs.org/docs/getting-started/react-essentials#client-components\n\n"),
+                format!("{filepath} must be a Client Component. Add the \"use client\" directive the top of the file to resolve this issue.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering/client-components\n\n"),
                 span
             )
         },
         RSCErrorKind::NextRscErrClientMetadataExport((source, span)) => {
-            (format!("You are attempting to export \"{source}\" from a component marked with \"use client\", which is disallowed. Either remove the export, or the \"use client\" directive. Read more: https://nextjs.org/docs/getting-started/react-essentials#the-use-client-directive\n\n"), span)
+            (format!("You are attempting to export \"{source}\" from a component marked with \"use client\", which is disallowed. Either remove the export, or the \"use client\" directive. Read more: https://nextjs.org/docs/app/api-reference/directives/use-client\n\n"), span)
         },
         RSCErrorKind::NextRscErrConflictMetadataExport(span) => (
             "\"metadata\" and \"generateMetadata\" cannot be exported at the same time, please keep one of them. Read more: https://nextjs.org/docs/app/api-reference/file-conventions/metadata\n\n".to_string(),

--- a/packages/next/src/build/webpack/plugins/wellknown-errors-plugin/parseRSC.ts
+++ b/packages/next/src/build/webpack/plugins/wellknown-errors-plugin/parseRSC.ts
@@ -30,7 +30,7 @@ function formatRSCErrorMessage(
   if (NEXT_RSC_ERR_REACT_API.test(message)) {
     const matches = message.match(NEXT_RSC_ERR_REACT_API)
     if (matches && matches[1] === 'Component') {
-      formattedMessage = `\n\nYou’re importing a class component. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.\nLearn more: https://nextjs.org/docs/getting-started/react-essentials#client-components\n\n`
+      formattedMessage = `\n\nYou’re importing a class component. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering/client-components\n\n`
     } else {
       formattedMessage = message.replace(
         NEXT_RSC_ERR_REACT_API,
@@ -45,7 +45,7 @@ function formatRSCErrorMessage(
     switch (matches && matches[1]) {
       case 'react-dom/server':
         // If importing "react-dom/server", we should show a different error.
-        formattedMessage = `\n\nYou're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.\nLearn more: https://nextjs.org/docs/getting-started/react-essentials`
+        formattedMessage = `\n\nYou're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering/server-components`
         break
       case 'next/router':
         // If importing "next/router", we should tell them to use "next/navigation".
@@ -55,7 +55,7 @@ function formatRSCErrorMessage(
       default:
         formattedMessage = message.replace(
           NEXT_RSC_ERR_SERVER_IMPORT,
-          `\n\nYou're importing a component that imports $1. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.\nLearn more: https://nextjs.org/docs/getting-started/react-essentials\n\n`
+          `\n\nYou're importing a component that imports $1. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering/client-components\n\n`
         )
     }
     formattedVerboseMessage = shouldAddUseClient
@@ -65,13 +65,13 @@ function formatRSCErrorMessage(
     if (isPagesDir) {
       formattedMessage = message.replace(
         NEXT_RSC_ERR_CLIENT_IMPORT,
-        `\n\nYou're importing a component that needs $1. That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/getting-started/react-essentials#server-components\n\n`
+        `\n\nYou're importing a component that needs $1. That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components\n\n`
       )
       formattedVerboseMessage = '\n\nImport trace for requested module:\n'
     } else {
       formattedMessage = message.replace(
         NEXT_RSC_ERR_CLIENT_IMPORT,
-        `\n\nYou're importing a component that needs $1. That only works in a Server Component but one of its parents is marked with "use client", so it's a Client Component.\nLearn more: https://nextjs.org/docs/getting-started/react-essentials\n\n`
+        `\n\nYou're importing a component that needs $1. That only works in a Server Component but one of its parents is marked with "use client", so it's a Client Component.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering/server-components\n\n`
       )
       formattedVerboseMessage =
         '\n\nOne of these is marked as a client entry with "use client":\n'
@@ -85,7 +85,7 @@ function formatRSCErrorMessage(
   } else if (NEXT_RSC_ERR_CLIENT_DIRECTIVE_PAREN.test(message)) {
     formattedMessage = message.replace(
       NEXT_RSC_ERR_CLIENT_DIRECTIVE_PAREN,
-      `\n\n"use client" must be a directive, and placed before other expressions. Remove the parentheses and move it to the top of the file to resolve this issue.\nLearn more: https://nextjs.org/docs/getting-started/react-essentials#the-use-client-directive\n\n`
+      `\n\n"use client" must be a directive, and placed before other expressions. Remove the parentheses and move it to the top of the file to resolve this issue.\nLearn more: https://nextjs.org/docs/app/api-reference/directives/use-client\n\n`
     )
     formattedVerboseMessage = '\n\nImport path:\n'
   } else if (NEXT_RSC_ERR_INVALID_API.test(message)) {
@@ -97,13 +97,13 @@ function formatRSCErrorMessage(
   } else if (NEXT_RSC_ERR_ERROR_FILE_SERVER_COMPONENT.test(message)) {
     formattedMessage = message.replace(
       NEXT_RSC_ERR_ERROR_FILE_SERVER_COMPONENT,
-      `\n\n${fileName} must be a Client Component. Add the "use client" directive the top of the file to resolve this issue.\nLearn more: https://nextjs.org/docs/getting-started/react-essentials#client-components\n\n`
+      `\n\n${fileName} must be a Client Component. Add the "use client" directive the top of the file to resolve this issue.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering/client-components\n\n`
     )
     formattedVerboseMessage = '\n\nImport path:\n'
   } else if (NEXT_RSC_ERR_CLIENT_METADATA_EXPORT.test(message)) {
     formattedMessage = message.replace(
       NEXT_RSC_ERR_CLIENT_METADATA_EXPORT,
-      `\n\nYou are attempting to export "$1" from a component marked with "use client", which is disallowed. Either remove the export, or the "use client" directive. Read more: https://nextjs.org/docs/getting-started/react-essentials#the-use-client-directive\n\n`
+      `\n\nYou are attempting to export "$1" from a component marked with "use client", which is disallowed. Either remove the export, or the "use client" directive. Read more: https://nextjs.org/docs/app/api-reference/directives/use-client\n\n`
     )
 
     formattedVerboseMessage = '\n\nFile path:\n'

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -196,7 +196,7 @@ describe('Error overlay - RSC build errors', () => {
           3 | export default function ClientOnlyLib() {
           4 |   return 'client-only-lib'
 
-        You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.\\nLearn more: https://nextjs.org/docs/getting-started/react-essentials\\n\\n"
+        You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.\\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering/client-components\\n\\n"
       `)
     } else {
       expect(await session.getRedboxSource()).toInclude(
@@ -342,7 +342,7 @@ describe('Error overlay - RSC build errors', () => {
             | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
         app/server-with-errors/error-file/error.js must be a Client Component. Add the "use client" directive the top of the file to resolve this issue.
-        Learn more: https://nextjs.org/docs/getting-started/react-essentials#client-components"
+        Learn more: https://nextjs.org/docs/app/building-your-application/rendering/client-components"
       `)
     } else {
       await check(() => session.getRedboxSource(), /Add the "use client"/)
@@ -353,7 +353,7 @@ describe('Error overlay - RSC build errors', () => {
       //   "./app/server-with-errors/error-file/error.js
       //   Error:   x TEST_DIR/app/server-with-errors/error-file/error.js must be a Client
       //     | Component. Add the "use client" directive the top of the file to resolve this issue.
-      //     | Learn more: https://nextjs.org/docs/getting-started/react-essentials#client-components
+      //     | Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
       //     |
       //     |
       //      ,----

--- a/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
+++ b/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
@@ -67,7 +67,7 @@ describe('Error Overlay for server components compiler errors in pages', () => {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
         "./components/Comp.js
-        Error:   x You're importing a component that needs "next/headers". That only works in a Server Component which is not supported in the pages/ directory. Read more: hhttps://nextjs.org/docs/app/building-
+        Error:   x You're importing a component that needs "next/headers". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-
           | your-application/rendering/server-components
           |
           |
@@ -129,8 +129,8 @@ describe('Error Overlay for server components compiler errors in pages', () => {
         )
       ).toMatchInlineSnapshot(`
         "./components/Comp.js
-        Error:   x You're importing a component that needs "server-only". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-
-          | your-application/rendering/server-components
+        Error:   x You're importing a component that needs "server-only". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-
+          | application/rendering/server-components
           |
           |
            ,-[1:1]

--- a/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
+++ b/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
@@ -61,7 +61,7 @@ describe('Error Overlay for server components compiler errors in pages', () => {
           3 | export default function Page() {
           4 |   return <p>hello world</p>
 
-        You're importing a component that needs "next/headers". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/getting-started/react-essentials#server-components"
+        You're importing a component that needs "next/headers". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components"
       `)
     } else {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
@@ -69,12 +69,12 @@ describe('Error Overlay for server components compiler errors in pages', () => {
         "./components/Comp.js
         Error:   x You're importing a component that needs "next/headers". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/getting-started/
           | react-essentials#server-components
-          | 
-          | 
+          |
+          |
            ,-[1:1]
          1 | import { cookies } from 'next/headers'
            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-         2 | 
+         2 |
          3 | export default function Page() {
          4 |   return <p>hello world</p>
            \`----
@@ -119,7 +119,7 @@ describe('Error Overlay for server components compiler errors in pages', () => {
           3 | export default function Page() {
           4 |   return 'hello world'
 
-        You're importing a component that needs "server-only". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/getting-started/react-essentials#server-components"
+        You're importing a component that needs "server-only". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components"
       `)
     } else {
       expect(
@@ -131,12 +131,12 @@ describe('Error Overlay for server components compiler errors in pages', () => {
         "./components/Comp.js
         Error:   x You're importing a component that needs "server-only". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/getting-started/
           | react-essentials#server-components
-          | 
-          | 
+          |
+          |
            ,-[1:1]
          1 | import 'server-only'
            : ^^^^^^^^^^^^^^^^^^^^
-         2 | 
+         2 |
          3 | export default function Page() {
          4 |   return 'hello world'
            \`----
@@ -178,7 +178,7 @@ describe('Error Overlay for server components compiler errors in pages', () => {
           3 | export default function Page() {
           4 |   return 'hello world'
 
-        You're importing a component that needs "unstable_after". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/getting-started/react-essentials#server-components"
+        You're importing a component that needs "unstable_after". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components"
       `)
     } else {
       expect(
@@ -190,12 +190,12 @@ describe('Error Overlay for server components compiler errors in pages', () => {
         "./components/Comp.js
         Error:   x You're importing a component that needs "unstable_after". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/getting-
           | started/react-essentials#server-components
-          | 
-          | 
+          |
+          |
            ,-[1:1]
          1 | import { unstable_after } from 'next/server'
            :          ^^^^^^^^^^^^^^
-         2 | 
+         2 |
          3 | export default function Page() {
          4 |   return 'hello world'
            \`----

--- a/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
+++ b/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
@@ -67,8 +67,8 @@ describe('Error Overlay for server components compiler errors in pages', () => {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
         "./components/Comp.js
-        Error:   x You're importing a component that needs "next/headers". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/getting-started/
-          | react-essentials#server-components
+        Error:   x You're importing a component that needs "next/headers". That only works in a Server Component which is not supported in the pages/ directory. Read more: hhttps://nextjs.org/docs/app/building-
+          | your-application/rendering/server-components
           |
           |
            ,-[1:1]
@@ -129,8 +129,8 @@ describe('Error Overlay for server components compiler errors in pages', () => {
         )
       ).toMatchInlineSnapshot(`
         "./components/Comp.js
-        Error:   x You're importing a component that needs "server-only". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/getting-started/
-          | react-essentials#server-components
+        Error:   x You're importing a component that needs "server-only". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-
+          | your-application/rendering/server-components
           |
           |
            ,-[1:1]
@@ -188,8 +188,8 @@ describe('Error Overlay for server components compiler errors in pages', () => {
         )
       ).toMatchInlineSnapshot(`
         "./components/Comp.js
-        Error:   x You're importing a component that needs "unstable_after". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/getting-
-          | started/react-essentials#server-components
+        Error:   x You're importing a component that needs "unstable_after". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-
+          | your-application/rendering/server-components
           |
           |
            ,-[1:1]

--- a/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
+++ b/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
@@ -67,8 +67,7 @@ describe('Error Overlay for server components compiler errors in pages', () => {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
         "./components/Comp.js
-        Error:   x You're importing a component that needs "next/headers". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-
-          | your-application/rendering/server-components
+        Error:   x You're importing a component that needs "next/headers". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
           |
           |
            ,-[1:1]
@@ -129,8 +128,7 @@ describe('Error Overlay for server components compiler errors in pages', () => {
         )
       ).toMatchInlineSnapshot(`
         "./components/Comp.js
-        Error:   x You're importing a component that needs "server-only". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-
-          | application/rendering/server-components
+        Error:   x You're importing a component that needs "server-only". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
           |
           |
            ,-[1:1]
@@ -188,8 +186,7 @@ describe('Error Overlay for server components compiler errors in pages', () => {
         )
       ).toMatchInlineSnapshot(`
         "./components/Comp.js
-        Error:   x You're importing a component that needs "unstable_after". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-
-          | your-application/rendering/server-components
+        Error:   x You're importing a component that needs "unstable_after". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
           |
           |
            ,-[1:1]

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -294,7 +294,7 @@ describe('react-dom/server in React Server environment', () => {
           6 |
 
         You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
-        Learn more: https://nextjs.org/docs/getting-started/react-essentials",
+        Learn more: https://nextjs.org/docs/app/building-your-application/rendering/server-components",
         }
       `)
     } else {
@@ -389,7 +389,7 @@ describe('react-dom/server in React Server environment', () => {
           6 |
 
         You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
-        Learn more: https://nextjs.org/docs/getting-started/react-essentials",
+        Learn more: https://nextjs.org/docs/app/building-your-application/rendering/server-components",
         }
       `)
     } else {
@@ -398,7 +398,7 @@ describe('react-dom/server in React Server environment', () => {
           "description": "Failed to compile",
           "source": "./app/exports/app-code/react-dom-server-node-implicit/page.js
         Error:   x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
-          | Learn more: https://nextjs.org/docs/getting-started/react-essentials
+          | Learn more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
            ,-[1:1]
          1 | import * as ReactDOMServerNode from 'react-dom/server'
            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -406,13 +406,13 @@ describe('react-dom/server in React Server environment', () => {
          3 | import ReactDOMServerNodeDefault from 'react-dom/server'
            \`----
           x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
-          | Learn more: https://nextjs.org/docs/getting-started/react-essentials
+          | Learn more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
            ,-[3:1]
          1 | import * as ReactDOMServerNode from 'react-dom/server'
          2 | // Fine to drop once React is on ESM
          3 | import ReactDOMServerNodeDefault from 'react-dom/server'
            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-         4 | 
+         4 |
          5 | export const runtime = 'nodejs'
            \`----",
         }


### PR DESCRIPTION
## Why?

Our RSC error messages have documentation links that need to be updated.

- Fixes https://github.com/vercel/next.js/issues/72566