### PR TITLE
Allow usage of Node.js prereleases

### DIFF
--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -24,7 +24,8 @@ import type { NextBuildOptions } from '../cli/next-build.js'
 if (
   !semver.satisfies(
     process.versions.node,
-    process.env.__NEXT_REQUIRED_NODE_VERSION_RANGE!
+    process.env.__NEXT_REQUIRED_NODE_VERSION_RANGE!,
+    { includePrerelease: true }
   )
 ) {
   console.error(


### PR DESCRIPTION
Local builds of Node.js will be considered prereleases e.g. a local build of Node.js will have `24.0.0-pre` as their version. Now these versions are accepted as long as their base version still matches.