### PR TITLE
Fix static indicator for pure IO case

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -562,7 +562,8 @@ async function generateDynamicFlightRenderResult(
       ctx,
       false,
       ctx.clientReferenceManifest,
-      ctx.workStore.route
+      ctx.workStore.route,
+      requestStore
     )
   }
 
@@ -1654,7 +1655,8 @@ async function renderToStream(
         ctx,
         res.statusCode === 404,
         clientReferenceManifest,
-        workStore.route
+        workStore.route,
+        requestStore
       )
 
       reactServerResult = new ReactServerResult(reactServerStream)
@@ -1980,7 +1982,8 @@ async function spawnDynamicValidationInDev(
   ctx: AppRenderContext,
   isNotFound: boolean,
   clientReferenceManifest: NonNullable<RenderOpts['clientReferenceManifest']>,
-  route: string
+  route: string,
+  requestStore: RequestStore
 ): Promise<void> {
   const { componentMod: ComponentMod } = ctx
 
@@ -2235,6 +2238,9 @@ async function spawnDynamicValidationInDev(
                 isPrerenderInterruptedError(err) ||
                 finalClientController.signal.aborted
               ) {
+                console.log('got prerender abort')
+                requestStore.usedDynamic = true
+
                 const componentStack: string | undefined = (errorInfo as any)
                   .componentStack
                 if (typeof componentStack === 'string') {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2238,7 +2238,6 @@ async function spawnDynamicValidationInDev(
                 isPrerenderInterruptedError(err) ||
                 finalClientController.signal.aborted
               ) {
-                console.log('got prerender abort')
                 requestStore.usedDynamic = true
 
                 const componentStack: string | undefined = (errorInfo as any)

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
@@ -29,8 +29,20 @@ describe('dynamic-io', () => {
       return staticIndicatorPresent
     }
 
-    it('should not have static indicator on dynamic route', async () => {
+    it('should not have static indicator on dynamic method route', async () => {
       const browser = await next.browser('/cases/dynamic_api_cookies')
+
+      await retry(async () => {
+        expect(await browser.eval('!!window.next.router ? "yes": "no"')).toBe(
+          'yes'
+        )
+      })
+
+      expect(await hasStaticIndicator(browser)).toBe(false)
+    })
+
+    it('should not have static indicator on dynamic IO route', async () => {
+      const browser = await next.browser('/cases/fetch_mixed')
 
       await retry(async () => {
         expect(await browser.eval('!!window.next.router ? "yes": "no"')).toBe(


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/72631 this ensures we properly update the `requestStore` when we detect pure IO case and no dynamic methods are used like `cookies()` or `headers()` e.g. just a fetch with no caching opts enabled.