### PR TITLE
Bump `@capsizecss/metrics` to 3.4.0 for Geist Google Font

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -152,7 +152,7 @@
     "@babel/runtime": "7.22.5",
     "@babel/traverse": "7.22.5",
     "@babel/types": "7.22.5",
-    "@capsizecss/metrics": "3.2.0",
+    "@capsizecss/metrics": "3.4.0",
     "@edge-runtime/cookies": "5.0.0",
     "@edge-runtime/ponyfill": "3.0.0",
     "@edge-runtime/primitives": "5.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -960,8 +960,8 @@ importers:
         specifier: 7.22.5
         version: 7.22.5
       '@capsizecss/metrics':
-        specifier: 3.2.0
-        version: 3.2.0
+        specifier: 3.4.0
+        version: 3.4.0
       '@edge-runtime/cookies':
         specifier: 5.0.0
         version: 5.0.0
@@ -3306,8 +3306,8 @@ packages:
   '@bundled-es-modules/statuses@1.0.1':
     resolution: {integrity: sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==}
 
-  '@capsizecss/metrics@3.2.0':
-    resolution: {integrity: sha512-EVWRXJaakH6NTq+7cZawgFiqA+UyESMszN/c1oDHbC/b0SAzQJ/QLS0xpaa3Y+YMfXOkEEjkuChYIV5pSkgmcg==}
+  '@capsizecss/metrics@3.4.0':
+    resolution: {integrity: sha512-hIn8MAHxLvwyUh6ZvLQHDt2GPShBz6+gxBs1JTD9GleBkht1AZvtCFo0adr7bQvYYuQzUJeKi69zqlAwgKMHNA==}
 
   '@csstools/postcss-color-function@1.1.0':
     resolution: {integrity: sha512-5D5ND/mZWcQoSfYnSPsXtuiFxhzmhxt6pcjrFLJyldj+p0ZN2vvRpYNX+lahFTtMhAYOa2WmkdGINr0yP0CvGA==}
@@ -17471,7 +17471,7 @@ snapshots:
     dependencies:
       statuses: 2.0.1
 
-  '@capsizecss/metrics@3.2.0': {}
+  '@capsizecss/metrics@3.4.0': {}
 
   '@csstools/postcss-color-function@1.1.0(postcss@8.4.31)':
     dependencies:

--- a/test/e2e/next-font/google-fetch-error.test.ts
+++ b/test/e2e/next-font/google-fetch-error.test.ts
@@ -38,22 +38,22 @@ describe('next/font/google fetch error', () => {
       const ascentOverride = await browser.eval(
         'Array.from(document.fonts.values()).find(font => font.family.includes("Inter Fallback")).ascentOverride'
       )
-      expect(ascentOverride).toBe('90.49%')
+      expect(ascentOverride).toMatchInlineSnapshot(`"90.44%"`)
 
       const descentOverride = await browser.eval(
         'Array.from(document.fonts.values()).find(font => font.family.includes("Inter Fallback")).descentOverride'
       )
-      expect(descentOverride).toBe('22.56%')
+      expect(descentOverride).toMatchInlineSnapshot(`"22.52%"`)
 
       const lineGapOverride = await browser.eval(
         'Array.from(document.fonts.values()).find(font => font.family.includes("Inter Fallback")).lineGapOverride'
       )
-      expect(lineGapOverride).toBe('0%')
+      expect(lineGapOverride).toMatchInlineSnapshot(`"0%"`)
 
       const sizeAdjust = await browser.eval(
         'Array.from(document.fonts.values()).find(font => font.family.includes("Inter Fallback")).sizeAdjust'
       )
-      expect(sizeAdjust).toBe('107.06%')
+      expect(sizeAdjust).toMatchInlineSnapshot(`"107.12%"`)
 
       expect(next.cliOutput.slice(outputIndex)).toInclude(
         'Failed to download `Inter` from Google Fonts. Using fallback font instead.'


### PR DESCRIPTION
### Why?

`next/font` depends on the Google Fonts metrics from the `@capsizecss/metrics`. Added support for Geist at https://github.com/seek-oss/capsize/pull/217, so we update version.

### How?

- Bump `@capsizecss/metrics` to 3.4.0
- Update the test to match the metrics.

#### Bonus

- Modified the test to use `.toMatchInlineSnapshot` to identify and update future changes more easily.

### RFC

The `@capsizecss` team is planning to [automate the updating process](https://github.com/seek-oss/capsize/pull/217#pullrequestreview-2431209858). Should we continue to depend on them or replace them with our custom script to fetch Google Font API (requires API key)?

x-ref: https://github.com/vercel/next.js/issues/47115
x-ref: [Twitter Feedback](https://x.com/illyism/status/1855500917589602706)