### PR TITLE
lint: do not error on quotes or apostrophes in JSX

### DIFF
--- a/packages/eslint-config-next/index.js
+++ b/packages/eslint-config-next/index.js
@@ -77,7 +77,9 @@ module.exports = {
     'jsx-a11y/role-has-required-aria-props': 'warn',
     'jsx-a11y/role-supports-aria-props': 'warn',
     'react/jsx-no-target-blank': 'off',
-    'react/no-unescaped-entities': 'off',
+    // Do not error on using quotes or apostrophes.
+    // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md#forbid
+    'react/no-unescaped-entities': ['error', { forbid: ['>', '}'] }],
   },
   parser: './parser.js',
   parserOptions: {

--- a/packages/eslint-config-next/index.js
+++ b/packages/eslint-config-next/index.js
@@ -77,6 +77,7 @@ module.exports = {
     'jsx-a11y/role-has-required-aria-props': 'warn',
     'jsx-a11y/role-supports-aria-props': 'warn',
     'react/jsx-no-target-blank': 'off',
+    'react/no-unescaped-entities': 'off',
   },
   parser: './parser.js',
   parserOptions: {

--- a/test/production/eslint/test/__snapshots__/next-build-and-lint.test.ts.snap
+++ b/test/production/eslint/test/__snapshots__/next-build-and-lint.test.ts.snap
@@ -179,7 +179,13 @@ exports[`Next Build production mode first time setup - ESLint v8 1`] = `
       2,
     ],
     "react/no-unescaped-entities": [
-      "off",
+      "error",
+      {
+        "forbid": [
+          ">",
+          "}",
+        ],
+      },
     ],
     "react/no-unknown-property": [
       "off",
@@ -379,7 +385,13 @@ exports[`Next Build production mode first time setup - ESLint v9 1`] = `
       2,
     ],
     "react/no-unescaped-entities": [
-      "off",
+      "error",
+      {
+        "forbid": [
+          ">",
+          "}",
+        ],
+      },
     ],
     "react/no-unknown-property": [
       "off",
@@ -715,7 +727,13 @@ exports[`Next Build production mode first time setup with TypeScript - ESLint v8
       2,
     ],
     "react/no-unescaped-entities": [
-      "off",
+      "error",
+      {
+        "forbid": [
+          ">",
+          "}",
+        ],
+      },
     ],
     "react/no-unknown-property": [
       "off",
@@ -1051,7 +1069,13 @@ exports[`Next Build production mode first time setup with TypeScript - ESLint v9
       2,
     ],
     "react/no-unescaped-entities": [
-      "off",
+      "error",
+      {
+        "forbid": [
+          ">",
+          "}",
+        ],
+      },
     ],
     "react/no-unknown-property": [
       "off",

--- a/test/production/eslint/test/__snapshots__/next-build-and-lint.test.ts.snap
+++ b/test/production/eslint/test/__snapshots__/next-build-and-lint.test.ts.snap
@@ -179,7 +179,7 @@ exports[`Next Build production mode first time setup - ESLint v8 1`] = `
       2,
     ],
     "react/no-unescaped-entities": [
-      2,
+      "off",
     ],
     "react/no-unknown-property": [
       "off",
@@ -379,7 +379,7 @@ exports[`Next Build production mode first time setup - ESLint v9 1`] = `
       2,
     ],
     "react/no-unescaped-entities": [
-      2,
+      "off",
     ],
     "react/no-unknown-property": [
       "off",
@@ -715,7 +715,7 @@ exports[`Next Build production mode first time setup with TypeScript - ESLint v8
       2,
     ],
     "react/no-unescaped-entities": [
-      2,
+      "off",
     ],
     "react/no-unknown-property": [
       "off",
@@ -1051,7 +1051,7 @@ exports[`Next Build production mode first time setup with TypeScript - ESLint v9
       2,
     ],
     "react/no-unescaped-entities": [
-      2,
+      "off",
     ],
     "react/no-unknown-property": [
       "off",


### PR DESCRIPTION
### Why?

Rule [react/no-unescaped-entities](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md) restricts quotes and apostrophes to be escaped, which is unnecessary.
However, preventing unexpected `>` or `}` is helpful. Although webpack treats it as a Syntax Error, we forbid it by default to know it ahead as we used to.

x-ref: [slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1731398409472609)
Closes NDX-463