### PR TITLE
Remove unused `enabled` config from server actions transforms

### DIFF
--- a/crates/next-core/src/next_shared/transforms/server_actions.rs
+++ b/crates/next-core/src/next_shared/transforms/server_actions.rs
@@ -43,7 +43,6 @@ impl CustomTransformer for NextServerActions {
             &FileName::Real(ctx.file_path_str.into()),
             Config {
                 is_react_server_layer: matches!(self.transform, ActionsTransform::Server),
-                enabled: true,
                 hash_salt: "".into(),
             },
             ctx.comments.clone(),

--- a/crates/next-custom-transforms/tests/errors.rs
+++ b/crates/next-custom-transforms/tests/errors.rs
@@ -185,7 +185,6 @@ fn react_server_actions_server_errors(input: PathBuf) {
                     &FileName::Real("/app/item.js".into()),
                     server_actions::Config {
                         is_react_server_layer: true,
-                        enabled: true,
                         hash_salt: "".into(),
                     },
                     tr.comments.as_ref().clone(),
@@ -224,7 +223,6 @@ fn react_server_actions_client_errors(input: PathBuf) {
                     &FileName::Real("/app/item.js".into()),
                     server_actions::Config {
                         is_react_server_layer: false,
-                        enabled: true,
                         hash_salt: "".into(),
                     },
                     tr.comments.as_ref().clone(),

--- a/crates/next-custom-transforms/tests/fixture.rs
+++ b/crates/next-custom-transforms/tests/fixture.rs
@@ -414,7 +414,6 @@ fn server_actions_server_fixture(input: PathBuf) {
                     &FileName::Real("/app/item.js".into()),
                     server_actions::Config {
                         is_react_server_layer: true,
-                        enabled: true,
                         hash_salt: "".into(),
                     },
                     _tr.comments.as_ref().clone(),
@@ -446,7 +445,6 @@ fn next_font_with_directive_fixture(input: PathBuf) {
                     &FileName::Real("/app/test.tsx".into()),
                     server_actions::Config {
                         is_react_server_layer: true,
-                        enabled: true,
                         hash_salt: "".into(),
                     },
                     _tr.comments.as_ref().clone(),
@@ -471,7 +469,6 @@ fn server_actions_client_fixture(input: PathBuf) {
                     &FileName::Real("/app/item.js".into()),
                     server_actions::Config {
                         is_react_server_layer: false,
-                        enabled: true,
                         hash_salt: "".into(),
                     },
                     _tr.comments.as_ref().clone(),

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -208,9 +208,6 @@ function getBaseSWCOptions({
     serverActions:
       isAppRouterPagesLayer && !jest
         ? {
-            // always enable server actions
-            // TODO: remove this option
-            enabled: true,
             isReactServerLayer,
             hashSalt: serverReferenceHashSalt,
           }


### PR DESCRIPTION
The option was always set to `true` so we can safely remove it. The experimental `serverActions` flag was removed a long time ago in #57145.