### PR TITLE
test: add wait for the error page navigation

### DIFF
--- a/test/development/acceptance-app/undefined-default-export.test.ts
+++ b/test/development/acceptance-app/undefined-default-export.test.ts
@@ -50,9 +50,13 @@ describe('Undefined default export', () => {
   })
 
   it('should error when page component export is not valid', async () => {
-    const { session, cleanup } = await sandbox(next, undefined, '/')
+    const { session, browser, cleanup } = await sandbox(next, undefined, '/')
 
     await next.patchFile('app/page.js', 'const a = 123')
+
+    // The page will fail build and navigate to /_error route of pages router.
+    // Wait for the DOM node #__next to be present
+    await browser.waitForElementByCss('#__next')
 
     await session.assertHasRedbox()
     expect(await session.getRedboxDescription()).toInclude(


### PR DESCRIPTION
When the export is invalid and fails the page build, since there's a navigation to `/_error` route, which waits for the `/_error` to be built and loaded, then we verify if the error dialog to pop up

x-ref: https://github.com/vercel/next.js/actions/runs/11816385255/job/32919640556?pr=72586