### PR TITLE
CNA: use eslint 9

### DIFF
--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -230,7 +230,7 @@ export const installTemplate = async ({
   if (eslint) {
     packageJson.devDependencies = {
       ...packageJson.devDependencies,
-      eslint: "^8",
+      eslint: "^9",
       "eslint-config-next": version,
     };
   }


### PR DESCRIPTION
### Why?

ESLint v8 is deprecated. Also, it's deprecated dependencies spam npm warning.

![image](https://github.com/user-attachments/assets/856a70a5-3185-44d6-9fa9-c773f898dc25)


Closes NDX-208