### PR TITLE
fix multi-level redirect in server actions

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -256,7 +256,7 @@ function getAppRelativeRedirectUrl(
   host: Host,
   redirectUrl: string
 ): URL | null {
-  if (redirectUrl.startsWith('/') || redirectUrl.startsWith('./')) {
+  if (redirectUrl.startsWith('/') || redirectUrl.startsWith('.')) {
     // Make sure we are appending the basePath to relative URLS
     return new URL(`${basePath}${redirectUrl}`, 'http://n')
   }

--- a/test/e2e/app-dir/server-actions-relative-redirect/app/actions.ts
+++ b/test/e2e/app-dir/server-actions-relative-redirect/app/actions.ts
@@ -6,6 +6,10 @@ export async function relativeRedirect() {
   return redirect('./subpage')
 }
 
+export async function multiRelativeRedirect() {
+  return redirect('../subpage')
+}
+
 export async function absoluteRedirect() {
   return redirect('/subpage')
 }

--- a/test/e2e/app-dir/server-actions-relative-redirect/app/subdir/page.tsx
+++ b/test/e2e/app-dir/server-actions-relative-redirect/app/subdir/page.tsx
@@ -1,7 +1,11 @@
 'use client'
 
 import { startTransition } from 'react'
-import { absoluteRedirect, relativeRedirect } from '../actions'
+import {
+  absoluteRedirect,
+  multiRelativeRedirect,
+  relativeRedirect,
+} from '../actions'
 
 export default function Page() {
   return (
@@ -16,6 +20,16 @@ export default function Page() {
         id="relative-subdir-redirect"
       >
         relative redirect
+      </button>
+      <button
+        onClick={async () => {
+          startTransition(async () => {
+            await multiRelativeRedirect()
+          })
+        }}
+        id="multi-relative-subdir-redirect"
+      >
+        multi-level relative redirect
       </button>
       <button
         onClick={async () => {

--- a/test/e2e/app-dir/server-actions-relative-redirect/next.config.js
+++ b/test/e2e/app-dir/server-actions-relative-redirect/next.config.js
@@ -1,8 +1,6 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {
-  experimental: {},
-}
+const nextConfig = {}
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/server-actions-relative-redirect/server-actions-relative-redirect.test.ts
+++ b/test/e2e/app-dir/server-actions-relative-redirect/server-actions-relative-redirect.test.ts
@@ -52,6 +52,7 @@ describe('server-actions-relative-redirect', () => {
 
   it('should work with multi-level relative redirect from subdir', async () => {
     const browser = await next.browser('/subdir')
+    await browser.eval('window.notReloaded = true')
     await browser.waitForElementByCss('#multi-relative-subdir-redirect').click()
 
     await retry(async () => {
@@ -59,5 +60,7 @@ describe('server-actions-relative-redirect', () => {
         'hello nested page'
       )
     })
+
+    expect(await browser.eval('window.notReloaded')).toBe(true)
   })
 })

--- a/test/e2e/app-dir/server-actions-relative-redirect/server-actions-relative-redirect.test.ts
+++ b/test/e2e/app-dir/server-actions-relative-redirect/server-actions-relative-redirect.test.ts
@@ -1,6 +1,5 @@
-// @ts-check
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('server-actions-relative-redirect', () => {
   const { next } = nextTestSetup({
@@ -11,51 +10,54 @@ describe('server-actions-relative-redirect', () => {
     const browser = await next.browser('/')
     await browser.waitForElementByCss('#relative-redirect').click()
 
-    await check(async () => {
+    await retry(async () => {
       expect(await browser.waitForElementByCss('#page-loaded').text()).toBe(
         'hello nested page'
       )
-
-      return 'success'
-    }, 'success')
+    })
   })
 
   it('should work with absolute redirect', async () => {
     const browser = await next.browser('/')
     await browser.waitForElementByCss('#absolute-redirect').click()
 
-    await check(async () => {
+    await retry(async () => {
       expect(await browser.waitForElementByCss('#page-loaded').text()).toBe(
         'hello nested page'
       )
-
-      return 'success'
-    }, 'success')
+    })
   })
 
   it('should work with relative redirect from subdir', async () => {
     const browser = await next.browser('/subdir')
     await browser.waitForElementByCss('#relative-subdir-redirect').click()
 
-    await check(async () => {
+    await retry(async () => {
       expect(await browser.waitForElementByCss('#page-loaded').text()).toBe(
         'hello subdir nested page'
       )
-
-      return 'success'
-    }, 'success')
+    })
   })
 
   it('should work with absolute redirect from subdir', async () => {
     const browser = await next.browser('/subdir')
     await browser.waitForElementByCss('#absolute-subdir-redirect').click()
 
-    await check(async () => {
+    await retry(async () => {
       expect(await browser.waitForElementByCss('#page-loaded').text()).toBe(
         'hello nested page'
       )
+    })
+  })
 
-      return 'success'
-    }, 'success')
+  it('should work with multi-level relative redirect from subdir', async () => {
+    const browser = await next.browser('/subdir')
+    await browser.waitForElementByCss('#multi-relative-subdir-redirect').click()
+
+    await retry(async () => {
+      expect(await browser.waitForElementByCss('#page-loaded').text()).toBe(
+        'hello nested page'
+      )
+    })
   })
 })


### PR DESCRIPTION
`redirect` in server actions has handling to support relative redirects (eg `redirect('./foo')`) but it doesn't handle a multi-level relative path, eg `redirect('../foo')`. 

This used to work by accident because the invalid URL would be handled as an error and then would trigger an MPA navigation. In Next 15, it surfaces an actual error because we are less tolerant to them.

Fixes #72765
Closes NDX-479