### PR TITLE
ci: flake detection should run in both bundlers

### DIFF
--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -9,7 +9,6 @@ describe('app dir - navigation', () => {
 
   describe('query string', () => {
     it('should set query correctly', async () => {
-      console.log('trigger change to validate test')
       const browser = await next.browser('/')
       expect(await browser.elementById('query').text()).toMatchInlineSnapshot(
         `""`

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -9,6 +9,7 @@ describe('app dir - navigation', () => {
 
   describe('query string', () => {
     it('should set query correctly', async () => {
+      console.log('trigger change to validate test')
       const browser = await next.browser('/')
       expect(await browser.elementById('query').text()).toMatchInlineSnapshot(
         `""`


### PR DESCRIPTION
We run flake detection on PRs to help catch flaky tests before they hit canary, but we currently only run flaky test detection in Webpack and not Turbopack. This is problematic because there's sufficient forking logic in tests for the different bundlers & we've seen a high likelihood of a test to flake more frequently in one bundler vs another due to things like differing compilation speeds and differing implementation of core features. 

This will add some additional time to this CI job to account for needing to run the tests 6 times, but will hopefully catch things before they become a problem later. I think we could also consider reducing the number of times per bundler to be 2 if it turns out to be adding too much time. 

This updates the flake detection job to run the tests multiple times in Turbopack as well. 

CI run: https://github.com/vercel/next.js/actions/runs/11822662639/job/32940264160?pr=72773