### PR TITLE
use explicit resource management for sandbox

### DIFF
--- a/test/development/acceptance-app/ReactRefresh.test.ts
+++ b/test/development/acceptance-app/ReactRefresh.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { outdent } from 'outdent'
@@ -11,7 +11,9 @@ describe('ReactRefresh app', () => {
   })
 
   test('can edit a component without losing state', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
+
     await session.patch(
       'index.js',
       outdent`
@@ -55,11 +57,11 @@ describe('ReactRefresh app', () => {
     expect(
       await session.evaluate(() => document.querySelector('p').textContent)
     ).toBe('Count: 2')
-    await cleanup()
   })
 
   test('cyclic dependencies', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.write(
       'NudgeOverview.js',
@@ -213,7 +215,5 @@ describe('ReactRefresh app', () => {
       await session.evaluate(() => document.querySelector('p').textContent)
     ).toBe('Hello: 300')
     expect(didFullRefresh).toBe(false)
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
@@ -1,4 +1,4 @@
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { describeVariants as describe } from 'next-test-utils'
@@ -13,7 +13,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
 
   // Module trace is only available with webpack 5
   test('Node.js builtins', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -34,6 +34,8 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
         ],
       ])
     )
+
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -71,12 +73,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
         ./app/page.js"
       `)
     }
-
-    await cleanup()
   })
 
   test('Module not found', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -123,12 +124,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
         ./app/page.js"
       `)
     }
-
-    await cleanup()
   })
 
   test('Module not found empty import trace', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'app/page.js',
@@ -175,12 +175,10 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
         https://nextjs.org/docs/messages/module-not-found"
       `)
     }
-
-    await cleanup()
   })
 
   test('Module not found missing global CSS', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -195,6 +193,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
         ],
       ])
     )
+    const { session } = sandbox
     await session.assertHasRedbox()
 
     const source = await session.getRedboxSource()
@@ -238,7 +237,5 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     expect(
       await session.evaluate(() => document.documentElement.innerHTML)
     ).toContain('index page')
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance-app/ReactRefreshLogBox-scss.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox-scss.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { outdent } from 'outdent'
@@ -16,7 +16,8 @@ describe.skip('ReactRefreshLogBox scss app', () => {
   })
 
   test('scss syntax errors', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.write('index.module.scss', `.button { font-size: 5px; }`)
     await session.patch(
@@ -44,12 +45,11 @@ describe.skip('ReactRefreshLogBox scss app', () => {
     // Fix syntax error
     await session.patch('index.module.scss', `.button { font-size: 5px; }`)
     await session.assertNoRedbox()
-
-    await cleanup()
   })
 
   test('scss module pure selector error', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.write('index.module.scss', `.button { font-size: 5px; }`)
     await session.patch(
@@ -72,7 +72,5 @@ describe.skip('ReactRefreshLogBox scss app', () => {
     await session.assertHasRedbox()
     const source2 = await session.getRedboxSource()
     expect(source2).toMatchSnapshot()
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import {
   check,
@@ -18,7 +18,8 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
   })
 
   test('should strip whitespace correctly with newline', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -42,14 +43,13 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
 
     await session.waitForAndOpenRuntimeError()
     expect(await session.getRedboxSource()).toMatchSnapshot()
-
-    await cleanup()
   })
 
   // https://github.com/pmmmwh/react-refresh-webpack-plugin/pull/3#issuecomment-554137807
   test('module init error not shown', async () => {
     // Start here:
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     // We start here.
     await session.patch(
@@ -91,13 +91,12 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     } else {
       expect(await session.getRedboxSource()).toMatchSnapshot()
     }
-
-    await cleanup()
   })
 
   // https://github.com/pmmmwh/react-refresh-webpack-plugin/pull/3#issuecomment-554152127
   test('boundaries', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.write(
       'FunctionDefault.js',
@@ -155,15 +154,14 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     expect(
       await session.evaluate(() => document.querySelector('h2').textContent)
     ).toBe('error')
-
-    await cleanup()
   })
 
   // TODO: investigate why this fails when running outside of the Next.js
   // monorepo e.g. fails when using pnpm create next-app
   // https://github.com/vercel/next.js/pull/23203
   test.skip('internal package errors', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     // Make a react build-time error.
     await session.patch(
@@ -182,12 +180,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     expect(await session.getRedboxSource()).toContain(
       `../../../../packages/next/dist/pages/_document.js`
     )
-
-    await cleanup()
   })
 
   test('unterminated JSX', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -258,13 +255,12 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
         ./app/page.js
       `)
     }
-
-    await cleanup()
   })
 
   // Module trace is only available with webpack 5
   test('conversion to class component (1)', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.write(
       'Child.js',
@@ -326,12 +322,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     expect(
       await session.evaluate(() => document.querySelector('p').textContent)
     ).toBe('hello new')
-
-    await cleanup()
   })
 
   test('css syntax errors', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.write('index.module.css', `.button {}`)
     await session.patch(
@@ -370,12 +365,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     await session.assertHasRedbox()
     const source2 = await session.getRedboxSource()
     expect(source2).toMatchSnapshot()
-
-    await cleanup()
   })
 
   test('logbox: anchors links in error messages', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -571,13 +565,12 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
           ).href
       )
     ).toBe(null)
-
-    await cleanup()
   })
 
   // TODO-APP: Catch errors that happen before useEffect
   test.skip('non-Error errors are handled properly', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -679,12 +672,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     expect(await session.getRedboxDescription()).toContain(
       `Error: A null error was thrown`
     )
-
-    await cleanup()
   })
 
   test('Should not show __webpack_exports__ when exporting anonymous arrow function', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -701,12 +693,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
 
     await session.assertHasRedbox()
     expect(await session.getRedboxSource()).toMatchSnapshot()
-
-    await cleanup()
   })
 
   test('Unhandled errors and rejections opens up in the minimized state', async () => {
-    const { session, browser, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session, browser } = sandbox
 
     const file = outdent`
       export default function Index() {
@@ -773,12 +764,10 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
 
     // Render error should "win" and show up in fullscreen
     await session.assertHasRedbox()
-
-    await cleanup()
   })
 
   test('Call stack for client error', async () => {
-    const { session, browser, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -795,29 +784,26 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
         ],
       ])
     )
+    const { session, browser } = sandbox
 
-    try {
-      await session.assertHasRedbox()
+    await session.assertHasRedbox()
 
-      // Should still show the errored line in source code
-      const source = await session.getRedboxSource()
-      expect(source).toContain('app/page.js')
-      expect(source).toContain(`throw new Error('Client error')`)
+    // Should still show the errored line in source code
+    const source = await session.getRedboxSource()
+    expect(source).toContain('app/page.js')
+    expect(source).toContain(`throw new Error('Client error')`)
 
-      const stackFrameElements = await browser.elementsByCss(
-        '[data-nextjs-call-stack-frame]'
-      )
-      const stackFrames = (
-        await Promise.all(stackFrameElements.map((f) => f.innerText()))
-      ).filter(Boolean)
-      expect(stackFrames).toEqual([])
-    } finally {
-      await cleanup()
-    }
+    const stackFrameElements = await browser.elementsByCss(
+      '[data-nextjs-call-stack-frame]'
+    )
+    const stackFrames = (
+      await Promise.all(stackFrameElements.map((f) => f.innerText()))
+    ).filter(Boolean)
+    expect(stackFrames).toEqual([])
   })
 
   test('Call stack for server error', async () => {
-    const { session, browser, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -830,29 +816,26 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
         ],
       ])
     )
+    const { session, browser } = sandbox
 
-    try {
-      await session.assertHasRedbox()
+    await session.assertHasRedbox()
 
-      // Should still show the errored line in source code
-      const source = await session.getRedboxSource()
-      expect(source).toContain('app/page.js')
-      expect(source).toContain(`throw new Error('Server error')`)
+    // Should still show the errored line in source code
+    const source = await session.getRedboxSource()
+    expect(source).toContain('app/page.js')
+    expect(source).toContain(`throw new Error('Server error')`)
 
-      const stackFrameElements = await browser.elementsByCss(
-        '[data-nextjs-call-stack-frame]'
-      )
-      const stackFrames = (
-        await Promise.all(stackFrameElements.map((f) => f.innerText()))
-      ).filter(Boolean)
-      expect(stackFrames).toEqual([])
-    } finally {
-      await cleanup()
-    }
+    const stackFrameElements = await browser.elementsByCss(
+      '[data-nextjs-call-stack-frame]'
+    )
+    const stackFrames = (
+      await Promise.all(stackFrameElements.map((f) => f.innerText()))
+    ).filter(Boolean)
+    expect(stackFrames).toEqual([])
   })
 
   test('should hide unrelated frames in stack trace with unknown anonymous calls', async () => {
-    const { session, browser, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -871,60 +854,57 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
         ],
       ])
     )
+    const { session, browser } = sandbox
 
-    try {
-      await session.assertHasRedbox()
+    await session.assertHasRedbox()
 
-      // Should still show the errored line in source code
-      const source = await session.getRedboxSource()
-      expect(source).toContain('app/page.js')
-      expect(source).toContain(
-        `throw new Error("This is an error from an anonymous function")`
-      )
+    // Should still show the errored line in source code
+    const source = await session.getRedboxSource()
+    expect(source).toContain('app/page.js')
+    expect(source).toContain(
+      `throw new Error("This is an error from an anonymous function")`
+    )
 
-      const stackFrameElements = await browser.elementsByCss(
-        '[data-nextjs-call-stack-frame]'
-      )
-      const stackFrames = await Promise.all(
-        stackFrameElements.map((f) => f.innerText())
-      )
-      expect(stackFrames).toEqual(
-        process.env.TURBOPACK
-          ? [
-              // TODO: Why is Turbopack off by one in the column?
-              outdent`
+    const stackFrameElements = await browser.elementsByCss(
+      '[data-nextjs-call-stack-frame]'
+    )
+    const stackFrames = await Promise.all(
+      stackFrameElements.map((f) => f.innerText())
+    )
+    expect(stackFrames).toEqual(
+      process.env.TURBOPACK
+        ? [
+            // TODO: Why is Turbopack off by one in the column?
+            outdent`
                 Page
                 app/page.js (5:6)
               `,
-              // TODO: Show useful stack
-              // Internal frames of React.
-              // Feel free to adjust until we show useful stacks.
-              '',
-              '',
-              '',
-              '',
-            ]
-          : [
-              outdent`
+            // TODO: Show useful stack
+            // Internal frames of React.
+            // Feel free to adjust until we show useful stacks.
+            '',
+            '',
+            '',
+            '',
+          ]
+        : [
+            outdent`
                 Page
                 app/page.js (5:5)
               `,
-              // TODO: Show useful stack
-              // Internal frames of React.
-              // Feel free to adjust until we show useful stacks.
-              '',
-              '',
-              '',
-              '',
-            ]
-      )
-    } finally {
-      await cleanup()
-    }
+            // TODO: Show useful stack
+            // Internal frames of React.
+            // Feel free to adjust until we show useful stacks.
+            '',
+            '',
+            '',
+            '',
+          ]
+    )
   })
 
   test('should hide unrelated frames in stack trace with nodejs internal calls', async () => {
-    const { session, browser, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -937,39 +917,36 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
         ],
       ])
     )
+    const { session, browser } = sandbox
 
-    try {
-      await session.assertHasRedbox()
+    await session.assertHasRedbox()
 
-      // Should still show the errored line in source code
-      const source = await session.getRedboxSource()
-      expect(source).toContain('app/page.js')
-      expect(source).toContain(`new URL("/", "invalid")`)
+    // Should still show the errored line in source code
+    const source = await session.getRedboxSource()
+    expect(source).toContain('app/page.js')
+    expect(source).toContain(`new URL("/", "invalid")`)
 
-      const stackFrameElements = await browser.elementsByCss(
-        '[data-nextjs-call-stack-frame]'
-      )
-      const stackFrames = await Promise.all(
-        stackFrameElements.map((f) => f.innerText())
-      )
-      expect(stackFrames).toEqual(
-        // TODO: Show useful stack
-        [
-          // Internal frames of React.
-          // Feel free to adjust until we show useful stacks.
-          '',
-          '',
-          '',
-          '',
-        ]
-      )
-    } finally {
-      await cleanup()
-    }
+    const stackFrameElements = await browser.elementsByCss(
+      '[data-nextjs-call-stack-frame]'
+    )
+    const stackFrames = await Promise.all(
+      stackFrameElements.map((f) => f.innerText())
+    )
+    expect(stackFrames).toEqual(
+      // TODO: Show useful stack
+      [
+        // Internal frames of React.
+        // Feel free to adjust until we show useful stacks.
+        '',
+        '',
+        '',
+        '',
+      ]
+    )
   })
 
   test('Server component errors should open up in fullscreen', async () => {
-    const { session, browser, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         // Start with error
@@ -984,6 +961,8 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
         ],
       ])
     )
+    const { session, browser } = sandbox
+
     await session.assertHasRedbox()
 
     // Remove error
@@ -1012,16 +991,15 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     )
 
     await session.assertHasRedbox()
-
-    await cleanup()
   })
 
   test('Import trace when module not found in layout', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
 
       new Map([['app/module.js', `import "non-existing-module"`]])
     )
+    const { session } = sandbox
 
     await session.patch(
       'app/layout.js',
@@ -1041,19 +1019,17 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
 
     await session.assertHasRedbox()
     expect(await session.getRedboxSource()).toMatchSnapshot()
-
-    await cleanup()
   })
 
   test("Can't resolve @import in CSS file", async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         ['app/styles1.css', '@import "./styles2.css"'],
         ['app/styles2.css', '@import "./boom.css"'],
       ])
     )
-
+    const { session } = sandbox
     await session.patch(
       'app/layout.js',
       outdent`
@@ -1096,14 +1072,13 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
         `)
       })
     }
-
-    await cleanup()
   })
 
   // TODO: The error overlay is not closed when restoring the working code.
   for (const type of ['server' /* , 'client' */]) {
     test(`${type} component can recover from error thrown in the module`, async () => {
-      const { session, cleanup } = await sandbox(next, undefined, '/' + type)
+      await using sandbox = await createSandbox(next, undefined, '/' + type)
+      const { session } = sandbox
 
       await next.patchFile('index.js', "throw new Error('module error')")
       await session.assertHasRedbox()
@@ -1112,13 +1087,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
         'export default function Page() {return <p>hello world</p>}'
       )
       await session.assertNoRedbox()
-
-      await cleanup()
     })
   }
 
   test('Should show error location for server actions in client component', async () => {
-    const { session, browser, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -1146,7 +1119,7 @@ export default function Home() {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await browser.elementByCss('#trigger-action').click()
 
     // Wait for patch to apply and new error to show.
@@ -1162,12 +1135,10 @@ export default function Home() {
           5 | }"
       `)
     })
-
-    await cleanup()
   })
 
   test('Should show error location for server actions in server component', async () => {
-    const { session, browser, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -1194,7 +1165,7 @@ export default function Home() {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await browser.elementByCss('#trigger-action').click()
 
     // Wait for patch to apply and new error to show.
@@ -1210,12 +1181,10 @@ export default function Home() {
           5 | }"
       `)
     })
-
-    await cleanup()
   })
 
   test('Should collapse bundler internal stack frames', async () => {
-    const { session, browser, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -1236,6 +1205,7 @@ export default function Home() {
         ],
       ])
     )
+    const { session, browser } = sandbox
 
     await session.assertHasRedbox()
 
@@ -1273,7 +1243,5 @@ export default function Home() {
         Next.js"
       `)
     }
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
@@ -1,4 +1,4 @@
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { outdent } from 'outdent'
@@ -12,7 +12,8 @@ describe.skip('ReactRefreshLogBox app', () => {
   })
 
   test('<Link> with multiple children', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -46,12 +47,11 @@ describe.skip('ReactRefreshLogBox app', () => {
           ).href
       )
     ).toMatch('https://nextjs.org/docs/messages/link-multiple-children')
-
-    await cleanup()
   })
 
   test('<Link> component props errors', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -202,12 +202,11 @@ describe.skip('ReactRefreshLogBox app', () => {
     )
     await session.assertHasRedbox()
     expect(await session.getRedboxDescription()).toMatchSnapshot()
-
-    await cleanup()
   })
 
   test('server-side only compilation errors', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'app/page.js',
@@ -228,6 +227,5 @@ describe.skip('ReactRefreshLogBox app', () => {
     )
 
     await session.assertHasRedbox()
-    await cleanup()
   })
 })

--- a/test/development/acceptance-app/ReactRefreshModule.test.ts
+++ b/test/development/acceptance-app/ReactRefreshModule.test.ts
@@ -1,6 +1,6 @@
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { outdent } from 'outdent'
 
 describe('ReactRefreshModule app', () => {
@@ -10,7 +10,8 @@ describe('ReactRefreshModule app', () => {
   })
 
   it('should allow any variable names', async () => {
-    const { session, cleanup } = await sandbox(next, new Map([]))
+    await using sandbox = await createSandbox(next, new Map([]))
+    const { session } = sandbox
     await session.assertNoRedbox()
 
     const variables = [
@@ -38,7 +39,5 @@ describe('ReactRefreshModule app', () => {
         `'${variable}' has already been declared`
       )
     }
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance-app/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance-app/ReactRefreshRegression.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { check } from 'next-test-utils'
@@ -56,7 +56,8 @@ describe('ReactRefreshRegression app', () => {
       `
     )
 
-    const { session, cleanup } = await sandbox(next, files)
+    await using sandbox = await createSandbox(next, files)
+    const { session } = sandbox
 
     // We start here.
     await session.patch(
@@ -76,13 +77,12 @@ describe('ReactRefreshRegression app', () => {
 
     // Verify no hydration mismatch:
     await session.assertNoRedbox()
-
-    await cleanup()
   })
 
   // https://github.com/vercel/next.js/issues/13978
   test('can fast refresh a page with static generation', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'app/page.js',
@@ -137,13 +137,12 @@ describe('ReactRefreshRegression app', () => {
     expect(
       await session.evaluate(() => document.querySelector('p').textContent)
     ).toBe('Count: 2')
-
-    await cleanup()
   })
 
   // https://github.com/vercel/next.js/issues/13978
   test('can fast refresh a page with dynamic rendering', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'app/page.js',
@@ -217,13 +216,12 @@ describe('ReactRefreshRegression app', () => {
       () => session.evaluate(() => document.querySelector('p').textContent),
       'Count: 2'
     )
-
-    await cleanup()
   })
 
   // https://github.com/vercel/next.js/issues/13978
   test('can fast refresh a page with config', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'app/page.js',
@@ -267,13 +265,12 @@ describe('ReactRefreshRegression app', () => {
     expect(
       await session.evaluate(() => document.querySelector('p').textContent)
     ).toBe('1')
-
-    await cleanup()
   })
 
   // https://github.com/vercel/next.js/issues/11504
   test('shows an overlay for anonymous function server-side error', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'app/page.js',
@@ -287,12 +284,11 @@ describe('ReactRefreshRegression app', () => {
       "> 1 | export default function () { throw new Error('boom'); }
           |                                    ^"
     `)
-
-    await cleanup()
   })
 
   test('shows an overlay for server-side error in server component', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'app/page.js',
@@ -306,12 +302,11 @@ describe('ReactRefreshRegression app', () => {
       "> 1 | export default function Page() { throw new Error('boom'); }
           |                                        ^"
     `)
-
-    await cleanup()
   })
 
   test('shows an overlay for server-side error in client component', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'app/page.js',
@@ -329,8 +324,6 @@ describe('ReactRefreshRegression app', () => {
         > 2 | export default function Page() { throw new Error('boom'); }
             |                                        ^"
       `)
-
-    await cleanup()
   })
 
   // https://github.com/vercel/next.js/issues/13574
@@ -359,7 +352,9 @@ describe('ReactRefreshRegression app', () => {
       `
     )
 
-    const { session, cleanup } = await sandbox(next, files)
+    await using sandbox = await createSandbox(next, files)
+    const { session } = sandbox
+
     expect(
       await session.evaluate(
         () => document.querySelector('#content').textContent
@@ -383,7 +378,5 @@ describe('ReactRefreshRegression app', () => {
         () => document.querySelector('#content').textContent
       )
     ).toBe('Hello Bar!')
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance-app/ReactRefreshRequire.test.ts
+++ b/test/development/acceptance-app/ReactRefreshRequire.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { outdent } from 'outdent'
@@ -12,7 +12,8 @@ describe('ReactRefreshRequire app', () => {
 
   // https://github.com/facebook/metro/blob/b651e535cd0fc5df6c0803b9aa647d664cb9a6c3/packages/metro/src/lib/polyfills/__tests__/require-test.js#L989-L1048
   test('re-runs accepted modules', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -63,13 +64,12 @@ describe('ReactRefreshRequire app', () => {
     // TODO:
     // expect(Refresh.performReactRefresh).toHaveBeenCalled();
     // expect(Refresh.performFullRefresh).not.toHaveBeenCalled();
-
-    await cleanup()
   })
 
   // https://github.com/facebook/metro/blob/b651e535cd0fc5df6c0803b9aa647d664cb9a6c3/packages/metro/src/lib/polyfills/__tests__/require-test.js#L1050-L1137
   test('propagates a hot update to closest accepted module', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -168,12 +168,11 @@ describe('ReactRefreshRequire app', () => {
     // TODO:
     // expect(Refresh.performReactRefresh).toHaveBeenCalled();
     // expect(Refresh.performFullRefresh).not.toHaveBeenCalled();
-
-    await cleanup()
   })
   // https://github.com/facebook/metro/blob/b651e535cd0fc5df6c0803b9aa647d664cb9a6c3/packages/metro/src/lib/polyfills/__tests__/require-test.js#L1139-L1307
   test('propagates hot update to all inverse dependencies', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -308,8 +307,6 @@ describe('ReactRefreshRequire app', () => {
     // TODO:
     // expect(Refresh.performReactRefresh).toHaveBeenCalled()
     // expect(Refresh.performFullRefresh).not.toHaveBeenCalled()
-
-    await cleanup()
   })
 
   // https://github.com/facebook/metro/blob/b651e535cd0fc5df6c0803b9aa647d664cb9a6c3/packages/metro/src/lib/polyfills/__tests__/require-test.js#L1309-L1406
@@ -370,7 +367,8 @@ describe('ReactRefreshRequire app', () => {
   // https://github.com/facebook/metro/blob/b651e535cd0fc5df6c0803b9aa647d664cb9a6c3/packages/metro/src/lib/polyfills/__tests__/require-test.js#L2373-L2472
   // TODO-APP: investigate why it fails in app
   test.skip('propagates a module that stops accepting in next version', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     // Accept in parent
     await session.write(
@@ -489,8 +487,6 @@ describe('ReactRefreshRequire app', () => {
 
     // expect(Refresh.performFullRefresh).toHaveBeenCalled();
     expect(didFullRefresh).toBe(true)
-
-    await cleanup()
   })
 
   // https://github.com/facebook/metro/blob/b651e535cd0fc5df6c0803b9aa647d664cb9a6c3/packages/metro/src/lib/polyfills/__tests__/require-test.js#L2474-L2521

--- a/test/development/acceptance-app/app-hmr-changes.test.ts
+++ b/test/development/acceptance-app/app-hmr-changes.test.ts
@@ -1,5 +1,5 @@
 import { FileRef, nextTestSetup } from 'e2e-utils'
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import path from 'path'
 
 jest.setTimeout(240 * 1000)
@@ -26,12 +26,12 @@ describe('Error overlay - RSC build errors', () => {
     'Skipped in webpack',
     () => {
       it('should handle successive HMR changes with errors correctly', async () => {
-        const { session, cleanup } = await sandbox(
+        await using sandbox = await createSandbox(
           next,
           undefined,
           '/2020/develop-preview-test'
         )
-
+        const { session } = sandbox
         expect(
           await session.evaluate('document.documentElement.innerHTML')
         ).toContain('A few years ago I tweeted')
@@ -62,8 +62,6 @@ describe('Error overlay - RSC build errors', () => {
         expect(
           await session.evaluate('document.documentElement.innerHTML')
         ).toContain('A few years ago I tweeted')
-
-        await cleanup()
       })
     }
   )

--- a/test/development/acceptance-app/dynamic-error.test.ts
+++ b/test/development/acceptance-app/dynamic-error.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { outdent } from 'outdent'
@@ -10,7 +10,7 @@ describe('dynamic = "error" in devmode', () => {
   })
 
   it('should show error overlay when dynamic is forced', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -29,12 +29,10 @@ describe('dynamic = "error" in devmode', () => {
       ]),
       '/server'
     )
-
+    const { session } = sandbox
     await session.assertHasRedbox()
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
       `"[ Server ] Error: Route /server with \`dynamic = "error"\` couldn't be rendered statically because it used \`cookies\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering"`
     )
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance-app/dynamic-metadata-error.test.ts
+++ b/test/development/acceptance-app/dynamic-metadata-error.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import path from 'path'
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
@@ -33,7 +33,7 @@ describe('dynamic metadata error', () => {
       return new ImageResponse(<div>icon</div>)
     }
     `
-    const { cleanup } = await sandbox(
+    await using _sandbox = await createSandbox(
       next,
       new Map([[iconFilePath, contentMissingIdProperty]]),
       '/metadata-base/unset/icon/100'
@@ -44,8 +44,6 @@ describe('dynamic metadata error', () => {
         `id property is required for every item returned from generateImageMetadata`
       )
     })
-
-    await cleanup()
   })
 
   it('should error when id is missing in generateSitemaps', async () => {
@@ -68,7 +66,7 @@ describe('dynamic metadata error', () => {
       ]
     }`
 
-    const { cleanup } = await sandbox(
+    await using _sandbox = await createSandbox(
       next,
       new Map([[sitemapFilePath, contentMissingIdProperty]]),
       '/metadata-base/unset/sitemap/100.xml'
@@ -79,8 +77,6 @@ describe('dynamic metadata error', () => {
         `id property is required for every item returned from generateSitemaps`
       )
     })
-
-    await cleanup()
   })
 
   it('should error if the default export of dynamic image is missing', async () => {
@@ -90,7 +86,7 @@ describe('dynamic metadata error', () => {
     export function foo() {}  
     `
 
-    const { cleanup } = await sandbox(
+    await using _sandbox = await createSandbox(
       next,
       new Map([[ogImageFilePath, ogImageFileContentWithoutDefaultExport]]),
       '/opengraph-image'
@@ -98,7 +94,5 @@ describe('dynamic metadata error', () => {
     await retry(async () => {
       expect(next.cliOutput).toContain(`Default export is missing in`)
     })
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance-app/editor-links.test.ts
+++ b/test/development/acceptance-app/editor-links.test.ts
@@ -1,7 +1,7 @@
 import { check } from 'next-test-utils'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { outdent } from 'outdent'
 
 async function clickSourceFile(browser: any) {
@@ -33,7 +33,7 @@ describe('Error overlay - editor links', () => {
 
   it('should be possible to open source file on build error', async () => {
     let editorRequestsCount = 0
-    const { session, browser, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -56,7 +56,7 @@ describe('Error overlay - editor links', () => {
         },
       }
     )
-
+    const { session, browser } = sandbox
     await session.patch(
       'index.js',
       outdent`
@@ -68,15 +68,13 @@ describe('Error overlay - editor links', () => {
     await session.assertHasRedbox()
     await clickSourceFile(browser)
     await check(() => editorRequestsCount, /1/)
-
-    await cleanup()
   })
   ;(process.env.TURBOPACK ? describe.skip : describe)(
     'opening links in import traces',
     () => {
       it('should be possible to open import trace files on RSC parse error', async () => {
         let editorRequestsCount = 0
-        const { session, browser, cleanup } = await sandbox(
+        await using sandbox = await createSandbox(
           next,
           new Map([
             [
@@ -101,7 +99,7 @@ describe('Error overlay - editor links', () => {
             },
           }
         )
-
+        const { session, browser } = sandbox
         await session.patch(
           'index.js',
           outdent`
@@ -113,13 +111,11 @@ describe('Error overlay - editor links', () => {
         await session.assertHasRedbox()
         await clickImportTraceFiles(browser)
         await check(() => editorRequestsCount, /4/)
-
-        await cleanup()
       })
 
       it('should be possible to open import trace files on module not found error', async () => {
         let editorRequestsCount = 0
-        const { session, browser, cleanup } = await sandbox(
+        await using sandbox = await createSandbox(
           next,
           new Map([
             [
@@ -144,7 +140,7 @@ describe('Error overlay - editor links', () => {
             },
           }
         )
-
+        const { session, browser } = sandbox
         await session.patch(
           'index.js',
           outdent`
@@ -156,8 +152,6 @@ describe('Error overlay - editor links', () => {
         await session.assertHasRedbox()
         await clickImportTraceFiles(browser)
         await check(() => editorRequestsCount, /3/)
-
-        await cleanup()
       })
     }
   )

--- a/test/development/acceptance-app/error-message-url.test.ts
+++ b/test/development/acceptance-app/error-message-url.test.ts
@@ -1,6 +1,6 @@
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { outdent } from 'outdent'
 
 describe('Error overlay - error message urls', () => {
@@ -10,7 +10,8 @@ describe('Error overlay - error message urls', () => {
   })
 
   it('should be possible to click url in build error', async () => {
-    const { session, browser, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session, browser } = sandbox
 
     const content = await next.readFile('app/page.js')
 
@@ -30,12 +31,10 @@ describe('Error overlay - error message urls', () => {
     expect(href).toEqual(
       'https://nextjs.org/docs/app/building-your-application/data-fetching'
     )
-
-    await cleanup()
   })
 
   it('should be possible to click url in runtime error', async () => {
-    const { session, browser, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -49,7 +48,7 @@ describe('Error overlay - error message urls', () => {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.waitForAndOpenRuntimeError()
 
     const link = await browser.elementByCss('#nextjs__container_errors__link a')
@@ -61,7 +60,5 @@ describe('Error overlay - error message urls', () => {
     expect(href).toEqual(
       'https://nextjs.org/docs/messages/react-hydration-error'
     )
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance-app/error-recovery.test.ts
+++ b/test/development/acceptance-app/error-recovery.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check, describeVariants as describe } from 'next-test-utils'
 import path from 'path'
@@ -12,7 +12,8 @@ describe.each(['default', 'turbo'])('Error recovery app %s', () => {
   })
 
   test('can recover from a syntax error without losing state', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -68,19 +69,13 @@ describe.each(['default', 'turbo'])('Error recovery app %s', () => {
       () => session.evaluate(() => document.querySelector('p').textContent),
       /Count: 1/
     )
-
-    await cleanup()
   })
 
   test.each([['client'], ['server']])(
     '%s component can recover from syntax error',
     async (type: string) => {
-      const { session, browser, cleanup } = await sandbox(
-        next,
-        undefined,
-        '/' + type
-      )
-
+      await using sandbox = await createSandbox(next, undefined, '/' + type)
+      const { session } = sandbox
       // Add syntax error
       await session.patch(
         `app/${type}/page.js`,
@@ -101,13 +96,16 @@ describe.each(['default', 'turbo'])('Error recovery app %s', () => {
         `
       )
 
-      await check(() => browser.elementByCss('p').text(), 'Hello world 2')
-      await cleanup()
+      await check(
+        () => session.evaluate(() => document.querySelector('p').textContent),
+        'Hello world 2'
+      )
     }
   )
 
   test('can recover from a event handler error', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -183,18 +181,13 @@ describe.each(['default', 'turbo'])('Error recovery app %s', () => {
 
     await session.assertNoRedbox()
     expect(await session.hasErrorToast()).toBe(false)
-
-    await cleanup()
   })
 
   test.each([['client'], ['server']])(
     '%s component can recover from a component error',
     async (type: string) => {
-      const { session, cleanup, browser } = await sandbox(
-        next,
-        undefined,
-        '/' + type
-      )
+      await using sandbox = await createSandbox(next, undefined, '/' + type)
+      const { session, browser } = sandbox
 
       await session.write(
         'child.js',
@@ -253,14 +246,13 @@ describe.each(['default', 'turbo'])('Error recovery app %s', () => {
       expect(
         await session.evaluate(() => document.querySelector('p').textContent)
       ).toBe('Hello')
-
-      await cleanup()
     }
   )
 
   // https://github.com/pmmmwh/react-refresh-webpack-plugin/pull/3#issuecomment-554150098
   test('syntax > runtime error', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     // Start here.
     await session.patch(
@@ -321,13 +313,12 @@ describe.each(['default', 'turbo'])('Error recovery app %s', () => {
     expect(await session.getRedboxSource()).toInclude(
       "Expected '}', got '<eof>'"
     )
-
-    await cleanup()
   })
 
   // https://github.com/pmmmwh/react-refresh-webpack-plugin/pull/3#issuecomment-554144016
   test('stuck error', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     // We start here.
     await session.patch(
@@ -386,13 +377,12 @@ describe.each(['default', 'turbo'])('Error recovery app %s', () => {
 
     // Expected: this fixes the problem
     await session.assertNoRedbox()
-
-    await cleanup()
   })
 
   // https://github.com/pmmmwh/react-refresh-webpack-plugin/pull/3#issuecomment-554137262
   test('render error not shown right after syntax error', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     // Starting here:
     await session.patch(
@@ -474,19 +464,15 @@ describe.each(['default', 'turbo'])('Error recovery app %s', () => {
     expect(await session.getRedboxSource()).toInclude(
       "throw new Error('nooo');"
     )
-
-    await cleanup()
   })
 
   test('displays build error on initial page load', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([['app/page.js', '{{{']])
     )
-
+    const { session } = sandbox
     await session.assertHasRedbox()
     await check(() => session.getRedboxSource(true), /Failed to compile/)
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { outdent } from 'outdent'
@@ -14,7 +14,7 @@ describe('Error overlay for hydration errors in App router', () => {
   })
 
   it('includes a React docs link when hydration error does occur', async () => {
-    const { browser } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -35,7 +35,7 @@ describe('Error overlay for hydration errors in App router', () => {
       '/',
       { pushErrorAsConsoleLog: true }
     )
-
+    const { browser } = sandbox
     const logs = await browser.log()
     expect(logs).toEqual(
       expect.arrayContaining([
@@ -51,7 +51,7 @@ describe('Error overlay for hydration errors in App router', () => {
   })
 
   it('should show correct hydration error when client and server render different text', async () => {
-    const { cleanup, session, browser } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -70,7 +70,7 @@ describe('Error overlay for hydration errors in App router', () => {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.waitForAndOpenRuntimeError()
 
     await session.assertHasRedbox()
@@ -130,12 +130,10 @@ describe('Error overlay for hydration errors in App router', () => {
     await session.assertNoRedbox()
 
     expect(await browser.elementByCss('.child').text()).toBe('Value')
-
-    await cleanup()
   })
 
   it('should show correct hydration error when client renders an extra element', async () => {
-    const { browser, cleanup, session } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -154,7 +152,7 @@ describe('Error overlay for hydration errors in App router', () => {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.waitForAndOpenRuntimeError()
 
     await session.assertHasRedbox()
@@ -179,12 +177,10 @@ describe('Error overlay for hydration errors in App router', () => {
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
       `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
     )
-
-    await cleanup()
   })
 
   it('should show correct hydration error when extra attributes set on server', async () => {
-    const { browser, cleanup, session } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -206,6 +202,7 @@ describe('Error overlay for hydration errors in App router', () => {
         ['app/page.js', `export default function Page() { return 'page' }`],
       ])
     )
+    const { session, browser } = sandbox
     await session.waitForAndOpenRuntimeError()
 
     await session.assertHasRedbox()
@@ -217,12 +214,10 @@ describe('Error overlay for hydration errors in App router', () => {
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
       `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
     )
-
-    await cleanup()
   })
 
   it('should show correct hydration error when client renders an extra text node', async () => {
-    const { browser, cleanup, session } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -243,7 +238,7 @@ describe('Error overlay for hydration errors in App router', () => {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.waitForAndOpenRuntimeError()
 
     await session.assertHasRedbox()
@@ -270,12 +265,10 @@ describe('Error overlay for hydration errors in App router', () => {
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
       `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
     )
-
-    await cleanup()
   })
 
   it('should show correct hydration error when server renders an extra element', async () => {
-    const { browser, cleanup, session } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -294,7 +287,7 @@ describe('Error overlay for hydration errors in App router', () => {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.waitForAndOpenRuntimeError()
 
     await session.assertHasRedbox()
@@ -318,12 +311,10 @@ describe('Error overlay for hydration errors in App router', () => {
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
       `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
     )
-
-    await cleanup()
   })
 
   it('should show correct hydration error when server renders an extra text node', async () => {
-    const { browser, cleanup, session } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -338,7 +329,7 @@ describe('Error overlay for hydration errors in App router', () => {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.waitForAndOpenRuntimeError()
 
     await session.assertHasRedbox()
@@ -363,12 +354,10 @@ describe('Error overlay for hydration errors in App router', () => {
         -    only"
       `)
     }
-
-    await cleanup()
   })
 
   it('should show correct hydration error when server renders an extra text node in an invalid place', async () => {
-    const { browser, cleanup, session } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -388,7 +377,7 @@ describe('Error overlay for hydration errors in App router', () => {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.waitForAndOpenRuntimeError()
 
     await session.assertHasRedbox()
@@ -415,12 +404,10 @@ describe('Error overlay for hydration errors in App router', () => {
         -  test
     }`)
     }
-
-    await cleanup()
   })
 
   it('should show correct hydration error when server renders an extra whitespace in an invalid place', async () => {
-    const { cleanup, session, browser } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -439,7 +426,7 @@ describe('Error overlay for hydration errors in App router', () => {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.waitForAndOpenRuntimeError()
 
     await session.assertHasRedbox()
@@ -474,12 +461,10 @@ describe('Error overlay for hydration errors in App router', () => {
     // FIXME: fix the `pseudoHtml` should be extracted from the description
     // const pseudoHtml = await session.getRedboxComponentStack()
     // expect(pseudoHtml).toMatchInlineSnapshot(``)
-
-    await cleanup()
   })
 
   it('should show correct hydration error when client renders an extra node inside Suspense content', async () => {
-    const { cleanup, session } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -503,7 +488,7 @@ describe('Error overlay for hydration errors in App router', () => {
         ],
       ])
     )
-
+    const { session } = sandbox
     await session.waitForAndOpenRuntimeError()
 
     const pseudoHtml = await session.getRedboxComponentStack()
@@ -529,12 +514,10 @@ describe('Error overlay for hydration errors in App router', () => {
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
       `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
     )
-
-    await cleanup()
   })
 
   it('should not show a hydration error when using `useId` in a client component', async () => {
-    const { cleanup, browser } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -557,6 +540,7 @@ describe('Error overlay for hydration errors in App router', () => {
       ])
     )
 
+    const { browser } = sandbox
     const logs = await browser.log()
     const errors = logs
       .filter((x) => x.source === 'error')
@@ -566,12 +550,10 @@ describe('Error overlay for hydration errors in App router', () => {
     expect(errors).not.toInclude(
       'Warning: Prop `%s` did not match. Server: %s Client: %s'
     )
-
-    await cleanup()
   })
 
   it('should only show one hydration error when bad nesting happened - p under p', async () => {
-    const { cleanup, session, browser } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -591,6 +573,7 @@ describe('Error overlay for hydration errors in App router', () => {
       ])
     )
 
+    const { session, browser } = sandbox
     await session.waitForAndOpenRuntimeError()
 
     await session.assertHasRedbox()
@@ -622,12 +605,10 @@ describe('Error overlay for hydration errors in App router', () => {
             ^^^"
       `)
     }
-
-    await cleanup()
   })
 
   it('should only show one hydration error when bad nesting happened - div under p', async () => {
-    const { cleanup, session, browser } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -651,6 +632,7 @@ describe('Error overlay for hydration errors in App router', () => {
       ])
     )
 
+    const { session, browser } = sandbox
     await session.waitForAndOpenRuntimeError()
 
     await session.assertHasRedbox()
@@ -671,12 +653,10 @@ describe('Error overlay for hydration errors in App router', () => {
             <div>
             ^^^^^"
     `)
-
-    await cleanup()
   })
 
   it('should only show one hydration error when bad nesting happened - div > tr', async () => {
-    const { cleanup, session, browser } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -691,6 +671,7 @@ describe('Error overlay for hydration errors in App router', () => {
       ])
     )
 
+    const { session, browser } = sandbox
     await session.waitForAndOpenRuntimeError()
 
     await session.assertHasRedbox()
@@ -723,12 +704,10 @@ describe('Error overlay for hydration errors in App router', () => {
             ^^^^
       `)
     }
-
-    await cleanup()
   })
 
   it('should show the highlighted bad nesting html snippet when bad nesting happened', async () => {
-    const { browser, cleanup, session } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -746,6 +725,7 @@ describe('Error overlay for hydration errors in App router', () => {
       ])
     )
 
+    const { session, browser } = sandbox
     await session.waitForAndOpenRuntimeError()
 
     await session.assertHasRedbox()
@@ -783,12 +763,10 @@ describe('Error overlay for hydration errors in App router', () => {
                   ^^^"
       `)
     }
-
-    await cleanup()
   })
 
   it('should show error if script is directly placed under html instead of body', async () => {
-    const { browser, cleanup, session } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -819,7 +797,7 @@ describe('Error overlay for hydration errors in App router', () => {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.waitForAndOpenRuntimeError()
 
     await session.assertHasRedbox()
@@ -851,11 +829,10 @@ describe('Error overlay for hydration errors in App router', () => {
         ^^^^^^^^
       `)
     }
-    await cleanup()
   })
 
   it('should collapse and uncollapse properly when there are many frames', async () => {
-    const { browser, cleanup, session } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -892,6 +869,7 @@ describe('Error overlay for hydration errors in App router', () => {
         ],
       ])
     )
+    const { session, browser } = sandbox
     await session.waitForAndOpenRuntimeError()
 
     await session.assertHasRedbox()
@@ -965,7 +943,5 @@ describe('Error overlay for hydration errors in App router', () => {
         -                            server"
       `)
     }
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance-app/invalid-imports.test.ts
+++ b/test/development/acceptance-app/invalid-imports.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { outdent } from 'outdent'
@@ -15,7 +15,7 @@ describe('Error Overlay invalid imports', () => {
   })
 
   it('should show error when using styled-jsx in server component', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -57,7 +57,7 @@ describe('Error Overlay invalid imports', () => {
         ],
       ])
     )
-
+    const { session } = sandbox
     const pageFile = 'app/page.js'
     const content = await next.readFile(pageFile)
     const withoutUseClient = content.replace("'use client'", '')
@@ -84,12 +84,10 @@ describe('Error Overlay invalid imports', () => {
               ./app/page.js"
           `)
     }
-
-    await cleanup()
   })
 
   it('should show error when external package imports client-only in server component', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -141,7 +139,7 @@ describe('Error Overlay invalid imports', () => {
         ],
       ])
     )
-
+    const { session } = sandbox
     const pageFile = 'app/page.js'
     const content = await next.readFile(pageFile)
     const withoutUseClient = content.replace("'use client'", '')
@@ -168,12 +166,10 @@ describe('Error Overlay invalid imports', () => {
         ./app/page.js"
       `)
     }
-
-    await cleanup()
   })
 
   it('should show error when external package imports server-only in client component', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -224,7 +220,7 @@ describe('Error Overlay invalid imports', () => {
         ],
       ])
     )
-
+    const { session } = sandbox
     const file = 'app/page.js'
     const content = await next.readFile(file)
     await session.patch(file, "'use client'\n" + content)
@@ -250,7 +246,5 @@ describe('Error Overlay invalid imports', () => {
         ./app/page.js"
       `)
     }
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -1,7 +1,7 @@
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import path from 'path'
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { outdent } from 'outdent'
 
 describe('Error overlay - RSC build errors', () => {
@@ -11,12 +11,12 @@ describe('Error overlay - RSC build errors', () => {
   })
 
   it('should throw an error when getServerSideProps is used', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       undefined,
       '/client-with-errors/get-server-side-props'
     )
-
+    const { session } = sandbox
     const pageFile = 'app/client-with-errors/get-server-side-props/page.js'
     const content = await next.readFile(pageFile)
     const uncomment = content.replace(
@@ -29,17 +29,15 @@ describe('Error overlay - RSC build errors', () => {
     expect(await session.getRedboxSource()).toInclude(
       '"getServerSideProps" is not supported in app/'
     )
-
-    await cleanup()
   })
 
   it('should throw an error when metadata export is used in client components', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       undefined,
       '/client-with-errors/metadata-export'
     )
-
+    const { session } = sandbox
     const pageFile = 'app/client-with-errors/metadata-export/page.js'
     const content = await next.readFile(pageFile)
 
@@ -72,17 +70,15 @@ describe('Error overlay - RSC build errors', () => {
     // Fix the error again to test error overlay works with hmr rebuild
     await session.patch(pageFile, content)
     await session.assertNoRedbox()
-
-    await cleanup()
   })
 
   it('should throw an error when metadata exports are used together in server components', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       undefined,
       '/server-with-errors/metadata-export'
     )
-
+    const { session } = sandbox
     const pageFile = 'app/server-with-errors/metadata-export/page.js'
     const content = await next.readFile(pageFile)
     const uncomment = content.replace(
@@ -95,18 +91,16 @@ describe('Error overlay - RSC build errors', () => {
     expect(await session.getRedboxSource()).toInclude(
       '"metadata" and "generateMetadata" cannot be exported at the same time, please keep one of them.'
     )
-
-    await cleanup()
   })
 
   // TODO: investigate flakey test case
   it.skip('should throw an error when getStaticProps is used', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       undefined,
       '/client-with-errors/get-static-props'
     )
-
+    const { session } = sandbox
     const pageFile = 'app/client-with-errors/get-static-props/page.js'
     const content = await next.readFile(pageFile)
     const uncomment = content.replace(
@@ -120,17 +114,15 @@ describe('Error overlay - RSC build errors', () => {
     expect(await session.getRedboxSource()).toInclude(
       '"getStaticProps" is not supported in app/'
     )
-
-    await cleanup()
   })
 
   it('should throw an error when "use client" is on the top level but after other expressions', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       undefined,
       '/swc/use-client'
     )
-
+    const { session } = sandbox
     const pageFile = 'app/swc/use-client/page.js'
     const content = await next.readFile(pageFile)
     const uncomment = content.replace("// 'use client'", "'use client'")
@@ -140,17 +132,15 @@ describe('Error overlay - RSC build errors', () => {
     expect(await session.getRedboxSource()).toInclude(
       'directive must be placed before other expressions'
     )
-
-    await cleanup()
   })
 
   it('should throw an error when "Component" is imported in server components', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       undefined,
       '/server-with-errors/class-component'
     )
-
+    const { session } = sandbox
     const pageFile = 'app/server-with-errors/class-component/page.js'
     const content = await next.readFile(pageFile)
     const uncomment = content.replace(
@@ -163,17 +153,15 @@ describe('Error overlay - RSC build errors', () => {
     expect(await session.getRedboxSource()).toInclude(
       `You’re importing a class component. It only works in a Client Component`
     )
-
-    await cleanup()
   })
 
   it('should allow to use and handle rsc poisoning client-only', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       undefined,
       '/server-with-errors/client-only-in-server'
     )
-
+    const { session } = sandbox
     const file =
       'app/server-with-errors/client-only-in-server/client-only-lib.js'
     const content = await next.readFile(file)
@@ -203,8 +191,6 @@ describe('Error overlay - RSC build errors', () => {
         `You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.`
       )
     }
-
-    await cleanup()
   })
 
   const invalidReactServerApis = [
@@ -227,12 +213,12 @@ describe('Error overlay - RSC build errors', () => {
   ]
   for (const api of invalidReactServerApis) {
     it(`should error when ${api} from react is used in server component`, async () => {
-      const { session, cleanup } = await sandbox(
+      await using sandbox = await createSandbox(
         next,
         undefined,
         `/server-with-errors/react-apis/${api.toLowerCase()}`
       )
-
+      const { session } = sandbox
       await session.assertHasRedbox()
       expect(await session.getRedboxSource()).toInclude(
         // `Component` has a custom error message
@@ -240,8 +226,6 @@ describe('Error overlay - RSC build errors', () => {
           ? `You’re importing a class component. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.`
           : `You're importing a component that needs \`${api}\`. This React hook only works in a client component. To fix, mark the file (or its parent) with the \`"use client"\` directive.`
       )
-
-      await cleanup()
     })
   }
 
@@ -253,28 +237,26 @@ describe('Error overlay - RSC build errors', () => {
   ]
   for (const api of invalidReactDomServerApis) {
     it(`should error when ${api} from react-dom is used in server component`, async () => {
-      const { session, cleanup } = await sandbox(
+      await using sandbox = await createSandbox(
         next,
         undefined,
         `/server-with-errors/react-dom-apis/${api.toLowerCase()}`
       )
-
+      const { session } = sandbox
       await session.assertHasRedbox()
       expect(await session.getRedboxSource()).toInclude(
         `You're importing a component that needs \`${api}\`. This React hook only works in a client component. To fix, mark the file (or its parent) with the \`"use client"\` directive.`
       )
-
-      await cleanup()
     })
   }
 
   it('should allow to use and handle rsc poisoning server-only', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       undefined,
       '/client-with-errors/server-only-in-client'
     )
-
+    const { session } = sandbox
     const file =
       'app/client-with-errors/server-only-in-client/server-only-lib.js'
     const content = await next.readFile(file)
@@ -289,17 +271,15 @@ describe('Error overlay - RSC build errors', () => {
     expect(await session.getRedboxSource()).toInclude(
       `You're importing a component that needs "server-only". That only works in a Server Component but one of its parents is marked with "use client", so it's a Client Component.`
     )
-
-    await cleanup()
   })
 
   it('should error for invalid undefined module retuning from next dynamic', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       undefined,
       '/client-with-errors/dynamic'
     )
-
+    const { session } = sandbox
     const file = 'app/client-with-errors/dynamic/page.js'
     const content = await next.readFile(file)
     await session.patch(
@@ -311,17 +291,15 @@ describe('Error overlay - RSC build errors', () => {
     expect(await session.getRedboxDescription()).toInclude(
       `Element type is invalid. Received a promise that resolves to: undefined. Lazy element type must resolve to a class or function.`
     )
-
-    await cleanup()
   })
 
   it('should throw an error when error file is a server component', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       undefined,
       '/server-with-errors/error-file'
     )
-
+    const { session } = sandbox
     // Remove "use client"
     await session.patch(
       'app/server-with-errors/error-file/error.js',
@@ -365,17 +343,15 @@ describe('Error overlay - RSC build errors', () => {
       //   ./app/server-with-errors/error-file/error.js"
       // `)
     }
-
-    await cleanup()
   })
 
   it('should throw an error when error file is a server component with empty error file', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       undefined,
       '/server-with-errors/error-file'
     )
-
+    const { session } = sandbox
     // Empty file
     await session.patch('app/server-with-errors/error-file/error.js', '')
 
@@ -398,8 +374,6 @@ describe('Error overlay - RSC build errors', () => {
     //   Import path:
     //   ./app/server-with-errors/error-file/error.js"
     // `)
-
-    await cleanup()
   })
 
   it('should freeze parent resolved metadata to avoid mutating in generateMetadata', async () => {
@@ -418,12 +392,12 @@ describe('Error overlay - RSC build errors', () => {
       }
     `
 
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       undefined,
       '/metadata/mutate'
     )
-
+    const { session } = sandbox
     await session.patch(pagePath, content)
 
     await session.assertHasRedbox()
@@ -431,7 +405,5 @@ describe('Error overlay - RSC build errors', () => {
     expect(await session.getRedboxDescription()).toContain(
       'Cannot add property x, object is not extensible'
     )
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance-app/server-components.test.ts
+++ b/test/development/acceptance-app/server-components.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { check } from 'next-test-utils'
@@ -13,7 +13,7 @@ describe('Error Overlay for server components', () => {
 
   describe('createContext called in Server Component', () => {
     it('should show error when React.createContext is called', async () => {
-      const { browser, cleanup } = await sandbox(
+      await using sandbox = await createSandbox(
         next,
         new Map([
           [
@@ -34,7 +34,7 @@ describe('Error Overlay for server components', () => {
           ],
         ])
       )
-
+      const { browser } = sandbox
       await check(async () => {
         expect(
           await browser
@@ -49,12 +49,10 @@ describe('Error Overlay for server components', () => {
       expect(next.cliOutput).toContain(
         'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
       )
-
-      await cleanup()
     })
 
     it('should show error when React.createContext is called in external package', async () => {
-      const { browser, cleanup } = await sandbox(
+      await using sandbox = await createSandbox(
         next,
         new Map([
           [
@@ -90,7 +88,7 @@ describe('Error Overlay for server components', () => {
           ],
         ])
       )
-
+      const { browser } = sandbox
       await check(async () => {
         expect(
           await browser
@@ -105,12 +103,10 @@ describe('Error Overlay for server components', () => {
       expect(next.cliOutput).toContain(
         'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
       )
-
-      await cleanup()
     })
 
     it('should show error when createContext is called in external package', async () => {
-      const { browser, cleanup } = await sandbox(
+      await using sandbox = await createSandbox(
         next,
         new Map([
           [
@@ -146,6 +142,7 @@ describe('Error Overlay for server components', () => {
           ],
         ])
       )
+      const { browser } = sandbox
       await check(async () => {
         expect(
           await browser
@@ -160,14 +157,12 @@ describe('Error Overlay for server components', () => {
       expect(next.cliOutput).toContain(
         'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
       )
-
-      await cleanup()
     })
   })
 
   describe('React component hooks called in Server Component', () => {
     it('should show error when React.<client-hook> is called', async () => {
-      const { browser, cleanup } = await sandbox(
+      await using sandbox = await createSandbox(
         next,
         new Map([
           [
@@ -182,7 +177,7 @@ describe('Error Overlay for server components', () => {
           ],
         ])
       )
-
+      const { browser } = sandbox
       await check(async () => {
         expect(
           await browser
@@ -197,12 +192,10 @@ describe('Error Overlay for server components', () => {
       expect(next.cliOutput).toContain(
         'useRef only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
       )
-
-      await cleanup()
     })
 
     it('should show error when React.experiment_useOptimistic is called', async () => {
-      const { browser, cleanup } = await sandbox(
+      await using sandbox = await createSandbox(
         next,
         new Map([
           [
@@ -217,7 +210,7 @@ describe('Error Overlay for server components', () => {
           ],
         ])
       )
-
+      const { browser } = sandbox
       await check(async () => {
         expect(
           await browser
@@ -232,12 +225,10 @@ describe('Error Overlay for server components', () => {
       expect(next.cliOutput).toContain(
         'experimental_useOptimistic only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
       )
-
-      await cleanup()
     })
 
     it('should show error when React.experiment_useOptimistic is renamed in destructuring', async () => {
-      const { browser, cleanup } = await sandbox(
+      await using sandbox = await createSandbox(
         next,
         new Map([
           [
@@ -252,7 +243,7 @@ describe('Error Overlay for server components', () => {
           ],
         ])
       )
-
+      const { browser } = sandbox
       await check(async () => {
         const html = await browser.eval('document.documentElement.innerHTML')
         expect(html).toContain('experimental_useOptimistic')
@@ -260,12 +251,10 @@ describe('Error Overlay for server components', () => {
       }, 'success')
 
       expect(next.cliOutput).toContain('experimental_useOptimistic')
-
-      await cleanup()
     })
 
     it('should show error when React.<client-hook> is called in external package', async () => {
-      const { browser, cleanup } = await sandbox(
+      await using sandbox = await createSandbox(
         next,
         new Map([
           [
@@ -298,7 +287,7 @@ describe('Error Overlay for server components', () => {
           ],
         ])
       )
-
+      const { browser } = sandbox
       await check(async () => {
         expect(
           await browser
@@ -313,12 +302,10 @@ describe('Error Overlay for server components', () => {
       expect(next.cliOutput).toContain(
         'useState only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
       )
-
-      await cleanup()
     })
 
     it('should show error when React client hook is called in external package', async () => {
-      const { browser, cleanup } = await sandbox(
+      await using sandbox = await createSandbox(
         next,
         new Map([
           [
@@ -351,7 +338,7 @@ describe('Error Overlay for server components', () => {
           ],
         ])
       )
-
+      const { browser } = sandbox
       await check(async () => {
         expect(
           await browser
@@ -366,14 +353,12 @@ describe('Error Overlay for server components', () => {
       expect(next.cliOutput).toContain(
         'useEffect only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
       )
-
-      await cleanup()
     })
   })
 
   describe('Class component used in Server Component', () => {
     it('should show error when Class Component is used', async () => {
-      const { browser, cleanup } = await sandbox(
+      await using sandbox = await createSandbox(
         next,
         new Map([
           [
@@ -389,7 +374,7 @@ describe('Error Overlay for server components', () => {
           ],
         ])
       )
-
+      const { browser } = sandbox
       await check(async () => {
         expect(
           await browser
@@ -404,12 +389,10 @@ describe('Error Overlay for server components', () => {
       expect(next.cliOutput).toContain(
         'This might be caused by a React Class Component being rendered in a Server Component'
       )
-
-      await cleanup()
     })
 
     it('should show error when React.PureComponent is rendered in external package', async () => {
-      const { browser, cleanup } = await sandbox(
+      await using sandbox = await createSandbox(
         next,
         new Map([
           [
@@ -443,7 +426,7 @@ describe('Error Overlay for server components', () => {
           ],
         ])
       )
-
+      const { browser } = sandbox
       await check(async () => {
         expect(
           await browser
@@ -458,12 +441,10 @@ describe('Error Overlay for server components', () => {
       expect(next.cliOutput).toContain(
         'This might be caused by a React Class Component being rendered in a Server Component'
       )
-
-      await cleanup()
     })
 
     it('should show error when Component is rendered in external package', async () => {
-      const { browser, cleanup } = await sandbox(
+      await using sandbox = await createSandbox(
         next,
         new Map([
           [
@@ -497,7 +478,7 @@ describe('Error Overlay for server components', () => {
           ],
         ])
       )
-
+      const { browser } = sandbox
       await check(async () => {
         expect(
           await browser
@@ -512,8 +493,6 @@ describe('Error Overlay for server components', () => {
       expect(next.cliOutput).toContain(
         'This might be caused by a React Class Component being rendered in a Server Component'
       )
-
-      await cleanup()
     })
   })
 
@@ -526,7 +505,7 @@ describe('Error Overlay for server components', () => {
       ['useSelectedLayoutSegment'],
       ['useSelectedLayoutSegments'],
     ])('should show error when %s is called', async (hook: string) => {
-      const { session, cleanup } = await sandbox(
+      await using sandbox = await createSandbox(
         next,
         new Map([
           [
@@ -540,7 +519,7 @@ describe('Error Overlay for server components', () => {
           ],
         ])
       )
-
+      const { session } = sandbox
       await session.assertHasRedbox()
       // In webpack when the message too long it gets truncated with `  | ` with new lines.
       // So we need to check for the first part of the message.
@@ -551,8 +530,6 @@ describe('Error Overlay for server components', () => {
       expect(normalizedSource).toContain(
         `import { ${hook} } from 'next/navigation'`
       )
-
-      await cleanup()
     })
   })
 })

--- a/test/development/acceptance-app/undefined-default-export.test.ts
+++ b/test/development/acceptance-app/undefined-default-export.test.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 
 describe('Undefined default export', () => {
   const { next } = nextTestSetup({
@@ -9,24 +9,22 @@ describe('Undefined default export', () => {
   })
 
   it('should error if page component does not have default export', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         ['app/(group)/specific-path/server/page.js', 'export const a = 123'],
       ]),
       '/specific-path/server'
     )
-
+    const { session } = sandbox
     await session.assertHasRedbox()
     expect(await session.getRedboxDescription()).toInclude(
       'The default export is not a React Component in "/specific-path/server/page"'
     )
-
-    await cleanup()
   })
 
   it('should error if not-found component does not have default export when trigger not-found boundary', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -40,17 +38,16 @@ describe('Undefined default export', () => {
       ]),
       '/will-not-found'
     )
-
+    const { session } = sandbox
     await session.assertHasRedbox()
     expect(await session.getRedboxDescription()).toInclude(
       'The default export is not a React Component in "/will-not-found/not-found"'
     )
-
-    await cleanup()
   })
 
   it('should error when page component export is not valid', async () => {
-    const { session, browser, cleanup } = await sandbox(next, undefined, '/')
+    await using sandbox = await createSandbox(next, undefined, '/')
+    const { session, browser } = sandbox
 
     await next.patchFile('app/page.js', 'const a = 123')
 
@@ -62,12 +59,10 @@ describe('Undefined default export', () => {
     expect(await session.getRedboxDescription()).toInclude(
       'The default export is not a React Component in "/page"'
     )
-
-    await cleanup()
   })
 
   it('should error when page component export is not valid on initial load', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -77,12 +72,10 @@ describe('Undefined default export', () => {
       ]),
       '/server-with-errors/page-export-initial-error'
     )
-
+    const { session } = sandbox
     await session.assertHasRedbox()
     expect(await session.getRedboxDescription()).toInclude(
       'The default export is not a React Component in "/server-with-errors/page-export-initial-error/page"'
     )
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance-app/version-staleness.test.ts
+++ b/test/development/acceptance-app/version-staleness.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { outdent } from 'outdent'
@@ -24,13 +24,13 @@ describe('Error Overlay version staleness', () => {
     )
     nextPackageJson.version = '1.0.0'
 
-    const { browser, session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         ['node_modules/next/package.json', JSON.stringify(nextPackageJson)],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.patch(
       'app/page.js',
       outdent`
@@ -56,8 +56,6 @@ describe('Error Overlay version staleness', () => {
         `"Next.js (1.0.0) is outdated (learn more)"`
       )
     }
-
-    await cleanup()
   })
 
   it('should show version staleness in render error', async () => {
@@ -67,13 +65,13 @@ describe('Error Overlay version staleness', () => {
     )
     nextPackageJson.version = '2.0.0'
 
-    const { browser, session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         ['node_modules/next/package.json', JSON.stringify(nextPackageJson)],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.patch(
       'app/page.js',
       outdent`
@@ -93,8 +91,6 @@ describe('Error Overlay version staleness', () => {
         `"Next.js (2.0.0) is outdated (learn more)"`
       )
     }
-
-    await cleanup()
   })
 
   it('should show version staleness in build error', async () => {
@@ -104,13 +100,13 @@ describe('Error Overlay version staleness', () => {
     )
     nextPackageJson.version = '3.0.0'
 
-    const { browser, session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         ['node_modules/next/package.json', JSON.stringify(nextPackageJson)],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.patch(
       'app/page.js',
       outdent`
@@ -127,7 +123,5 @@ describe('Error Overlay version staleness', () => {
         `"Next.js (3.0.0) is outdated (learn more)"`
       )
     }
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance/ReactRefresh.test.ts
+++ b/test/development/acceptance/ReactRefresh.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { outdent } from 'outdent'
@@ -11,7 +11,8 @@ describe('ReactRefresh', () => {
   })
 
   test('can edit a component without losing state', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -61,12 +62,11 @@ describe('ReactRefresh', () => {
     expect(
       await session.evaluate(() => document.querySelector('p').textContent)
     ).toBe('Count: 2')
-
-    await cleanup()
   })
 
   test('cyclic dependencies', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.write(
       'NudgeOverview.js',
@@ -220,7 +220,5 @@ describe('ReactRefresh', () => {
       await session.evaluate(() => document.querySelector('p').textContent)
     ).toBe('Hello: 300')
     expect(didFullRefresh).toBe(false)
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
@@ -1,4 +1,4 @@
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import { describeVariants as describe } from 'next-test-utils'
 import { outdent } from 'outdent'
@@ -13,10 +13,11 @@ describe.each(['default', 'turbo'])(
     })
 
     test('empty _app shows logbox', async () => {
-      const { session, cleanup } = await sandbox(
+      await using sandbox = await createSandbox(
         next,
         new Map([['pages/_app.js', ``]])
       )
+      const { session } = sandbox
       await session.assertHasRedbox()
       expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
         `"Error: The default export is not a React Component in page: "/_app""`
@@ -32,14 +33,14 @@ describe.each(['default', 'turbo'])(
       `
       )
       await session.assertNoRedbox()
-      await cleanup()
     })
 
     test('empty _document shows logbox', async () => {
-      const { session, cleanup } = await sandbox(
+      await using sandbox = await createSandbox(
         next,
         new Map([['pages/_document.js', ``]])
       )
+      const { session } = sandbox
       await session.assertHasRedbox()
       expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
         `"Error: The default export is not a React Component in page: "/_document""`
@@ -73,11 +74,10 @@ describe.each(['default', 'turbo'])(
       `
       )
       await session.assertNoRedbox()
-      await cleanup()
     })
 
     test('_app syntax error shows logbox', async () => {
-      const { session, cleanup } = await sandbox(
+      await using sandbox = await createSandbox(
         next,
         new Map([
           [
@@ -91,6 +91,7 @@ describe.each(['default', 'turbo'])(
           ],
         ])
       )
+      const { session } = sandbox
       await session.assertHasRedbox()
       const content = await session.getRedboxSource()
       const source = next.normalizeTestDirContent(content)
@@ -141,11 +142,10 @@ describe.each(['default', 'turbo'])(
       `
       )
       await session.assertNoRedbox()
-      await cleanup()
     })
 
     test('_document syntax error shows logbox', async () => {
-      const { session, cleanup } = await sandbox(
+      await using sandbox = await createSandbox(
         next,
         new Map([
           [
@@ -177,6 +177,7 @@ describe.each(['default', 'turbo'])(
           ],
         ])
       )
+      const { session } = sandbox
       await session.assertHasRedbox()
       const source = next.normalizeTestDirContent(
         await session.getRedboxSource()
@@ -242,7 +243,6 @@ describe.each(['default', 'turbo'])(
       `
       )
       await session.assertNoRedbox()
-      await cleanup()
     })
   }
 )

--- a/test/development/acceptance/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-builtins.test.ts
@@ -1,4 +1,4 @@
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import { describeVariants as describe } from 'next-test-utils'
 import { outdent } from 'outdent'
@@ -12,7 +12,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
   // Module trace is only available with webpack 5
   test('Node.js builtins', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -33,7 +33,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
         ],
       ])
     )
-
+    const { session } = sandbox
     await session.patch(
       'index.js',
       outdent`
@@ -70,12 +70,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
         ./pages/index.js"
       `)
     }
-
-    await cleanup()
   })
 
   test('Module not found', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -123,12 +122,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
         ./pages/index.js"
       `)
     }
-
-    await cleanup()
   })
 
   test('Module not found (empty import trace)', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'pages/index.js',
@@ -173,12 +171,10 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
         https://nextjs.org/docs/messages/module-not-found"
       `)
     }
-
-    await cleanup()
   })
 
   test('Module not found (missing global CSS)', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -201,6 +197,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
         ],
       ])
     )
+    const { session } = sandbox
     await session.assertHasRedbox()
 
     const source = await session.getRedboxSource()
@@ -242,7 +239,5 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     expect(
       await session.evaluate(() => document.documentElement.innerHTML)
     ).toContain('index page')
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance/ReactRefreshLogBox-scss.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-scss.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 
@@ -15,7 +15,8 @@ describe.skip('ReactRefreshLogBox scss', () => {
   })
 
   test('scss syntax errors', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.write('index.module.scss', `.button { font-size: 5px; }`)
     await session.patch(
@@ -39,12 +40,11 @@ describe.skip('ReactRefreshLogBox scss', () => {
     await session.assertHasRedbox()
     const source = await session.getRedboxSource()
     expect(source).toMatchSnapshot()
-
-    await cleanup()
   })
 
   test('scss module pure selector error', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.write('index.module.scss', `.button { font-size: 5px; }`)
     await session.patch(
@@ -67,7 +67,5 @@ describe.skip('ReactRefreshLogBox scss', () => {
     await session.assertHasRedbox()
     const source2 = await session.getRedboxSource()
     expect(source2).toMatchSnapshot()
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import { describeVariants as describe } from 'next-test-utils'
 import path from 'path'
@@ -12,7 +12,8 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
   })
 
   test('should strip whitespace correctly with newline', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -37,14 +38,13 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
     await session.assertHasRedbox()
     expect(await session.getRedboxSource()).toMatchSnapshot()
-
-    await cleanup()
   })
 
   // https://github.com/pmmmwh/react-refresh-webpack-plugin/pull/3#issuecomment-554137807
   test('module init error not shown', async () => {
     // Start here:
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     // We start here.
     await session.patch(
@@ -82,13 +82,12 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
     await session.assertHasRedbox()
     expect(await session.getRedboxSource()).toMatchSnapshot()
-
-    await cleanup()
   })
 
   // https://github.com/pmmmwh/react-refresh-webpack-plugin/pull/3#issuecomment-554152127
   test('boundaries', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.write(
       'FunctionDefault.js',
@@ -146,15 +145,14 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     expect(
       await session.evaluate(() => document.querySelector('h2').textContent)
     ).toBe('error')
-
-    await cleanup()
   })
 
   // TODO: investigate why this fails when running outside of the Next.js
   // monorepo e.g. fails when using pnpm create next-app
   // https://github.com/vercel/next.js/pull/23203
   test.skip('internal package errors', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     // Make a react build-time error.
     await session.patch(
@@ -172,12 +170,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     expect(await session.getRedboxSource()).toContain(
       `../../../../packages/next/dist/pages/_document.js`
     )
-
-    await cleanup()
   })
 
   test('unterminated JSX', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -247,13 +244,12 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
         ./pages/index.js"
       `)
     }
-
-    await cleanup()
   })
 
   // Module trace is only available with webpack 5
   test('conversion to class component (1)', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.write(
       'Child.js',
@@ -315,12 +311,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     expect(
       await session.evaluate(() => document.querySelector('p').textContent)
     ).toBe('hello new')
-
-    await cleanup()
   })
 
   test('css syntax errors', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.write('index.module.css', `.button {}`)
     await session.patch(
@@ -366,12 +361,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     await session.assertHasRedbox()
     const source2 = await session.getRedboxSource()
     expect(source2).toMatchSnapshot()
-
-    await cleanup()
   })
 
   test('logbox: anchors links in error messages', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -632,12 +626,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
           ).href
       )
     ).toBe(null)
-
-    await cleanup()
   })
 
   test('non-Error errors are handled properly', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -741,12 +734,10 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     expect(await session.getRedboxDescription()).toContain(
       `Error: A null error was thrown`
     )
-
-    await cleanup()
   })
 
   test('Call stack count is correct for pages error', async () => {
-    const { session, browser, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -762,7 +753,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.assertHasRedbox()
 
     // Expect more than the default amount of frames
@@ -778,12 +769,10 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     )
     // Expect some of the call stack frames to be grouped (by React or Next.js)
     expect(moduleGroup.length).toBeGreaterThan(0)
-
-    await cleanup()
   })
 
   test('should hide unrelated frames in stack trace with unknown anonymous calls', async () => {
-    const { session, browser, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -802,6 +791,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
         ],
       ])
     )
+    const { session, browser } = sandbox
     await session.assertHasRedbox()
     let callStackFrames = await browser.elementsByCss(
       '[data-nextjs-call-stack-frame]'
@@ -810,12 +800,10 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     expect(texts).not.toContain('stringify\n<anonymous>')
     expect(texts).not.toContain('<unknown>\n<anonymous>')
     expect(texts).toContain('foo\nbar (1:1)')
-
-    await cleanup()
   })
 
   test('should hide unrelated frames in stack trace with node:internal calls', async () => {
-    const { session, browser, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -831,6 +819,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
         ],
       ])
     )
+    const { session, browser } = sandbox
     await session.assertHasRedbox()
 
     // Should still show the errored line in source code
@@ -844,7 +833,5 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     const texts = await Promise.all(callStackFrames.map((f) => f.innerText()))
 
     expect(texts.filter((t) => t.includes('node:internal'))).toHaveLength(0)
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance/ReactRefreshLogBoxMisc.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBoxMisc.test.ts
@@ -1,4 +1,4 @@
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { outdent } from 'outdent'
@@ -12,7 +12,8 @@ describe.skip('ReactRefreshLogBox', () => {
   })
 
   test('<Link> with multiple children', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -46,12 +47,11 @@ describe.skip('ReactRefreshLogBox', () => {
           ).href
       )
     ).toMatch('https://nextjs.org/docs/messages/link-multiple-children')
-
-    await cleanup()
   })
 
   test('<Link> component props errors', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -202,12 +202,11 @@ describe.skip('ReactRefreshLogBox', () => {
     )
     await session.assertHasRedbox()
     expect(await session.getRedboxDescription()).toMatchSnapshot()
-
-    await cleanup()
   })
 
   test('server-side only compilation errors', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'pages/index.js',
@@ -227,6 +226,5 @@ describe.skip('ReactRefreshLogBox', () => {
     )
 
     await session.assertHasRedbox()
-    await cleanup()
   })
 })

--- a/test/development/acceptance/ReactRefreshModule.test.ts
+++ b/test/development/acceptance/ReactRefreshModule.test.ts
@@ -1,5 +1,5 @@
 import { FileRef, nextTestSetup } from 'e2e-utils'
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import path from 'path'
 
 describe('ReactRefreshModule', () => {
@@ -9,7 +9,8 @@ describe('ReactRefreshModule', () => {
   })
 
   it('should allow any variable names', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
     await session.assertNoRedbox()
 
     const variables = [
@@ -34,7 +35,5 @@ describe('ReactRefreshModule', () => {
         `'${variable}' has already been declared`
       )
     }
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance/ReactRefreshRegression.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import { outdent } from 'outdent'
@@ -56,7 +56,8 @@ describe('ReactRefreshRegression', () => {
       ],
     ])
 
-    const { session, cleanup } = await sandbox(next, files)
+    await using sandbox = await createSandbox(next, files)
+    const { session } = sandbox
 
     // We start here.
     await session.patch(
@@ -76,13 +77,12 @@ describe('ReactRefreshRegression', () => {
 
     // Verify no hydration mismatch:
     await session.assertNoRedbox()
-
-    await cleanup()
   })
 
   // https://github.com/vercel/next.js/issues/13978
   test('can fast refresh a page with getStaticProps', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'pages/index.js',
@@ -139,13 +139,12 @@ describe('ReactRefreshRegression', () => {
     expect(
       await session.evaluate(() => document.querySelector('p').textContent)
     ).toBe('Count: 2')
-
-    await cleanup()
   })
 
   // https://github.com/vercel/next.js/issues/13978
   test('can fast refresh a page with getServerSideProps', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'pages/index.js',
@@ -202,13 +201,12 @@ describe('ReactRefreshRegression', () => {
     expect(
       await session.evaluate(() => document.querySelector('p').textContent)
     ).toBe('Count: 2')
-
-    await cleanup()
   })
 
   // https://github.com/vercel/next.js/issues/13978
   test('can fast refresh a page with config', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'pages/index.js',
@@ -265,13 +263,12 @@ describe('ReactRefreshRegression', () => {
     expect(
       await session.evaluate(() => document.querySelector('p').textContent)
     ).toBe('Count: 2')
-
-    await cleanup()
   })
 
   // https://github.com/vercel/next.js/issues/11504
   test('shows an overlay for a server-side error', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'pages/index.js',
@@ -291,13 +288,11 @@ describe('ReactRefreshRegression', () => {
       "> 1 | export default function () { throw new Error('boom'); }
           |                                    ^"
     `)
-
-    await cleanup()
   })
 
   // https://github.com/vercel/next.js/issues/13574
   test('custom loader mdx should have Fast Refresh enabled', async () => {
-    const { session, cleanup } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -315,6 +310,7 @@ describe('ReactRefreshRegression', () => {
       ]),
       '/mdx'
     )
+    const { session } = sandbox
     expect(
       await session.evaluate(
         () => document.querySelector('#__next').textContent
@@ -338,7 +334,5 @@ describe('ReactRefreshRegression', () => {
         () => document.querySelector('#__next').textContent
       )
     ).toBe('Hello Bar!')
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance/ReactRefreshRequire.test.ts
+++ b/test/development/acceptance/ReactRefreshRequire.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 
@@ -11,7 +11,8 @@ describe('ReactRefreshRequire', () => {
 
   // https://github.com/facebook/metro/blob/b651e535cd0fc5df6c0803b9aa647d664cb9a6c3/packages/metro/src/lib/polyfills/__tests__/require-test.js#L989-L1048
   test('re-runs accepted modules', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -62,13 +63,12 @@ describe('ReactRefreshRequire', () => {
     // TODO:
     // expect(Refresh.performReactRefresh).toHaveBeenCalled();
     // expect(Refresh.performFullRefresh).not.toHaveBeenCalled();
-
-    await cleanup()
   })
 
   // https://github.com/facebook/metro/blob/b651e535cd0fc5df6c0803b9aa647d664cb9a6c3/packages/metro/src/lib/polyfills/__tests__/require-test.js#L1050-L1137
   test('propagates a hot update to closest accepted module', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -167,12 +167,11 @@ describe('ReactRefreshRequire', () => {
     // TODO:
     // expect(Refresh.performReactRefresh).toHaveBeenCalled();
     // expect(Refresh.performFullRefresh).not.toHaveBeenCalled();
-
-    await cleanup()
   })
   // https://github.com/facebook/metro/blob/b651e535cd0fc5df6c0803b9aa647d664cb9a6c3/packages/metro/src/lib/polyfills/__tests__/require-test.js#L1139-L1307
   test('propagates hot update to all inverse dependencies', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -307,8 +306,6 @@ describe('ReactRefreshRequire', () => {
     // TODO:
     // expect(Refresh.performReactRefresh).toHaveBeenCalled()
     // expect(Refresh.performFullRefresh).not.toHaveBeenCalled()
-
-    await cleanup()
   })
 
   // https://github.com/facebook/metro/blob/b651e535cd0fc5df6c0803b9aa647d664cb9a6c3/packages/metro/src/lib/polyfills/__tests__/require-test.js#L1309-L1406
@@ -368,7 +365,8 @@ describe('ReactRefreshRequire', () => {
 
   // https://github.com/facebook/metro/blob/b651e535cd0fc5df6c0803b9aa647d664cb9a6c3/packages/metro/src/lib/polyfills/__tests__/require-test.js#L2373-L2472
   test('propagates a module that stops accepting in next version', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     // Accept in parent
     await session.write(
@@ -487,8 +485,6 @@ describe('ReactRefreshRequire', () => {
 
     // expect(Refresh.performFullRefresh).toHaveBeenCalled();
     expect(didFullRefresh).toBe(true)
-
-    await cleanup()
   })
 
   // https://github.com/facebook/metro/blob/b651e535cd0fc5df6c0803b9aa647d664cb9a6c3/packages/metro/src/lib/polyfills/__tests__/require-test.js#L2474-L2521

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check, describeVariants as describe } from 'next-test-utils'
 import { outdent } from 'outdent'
@@ -12,7 +12,8 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
   })
 
   test('logbox: can recover from a syntax error without losing state', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -68,12 +69,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     )
 
     await session.assertNoRedbox()
-
-    await cleanup()
   })
 
   test('logbox: can recover from a event handler error', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.patch(
       'index.js',
@@ -159,12 +159,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     ).toBe('Count: 2')
 
     await session.assertNoRedbox()
-
-    await cleanup()
   })
 
   test('logbox: can recover from a component error', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     await session.write(
       'child.js',
@@ -223,13 +222,12 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     expect(
       await session.evaluate(() => document.querySelector('p').textContent)
     ).toBe('Hello')
-
-    await cleanup()
   })
 
   // https://github.com/pmmmwh/react-refresh-webpack-plugin/pull/3#issuecomment-554137262
   test('render error not shown right after syntax error', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     // Starting here:
     await session.patch(
@@ -311,13 +309,12 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     expect(await session.getRedboxSource()).toInclude(
       "throw new Error('nooo');"
     )
-
-    await cleanup()
   })
 
   // https://github.com/pmmmwh/react-refresh-webpack-plugin/pull/3#issuecomment-554144016
   test('stuck error', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     // We start here.
     await session.patch(
@@ -376,13 +373,12 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
     // Expected: this fixes the problem
     await session.assertNoRedbox()
-
-    await cleanup()
   })
 
   // https://github.com/pmmmwh/react-refresh-webpack-plugin/pull/3#issuecomment-554150098
   test('syntax > runtime error', async () => {
-    const { session, cleanup } = await sandbox(next)
+    await using sandbox = await createSandbox(next)
+    const { session } = sandbox
 
     // Start here.
     await session.patch(
@@ -507,7 +503,5 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
         ./pages/index.js"
       `)
     }
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { outdent } from 'outdent'
@@ -15,7 +15,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
   })
 
   it('includes a React docs link when hydration error does occur', async () => {
-    const { browser } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -35,7 +35,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
       '/',
       { pushErrorAsConsoleLog: true }
     )
-
+    const { browser } = sandbox
     const logs = await browser.log()
     expect(logs).toEqual(
       expect.arrayContaining([
@@ -54,7 +54,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
   })
 
   it('should show correct hydration error when client and server render different text', async () => {
-    const { cleanup, session, browser } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -72,6 +72,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
+    const { session, browser } = sandbox
 
     await session.assertHasRedbox()
     expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 2 : 1)
@@ -174,12 +175,10 @@ describe('Error overlay for hydration errors in Pages router', () => {
     await session.assertNoRedbox()
 
     expect(await browser.elementByCss('.child').text()).toBe('Value')
-
-    await cleanup()
   })
 
   it('should show correct hydration error when client renders an extra element', async () => {
-    const { browser, cleanup, session } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -197,7 +196,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.assertHasRedbox()
     await retry(async () => {
       await expect(await getRedboxTotalErrorCount(browser)).toBe(
@@ -259,12 +258,10 @@ describe('Error overlay for hydration errors in Pages router', () => {
         `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
       )
     }
-
-    await cleanup()
   })
 
   it('should show correct hydration error when client renders an extra text node', async () => {
-    const { browser, cleanup, session } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -284,7 +281,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.assertHasRedbox()
     await retry(async () => {
       await expect(await getRedboxTotalErrorCount(browser)).toBe(
@@ -348,12 +345,10 @@ describe('Error overlay for hydration errors in Pages router', () => {
         `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
       )
     }
-
-    await cleanup()
   })
 
   it('should show correct hydration error when server renders an extra element', async () => {
-    const { browser, cleanup, session } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -371,7 +366,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.assertHasRedbox()
     expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 2 : 1)
 
@@ -420,12 +415,10 @@ describe('Error overlay for hydration errors in Pages router', () => {
         `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
       )
     }
-
-    await cleanup()
   })
 
   it('should show correct hydration error when server renders an extra text node', async () => {
-    const { browser, cleanup, session } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -439,7 +432,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.assertHasRedbox()
     expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 2 : 1)
 
@@ -498,12 +491,10 @@ describe('Error overlay for hydration errors in Pages router', () => {
         `)
       }
     }
-
-    await cleanup()
   })
 
   it('should show correct hydration error when server renders an extra text node in an invalid place', async () => {
-    const { browser, cleanup, session } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -522,7 +513,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.assertHasRedbox()
 
     await retry(async () => {
@@ -586,12 +577,10 @@ describe('Error overlay for hydration errors in Pages router', () => {
         `)
       }
     }
-
-    await cleanup()
   })
 
   it('should show correct hydration error when server renders an extra whitespace in an invalid place', async () => {
-    const { cleanup, session } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -609,7 +598,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-
+    const { session } = sandbox
     // FIXME: Should have getRedboxDescription() "text nodes cannot be a child of tr"
     await expect(session.hasErrorToast()).resolves.toBe(false)
 
@@ -626,12 +615,10 @@ describe('Error overlay for hydration errors in Pages router', () => {
     // expect(pseudoHtml).toEqual(outdent`
     //   Something
     // `)
-
-    await cleanup()
   })
 
   it('should show correct hydration error when client renders an extra node inside Suspense content', async () => {
-    const { cleanup, session } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -654,7 +641,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-
+    const { session } = sandbox
     const pseudoHtml = await session.getRedboxComponentStack()
     if (isTurbopack) {
       if (isReact18) {
@@ -707,12 +694,10 @@ describe('Error overlay for hydration errors in Pages router', () => {
         `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
       )
     }
-
-    await cleanup()
   })
 
   it('should not show a hydration error when using `useId` in a client component', async () => {
-    const { cleanup, browser } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -734,7 +719,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-
+    const { browser } = sandbox
     const logs = await browser.log()
     const errors = logs
       .filter((x) => x.source === 'error')
@@ -744,12 +729,10 @@ describe('Error overlay for hydration errors in Pages router', () => {
     expect(errors).not.toInclude(
       'Warning: Prop `%s` did not match. Server: %s Client: %s'
     )
-
-    await cleanup()
   })
 
   it('should only show one hydration error when bad nesting happened - p under p', async () => {
-    const { cleanup, session, browser } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -768,7 +751,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.assertHasRedbox()
     await retry(async () => {
       expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
@@ -828,12 +811,10 @@ describe('Error overlay for hydration errors in Pages router', () => {
         `)
       }
     }
-
-    await cleanup()
   })
 
   it('should only show one hydration error when bad nesting happened - div under p', async () => {
-    const { cleanup, session, browser } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -856,7 +837,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.assertHasRedbox()
     await retry(async () => {
       expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
@@ -895,12 +876,10 @@ describe('Error overlay for hydration errors in Pages router', () => {
               ^^^^^"
       `)
     }
-
-    await cleanup()
   })
 
   it('should only show one hydration error when bad nesting happened - div > tr', async () => {
-    const { cleanup, session, browser } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -913,7 +892,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.assertHasRedbox()
     await retry(async () => {
       expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
@@ -973,12 +952,10 @@ describe('Error overlay for hydration errors in Pages router', () => {
         `)
       }
     }
-
-    await cleanup()
   })
 
   it('should show the highlighted bad nesting html snippet when bad nesting happened', async () => {
-    const { browser, cleanup, session } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -995,7 +972,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.assertHasRedbox()
     await retry(async () => {
       expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
@@ -1062,12 +1039,10 @@ describe('Error overlay for hydration errors in Pages router', () => {
         `)
       }
     }
-
-    await cleanup()
   })
 
   it('should show error if script is directly placed under html instead of body', async () => {
-    const { session } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -1103,13 +1078,13 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-
+    const { session } = sandbox
     // FIXME: Should have a redbox just like with App router
     await session.assertNoRedbox()
   })
 
   it('should collapse and uncollapse properly when there are many frames', async () => {
-    const { browser, cleanup, session } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -1147,7 +1122,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-
+    const { session, browser } = sandbox
     await session.assertHasRedbox()
     await retry(async () => {
       await expect(await getRedboxTotalErrorCount(browser)).toBe(
@@ -1283,7 +1258,5 @@ describe('Error overlay for hydration errors in Pages router', () => {
         `)
       }
     }
-
-    await cleanup()
   })
 })

--- a/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
+++ b/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { outdent } from 'outdent'
 
 const initialFiles = new Map([
@@ -31,7 +31,8 @@ describe('Error Overlay for server components compiler errors in pages', () => {
   })
 
   test("importing 'next/headers' in pages", async () => {
-    const { session, cleanup } = await sandbox(next, initialFiles)
+    await using sandbox = await createSandbox(next, initialFiles)
+    const { session } = sandbox
 
     await session.patch(
       'components/Comp.js',
@@ -84,12 +85,11 @@ describe('Error Overlay for server components compiler errors in pages', () => {
         ./pages/index.js"
       `)
     }
-
-    await cleanup()
   })
 
   test("importing 'server-only' in pages", async () => {
-    const { session, cleanup } = await sandbox(next, initialFiles)
+    await using sandbox = await createSandbox(next, initialFiles)
+    const { session } = sandbox
 
     await next.patchFile(
       'components/Comp.js',
@@ -144,11 +144,11 @@ describe('Error Overlay for server components compiler errors in pages', () => {
         Import trace for requested module:"
         `)
     }
-    await cleanup()
   })
 
   test("importing unstable_after from 'next/server' in pages", async () => {
-    const { session, cleanup } = await sandbox(next, initialFiles)
+    await using sandbox = await createSandbox(next, initialFiles)
+    const { session } = sandbox
 
     await next.patchFile(
       'components/Comp.js',
@@ -203,7 +203,6 @@ describe('Error Overlay for server components compiler errors in pages', () => {
         Import trace for requested module:"
       `)
     }
-    await cleanup()
   })
 })
 

--- a/test/development/app-dir/basic/basic.test.ts
+++ b/test/development/app-dir/basic/basic.test.ts
@@ -1,6 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 import { describeVariants as describe, waitFor } from 'next-test-utils'
-import { sandbox, waitForHydration } from 'development-sandbox'
+import { createSandbox, waitForHydration } from 'development-sandbox'
 
 describe.each(['default', 'turbo'])('basic app-dir tests', () => {
   const { next } = nextTestSetup({
@@ -8,7 +8,8 @@ describe.each(['default', 'turbo'])('basic app-dir tests', () => {
   })
 
   it('should reload app pages without error', async () => {
-    const { session, cleanup, browser } = await sandbox(next, undefined, '/')
+    await using sandbox = await createSandbox(next, undefined, '/')
+    const { session, browser } = sandbox
     await session.assertNoRedbox()
 
     browser.refresh()
@@ -20,7 +21,5 @@ describe.each(['default', 'turbo'])('basic app-dir tests', () => {
       await session.assertNoRedbox()
       await waitFor(1000)
     }
-
-    await cleanup()
   })
 })

--- a/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
+++ b/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
@@ -9,7 +9,7 @@ import {
   waitForAndOpenRuntimeError,
   getRedboxSource,
 } from 'next-test-utils'
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import { outdent } from 'outdent'
 
 describe('Dynamic IO Dev Errors', () => {
@@ -73,7 +73,7 @@ describe('Dynamic IO Dev Errors', () => {
   })
 
   it('should clear segment errors after correcting them', async () => {
-    const { cleanup, session, browser } = await sandbox(
+    await using sandbox = await createSandbox(
       next,
       new Map([
         [
@@ -89,7 +89,7 @@ describe('Dynamic IO Dev Errors', () => {
         ],
       ])
     )
-
+    const { browser, session } = sandbox
     await assertHasRedbox(browser)
     const redbox = {
       description: await getRedboxDescription(browser),
@@ -115,7 +115,5 @@ describe('Dynamic IO Dev Errors', () => {
     await retry(async () => {
       assertNoRedbox(browser)
     })
-
-    await cleanup()
   })
 })

--- a/test/development/middleware-warnings/index.test.ts
+++ b/test/development/middleware-warnings/index.test.ts
@@ -1,5 +1,5 @@
 import { FileRef, nextTestSetup } from 'e2e-utils'
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 import path from 'path'
 import { outdent } from 'outdent'
 
@@ -13,9 +13,6 @@ describe('middlewares', () => {
     ),
     skipStart: true,
   })
-
-  let cleanup
-  afterEach(() => cleanup?.())
 
   it.each([
     {
@@ -71,7 +68,10 @@ describe('middlewares', () => {
       `,
     },
   ])('does not warn when $title', async ({ code }) => {
-    ;({ cleanup } = await sandbox(next, new Map([[middlewarePath, code]])))
+    await using _sandbox = await createSandbox(
+      next,
+      new Map([[middlewarePath, code]])
+    )
     expect(next.cliOutput).not.toMatch(middlewareWarning)
   })
 
@@ -93,7 +93,10 @@ describe('middlewares', () => {
       `,
     },
   ])('does not warn when $title', async ({ code }) => {
-    ;({ cleanup } = await sandbox(next, new Map([[middlewarePath, code]])))
+    await using _sandbox = await createSandbox(
+      next,
+      new Map([[middlewarePath, code]])
+    )
     expect(next.cliOutput).not.toMatch(middlewareWarning)
   })
 })

--- a/test/e2e/app-dir/logging/fetch-logging.test.ts
+++ b/test/e2e/app-dir/logging/fetch-logging.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs'
 import stripAnsi from 'strip-ansi'
 import { retry } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
-import { sandbox } from 'development-sandbox'
+import { createSandbox } from 'development-sandbox'
 
 const cacheReasonRegex = /Cache (missed|skipped) reason: /
 
@@ -52,11 +52,13 @@ describe('app-dir - fetch logging', () => {
 
   isNextDev &&
     it('should not log requests for HMR refreshes', async () => {
-      const { browser, cleanup, session } = await sandbox(
+      await using sandbox = await createSandbox(
         next,
         undefined,
         '/fetch-no-store'
       )
+
+      const { browser, session } = sandbox
 
       let headline = await browser.waitForElementByCss('h1').text()
       expect(headline).toBe('Hello World!')
@@ -74,8 +76,6 @@ describe('app-dir - fetch logging', () => {
         expect(logs).not.toInclude(` │ GET `)
         // TODO: remove custom duration in case we increase the default.
       }, 5000)
-
-      await cleanup()
     })
 
   // TODO: remove when there is a test for isNextDev === false

--- a/test/e2e/app-dir/next-after-app/index.test.ts
+++ b/test/e2e/app-dir/next-after-app/index.test.ts
@@ -3,7 +3,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import { createProxyServer } from 'next/experimental/testmode/proxy'
 import { outdent } from 'outdent'
-import { sandbox } from '../../../lib/development-sandbox'
+import { createSandbox } from '../../../lib/development-sandbox'
 import * as Log from './utils/log'
 
 const runtimes = ['nodejs', 'edge']
@@ -270,10 +270,10 @@ describe.each(runtimes)('unstable_after() in %s runtime', (runtimeValue) => {
   })
 
   describe('uses waitUntil from request context if available', () => {
-    let sanboxed: Awaited<ReturnType<typeof sandbox>>
+    let sanboxed: Awaited<ReturnType<typeof createSandbox>>
     beforeAll(async () => {
       resetLogIsolation() // sandbox resets `next.cliOutput` to empty
-      sanboxed = await sandbox(
+      sanboxed = await createSandbox(
         next,
         new Map([
           [
@@ -298,7 +298,7 @@ describe.each(runtimes)('unstable_after() in %s runtime', (runtimeValue) => {
       )
     })
     afterAll(async () => {
-      await sanboxed.cleanup()
+      await sanboxed[Symbol.asyncDispose]()
     })
 
     it.each([

--- a/test/e2e/app-dir/next-after-app/index.test.ts
+++ b/test/e2e/app-dir/next-after-app/index.test.ts
@@ -270,10 +270,29 @@ describe.each(runtimes)('unstable_after() in %s runtime', (runtimeValue) => {
   })
 
   describe('uses waitUntil from request context if available', () => {
-    let sanboxed: Awaited<ReturnType<typeof createSandbox>>
-    beforeAll(async () => {
+    it.each([
+      {
+        name: 'in a page',
+        path: '/provided-request-context/page',
+        expectedLog: { source: '[page] /provided-request-context/page' },
+      },
+      {
+        name: 'in a route handler',
+        path: '/provided-request-context/route',
+        expectedLog: {
+          source: '[route handler] /provided-request-context/route',
+        },
+      },
+      {
+        name: 'in middleware',
+        path: '/provided-request-context/middleware',
+        expectedLog: {
+          source: '[middleware] /provided-request-context/middleware',
+        },
+      },
+    ])('$name', async ({ path, expectedLog }) => {
       resetLogIsolation() // sandbox resets `next.cliOutput` to empty
-      sanboxed = await createSandbox(
+      await using _sandbox = await createSandbox(
         next,
         new Map([
           [
@@ -296,32 +315,7 @@ describe.each(runtimes)('unstable_after() in %s runtime', (runtimeValue) => {
           ],
         ])
       )
-    })
-    afterAll(async () => {
-      await sanboxed[Symbol.asyncDispose]()
-    })
 
-    it.each([
-      {
-        name: 'in a page',
-        path: '/provided-request-context/page',
-        expectedLog: { source: '[page] /provided-request-context/page' },
-      },
-      {
-        name: 'in a route handler',
-        path: '/provided-request-context/route',
-        expectedLog: {
-          source: '[route handler] /provided-request-context/route',
-        },
-      },
-      {
-        name: 'in middleware',
-        path: '/provided-request-context/middleware',
-        expectedLog: {
-          source: '[middleware] /provided-request-context/middleware',
-        },
-      },
-    ])('$name', async ({ path, expectedLog }) => {
       await next.browser(pathPrefix + path)
       await retry(() => {
         const logs = getLogs()

--- a/test/jest-setup-after-env.ts
+++ b/test/jest-setup-after-env.ts
@@ -6,3 +6,16 @@ expect.extend(matchers)
 // A default max-timeout of 90 seconds is allowed
 // per test we should aim to bring this down though
 jest.setTimeout((process.platform === 'win32' ? 180 : 60) * 1000)
+
+// Polyfill for `using` https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html
+if (!Symbol.dispose) {
+  Object.defineProperty(Symbol, 'dispose', {
+    value: Symbol('Symbol.dispose'),
+  })
+}
+
+if (!Symbol.asyncDispose) {
+  Object.defineProperty(Symbol, 'asyncDispose', {
+    value: Symbol('Symbol.asyncDispose'),
+  })
+}

--- a/test/lib/development-sandbox.ts
+++ b/test/lib/development-sandbox.ts
@@ -32,7 +32,7 @@ export function waitForHydration(browser: BrowserInterface): Promise<void> {
   })
 }
 
-export async function sandbox(
+export async function createSandbox(
   next: NextInstance,
   initialFiles?: Map<string, string | ((contents: string) => string)>,
   initialUrl: string = '/',
@@ -154,7 +154,7 @@ export async function sandbox(
         return getVersionCheckerText(browser)
       },
     },
-    async cleanup() {
+    [Symbol.asyncDispose]: async () => {
       await browser.close()
       await next.stop()
       await next.clean()

--- a/test/lib/development-sandbox.ts
+++ b/test/lib/development-sandbox.ts
@@ -38,126 +38,142 @@ export async function createSandbox(
   initialUrl: string = '/',
   webDriverOptions: WebdriverOptions = undefined
 ) {
-  await next.stop()
-  await next.clean()
+  let unwrappedByTypeScriptUsingKeyword = false
 
-  if (initialFiles) {
-    for (const [k, v] of initialFiles.entries()) {
-      await next.patchFile(k, v)
+  try {
+    await next.stop()
+    await next.clean()
+    if (initialFiles) {
+      for (const [k, v] of initialFiles.entries()) {
+        await next.patchFile(k, v)
+      }
     }
-  }
+    await next.start()
 
-  await next.start()
-  const browser = await webdriver(next.url, initialUrl, webDriverOptions)
-  return {
-    browser,
-    session: {
-      async write(filename, content) {
-        // Update the file on filesystem
-        await next.patchFile(filename, content)
+    const browser = await webdriver(next.url, initialUrl, webDriverOptions)
+    return {
+      browser,
+      session: {
+        async write(filename, content) {
+          // Update the file on filesystem
+          await next.patchFile(filename, content)
+        },
+        async patch(filename, content) {
+          // Register an event for HMR completion
+          await browser.eval(function () {
+            ;(window as any).__HMR_STATE = 'pending'
+
+            var timeout = setTimeout(() => {
+              ;(window as any).__HMR_STATE = 'timeout'
+            }, 30 * 1000)
+            ;(window as any).__NEXT_HMR_CB = function () {
+              clearTimeout(timeout)
+              ;(window as any).__HMR_STATE = 'success'
+            }
+          })
+
+          await this.write(filename, content)
+
+          for (;;) {
+            const status = await browser.eval(() => (window as any).__HMR_STATE)
+            if (!status) {
+              await waitFor(750)
+
+              // Wait for application to re-hydrate:
+              await waitForHydration(browser)
+
+              console.log('Application re-loaded.')
+              // Slow down tests a bit:
+              await waitFor(750)
+              return false
+            }
+            if (status === 'success') {
+              console.log('Hot update complete.')
+              break
+            }
+            if (status !== 'pending') {
+              throw new Error(
+                `Application is in inconsistent state: ${status}.`
+              )
+            }
+
+            await waitFor(30)
+          }
+
+          // Slow down tests a bit (we don't know how long re-rendering takes):
+          await waitFor(750)
+          return true
+        },
+        async remove(filename) {
+          await next.deleteFile(filename)
+        },
+        async evaluate(snippet: string | Function) {
+          if (typeof snippet === 'function' || typeof snippet === 'string') {
+            const result = await browser.eval(snippet)
+            await waitFor(30)
+            return result
+          } else {
+            throw new Error(
+              `You must pass a string or function to be evaluated in the browser.`
+            )
+          }
+        },
+        async assertHasRedbox() {
+          return assertHasRedbox(browser)
+        },
+        async assertNoRedbox() {
+          return assertNoRedbox(browser)
+        },
+        async waitForAndOpenRuntimeError() {
+          return waitForAndOpenRuntimeError(browser)
+        },
+        async hasErrorToast() {
+          return Boolean(await hasErrorToast(browser))
+        },
+        async getRedboxDescription() {
+          return getRedboxDescription(browser)
+        },
+        async getRedboxDescriptionWarning() {
+          return getRedboxDescriptionWarning(browser)
+        },
+        async getRedboxErrorLink() {
+          return getRedboxErrorLink(browser)
+        },
+        async getRedboxSource(includeHeader = false) {
+          const header = includeHeader ? await getRedboxHeader(browser) : ''
+          const source = await getRedboxSource(browser)
+
+          if (includeHeader) {
+            return `${header}\n\n${source}`
+          }
+          return source
+        },
+        async getRedboxComponentStack() {
+          return getRedboxComponentStack(browser)
+        },
+        async toggleCollapseComponentStack() {
+          return toggleCollapseComponentStack(browser)
+        },
+        async getVersionCheckerText() {
+          return getVersionCheckerText(browser)
+        },
       },
-      async patch(filename, content) {
-        // Register an event for HMR completion
-        await browser.eval(function () {
-          ;(window as any).__HMR_STATE = 'pending'
-
-          var timeout = setTimeout(() => {
-            ;(window as any).__HMR_STATE = 'timeout'
-          }, 30 * 1000)
-          ;(window as any).__NEXT_HMR_CB = function () {
-            clearTimeout(timeout)
-            ;(window as any).__HMR_STATE = 'success'
-          }
-        })
-
-        await this.write(filename, content)
-
-        for (;;) {
-          const status = await browser.eval(() => (window as any).__HMR_STATE)
-          if (!status) {
-            await waitFor(750)
-
-            // Wait for application to re-hydrate:
-            await waitForHydration(browser)
-
-            console.log('Application re-loaded.')
-            // Slow down tests a bit:
-            await waitFor(750)
-            return false
-          }
-          if (status === 'success') {
-            console.log('Hot update complete.')
-            break
-          }
-          if (status !== 'pending') {
-            throw new Error(`Application is in inconsistent state: ${status}.`)
-          }
-
-          await waitFor(30)
+      get [Symbol.asyncDispose]() {
+        unwrappedByTypeScriptUsingKeyword = true
+        return async () => {
+          await browser.close()
+          await next.stop()
+          await next.clean()
         }
-
-        // Slow down tests a bit (we don't know how long re-rendering takes):
-        await waitFor(750)
-        return true
       },
-      async remove(filename) {
-        await next.deleteFile(filename)
-      },
-      async evaluate(snippet: string | Function) {
-        if (typeof snippet === 'function' || typeof snippet === 'string') {
-          const result = await browser.eval(snippet)
-          await waitFor(30)
-          return result
-        } else {
-          throw new Error(
-            `You must pass a string or function to be evaluated in the browser.`
-          )
-        }
-      },
-      async assertHasRedbox() {
-        return assertHasRedbox(browser)
-      },
-      async assertNoRedbox() {
-        return assertNoRedbox(browser)
-      },
-      async waitForAndOpenRuntimeError() {
-        return waitForAndOpenRuntimeError(browser)
-      },
-      async hasErrorToast() {
-        return Boolean(await hasErrorToast(browser))
-      },
-      async getRedboxDescription() {
-        return getRedboxDescription(browser)
-      },
-      async getRedboxDescriptionWarning() {
-        return getRedboxDescriptionWarning(browser)
-      },
-      async getRedboxErrorLink() {
-        return getRedboxErrorLink(browser)
-      },
-      async getRedboxSource(includeHeader = false) {
-        const header = includeHeader ? await getRedboxHeader(browser) : ''
-        const source = await getRedboxSource(browser)
-
-        if (includeHeader) {
-          return `${header}\n\n${source}`
-        }
-        return source
-      },
-      async getRedboxComponentStack() {
-        return getRedboxComponentStack(browser)
-      },
-      async toggleCollapseComponentStack() {
-        return toggleCollapseComponentStack(browser)
-      },
-      async getVersionCheckerText() {
-        return getVersionCheckerText(browser)
-      },
-    },
-    [Symbol.asyncDispose]: async () => {
-      await browser.close()
-      await next.stop()
-      await next.clean()
-    },
+    }
+  } finally {
+    setImmediate(() => {
+      if (!unwrappedByTypeScriptUsingKeyword) {
+        throw new Error(
+          'You must use `using` to create a sandbox, i.e., `await using sandbox = await createSandbox(`'
+        )
+      }
+    })
   }
 }


### PR DESCRIPTION
Migrated every instance of `sandbox` to use the `using` keyword so that the `cleanup` will be automatically performed when the execution leaves the scope.