### PR TITLE
examples(with-supabase): fix action type error

### DIFF
--- a/examples/with-supabase/app/actions.ts
+++ b/examples/with-supabase/app/actions.ts
@@ -12,7 +12,11 @@ export const signUpAction = async (formData: FormData) => {
   const origin = (await headers()).get("origin");
 
   if (!email || !password) {
-    return { error: "Email and password are required" };
+    return encodedRedirect(
+      "error",
+      "/sign-up",
+      "Email and password are required",
+    );
   }
 
   const { error } = await supabase.auth.signUp({

--- a/examples/with-supabase/package.json
+++ b/examples/with-supabase/package.json
@@ -12,25 +12,25 @@
     "@radix-ui/react-slot": "^1.1.0",
     "@supabase/ssr": "latest",
     "@supabase/supabase-js": "latest",
-    "autoprefixer": "10.4.17",
+    "autoprefixer": "10.4.20",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "geist": "^1.2.1",
-    "lucide-react": "^0.436.0",
+    "lucide-react": "^0.456.0",
     "next": "latest",
-    "next-themes": "^0.3.0",
+    "next-themes": "^0.4.3",
     "prettier": "^3.3.3",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
   },
   "devDependencies": {
-    "@types/node": "20.10.6",
-    "@types/react": "18.2.46",
-    "@types/react-dom": "18.2.18",
-    "postcss": "8.4.33",
+    "@types/node": "22.9.0",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "18.3.1",
+    "postcss": "8.4.49",
     "tailwind-merge": "^2.5.2",
-    "tailwindcss": "3.4.1",
+    "tailwindcss": "3.4.14",
     "tailwindcss-animate": "^1.0.7",
-    "typescript": "5.3.3"
+    "typescript": "5.6.3"
   }
 }


### PR DESCRIPTION
## Why?

There is a type issue with one of the form actions.

```
app/(auth-pages)/sign-up/page.tsx:42:25 - error TS2322: Type '(formData: FormData) => Promise<{ error: string; }>' is not assignable to type 'string | ((formData: FormData) => void | Promise<void>) | undefined'.
  Type '(formData: FormData) => Promise<{ error: string; }>' is not assignable to type '(formData: FormData) => void | Promise<void>'.
    Type 'Promise<{ error: string; }>' is not assignable to type 'void | Promise<void>'.
      Type 'Promise<{ error: string; }>' is not assignable to type 'Promise<void>'.
        Type '{ error: string; }' is not assignable to type 'void'.

42           <SubmitButton formAction={signUpAction} pendingText="Signing up...">
```

- x-ref: https://github.com/vercel/next.js/discussions/72778