### PR TITLE
refactor(turbopack): Use `ResolvedVc` for `turbopack-core`

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -309,24 +309,32 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    fn rsc_module_context(self: Vc<Self>) -> Vc<ModuleAssetContext> {
+    async fn rsc_module_context(self: Vc<Self>) -> Result<Vc<ModuleAssetContext>> {
         let transitions = [
             (
                 ECMASCRIPT_CLIENT_TRANSITION_NAME.into(),
-                self.client_reference_transition(),
+                self.client_reference_transition().to_resolved().await?,
             ),
             (
                 "next-dynamic".into(),
-                Vc::upcast(NextDynamicTransition::new(Vc::upcast(
-                    self.client_transition(),
-                ))),
+                ResolvedVc::upcast(
+                    NextDynamicTransition::new(Vc::upcast(self.client_transition()))
+                        .to_resolved()
+                        .await?,
+                ),
             ),
-            ("next-ssr".into(), Vc::upcast(self.ssr_transition())),
-            ("next-shared".into(), Vc::upcast(self.shared_transition())),
+            (
+                "next-ssr".into(),
+                ResolvedVc::upcast(self.ssr_transition().to_resolved().await?),
+            ),
+            (
+                "next-shared".into(),
+                ResolvedVc::upcast(self.shared_transition().to_resolved().await?),
+            ),
         ]
         .into_iter()
         .collect();
-        ModuleAssetContext::new(
+        Ok(ModuleAssetContext::new(
             TransitionOptions {
                 named_transitions: transitions,
                 transition_rules: vec![TransitionRule::new(
@@ -340,31 +348,38 @@ impl AppProject {
             self.rsc_module_options_context(),
             self.rsc_resolve_options_context(),
             Vc::cell("app-rsc".into()),
-        )
+        ))
     }
 
     #[turbo_tasks::function]
-    fn edge_rsc_module_context(self: Vc<Self>) -> Vc<ModuleAssetContext> {
+    async fn edge_rsc_module_context(self: Vc<Self>) -> Result<Vc<ModuleAssetContext>> {
         let transitions = [
             (
                 ECMASCRIPT_CLIENT_TRANSITION_NAME.into(),
-                self.edge_client_reference_transition(),
+                self.edge_client_reference_transition()
+                    .to_resolved()
+                    .await?,
             ),
             (
                 "next-dynamic".into(),
-                Vc::upcast(NextDynamicTransition::new(Vc::upcast(
-                    self.client_transition(),
-                ))),
+                ResolvedVc::upcast(
+                    NextDynamicTransition::new(Vc::upcast(self.client_transition()))
+                        .to_resolved()
+                        .await?,
+                ),
             ),
-            ("next-ssr".into(), Vc::upcast(self.edge_ssr_transition())),
+            (
+                "next-ssr".into(),
+                ResolvedVc::upcast(self.edge_ssr_transition().to_resolved().await?),
+            ),
             (
                 "next-shared".into(),
-                Vc::upcast(self.edge_shared_transition()),
+                ResolvedVc::upcast(self.edge_shared_transition().to_resolved().await?),
             ),
         ]
         .into_iter()
         .collect();
-        ModuleAssetContext::new(
+        Ok(ModuleAssetContext::new(
             TransitionOptions {
                 named_transitions: transitions,
                 transition_rules: vec![TransitionRule::new(
@@ -378,29 +393,37 @@ impl AppProject {
             self.edge_rsc_module_options_context(),
             self.edge_rsc_resolve_options_context(),
             Vc::cell("app-edge-rsc".into()),
-        )
+        ))
     }
 
     #[turbo_tasks::function]
-    fn route_module_context(self: Vc<Self>) -> Vc<ModuleAssetContext> {
+    async fn route_module_context(self: Vc<Self>) -> Result<Vc<ModuleAssetContext>> {
         let transitions = [
             (
                 ECMASCRIPT_CLIENT_TRANSITION_NAME.into(),
-                self.client_reference_transition(),
+                self.client_reference_transition().to_resolved().await?,
             ),
             (
                 "next-dynamic".into(),
-                Vc::upcast(NextDynamicTransition::new(Vc::upcast(
-                    self.client_transition(),
-                ))),
+                ResolvedVc::upcast(
+                    NextDynamicTransition::new(Vc::upcast(self.client_transition()))
+                        .to_resolved()
+                        .await?,
+                ),
             ),
-            ("next-ssr".into(), Vc::upcast(self.ssr_transition())),
-            ("next-shared".into(), Vc::upcast(self.shared_transition())),
+            (
+                "next-ssr".into(),
+                ResolvedVc::upcast(self.ssr_transition().to_resolved().await?),
+            ),
+            (
+                "next-shared".into(),
+                ResolvedVc::upcast(self.shared_transition().to_resolved().await?),
+            ),
         ]
         .into_iter()
         .collect();
 
-        ModuleAssetContext::new(
+        Ok(ModuleAssetContext::new(
             TransitionOptions {
                 named_transitions: transitions,
                 ..Default::default()
@@ -410,31 +433,38 @@ impl AppProject {
             self.route_module_options_context(),
             self.route_resolve_options_context(),
             Vc::cell("app-route".into()),
-        )
+        ))
     }
 
     #[turbo_tasks::function]
-    fn edge_route_module_context(self: Vc<Self>) -> Vc<ModuleAssetContext> {
+    async fn edge_route_module_context(self: Vc<Self>) -> Result<Vc<ModuleAssetContext>> {
         let transitions = [
             (
                 ECMASCRIPT_CLIENT_TRANSITION_NAME.into(),
-                self.edge_client_reference_transition(),
+                self.edge_client_reference_transition()
+                    .to_resolved()
+                    .await?,
             ),
             (
                 "next-dynamic".into(),
-                Vc::upcast(NextDynamicTransition::new(Vc::upcast(
-                    self.client_transition(),
-                ))),
+                ResolvedVc::upcast(
+                    NextDynamicTransition::new(Vc::upcast(self.client_transition()))
+                        .to_resolved()
+                        .await?,
+                ),
             ),
-            ("next-ssr".into(), Vc::upcast(self.ssr_transition())),
+            (
+                "next-ssr".into(),
+                ResolvedVc::upcast(self.edge_ssr_transition().to_resolved().await?),
+            ),
             (
                 "next-shared".into(),
-                Vc::upcast(self.edge_shared_transition()),
+                ResolvedVc::upcast(self.edge_shared_transition().to_resolved().await?),
             ),
         ]
         .into_iter()
         .collect();
-        ModuleAssetContext::new(
+        Ok(ModuleAssetContext::new(
             TransitionOptions {
                 named_transitions: transitions,
                 ..Default::default()
@@ -444,7 +474,7 @@ impl AppProject {
             self.edge_route_module_options_context(),
             self.edge_route_resolve_options_context(),
             Vc::cell("app-edge-route".into()),
-        )
+        ))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -256,19 +256,21 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    fn transitions(self: Vc<Self>) -> Vc<TransitionOptions> {
-        TransitionOptions {
+    async fn transitions(self: Vc<Self>) -> Result<Vc<TransitionOptions>> {
+        Ok(TransitionOptions {
             named_transitions: [(
                 "next-dynamic".into(),
-                Vc::upcast(NextDynamicTransition::new(Vc::upcast(
-                    self.client_transition(),
-                ))),
+                ResolvedVc::upcast(
+                    NextDynamicTransition::new(Vc::upcast(self.client_transition()))
+                        .to_resolved()
+                        .await?,
+                ),
             )]
             .into_iter()
             .collect(),
             ..Default::default()
         }
-        .cell()
+        .cell())
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -944,7 +944,10 @@ impl Project {
         if let Some(app_project) = app_project {
             transitions.push((
                 ECMASCRIPT_CLIENT_TRANSITION_NAME.into(),
-                app_project.edge_client_reference_transition(),
+                app_project
+                    .edge_client_reference_transition()
+                    .to_resolved()
+                    .await?,
             ));
         }
 
@@ -1025,7 +1028,10 @@ impl Project {
         if let Some(app_project) = app_project {
             transitions.push((
                 ECMASCRIPT_CLIENT_TRANSITION_NAME.into(),
-                app_project.client_reference_transition(),
+                app_project
+                    .client_reference_transition()
+                    .to_resolved()
+                    .await?,
             ));
         }
 

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1081,7 +1081,10 @@ impl Project {
         if let Some(app_project) = app_project {
             transitions.push((
                 ECMASCRIPT_CLIENT_TRANSITION_NAME.into(),
-                app_project.edge_client_reference_transition(),
+                app_project
+                    .edge_client_reference_transition()
+                    .to_resolved()
+                    .await?,
             ));
         }
 

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -384,9 +384,12 @@ pub async fn get_client_module_options_context(
         rules: vec![
             (
                 foreign_code_context_condition(next_config, project_path).await?,
-                foreign_codes_options_context.cell(),
+                foreign_codes_options_context.resolved_cell(),
             ),
-            (internal_assets_conditions(), internal_context.cell()),
+            (
+                internal_assets_conditions(),
+                internal_context.resolved_cell(),
+            ),
         ],
         module_rules: next_client_rules,
         ..module_options_context

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -232,16 +232,24 @@ pub async fn get_client_module_options_context(
         *execution_context,
     );
 
-    let tsconfig = get_typescript_transform_options(*project_path);
+    let tsconfig = get_typescript_transform_options(*project_path)
+        .to_resolved()
+        .await?;
     let decorators_options = get_decorators_transform_options(*project_path);
-    let enable_mdx_rs = *next_config.mdx_rs().await?;
+    let enable_mdx_rs = if let Some(mdx_rs) = *next_config.mdx_rs().await? {
+        Some(mdx_rs.to_resolved().await?)
+    } else {
+        None
+    };
     let jsx_runtime_options = get_jsx_transform_options(
         *project_path,
         mode,
         Some(resolve_options_context),
         false,
         next_config,
-    );
+    )
+    .to_resolved()
+    .await?;
 
     // A separate webpack rules will be applied to codes matching
     // foreign_code_context_condition. This allows to import codes from
@@ -298,7 +306,7 @@ pub async fn get_client_module_options_context(
 
     let postcss_transform_options = PostCssTransformOptions {
         postcss_package: Some(
-            get_postcss_package_mapping(project_path)
+            get_postcss_package_mapping(*project_path)
                 .to_resolved()
                 .await?,
         ),

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -142,21 +142,21 @@ pub enum ClientContextType {
 
 #[turbo_tasks::function]
 pub async fn get_client_resolve_options_context(
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
     ty: Value<ClientContextType>,
     mode: Vc<NextMode>,
     next_config: Vc<NextConfig>,
     execution_context: Vc<ExecutionContext>,
 ) -> Result<Vc<ResolveOptionsContext>> {
     let next_client_import_map =
-        get_next_client_import_map(project_path, ty, next_config, execution_context)
+        get_next_client_import_map(*project_path, ty, next_config, execution_context)
             .to_resolved()
             .await?;
     let next_client_fallback_import_map = get_next_client_fallback_import_map(ty)
         .to_resolved()
         .await?;
     let next_client_resolved_map =
-        get_next_client_resolved_map(project_path, project_path, *mode.await?)
+        get_next_client_resolved_map(*project_path, project_path, *mode.await?)
             .to_resolved()
             .await?;
     let custom_conditions = vec![mode.await?.condition().into()];
@@ -175,18 +175,18 @@ pub async fn get_client_resolve_options_context(
                     .await?,
             ),
             ResolvedVc::upcast(
-                ModuleFeatureReportResolvePlugin::new(project_path)
+                ModuleFeatureReportResolvePlugin::new(*project_path)
                     .to_resolved()
                     .await?,
             ),
             ResolvedVc::upcast(
-                NextFontLocalResolvePlugin::new(project_path)
+                NextFontLocalResolvePlugin::new(*project_path)
                     .to_resolved()
                     .await?,
             ),
         ],
         after_resolve_plugins: vec![ResolvedVc::upcast(
-            NextSharedRuntimeResolvePlugin::new(project_path)
+            NextSharedRuntimeResolvePlugin::new(*project_path)
                 .to_resolved()
                 .await?,
         )],

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -274,8 +274,13 @@ pub async fn get_client_module_options_context(
     };
 
     // Now creates a webpack rules that applies to all codes.
-    let enable_webpack_loaders =
-        webpack_loader_options(project_path, next_config, false, conditions).await?;
+    let enable_webpack_loaders = if let Some(vc) =
+        webpack_loader_options(project_path, next_config, false, conditions).await?
+    {
+        Some(vc.to_resolved().await?)
+    } else {
+        None
+    };
 
     let tree_shaking_mode_for_user_code = *next_config
         .tree_shaking_mode_for_user_code(next_mode.is_development())

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -224,8 +224,13 @@ pub async fn get_client_module_options_context(
     next_config: Vc<NextConfig>,
 ) -> Result<Vc<ModuleOptionsContext>> {
     let next_mode = mode.await?;
-    let resolve_options_context =
-        get_client_resolve_options_context(project_path, ty, mode, next_config, *execution_context);
+    let resolve_options_context = get_client_resolve_options_context(
+        *project_path,
+        ty,
+        mode,
+        next_config,
+        *execution_context,
+    );
 
     let tsconfig = get_typescript_transform_options(*project_path);
     let decorators_options = get_decorators_transform_options(*project_path);

--- a/crates/next-core/src/next_client/transforms.rs
+++ b/crates/next-core/src/next_client/transforms.rs
@@ -93,7 +93,7 @@ pub async fn get_next_client_transforms_rules(
             get_next_dynamic_transform_rule(false, false, is_app_dir, mode, enable_mdx_rs).await?,
         );
 
-        rules.push(get_next_image_rule());
+        rules.push(get_next_image_rule().await?);
         rules.push(get_next_page_static_info_assert_rule(
             enable_mdx_rs,
             None,

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
@@ -116,11 +116,11 @@ impl Transition for NextEcmascriptClientReferenceTransition {
         // the context.
         let module_asset_context = module_asset_context.await?;
         let server_context = ModuleAssetContext::new(
-            module_asset_context.transitions,
-            module_asset_context.compile_time_info,
-            module_asset_context.module_options_context,
-            module_asset_context.resolve_options_context,
-            module_asset_context.layer,
+            *module_asset_context.transitions,
+            *module_asset_context.compile_time_info,
+            *module_asset_context.module_options_context,
+            *module_asset_context.resolve_options_context,
+            *module_asset_context.layer,
         );
 
         Ok(ProcessResult::Module(ResolvedVc::upcast(

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -921,8 +921,8 @@ impl NextConfig {
         let active_conditions = active_conditions.into_iter().collect::<HashSet<_>>();
         let mut rules = FxIndexMap::default();
         for (ext, rule) in turbo_rules.iter() {
-            fn transform_loaders(loaders: &[LoaderItem]) -> Vc<WebpackLoaderItems> {
-                Vc::cell(
+            fn transform_loaders(loaders: &[LoaderItem]) -> ResolvedVc<WebpackLoaderItems> {
+                ResolvedVc::cell(
                     loaders
                         .iter()
                         .map(|item| match item {
@@ -990,7 +990,7 @@ impl NextConfig {
                 }
             }
         }
-        Vc::cell(Some(Vc::cell(rules)))
+        Vc::cell(Some(ResolvedVc::cell(rules)))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -89,21 +89,21 @@ pub fn get_edge_compile_time_info(
 
 #[turbo_tasks::function]
 pub async fn get_edge_resolve_options_context(
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
     ty: Value<ServerContextType>,
     mode: Vc<NextMode>,
     next_config: Vc<NextConfig>,
     execution_context: Vc<ExecutionContext>,
 ) -> Result<Vc<ResolveOptionsContext>> {
     let next_edge_import_map =
-        get_next_edge_import_map(project_path, ty, next_config, execution_context)
+        get_next_edge_import_map(*project_path, ty, next_config, execution_context)
             .to_resolved()
             .await?;
 
     let ty: ServerContextType = ty.into_value();
 
     let mut before_resolve_plugins = vec![ResolvedVc::upcast(
-        ModuleFeatureReportResolvePlugin::new(project_path)
+        ModuleFeatureReportResolvePlugin::new(*project_path)
             .to_resolved()
             .await?,
     )];
@@ -114,7 +114,7 @@ pub async fn get_edge_resolve_options_context(
             | ServerContextType::AppRSC { .. }
     ) {
         before_resolve_plugins.push(ResolvedVc::upcast(
-            NextFontLocalResolvePlugin::new(project_path)
+            NextFontLocalResolvePlugin::new(*project_path)
                 .to_resolved()
                 .await?,
         ));
@@ -129,7 +129,7 @@ pub async fn get_edge_resolve_options_context(
             | ServerContextType::Instrumentation { .. }
     ) {
         before_resolve_plugins.push(ResolvedVc::upcast(
-            get_invalid_client_only_resolve_plugin(project_path)
+            get_invalid_client_only_resolve_plugin(*project_path)
                 .to_resolved()
                 .await?,
         ));
@@ -141,7 +141,7 @@ pub async fn get_edge_resolve_options_context(
     }
 
     let after_resolve_plugins = vec![ResolvedVc::upcast(
-        NextSharedRuntimeResolvePlugin::new(project_path)
+        NextSharedRuntimeResolvePlugin::new(*project_path)
             .to_resolved()
             .await?,
     )];

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -129,7 +129,7 @@ pub async fn get_edge_resolve_options_context(
             | ServerContextType::Instrumentation { .. }
     ) {
         before_resolve_plugins.push(ResolvedVc::upcast(
-            get_invalid_client_only_resolve_plugin(*project_path)
+            get_invalid_client_only_resolve_plugin(project_path)
                 .to_resolved()
                 .await?,
         ));

--- a/crates/next-core/src/next_font/google/font_fallback.rs
+++ b/crates/next-core/src/next_font/google/font_fallback.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{trace::TraceRawVcs, RcStr, Vc};
+use turbo_tasks::{trace::TraceRawVcs, RcStr, ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{IssueExt, IssueSeverity, StyledString};
 
@@ -44,7 +44,7 @@ struct Fallback {
 
 #[turbo_tasks::function]
 pub(super) async fn get_font_fallback(
-    lookup_path: Vc<FileSystemPath>,
+    lookup_path: ResolvedVc<FileSystemPath>,
     options_vc: Vc<NextFontGoogleOptions>,
 ) -> Result<Vc<FontFallback>> {
     let options = options_vc.await?;
@@ -74,7 +74,7 @@ pub(super) async fn get_font_fallback(
                 .cell(),
                 Err(_) => {
                     NextFontIssue {
-                        path: lookup_path,
+                        path: *lookup_path,
                         title: StyledString::Text(
                             format!(
                                 "Failed to find font override values for font `{}`",

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -398,7 +398,7 @@ impl ImportMappingReplacement for NextFontGoogleFontFileReplacer {
 }
 
 #[turbo_tasks::function]
-async fn load_font_data(project_root: Vc<FileSystemPath>) -> Result<Vc<FontData>> {
+async fn load_font_data(project_root: ResolvedVc<FileSystemPath>) -> Result<Vc<FontData>> {
     let data: FontData = load_next_js_templateon(
         project_root,
         "dist/compiled/@next/font/dist/google/font-data.json".into(),

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -516,7 +516,7 @@ async fn insert_unsupported_node_internal_aliases(
 
 pub fn get_next_client_resolved_map(
     _context: Vc<FileSystemPath>,
-    _root: Vc<FileSystemPath>,
+    _root: ResolvedVc<FileSystemPath>,
     _mode: NextMode,
 ) -> Vc<ResolvedMap> {
     let glob_mappings = vec![];

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -128,7 +128,7 @@ pub async fn get_server_resolve_options_context(
     execution_context: Vc<ExecutionContext>,
 ) -> Result<Vc<ResolveOptionsContext>> {
     let next_server_import_map =
-        get_next_server_import_map(project_path, ty, next_config, execution_context)
+        get_next_server_import_map(*project_path, ty, next_config, execution_context)
             .to_resolved()
             .await?;
     let foreign_code_context_condition =
@@ -185,7 +185,7 @@ pub async fn get_server_resolve_options_context(
     let ty = ty.into_value();
 
     let server_external_packages_plugin = ExternalCjsModulesResolvePlugin::new(
-        project_path,
+        *project_path,
         project_path.root(),
         ExternalPredicate::Only(ResolvedVc::cell(external_packages)).cell(),
         *next_config.import_externals().await?,

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -134,7 +134,7 @@ pub async fn get_server_resolve_options_context(
     let foreign_code_context_condition =
         foreign_code_context_condition(next_config, project_path).await?;
     let root_dir = project_path.root().to_resolved().await?;
-    let module_feature_report_resolve_plugin = ModuleFeatureReportResolvePlugin::new(project_path)
+    let module_feature_report_resolve_plugin = ModuleFeatureReportResolvePlugin::new(*project_path)
         .to_resolved()
         .await?;
     let invalid_client_only_resolve_plugin = get_invalid_client_only_resolve_plugin(project_path)

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -152,7 +152,7 @@ pub async fn get_server_resolve_options_context(
     )
     .await?;
 
-    let mut transpiled_packages = get_transpiled_packages(next_config, project_path)
+    let mut transpiled_packages = get_transpiled_packages(next_config, *project_path)
         .await?
         .clone_value();
 
@@ -210,7 +210,7 @@ pub async fn get_server_resolve_options_context(
         server_external_packages_plugin
     } else {
         ExternalCjsModulesResolvePlugin::new(
-            project_path,
+            *project_path,
             project_path.root(),
             ExternalPredicate::AllExcept(ResolvedVc::cell(transpiled_packages)).cell(),
             *next_config.import_externals().await?,
@@ -219,11 +219,11 @@ pub async fn get_server_resolve_options_context(
         .await?
     };
 
-    let next_external_plugin = NextExternalResolvePlugin::new(project_path)
+    let next_external_plugin = NextExternalResolvePlugin::new(*project_path)
         .to_resolved()
         .await?;
     let next_node_shared_runtime_plugin =
-        NextNodeSharedRuntimeResolvePlugin::new(project_path, Value::new(ty))
+        NextNodeSharedRuntimeResolvePlugin::new(*project_path, Value::new(ty))
             .to_resolved()
             .await?;
 
@@ -233,7 +233,7 @@ pub async fn get_server_resolve_options_context(
         | ServerContextType::AppRSC { .. } => {
             vec![
                 ResolvedVc::upcast(
-                    NextFontLocalResolvePlugin::new(project_path)
+                    NextFontLocalResolvePlugin::new(*project_path)
                         .to_resolved()
                         .await?,
                 ),
@@ -629,11 +629,11 @@ pub async fn get_server_module_options_context(
                 rules: vec![
                     (
                         foreign_code_context_condition,
-                        foreign_code_module_options_context.cell(),
+                        foreign_code_module_options_context.resolved_cell(),
                     ),
                     (
                         internal_assets_conditions(),
-                        internal_module_options_context.cell(),
+                        internal_module_options_context.resolved_cell(),
                     ),
                 ],
                 module_rules: next_server_rules,
@@ -672,7 +672,9 @@ pub async fn get_server_module_options_context(
             };
             let internal_module_options_context = ModuleOptionsContext {
                 ecmascript: EcmascriptOptionsContext {
-                    enable_typescript_transform: Some(TypescriptTransformOptions::default().cell()),
+                    enable_typescript_transform: Some(
+                        TypescriptTransformOptions::default().resolved_cell(),
+                    ),
                     ..module_options_context.ecmascript.clone()
                 },
                 module_rules: foreign_next_server_rules,
@@ -692,11 +694,11 @@ pub async fn get_server_module_options_context(
                 rules: vec![
                     (
                         foreign_code_context_condition,
-                        foreign_code_module_options_context.cell(),
+                        foreign_code_module_options_context.resolved_cell(),
                     ),
                     (
                         internal_assets_conditions(),
-                        internal_module_options_context.cell(),
+                        internal_module_options_context.resolved_cell(),
                     ),
                 ],
                 module_rules: next_server_rules,
@@ -747,7 +749,9 @@ pub async fn get_server_module_options_context(
             };
             let internal_module_options_context = ModuleOptionsContext {
                 ecmascript: EcmascriptOptionsContext {
-                    enable_typescript_transform: Some(TypescriptTransformOptions::default().cell()),
+                    enable_typescript_transform: Some(
+                        TypescriptTransformOptions::default().resolved_cell(),
+                    ),
                     ..module_options_context.ecmascript.clone()
                 },
                 module_rules: foreign_next_server_rules,
@@ -766,11 +770,11 @@ pub async fn get_server_module_options_context(
                 rules: vec![
                     (
                         foreign_code_context_condition,
-                        foreign_code_module_options_context.cell(),
+                        foreign_code_module_options_context.resolved_cell(),
                     ),
                     (
                         internal_assets_conditions(),
-                        internal_module_options_context.cell(),
+                        internal_module_options_context.resolved_cell(),
                     ),
                 ],
                 module_rules: next_server_rules,
@@ -820,7 +824,9 @@ pub async fn get_server_module_options_context(
             };
             let internal_module_options_context = ModuleOptionsContext {
                 ecmascript: EcmascriptOptionsContext {
-                    enable_typescript_transform: Some(TypescriptTransformOptions::default().cell()),
+                    enable_typescript_transform: Some(
+                        TypescriptTransformOptions::default().resolved_cell(),
+                    ),
                     ..module_options_context.ecmascript.clone()
                 },
                 module_rules: internal_custom_rules,
@@ -839,11 +845,11 @@ pub async fn get_server_module_options_context(
                 rules: vec![
                     (
                         foreign_code_context_condition,
-                        foreign_code_module_options_context.cell(),
+                        foreign_code_module_options_context.resolved_cell(),
                     ),
                     (
                         internal_assets_conditions(),
-                        internal_module_options_context.cell(),
+                        internal_module_options_context.resolved_cell(),
                     ),
                 ],
                 module_rules: next_server_rules,

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -921,7 +921,9 @@ pub async fn get_server_module_options_context(
             };
             let internal_module_options_context = ModuleOptionsContext {
                 ecmascript: EcmascriptOptionsContext {
-                    enable_typescript_transform: Some(TypescriptTransformOptions::default().cell()),
+                    enable_typescript_transform: Some(
+                        TypescriptTransformOptions::default().resolved_cell(),
+                    ),
                     ..module_options_context.ecmascript.clone()
                 },
                 module_rules: internal_custom_rules,
@@ -940,11 +942,11 @@ pub async fn get_server_module_options_context(
                 rules: vec![
                     (
                         foreign_code_context_condition,
-                        foreign_code_module_options_context.cell(),
+                        foreign_code_module_options_context.resolved_cell(),
                     ),
                     (
                         internal_assets_conditions(),
-                        internal_module_options_context.cell(),
+                        internal_module_options_context.resolved_cell(),
                     ),
                 ],
                 module_rules: next_server_rules,

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -434,8 +434,8 @@ pub async fn get_server_module_options_context(
         config_location: PostCssConfigLocation::ProjectPath,
         ..postcss_transform_options.clone()
     };
-    let enable_postcss_transform = Some(postcss_transform_options.cell());
-    let enable_foreign_postcss_transform = Some(postcss_foreign_transform_options.cell());
+    let enable_postcss_transform = Some(postcss_transform_options.resolved_cell());
+    let enable_foreign_postcss_transform = Some(postcss_foreign_transform_options.resolved_cell());
 
     let mut conditions = vec![mode.await?.condition().into()];
     conditions.extend(

--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -142,7 +142,7 @@ pub async fn get_next_server_transforms_rules(
         // rules.push(get_next_optimize_server_react_rule(enable_mdx_rs,
         // optimize_use_state))
 
-        rules.push(get_next_image_rule());
+        rules.push(get_next_image_rule().await?);
     }
 
     if let NextRuntime::Edge = next_runtime {

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -170,7 +170,7 @@ pub(crate) fn get_invalid_client_only_resolve_plugin(
 /// Only the contexts that alises `server-only` to
 /// `next/dist/compiled/server-only/index` should use this.
 pub(crate) fn get_invalid_server_only_resolve_plugin(
-    root: Vc<FileSystemPath>,
+    root: ResolvedVc<FileSystemPath>,
 ) -> Vc<InvalidImportResolvePlugin> {
     InvalidImportResolvePlugin::new(
         root,
@@ -185,7 +185,7 @@ pub(crate) fn get_invalid_server_only_resolve_plugin(
 
 /// Returns a resolve plugin if context have imports to `styled-jsx`.
 pub(crate) fn get_invalid_styled_jsx_resolve_plugin(
-    root: Vc<FileSystemPath>,
+    root: ResolvedVc<FileSystemPath>,
 ) -> Vc<InvalidImportResolvePlugin> {
     InvalidImportResolvePlugin::new(
         root,

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -156,7 +156,7 @@ pub(crate) fn get_invalid_client_only_resolve_plugin(
     root: ResolvedVc<FileSystemPath>,
 ) -> Vc<InvalidImportResolvePlugin> {
     InvalidImportResolvePlugin::new(
-        root,
+        *root,
         "client-only".into(),
         vec![
             "'client-only' cannot be imported from a Server Component module. It should only be \

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -188,7 +188,7 @@ pub(crate) fn get_invalid_styled_jsx_resolve_plugin(
     root: ResolvedVc<FileSystemPath>,
 ) -> Vc<InvalidImportResolvePlugin> {
     InvalidImportResolvePlugin::new(
-        root,
+        *root,
         "styled-jsx".into(),
         vec![
             "'client-only' cannot be imported from a Server Component module. It should only be \

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -153,7 +153,7 @@ impl BeforeResolvePlugin for InvalidImportResolvePlugin {
 /// Only the contexts that alises `client-only` to
 /// `next/dist/compiled/client-only/error` should use this.
 pub(crate) fn get_invalid_client_only_resolve_plugin(
-    root: Vc<FileSystemPath>,
+    root: ResolvedVc<FileSystemPath>,
 ) -> Vc<InvalidImportResolvePlugin> {
     InvalidImportResolvePlugin::new(
         root,
@@ -173,7 +173,7 @@ pub(crate) fn get_invalid_server_only_resolve_plugin(
     root: ResolvedVc<FileSystemPath>,
 ) -> Vc<InvalidImportResolvePlugin> {
     InvalidImportResolvePlugin::new(
-        root,
+        *root,
         "server-only".into(),
         vec![
             "'server-only' cannot be imported from a Client Component module. It should only be \

--- a/crates/next-core/src/next_shared/transforms/debug_fn_name.rs
+++ b/crates/next-core/src/next_shared/transforms/debug_fn_name.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::debug_fn_name::debug_fn_name;
 use swc_core::ecma::{ast::Program, visit::VisitMutWith};
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 
@@ -15,8 +15,8 @@ pub fn get_debug_fn_name_rule(enable_mdx_rs: bool) -> ModuleRule {
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: Vc::cell(vec![]),
-            append: Vc::cell(vec![debug_fn_name_transform]),
+            prepend: ResolvedVc::cell(vec![]),
+            append: ResolvedVc::cell(vec![debug_fn_name_transform]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/crates/next-core/src/next_shared/transforms/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod styled_components;
 pub(crate) mod styled_jsx;
 pub(crate) mod swc_ecma_transform_plugins;
 
+use anyhow::Result;
 pub use modularize_imports::{get_next_modularize_imports_rule, ModularizeImportPackageConfig};
 pub use next_dynamic::get_next_dynamic_transform_rule;
 pub use next_font::get_next_font_transform_rule;
@@ -38,8 +39,8 @@ use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform};
 
 use crate::next_image::{module::BlurPlaceholderMode, StructuredImageModuleType};
 
-pub fn get_next_image_rule() -> ModuleRule {
-    ModuleRule::new(
+pub async fn get_next_image_rule() -> Result<ModuleRule> {
+    Ok(ModuleRule::new(
         RuleCondition::All(vec![
             // avoid urlAssetReference to be affected by this rule, since urlAssetReference
             // requires raw module to have its paths in the export
@@ -63,11 +64,13 @@ pub fn get_next_image_rule() -> ModuleRule {
             ]),
         ]),
         vec![ModuleRuleEffect::ModuleType(ModuleType::Custom(
-            Vc::upcast(StructuredImageModuleType::new(Value::new(
-                BlurPlaceholderMode::DataUrl,
-            ))),
+            ResolvedVc::upcast(
+                StructuredImageModuleType::new(Value::new(BlurPlaceholderMode::DataUrl))
+                    .to_resolved()
+                    .await?,
+            ),
         ))],
-    )
+    ))
 }
 
 fn match_js_extension(enable_mdx_rs: bool) -> Vec<RuleCondition> {

--- a/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/crates/next-core/src/next_shared/transforms/mod.rs
@@ -30,7 +30,7 @@ pub use next_font::get_next_font_transform_rule;
 pub use next_lint::get_next_lint_transform_rule;
 pub use next_strip_page_exports::get_next_pages_transforms_rule;
 pub use server_actions::get_server_actions_transform_rule;
-use turbo_tasks::{ReadRef, Value, Vc};
+use turbo_tasks::{ReadRef, ResolvedVc, Value, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect, ModuleType, RuleCondition};
 use turbopack_core::reference_type::{ReferenceType, UrlReferenceSubType};
@@ -135,9 +135,15 @@ pub(crate) fn get_ecma_transform_rule(
 ) -> ModuleRule {
     let transformer = EcmascriptInputTransform::Plugin(Vc::cell(transformer as _));
     let (prepend, append) = if prepend {
-        (Vc::cell(vec![transformer]), Vc::cell(vec![]))
+        (
+            ResolvedVc::cell(vec![transformer]),
+            ResolvedVc::cell(vec![]),
+        )
     } else {
-        (Vc::cell(vec![]), Vc::cell(vec![transformer]))
+        (
+            ResolvedVc::cell(vec![]),
+            ResolvedVc::cell(vec![transformer]),
+        )
     };
 
     ModuleRule::new(

--- a/crates/next-core/src/next_shared/transforms/modularize_imports.rs
+++ b/crates/next-core/src/next_shared/transforms/modularize_imports.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use modularize_imports::{modularize_imports, PackageConfig};
 use serde::{Deserialize, Serialize};
 use swc_core::ecma::ast::Program;
-use turbo_tasks::{trace::TraceRawVcs, FxIndexMap, Vc};
+use turbo_tasks::{trace::TraceRawVcs, FxIndexMap, ResolvedVc, Vc};
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 
@@ -41,8 +41,8 @@ pub fn get_next_modularize_imports_rule(
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: Vc::cell(vec![]),
-            append: Vc::cell(vec![transformer]),
+            prepend: ResolvedVc::cell(vec![]),
+            append: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_amp_attributes.rs
+++ b/crates/next-core/src/next_shared/transforms/next_amp_attributes.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::amp_attributes::amp_attributes;
 use swc_core::ecma::ast::*;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 
@@ -14,8 +14,8 @@ pub fn get_next_amp_attr_rule(enable_mdx_rs: bool) -> ModuleRule {
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: Vc::cell(vec![]),
-            append: Vc::cell(vec![transformer]),
+            prepend: ResolvedVc::cell(vec![]),
+            append: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_cjs_optimizer.rs
+++ b/crates/next-core/src/next_shared/transforms/next_cjs_optimizer.rs
@@ -6,7 +6,7 @@ use swc_core::{
     common::SyntaxContext,
     ecma::{ast::*, visit::VisitMutWith},
 };
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 
@@ -52,8 +52,8 @@ pub fn get_next_cjs_optimizer_rule(enable_mdx_rs: bool) -> ModuleRule {
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: Vc::cell(vec![]),
-            append: Vc::cell(vec![transformer]),
+            prepend: ResolvedVc::cell(vec![]),
+            append: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_disallow_re_export_all_in_page.rs
+++ b/crates/next-core/src/next_shared/transforms/next_disallow_re_export_all_in_page.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::disallow_re_export_all_in_page::disallow_re_export_all_in_page;
 use swc_core::ecma::ast::*;
-use turbo_tasks::{ReadRef, Vc};
+use turbo_tasks::{ReadRef, ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
@@ -18,8 +18,8 @@ pub fn get_next_disallow_export_all_in_page_rule(
     ModuleRule::new(
         module_rule_match_pages_page_file(enable_mdx_rs, pages_dir),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: Vc::cell(vec![]),
-            append: Vc::cell(vec![transformer]),
+            prepend: ResolvedVc::cell(vec![]),
+            append: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_dynamic.rs
+++ b/crates/next-core/src/next_shared/transforms/next_dynamic.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::dynamic::{next_dynamic, NextDynamicMode};
 use swc_core::{common::FileName, ecma::ast::Program};
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 
@@ -26,8 +26,8 @@ pub async fn get_next_dynamic_transform_rule(
     Ok(ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: Vc::cell(vec![]),
-            append: Vc::cell(vec![dynamic_transform]),
+            prepend: ResolvedVc::cell(vec![]),
+            append: ResolvedVc::cell(vec![dynamic_transform]),
         }],
     ))
 }

--- a/crates/next-core/src/next_shared/transforms/next_edge_node_api_assert.rs
+++ b/crates/next-core/src/next_shared/transforms/next_edge_node_api_assert.rs
@@ -5,7 +5,7 @@ use swc_core::{
     common::SyntaxContext,
     ecma::{ast::*, utils::ExprCtx, visit::VisitWith},
 };
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 
@@ -23,8 +23,8 @@ pub fn next_edge_node_api_assert(
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: Vc::cell(vec![]),
-            append: Vc::cell(vec![transformer]),
+            prepend: ResolvedVc::cell(vec![]),
+            append: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_font.rs
+++ b/crates/next-core/src/next_shared/transforms/next_font.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::fonts::*;
 use swc_core::ecma::{ast::Program, atoms::JsWord, visit::VisitMutWith};
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 
@@ -23,8 +23,8 @@ pub fn get_next_font_transform_rule(enable_mdx_rs: bool) -> ModuleRule {
         // TODO: Only match in pages (not pages/api), app/, etc.
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: Vc::cell(vec![]),
-            append: Vc::cell(vec![transformer]),
+            prepend: ResolvedVc::cell(vec![]),
+            append: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_middleware_dynamic_assert.rs
+++ b/crates/next-core/src/next_shared/transforms/next_middleware_dynamic_assert.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::middleware_dynamic::next_middleware_dynamic;
 use swc_core::ecma::{ast::*, visit::VisitMutWith};
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 
@@ -14,8 +14,8 @@ pub fn get_middleware_dynamic_assert_rule(enable_mdx_rs: bool) -> ModuleRule {
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: Vc::cell(vec![]),
-            append: Vc::cell(vec![transformer]),
+            prepend: ResolvedVc::cell(vec![]),
+            append: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_optimize_server_react.rs
+++ b/crates/next-core/src/next_shared/transforms/next_optimize_server_react.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::optimize_server_react::{optimize_server_react, Config};
 use swc_core::ecma::ast::*;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 
@@ -20,8 +20,8 @@ pub fn get_next_optimize_server_react_rule(
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: Vc::cell(vec![]),
-            append: Vc::cell(vec![transformer]),
+            prepend: ResolvedVc::cell(vec![]),
+            append: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_page_config.rs
+++ b/crates/next-core/src/next_shared/transforms/next_page_config.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::page_config::page_config;
 use swc_core::ecma::ast::*;
-use turbo_tasks::{ReadRef, Vc};
+use turbo_tasks::{ReadRef, ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
@@ -20,8 +20,8 @@ pub fn get_next_page_config_rule(
     ModuleRule::new(
         module_rule_match_pages_page_file(enable_mdx_rs, pages_dir),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: Vc::cell(vec![]),
-            append: Vc::cell(vec![transformer]),
+            prepend: ResolvedVc::cell(vec![]),
+            append: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
+++ b/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
@@ -5,7 +5,7 @@ use next_custom_transforms::transforms::page_static_info::{
 };
 use serde_json::Value;
 use swc_core::ecma::ast::Program;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_core::issue::{
@@ -32,8 +32,8 @@ pub fn get_next_page_static_info_assert_rule(
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: Vc::cell(vec![transformer]),
-            append: Vc::cell(vec![]),
+            prepend: ResolvedVc::cell(vec![transformer]),
+            append: ResolvedVc::cell(vec![]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_pure.rs
+++ b/crates/next-core/src/next_shared/transforms/next_pure.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::pure::pure_magic;
 use swc_core::ecma::{ast::*, visit::VisitMutWith};
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 
@@ -13,8 +13,8 @@ pub fn get_next_pure_rule(enable_mdx_rs: bool) -> ModuleRule {
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: Vc::cell(vec![]),
-            append: Vc::cell(vec![transformer]),
+            prepend: ResolvedVc::cell(vec![]),
+            append: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_shake_exports.rs
+++ b/crates/next-core/src/next_shared/transforms/next_shake_exports.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::shake_exports::{shake_exports, Config};
 use swc_core::ecma::ast::*;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 
@@ -15,8 +15,8 @@ pub fn get_next_shake_exports_rule(enable_mdx_rs: bool, ignore: Vec<String>) -> 
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: Vc::cell(vec![]),
-            append: Vc::cell(vec![transformer]),
+            prepend: ResolvedVc::cell(vec![]),
+            append: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
+++ b/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
@@ -4,7 +4,7 @@ use next_custom_transforms::transforms::strip_page_exports::{
     next_transform_strip_page_exports, ExportFilter,
 };
 use swc_core::ecma::ast::Program;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect, RuleCondition};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
@@ -43,8 +43,8 @@ pub async fn get_next_pages_transforms_rule(
             module_rule_match_js_no_url(enable_mdx_rs),
         ]),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: Vc::cell(vec![]),
-            append: Vc::cell(vec![strip_transform]),
+            prepend: ResolvedVc::cell(vec![]),
+            append: ResolvedVc::cell(vec![strip_transform]),
         }],
     ))
 }

--- a/crates/next-core/src/next_shared/transforms/relay.rs
+++ b/crates/next-core/src/next_shared/transforms/relay.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::ModuleRule;
 use turbopack_ecmascript_plugins::transform::relay::RelayTransformer;
@@ -10,7 +10,7 @@ use crate::next_config::NextConfig;
 /// Returns a transform rule for the relay graphql transform.
 pub async fn get_relay_transform_rule(
     next_config: Vc<NextConfig>,
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
 ) -> Result<Option<ModuleRule>> {
     let enable_mdx_rs = next_config.mdx_rs().await?.is_some();
     let project_path = &*project_path.await?;

--- a/crates/next-core/src/next_shared/transforms/server_actions.rs
+++ b/crates/next-core/src/next_shared/transforms/server_actions.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::server_actions::{server_actions, Config};
 use swc_core::{common::FileName, ecma::ast::Program};
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 
@@ -27,8 +27,8 @@ pub fn get_server_actions_transform_rule(
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: Vc::cell(vec![]),
-            append: Vc::cell(vec![transformer]),
+            prepend: ResolvedVc::cell(vec![]),
+            append: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 #[allow(unused_imports)]
 use turbo_tasks::RcStr;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::ModuleRule;
 
@@ -9,7 +9,7 @@ use crate::next_config::NextConfig;
 
 pub async fn get_swc_ecma_transform_plugin_rule(
     next_config: Vc<NextConfig>,
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
 ) -> Result<Option<ModuleRule>> {
     match next_config.experimental().await?.swc_plugins.as_ref() {
         Some(plugin_configs) if !plugin_configs.is_empty() => {
@@ -31,7 +31,7 @@ pub async fn get_swc_ecma_transform_plugin_rule(
 
 #[cfg(feature = "plugin")]
 pub async fn get_swc_ecma_transform_rule_impl(
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
     plugin_configs: &[(RcStr, serde_json::Value)],
     enable_mdx_rs: bool,
 ) -> Result<Option<ModuleRule>> {
@@ -59,7 +59,7 @@ pub async fn get_swc_ecma_transform_rule_impl(
         // Current resolve will fail with latter.
         let request = Request::parse(Value::new(Pattern::Constant(name.as_str().into())));
         let resolve_options = resolve_options(
-            project_path,
+            *project_path,
             ResolveOptionsContext {
                 enable_node_modules: Some(project_path.root().to_resolved().await?),
                 enable_node_native_modules: true,
@@ -70,14 +70,14 @@ pub async fn get_swc_ecma_transform_rule_impl(
 
         let plugin_wasm_module_resolve_result = handle_resolve_error(
             resolve(
-                project_path,
+                *project_path,
                 Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
                 request,
                 resolve_options,
             )
             .as_raw_module_result(),
             Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
-            project_path,
+            *project_path,
             request,
             resolve_options,
             false,

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -27,7 +27,7 @@ const BABEL_CONFIG_FILES: &[&str] = &[
 #[turbo_tasks::function]
 pub async fn maybe_add_babel_loader(
     project_root: Vc<FileSystemPath>,
-    webpack_rules: Option<Vc<WebpackRules>>,
+    webpack_rules: Option<ResolvedVc<WebpackRules>>,
 ) -> Result<Vc<OptionWebpackRules>> {
     let has_babel_config = {
         let mut has_babel_config = false;

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{Value, Vc};
+use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbo_tasks_fs::{self, FileSystemEntryType, FileSystemPath};
 use turbopack::module_options::{LoaderRuleItem, OptionWebpackRules, WebpackRules};
 use turbopack_core::{
@@ -89,12 +89,12 @@ pub async fn maybe_add_babel_loader(
                 if let Some(rule) = rule {
                     let mut loaders = rule.loaders.await?.clone_value();
                     loaders.push(loader);
-                    rule.loaders = Vc::cell(loaders);
+                    rule.loaders = ResolvedVc::cell(loaders);
                 } else {
                     rules.insert(
                         pattern.into(),
                         LoaderRuleItem {
-                            loaders: Vc::cell(vec![loader]),
+                            loaders: ResolvedVc::cell(vec![loader]),
                             rename_as: Some("*".into()),
                         },
                     );

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -104,7 +104,7 @@ pub async fn maybe_add_babel_loader(
         }
 
         if has_changed {
-            return Ok(Vc::cell(Some(Vc::cell(rules))));
+            return Ok(Vc::cell(Some(ResolvedVc::cell(rules))));
         }
     }
     Ok(Vc::cell(webpack_rules))

--- a/crates/next-core/src/next_shared/webpack_rules/mod.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/mod.rs
@@ -17,19 +17,23 @@ pub async fn webpack_loader_options(
     conditions: Vec<RcStr>,
 ) -> Result<Option<Vc<WebpackLoadersOptions>>> {
     let rules = *next_config.webpack_rules(conditions).await?;
-    let rules = *maybe_add_sass_loader(next_config.sass_config(), rules).await?;
+    let rules = *maybe_add_sass_loader(next_config.sass_config(), rules.map(|v| *v)).await?;
     let rules = if foreign {
         rules
     } else {
-        *maybe_add_babel_loader(*project_path, rules).await?
+        *maybe_add_babel_loader(*project_path, rules.map(|v| *v)).await?
     };
-    Ok(rules.map(|rules| {
-        WebpackLoadersOptions {
-            rules,
-            loader_runner_package: Some(loader_runner_package_mapping()),
-        }
-        .cell()
-    }))
+    Ok(if let Some(rules) = rules {
+        Some(
+            WebpackLoadersOptions {
+                rules,
+                loader_runner_package: Some(loader_runner_package_mapping().to_resolved().await?),
+            }
+            .cell(),
+        )
+    } else {
+        None
+    })
 }
 
 #[turbo_tasks::function]

--- a/crates/next-core/src/next_shared/webpack_rules/mod.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/mod.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{RcStr, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::WebpackLoadersOptions;
 use turbopack_core::resolve::options::ImportMapping;
@@ -11,7 +11,7 @@ pub(crate) mod babel;
 pub(crate) mod sass;
 
 pub async fn webpack_loader_options(
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
     next_config: Vc<NextConfig>,
     foreign: bool,
     conditions: Vec<RcStr>,
@@ -21,7 +21,7 @@ pub async fn webpack_loader_options(
     let rules = if foreign {
         rules
     } else {
-        *maybe_add_babel_loader(project_path, rules).await?
+        *maybe_add_babel_loader(*project_path, rules).await?
     };
     Ok(rules.map(|rules| {
         WebpackLoadersOptions {

--- a/crates/next-core/src/next_shared/webpack_rules/sass.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/sass.rs
@@ -2,7 +2,7 @@ use std::mem::take;
 
 use anyhow::{bail, Result};
 use serde_json::Value as JsonValue;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::module_options::{LoaderRuleItem, OptionWebpackRules, WebpackRules};
 use turbopack_node::transforms::webpack::WebpackLoaderItem;
 
@@ -71,17 +71,17 @@ pub async fn maybe_add_sass_loader(
             let mut loaders = rule.loaders.await?.clone_value();
             loaders.push(resolve_url_loader);
             loaders.push(sass_loader);
-            rule.loaders = Vc::cell(loaders);
+            rule.loaders = ResolvedVc::cell(loaders);
         } else {
             rules.insert(
                 pattern.into(),
                 LoaderRuleItem {
-                    loaders: Vc::cell(vec![resolve_url_loader, sass_loader]),
+                    loaders: ResolvedVc::cell(vec![resolve_url_loader, sass_loader]),
                     rename_as: Some(format!("*{rename}").into()),
                 },
             );
         }
     }
 
-    Ok(Vc::cell(Some(Vc::cell(rules))))
+    Ok(Vc::cell(Some(ResolvedVc::cell(rules))))
 }

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -92,7 +92,7 @@ pub fn get_asset_path_from_pathname(pathname: &str, ext: &str) -> String {
 #[turbo_tasks::function]
 pub async fn get_transpiled_packages(
     next_config: Vc<NextConfig>,
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
 ) -> Result<Vc<Vec<RcStr>>> {
     let mut transpile_packages: Vec<RcStr> = next_config.transpile_packages().await?.clone_value();
 

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -861,7 +861,7 @@ pub fn virtual_next_js_template_path(
 }
 
 pub async fn load_next_js_templateon<T: DeserializeOwned>(
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
     path: RcStr,
 ) -> Result<T> {
     let file_path = get_next_package(project_path).join(path.clone());

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -5,7 +5,8 @@ use swc_core::{
     ecma::ast::{Expr, Lit, Program},
 };
 use turbo_tasks::{
-    trace::TraceRawVcs, FxIndexMap, FxIndexSet, RcStr, TaskInput, ValueDefault, ValueToString, Vc,
+    trace::TraceRawVcs, FxIndexMap, FxIndexSet, RcStr, ResolvedVc, TaskInput, ValueDefault,
+    ValueToString, Vc,
 };
 use turbo_tasks_fs::{
     self, json::parse_json_rope_with_source_context, rope::Rope, util::join_path, File,
@@ -108,16 +109,16 @@ pub async fn get_transpiled_packages(
 
 pub async fn foreign_code_context_condition(
     next_config: Vc<NextConfig>,
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
 ) -> Result<ContextCondition> {
-    let transpiled_packages = get_transpiled_packages(next_config, project_path).await?;
+    let transpiled_packages = get_transpiled_packages(next_config, *project_path).await?;
 
     // The next template files are allowed to import the user's code via import
     // mapping, and imports must use the project-level [ResolveOptions] instead
     // of the `node_modules` specific resolve options (the template files are
     // technically node module files).
     let not_next_template_dir = ContextCondition::not(ContextCondition::InPath(
-        get_next_package(project_path).join(NEXT_TEMPLATE_PATH.into()),
+        get_next_package(*project_path).join(NEXT_TEMPLATE_PATH.into()),
     ));
 
     let result = ContextCondition::all(vec![

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -864,7 +864,7 @@ pub async fn load_next_js_templateon<T: DeserializeOwned>(
     project_path: ResolvedVc<FileSystemPath>,
     path: RcStr,
 ) -> Result<T> {
-    let file_path = get_next_package(project_path).join(path.clone());
+    let file_path = get_next_package(*project_path).join(path.clone());
 
     let content = &*file_path.read().await?;
 

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -128,7 +128,7 @@ async fn get_client_module_options_context(
             react_refresh: enable_react_refresh,
             ..Default::default()
         }
-        .cell(),
+        .resolved_cell(),
     );
 
     let versions = *env.runtime_versions().await?;

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -143,7 +143,7 @@ async fn get_client_module_options_context(
     let module_rules = ModuleRule::new(
         conditions,
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: Vc::cell(vec![
+            prepend: ResolvedVc::cell(vec![
                 EcmascriptInputTransform::Plugin(Vc::cell(Box::new(
                     EmotionTransformer::new(&EmotionTransformConfig::default())
                         .expect("Should be able to create emotion transformer"),

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -7,7 +7,7 @@ use turbopack::{
     ecmascript::{EcmascriptInputTransform, TreeShakingMode},
     module_options::{
         EcmascriptOptionsContext, JsxTransformOptions, ModuleOptionsContext, ModuleRule,
-        ModuleRuleEffect, RuleCondition,
+        ModuleRuleEffect, RuleCondition, TypescriptTransformOptions,
     },
     ModuleAssetContext,
 };
@@ -155,20 +155,22 @@ async fn get_client_module_options_context(
                     versions,
                 )) as _)),
             ]),
-            append: Vc::cell(vec![]),
+            append: ResolvedVc::cell(vec![]),
         }],
     );
 
     let module_options_context = ModuleOptionsContext {
         ecmascript: EcmascriptOptionsContext {
             enable_jsx,
-            enable_typescript_transform: Some(Default::default()),
+            enable_typescript_transform: Some(
+                TypescriptTransformOptions::default().resolved_cell(),
+            ),
             ..Default::default()
         },
-        enable_postcss_transform: Some(PostCssTransformOptions::default().cell()),
+        enable_postcss_transform: Some(PostCssTransformOptions::default().resolved_cell()),
         rules: vec![(
             foreign_code_context_condition().await?,
-            module_options_context.clone().cell(),
+            module_options_context.clone().resolved_cell(),
         )],
         module_rules: vec![module_rules],
         ..module_options_context

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -49,7 +49,7 @@ pub async fn make_chunk_group(
         .keys()
         .copied()
         .chain(self_async_children.into_iter())
-        .map(|chunk_item| (chunk_item, AutoSet::<Vc<Box<dyn ChunkItem>>>::new()))
+        .map(|chunk_item| (chunk_item, AutoSet::<ResolvedVc<Box<dyn ChunkItem>>>::new()))
         .collect::<FxIndexMap<_, _>>();
 
     // Propagate async inheritance
@@ -92,6 +92,7 @@ pub async fn make_chunk_group(
                     .iter()
                     .copied()
                     .filter(|item| referenced_async_modules.contains(item))
+                    .map(|v| *v)
                     .collect()
             } else {
                 Default::default()
@@ -182,7 +183,7 @@ pub async fn make_chunk_group(
 }
 
 async fn references_to_output_assets(
-    references: FxIndexSet<Vc<Box<dyn ModuleReference>>>,
+    references: FxIndexSet<ResolvedVc<Box<dyn ModuleReference>>>,
 ) -> Result<Vc<OutputAssets>> {
     let output_assets = references
         .into_iter()

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -147,7 +147,7 @@ pub async fn make_chunk_group(
     // Pass chunk items to chunking algorithm
     let mut chunks = make_chunks(
         chunking_context,
-        Vc::cell(chunk_items.into_iter().collect()),
+        Vc::cell(chunk_items.into_iter().map(|(k, v)| (*k, v)).collect()),
         "".into(),
         references_to_output_assets(external_module_references).await?,
     )

--- a/turbopack/crates/turbopack-core/src/chunk/chunking.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use tracing::Level;
-use turbo_tasks::{FxIndexMap, RcStr, ReadRef, TryJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{FxIndexMap, RcStr, ReadRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 
 use super::{
     AsyncModuleInfo, Chunk, ChunkItem, ChunkItemsWithAsyncModuleInfo, ChunkType, ChunkingContext,
@@ -126,8 +126,8 @@ type ChunkItemWithInfo = (
 struct SplitContext<'a> {
     ty: Vc<Box<dyn ChunkType>>,
     chunking_context: Vc<Box<dyn ChunkingContext>>,
-    chunks: &'a mut Vec<Vc<Box<dyn Chunk>>>,
-    referenced_output_assets: &'a mut Vc<OutputAssets>,
+    chunks: &'a mut Vec<ResolvedVc<Box<dyn Chunk>>>,
+    referenced_output_assets: &'a mut ResolvedVc<OutputAssets>,
     empty_referenced_output_assets: Vc<OutputAssets>,
 }
 

--- a/turbopack/crates/turbopack-core/src/chunk/chunking.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking.rs
@@ -46,7 +46,7 @@ pub async fn make_chunks(
     chunking_context: Vc<Box<dyn ChunkingContext>>,
     chunk_items: Vc<ChunkItemsWithAsyncModuleInfo>,
     key_prefix: RcStr,
-    mut referenced_output_assets: Vc<OutputAssets>,
+    mut referenced_output_assets: ResolvedVc<OutputAssets>,
 ) -> Result<Vc<Chunks>> {
     let chunk_items = chunk_items
         .await?

--- a/turbopack/crates/turbopack-core/src/chunk/data.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/data.rs
@@ -58,7 +58,7 @@ impl ChunkData {
                     module_chunks: Vec::new(),
                     references: OutputAssets::empty(),
                 }
-                .cell(),
+                .resolved_cell(),
             )));
         };
 
@@ -113,7 +113,7 @@ impl ChunkData {
                 module_chunks,
                 references: Vc::cell(module_chunks_references),
             }
-            .cell(),
+            .resolved_cell(),
         )))
     }
 

--- a/turbopack/crates/turbopack-core/src/chunk/data.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/data.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{RcStr, ReadRef, TryJoinIterExt, Vc};
+use turbo_tasks::{RcStr, ReadRef, ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
@@ -17,14 +17,14 @@ pub struct ChunkData {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct ChunkDataOption(Option<Vc<ChunkData>>);
+pub struct ChunkDataOption(Option<ResolvedVc<ChunkData>>);
 
 // NOTE(alexkirsz) Our convention for naming vector types is to add an "s" to
 // the end of the type name, but in this case it would be both gramatically
 // incorrect and clash with the variable names everywhere.
 // TODO(WEB-101) Should fix this.
 #[turbo_tasks::value(transparent)]
-pub struct ChunksData(Vec<Vc<ChunkData>>);
+pub struct ChunksData(Vec<ResolvedVc<ChunkData>>);
 
 #[turbo_tasks::function]
 fn module_chunk_reference_description() -> Vc<RcStr> {

--- a/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use turbo_tasks::{Upcast, Value, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, Upcast, Value, ValueToString, Vc};
 
 use super::ChunkableModule;
 use crate::{
@@ -57,7 +57,7 @@ async fn to_evaluatable(
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct EvaluatableAssets(Vec<Vc<Box<dyn EvaluatableAsset>>>);
+pub struct EvaluatableAssets(Vec<ResolvedVc<Box<dyn EvaluatableAsset>>>);
 
 #[turbo_tasks::value_impl]
 impl EvaluatableAssets {

--- a/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
@@ -67,19 +67,19 @@ impl EvaluatableAssets {
     }
 
     #[turbo_tasks::function]
-    pub fn one(entry: Vc<Box<dyn EvaluatableAsset>>) -> Vc<EvaluatableAssets> {
+    pub fn one(entry: ResolvedVc<Box<dyn EvaluatableAsset>>) -> Vc<EvaluatableAssets> {
         EvaluatableAssets(vec![entry]).cell()
     }
 
     #[turbo_tasks::function]
-    pub fn many(assets: Vec<Vc<Box<dyn EvaluatableAsset>>>) -> Vc<EvaluatableAssets> {
+    pub fn many(assets: Vec<ResolvedVc<Box<dyn EvaluatableAsset>>>) -> Vc<EvaluatableAssets> {
         EvaluatableAssets(assets).cell()
     }
 
     #[turbo_tasks::function]
     pub async fn with_entry(
         self: Vc<Self>,
-        entry: Vc<Box<dyn EvaluatableAsset>>,
+        entry: ResolvedVc<Box<dyn EvaluatableAsset>>,
     ) -> Result<Vc<EvaluatableAssets>> {
         let mut entries = self.await?.clone_value();
         entries.push(entry);

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -186,7 +186,7 @@ pub trait ChunkableModuleReference: ModuleReference + ValueToString {
     }
 }
 
-type AsyncInfo = FxIndexMap<Vc<Box<dyn ChunkItem>>, Vec<Vc<Box<dyn ChunkItem>>>>;
+type AsyncInfo = FxIndexMap<ResolvedVc<Box<dyn ChunkItem>>, Vec<ResolvedVc<Box<dyn ChunkItem>>>>;
 
 pub struct ChunkContentResult {
     pub chunk_items: FxIndexSet<ResolvedVc<Box<dyn ChunkItem>>>,

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -342,7 +342,7 @@ async fn graph_node_to_referenced_nodes(
         .map(|reference| async {
             let reference = *reference;
             let Some(chunkable_module_reference) =
-                Vc::try_resolve_downcast::<Box<dyn ChunkableModuleReference>>(reference).await?
+                ResolvedVc::try_downcast::<Box<dyn ChunkableModuleReference>>(reference).await?
             else {
                 return Ok(vec![ChunkGraphEdge {
                     key: None,
@@ -527,7 +527,7 @@ impl Visit<ChunkContentGraphNode, ()> for ChunkContentVisit {
             }
         };
 
-        if !self.processed_modules.insert(*module) {
+        if !self.processed_modules.insert(module) {
             return VisitControlFlow::Skip(node);
         }
 

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -84,7 +84,7 @@ impl ModuleId {
 
 /// A list of module ids.
 #[turbo_tasks::value(transparent, shared)]
-pub struct ModuleIds(Vec<Vc<ModuleId>>);
+pub struct ModuleIds(Vec<ResolvedVc<ModuleId>>);
 
 /// A [Module] that can be converted into a [Chunk].
 #[turbo_tasks::value_trait]
@@ -189,9 +189,9 @@ pub trait ChunkableModuleReference: ModuleReference + ValueToString {
 type AsyncInfo = FxIndexMap<Vc<Box<dyn ChunkItem>>, Vec<Vc<Box<dyn ChunkItem>>>>;
 
 pub struct ChunkContentResult {
-    pub chunk_items: FxIndexSet<Vc<Box<dyn ChunkItem>>>,
+    pub chunk_items: FxIndexSet<ResolvedVc<Box<dyn ChunkItem>>>,
     pub async_modules: FxIndexSet<ResolvedVc<Box<dyn ChunkableModule>>>,
-    pub external_module_references: FxIndexSet<Vc<Box<dyn ModuleReference>>>,
+    pub external_module_references: FxIndexSet<ResolvedVc<Box<dyn ModuleReference>>>,
     /// A map from local module to all children from which the async module
     /// status is inherited
     pub forward_edges_inherit_async: AsyncInfo,
@@ -503,8 +503,8 @@ async fn graph_node_to_referenced_nodes(
 
 struct ChunkContentVisit {
     chunking_context: Vc<Box<dyn ChunkingContext>>,
-    available_chunk_items: Option<Vc<AvailableChunkItems>>,
-    processed_modules: HashSet<Vc<Box<dyn Module>>>,
+    available_chunk_items: Option<ResolvedVc<AvailableChunkItems>>,
+    processed_modules: HashSet<ResolvedVc<Box<dyn Module>>>,
 }
 
 type ChunkItemToGraphNodesEdges = impl Iterator<Item = ChunkGraphEdge>;
@@ -729,7 +729,7 @@ pub fn round_chunk_item_size(size: usize) -> usize {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct ChunkItems(pub Vec<Vc<Box<dyn ChunkItem>>>);
+pub struct ChunkItems(pub Vec<ResolvedVc<Box<dyn ChunkItem>>>);
 
 #[turbo_tasks::value]
 pub struct AsyncModuleInfo {

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -266,8 +266,8 @@ impl FreeVarReferences {
 #[derive(Debug, Clone)]
 pub struct CompileTimeInfo {
     pub environment: Vc<Environment>,
-    pub defines: Vc<CompileTimeDefines>,
-    pub free_var_references: Vc<FreeVarReferences>,
+    pub defines: ResolvedVc<CompileTimeDefines>,
+    pub free_var_references: ResolvedVc<FreeVarReferences>,
 }
 
 impl CompileTimeInfo {

--- a/turbopack/crates/turbopack-core/src/condition.rs
+++ b/turbopack/crates/turbopack-core/src/condition.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use futures::{stream, StreamExt};
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{trace::TraceRawVcs, Vc};
+use turbo_tasks::{trace::TraceRawVcs, ResolvedVc};
 use turbo_tasks_fs::FileSystemPath;
 
 #[derive(Debug, Clone, Serialize, Deserialize, TraceRawVcs, PartialEq, Eq)]
@@ -10,7 +10,7 @@ pub enum ContextCondition {
     Any(Vec<ContextCondition>),
     Not(Box<ContextCondition>),
     InDirectory(String),
-    InPath(Vc<FileSystemPath>),
+    InPath(ResolvedVc<FileSystemPath>),
 }
 
 impl ContextCondition {

--- a/turbopack/crates/turbopack-core/src/context.rs
+++ b/turbopack/crates/turbopack-core/src/context.rs
@@ -17,7 +17,7 @@ pub enum ProcessResult {
     Module(ResolvedVc<Box<dyn Module>>),
 
     /// A module could not be created (according to the rules, e.g. no module type was assigned)
-    Unknown(Vc<Box<dyn Source>>),
+    Unknown(ResolvedVc<Box<dyn Source>>),
 
     /// Reference is ignored. This should lead to no module being included by
     /// the reference.

--- a/turbopack/crates/turbopack-core/src/diagnostics/mod.rs
+++ b/turbopack/crates/turbopack-core/src/diagnostics/mod.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use turbo_tasks::{emit, CollectiblesSource, FxIndexMap, RcStr, Upcast, Vc};
+use turbo_tasks::{emit, CollectiblesSource, FxIndexMap, RcStr, ResolvedVc, Upcast, Vc};
 
 #[turbo_tasks::value(serialization = "none")]
 #[derive(Clone, Debug)]
@@ -110,5 +110,5 @@ where
 #[derive(Debug)]
 #[turbo_tasks::value]
 pub struct CapturedDiagnostics {
-    pub diagnostics: auto_hash_map::AutoSet<Vc<Box<dyn Diagnostic>>>,
+    pub diagnostics: auto_hash_map::AutoSet<ResolvedVc<Box<dyn Diagnostic>>>,
 }

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -55,10 +55,10 @@ impl Environment {
 #[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(Debug, Hash, Clone, Copy)]
 pub enum ExecutionEnvironment {
-    NodeJsBuildTime(Vc<NodeJsEnvironment>),
-    NodeJsLambda(Vc<NodeJsEnvironment>),
-    EdgeWorker(Vc<EdgeWorkerEnvironment>),
-    Browser(Vc<BrowserEnvironment>),
+    NodeJsBuildTime(ResolvedVc<NodeJsEnvironment>),
+    NodeJsLambda(ResolvedVc<NodeJsEnvironment>),
+    EdgeWorker(ResolvedVc<EdgeWorkerEnvironment>),
+    Browser(ResolvedVc<BrowserEnvironment>),
     // TODO allow custom trait here
     Custom(u8),
 }

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -19,7 +19,7 @@ pub struct AssetIdent {
     /// The assets that are nested in this asset
     pub assets: Vec<(ResolvedVc<RcStr>, ResolvedVc<AssetIdent>)>,
     /// The modifiers of this asset (e.g. `client chunks`)
-    pub modifiers: Vec<Vc<RcStr>>,
+    pub modifiers: Vec<ResolvedVc<RcStr>>,
     /// The parts of the asset that are (ECMAScript) modules
     pub parts: Vec<ResolvedVc<ModulePart>>,
     /// The asset layer the asset was created from.

--- a/turbopack/crates/turbopack-core/src/introspect/mod.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/mod.rs
@@ -3,12 +3,12 @@ pub mod output_asset;
 pub mod source;
 pub mod utils;
 
-use turbo_tasks::{FxIndexSet, RcStr, Vc};
+use turbo_tasks::{FxIndexSet, RcStr, ResolvedVc, Vc};
 
 type VcDynIntrospectable = Vc<Box<dyn Introspectable>>;
 
 #[turbo_tasks::value(transparent)]
-pub struct IntrospectableChildren(FxIndexSet<(Vc<RcStr>, VcDynIntrospectable)>);
+pub struct IntrospectableChildren(FxIndexSet<(ResolvedVc<RcStr>, VcDynIntrospectable)>);
 
 #[turbo_tasks::value_trait]
 pub trait Introspectable {

--- a/turbopack/crates/turbopack-core/src/introspect/module.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/module.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{RcStr, ValueToString, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, ValueToString, Vc};
 
 use super::{
     utils::{children_from_module_references, content_to_details},
@@ -8,7 +8,7 @@ use super::{
 use crate::{asset::Asset, module::Module};
 
 #[turbo_tasks::value]
-pub struct IntrospectableModule(Vc<Box<dyn Module>>);
+pub struct IntrospectableModule(ResolvedVc<Box<dyn Module>>);
 
 #[turbo_tasks::value_impl]
 impl IntrospectableModule {

--- a/turbopack/crates/turbopack-core/src/introspect/source.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/source.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
-use turbo_tasks::{RcStr, ValueToString, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, ValueToString, Vc};
 
 use super::{utils::content_to_details, Introspectable};
 use crate::{asset::Asset, source::Source};
 
 #[turbo_tasks::value]
-pub struct IntrospectableSource(Vc<Box<dyn Source>>);
+pub struct IntrospectableSource(ResolvedVc<Box<dyn Source>>);
 
 #[turbo_tasks::value_impl]
 impl IntrospectableSource {

--- a/turbopack/crates/turbopack-core/src/issue/analyze.rs
+++ b/turbopack/crates/turbopack-core/src/issue/analyze.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{RcStr, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use super::{
@@ -15,7 +15,7 @@ pub struct AnalyzeIssue {
     pub title: Vc<RcStr>,
     pub message: Vc<StyledString>,
     pub code: Option<RcStr>,
-    pub source: Option<Vc<IssueSource>>,
+    pub source: Option<ResolvedVc<IssueSource>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -202,7 +202,7 @@ trait IssueProcessingPath {
 
 #[turbo_tasks::value]
 pub struct IssueProcessingPathItem {
-    pub file_path: Option<Vc<FileSystemPath>>,
+    pub file_path: Option<ResolvedVc<FileSystemPath>>,
     pub description: Vc<RcStr>,
 }
 
@@ -238,7 +238,7 @@ impl IssueProcessingPathItem {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct OptionIssueProcessingPathItems(Option<Vec<Vc<IssueProcessingPathItem>>>);
+pub struct OptionIssueProcessingPathItems(Option<Vec<ResolvedVc<IssueProcessingPathItem>>>);
 
 #[turbo_tasks::value_impl]
 impl OptionIssueProcessingPathItems {
@@ -264,7 +264,7 @@ impl OptionIssueProcessingPathItems {
 }
 
 #[turbo_tasks::value]
-struct RootIssueProcessingPath(Vc<Box<dyn Issue>>);
+struct RootIssueProcessingPath(ResolvedVc<Box<dyn Issue>>);
 
 #[turbo_tasks::value_impl]
 impl IssueProcessingPath for RootIssueProcessingPath {
@@ -280,8 +280,8 @@ impl IssueProcessingPath for RootIssueProcessingPath {
 
 #[turbo_tasks::value]
 struct ItemIssueProcessingPath(
-    Option<Vc<IssueProcessingPathItem>>,
-    AutoSet<Vc<Box<dyn IssueProcessingPath>>>,
+    Option<ResolvedVc<IssueProcessingPathItem>>,
+    AutoSet<ResolvedVc<Box<dyn IssueProcessingPath>>>,
 );
 
 #[turbo_tasks::value_impl]
@@ -361,7 +361,7 @@ pub struct Issues(Vec<ResolvedVc<Box<dyn Issue>>>);
 #[turbo_tasks::value(shared)]
 #[derive(Debug)]
 pub struct CapturedIssues {
-    issues: AutoSet<Vc<Box<dyn Issue>>>,
+    issues: AutoSet<ResolvedVc<Box<dyn Issue>>>,
     #[cfg(feature = "issue_path")]
     processing_path: Vc<ItemIssueProcessingPath>,
 }
@@ -637,10 +637,10 @@ async fn source_pos(
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct OptionIssueSource(Option<Vc<IssueSource>>);
+pub struct OptionIssueSource(Option<ResolvedVc<IssueSource>>);
 
 #[turbo_tasks::value(transparent)]
-pub struct OptionStyledString(Option<Vc<StyledString>>);
+pub struct OptionStyledString(Option<ResolvedVc<StyledString>>);
 
 #[turbo_tasks::value(shared, serialization = "none")]
 #[derive(Clone, Debug, PartialOrd, Ord, DeterministicHash, Serialize)]

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -33,7 +33,7 @@ pub trait ModuleReference: ValueToString {
 
 /// Multiple [ModuleReference]s
 #[turbo_tasks::value(transparent)]
-pub struct ModuleReferences(Vec<Vc<Box<dyn ModuleReference>>>);
+pub struct ModuleReferences(Vec<ResolvedVc<Box<dyn ModuleReference>>>);
 
 #[turbo_tasks::value_impl]
 impl ModuleReferences {

--- a/turbopack/crates/turbopack-core/src/reference_type.rs
+++ b/turbopack/crates/turbopack-core/src/reference_type.rs
@@ -165,7 +165,7 @@ impl ImportContext {
 #[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(Debug, Clone, Hash)]
 pub enum CssReferenceSubType {
-    AtImport(Option<Vc<ImportContext>>),
+    AtImport(Option<ResolvedVc<ImportContext>>),
     Compose,
     /// Reference from any asset to a CSS-parseable asset.
     ///
@@ -232,7 +232,7 @@ pub enum ReferenceType {
     Worker(WorkerReferenceSubType),
     Entry(EntryReferenceSubType),
     Runtime,
-    Internal(Vc<InnerAssets>),
+    Internal(ResolvedVc<InnerAssets>),
     Custom(u8),
     Undefined,
 }

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -69,7 +69,7 @@ pub enum ModuleResolveResultItem {
     OutputAsset(ResolvedVc<Box<dyn OutputAsset>>),
     External(RcStr, ExternalType),
     /// A module could not be created (according to the rules, e.g. no module type as assigned)
-    Unknown(Vc<Box<dyn Source>>),
+    Unknown(ResolvedVc<Box<dyn Source>>),
     Ignore,
     Error(ResolvedVc<RcStr>),
     Empty,
@@ -387,7 +387,7 @@ pub enum ResolveResultItem {
     Source(ResolvedVc<Box<dyn Source>>),
     External(RcStr, ExternalType),
     Ignore,
-    Error(Vc<RcStr>),
+    Error(ResolvedVc<RcStr>),
     Empty,
     Custom(u8),
 }
@@ -961,7 +961,7 @@ impl ResolveResult {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct ResolveResultOption(Option<Vc<ResolveResult>>);
+pub struct ResolveResultOption(Option<ResolvedVc<ResolveResult>>);
 
 #[turbo_tasks::value_impl]
 impl ResolveResultOption {

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use lazy_static::lazy_static;
 use regex::Regex;
-use turbo_tasks::{RcStr, TryJoinIterExt, Value, ValueToString, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, TryJoinIterExt, Value, ValueToString, Vc};
 
 use super::pattern::Pattern;
 
@@ -51,7 +51,7 @@ pub enum Request {
     },
     Dynamic,
     Alternatives {
-        requests: Vec<Vc<Request>>,
+        requests: Vec<ResolvedVc<Request>>,
     },
 }
 

--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -1299,8 +1299,8 @@ impl ValueToString for Pattern {
 
 #[derive(Debug, PartialEq, Eq, Clone, TraceRawVcs, Serialize, Deserialize)]
 pub enum PatternMatch {
-    File(RcStr, Vc<FileSystemPath>),
-    Directory(RcStr, Vc<FileSystemPath>),
+    File(RcStr, ResolvedVc<FileSystemPath>),
+    Directory(RcStr, ResolvedVc<FileSystemPath>),
 }
 
 impl PatternMatch {

--- a/turbopack/crates/turbopack-core/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/mod.rs
@@ -7,7 +7,7 @@ use ref_cast::RefCast;
 use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sourcemap::{DecodedMap, SourceMap as RegularMap, SourceMapBuilder, SourceMapIndex};
-use turbo_tasks::{RcStr, TryJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::{
     rope::{Rope, RopeBuilder},
     File, FileContent, FileSystem, FileSystemPath, VirtualFileSystem,
@@ -57,7 +57,7 @@ pub enum SourceMap {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct OptionSourceMap(Option<Vc<SourceMap>>);
+pub struct OptionSourceMap(Option<ResolvedVc<SourceMap>>);
 
 #[turbo_tasks::value_impl]
 impl OptionSourceMap {
@@ -87,7 +87,7 @@ pub enum Token {
 #[derive(Clone, Debug)]
 pub struct TokenWithSource {
     pub token: Vc<Token>,
-    pub source_content: Option<Vc<Box<dyn Source>>>,
+    pub source_content: Option<ResolvedVc<Box<dyn Source>>>,
 }
 
 /// A SyntheticToken represents a region of the generated file that was created

--- a/turbopack/crates/turbopack-core/src/source_transform.rs
+++ b/turbopack/crates/turbopack-core/src/source_transform.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 
 use crate::source::Source;
 
@@ -8,7 +8,7 @@ pub trait SourceTransform {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct SourceTransforms(Vec<Vc<Box<dyn SourceTransform>>>);
+pub struct SourceTransforms(Vec<ResolvedVc<Box<dyn SourceTransform>>>);
 
 #[turbo_tasks::value_impl]
 impl SourceTransforms {

--- a/turbopack/crates/turbopack-core/src/version.rs
+++ b/turbopack/crates/turbopack-core/src/version.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
 use turbo_tasks::{
-    debug::ValueDebugFormat, trace::TraceRawVcs, IntoTraitRef, RcStr, ReadRef, State, TraitRef, Vc,
+    debug::ValueDebugFormat, trace::TraceRawVcs, IntoTraitRef, RcStr, ReadRef, ResolvedVc, State,
+    TraitRef, Vc,
 };
 use turbo_tasks_fs::{FileContent, LinkType};
 use turbo_tasks_hash::{encode_hex, hash_xxh3_hash64};
@@ -10,7 +11,7 @@ use turbo_tasks_hash::{encode_hex, hash_xxh3_hash64};
 use crate::asset::AssetContent;
 
 #[turbo_tasks::value(transparent)]
-pub struct OptionVersionedContent(Option<Vc<Box<dyn VersionedContent>>>);
+pub struct OptionVersionedContent(Option<ResolvedVc<Box<dyn VersionedContent>>>);
 
 /// The content of an [Asset] alongside its version.
 #[turbo_tasks::value_trait]
@@ -145,7 +146,7 @@ pub trait VersionedContentMerger {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct VersionedContents(Vec<Vc<Box<dyn VersionedContent>>>);
+pub struct VersionedContents(Vec<ResolvedVc<Box<dyn VersionedContent>>>);
 
 #[turbo_tasks::value]
 pub struct NotFoundVersion;

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/asset_context.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/asset_context.rs
@@ -12,7 +12,9 @@ use turbopack_ecmascript::TreeShakingMode;
 pub fn get_runtime_asset_context(environment: Vc<Environment>) -> Vc<Box<dyn AssetContext>> {
     let module_options_context = ModuleOptionsContext {
         ecmascript: EcmascriptOptionsContext {
-            enable_typescript_transform: Some(TypescriptTransformOptions::default().cell()),
+            enable_typescript_transform: Some(
+                TypescriptTransformOptions::default().resolved_cell(),
+            ),
             ..Default::default()
         },
         // TODO: Somehow this fails to compile when enabled.

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -23,7 +23,7 @@ use turbo_tasks_fs::{
 use turbo_tasks_memory::MemoryBackend;
 use turbopack::{
     ecmascript::TreeShakingMode,
-    module_options::{EcmascriptOptionsContext, ModuleOptionsContext},
+    module_options::{EcmascriptOptionsContext, ModuleOptionsContext, TypescriptTransformOptions},
     ModuleAssetContext,
 };
 use turbopack_core::{
@@ -282,7 +282,9 @@ async fn run_test(prepared_test: Vc<PreparedTest>) -> Result<Vc<RunTestResult>> 
         compile_time_info,
         ModuleOptionsContext {
             ecmascript: EcmascriptOptionsContext {
-                enable_typescript_transform: Some(Default::default()),
+                enable_typescript_transform: Some(
+                    TypescriptTransformOptions::default().resolved_cell(),
+                ),
                 import_externals: true,
                 ..Default::default()
             },
@@ -294,7 +296,7 @@ async fn run_test(prepared_test: Vc<PreparedTest>) -> Result<Vc<RunTestResult>> 
                     tree_shaking_mode: options.tree_shaking_mode,
                     ..Default::default()
                 }
-                .cell(),
+                .resolved_cell(),
             )],
             ..Default::default()
         }

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -248,16 +248,16 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
     let module_rules = ModuleRule::new(
         conditions,
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: Vc::cell(vec![
-                EcmascriptInputTransform::Plugin(Vc::cell(Box::new(
+            prepend: ResolvedVc::cell(vec![
+                EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(
                     EmotionTransformer::new(&EmotionTransformConfig::default())
                         .expect("Should be able to create emotion transformer"),
                 ) as _)),
-                EcmascriptInputTransform::Plugin(Vc::cell(Box::new(
+                EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(
                     StyledComponentsTransformer::new(&StyledComponentsTransformConfig::default()),
                 ) as _)),
             ]),
-            append: Vc::cell(vec![]),
+            append: ResolvedVc::cell(vec![]),
         }],
     );
     let asset_context: Vc<Box<dyn AssetContext>> = Vc::upcast(ModuleAssetContext::new(
@@ -265,7 +265,7 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         compile_time_info,
         ModuleOptionsContext {
             ecmascript: EcmascriptOptionsContext {
-                enable_jsx: Some(JsxTransformOptions::cell(JsxTransformOptions {
+                enable_jsx: Some(JsxTransformOptions::resolved_cell(JsxTransformOptions {
                     development: true,
                     ..Default::default()
                 })),
@@ -284,7 +284,7 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                     },
                     ..Default::default()
                 }
-                .cell(),
+                .resolved_cell(),
             )],
             module_rules: vec![module_rules],
             tree_shaking_mode: options.tree_shaking_mode,

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -249,11 +249,11 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         conditions,
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
             prepend: ResolvedVc::cell(vec![
-                EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(
+                EcmascriptInputTransform::Plugin(Vc::cell(Box::new(
                     EmotionTransformer::new(&EmotionTransformConfig::default())
                         .expect("Should be able to create emotion transformer"),
                 ) as _)),
-                EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(
+                EcmascriptInputTransform::Plugin(Vc::cell(Box::new(
                     StyledComponentsTransformer::new(&StyledComponentsTransformConfig::default()),
                 ) as _)),
             ]),

--- a/turbopack/crates/turbopack/src/evaluate_context.rs
+++ b/turbopack/crates/turbopack/src/evaluate_context.rs
@@ -15,7 +15,7 @@ use turbopack_node::execution_context::ExecutionContext;
 use turbopack_resolve::resolve_options_context::ResolveOptionsContext;
 
 use crate::{
-    module_options::{EcmascriptOptionsContext, ModuleOptionsContext},
+    module_options::{EcmascriptOptionsContext, ModuleOptionsContext, TypescriptTransformOptions},
     transition::TransitionOptions,
     ModuleAssetContext,
 };
@@ -103,7 +103,9 @@ pub async fn node_evaluate_asset_context(
         ModuleOptionsContext {
             tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
             ecmascript: EcmascriptOptionsContext {
-                enable_typescript_transform: Some(Default::default()),
+                enable_typescript_transform: Some(
+                    TypescriptTransformOptions::default().resolved_cell(),
+                ),
                 ignore_dynamic_requests,
                 ..Default::default()
             },

--- a/turbopack/crates/turbopack/src/graph/mod.rs
+++ b/turbopack/crates/turbopack/src/graph/mod.rs
@@ -129,7 +129,7 @@ pub async fn aggregate(asset: Vc<Box<dyn OutputAsset>>) -> Result<Vc<AggregatedG
 struct AggregationCost(usize);
 
 #[turbo_tasks::function]
-async fn aggregate_more(node: Vc<AggregatedGraph>) -> Result<Vc<AggregatedGraph>> {
+async fn aggregate_more(node: ResolvedVc<AggregatedGraph>) -> Result<Vc<AggregatedGraph>> {
     let node_data = node.await?;
     let depth = node_data.depth();
     let mut in_progress = HashSet::new();
@@ -152,20 +152,20 @@ async fn aggregate_more(node: Vc<AggregatedGraph>) -> Result<Vc<AggregatedGraph>
         for valued_refs in valued_refs {
             let valued_refs = valued_refs.await?;
             for &reference in valued_refs.inner.iter() {
-                content.insert(*reference);
+                content.insert(reference);
             }
             for &reference in valued_refs.references.iter() {
                 if content.contains(&reference) {
                     continue;
                 }
-                references.insert(*reference);
+                references.insert(reference);
             }
             for &reference in valued_refs.outer.iter() {
                 if content.contains(&reference) {
                     continue;
                 }
                 references.remove(&reference);
-                in_progress.insert(*reference);
+                in_progress.insert(reference);
             }
         }
     }

--- a/turbopack/crates/turbopack/src/graph/mod.rs
+++ b/turbopack/crates/turbopack/src/graph/mod.rs
@@ -9,8 +9,8 @@ pub enum AggregatedGraph {
     Leaf(ResolvedVc<Box<dyn OutputAsset>>),
     Node {
         depth: usize,
-        content: HashSet<Vc<AggregatedGraph>>,
-        references: HashSet<Vc<AggregatedGraph>>,
+        content: HashSet<ResolvedVc<AggregatedGraph>>,
+        references: HashSet<ResolvedVc<AggregatedGraph>>,
     },
 }
 
@@ -187,8 +187,8 @@ struct AggregatedGraphsSet {
 
 #[turbo_tasks::value(shared)]
 pub enum AggregatedGraphNodeContent {
-    Asset(Vc<Box<dyn OutputAsset>>),
-    Children(HashSet<Vc<AggregatedGraph>>),
+    Asset(ResolvedVc<Box<dyn OutputAsset>>),
+    Children(HashSet<ResolvedVc<AggregatedGraph>>),
 }
 
 #[turbo_tasks::value(shared)]

--- a/turbopack/crates/turbopack/src/graph/mod.rs
+++ b/turbopack/crates/turbopack/src/graph/mod.rs
@@ -36,7 +36,7 @@ impl AggregatedGraph {
     #[turbo_tasks::function]
     pub async fn content(self: Vc<Self>) -> Result<Vc<AggregatedGraphNodeContent>> {
         Ok(match *self.await? {
-            AggregatedGraph::Leaf(asset) => AggregatedGraphNodeContent::Asset(*asset).into(),
+            AggregatedGraph::Leaf(asset) => AggregatedGraphNodeContent::Asset(asset).into(),
             AggregatedGraph::Node { ref content, .. } => {
                 AggregatedGraphNodeContent::Children(content.clone()).into()
             }
@@ -60,7 +60,7 @@ impl AggregatedGraph {
                 let mut set = HashSet::new();
                 for item in references
                     .iter()
-                    .map(|&reference| aggregate_more(reference))
+                    .map(|&reference| aggregate_more(*reference))
                     .collect::<Vec<_>>()
                     .into_iter()
                 {

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -63,10 +63,7 @@ use turbopack_resolve::{resolve_options_context::ResolveOptionsContext, typescri
 use turbopack_static::StaticModuleAsset;
 use turbopack_wasm::{module_asset::WebAssemblyModuleAsset, source::WebAssemblySource};
 
-use self::{
-    module_options::CustomModuleType,
-    transition::{Transition, TransitionOptions},
-};
+use self::transition::{Transition, TransitionOptions};
 
 #[turbo_tasks::function]
 async fn apply_module_type(
@@ -366,11 +363,11 @@ impl ModuleAssetContext {
 
     #[turbo_tasks::function]
     fn new_without_replace_externals(
-        transitions: Vc<TransitionOptions>,
-        compile_time_info: Vc<CompileTimeInfo>,
-        module_options_context: Vc<ModuleOptionsContext>,
-        resolve_options_context: Vc<ResolveOptionsContext>,
-        layer: Vc<RcStr>,
+        transitions: ResolvedVc<TransitionOptions>,
+        compile_time_info: ResolvedVc<CompileTimeInfo>,
+        module_options_context: ResolvedVc<ModuleOptionsContext>,
+        resolve_options_context: ResolvedVc<ResolveOptionsContext>,
+        layer: ResolvedVc<RcStr>,
     ) -> Vc<Self> {
         Self::cell(ModuleAssetContext {
             transitions,
@@ -385,12 +382,12 @@ impl ModuleAssetContext {
 
     #[turbo_tasks::function]
     pub fn module_options_context(&self) -> Vc<ModuleOptionsContext> {
-        self.module_options_context
+        *self.module_options_context
     }
 
     #[turbo_tasks::function]
     pub fn resolve_options_context(&self) -> Vc<ResolveOptionsContext> {
-        self.resolve_options_context
+        *self.resolve_options_context
     }
 
     #[turbo_tasks::function]
@@ -414,11 +411,11 @@ impl ModuleAssetContext {
             .await?;
 
         Ok(ModuleAssetContext::new(
-            this.transitions,
-            this.compile_time_info,
-            this.module_options_context,
+            *this.transitions,
+            *this.compile_time_info,
+            *this.module_options_context,
             resolve_options_context,
-            this.layer,
+            *this.layer,
         ))
     }
 
@@ -633,12 +630,12 @@ async fn process_default_internal(
 impl AssetContext for ModuleAssetContext {
     #[turbo_tasks::function]
     fn compile_time_info(&self) -> Vc<CompileTimeInfo> {
-        self.compile_time_info
+        *self.compile_time_info
     }
 
     #[turbo_tasks::function]
     fn layer(&self) -> Vc<RcStr> {
-        self.layer
+        *self.layer
     }
 
     #[turbo_tasks::function]
@@ -656,7 +653,7 @@ impl AssetContext for ModuleAssetContext {
         // TODO move `apply_commonjs/esm_resolve_options` etc. to here
         Ok(resolve_options(
             origin_path.parent().resolve().await?,
-            module_asset_context.await?.resolve_options_context,
+            *module_asset_context.await?.resolve_options_context,
         ))
     }
 
@@ -747,21 +744,21 @@ impl AssetContext for ModuleAssetContext {
         Ok(
             if let Some(transition) = self.transitions.await?.get_named(transition) {
                 Vc::upcast(ModuleAssetContext::new_transition(
-                    self.transitions,
-                    self.compile_time_info,
-                    self.module_options_context,
-                    self.resolve_options_context,
-                    self.layer,
+                    *self.transitions,
+                    *self.compile_time_info,
+                    *self.module_options_context,
+                    *self.resolve_options_context,
+                    *self.layer,
                     transition,
                 ))
             } else {
                 // TODO report issue
                 Vc::upcast(ModuleAssetContext::new(
-                    self.transitions,
-                    self.compile_time_info,
-                    self.module_options_context,
-                    self.resolve_options_context,
-                    self.layer,
+                    *self.transitions,
+                    *self.compile_time_info,
+                    *self.module_options_context,
+                    *self.resolve_options_context,
+                    *self.layer,
                 ))
             },
         )
@@ -804,10 +801,10 @@ async fn emit_aggregated_assets(
     output_dir: Vc<FileSystemPath>,
 ) -> Result<Vc<Completion>> {
     Ok(match &*aggregated.content().await? {
-        AggregatedGraphNodeContent::Asset(asset) => emit_asset_into_dir(*asset, output_dir),
+        AggregatedGraphNodeContent::Asset(asset) => emit_asset_into_dir(**asset, output_dir),
         AggregatedGraphNodeContent::Children(children) => {
             for aggregated in children {
-                emit_aggregated_assets(*aggregated, output_dir).await?;
+                emit_aggregated_assets(**aggregated, output_dir).await?;
             }
             Completion::new()
         }
@@ -840,15 +837,14 @@ struct ReferencesList {
 }
 
 #[turbo_tasks::function]
-async fn compute_back_references(aggregated: Vc<AggregatedGraph>) -> Result<Vc<ReferencesList>> {
+async fn compute_back_references(
+    aggregated: ResolvedVc<AggregatedGraph>,
+) -> Result<Vc<ReferencesList>> {
     Ok(match &*aggregated.content().await? {
         &AggregatedGraphNodeContent::Asset(asset) => {
             let mut referenced_by = HashMap::new();
-            for reference in asset.references().await?.iter() {
-                referenced_by.insert(
-                    reference.to_resolved().await?,
-                    [asset].into_iter().collect(),
-                );
+            for &reference in asset.references().await?.iter() {
+                referenced_by.insert(reference, [*asset].into_iter().collect());
             }
             ReferencesList { referenced_by }.into()
         }
@@ -857,7 +853,7 @@ async fn compute_back_references(aggregated: Vc<AggregatedGraph>) -> Result<Vc<R
                 HashMap::<ResolvedVc<Box<dyn OutputAsset>>, OutputAssetSet>::new();
             let lists = children
                 .iter()
-                .map(|child| compute_back_references(*child))
+                .map(|child| compute_back_references(**child))
                 .collect::<Vec<_>>();
             for list in lists {
                 for (key, values) in list.await?.referenced_by.iter() {

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -750,7 +750,7 @@ impl AssetContext for ModuleAssetContext {
                     *self.module_options_context,
                     *self.resolve_options_context,
                     *self.layer,
-                    transition,
+                    *transition,
                 ))
             } else {
                 // TODO report issue

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -64,6 +64,7 @@ use turbopack_static::StaticModuleAsset;
 use turbopack_wasm::{module_asset::WebAssemblyModuleAsset, source::WebAssemblySource};
 
 use self::transition::{Transition, TransitionOptions};
+use crate::module_options::CustomModuleType;
 
 #[turbo_tasks::function]
 async fn apply_module_type(
@@ -103,8 +104,8 @@ async fn apply_module_type(
             let mut builder = EcmascriptModuleAsset::builder(
                 source,
                 Vc::upcast(context_for_module),
-                *transforms,
-                *options,
+                **transforms,
+                **options,
                 module_asset_context.compile_time_info(),
             );
             match module_type {

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -312,11 +312,11 @@ async fn apply_reexport_tree_shaking(
 #[turbo_tasks::value]
 #[derive(Debug)]
 pub struct ModuleAssetContext {
-    pub transitions: Vc<TransitionOptions>,
-    pub compile_time_info: Vc<CompileTimeInfo>,
-    pub module_options_context: Vc<ModuleOptionsContext>,
-    pub resolve_options_context: Vc<ResolveOptionsContext>,
-    pub layer: Vc<RcStr>,
+    pub transitions: ResolvedVc<TransitionOptions>,
+    pub compile_time_info: ResolvedVc<CompileTimeInfo>,
+    pub module_options_context: ResolvedVc<ModuleOptionsContext>,
+    pub resolve_options_context: ResolvedVc<ResolveOptionsContext>,
+    pub layer: ResolvedVc<RcStr>,
     transition: Option<ResolvedVc<Box<dyn Transition>>>,
     /// Whether to replace external resolutions with CachedExternalModules. Used with
     /// ModuleOptionsContext.enable_externals_tracing to handle transitive external dependencies.

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -327,11 +327,11 @@ pub struct ModuleAssetContext {
 impl ModuleAssetContext {
     #[turbo_tasks::function]
     pub fn new(
-        transitions: Vc<TransitionOptions>,
-        compile_time_info: Vc<CompileTimeInfo>,
-        module_options_context: Vc<ModuleOptionsContext>,
-        resolve_options_context: Vc<ResolveOptionsContext>,
-        layer: Vc<RcStr>,
+        transitions: ResolvedVc<TransitionOptions>,
+        compile_time_info: ResolvedVc<CompileTimeInfo>,
+        module_options_context: ResolvedVc<ModuleOptionsContext>,
+        resolve_options_context: ResolvedVc<ResolveOptionsContext>,
+        layer: ResolvedVc<RcStr>,
     ) -> Vc<Self> {
         Self::cell(ModuleAssetContext {
             transitions,
@@ -346,11 +346,11 @@ impl ModuleAssetContext {
 
     #[turbo_tasks::function]
     pub fn new_transition(
-        transitions: Vc<TransitionOptions>,
-        compile_time_info: Vc<CompileTimeInfo>,
-        module_options_context: Vc<ModuleOptionsContext>,
-        resolve_options_context: Vc<ResolveOptionsContext>,
-        layer: Vc<RcStr>,
+        transitions: ResolvedVc<TransitionOptions>,
+        compile_time_info: ResolvedVc<CompileTimeInfo>,
+        module_options_context: ResolvedVc<ModuleOptionsContext>,
+        resolve_options_context: ResolvedVc<ResolveOptionsContext>,
+        layer: ResolvedVc<RcStr>,
         transition: ResolvedVc<Box<dyn Transition>>,
     ) -> Vc<Self> {
         Self::cell(ModuleAssetContext {

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -104,7 +104,7 @@ async fn apply_module_type(
             let mut builder = EcmascriptModuleAsset::builder(
                 source,
                 Vc::upcast(context_for_module),
-                **transforms,
+                *transforms,
                 **options,
                 module_asset_context.compile_time_info(),
             );
@@ -561,7 +561,7 @@ async fn process_default_internal(
                                 transforms,
                                 options,
                             }) => Some(ModuleType::Ecmascript {
-                                transforms: prepend.extend(transforms).extend(*append),
+                                transforms: prepend.extend(transforms).extend(**append),
                                 options,
                             }),
                             Some(ModuleType::Typescript {
@@ -570,7 +570,7 @@ async fn process_default_internal(
                                 analyze_types,
                                 options,
                             }) => Some(ModuleType::Typescript {
-                                transforms: prepend.extend(transforms).extend(*append),
+                                transforms: prepend.extend(transforms).extend(**append),
                                 tsx,
                                 analyze_types,
                                 options,

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -180,7 +180,7 @@ impl ModuleOptions {
             } else {
                 vec![transform.clone()]
             };
-            ResolvedVc::cell(
+            Vc::cell(
                 base_transforms
                     .iter()
                     .cloned()
@@ -188,7 +188,7 @@ impl ModuleOptions {
                     .collect(),
             )
         } else {
-            ResolvedVc::cell(transforms.clone())
+            Vc::cell(transforms.clone())
         };
 
         // Apply decorators transform for the ModuleType::Ecmascript as well after
@@ -199,7 +199,7 @@ impl ModuleOptions {
         // Since typescript transform (`ts_app_transforms`) needs to apply decorators
         // _before_ stripping types, we create ts_app_transforms first in a
         // specific order with typescript, then apply decorators to app_transforms.
-        let app_transforms = ResolvedVc::cell(
+        let app_transforms = Vc::cell(
             if let Some(decorators_transform) = &decorators_transform {
                 vec![decorators_transform.clone()]
             } else {
@@ -245,7 +245,7 @@ impl ModuleOptions {
                         specified_module_type: SpecifiedModuleType::CommonJs,
                         ..ecmascript_options
                     }
-                    .into(),
+                    .resolved_cell(),
                 })],
             ),
             ModuleRule::new_all(
@@ -276,7 +276,7 @@ impl ModuleOptions {
                         specified_module_type: SpecifiedModuleType::EcmaScript,
                         ..ecmascript_options
                     }
-                    .into(),
+                    .resolved_cell(),
                 })],
             ),
             ModuleRule::new_all(
@@ -289,7 +289,7 @@ impl ModuleOptions {
                         specified_module_type: SpecifiedModuleType::EcmaScript,
                         ..ecmascript_options
                     }
-                    .into(),
+                    .resolved_cell(),
                 })],
             ),
             ModuleRule::new_all(
@@ -302,7 +302,7 @@ impl ModuleOptions {
                         specified_module_type: SpecifiedModuleType::CommonJs,
                         ..ecmascript_options
                     }
-                    .into(),
+                    .resolved_cell(),
                 })],
             ),
             ModuleRule::new_all(
@@ -315,7 +315,7 @@ impl ModuleOptions {
                         specified_module_type: SpecifiedModuleType::CommonJs,
                         ..ecmascript_options
                     }
-                    .into(),
+                    .resolved_cell(),
                 })],
             ),
             ModuleRule::new(
@@ -410,7 +410,7 @@ impl ModuleOptions {
 
                 rules.push(ModuleRule::new(
                     RuleCondition::ResourcePathEndsWith(".css".to_string()),
-                    vec![ModuleRuleEffect::SourceTransforms(Vc::cell(vec![
+                    vec![ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![
                         Vc::upcast(PostCssTransform::new(
                             node_evaluate_asset_context(
                                 *execution_context,
@@ -519,7 +519,7 @@ impl ModuleOptions {
                     RuleCondition::ResourcePathEndsWith(".md".to_string()),
                     RuleCondition::ResourcePathEndsWith(".mdx".to_string()),
                 ]),
-                vec![ModuleRuleEffect::SourceTransforms(Vc::cell(vec![
+                vec![ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![
                     Vc::upcast(MdxTransform::new(mdx_transform_options)),
                 ]))],
             ));
@@ -552,7 +552,7 @@ impl ModuleOptions {
                         },
                         RuleCondition::not(RuleCondition::ResourceIsVirtualSource),
                     ]),
-                    vec![ModuleRuleEffect::SourceTransforms(Vc::cell(vec![
+                    vec![ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![
                         Vc::upcast(WebpackLoaders::new(
                             node_evaluate_asset_context(
                                 *execution_context,

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -98,7 +98,7 @@ impl ModuleOptions {
                 if condition.matches(&path_value).await? {
                     return Ok(ModuleOptions::new(
                         path,
-                        *new_context,
+                        **new_context,
                         resolve_options_context,
                     ));
                 }
@@ -501,7 +501,9 @@ impl ModuleOptions {
                 (None, None, false)
             };
 
-            let mdx_options = &*enable_mdx_rs.unwrap_or(Default::default()).await?;
+            let mdx_options = &*enable_mdx_rs
+                .unwrap_or_else(|| MdxTransformOptions::default().resolved_cell())
+                .await?;
 
             let mdx_transform_options = (MdxTransformOptions {
                 development: Some(development),
@@ -532,7 +534,7 @@ impl ModuleOptions {
             {
                 package_import_map_from_import_mapping(
                     "loader-runner".into(),
-                    loader_runner_package,
+                    *loader_runner_package,
                 )
             } else {
                 package_import_map_from_context("loader-runner".into(), path)
@@ -560,7 +562,7 @@ impl ModuleOptions {
                                 false,
                             ),
                             *execution_context,
-                            rule.loaders,
+                            *rule.loaders,
                             rule.rename_as.clone(),
                             resolve_options_context,
                         )),

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -132,7 +132,7 @@ impl ModuleOptions {
             refresh,
             ..Default::default()
         };
-        let ecmascript_options_vc = ecmascript_options.cell();
+        let ecmascript_options_vc = ecmascript_options.resolved_cell();
 
         if let Some(env) = preset_env_versions {
             transforms.push(EcmascriptInputTransform::PresetEnv(

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -180,7 +180,7 @@ impl ModuleOptions {
             } else {
                 vec![transform.clone()]
             };
-            Vc::cell(
+            ResolvedVc::cell(
                 base_transforms
                     .iter()
                     .cloned()
@@ -188,7 +188,7 @@ impl ModuleOptions {
                     .collect(),
             )
         } else {
-            Vc::cell(transforms.clone())
+            ResolvedVc::cell(transforms.clone())
         };
 
         // Apply decorators transform for the ModuleType::Ecmascript as well after
@@ -199,7 +199,7 @@ impl ModuleOptions {
         // Since typescript transform (`ts_app_transforms`) needs to apply decorators
         // _before_ stripping types, we create ts_app_transforms first in a
         // specific order with typescript, then apply decorators to app_transforms.
-        let app_transforms = Vc::cell(
+        let app_transforms = ResolvedVc::cell(
             if let Some(decorators_transform) = &decorators_transform {
                 vec![decorators_transform.clone()]
             } else {
@@ -234,7 +234,7 @@ impl ModuleOptions {
                         specified_module_type: SpecifiedModuleType::EcmaScript,
                         ..ecmascript_options
                     }
-                    .into(),
+                    .resolved_cell(),
                 })],
             ),
             ModuleRule::new_all(

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -16,7 +16,7 @@ use super::ModuleRule;
 
 #[derive(Clone, PartialEq, Eq, Debug, TraceRawVcs, Serialize, Deserialize)]
 pub struct LoaderRuleItem {
-    pub loaders: Vc<WebpackLoaderItems>,
+    pub loaders: ResolvedVc<WebpackLoaderItems>,
     pub rename_as: Option<RcStr>,
 }
 
@@ -26,13 +26,13 @@ pub struct WebpackRules(FxIndexMap<RcStr, LoaderRuleItem>);
 
 #[derive(Default)]
 #[turbo_tasks::value(transparent)]
-pub struct OptionWebpackRules(Option<Vc<WebpackRules>>);
+pub struct OptionWebpackRules(Option<ResolvedVc<WebpackRules>>);
 
 #[turbo_tasks::value(shared)]
 #[derive(Clone, Debug)]
 pub struct WebpackLoadersOptions {
-    pub rules: Vc<WebpackRules>,
-    pub loader_runner_package: Option<Vc<ImportMapping>>,
+    pub rules: ResolvedVc<WebpackRules>,
+    pub loader_runner_package: Option<ResolvedVc<ImportMapping>>,
 }
 
 /// The kind of decorators transform to use.
@@ -113,12 +113,12 @@ pub struct ModuleOptionsContext {
     pub ecmascript: EcmascriptOptionsContext,
     pub css: CssOptionsContext,
 
-    pub enable_postcss_transform: Option<Vc<PostCssTransformOptions>>,
-    pub enable_webpack_loaders: Option<Vc<WebpackLoadersOptions>>,
+    pub enable_postcss_transform: Option<ResolvedVc<PostCssTransformOptions>>,
+    pub enable_webpack_loaders: Option<ResolvedVc<WebpackLoadersOptions>>,
     // [Note]: currently mdx, and mdx_rs have different configuration entrypoint from next.config.js,
     // however we might want to unify them in the future.
     pub enable_mdx: bool,
-    pub enable_mdx_rs: Option<Vc<MdxTransformOptions>>,
+    pub enable_mdx_rs: Option<ResolvedVc<MdxTransformOptions>>,
 
     pub preset_env_versions: Option<ResolvedVc<Environment>>,
     pub execution_context: Option<ResolvedVc<ExecutionContext>>,
@@ -130,13 +130,13 @@ pub struct ModuleOptionsContext {
     ///
     /// The filepath is the directory from which the bundled files will require the externals at
     /// runtime.
-    pub enable_externals_tracing: Option<Vc<FileSystemPath>>,
+    pub enable_externals_tracing: Option<ResolvedVc<FileSystemPath>>,
 
     /// Custom rules to be applied after all default rules.
     pub module_rules: Vec<ModuleRule>,
     /// A list of rules to use a different module option context for certain
     /// context paths. The first matching is used.
-    pub rules: Vec<(ContextCondition, Vc<ModuleOptionsContext>)>,
+    pub rules: Vec<(ContextCondition, ResolvedVc<ModuleOptionsContext>)>,
     pub placeholder_for_future_extensions: (),
 }
 
@@ -145,11 +145,11 @@ pub struct ModuleOptionsContext {
 #[serde(default)]
 pub struct EcmascriptOptionsContext {
     pub enable_typeof_window_inlining: Option<TypeofWindow>,
-    pub enable_jsx: Option<Vc<JsxTransformOptions>>,
+    pub enable_jsx: Option<ResolvedVc<JsxTransformOptions>>,
     /// Follow type references and resolve declaration files in additional to
     /// normal resolution.
     pub enable_types: bool,
-    pub enable_typescript_transform: Option<Vc<TypescriptTransformOptions>>,
+    pub enable_typescript_transform: Option<ResolvedVc<TypescriptTransformOptions>>,
     pub enable_decorators: Option<ResolvedVc<DecoratorsOptions>>,
     pub esm_url_rewrite_behavior: Option<UrlRewriteBehavior>,
     /// References to externals from ESM imports should use `import()` and make

--- a/turbopack/crates/turbopack/src/module_options/module_rule.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_rule.rs
@@ -79,12 +79,12 @@ pub enum ModuleRuleEffect {
 #[derive(Hash, Debug, Copy, Clone)]
 pub enum ModuleType {
     Ecmascript {
-        transforms: ResolvedVc<EcmascriptInputTransforms>,
+        transforms: Vc<EcmascriptInputTransforms>,
         #[turbo_tasks(trace_ignore)]
         options: ResolvedVc<EcmascriptOptions>,
     },
     Typescript {
-        transforms: ResolvedVc<EcmascriptInputTransforms>,
+        transforms: Vc<EcmascriptInputTransforms>,
         // parse JSX syntax.
         tsx: bool,
         // follow references to imported types.
@@ -93,7 +93,7 @@ pub enum ModuleType {
         options: ResolvedVc<EcmascriptOptions>,
     },
     TypescriptDeclaration {
-        transforms: ResolvedVc<EcmascriptInputTransforms>,
+        transforms: Vc<EcmascriptInputTransforms>,
         #[turbo_tasks(trace_ignore)]
         options: ResolvedVc<EcmascriptOptions>,
     },

--- a/turbopack/crates/turbopack/src/module_options/module_rule.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_rule.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{trace::TraceRawVcs, Vc};
+use turbo_tasks::{trace::TraceRawVcs, ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     reference_type::ReferenceType, source::Source, source_transform::SourceTransforms,

--- a/turbopack/crates/turbopack/src/module_options/module_rule.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_rule.rs
@@ -69,33 +69,33 @@ pub enum ModuleRuleEffect {
     /// transforms. First argument will prepend the existing transforms, and
     /// the second argument will append the new transforms.
     ExtendEcmascriptTransforms {
-        prepend: Vc<EcmascriptInputTransforms>,
-        append: Vc<EcmascriptInputTransforms>,
+        prepend: ResolvedVc<EcmascriptInputTransforms>,
+        append: ResolvedVc<EcmascriptInputTransforms>,
     },
-    SourceTransforms(Vc<SourceTransforms>),
+    SourceTransforms(ResolvedVc<SourceTransforms>),
 }
 
 #[turbo_tasks::value(serialization = "auto_for_input", shared)]
 #[derive(Hash, Debug, Copy, Clone)]
 pub enum ModuleType {
     Ecmascript {
-        transforms: Vc<EcmascriptInputTransforms>,
+        transforms: ResolvedVc<EcmascriptInputTransforms>,
         #[turbo_tasks(trace_ignore)]
-        options: Vc<EcmascriptOptions>,
+        options: ResolvedVc<EcmascriptOptions>,
     },
     Typescript {
-        transforms: Vc<EcmascriptInputTransforms>,
+        transforms: ResolvedVc<EcmascriptInputTransforms>,
         // parse JSX syntax.
         tsx: bool,
         // follow references to imported types.
         analyze_types: bool,
         #[turbo_tasks(trace_ignore)]
-        options: Vc<EcmascriptOptions>,
+        options: ResolvedVc<EcmascriptOptions>,
     },
     TypescriptDeclaration {
-        transforms: Vc<EcmascriptInputTransforms>,
+        transforms: ResolvedVc<EcmascriptInputTransforms>,
         #[turbo_tasks(trace_ignore)]
-        options: Vc<EcmascriptOptions>,
+        options: ResolvedVc<EcmascriptOptions>,
     },
     Json,
     Raw,
@@ -108,5 +108,5 @@ pub enum ModuleType {
     WebAssembly {
         source_ty: WebAssemblySourceType,
     },
-    Custom(Vc<Box<dyn CustomModuleType>>),
+    Custom(ResolvedVc<Box<dyn CustomModuleType>>),
 }

--- a/turbopack/crates/turbopack/src/module_options/transition_rule.rs
+++ b/turbopack/crates/turbopack/src/module_options/transition_rule.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{trace::TraceRawVcs, Vc};
+use turbo_tasks::{trace::TraceRawVcs, ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{reference_type::ReferenceType, source::Source};
 

--- a/turbopack/crates/turbopack/src/module_options/transition_rule.rs
+++ b/turbopack/crates/turbopack/src/module_options/transition_rule.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{trace::TraceRawVcs, ResolvedVc, Vc};
+use turbo_tasks::{trace::TraceRawVcs, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{reference_type::ReferenceType, source::Source};
 
@@ -10,7 +10,7 @@ use crate::transition::Transition;
 #[derive(Debug, Clone, Serialize, Deserialize, TraceRawVcs, PartialEq, Eq)]
 pub struct TransitionRule {
     condition: RuleCondition,
-    transition: ResolvedVc<Box<dyn Transition>>,
+    transition: Vc<Box<dyn Transition>>,
     match_mode: MatchMode,
 }
 

--- a/turbopack/crates/turbopack/src/module_options/transition_rule.rs
+++ b/turbopack/crates/turbopack/src/module_options/transition_rule.rs
@@ -10,7 +10,7 @@ use crate::transition::Transition;
 #[derive(Debug, Clone, Serialize, Deserialize, TraceRawVcs, PartialEq, Eq)]
 pub struct TransitionRule {
     condition: RuleCondition,
-    transition: Vc<Box<dyn Transition>>,
+    transition: ResolvedVc<Box<dyn Transition>>,
     match_mode: MatchMode,
 }
 

--- a/turbopack/crates/turbopack/src/rebase/mod.rs
+++ b/turbopack/crates/turbopack/src/rebase/mod.rs
@@ -25,9 +25,9 @@ pub struct RebasedAsset {
 impl RebasedAsset {
     #[turbo_tasks::function]
     pub fn new(
-        source: Vc<Box<dyn Module>>,
-        input_dir: Vc<FileSystemPath>,
-        output_dir: Vc<FileSystemPath>,
+        source: ResolvedVc<Box<dyn Module>>,
+        input_dir: ResolvedVc<FileSystemPath>,
+        output_dir: ResolvedVc<FileSystemPath>,
     ) -> Vc<Self> {
         Self::cell(RebasedAsset {
             source,
@@ -43,20 +43,20 @@ impl OutputAsset for RebasedAsset {
     fn ident(&self) -> Vc<AssetIdent> {
         AssetIdent::from_path(FileSystemPath::rebase(
             self.source.ident().path(),
-            self.input_dir,
-            self.output_dir,
+            *self.input_dir,
+            *self.output_dir,
         ))
     }
 
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<OutputAssets>> {
         let mut references = Vec::new();
-        for &module in referenced_modules_and_affecting_sources(self.source)
+        for &module in referenced_modules_and_affecting_sources(*self.source)
             .await?
             .iter()
         {
             references.push(ResolvedVc::upcast(
-                RebasedAsset::new(*module, self.input_dir, self.output_dir)
+                RebasedAsset::new(*module, *self.input_dir, *self.output_dir)
                     .to_resolved()
                     .await?,
             ));

--- a/turbopack/crates/turbopack/src/rebase/mod.rs
+++ b/turbopack/crates/turbopack/src/rebase/mod.rs
@@ -16,9 +16,9 @@ use turbopack_core::{
 #[turbo_tasks::value]
 #[derive(Hash)]
 pub struct RebasedAsset {
-    source: Vc<Box<dyn Module>>,
-    input_dir: Vc<FileSystemPath>,
-    output_dir: Vc<FileSystemPath>,
+    source: ResolvedVc<Box<dyn Module>>,
+    input_dir: ResolvedVc<FileSystemPath>,
+    output_dir: ResolvedVc<FileSystemPath>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack/src/transition/context_transition.rs
+++ b/turbopack/crates/turbopack/src/transition/context_transition.rs
@@ -7,10 +7,10 @@ use crate::{module_options::ModuleOptionsContext, transition::Transition};
 /// A transition that only affects the asset context.
 #[turbo_tasks::value(shared)]
 pub struct ContextTransition {
-    compile_time_info: Vc<CompileTimeInfo>,
-    module_options_context: Vc<ModuleOptionsContext>,
-    resolve_options_context: Vc<ResolveOptionsContext>,
-    layer: Vc<RcStr>,
+    compile_time_info: ResolvedVc<CompileTimeInfo>,
+    module_options_context: ResolvedVc<ModuleOptionsContext>,
+    resolve_options_context: ResolvedVc<ResolveOptionsContext>,
+    layer: ResolvedVc<RcStr>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack/src/transition/context_transition.rs
+++ b/turbopack/crates/turbopack/src/transition/context_transition.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::{RcStr, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, Vc};
 use turbopack_core::compile_time_info::CompileTimeInfo;
 use turbopack_resolve::resolve_options_context::ResolveOptionsContext;
 

--- a/turbopack/crates/turbopack/src/transition/context_transition.rs
+++ b/turbopack/crates/turbopack/src/transition/context_transition.rs
@@ -17,10 +17,10 @@ pub struct ContextTransition {
 impl ContextTransition {
     #[turbo_tasks::function]
     pub fn new(
-        compile_time_info: Vc<CompileTimeInfo>,
-        module_options_context: Vc<ModuleOptionsContext>,
-        resolve_options_context: Vc<ResolveOptionsContext>,
-        layer: Vc<RcStr>,
+        compile_time_info: ResolvedVc<CompileTimeInfo>,
+        module_options_context: ResolvedVc<ModuleOptionsContext>,
+        resolve_options_context: ResolvedVc<ResolveOptionsContext>,
+        layer: ResolvedVc<RcStr>,
     ) -> Vc<ContextTransition> {
         ContextTransition {
             module_options_context,

--- a/turbopack/crates/turbopack/src/transition/context_transition.rs
+++ b/turbopack/crates/turbopack/src/transition/context_transition.rs
@@ -39,12 +39,12 @@ impl Transition for ContextTransition {
         &self,
         _compile_time_info: Vc<CompileTimeInfo>,
     ) -> Vc<CompileTimeInfo> {
-        self.compile_time_info
+        *self.compile_time_info
     }
 
     #[turbo_tasks::function]
     fn process_layer(&self, _layer: Vc<RcStr>) -> Vc<RcStr> {
-        self.layer
+        *self.layer
     }
 
     #[turbo_tasks::function]
@@ -52,7 +52,7 @@ impl Transition for ContextTransition {
         &self,
         _context: Vc<ModuleOptionsContext>,
     ) -> Vc<ModuleOptionsContext> {
-        self.module_options_context
+        *self.module_options_context
     }
 
     #[turbo_tasks::function]
@@ -60,6 +60,6 @@ impl Transition for ContextTransition {
         &self,
         _context: Vc<ResolveOptionsContext>,
     ) -> Vc<ResolveOptionsContext> {
-        self.resolve_options_context
+        *self.resolve_options_context
     }
 }

--- a/turbopack/crates/turbopack/src/transition/full_context_transition.rs
+++ b/turbopack/crates/turbopack/src/transition/full_context_transition.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 
 use crate::{transition::Transition, ModuleAssetContext};
 

--- a/turbopack/crates/turbopack/src/transition/full_context_transition.rs
+++ b/turbopack/crates/turbopack/src/transition/full_context_transition.rs
@@ -5,7 +5,7 @@ use crate::{transition::Transition, ModuleAssetContext};
 /// A transition that only affects the asset context.
 #[turbo_tasks::value(shared)]
 pub struct FullContextTransition {
-    module_context: Vc<ModuleAssetContext>,
+    module_context: ResolvedVc<ModuleAssetContext>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack/src/transition/full_context_transition.rs
+++ b/turbopack/crates/turbopack/src/transition/full_context_transition.rs
@@ -11,7 +11,7 @@ pub struct FullContextTransition {
 #[turbo_tasks::value_impl]
 impl FullContextTransition {
     #[turbo_tasks::function]
-    pub fn new(module_context: Vc<ModuleAssetContext>) -> Vc<FullContextTransition> {
+    pub fn new(module_context: ResolvedVc<ModuleAssetContext>) -> Vc<FullContextTransition> {
         FullContextTransition { module_context }.cell()
     }
 }
@@ -23,6 +23,6 @@ impl Transition for FullContextTransition {
         &self,
         _module_asset_context: Vc<ModuleAssetContext>,
     ) -> Vc<ModuleAssetContext> {
-        self.module_context
+        *self.module_context
     }
 }

--- a/turbopack/crates/turbopack/src/transition/mod.rs
+++ b/turbopack/crates/turbopack/src/transition/mod.rs
@@ -67,14 +67,14 @@ pub trait Transition {
     ) -> Result<Vc<ModuleAssetContext>> {
         let module_asset_context = module_asset_context.await?;
         let compile_time_info =
-            self.process_compile_time_info(module_asset_context.compile_time_info);
+            self.process_compile_time_info(*module_asset_context.compile_time_info);
         let module_options_context =
-            self.process_module_options_context(module_asset_context.module_options_context);
+            self.process_module_options_context(*module_asset_context.module_options_context);
         let resolve_options_context =
-            self.process_resolve_options_context(module_asset_context.resolve_options_context);
-        let layer = self.process_layer(module_asset_context.layer);
+            self.process_resolve_options_context(*module_asset_context.resolve_options_context);
+        let layer = self.process_layer(*module_asset_context.layer);
         let module_asset_context = ModuleAssetContext::new(
-            module_asset_context.transitions,
+            *module_asset_context.transitions,
             compile_time_info,
             module_options_context,
             resolve_options_context,
@@ -125,7 +125,7 @@ impl ValueDefault for TransitionOptions {
 }
 
 impl TransitionOptions {
-    pub fn get_named(&self, name: RcStr) -> Option<Vc<Box<dyn Transition>>> {
+    pub fn get_named(&self, name: RcStr) -> Option<ResolvedVc<Box<dyn Transition>>> {
         self.named_transitions.get(&name).copied()
     }
 

--- a/turbopack/crates/turbopack/src/transition/mod.rs
+++ b/turbopack/crates/turbopack/src/transition/mod.rs
@@ -111,7 +111,7 @@ pub trait Transition {
 #[turbo_tasks::value(shared)]
 #[derive(Default)]
 pub struct TransitionOptions {
-    pub named_transitions: HashMap<RcStr, Vc<Box<dyn Transition>>>,
+    pub named_transitions: HashMap<RcStr, ResolvedVc<Box<dyn Transition>>>,
     pub transition_rules: Vec<TransitionRule>,
     pub placeholder_for_future_extensions: (),
 }

--- a/turbopack/crates/turbopack/src/transition/mod.rs
+++ b/turbopack/crates/turbopack/src/transition/mod.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use anyhow::Result;
 pub use context_transition::ContextTransition;
 pub use full_context_transition::FullContextTransition;
-use turbo_tasks::{RcStr, Value, ValueDefault, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, Value, ValueDefault, Vc};
 use turbopack_core::{
     compile_time_info::CompileTimeInfo, context::ProcessResult, module::Module,
     reference_type::ReferenceType, source::Source,

--- a/turbopack/crates/turbopack/src/unsupported_sass.rs
+++ b/turbopack/crates/turbopack/src/unsupported_sass.rs
@@ -16,7 +16,7 @@ use turbopack_core::{
 /// Resolve plugins that warns when importing a sass file.
 #[turbo_tasks::value]
 pub(crate) struct UnsupportedSassResolvePlugin {
-    root: Vc<FileSystemPath>,
+    root: ResolvedVc<FileSystemPath>,
 }
 
 #[turbo_tasks::value_impl]
@@ -58,8 +58,8 @@ impl AfterResolvePlugin for UnsupportedSassResolvePlugin {
 
 #[turbo_tasks::value(shared)]
 struct UnsupportedSassModuleIssue {
-    file_path: Vc<FileSystemPath>,
-    request: Vc<Request>,
+    file_path: ResolvedVc<FileSystemPath>,
+    request: ResolvedVc<Request>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack/src/unsupported_sass.rs
+++ b/turbopack/crates/turbopack/src/unsupported_sass.rs
@@ -22,7 +22,7 @@ pub(crate) struct UnsupportedSassResolvePlugin {
 #[turbo_tasks::value_impl]
 impl UnsupportedSassResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(root: Vc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(root: ResolvedVc<FileSystemPath>) -> Vc<Self> {
         UnsupportedSassResolvePlugin { root }.cell()
     }
 }
@@ -37,10 +37,10 @@ impl AfterResolvePlugin for UnsupportedSassResolvePlugin {
     #[turbo_tasks::function]
     async fn after_resolve(
         &self,
-        fs_path: Vc<FileSystemPath>,
-        lookup_path: Vc<FileSystemPath>,
+        fs_path: ResolvedVc<FileSystemPath>,
+        lookup_path: ResolvedVc<FileSystemPath>,
         _reference_type: Value<ReferenceType>,
-        request: Vc<Request>,
+        request: ResolvedVc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
         let extension = fs_path.extension().await?;
         if ["sass", "scss"].iter().any(|ext| *ext == &**extension) {
@@ -83,7 +83,7 @@ impl Issue for UnsupportedSassModuleIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        self.file_path
+        *self.file_path
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack/src/unsupported_sass.rs
+++ b/turbopack/crates/turbopack/src/unsupported_sass.rs
@@ -1,7 +1,7 @@
 //! TODO(WEB-741) Remove this file once Sass is supported.
 
 use anyhow::Result;
-use turbo_tasks::{Value, Vc};
+use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbo_tasks_fs::{glob::Glob, FileSystemPath};
 use turbopack_core::{
     issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},


### PR DESCRIPTION
### What?

Follow-up for https://github.com/vercel/next.js/pull/72791

### Why?

We need to refactor this for future works.

### How?


Closes PACK-3480