### PR TITLE
Consolidate server actions transform errors into `emit_error` function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4063,6 +4063,7 @@ dependencies = [
  "either",
  "fxhash",
  "hex",
+ "indoc",
  "lazy_static",
  "modularize_imports",
  "once_cell",

--- a/crates/next-custom-transforms/Cargo.toml
+++ b/crates/next-custom-transforms/Cargo.toml
@@ -19,6 +19,7 @@ easy-error = "1.0.0"
 either = "1"
 fxhash = "0.2.1"
 hex = "0.4.3"
+indoc = { workspace = true }
 once_cell = { workspace = true }
 pathdiff = { workspace = true }
 regex = "1.5"

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/1/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/1/output.stderr
@@ -1,4 +1,5 @@
-  x Server Actions must be async functions
+  x Server Actions must be async functions.
+  | 
    ,-[input.js:3:1]
  2 | 
  3 | export function foo() {}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/11/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/11/output.stderr
@@ -1,4 +1,5 @@
   x The "use server" directive must be at the top of the file, and cannot be wrapped in parentheses.
+  | 
    ,-[input.js:2:1]
  1 | import 'react'
  2 | ;('use sevrer')

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/14/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/14/output.stderr
@@ -1,4 +1,5 @@
   x "use cache" functions must be async functions.
+  | 
    ,-[input.js:3:1]
  2 | 
  3 | export default function () {}
@@ -6,6 +7,7 @@
  4 | export function foo() {}
    `----
   x "use cache" functions must be async functions.
+  | 
    ,-[input.js:4:1]
  3 | export default function () {}
  4 | export function foo() {}
@@ -13,6 +15,7 @@
  5 | export const bar = () => {}
    `----
   x "use cache" functions must be async functions.
+  | 
    ,-[input.js:5:1]
  4 | export function foo() {}
  5 | export const bar = () => {}
@@ -20,6 +23,7 @@
  6 | export const baz = 42
    `----
   x Only async functions are allowed to be exported in a "use cache" file.
+  | 
    ,-[input.js:6:1]
  5 | export const bar = () => {}
  6 | export const baz = 42

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/15/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/15/output.stderr
@@ -1,10 +1,12 @@
   x "use cache" functions must be async functions.
+  | 
    ,-[input.js:1:1]
  1 | ,-> export default function () {
  2 | |     'use cache'
  3 | `-> }
    `----
   x "use cache" functions must be async functions.
+  | 
    ,-[input.js:5:1]
  4 | 
  5 | export function foo() {
@@ -12,6 +14,7 @@
  6 |   'use cache'
    `----
   x "use cache" functions must be async functions.
+  | 
     ,-[input.js:9:1]
   8 |     
   9 | ,-> export const bar = () => {

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/2/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/2/output.stderr
@@ -1,4 +1,5 @@
-  x Server Actions must be async functions
+  x Server Actions must be async functions.
+  | 
    ,-[input.js:7:1]
  6 | 
  7 | export function bar() {}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/3/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/3/output.stderr
@@ -1,4 +1,5 @@
   x Only async functions are allowed to be exported in a "use server" file.
+  | 
    ,-[input.js:3:1]
  2 | 
  3 | export const x = 1

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/4/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/4/output.stderr
@@ -1,4 +1,5 @@
   x Only async functions are allowed to be exported in a "use server" file.
+  | 
    ,-[input.js:3:1]
  2 |     
  3 | ,-> export default class Component {

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/5/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/5/output.stderr
@@ -1,4 +1,5 @@
   x Only async functions are allowed to be exported in a "use server" file.
+  | 
    ,-[input.js:3:1]
  2 | 
  3 | export * from 'foo'

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/6/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/6/output.stderr
@@ -1,4 +1,5 @@
   x Server Actions must be async functions.
+  | 
    ,-[input.js:3:1]
  2 | 
  3 | export default () => {}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/7/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/7/output.stderr
@@ -1,4 +1,5 @@
   x Server Actions must be async functions.
+  | 
    ,-[input.js:1:1]
  1 | ,-> const foo = () => {
  2 | |     'use server'

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/8/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/8/output.stderr
@@ -1,4 +1,5 @@
   x The "use server" directive must be at the top of the function body.
+  | 
     ,-[input.js:10:1]
   9 |   // prettier-ignore
  10 |   'use server'

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/9/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/9/output.stderr
@@ -1,4 +1,5 @@
   x The "use server" directive must be at the top of the file.
+  | 
    ,-[input.js:4:1]
  3 | // prettier-ignore
  4 | 'use server'


### PR DESCRIPTION
This improves maintainability and readability by decluttering the server actions transforms implementation, dedupes a few error messages, and consistently uses periods and trailing newlines for all error messages.

The same approach is already used for the React Server Components transforms.