### PR TITLE
error-overlay: Rename "Error" to "Issue"

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
@@ -255,7 +255,7 @@ export function Errors({
             <line x1="12" y1="16" x2="12.01" y2="16"></line>
           </svg>
           <span>
-            {readyErrors.length} error{readyErrors.length > 1 ? 's' : ''}
+            {readyErrors.length} issue{readyErrors.length > 1 ? 's' : ''}
           </span>
           <button
             data-nextjs-toast-errors-hide-button
@@ -265,7 +265,7 @@ export function Errors({
               e.stopPropagation()
               hide()
             }}
-            aria-label="Hide Errors"
+            aria-label="Hide Issues"
           >
             <CloseIcon />
           </button>
@@ -315,7 +315,7 @@ export function Errors({
                 <span data-nextjs-dialog-header-total-count>
                   {readyErrors.length}
                 </span>
-                {' error'}
+                {' issue'}
                 {readyErrors.length < 2 ? '' : 's'}
               </small>
               <VersionStalenessInfo versionInfo={versionInfo} />

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -736,20 +736,20 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     // Unhandled error and rejection in setTimeout
     expect(
       await browser.waitForElementByCss('.nextjs-toast-errors').text()
-    ).toBe('2 errors')
+    ).toBe('2 issues')
 
     // Unhandled error in event handler
     await browser.elementById('unhandled-error').click()
     await check(
       () => browser.elementByCss('.nextjs-toast-errors').text(),
-      /3 errors/
+      /3 issues/
     )
 
     // Unhandled rejection in event handler
     await browser.elementById('unhandled-rejection').click()
     await check(
       () => browser.elementByCss('.nextjs-toast-errors').text(),
-      /4 errors/
+      /4 issues/
     )
     await session.assertNoRedbox()
 

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -919,7 +919,7 @@ export function getRedboxHeader(browser: BrowserInterface) {
 
 export async function getRedboxTotalErrorCount(browser: BrowserInterface) {
   const header = (await getRedboxHeader(browser)) || ''
-  return parseInt(header.match(/\d+ of (\d+) error/)?.[1], 10)
+  return parseInt(header.match(/\d+ of (\d+) issue/)?.[1], 10)
 }
 
 export function getRedboxSource(browser: BrowserInterface) {


### PR DESCRIPTION
The error overlay now displays `console.error` calls as well. We want to get away from the "error" branding since we will start surfacing `console.warn` and other "issues" in this overlay as well.