### PR TITLE
test: fix hydration error on not-found test texture

### DIFF
--- a/test/e2e/app-dir/not-found-default/app/(group)/layout.js
+++ b/test/e2e/app-dir/not-found-default/app/(group)/layout.js
@@ -1,7 +1,3 @@
 export default function RootLayout({ children }) {
-  return (
-    <html className="group-root-layout">
-      <body>{children}</body>
-    </html>
-  )
+  return <div className="group-root-layout">{children}</div>
 }

--- a/test/e2e/app-dir/not-found-default/index.test.ts
+++ b/test/e2e/app-dir/not-found-default/index.test.ts
@@ -1,5 +1,9 @@
 import { nextTestSetup } from 'e2e-utils'
-import { assertHasRedbox, check, getRedboxDescription } from 'next-test-utils'
+import {
+  assertHasRedbox,
+  assertNoRedbox,
+  getRedboxDescription,
+} from 'next-test-utils'
 
 describe('app dir - not found with default 404 page', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
@@ -17,13 +21,10 @@ describe('app dir - not found with default 404 page', () => {
     await browser.elementByCss('#trigger-not-found').click()
 
     if (isNextDev) {
-      await check(async () => {
-        await assertHasRedbox(browser)
-        expect(await getRedboxDescription(browser)).toMatch(
-          /notFound\(\) is not allowed to use in root layout/
-        )
-        return 'success'
-      }, /success/)
+      await assertHasRedbox(browser)
+      expect(await getRedboxDescription(browser)).toMatch(
+        /notFound\(\) is not allowed to use in root layout/
+      )
     }
   })
 
@@ -83,9 +84,8 @@ describe('app dir - not found with default 404 page', () => {
     )
 
     await browser.loadPage(next.url + '/group-dynamic/404')
+    await assertNoRedbox(browser)
+    await browser.waitForElementByCss('.group-root-layout')
     expect(await browser.elementByCss('.next-error-h1').text()).toBe('404')
-    expect(await browser.elementByCss('html').getAttribute('class')).toBe(
-      'group-root-layout'
-    )
   })
 })


### PR DESCRIPTION
Found a hydration error case while testing #72785 

The nested gourp should not hold html/body tag on layout as it's already existed in the root layout