### PR TITLE
refactor(turbo-tasks): Simplify most type bounds on Vc<T> and related types

### DIFF
--- a/turbopack/crates/turbo-tasks/src/collectibles.rs
+++ b/turbopack/crates/turbo-tasks/src/collectibles.rs
@@ -3,6 +3,6 @@ use auto_hash_map::AutoSet;
 use crate::{Vc, VcValueTrait};
 
 pub trait CollectiblesSource {
-    fn take_collectibles<T: VcValueTrait + Send>(self) -> AutoSet<Vc<T>>;
-    fn peek_collectibles<T: VcValueTrait + Send>(self) -> AutoSet<Vc<T>>;
+    fn take_collectibles<T: VcValueTrait>(self) -> AutoSet<Vc<T>>;
+    fn peek_collectibles<T: VcValueTrait>(self) -> AutoSet<Vc<T>>;
 }

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -504,7 +504,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
     /// Creates a new root task
     pub fn spawn_root_task<T, F, Fut>(&self, functor: F) -> TaskId
     where
-        T: Send,
+        T: ?Sized,
         F: Fn() -> Fut + Send + Sync + Clone + 'static,
         Fut: Future<Output = Result<Vc<T>>> + Send,
     {
@@ -529,7 +529,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
     #[track_caller]
     pub fn spawn_once_task<T, Fut>(&self, future: Fut) -> TaskId
     where
-        T: Send,
+        T: ?Sized,
         Fut: Future<Output = Result<Vc<T>>> + Send + 'static,
     {
         let id = self.backend.create_transient_task(
@@ -1741,7 +1741,7 @@ pub fn notify_scheduled_tasks() {
     with_turbo_tasks(|tt| tt.notify_scheduled_tasks())
 }
 
-pub fn emit<T: VcValueTrait + Send>(collectible: Vc<T>) {
+pub fn emit<T: VcValueTrait + ?Sized>(collectible: Vc<T>) {
     with_turbo_tasks(|tt| tt.emit_collectible(T::get_trait_type_id(), collectible.node))
 }
 

--- a/turbopack/crates/turbo-tasks/src/raw_vc.rs
+++ b/turbopack/crates/turbo-tasks/src/raw_vc.rs
@@ -252,7 +252,7 @@ impl RawVc {
 }
 
 impl CollectiblesSource for RawVc {
-    fn peek_collectibles<T: VcValueTrait + Send>(self) -> AutoSet<Vc<T>> {
+    fn peek_collectibles<T: VcValueTrait + ?Sized>(self) -> AutoSet<Vc<T>> {
         let tt = turbo_tasks();
         tt.notify_scheduled_tasks();
         let map = tt.read_task_collectibles(self.get_task_id(), T::get_trait_type_id());
@@ -261,7 +261,7 @@ impl CollectiblesSource for RawVc {
             .collect()
     }
 
-    fn take_collectibles<T: VcValueTrait + Send>(self) -> AutoSet<Vc<T>> {
+    fn take_collectibles<T: VcValueTrait + ?Sized>(self) -> AutoSet<Vc<T>> {
         let tt = turbo_tasks();
         tt.notify_scheduled_tasks();
         let map = tt.read_task_collectibles(self.get_task_id(), T::get_trait_type_id());
@@ -429,8 +429,5 @@ impl Future for ReadRawVcFuture {
         }
     }
 }
-
-unsafe impl Send for ReadRawVcFuture {}
-unsafe impl Sync for ReadRawVcFuture {}
 
 impl Unpin for ReadRawVcFuture {}

--- a/turbopack/crates/turbo-tasks/src/task/from_task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/from_task_input.rs
@@ -12,14 +12,14 @@ mod private {
     /// Implements the sealed trait pattern:
     /// <https://rust-lang.github.io/api-guidelines/future-proofing.html>
     pub trait Sealed {}
-    impl<T> Sealed for ResolvedVc<T> where T: Send {}
+    impl<T> Sealed for ResolvedVc<T> where T: ?Sized {}
     impl<T> Sealed for Vec<T> where T: FromTaskInput {}
     impl<T> Sealed for Option<T> where T: FromTaskInput {}
 }
 
 impl<T> FromTaskInput for ResolvedVc<T>
 where
-    T: Send,
+    T: ?Sized,
 {
     type TaskInput = Vc<T>;
     fn from_task_input(from: Vc<T>) -> ResolvedVc<T> {

--- a/turbopack/crates/turbo-tasks/src/task/from_task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/from_task_input.rs
@@ -19,7 +19,7 @@ mod private {
 
 impl<T> FromTaskInput for ResolvedVc<T>
 where
-    T: ?Sized,
+    T: Send + Sync + ?Sized,
 {
     type TaskInput = Vc<T>;
     fn from_task_input(from: Vc<T>) -> ResolvedVc<T> {

--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -95,7 +95,7 @@ where
 
 impl<T> TaskInput for Vc<T>
 where
-    T: Send,
+    T: ?Sized,
 {
     fn is_resolved(&self) -> bool {
         Vc::is_resolved(*self)
@@ -114,7 +114,7 @@ where
 // `Vc`, but it is useful for structs that contain `ResolvedVc` and want to derive `TaskInput`.
 impl<T> TaskInput for ResolvedVc<T>
 where
-    T: Send,
+    T: ?Sized,
 {
     fn is_resolved(&self) -> bool {
         true

--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -95,7 +95,7 @@ where
 
 impl<T> TaskInput for Vc<T>
 where
-    T: ?Sized,
+    T: Send + Sync + ?Sized,
 {
     fn is_resolved(&self) -> bool {
         Vc::is_resolved(*self)
@@ -114,7 +114,7 @@ where
 // `Vc`, but it is useful for structs that contain `ResolvedVc` and want to derive `TaskInput`.
 impl<T> TaskInput for ResolvedVc<T>
 where
-    T: ?Sized,
+    T: Send + Sync + ?Sized,
 {
     fn is_resolved(&self) -> bool {
         true

--- a/turbopack/crates/turbo-tasks/src/task/task_output.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_output.rs
@@ -15,7 +15,7 @@ pub trait TaskOutput {
 
 impl<T> TaskOutput for Vc<T>
 where
-    T: ?Sized + Send,
+    T: ?Sized,
 {
     type Return = Vc<T>;
 

--- a/turbopack/crates/turbo-tasks/src/trait_ref.rs
+++ b/turbopack/crates/turbo-tasks/src/trait_ref.rs
@@ -100,7 +100,7 @@ where
 
 impl<T> TraitRef<T>
 where
-    T: VcValueTrait + ?Sized + Send,
+    T: VcValueTrait + ?Sized,
 {
     /// Returns a new cell that points to a value that implements the value
     /// trait `T`.
@@ -130,7 +130,7 @@ pub trait IntoTraitRef {
 
 impl<T> IntoTraitRef for Vc<T>
 where
-    T: VcValueTrait + ?Sized + Send,
+    T: VcValueTrait + ?Sized,
 {
     type ValueTrait = T;
 

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -203,19 +203,6 @@ where
 
 impl<T> Copy for Vc<T> where T: ?Sized {}
 
-// SAFETY: `Vc<T>` doesn't auto-implement these for all `T` because we use `PhantomData<T>`, and `T`
-// isn't `Send + Sync` on the struct. `Vc<T>` is really just a few indexes, which are always `Send +
-// Sync`.
-//
-// The bounds are checked during construction before writing to the global cells. It's impossible to
-// construct or cast to a `Vc` that doesn't contain a `T: Send` as all constructors require
-// `T: VcValueType` or `T: VcValueTrait`, both of which are subtraits of `Send + Sync`.
-//
-// These unsafe implementations are provided for convenience, so that callsites don't need to
-// enforce `T: Send + Sync` themselves.
-unsafe impl<T> Send for Vc<T> where T: ?Sized {}
-unsafe impl<T> Sync for Vc<T> where T: ?Sized {}
-
 impl<T> Clone for Vc<T>
 where
     T: ?Sized,
@@ -523,7 +510,7 @@ where
 
 impl<T> ValueDebugFormat for Vc<T>
 where
-    T: Upcast<Box<dyn ValueDebug>> + ?Sized,
+    T: Upcast<Box<dyn ValueDebug>> + Send + Sync + ?Sized,
 {
     fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
         ValueDebugFormatString::Async(Box::pin(async move {

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -2,6 +2,7 @@ use std::{
     any::Any,
     cell::RefCell,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    fmt::Debug,
     future::IntoFuture,
     hash::{Hash, Hasher},
     marker::PhantomData,
@@ -32,16 +33,16 @@ use crate::{
 #[serde(transparent, bound = "")]
 pub struct ResolvedVc<T>
 where
-    T: ?Sized + Send,
+    T: ?Sized,
 {
     pub(crate) node: Vc<T>,
 }
 
-impl<T> Copy for ResolvedVc<T> where T: ?Sized + Send {}
+impl<T> Copy for ResolvedVc<T> where T: ?Sized {}
 
 impl<T> Clone for ResolvedVc<T>
 where
-    T: ?Sized + Send,
+    T: ?Sized,
 {
     fn clone(&self) -> Self {
         *self
@@ -50,7 +51,7 @@ where
 
 impl<T> Deref for ResolvedVc<T>
 where
-    T: ?Sized + Send,
+    T: ?Sized,
 {
     type Target = Vc<T>;
 
@@ -61,18 +62,18 @@ where
 
 impl<T> PartialEq<ResolvedVc<T>> for ResolvedVc<T>
 where
-    T: ?Sized + Send,
+    T: ?Sized,
 {
     fn eq(&self, other: &Self) -> bool {
         self.node == other.node
     }
 }
 
-impl<T> Eq for ResolvedVc<T> where T: ?Sized + Send {}
+impl<T> Eq for ResolvedVc<T> where T: ?Sized {}
 
 impl<T> Hash for ResolvedVc<T>
 where
-    T: ?Sized + Send,
+    T: ?Sized,
 {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.node.hash(state);
@@ -126,7 +127,7 @@ where
 
 impl<T> ResolvedVc<T>
 where
-    T: ?Sized + Send,
+    T: ?Sized,
 {
     /// Upcasts the given `ResolvedVc<T>` to a `ResolvedVc<Box<dyn K>>`.
     ///
@@ -135,7 +136,7 @@ where
     pub fn upcast<K>(this: Self) -> ResolvedVc<K>
     where
         T: Upcast<K>,
-        K: VcValueTrait + ?Sized + Send,
+        K: VcValueTrait + ?Sized,
     {
         ResolvedVc {
             node: Vc::upcast(this.node),
@@ -145,7 +146,7 @@ where
 
 impl<T> ResolvedVc<T>
 where
-    T: VcValueTrait + ?Sized + Send,
+    T: VcValueTrait + ?Sized,
 {
     /// Attempts to sidecast the given `Vc<Box<dyn T>>` to a `Vc<Box<dyn K>>`.
     ///
@@ -157,7 +158,7 @@ where
     /// See also: [`Vc::try_resolve_sidecast`].
     pub async fn try_sidecast<K>(this: Self) -> Result<Option<ResolvedVc<K>>, ResolveTypeError>
     where
-        K: VcValueTrait + ?Sized + Send,
+        K: VcValueTrait + ?Sized,
     {
         // must be async, as we must read the cell to determine the type
         Ok(Vc::try_resolve_sidecast(this.node)
@@ -174,7 +175,7 @@ where
     pub async fn try_downcast<K>(this: Self) -> Result<Option<ResolvedVc<K>>, ResolveTypeError>
     where
         K: Upcast<T>,
-        K: VcValueTrait + ?Sized + Send,
+        K: VcValueTrait + ?Sized,
     {
         Ok(Vc::try_resolve_downcast(this.node)
             .await?
@@ -197,9 +198,15 @@ where
     }
 }
 
-impl<T> std::fmt::Debug for ResolvedVc<T>
+/// Generates an opaque debug representation of the [`ResolvedVc`] itself, but not the data inside
+/// of it.
+///
+/// This is implemented to allow types containing [`ResolvedVc`] to implement the synchronous
+/// [`Debug`] trait, but in most cases users should use the [`ValueDebug`] implementation to get a
+/// string representation of the contents of the cell.
+impl<T> Debug for ResolvedVc<T>
 where
-    T: Send,
+    T: ?Sized,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ResolvedVc")
@@ -210,7 +217,7 @@ where
 
 impl<T> TraceRawVcs for ResolvedVc<T>
 where
-    T: ?Sized + Send,
+    T: ?Sized,
 {
     fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
         TraceRawVcs::trace_raw_vcs(&self.node, trace_context);
@@ -219,7 +226,7 @@ where
 
 impl<T> ValueDebugFormat for ResolvedVc<T>
 where
-    T: ?Sized + Send,
+    T: ?Sized,
     T: Upcast<Box<dyn ValueDebug>>,
 {
     fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
@@ -237,7 +244,7 @@ where
 /// crate::value] to do it for you.
 pub unsafe trait ResolvedValue {}
 
-unsafe impl<T: ?Sized + Send + ResolvedValue> ResolvedValue for ResolvedVc<T> {}
+unsafe impl<T: ?Sized + ResolvedValue> ResolvedValue for ResolvedVc<T> {}
 
 macro_rules! impl_resolved {
     ($ty:ty) => {

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -174,8 +174,7 @@ where
     /// See also: [`Vc::try_resolve_downcast`].
     pub async fn try_downcast<K>(this: Self) -> Result<Option<ResolvedVc<K>>, ResolveTypeError>
     where
-        K: Upcast<T>,
-        K: VcValueTrait + ?Sized,
+        K: Upcast<T> + VcValueTrait + ?Sized,
     {
         Ok(Vc::try_resolve_downcast(this.node)
             .await?
@@ -189,8 +188,7 @@ where
     /// See also: [`Vc::try_resolve_downcast_type`].
     pub async fn try_downcast_type<K>(this: Self) -> Result<Option<ResolvedVc<K>>, ResolveTypeError>
     where
-        K: Upcast<T>,
-        K: VcValueType,
+        K: Upcast<T> + VcValueType,
     {
         Ok(Vc::try_resolve_downcast_type(this.node)
             .await?

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -226,8 +226,7 @@ where
 
 impl<T> ValueDebugFormat for ResolvedVc<T>
 where
-    T: ?Sized,
-    T: Upcast<Box<dyn ValueDebug>>,
+    T: Upcast<Box<dyn ValueDebug>> + Send + Sync + ?Sized,
 {
     fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
         self.node.value_debug_format(depth)

--- a/turbopack/crates/turbo-tasks/src/vc/traits.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/traits.rs
@@ -23,8 +23,8 @@ pub unsafe trait VcValueType: ShrinkToFit + Sized + Send + Sync + 'static {
 }
 
 /// A trait implemented on all values trait object references that can be put
-/// into a Value Cell ([`Vc<&dyn Trait>`][crate::Vc]).
-pub trait VcValueTrait {
+/// into a Value Cell ([`Vc<Box<dyn Trait>>`][crate::Vc]).
+pub trait VcValueTrait: Send + Sync + 'static {
     fn get_trait_type_id() -> TraitTypeId;
 }
 
@@ -35,9 +35,9 @@ pub trait VcValueTrait {
 ///
 /// The implementor of this trait must ensure that `Self` implements the
 /// trait `T`.
-pub unsafe trait Upcast<T>: Send
+pub unsafe trait Upcast<T>
 where
-    T: VcValueTrait + ?Sized + Send,
+    T: VcValueTrait + ?Sized,
 {
 }
 
@@ -48,9 +48,9 @@ where
 ///
 /// The implementor of this trait must ensure that `Self` implements the
 /// trait `T`.
-pub unsafe trait Dynamic<T>: Send
+pub unsafe trait Dynamic<T>
 where
-    T: VcValueTrait + ?Sized + Send,
+    T: VcValueTrait + ?Sized,
 {
 }
 

--- a/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
@@ -17,7 +17,7 @@ use crate::{
 #[turbo_tasks::value_trait]
 pub trait EvaluatableAsset: Asset + Module + ChunkableModule {}
 
-pub trait EvaluatableAssetExt: Send {
+pub trait EvaluatableAssetExt {
     fn to_evaluatable(
         self: Vc<Self>,
         asset_context: Vc<Box<dyn AssetContext>>,

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -758,7 +758,7 @@ pub type ChunkItemWithAsyncModuleInfo = (Vc<Box<dyn ChunkItem>>, Option<Vc<Async
 #[turbo_tasks::value(transparent)]
 pub struct ChunkItemsWithAsyncModuleInfo(Vec<ChunkItemWithAsyncModuleInfo>);
 
-pub trait ChunkItemExt: Send {
+pub trait ChunkItemExt {
     /// Returns the module id of this chunk item.
     fn id(self: Vc<Self>) -> Vc<ModuleId>;
 }

--- a/turbopack/crates/turbopack-dev-server/src/source/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/mod.rs
@@ -417,7 +417,7 @@ pub trait ContentSource {
     }
 }
 
-pub trait ContentSourceExt: Send {
+pub trait ContentSourceExt {
     fn issue_file_path(
         self: Vc<Self>,
         file_path: Vc<FileSystemPath>,

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -227,7 +227,7 @@ pub trait EcmascriptChunkItem: ChunkItem {
     }
 }
 
-pub trait EcmascriptChunkItemExt: Send {
+pub trait EcmascriptChunkItemExt {
     /// Generates the module factory for this chunk item.
     fn code(self: Vc<Self>, async_module_info: Option<Vc<AsyncModuleInfo>>) -> Vc<Code>;
 }


### PR DESCRIPTION
`Vc<T>` had a type bound that `T: Send + ?Sized`. The general recommendation is to remove all type bounds from the struct that aren't necessary:

- https://rust-lang.github.io/api-guidelines/future-proofing.html#c-struct-bounds
- https://github.com/rust-lang/api-guidelines/issues/6
- https://github.com/rust-lang/rust-clippy/issues/1689

The reasoning is that type bounds on structs are "infectious". Any generic function, trait, or struct referring to `Vc<T>` was required to add `T: Send` bounds.

*Sidenote: The [`implied_bounds` feature](https://rust-lang.github.io/rfcs/2089-implied-bounds.html) might mitigate some of this if ever stabilized.*

Removing the `T: Send` type bound from `Vc<T>` means that there's less places where we need to specify it.

This pattern can be seen in many parts of the stdlib. For example, `Arc<T>` doesn't require that `T: Send + Sync`, though in reality to do anything useful with it, you need `T: Send + Sync`.

## Is this safe?

Yes, bounds are checked during cell construction, and the lower-level APIs used for creating cells require `Send + Sync`, so this would be hard to mess up without explicitly unsafe code.

Also, `Vc<T>` also technically requires that `T: Sync`, but that wasn't enforced in the struct definition (only during cell construction). We did just fine without that bound on the struct.

## Why are you leaving `?Sized`?

There's an implicit `Sized` bound on type parameters in struct definitions unless explicitly specified otherwise with `?Sized`.

Right now this bound isn't used. We use a box, e.g. `Vc<Box<dyn Foo>>`, but in the future we might be able to drop that intermediate box from the type signature. I'm leaving the `?Sized` bound in place (and adding it in a few places where it was missing) in hopes of that.

Closes PACK-3474