### PR TITLE
fix(turbopack): type error when "dynamic_embed_contents" is on

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/embed/dir.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/dir.rs
@@ -56,7 +56,7 @@ macro_rules! embed_directory_internal {
 
         let path = $path.replace("$CARGO_MANIFEST_DIR", env!("CARGO_MANIFEST_DIR"));
 
-        turbo_tasks_fs::embed::directory_from_relative_path($name.to_string(), path)
+        turbo_tasks_fs::embed::directory_from_relative_path($name.into(), path.into())
     }};
 }
 

--- a/turbopack/crates/turbo-tasks-fs/src/embed/file.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/file.rs
@@ -45,8 +45,8 @@ macro_rules! embed_file {
         let _ = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/", $path));
 
         turbo_tasks_fs::embed::content_from_relative_path(
-            env!("CARGO_MANIFEST_DIR").to_string(),
-            $path.to_string(),
+            env!("CARGO_MANIFEST_DIR").into(),
+            $path.into(),
         )
     }};
 }


### PR DESCRIPTION
`dynamic_embed_contents` is off by default, so i guess we missed some type errors when refactoring stuff to `RcStr`