### PR TITLE
Emit build error for unknown cache kinds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4086,6 +4086,7 @@ dependencies = [
  "swc_relay",
  "testing",
  "tracing",
+ "turbo-rcstr",
  "turbopack-ecmascript-plugins",
  "walkdir",
 ]

--- a/crates/next-core/src/next_client/transforms.rs
+++ b/crates/next-core/src/next_client/transforms.rs
@@ -47,12 +47,7 @@ pub async fn get_next_client_transforms_rules(
         rules.push(get_debug_fn_name_rule(enable_mdx_rs));
     }
 
-    let dynamic_io_enabled = next_config
-        .experimental()
-        .await?
-        .dynamic_io
-        .unwrap_or(false);
-
+    let dynamic_io_enabled = *next_config.enable_dynamic_io().await?;
     let mut is_app_dir = false;
 
     match context_ty {

--- a/crates/next-core/src/next_client/transforms.rs
+++ b/crates/next-core/src/next_client/transforms.rs
@@ -48,6 +48,7 @@ pub async fn get_next_client_transforms_rules(
     }
 
     let dynamic_io_enabled = *next_config.enable_dynamic_io().await?;
+    let cache_kinds = next_config.cache_kinds().to_resolved().await?;
     let mut is_app_dir = false;
 
     match context_ty {
@@ -74,6 +75,7 @@ pub async fn get_next_client_transforms_rules(
                 ActionsTransform::Client,
                 enable_mdx_rs,
                 dynamic_io_enabled,
+                cache_kinds,
             ));
         }
         ClientContextType::Fallback | ClientContextType::Other => {}

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use anyhow::{bail, Context, Result};
+use rustc_hash::FxHashSet;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value as JsonValue;
 use turbo_rcstr::RcStr;
@@ -39,6 +40,9 @@ struct CustomRoutes {
 
 #[turbo_tasks::value(transparent)]
 pub struct ModularizeImports(FxIndexMap<String, ModularizeImportPackageConfig>);
+
+#[turbo_tasks::value(transparent)]
+pub struct CacheKinds(FxHashSet<String>);
 
 #[turbo_tasks::value(serialization = "custom", eq = "manual")]
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
@@ -529,6 +533,7 @@ pub struct ExperimentalConfig {
     after: Option<bool>,
     amp: Option<serde_json::Value>,
     app_document_preloading: Option<bool>,
+    cache_handlers: Option<FxIndexMap<String, String>>,
     cache_life: Option<FxIndexMap<String, CacheLifeProfile>>,
     case_sensitive_routes: Option<bool>,
     cpus: Option<f64>,
@@ -1157,6 +1162,19 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub fn enable_dynamic_io(&self) -> Vc<bool> {
         Vc::cell(self.experimental.dynamic_io.unwrap_or(false))
+    }
+
+    #[turbo_tasks::function]
+    pub fn cache_kinds(&self) -> Vc<CacheKinds> {
+        Vc::cell(
+            self.experimental
+                .cache_handlers
+                .clone()
+                .unwrap_or_default()
+                .keys()
+                .cloned()
+                .collect(),
+        )
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1150,10 +1150,8 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn enable_react_owner_stack(self: Vc<Self>) -> Result<Vc<bool>> {
-        Ok(Vc::cell(
-            self.await?.experimental.react_owner_stack.unwrap_or(false),
-        ))
+    pub fn enable_react_owner_stack(&self) -> Vc<bool> {
+        Vc::cell(self.experimental.react_owner_stack.unwrap_or(false))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -42,7 +42,7 @@ struct CustomRoutes {
 pub struct ModularizeImports(FxIndexMap<String, ModularizeImportPackageConfig>);
 
 #[turbo_tasks::value(transparent)]
-pub struct CacheKinds(FxHashSet<String>);
+pub struct CacheKinds(FxHashSet<RcStr>);
 
 #[turbo_tasks::value(serialization = "custom", eq = "manual")]
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
@@ -1169,11 +1169,9 @@ impl NextConfig {
         Vc::cell(
             self.experimental
                 .cache_handlers
-                .clone()
-                .unwrap_or_default()
-                .keys()
-                .cloned()
-                .collect(),
+                .as_ref()
+                .map(|handlers| handlers.keys().map(|kind| RcStr::from(&**kind)).collect())
+                .unwrap_or_default(),
         )
     }
 

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -520,7 +520,7 @@ pub struct ExperimentalConfig {
     pub sri: Option<SubResourceIntegrity>,
     react_compiler: Option<ReactCompilerOptionsOrBoolean>,
     #[serde(rename = "dynamicIO")]
-    pub dynamic_io: Option<bool>,
+    dynamic_io: Option<bool>,
     // ---
     // UNSUPPORTED
     // ---
@@ -1152,6 +1152,11 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub fn enable_react_owner_stack(&self) -> Vc<bool> {
         Vc::cell(self.experimental.react_owner_stack.unwrap_or(false))
+    }
+
+    #[turbo_tasks::function]
+    pub fn enable_dynamic_io(&self) -> Vc<bool> {
+        Vc::cell(self.experimental.dynamic_io.unwrap_or(false))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -533,7 +533,7 @@ pub struct ExperimentalConfig {
     after: Option<bool>,
     amp: Option<serde_json::Value>,
     app_document_preloading: Option<bool>,
-    cache_handlers: Option<FxIndexMap<String, String>>,
+    cache_handlers: Option<FxIndexMap<RcStr, RcStr>>,
     cache_life: Option<FxIndexMap<String, CacheLifeProfile>>,
     case_sensitive_routes: Option<bool>,
     cpus: Option<f64>,
@@ -1170,7 +1170,7 @@ impl NextConfig {
             self.experimental
                 .cache_handlers
                 .as_ref()
-                .map(|handlers| handlers.keys().map(|kind| RcStr::from(&**kind)).collect())
+                .map(|handlers| handlers.keys().cloned().collect())
                 .unwrap_or_default(),
         )
     }

--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -54,12 +54,7 @@ pub async fn get_next_server_transforms_rules(
         ));
     }
 
-    let dynamic_io_enabled = next_config
-        .experimental()
-        .await?
-        .dynamic_io
-        .unwrap_or(false);
-
+    let dynamic_io_enabled = *next_config.enable_dynamic_io().await?;
     let mut is_app_dir = false;
 
     let is_server_components = match context_ty {

--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -55,6 +55,7 @@ pub async fn get_next_server_transforms_rules(
     }
 
     let dynamic_io_enabled = *next_config.enable_dynamic_io().await?;
+    let cache_kinds = next_config.cache_kinds().to_resolved().await?;
     let mut is_app_dir = false;
 
     let is_server_components = match context_ty {
@@ -91,6 +92,7 @@ pub async fn get_next_server_transforms_rules(
                 ActionsTransform::Client,
                 mdx_rs,
                 dynamic_io_enabled,
+                cache_kinds,
             ));
 
             is_app_dir = true;
@@ -102,6 +104,7 @@ pub async fn get_next_server_transforms_rules(
                 ActionsTransform::Server,
                 mdx_rs,
                 dynamic_io_enabled,
+                cache_kinds,
             ));
 
             is_app_dir = true;
@@ -113,6 +116,7 @@ pub async fn get_next_server_transforms_rules(
                 ActionsTransform::Server,
                 mdx_rs,
                 dynamic_io_enabled,
+                cache_kinds,
             ));
 
             is_app_dir = true;

--- a/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
+++ b/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
@@ -34,11 +34,7 @@ pub async fn get_next_react_server_components_transform_rule(
     app_dir: Option<Vc<FileSystemPath>>,
 ) -> Result<ModuleRule> {
     let enable_mdx_rs = next_config.mdx_rs().await?.is_some();
-    let dynamic_io_enabled = next_config
-        .experimental()
-        .await?
-        .dynamic_io
-        .unwrap_or(false);
+    let dynamic_io_enabled = *next_config.enable_dynamic_io().await?;
     Ok(get_ecma_transform_rule(
         Box::new(NextJsReactServerComponents::new(
             is_react_server_layer,

--- a/crates/next-core/src/next_shared/transforms/server_actions.rs
+++ b/crates/next-core/src/next_shared/transforms/server_actions.rs
@@ -7,6 +7,7 @@ use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 
 use super::module_rule_match_js_no_url;
+use crate::next_config::CacheKinds;
 
 #[derive(Debug)]
 pub enum ActionsTransform {
@@ -19,11 +20,13 @@ pub fn get_server_actions_transform_rule(
     transform: ActionsTransform,
     enable_mdx_rs: bool,
     dynamic_io_enabled: bool,
+    cache_kinds: ResolvedVc<CacheKinds>,
 ) -> ModuleRule {
     let transformer =
         EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(NextServerActions {
             transform,
             dynamic_io_enabled,
+            cache_kinds,
         }) as _));
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
@@ -38,6 +41,7 @@ pub fn get_server_actions_transform_rule(
 struct NextServerActions {
     transform: ActionsTransform,
     dynamic_io_enabled: bool,
+    cache_kinds: ResolvedVc<CacheKinds>,
 }
 
 #[async_trait]
@@ -50,6 +54,7 @@ impl CustomTransformer for NextServerActions {
                 is_react_server_layer: matches!(self.transform, ActionsTransform::Server),
                 dynamic_io_enabled: self.dynamic_io_enabled,
                 hash_salt: "".into(),
+                cache_kinds: self.cache_kinds.await?.clone_value(),
             },
             ctx.comments.clone(),
         );

--- a/crates/next-custom-transforms/Cargo.toml
+++ b/crates/next-custom-transforms/Cargo.toml
@@ -56,6 +56,7 @@ styled_jsx = { workspace = true }
 swc_emotion = { workspace = true }
 swc_relay = { workspace = true }
 turbopack-ecmascript-plugins = { workspace = true, optional = true }
+turbo-rcstr = { workspace = true }
 
 react_remove_properties = "0.24.25"
 remove_console = "0.25.25"

--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -2938,7 +2938,7 @@ fn emit_error(error_kind: ServerActionsErrorKind) {
             span,
             formatdoc! {
                 r#"
-                    Unknown cache kind "{cache_kind}". Please configure a cache handler for this kind in the experimental "cacheHandlers" object in your Next.js config.
+                    Unknown cache kind "{cache_kind}". Please configure a cache handler for this kind in the "experimental.cacheHandlers" object in your Next.js config.
                 "#
             },
         ),

--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -23,6 +23,7 @@ use swc_core::{
         visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith},
     },
 };
+use turbo_rcstr::RcStr;
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
@@ -30,7 +31,7 @@ pub struct Config {
     pub is_react_server_layer: bool,
     pub dynamic_io_enabled: bool,
     pub hash_salt: String,
-    pub cache_kinds: FxHashSet<String>,
+    pub cache_kinds: FxHashSet<RcStr>,
 }
 
 enum DirectiveLocation {
@@ -69,7 +70,7 @@ enum ServerActionsErrorKind {
     },
     UnknownCacheKind {
         span: Span,
-        cache_kind: String,
+        cache_kind: RcStr,
     },
     UseCacheWithoutDynamicIO {
         span: Span,
@@ -84,6 +85,12 @@ enum ServerActionsErrorKind {
 /// A mapping of hashed action id to the action's exported function name.
 // Using BTreeMap to ensure the order of the actions is deterministic.
 pub type ActionsMap = BTreeMap<String, String>;
+
+// Directive-level information about a function body
+struct BodyInfo {
+    is_action_fn: bool,
+    cache_kind: Option<RcStr>,
+}
 
 #[tracing::instrument(level = tracing::Level::TRACE, skip_all)]
 pub fn server_actions<C: Comments>(file_name: &FileName, config: Config, comments: C) -> impl Pass {
@@ -143,7 +150,7 @@ struct ServerActions<C: Comments> {
 
     start_pos: BytePos,
     in_action_file: bool,
-    file_cache_kind: Option<String>,
+    file_cache_kind: Option<RcStr>,
     in_exported_expr: bool,
     in_default_export_decl: bool,
     in_callee: bool,
@@ -302,7 +309,7 @@ impl<C: Comments> ServerActions<C> {
     }
 
     // Check if the function or arrow function is an action or cache function
-    fn get_body_info(&mut self, maybe_body: Option<&mut BlockStmt>) -> (bool, Option<String>) {
+    fn get_body_info(&mut self, maybe_body: Option<&mut BlockStmt>) -> BodyInfo {
         let mut is_action_fn = false;
         let mut cache_kind = None;
 
@@ -346,7 +353,10 @@ impl<C: Comments> ServerActions<C> {
             }
         }
 
-        (is_action_fn, cache_kind)
+        BodyInfo {
+            is_action_fn,
+            cache_kind,
+        }
     }
 
     fn maybe_hoist_and_create_proxy_for_server_action_arrow_expr(
@@ -887,7 +897,10 @@ impl<C: Comments> VisitMut for ServerActions<C> {
     }
 
     fn visit_mut_fn_expr(&mut self, f: &mut FnExpr) {
-        let (is_action_fn, cache_kind) = self.get_body_info(f.function.body.as_mut());
+        let BodyInfo {
+            is_action_fn,
+            cache_kind,
+        } = self.get_body_info(f.function.body.as_mut());
 
         let declared_idents_until = self.declared_idents.len();
         let current_names = take(&mut self.names);
@@ -1002,7 +1015,10 @@ impl<C: Comments> VisitMut for ServerActions<C> {
             self.in_exported_expr = true
         }
 
-        let (is_action_fn, cache_kind) = self.get_body_info(f.function.body.as_mut());
+        let BodyInfo {
+            is_action_fn,
+            cache_kind,
+        } = self.get_body_info(f.function.body.as_mut());
 
         let declared_idents_until = self.declared_idents.len();
         let current_names = take(&mut self.names);
@@ -1142,12 +1158,14 @@ impl<C: Comments> VisitMut for ServerActions<C> {
     fn visit_mut_arrow_expr(&mut self, a: &mut ArrowExpr) {
         // Arrow expressions need to be visited in prepass to determine if it's
         // an action function or not.
-        let (is_action_fn, cache_kind) =
-            self.get_body_info(if let BlockStmtOrExpr::BlockStmt(block) = &mut *a.body {
-                Some(block)
-            } else {
-                None
-            });
+        let BodyInfo {
+            is_action_fn,
+            cache_kind,
+        } = self.get_body_info(if let BlockStmtOrExpr::BlockStmt(block) = &mut *a.body {
+            Some(block)
+        } else {
+            None
+        });
 
         let declared_idents_until = self.declared_idents.len();
         let current_names = take(&mut self.names);
@@ -2352,7 +2370,7 @@ fn detect_similar_strings(a: &str, b: &str) -> bool {
 fn remove_server_directive_index_in_module(
     stmts: &mut Vec<ModuleItem>,
     in_action_file: &mut bool,
-    file_cache_kind: &mut Option<String>,
+    file_cache_kind: &mut Option<RcStr>,
     has_action: &mut bool,
     has_cache: &mut bool,
     config: &Config,
@@ -2392,8 +2410,7 @@ fn remove_server_directive_index_in_module(
                             *file_cache_kind = Some("default".into());
                         } else {
                             // Slice the value after "use cache: "
-                            let cache_kind_str: String =
-                                value.split_at("use cache: ".len()).1.into();
+                            let cache_kind_str = RcStr::from(value.split_at("use cache: ".len()).1);
 
                             if !config.cache_kinds.contains(&cache_kind_str) {
                                 emit_error(ServerActionsErrorKind::UnknownCacheKind {
@@ -2503,7 +2520,7 @@ fn has_body_directive(maybe_body: &Option<BlockStmt>) -> (bool, bool) {
 fn remove_server_directive_index_in_fn(
     stmts: &mut Vec<Stmt>,
     is_action_fn: &mut bool,
-    cache_kind: &mut Option<String>,
+    cache_kind: &mut Option<RcStr>,
     action_span: &mut Option<Span>,
     config: &Config,
 ) {
@@ -2548,7 +2565,7 @@ fn remove_server_directive_index_in_fn(
                         *cache_kind = Some("default".into());
                     } else {
                         // Slice the value after "use cache: "
-                        let cache_kind_str: String = value.split_at("use cache: ".len()).1.into();
+                        let cache_kind_str = RcStr::from(value.split_at("use cache: ".len()).1);
 
                         if !config.cache_kinds.contains(&cache_kind_str) {
                             emit_error(ServerActionsErrorKind::UnknownCacheKind {

--- a/crates/next-custom-transforms/tests/errors.rs
+++ b/crates/next-custom-transforms/tests/errors.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{iter::FromIterator, path::PathBuf};
 
 use next_custom_transforms::transforms::{
     disallow_re_export_all_in_page::disallow_re_export_all_in_page,
@@ -11,6 +11,7 @@ use next_custom_transforms::transforms::{
     },
     strip_page_exports::{next_transform_strip_page_exports, ExportFilter},
 };
+use rustc_hash::FxHashSet;
 use swc_core::{
     common::{FileName, Mark},
     ecma::{
@@ -187,6 +188,7 @@ fn react_server_actions_server_errors(input: PathBuf) {
                         is_react_server_layer: true,
                         dynamic_io_enabled: true,
                         hash_salt: "".into(),
+                        cache_kinds: FxHashSet::default(),
                     },
                     tr.comments.as_ref().clone(),
                 ),
@@ -226,6 +228,7 @@ fn react_server_actions_client_errors(input: PathBuf) {
                         is_react_server_layer: false,
                         dynamic_io_enabled: true,
                         hash_salt: "".into(),
+                        cache_kinds: FxHashSet::default(),
                     },
                     tr.comments.as_ref().clone(),
                 ),
@@ -283,6 +286,7 @@ fn use_cache_not_allowed(input: PathBuf) {
                         is_react_server_layer: true,
                         dynamic_io_enabled: false,
                         hash_salt: "".into(),
+                        cache_kinds: FxHashSet::from_iter(["x".into()]),
                     },
                     tr.comments.as_ref().clone(),
                 ),

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/16/input.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/16/input.js
@@ -1,0 +1,5 @@
+'use cache: x'
+
+export async function foo() {
+  return 'data'
+}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/16/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/16/output.js
@@ -1,0 +1,11 @@
+/* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
+export var $$RSC_SERVER_CACHE_0 = $$cache__("x", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function foo() {
+    return 'data';
+});
+Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+    "value": "foo",
+    "writable": false
+});
+export var foo = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/16/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/16/output.stderr
@@ -1,0 +1,6 @@
+  x Unknown cache kind "x". Please configure a cache handler for this kind in the experimental "cacheHandlers" object in your Next.js config.
+  | 
+   ,-[input.js:1:1]
+ 1 | 'use cache: x'
+   : ^^^^^^^^^^^^^^
+   `----

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/16/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/16/output.stderr
@@ -1,4 +1,4 @@
-  x Unknown cache kind "x". Please configure a cache handler for this kind in the experimental "cacheHandlers" object in your Next.js config.
+  x Unknown cache kind "x". Please configure a cache handler for this kind in the "experimental.cacheHandlers" object in your Next.js config.
   | 
    ,-[input.js:1:1]
  1 | 'use cache: x'

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/17/input.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/17/input.js
@@ -1,0 +1,5 @@
+export async function foo() {
+  'use cache: x'
+
+  return 'data'
+}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/17/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/17/output.js
@@ -1,0 +1,11 @@
+/* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
+export var $$RSC_SERVER_CACHE_0 = $$cache__("x", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function foo() {
+    return 'data';
+});
+Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+    "value": "foo",
+    "writable": false
+});
+export var foo = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/17/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/17/output.stderr
@@ -1,0 +1,7 @@
+  x Unknown cache kind "x". Please configure a cache handler for this kind in the experimental "cacheHandlers" object in your Next.js config.
+  | 
+   ,-[input.js:2:1]
+ 1 | export async function foo() {
+ 2 |   'use cache: x'
+   :   ^^^^^^^^^^^^^^
+   `----

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/17/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/17/output.stderr
@@ -1,4 +1,4 @@
-  x Unknown cache kind "x". Please configure a cache handler for this kind in the experimental "cacheHandlers" object in your Next.js config.
+  x Unknown cache kind "x". Please configure a cache handler for this kind in the "experimental.cacheHandlers" object in your Next.js config.
   | 
    ,-[input.js:2:1]
  1 | export async function foo() {

--- a/crates/next-custom-transforms/tests/fixture.rs
+++ b/crates/next-custom-transforms/tests/fixture.rs
@@ -1,5 +1,6 @@
 use std::{
     env::current_dir,
+    iter::FromIterator,
     path::{Path, PathBuf},
 };
 
@@ -21,6 +22,7 @@ use next_custom_transforms::transforms::{
     strip_page_exports::{next_transform_strip_page_exports, ExportFilter},
     warn_for_edge_runtime::warn_for_edge_runtime,
 };
+use rustc_hash::FxHashSet;
 use serde::de::DeserializeOwned;
 use swc_core::{
     common::{comments::SingleThreadedComments, FileName, Mark, SyntaxContext},
@@ -416,6 +418,7 @@ fn server_actions_server_fixture(input: PathBuf) {
                         is_react_server_layer: true,
                         dynamic_io_enabled: true,
                         hash_salt: "".into(),
+                        cache_kinds: FxHashSet::from_iter(["x".into()]),
                     },
                     _tr.comments.as_ref().clone(),
                 ),
@@ -448,6 +451,7 @@ fn next_font_with_directive_fixture(input: PathBuf) {
                         is_react_server_layer: true,
                         dynamic_io_enabled: true,
                         hash_salt: "".into(),
+                        cache_kinds: FxHashSet::default(),
                     },
                     _tr.comments.as_ref().clone(),
                 ),
@@ -473,6 +477,7 @@ fn server_actions_client_fixture(input: PathBuf) {
                         is_react_server_layer: false,
                         dynamic_io_enabled: true,
                         hash_salt: "".into(),
+                        cache_kinds: FxHashSet::default(),
                     },
                     _tr.comments.as_ref().clone(),
                 ),

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -65,6 +65,7 @@ function getBaseSWCOptions({
   serverReferenceHashSalt,
   bundleLayer,
   isDynamicIo,
+  cacheHandlers,
 }: {
   filename: string
   jest?: boolean
@@ -82,6 +83,7 @@ function getBaseSWCOptions({
   serverReferenceHashSalt: string
   bundleLayer?: WebpackLayerName
   isDynamicIo?: boolean
+  cacheHandlers?: ExperimentalConfig['cacheHandlers']
 }) {
   const isReactServerLayer = isWebpackServerOnlyLayer(bundleLayer)
   const isAppRouterPagesLayer = isWebpackAppPagesLayer(bundleLayer)
@@ -211,6 +213,7 @@ function getBaseSWCOptions({
             isReactServerLayer,
             dynamicIoEnabled: isDynamicIo,
             hashSalt: serverReferenceHashSalt,
+            cacheKinds: cacheHandlers ? Object.keys(cacheHandlers) : [],
           }
         : undefined,
     // For app router we prefer to bundle ESM,
@@ -355,6 +358,7 @@ export function getLoaderSWCOptions({
   serverReferenceHashSalt,
   bundleLayer,
   esm,
+  cacheHandlers,
 }: {
   filename: string
   development: boolean
@@ -379,6 +383,7 @@ export function getLoaderSWCOptions({
   serverComponents?: boolean
   serverReferenceHashSalt: string
   bundleLayer?: WebpackLayerName
+  cacheHandlers: ExperimentalConfig['cacheHandlers']
 }) {
   let baseOptions: any = getBaseSWCOptions({
     filename,
@@ -396,6 +401,7 @@ export function getLoaderSWCOptions({
     serverReferenceHashSalt,
     esm: !!esm,
     isDynamicIo,
+    cacheHandlers,
   })
   baseOptions.fontLoaders = {
     fontLoaders: ['next/font/local', 'next/font/google'],

--- a/packages/next/src/build/webpack/loaders/next-swc-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-swc-loader.ts
@@ -142,6 +142,7 @@ async function loaderTransform(
     serverReferenceHashSalt,
     bundleLayer,
     esm,
+    cacheHandlers: nextConfig.experimental?.cacheHandlers,
   })
 
   const programmaticOptions = {

--- a/test/e2e/app-dir/use-cache-unknown-cache-kind/app/layout.tsx
+++ b/test/e2e/app-dir/use-cache-unknown-cache-kind/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/use-cache-unknown-cache-kind/app/page.tsx
+++ b/test/e2e/app-dir/use-cache-unknown-cache-kind/app/page.tsx
@@ -1,0 +1,5 @@
+'use cache: custom'
+
+export default async function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/use-cache-unknown-cache-kind/next.config.js
+++ b/test/e2e/app-dir/use-cache-unknown-cache-kind/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    dynamicIO: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
+++ b/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
@@ -1,0 +1,155 @@
+import { nextTestSetup } from 'e2e-utils'
+import { NextConfig } from 'next'
+import {
+  assertHasRedbox,
+  assertNoRedbox,
+  getRedboxDescription,
+  getRedboxSource,
+  retry,
+} from 'next-test-utils'
+import stripAnsi from 'strip-ansi'
+
+const nextConfigWithCacheHandler: NextConfig = {
+  experimental: {
+    dynamicIO: true,
+    cacheHandlers: {
+      custom: require.resolve('next/dist/server/lib/cache-handlers/default'),
+    },
+  },
+}
+
+describe('use-cache-unknown-cache-kind', () => {
+  const { next, isNextStart, isTurbopack, skipped } = nextTestSetup({
+    files: __dirname,
+    skipStart: process.env.NEXT_TEST_MODE !== 'dev',
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  if (isNextStart) {
+    it('should fail the build with an error', async () => {
+      const { cliOutput } = await next.build()
+      const buildOutput = getBuildOutput(cliOutput)
+
+      if (isTurbopack) {
+        expect(buildOutput).toMatchInlineSnapshot(`
+          "Error: Turbopack build failed with 1 errors:
+          Page: {"type":"app","side":"server","page":"/page"}
+          ./app/page.tsx:1:1
+          Ecmascript file had an error
+          > 1 | 'use cache: custom'
+              | ^^^^^^^^^^^^^^^^^^^
+            2 |
+            3 | export default async function Page() {
+            4 |   return <p>hello world</p>
+
+          Unknown cache kind "custom". Please configure a cache handler for this kind in the experimental "cacheHandlers" object in your Next.js config.
+
+
+
+              at <unknown> (./app/page.tsx:1:1)"
+        `)
+      } else {
+        expect(buildOutput).toMatchInlineSnapshot(`
+          "
+          ./app/page.tsx
+          Error:   x Unknown cache kind "custom". Please configure a cache handler for this kind in the experimental "cacheHandlers" object in your Next.js config.
+            | 
+             ,-[1:1]
+           1 | 'use cache: custom'
+             : ^^^^^^^^^^^^^^^^^^^
+           2 | 
+           3 | export default async function Page() {
+           4 |   return <p>hello world</p>
+             \`----
+
+          Import trace for requested module:
+          ./app/page.tsx
+
+
+          > Build failed because of webpack errors
+          "
+        `)
+      }
+    })
+  } else {
+    it('should show a build error', async () => {
+      const browser = await next.browser('/')
+
+      await assertHasRedbox(browser)
+
+      const errorDescription = await getRedboxDescription(browser)
+      const errorSource = await getRedboxSource(browser)
+
+      expect(errorDescription).toBe('Failed to compile')
+
+      if (isTurbopack) {
+        expect(errorSource).toMatchInlineSnapshot(`
+            "./app/page.tsx:1:1
+            Ecmascript file had an error
+            > 1 | 'use cache: custom'
+                | ^^^^^^^^^^^^^^^^^^^
+              2 |
+              3 | export default async function Page() {
+              4 |   return <p>hello world</p>
+
+            Unknown cache kind "custom". Please configure a cache handler for this kind in the experimental "cacheHandlers" object in your Next.js config."
+          `)
+      } else {
+        expect(errorSource).toMatchInlineSnapshot(`
+            "./app/page.tsx
+            Error:   x Unknown cache kind "custom". Please configure a cache handler for this kind in the experimental "cacheHandlers" object in your Next.js config.
+              | 
+               ,-[1:1]
+             1 | 'use cache: custom'
+               : ^^^^^^^^^^^^^^^^^^^
+             2 | 
+             3 | export default async function Page() {
+             4 |   return <p>hello world</p>
+               \`----"
+          `)
+      }
+    })
+
+    it('should recover from the build error if the cache handler is defined', async () => {
+      const browser = await next.browser('/')
+
+      await assertHasRedbox(browser)
+
+      await next.patchFile(
+        'next.config.js',
+        `module.exports = ${JSON.stringify(nextConfigWithCacheHandler)}`,
+        () =>
+          retry(async () => {
+            expect(await browser.elementByCss('p').text()).toBe('hello world')
+            await assertNoRedbox(browser)
+          })
+      )
+    })
+  }
+})
+
+function getBuildOutput(cliOutput: string): string {
+  const lines: string[] = []
+  let skipLines = true
+
+  for (const line of cliOutput.split('\n')) {
+    if (!skipLines) {
+      if (line.includes('at turbopackBuild')) {
+        break
+      }
+
+      lines.push(stripAnsi(line))
+    } else if (
+      line.includes('Build error occurred') ||
+      line.includes('Failed to compile')
+    ) {
+      skipLines = false
+    }
+  }
+
+  return lines.join('\n')
+}

--- a/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
+++ b/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
@@ -46,7 +46,7 @@ describe('use-cache-unknown-cache-kind', () => {
             3 | export default async function Page() {
             4 |   return <p>hello world</p>
 
-          Unknown cache kind "custom". Please configure a cache handler for this kind in the experimental "cacheHandlers" object in your Next.js config.
+          Unknown cache kind "custom". Please configure a cache handler for this kind in the "experimental.cacheHandlers" object in your Next.js config.
 
 
 
@@ -56,7 +56,7 @@ describe('use-cache-unknown-cache-kind', () => {
         expect(buildOutput).toMatchInlineSnapshot(`
           "
           ./app/page.tsx
-          Error:   x Unknown cache kind "custom". Please configure a cache handler for this kind in the experimental "cacheHandlers" object in your Next.js config.
+          Error:   x Unknown cache kind "custom". Please configure a cache handler for this kind in the "experimental.cacheHandlers" object in your Next.js config.
             | 
              ,-[1:1]
            1 | 'use cache: custom'
@@ -96,12 +96,12 @@ describe('use-cache-unknown-cache-kind', () => {
               3 | export default async function Page() {
               4 |   return <p>hello world</p>
 
-            Unknown cache kind "custom". Please configure a cache handler for this kind in the experimental "cacheHandlers" object in your Next.js config."
+            Unknown cache kind "custom". Please configure a cache handler for this kind in the "experimental.cacheHandlers" object in your Next.js config."
           `)
       } else {
         expect(errorSource).toMatchInlineSnapshot(`
             "./app/page.tsx
-            Error:   x Unknown cache kind "custom". Please configure a cache handler for this kind in the experimental "cacheHandlers" object in your Next.js config.
+            Error:   x Unknown cache kind "custom". Please configure a cache handler for this kind in the "experimental.cacheHandlers" object in your Next.js config.
               | 
                ,-[1:1]
              1 | 'use cache: custom'


### PR DESCRIPTION
When a `"use cache"` directive with a custom cache kind is used, e.g. `"use cache: custom"`, a cache handler with the same name must be specified in the Next.js config:

```js
/**
 * @type {import('next').NextConfig}
 */
const nextConfig = {
  experimental: {
    dynamicIO: true,
    cacheHandlers: {
      custom: require.resolve('path/to/custom/cache/handler'),
    },
  },
}

module.exports = nextConfig
```

If this is not the case, we emit a build error with an error message that explains this requirement.

<img width="795" alt="Screenshot 2024-11-14 at 23 30 01" src="https://github.com/user-attachments/assets/bd138c97-608f-42ce-abb2-edb3e44edc3f">

When we'll get a docs page for this experimental config, we will add the usual "Read more: ..." hint as well.