### PR TITLE
refactor(turbopack): Cleanup tree shaking graph logic

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -398,24 +398,24 @@ impl DepGraph {
             let mut use_export_instead_of_declarator = false;
 
             for item in group {
-                match item {
-                    ItemId::Group(ItemIdGroupKind::Export(..)) => {
-                        if let Some(export) = &data[item].export {
-                            use_export_instead_of_declarator = true;
-                            exports.insert(Key::Export(export.as_str().into()), ix as u32);
+                if let ItemId::Group(ItemIdGroupKind::Export(..)) = item {
+                    if let Some(export) = &data[item].export {
+                        use_export_instead_of_declarator = true;
 
-                            let s = ExportSpecifier::Named(ExportNamedSpecifier {
-                                span: DUMMY_SP,
-                                orig: ModuleExportName::Ident(Ident::new(
-                                    export.clone(),
-                                    DUMMY_SP,
-                                    Default::default(),
-                                )),
-                                exported: None,
-                                is_type_only: false,
-                            });
-                            exports_module.body.push(ModuleItem::ModuleDecl(
-                                ModuleDecl::ExportNamed(NamedExport {
+                        let s = ExportSpecifier::Named(ExportNamedSpecifier {
+                            span: DUMMY_SP,
+                            orig: ModuleExportName::Ident(Ident::new(
+                                export.clone(),
+                                DUMMY_SP,
+                                Default::default(),
+                            )),
+                            exported: None,
+                            is_type_only: false,
+                        });
+                        exports_module
+                            .body
+                            .push(ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(
+                                NamedExport {
                                     span: DUMMY_SP,
                                     specifiers: vec![s],
                                     src: Some(Box::new(TURBOPACK_PART_IMPORT_SOURCE.into())),
@@ -423,15 +423,9 @@ impl DepGraph {
                                     with: Some(Box::new(create_turbopack_part_id_assert(
                                         PartId::Export(export.as_str().into()),
                                     ))),
-                                }),
-                            ));
-                        }
+                                },
+                            )));
                     }
-                    ItemId::Group(ItemIdGroupKind::ModuleEvaluation) => {
-                        exports.insert(Key::ModuleEvaluation, ix as u32);
-                    }
-
-                    _ => {}
                 }
             }
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -261,7 +261,7 @@ impl DepGraph {
         data: &FxHashMap<ItemId, ItemData>,
     ) -> SplitModuleResult {
         let groups = self.finalize(data);
-        let mut exports = FxHashMap::default();
+        let mut outputs = FxHashMap::default();
         let mut part_deps = FxHashMap::<_, Vec<PartId>>::default();
 
         let star_reexports: Vec<_> = data
@@ -280,7 +280,22 @@ impl DepGraph {
                 body: data.values().map(|v| v.content.clone()).collect(),
                 shebang: None,
             });
-            exports.insert(Key::ModuleEvaluation, 0);
+            outputs.insert(Key::ModuleEvaluation, 0);
+        }
+
+        for (ix, group) in groups.graph_ix.iter().enumerate() {
+            for id in group {
+                match id {
+                    ItemId::Group(ItemIdGroupKind::Export(_, export)) => {
+                        outputs.insert(Key::Export(export.as_str().into()), ix as u32);
+                    }
+                    ItemId::Group(ItemIdGroupKind::ModuleEvaluation) => {
+                        outputs.insert(Key::ModuleEvaluation, ix as u32);
+                    }
+
+                    _ => {}
+                }
+            }
         }
 
         // See https://github.com/vercel/next.js/pull/71234#issuecomment-2409810084
@@ -288,7 +303,6 @@ impl DepGraph {
         // side effects.
         let mut importer = FxHashMap::default();
         let mut declarator = FxHashMap::default();
-        let mut exporter = FxHashMap::default();
 
         for (ix, group) in groups.graph_ix.iter().enumerate() {
             for id in group {
@@ -296,10 +310,6 @@ impl DepGraph {
 
                 for var in item.var_decls.iter() {
                     declarator.entry(var.clone()).or_insert_with(|| ix as u32);
-                }
-
-                if let Some(export) = &item.export {
-                    exporter.insert(export.clone(), ix as u32);
                 }
 
                 if let ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
@@ -345,12 +355,6 @@ impl DepGraph {
                 })
                 .collect::<FxIndexSet<_>>();
 
-            for item in group {
-                if let ItemId::Group(ItemIdGroupKind::Export(id, _)) = item {
-                    required_vars.insert(id);
-                }
-            }
-
             for id in group {
                 let data = data.get(id).unwrap();
 
@@ -367,7 +371,7 @@ impl DepGraph {
                 {
                     if !specifiers.is_empty() {
                         if let Some(dep) = importer.get(&src.value) {
-                            if *dep != ix as u32 {
+                            if *dep != ix as u32 && part_deps_done.insert(*dep) {
                                 part_deps
                                     .entry(ix as u32)
                                     .or_default()
@@ -699,7 +703,7 @@ impl DepGraph {
             modules.push(chunk);
         }
 
-        exports.insert(Key::Exports, modules.len() as u32);
+        outputs.insert(Key::Exports, modules.len() as u32);
 
         for star in &star_reexports {
             exports_module
@@ -710,7 +714,7 @@ impl DepGraph {
         modules.push(exports_module);
 
         SplitModuleResult {
-            entrypoints: exports,
+            entrypoints: outputs,
             part_deps,
             modules,
             star_reexports,

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/1/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/1/output.md
@@ -461,9 +461,6 @@ import "module";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
 import { upper } from "module";
 export { upper as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -722,9 +719,6 @@ import "module";
 ```
 ## Part 6
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/2/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/2/output.md
@@ -498,9 +498,6 @@ import "module";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { upper } from "module";
 export { upper as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -765,9 +762,6 @@ import "module";
 ```
 ## Part 7
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/amphtml-document/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/amphtml-document/output.md
@@ -350,9 +350,6 @@ import "react/jsx-runtime";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { jsx as _jsx } from "react/jsx-runtime";
 export { _jsx as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -364,9 +361,6 @@ export { _jsx as b } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { jsxs as _jsxs } from "react/jsx-runtime";
 export { _jsxs as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -375,9 +369,6 @@ export { _jsxs as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 5
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
@@ -400,9 +391,6 @@ import 'next/document';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import Document from 'next/document';
 export { Document as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -411,9 +399,6 @@ export { Document as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
@@ -428,9 +413,6 @@ export { Html as f } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { Head } from 'next/document';
 export { Head as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -442,9 +424,6 @@ export { Head as g } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { Main } from 'next/document';
 export { Main as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -453,9 +432,6 @@ export { Main as h } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 11
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
@@ -597,9 +573,6 @@ import "react/jsx-runtime";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { jsx as _jsx } from "react/jsx-runtime";
 export { _jsx as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -611,9 +584,6 @@ export { _jsx as b } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { jsxs as _jsxs } from "react/jsx-runtime";
 export { _jsxs as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -622,9 +592,6 @@ export { _jsxs as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 5
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
@@ -647,9 +614,6 @@ import 'next/document';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import Document from 'next/document';
 export { Document as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -658,9 +622,6 @@ export { Document as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
@@ -675,9 +636,6 @@ export { Html as f } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { Head } from 'next/document';
 export { Head as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -689,9 +647,6 @@ export { Head as g } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { Main } from 'next/document';
 export { Main as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -700,9 +655,6 @@ export { Main as h } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 11
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/app-route/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/app-route/output.md
@@ -463,9 +463,6 @@ import '../../server/future/route-modules/app-route/module.compiled';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 7
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
 import { AppRouteRouteModule } from '../../server/future/route-modules/app-route/module.compiled';
 export { AppRouteRouteModule as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -482,9 +479,6 @@ import '../../server/future/route-kind';
 ```
 ## Part 10
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
@@ -507,9 +501,6 @@ import '../../server/lib/patch-fetch';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 11
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
-};
 import { patchFetch as _patchFetch } from '../../server/lib/patch-fetch';
 export { _patchFetch as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -526,9 +517,6 @@ import 'VAR_USERLAND';
 ```
 ## Part 14
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
@@ -754,9 +742,6 @@ import '../../server/future/route-modules/app-route/module.compiled';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 7
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
 import { AppRouteRouteModule } from '../../server/future/route-modules/app-route/module.compiled';
 export { AppRouteRouteModule as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -773,9 +758,6 @@ import '../../server/future/route-kind';
 ```
 ## Part 10
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
@@ -798,9 +780,6 @@ import '../../server/lib/patch-fetch';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 11
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
-};
 import { patchFetch as _patchFetch } from '../../server/lib/patch-fetch';
 export { _patchFetch as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -817,9 +796,6 @@ import 'VAR_USERLAND';
 ```
 ## Part 14
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/dce/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/dce/output.md
@@ -123,9 +123,6 @@ import './module';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
 import { baz } from './module';
 export { baz as a } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -181,9 +178,6 @@ import './module';
 ```
 ## Part 2
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/export-named/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/export-named/output.md
@@ -117,9 +117,6 @@ import "./lib";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { cat as __TURBOPACK__reexport__cat__ } from "./lib";
 export { __TURBOPACK__reexport__cat__ as a } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -178,9 +175,6 @@ import "./lib";
 ```
 ## Part 3
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-2/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-2/output.md
@@ -732,9 +732,6 @@ import 'react';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
-};
 import React from 'react';
 export { React as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -751,9 +748,6 @@ import '../../client/components/hooks-server-context';
 ```
 ## Part 12
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 11
 };
@@ -776,9 +770,6 @@ import '../../client/components/static-generation-bailout';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
-};
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout';
 export { StaticGenBailoutError as k } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -795,9 +786,6 @@ import '../../lib/url';
 ```
 ## Part 16
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 15
 };
@@ -1182,9 +1170,6 @@ import 'react';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
-};
 import React from 'react';
 export { React as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1201,9 +1186,6 @@ import '../../client/components/hooks-server-context';
 ```
 ## Part 12
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 11
 };
@@ -1226,9 +1208,6 @@ import '../../client/components/static-generation-bailout';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
-};
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout';
 export { StaticGenBailoutError as k } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1245,9 +1224,6 @@ import '../../lib/url';
 ```
 ## Part 16
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 15
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-3/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-3/output.md
@@ -1104,9 +1104,6 @@ import "node:net";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
-};
 import { createConnection } from "node:net";
 export { createConnection as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1126,9 +1123,6 @@ import "../compiled/stacktrace-parser";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
 import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
 export { parseStackTrace as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1145,9 +1139,6 @@ import "./error";
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 7
 };
@@ -1509,9 +1500,6 @@ import "node:net";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
-};
 import { createConnection } from "node:net";
 export { createConnection as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1531,9 +1519,6 @@ import "../compiled/stacktrace-parser";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
 import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
 export { parseStackTrace as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1550,9 +1535,6 @@ import "./error";
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 7
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/ipc-evaluate/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/ipc-evaluate/output.md
@@ -267,9 +267,6 @@ import "./index";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { IPC } from "./index";
 export { IPC as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -441,9 +438,6 @@ import "./index";
 ```
 ## Part 3
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/ipc-index/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/ipc-index/output.md
@@ -1104,9 +1104,6 @@ import "node:net";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
-};
 import { createConnection } from "node:net";
 export { createConnection as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1126,9 +1123,6 @@ import "../compiled/stacktrace-parser";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
 import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
 export { parseStackTrace as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1145,9 +1139,6 @@ import "./error";
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 7
 };
@@ -1509,9 +1500,6 @@ import "node:net";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
-};
 import { createConnection } from "node:net";
 export { createConnection as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1531,9 +1519,6 @@ import "../compiled/stacktrace-parser";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
 import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
 export { parseStackTrace as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1550,9 +1535,6 @@ import "./error";
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 7
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/mui-sys/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/mui-sys/output.md
@@ -1208,9 +1208,6 @@ import './style';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
 import style from './style';
 export { style as n } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1227,9 +1224,6 @@ import './compose';
 ```
 ## Part 17
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
@@ -1252,9 +1246,6 @@ import './spacing';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
-};
 import { createUnaryUnit } from './spacing';
 export { createUnaryUnit as p } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1263,9 +1254,6 @@ export { createUnaryUnit as p } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 20
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
@@ -1288,9 +1276,6 @@ import './breakpoints';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 21
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
-};
 import { handleBreakpoints } from './breakpoints';
 export { handleBreakpoints as r } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1307,9 +1292,6 @@ import './responsivePropType';
 ```
 ## Part 24
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 23
 };
@@ -1942,9 +1924,6 @@ import './style';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
 import style from './style';
 export { style as n } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1961,9 +1940,6 @@ import './compose';
 ```
 ## Part 17
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
@@ -1986,9 +1962,6 @@ import './spacing';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
-};
 import { createUnaryUnit } from './spacing';
 export { createUnaryUnit as p } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1997,9 +1970,6 @@ export { createUnaryUnit as p } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 20
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
@@ -2022,9 +1992,6 @@ import './breakpoints';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 21
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
-};
 import { handleBreakpoints } from './breakpoints';
 export { handleBreakpoints as r } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -2041,9 +2008,6 @@ import './responsivePropType';
 ```
 ## Part 24
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 23
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nanoid/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nanoid/output.md
@@ -479,9 +479,6 @@ import 'crypto';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import crypto from 'crypto';
 export { crypto as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -498,9 +495,6 @@ import './url-alphabet/index.js';
 ```
 ## Part 9
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
@@ -766,9 +760,6 @@ import 'crypto';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import crypto from 'crypto';
 export { crypto as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -785,9 +776,6 @@ import './url-alphabet/index.js';
 ```
 ## Part 9
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/next-response/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/next-response/output.md
@@ -489,9 +489,6 @@ import '../../web/spec-extension/cookies';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { stringifyCookie } from '../../web/spec-extension/cookies';
 export { stringifyCookie as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -508,9 +505,6 @@ import '../next-url';
 ```
 ## Part 5
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
@@ -533,9 +527,6 @@ import '../utils';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { toNodeOutgoingHttpHeaders } from '../utils';
 export { toNodeOutgoingHttpHeaders as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -544,9 +535,6 @@ export { toNodeOutgoingHttpHeaders as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
@@ -569,9 +557,6 @@ import './adapters/reflect';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
-};
 import { ReflectAdapter } from './adapters/reflect';
 export { ReflectAdapter as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -588,9 +573,6 @@ import './cookies';
 ```
 ## Part 12
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 11
 };
@@ -825,9 +807,6 @@ import '../../web/spec-extension/cookies';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { stringifyCookie } from '../../web/spec-extension/cookies';
 export { stringifyCookie as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -844,9 +823,6 @@ import '../next-url';
 ```
 ## Part 5
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
@@ -869,9 +845,6 @@ import '../utils';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { toNodeOutgoingHttpHeaders } from '../utils';
 export { toNodeOutgoingHttpHeaders as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -880,9 +853,6 @@ export { toNodeOutgoingHttpHeaders as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
@@ -905,9 +875,6 @@ import './adapters/reflect';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
-};
 import { ReflectAdapter } from './adapters/reflect';
 export { ReflectAdapter as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -924,9 +891,6 @@ import './cookies';
 ```
 ## Part 12
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 11
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nextjs-tracer/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nextjs-tracer/output.md
@@ -723,9 +723,6 @@ import './constants';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { LogSpanAllowList } from './constants';
 export { LogSpanAllowList as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -734,9 +731,6 @@ export { LogSpanAllowList as f } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
@@ -1188,9 +1182,6 @@ import './constants';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import { LogSpanAllowList } from './constants';
 export { LogSpanAllowList as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1199,9 +1190,6 @@ export { LogSpanAllowList as f } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/node-fetch/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/node-fetch/output.md
@@ -179,9 +179,6 @@ import 'node:stream';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import Stream from 'node:stream';
 export { Stream as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -263,9 +260,6 @@ import 'node:stream';
 ```
 ## Part 3
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/otel-core/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/otel-core/output.md
@@ -247,9 +247,6 @@ import '../../utils/environment';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
-};
 import { DEFAULT_ENVIRONMENT } from '../../utils/environment';
 export { DEFAULT_ENVIRONMENT as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -258,9 +255,6 @@ export { DEFAULT_ENVIRONMENT as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 5
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
@@ -280,9 +274,6 @@ import './globalThis';
 ```
 ## Part 7
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
@@ -402,9 +393,6 @@ import '../../utils/environment';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
-};
 import { DEFAULT_ENVIRONMENT } from '../../utils/environment';
 export { DEFAULT_ENVIRONMENT as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -413,9 +401,6 @@ export { DEFAULT_ENVIRONMENT as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 5
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
@@ -435,9 +420,6 @@ import './globalThis';
 ```
 ## Part 7
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/route-handler/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/route-handler/output.md
@@ -180,9 +180,6 @@ import "next/server";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
-};
 import { NextResponse } from "next/server";
 export { NextResponse as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -279,9 +276,6 @@ import "next/server";
 ```
 ## Part 4
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/template-pages/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/template-pages/output.md
@@ -934,9 +934,6 @@ import '../../server/future/route-modules/pages/module.compiled';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
-};
 import { PagesRouteModule } from '../../server/future/route-modules/pages/module.compiled';
 export { PagesRouteModule as m } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -953,9 +950,6 @@ import '../../server/future/route-kind';
 ```
 ## Part 16
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 15
 };
@@ -978,9 +972,6 @@ import './helpers';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 17
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
-};
 import { hoist } from './helpers';
 export { hoist as o } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -997,9 +988,6 @@ import 'VAR_MODULE_DOCUMENT';
 ```
 ## Part 20
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 19
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 19
 };
@@ -1022,9 +1010,6 @@ import 'VAR_MODULE_APP';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 21
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
-};
 import App from 'VAR_MODULE_APP';
 export { App as q } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1041,9 +1026,6 @@ import 'VAR_USERLAND';
 ```
 ## Part 24
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 23
 };
@@ -1515,9 +1497,6 @@ import '../../server/future/route-modules/pages/module.compiled';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
-};
 import { PagesRouteModule } from '../../server/future/route-modules/pages/module.compiled';
 export { PagesRouteModule as m } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1534,9 +1513,6 @@ import '../../server/future/route-kind';
 ```
 ## Part 16
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 15
 };
@@ -1559,9 +1535,6 @@ import './helpers';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 17
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
-};
 import { hoist } from './helpers';
 export { hoist as o } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1578,9 +1551,6 @@ import 'VAR_MODULE_DOCUMENT';
 ```
 ## Part 20
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 19
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 19
 };
@@ -1603,9 +1573,6 @@ import 'VAR_MODULE_APP';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 21
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
-};
 import App from 'VAR_MODULE_APP';
 export { App as q } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -1622,9 +1589,6 @@ import 'VAR_USERLAND';
 ```
 ## Part 24
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 23
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/test-config-1/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/test-config-1/output.md
@@ -461,9 +461,6 @@ import "module";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
 import { upper } from "module";
 export { upper as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -722,9 +719,6 @@ import "module";
 ```
 ## Part 6
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/typeof-1/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/typeof-1/output.md
@@ -221,9 +221,6 @@ import 'next/server';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { NextResponse } from 'next/server';
 export { NextResponse as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -243,9 +240,6 @@ import '../../ClientComponent';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
 import { ClientComponent } from '../../ClientComponent';
 export { ClientComponent as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -262,9 +256,6 @@ import 'my-module/MyModuleClientComponent';
 ```
 ## Part 7
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
@@ -354,9 +345,6 @@ import 'next/server';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
 import { NextResponse } from 'next/server';
 export { NextResponse as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -376,9 +364,6 @@ import '../../ClientComponent';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
 import { ClientComponent } from '../../ClientComponent';
 export { ClientComponent as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -395,9 +380,6 @@ import 'my-module/MyModuleClientComponent';
 ```
 ## Part 7
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_bf6154._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_bf6154._.js
@@ -103,7 +103,6 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 ;
 ;
 ;
-;
 }}),
 "[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/module.js [test] (ecmascript) <export fakeCat>": ((__turbopack_context__) => {
 "use strict";

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_bf6154._.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_bf6154._.js.map
@@ -17,9 +17,9 @@
     {"offset": {"line": 81, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":""}},
     {"offset": {"line": 87, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
     {"offset": {"line": 93, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":""}},
-    {"offset": {"line": 106, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
-    {"offset": {"line": 112, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":""}},
-    {"offset": {"line": 118, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
-    {"offset": {"line": 124, "column": 0}, "map": {"version":3,"sources":["turbopack://[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/index.js"],"sourcesContent":["import { fakeCat } from \"./module\";\n\n\nconsole.log(fakeCat)\n"],"names":[],"mappings":";AAAA;AAAA;;AAGA,QAAQ,GAAG,CAAC,iPAAA,CAAA,UAAO"}},
-    {"offset": {"line": 129, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
+    {"offset": {"line": 105, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 111, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":""}},
+    {"offset": {"line": 117, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 123, "column": 0}, "map": {"version":3,"sources":["turbopack://[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/index.js"],"sourcesContent":["import { fakeCat } from \"./module\";\n\n\nconsole.log(fakeCat)\n"],"names":[],"mappings":";AAAA;AAAA;;AAGA,QAAQ,GAAG,CAAC,iPAAA,CAAA,UAAO"}},
+    {"offset": {"line": 128, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
 }

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-namespace_input_ed851f._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-namespace_input_ed851f._.js
@@ -232,7 +232,6 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 ;
 ;
 ;
-;
 }}),
 "[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/module.js [test] (ecmascript) <export lib>": ((__turbopack_context__) => {
 "use strict";

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-namespace_input_ed851f._.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-namespace_input_ed851f._.js.map
@@ -31,9 +31,9 @@
     {"offset": {"line": 205, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":""}},
     {"offset": {"line": 219, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
     {"offset": {"line": 225, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":""}},
-    {"offset": {"line": 235, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
-    {"offset": {"line": 241, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":""}},
-    {"offset": {"line": 247, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
-    {"offset": {"line": 253, "column": 0}, "map": {"version":3,"sources":["turbopack://[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/index.js"],"sourcesContent":["import {lib} from './module'\n\nconsole.log(lib.cat)\n"],"names":[],"mappings":";AAAA;AAAA;;AAEA,QAAQ,GAAG,CAAC,iPAAA,CAAA,MAAG,CAAC,GAAG"}},
-    {"offset": {"line": 258, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
+    {"offset": {"line": 234, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 240, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":""}},
+    {"offset": {"line": 246, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 252, "column": 0}, "map": {"version":3,"sources":["turbopack://[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/index.js"],"sourcesContent":["import {lib} from './module'\n\nconsole.log(lib.cat)\n"],"names":[],"mappings":";AAAA;AAAA;;AAEA,QAAQ,GAAG,CAAC,iPAAA,CAAA,MAAG,CAAC,GAAG"}},
+    {"offset": {"line": 257, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
 }


### PR DESCRIPTION
### What?

Cleanup logic.

 - Remove duplicate imports.
 - Rename `exports` to `outputs` as it's more intuitive.
 - Do not track the `ix` of each exports, as it's not used.


### Why?


### How?


Closes PACK-3475