### PR TITLE
docs: add and unify notes to error pages

### DIFF
--- a/errors/api-routes-response-size-limit.mdx
+++ b/errors/api-routes-response-size-limit.mdx
@@ -29,4 +29,4 @@ export const config = {
 }
 ```
 
-**Note:** Increasing the response limit can have significant impacts on performance and should only be done after careful consideration.
+> **Note**: Increasing the response limit can have significant impacts on performance and should only be done after careful consideration.

--- a/errors/class-component-in-server-component.mdx
+++ b/errors/class-component-in-server-component.mdx
@@ -54,4 +54,4 @@ export default class Page extends React.Component {
 
 ## Useful Links
 
-[Server Components](/docs/app/building-your-application/rendering/server-components)
+- [Server Components](/docs/app/building-your-application/rendering/server-components)

--- a/errors/context-in-server-component.mdx
+++ b/errors/context-in-server-component.mdx
@@ -29,4 +29,4 @@ const Context = createContext()
 
 ## Useful Links
 
-[Server and Client Components Composition Patterns](/docs/app/building-your-application/rendering/composition-patterns)
+- [Server and Client Components Composition Patterns](/docs/app/building-your-application/rendering/composition-patterns)

--- a/errors/fast-refresh-reload.mdx
+++ b/errors/fast-refresh-reload.mdx
@@ -18,4 +18,4 @@ Fast Refresh had to perform a full reload when you edited a file. It may be beca
 
 ## Useful Links
 
-[Fast Refresh documentation](/docs/architecture/fast-refresh)
+- [Fast Refresh documentation](/docs/architecture/fast-refresh)

--- a/errors/google-font-preconnect.mdx
+++ b/errors/google-font-preconnect.mdx
@@ -2,7 +2,7 @@
 title: Google Font Preconnect
 ---
 
-> Next.js automatically adds `<link rel="preconnect" />` after version `12.0.1`.
+> **Note**: Next.js automatically adds `<link rel="preconnect" />` after version `12.0.1`.
 
 > Ensure `preconnect` is used with Google Fonts.
 
@@ -18,7 +18,7 @@ Add `rel="preconnect"` to the Google Font domain `<link>` tag:
 <link rel="preconnect" href="https://fonts.gstatic.com" />
 ```
 
-Note: a **separate** link with `dns-prefetch` can be used as a fallback for browsers that don't support `preconnect` although this is not required.
+> **Note**: a **separate** link with `dns-prefetch` can be used as a fallback for browsers that don't support `preconnect` although this is not required.
 
 ## Useful Links
 

--- a/errors/google-fonts-missing-subsets.mdx
+++ b/errors/google-fonts-missing-subsets.mdx
@@ -14,7 +14,7 @@ Preload is enabled for a font that is missing a specified subset.
 const inter = Inter({ subsets: ['latin'] })
 ```
 
-Note: previously it was possible to specify default subsets in your `next.config.js` with the `experimental.fontLoaders` option, but this is no longer supported.
+> **Note**: previously it was possible to specify default subsets in your `next.config.js` with the `experimental.fontLoaders` option, but this is no longer supported.
 
 ### Disable preloading for that font
 
@@ -29,4 +29,4 @@ const notoSansJapanese = Noto_Sans_JP({
 
 ## Useful Links
 
-[Specifying a subset](/docs/pages/building-your-application/optimizing/fonts#specifying-a-subset)
+- [Specifying a subset](/docs/pages/building-your-application/optimizing/fonts#specifying-a-subset)

--- a/errors/gssp-export.mdx
+++ b/errors/gssp-export.mdx
@@ -40,8 +40,10 @@ It is not possible to use `getServerSideProps` without a server, so you'll need 
    }
    ```
 
-> **Note**: Removing export does not mean your entire application is no longer static.
-> Pages that use `getStaticProps` or [no lifecycle](/docs/pages/building-your-application/rendering/automatic-static-optimization) **will still be static**!
+> **Note**: 
+>
+> - Removing export does not mean your entire application is no longer static.
+> - Pages that use `getStaticProps` or [no lifecycle](/docs/pages/building-your-application/rendering/automatic-static-optimization) **will still be static**!
 
 ## Useful Links
 

--- a/errors/gssp-export.mdx
+++ b/errors/gssp-export.mdx
@@ -40,7 +40,7 @@ It is not possible to use `getServerSideProps` without a server, so you'll need 
    }
    ```
 
-> **Note**: 
+> **Note**:
 >
 > - Removing export does not mean your entire application is no longer static.
 > - Pages that use `getStaticProps` or [no lifecycle](/docs/pages/building-your-application/rendering/automatic-static-optimization) **will still be static**!

--- a/errors/href-interpolation-failed.mdx
+++ b/errors/href-interpolation-failed.mdx
@@ -6,7 +6,7 @@ title: '`href` Interpolation Failed'
 
 Somewhere you are utilizing the `next/link` component, `Router#push`, or `Router#replace` with `href` interpolation to build dynamic routes but did not provide all of the needed dynamic route params to properly interpolate the `href`.
 
-Note: this error will only show when the `next/link` component is clicked not when only rendered.
+> **Note**: this error will only show when the `next/link` component is clicked not when only rendered.
 
 **Invalid `href` interpolation**
 

--- a/errors/incompatible-href-as.mdx
+++ b/errors/incompatible-href-as.mdx
@@ -6,7 +6,7 @@ title: 'Incompatible `href` and `as` values'
 
 Somewhere you are utilizing the `next/link` component, `Router#push`, or `Router#replace` with a dynamic route in your `href` that has an incompatible `as` value. The `as` value is incompatible when the path doesn't provide only the expected parameters for the dynamic route.
 
-Note: this error will only show when the `next/link` component is clicked not when only rendered.
+> **Note**: this error will only show when the `next/link` component is clicked not when only rendered.
 
 **Incompatible `href` and `as`**
 

--- a/errors/invalid-relative-url-external-as.mdx
+++ b/errors/invalid-relative-url-external-as.mdx
@@ -6,7 +6,7 @@ title: 'Invalid relative `href` and external `as` values'
 
 Somewhere you are utilizing the `next/link` component, `Router#push`, or `Router#replace` with a relative route in your `href` that has an external `as` value. The `as` value must be relative also or only `href` should be used with an external URL.
 
-Note: this error will only show when the `next/link` component is clicked not when only rendered.
+> **Note**: this error will only show when the `next/link` component is clicked not when only rendered.
 
 **Incompatible `href` and `as`**
 

--- a/errors/link-multiple-children.mdx
+++ b/errors/link-multiple-children.mdx
@@ -37,6 +37,6 @@ export default function Home() {
 }
 ```
 
-> **Good to know:**
+> **Good to know**:
 >
 > - As on Next.js 13.0, `<Link>` no longer requires a child `<a>` tag. A [codemod](/docs/app/building-your-application/upgrading/codemods#remove-a-tags-from-link-components) is provided to automatically update your codebase.

--- a/errors/missing-suspense-with-csr-bailout.mdx
+++ b/errors/missing-suspense-with-csr-bailout.mdx
@@ -58,7 +58,7 @@ This will ensure the page does not de-opt to client-side rendering.
 
 ## Disabling
 
-> Note: This is only available with Next.js version 14.x. If you're in versions above 14 please fix it with the approach above.
+> **Note**: This is only available with Next.js version 14.x. If you're in versions above 14 please fix it with the approach above.
 
 We don't recommend disabling this rule. However, if you need to, you can disable it by setting the `missingSuspenseWithCSRBailout` option to `false` in your `next.config.js`:
 

--- a/errors/next-config-error.mdx
+++ b/errors/next-config-error.mdx
@@ -10,7 +10,7 @@ When attempting to load your `next.config.js` or `next.config.mjs` file, an erro
 
 See the error message in your terminal where you started `next` to see more context.
 
-> Note: This config file is not transpiled by Next.js, so only use features supported by your current Node.js version.
+> **Note**: This config file is not transpiled by Next.js, so only use features supported by your current Node.js version.
 
 ## Useful Links
 

--- a/errors/next-prerender-current-time.mdx
+++ b/errors/next-prerender-current-time.mdx
@@ -39,7 +39,7 @@ export default async function Page() {
 }
 ```
 
-Note: If you need report an absolute time to an observability tool you can also use `performance.timeOrigin + performance.now()`.
+> **Note**: If you need report an absolute time to an observability tool you can also use `performance.timeOrigin + performance.now()`.
 
 ### Cacheable use cases
 

--- a/errors/no-img-element.mdx
+++ b/errors/no-img-element.mdx
@@ -12,7 +12,7 @@ An `<img>` element was used to display an image instead of `<Image />` from `nex
 
 1. Use [`next/image`](/docs/pages/api-reference/components/image) to improve performance with automatic [Image Optimization](/docs/pages/building-your-application/optimizing/images).
 
-> Note: If deploying to a [managed hosting provider](/docs/pages/building-your-application/deploying), remember to check provider pricing since optimized images might be charged differently than the original images.
+> **Note**: If deploying to a [managed hosting provider](/docs/pages/building-your-application/deploying), remember to check provider pricing since optimized images might be charged differently than the original images.
 >
 > Common image optimization platform pricing:
 >
@@ -20,7 +20,7 @@ An `<img>` element was used to display an image instead of `<Image />` from `nex
 > - [Cloudinary pricing](https://cloudinary.com/pricing)
 > - [imgix pricing](https://imgix.com/pricing)
 
-> Note: If self-hosting, remember to install [`sharp`](https://www.npmjs.com/package/sharp) and check if your server has enough storage to cache the optimized images.
+> **Note**: If self-hosting, remember to install [`sharp`](https://www.npmjs.com/package/sharp) and check if your server has enough storage to cache the optimized images.
 
 ```jsx filename="pages/index.js"
 import Image from 'next/image'

--- a/errors/no-script-in-document.mdx
+++ b/errors/no-script-in-document.mdx
@@ -4,7 +4,7 @@ title: No Script in Document
 
 > Prevent usage of `next/script` in `pages/_document.js`.
 
-> ⚠️ This error is not relevant in Next.js versions 12.1.6 or later. Please refer to the updated [error message](/docs/messages/no-before-interactive-script-outside-document).
+> **Note**: ⚠️ This error is not relevant in Next.js versions 12.1.6 or later. Please refer to the updated [error message](/docs/messages/no-before-interactive-script-outside-document).
 
 ## Why This Error Occurred
 

--- a/errors/parallel-build-without-worker.mdx
+++ b/errors/parallel-build-without-worker.mdx
@@ -15,4 +15,4 @@ Build workers are enabled by default unless you have a custom webpack config. Yo
 
 ## Useful Links
 
-Also see https://nextjs.org/docs/messages/webpack-build-worker-opt-out
+- Also see https://nextjs.org/docs/messages/webpack-build-worker-opt-out

--- a/errors/react-client-hook-in-server-component.mdx
+++ b/errors/react-client-hook-in-server-component.mdx
@@ -40,4 +40,4 @@ export default function Example() {
 
 ## Useful Links
 
-[Server Components](/docs/app/building-your-application/rendering/server-components)
+- [Server Components](/docs/app/building-your-application/rendering/server-components)

--- a/errors/returning-response-body-in-middleware.mdx
+++ b/errors/returning-response-body-in-middleware.mdx
@@ -2,7 +2,7 @@
 title: Returning response body in Middleware
 ---
 
-> Note: In Next.js v13.0.0 you can now respond to Middleware directly by returning a `NextResponse`. For more information, see [Producing a Response](/docs/pages/building-your-application/routing/middleware#producing-a-response).
+> **Note**: In Next.js v13.0.0 you can now respond to Middleware directly by returning a `NextResponse`. For more information, see [Producing a Response](/docs/pages/building-your-application/routing/middleware#producing-a-response).
 
 ## Why This Error Occurred
 

--- a/errors/sharp-missing-in-production.mdx
+++ b/errors/sharp-missing-in-production.mdx
@@ -38,7 +38,7 @@ Then, build your project with `next build`. Finally, restart the server with eit
 
 - If `sharp` is already installed but can't be resolved, set the `NEXT_SHARP_PATH` environment variable such as `export NEXT_SHARP_PATH=/tmp/node_modules/sharp`. Then, build your project with `next build`. Finally, restart the server with either `next start` for production mode or `node .next/standalone/server.js` for standalone mode.
 
-> Note: This is not necessary for Vercel deployments, since `sharp` is installed automatically for you.
+> **Note**: This is not necessary for Vercel deployments, since `sharp` is installed automatically for you.
 
 ## Useful Links
 

--- a/errors/sharp-version-avif.mdx
+++ b/errors/sharp-version-avif.mdx
@@ -18,7 +18,7 @@ AVIF support was added to [`sharp`](https://www.npmjs.com/package/sharp) in vers
 
 After choosing an option above, reboot the server by running either `next dev` or `next start` for development or production respectively.
 
-> Note: This is not necessary for Vercel deployments, since `sharp` is installed automatically for you.
+> **Note**: This is not necessary for Vercel deployments, since `sharp` is installed automatically for you.
 
 ## Useful Links
 

--- a/errors/url-deprecated.mdx
+++ b/errors/url-deprecated.mdx
@@ -8,7 +8,7 @@ In versions prior to 6.x the `url` property got magically injected into every `P
 
 The reason this is going away is that we want to make things very predictable and explicit. Having a magical url property coming out of nowhere doesn't aid that goal.
 
-> ⚠️ In some cases using React Dev Tools may trigger this warning even if you do not reference `url` anywhere in your code. Try temporarily disabling the extension and see if the warning persists.
+> **Note**: ⚠️ In some cases using React Dev Tools may trigger this warning even if you do not reference `url` anywhere in your code. Try temporarily disabling the extension and see if the warning persists.
 
 ## Possible Ways to Fix It
 


### PR DESCRIPTION
## Description
Unify the note format according to the [contribution guide](https://nextjs.org/docs/community/contribution-guide#notes).
In addition, add missing bullet points to useful links.

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide