### PR TITLE
docs: fix code block language

### DIFF
--- a/errors/next-dynamic-api-wrong-context.mdx
+++ b/errors/next-dynamic-api-wrong-context.mdx
@@ -14,7 +14,7 @@ Make sure that all Dynamic API calls happen in a request scope.
 
 Example:
 
-```jsx filename="app/page.js"
+```diff filename="app/page.js"
 import { cookies } from 'next/headers'
 
 - const cookieStore = cookies()
@@ -24,7 +24,7 @@ export default function Page() {
 }
 ```
 
-```jsx filename="app/foo/route.js"
+```diff filename="app/foo/route.js"
 import { headers } from 'next/headers'
 
 - const headersList = headers()


### PR DESCRIPTION
## Summary
Change `jsx` to `diff` in [next-dynamic-api-wrong-context](https://github.com/vercel/next.js/blob/canary/errors/next-dynamic-api-wrong-context.mdx) error page.

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide