### PR TITLE
"Fix": Lift type check out of loop

### DIFF
--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -336,14 +336,13 @@ export function listenForDynamicRequest(
 ) {
   responsePromise.then(
     ({ flightData }: FetchServerResponseResult) => {
+      if (typeof flightData === 'string') {
+        // Happens when navigating to page in `pages` from `app`. We shouldn't
+        // get here because should have already handled this during
+        // the prefetch.
+        return
+      }
       for (const normalizedFlightData of flightData) {
-        if (typeof normalizedFlightData === 'string') {
-          // Happens when navigating to page in `pages` from `app`. We shouldn't
-          // get here because should have already handled this during
-          // the prefetch.
-          continue
-        }
-
         const {
           segmentPath,
           tree: serverRouterState,


### PR DESCRIPTION
Hehe. `flightData` is either an array or a string. There's a loop that's meant to iterate over `flightData` in the case where it's an array, but we neglected to check whether it was an array or a string, and since strings are iterable types, the type system did not complain.

The check that should have been before the loop was instead inside the loop... and it happened to work anyway, because when you iterate over a string, each item is a character, and characters have the type "string".

So the code works despite being nonsensical. In conclusion, lmfao.