### PR TITLE
hide stack trace in CanaryOnlyError

### DIFF
--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -71,6 +71,29 @@ describe('loadConfig', () => {
       delete process.env.__NEXT_VERSION
     })
 
+    it('should not print a stack trace when throwing an error', async () => {
+      const loadConfigPromise = loadConfig('', __dirname, {
+        customConfig: {
+          experimental: {
+            ppr: true,
+          },
+        },
+      })
+
+      await expect(loadConfigPromise).rejects.toThrow(
+        /The experimental feature "experimental.ppr" can only be enabled when using the latest canary version of Next.js./
+      )
+
+      try {
+        await loadConfigPromise
+      } catch (error: any) {
+        expect(error).toBeInstanceOf(Error)
+
+        // Check that there's no stack trace
+        expect(error.stack).toBeUndefined()
+      }
+    })
+
     it('errors when using PPR if not in canary', async () => {
       await expect(
         loadConfig('', __dirname, {

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1283,5 +1283,8 @@ class CanaryOnlyError extends Error {
     super(
       `The experimental feature "${feature}" can only be enabled when using the latest canary version of Next.js.`
     )
+    // This error is meant to interrupt the server start/build process
+    // but the stack trace isn't meaningful, as it points to internal code.
+    this.stack = undefined
   }
 }


### PR DESCRIPTION
This error doesn't point to any particularly meaningful line of code to the user, we just use it to have a well-known error message for when a feature should only be used in canary. This hides the stack trace so the error is surfaced more clearly. 