### PR TITLE
Extract shared fetchFromServerResponse logic to separate functions

### DIFF
--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -17,6 +17,7 @@ import type {
 } from '../../../server/app-render/types'
 import {
   NEXT_ROUTER_PREFETCH_HEADER,
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   NEXT_ROUTER_STATE_TREE_HEADER,
   NEXT_RSC_UNION_QUERY,
   NEXT_URL,
@@ -50,6 +51,18 @@ export type FetchServerResponseResult = {
   prerendered: boolean
   postponed: boolean
   staleTime: number
+}
+
+export type RequestHeaders = {
+  [RSC_HEADER]?: '1'
+  [NEXT_ROUTER_STATE_TREE_HEADER]?: string
+  [NEXT_URL]?: string
+  [NEXT_ROUTER_PREFETCH_HEADER]?: '1'
+  [NEXT_ROUTER_SEGMENT_PREFETCH_HEADER]?: string
+  'x-deployment-id'?: string
+  [NEXT_HMR_REFRESH_HEADER]?: '1'
+  // A header that is only added in test mode to assert on fetch priority
+  'Next-Test-Fetch-Priority'?: RequestInit['priority']
 }
 
 function urlToUrlWithoutFlightMarker(url: string): URL {
@@ -90,16 +103,7 @@ export async function fetchServerResponse(
 ): Promise<FetchServerResponseResult> {
   const { flightRouterState, nextUrl, prefetchKind } = options
 
-  const headers: {
-    [RSC_HEADER]: '1'
-    [NEXT_ROUTER_STATE_TREE_HEADER]: string
-    [NEXT_URL]?: string
-    [NEXT_ROUTER_PREFETCH_HEADER]?: '1'
-    'x-deployment-id'?: string
-    [NEXT_HMR_REFRESH_HEADER]?: '1'
-    // A header that is only added in test mode to assert on fetch priority
-    'Next-Test-Fetch-Priority'?: RequestInit['priority']
-  } = {
+  const headers: RequestHeaders = {
     // Enable flight response
     [RSC_HEADER]: '1',
     // Provide the current router state
@@ -126,33 +130,7 @@ export async function fetchServerResponse(
     headers[NEXT_URL] = nextUrl
   }
 
-  if (process.env.NEXT_DEPLOYMENT_ID) {
-    headers['x-deployment-id'] = process.env.NEXT_DEPLOYMENT_ID
-  }
-
-  const uniqueCacheQuery = hexHash(
-    [
-      headers[NEXT_ROUTER_PREFETCH_HEADER] || '0',
-      headers[NEXT_ROUTER_STATE_TREE_HEADER],
-      headers[NEXT_URL],
-    ].join(',')
-  )
-
   try {
-    let fetchUrl = new URL(url)
-    if (process.env.NODE_ENV === 'production') {
-      if (process.env.__NEXT_CONFIG_OUTPUT === 'export') {
-        if (fetchUrl.pathname.endsWith('/')) {
-          fetchUrl.pathname += 'index.txt'
-        } else {
-          fetchUrl.pathname += '.txt'
-        }
-      }
-    }
-
-    // Add unique cache query to avoid caching conflicts on CDN which don't respect the Vary header
-    fetchUrl.searchParams.set(NEXT_RSC_UNION_QUERY, uniqueCacheQuery)
-
     // When creating a "temporary" prefetch (the "on-demand" prefetch that gets created on navigation, if one doesn't exist)
     // we send the request with a "high" priority as it's in response to a user interaction that could be blocking a transition.
     // Otherwise, all other prefetches are sent with a "low" priority.
@@ -163,16 +141,7 @@ export async function fetchServerResponse(
         : 'low'
       : 'auto'
 
-    if (process.env.__NEXT_TEST_MODE) {
-      headers['Next-Test-Fetch-Priority'] = fetchPriority
-    }
-
-    const res = await fetch(fetchUrl, {
-      // Backwards compat for older browsers. `same-origin` is the default in modern browsers.
-      credentials: 'same-origin',
-      headers,
-      priority: fetchPriority,
-    })
+    const res = await createFetch(url, headers, fetchPriority)
 
     const responseUrl = urlToUrlWithoutFlightMarker(res.url)
     const canonicalUrl = res.redirected ? responseUrl : undefined
@@ -216,10 +185,9 @@ export async function fetchServerResponse(
     const flightStream = postponed
       ? createUnclosingPrefetchStream(res.body)
       : res.body
-    const response: NavigationFlightResponse = await createFromReadableStream(
-      flightStream,
-      { callServer, findSourceMapURL }
-    )
+    const response = await (createFromNextReadableStream(
+      flightStream
+    ) as Promise<NavigationFlightResponse>)
 
     if (getAppBuildId() !== response.b) {
       return doMpaNavigation(res.url)
@@ -252,7 +220,65 @@ export async function fetchServerResponse(
   }
 }
 
-function createUnclosingPrefetchStream(
+export function createFetch(
+  url: URL,
+  headers: RequestHeaders,
+  fetchPriority: 'auto' | 'high' | 'low' | null
+) {
+  const fetchUrl = new URL(url)
+
+  if (process.env.NODE_ENV === 'production') {
+    if (process.env.__NEXT_CONFIG_OUTPUT === 'export') {
+      if (fetchUrl.pathname.endsWith('/')) {
+        fetchUrl.pathname += 'index.txt'
+      } else {
+        fetchUrl.pathname += '.txt'
+      }
+    }
+  }
+
+  // This is used to cache bust CDNs that don't support custom headers. The
+  // result is stored in a search param.
+  // TODO: Given that we have to use a search param anyway, we might as well
+  // _only_ use a search param and not bother with the custom headers.
+  // Add unique cache query to avoid caching conflicts on CDN which don't respect the Vary header
+  const uniqueCacheQuery = hexHash(
+    [
+      headers[NEXT_ROUTER_PREFETCH_HEADER] || '0',
+      headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] || '0',
+      headers[NEXT_ROUTER_STATE_TREE_HEADER],
+      headers[NEXT_URL],
+    ].join(',')
+  )
+
+  fetchUrl.searchParams.set(NEXT_RSC_UNION_QUERY, uniqueCacheQuery)
+
+  if (process.env.__NEXT_TEST_MODE && fetchPriority !== null) {
+    headers['Next-Test-Fetch-Priority'] = fetchPriority
+  }
+
+  if (process.env.NEXT_DEPLOYMENT_ID) {
+    headers['x-deployment-id'] = process.env.NEXT_DEPLOYMENT_ID
+  }
+
+  return fetch(fetchUrl, {
+    // Backwards compat for older browsers. `same-origin` is the default in modern browsers.
+    credentials: 'same-origin',
+    headers,
+    priority: fetchPriority || undefined,
+  })
+}
+
+export function createFromNextReadableStream(
+  flightStream: ReadableStream<Uint8Array>
+): Promise<unknown> {
+  return createFromReadableStream(flightStream, {
+    callServer,
+    findSourceMapURL,
+  })
+}
+
+export function createUnclosingPrefetchStream(
   originalFlightStream: ReadableStream<Uint8Array>
 ): ReadableStream<Uint8Array> {
   // When PPR is enabled, prefetch streams may contain references that never


### PR DESCRIPTION
In the Segment Cache implementation, I won't be using the main fetchFromServerResponse function because the protocol for per-segment prefetches is different. But there's a lot of logic (e.g. setting headers, decoding the Flight stream, validating the response) that can be shared. So I've extracted the shared bits into separate functions.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
