### PR TITLE
Add explicit section about type overriding for v15

### DIFF
--- a/docs/01-app/02-building-your-application/11-upgrading/02-version-15.mdx
+++ b/docs/01-app/02-building-your-application/11-upgrading/02-version-15.mdx
@@ -22,7 +22,6 @@ npm i next@latest react@rc react-dom@rc eslint-config-next@latest
 > **Good to know:**
 >
 > - If you see a peer dependencies warning, you may need to update `react` and `react-dom` to the suggested versions, or you use the `--force` or `--legacy-peer-deps` flag to ignore the warning. This won't be necessary once both Next.js 15 and React 19 are stable.
-> - If you are using TypeScript, you'll need to temporarily override the React types. See the [React 19 RC upgrade guide](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#installing) for more information.
 
 ## React 19
 
@@ -30,6 +29,23 @@ npm i next@latest react@rc react-dom@rc eslint-config-next@latest
 - `useFormState` has been replaced by `useActionState`. The `useFormState` hook is still available in React 19, but it is deprecated and will be removed in a future release. `useActionState` is recommended and includes additional properties like reading the `pending` state directly. [Learn more](https://react.dev/reference/react/useActionState).
 - `useFormStatus` now includes additional keys like `data`, `method`, and `action`. If you are not using React 19, only the `pending` key is available. [Learn more](https://react.dev/reference/react-dom/hooks/useFormStatus).
 - Read more in the [React 19 upgrade guide](https://react.dev/blog/2024/04/25/react-19-upgrade-guide).
+
+### Updating types for react 19
+
+If you are using TypeScript, you'll need to temporarily override the React types. Below is an example of the necessary type overrides needed in your `package.json`. See the [React 19 RC upgrade guide](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#installing) for more information.
+
+```json
+{
+  "dependencies": {
+    "@types/react": "npm:types-react@rc",
+    "@types/react-dom": "npm:types-react-dom@rc"
+  },
+  "overrides": {
+    "@types/react": "npm:types-react@rc",
+    "@types/react-dom": "npm:types-react-dom@rc"
+  }
+}
+```
 
 ## Async Request APIs (Breaking change)
 


### PR DESCRIPTION
This breaks out the type overriding note from a small good to know section to it's own section as it's fairly important and easy to miss currently. Also the minimal note isn't getting picked up in our search currently. 

x-ref: [slack thread](https://vercel.slack.com/archives/C0676QZBWKS/p1731602395153929)