### PR TITLE
Ensure host is in allowed headers

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -316,6 +316,7 @@ export interface DynamicSsgRoute {
  * this includes both headers used by the pages and app routers.
  */
 const ALLOWED_HEADERS: string[] = [
+  'host',
   MATCHED_PATH_HEADER,
   PRERENDER_REVALIDATE_HEADER,
   PRERENDER_REVALIDATE_ONLY_GENERATED_HEADER,

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -1136,6 +1136,7 @@ describe('app-dir static/dynamic handling', () => {
         {
           "/": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1159,6 +1160,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/api/large-data": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1186,6 +1188,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/articles/works": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1209,6 +1212,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/blog/seb": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1232,6 +1236,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/blog/seb/second-post": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1255,6 +1260,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/blog/styfle": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1278,6 +1284,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/blog/styfle/first-post": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1301,6 +1308,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/blog/styfle/second-post": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1324,6 +1332,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/blog/tim": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1347,6 +1356,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/blog/tim/first-post": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1370,6 +1380,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/default-config-fetch": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1393,6 +1404,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/force-cache": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1416,6 +1428,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/force-static-fetch-no-store": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1439,6 +1452,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/force-static/first": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1462,6 +1476,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/force-static/second": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1485,6 +1500,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/gen-params-dynamic-revalidate/one": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1508,6 +1524,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/hooks/use-pathname/slug": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1531,6 +1548,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/hooks/use-search-params/force-static": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1554,6 +1572,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/hooks/use-search-params/with-suspense": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1577,6 +1596,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/isr-error-handling": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1600,6 +1620,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/no-config-fetch": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1623,6 +1644,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/no-store/static": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1646,6 +1668,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/partial-gen-params-no-additional-lang/en/RAND": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1669,6 +1692,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/partial-gen-params-no-additional-lang/en/first": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1692,6 +1716,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/partial-gen-params-no-additional-lang/en/second": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1715,6 +1740,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/partial-gen-params-no-additional-lang/fr/RAND": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1738,6 +1764,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/partial-gen-params-no-additional-lang/fr/first": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1761,6 +1788,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/partial-gen-params-no-additional-lang/fr/second": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1784,6 +1812,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/partial-gen-params-no-additional-slug/en/RAND": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1807,6 +1836,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/partial-gen-params-no-additional-slug/en/first": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1830,6 +1860,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/partial-gen-params-no-additional-slug/en/second": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1853,6 +1884,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/partial-gen-params-no-additional-slug/fr/RAND": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1876,6 +1908,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/partial-gen-params-no-additional-slug/fr/first": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1899,6 +1932,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/partial-gen-params-no-additional-slug/fr/second": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1922,6 +1956,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/route-handler/no-store-force-static": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1949,6 +1984,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/route-handler/revalidate-360-isr": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1976,6 +2012,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/route-handler/static-cookies": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2003,6 +2040,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/ssg-draft-mode": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2026,6 +2064,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/ssg-draft-mode/test": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2049,6 +2088,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/ssg-draft-mode/test-2": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2072,6 +2112,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/strip-header-traceparent": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2095,6 +2136,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/unstable-cache/fetch/no-cache": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2118,6 +2160,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/unstable-cache/fetch/no-store": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2141,6 +2184,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/variable-config-revalidate/revalidate-3": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2164,6 +2208,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/variable-revalidate-stable/revalidate-3": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2187,6 +2232,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/variable-revalidate/authorization": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2210,6 +2256,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/variable-revalidate/cookie": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2233,6 +2280,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/variable-revalidate/encoding": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2256,6 +2304,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/variable-revalidate/headers-instance": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2279,6 +2328,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/variable-revalidate/post-method": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2302,6 +2352,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/variable-revalidate/revalidate-3": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2325,6 +2376,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/variable-revalidate/revalidate-360-isr": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2352,6 +2404,7 @@ describe('app-dir static/dynamic handling', () => {
         {
           "/articles/[slug]": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2376,6 +2429,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/blog/[author]": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2400,6 +2454,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/blog/[author]/[slug]": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2424,6 +2479,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/dynamic-error/[id]": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2448,6 +2504,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/force-static/[slug]": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2472,6 +2529,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/gen-params-dynamic-revalidate/[slug]": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2496,6 +2554,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/hooks/use-pathname/[slug]": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2520,6 +2579,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/partial-gen-params-no-additional-lang/[lang]/[slug]": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2544,6 +2604,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/partial-gen-params-no-additional-slug/[lang]/[slug]": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2568,6 +2629,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/ssg-draft-mode/[[...route]]": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -2592,6 +2654,7 @@ describe('app-dir static/dynamic handling', () => {
           },
           "/static-to-dynamic-error-forced/[id]": {
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -94,6 +94,7 @@ describe('Prerender', () => {
   }
 
   const allowHeader = [
+    'host',
     'x-matched-path',
     'x-prerender-revalidate',
     'x-prerender-revalidate-if-generated',

--- a/test/integration/404-page-ssg/test/index.test.js
+++ b/test/integration/404-page-ssg/test/index.test.js
@@ -68,6 +68,7 @@ const runTests = (isDev) => {
       )
       expect(data.routes['/404']).toEqual({
         allowHeader: [
+          'host',
           'x-matched-path',
           'x-prerender-revalidate',
           'x-prerender-revalidate-if-generated',

--- a/test/integration/i18n-support/test/shared.js
+++ b/test/integration/i18n-support/test/shared.js
@@ -783,6 +783,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/index.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -795,6 +796,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/index.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -807,6 +809,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/404.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -819,6 +822,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/frank.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -831,6 +835,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/gsp.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -843,6 +848,7 @@ export function runTests(ctx) {
             "srcRoute": "/gsp/fallback/[slug]",
             "dataRoute": "/_next/data/BUILD_ID/do-BE/gsp/fallback/always.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -855,6 +861,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/not-found.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -867,6 +874,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/404.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -879,6 +887,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/frank.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -891,6 +900,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/gsp.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -903,6 +913,7 @@ export function runTests(ctx) {
             "srcRoute": "/gsp/fallback/[slug]",
             "dataRoute": "/_next/data/BUILD_ID/do/gsp/fallback/always.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -915,6 +926,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/not-found.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -927,6 +939,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/index.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -939,6 +952,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/index.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -951,6 +965,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/404.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -963,6 +978,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/frank.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -975,6 +991,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/gsp.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -987,6 +1004,7 @@ export function runTests(ctx) {
             "srcRoute": "/gsp/fallback/[slug]",
             "dataRoute": "/_next/data/BUILD_ID/en-US/gsp/fallback/always.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -999,6 +1017,7 @@ export function runTests(ctx) {
             "srcRoute": "/gsp/fallback/[slug]",
             "dataRoute": "/_next/data/BUILD_ID/en-US/gsp/fallback/first.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1011,6 +1030,7 @@ export function runTests(ctx) {
             "srcRoute": "/gsp/fallback/[slug]",
             "dataRoute": "/_next/data/BUILD_ID/en-US/gsp/fallback/second.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1023,6 +1043,7 @@ export function runTests(ctx) {
             "srcRoute": "/gsp/no-fallback/[slug]",
             "dataRoute": "/_next/data/BUILD_ID/en-US/gsp/no-fallback/first.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1035,6 +1056,7 @@ export function runTests(ctx) {
             "srcRoute": "/gsp/no-fallback/[slug]",
             "dataRoute": "/_next/data/BUILD_ID/en-US/gsp/no-fallback/second.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1047,6 +1069,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/not-found.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1059,6 +1082,7 @@ export function runTests(ctx) {
             "srcRoute": "/not-found/blocking-fallback/[slug]",
             "dataRoute": "/_next/data/BUILD_ID/en-US/not-found/blocking-fallback/first.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1071,6 +1095,7 @@ export function runTests(ctx) {
             "srcRoute": "/not-found/blocking-fallback/[slug]",
             "dataRoute": "/_next/data/BUILD_ID/en-US/not-found/blocking-fallback/second.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1083,6 +1108,7 @@ export function runTests(ctx) {
             "srcRoute": "/not-found/fallback/[slug]",
             "dataRoute": "/_next/data/BUILD_ID/en-US/not-found/fallback/first.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1095,6 +1121,7 @@ export function runTests(ctx) {
             "srcRoute": "/not-found/fallback/[slug]",
             "dataRoute": "/_next/data/BUILD_ID/en-US/not-found/fallback/second.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1107,6 +1134,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/404.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1119,6 +1147,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/frank.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1131,6 +1160,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/gsp.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1143,6 +1173,7 @@ export function runTests(ctx) {
             "srcRoute": "/gsp/fallback/[slug]",
             "dataRoute": "/_next/data/BUILD_ID/en/gsp/fallback/always.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1155,6 +1186,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/not-found.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1167,6 +1199,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/index.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1179,6 +1212,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/index.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1191,6 +1225,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/404.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1203,6 +1238,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/frank.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1215,6 +1251,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/gsp.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1227,6 +1264,7 @@ export function runTests(ctx) {
             "srcRoute": "/gsp/fallback/[slug]",
             "dataRoute": "/_next/data/BUILD_ID/fr-BE/gsp/fallback/always.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1239,6 +1277,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/not-found.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1251,6 +1290,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/404.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1263,6 +1303,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/frank.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1275,6 +1316,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/gsp.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1287,6 +1329,7 @@ export function runTests(ctx) {
             "srcRoute": "/gsp/fallback/[slug]",
             "dataRoute": "/_next/data/BUILD_ID/fr/gsp/fallback/always.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1299,6 +1342,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/not-found.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1311,6 +1355,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/index.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1323,6 +1368,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/index.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1335,6 +1381,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/404.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1347,6 +1394,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/frank.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1359,6 +1407,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/gsp.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1371,6 +1420,7 @@ export function runTests(ctx) {
             "srcRoute": "/gsp/fallback/[slug]",
             "dataRoute": "/_next/data/BUILD_ID/go-BE/gsp/fallback/always.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1383,6 +1433,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/not-found.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1395,6 +1446,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/404.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1407,6 +1459,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/frank.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1419,6 +1472,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/gsp.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1431,6 +1485,7 @@ export function runTests(ctx) {
             "srcRoute": "/gsp/fallback/[slug]",
             "dataRoute": "/_next/data/BUILD_ID/go/gsp/fallback/always.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1443,6 +1498,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/not-found.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1455,6 +1511,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/index.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1467,6 +1524,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/index.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1479,6 +1537,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/404.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1491,6 +1550,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/frank.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1503,6 +1563,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/gsp.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1515,6 +1576,7 @@ export function runTests(ctx) {
             "srcRoute": "/gsp/fallback/[slug]",
             "dataRoute": "/_next/data/BUILD_ID/nl-BE/gsp/fallback/always.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1527,6 +1589,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/not-found.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1539,6 +1602,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/index.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1551,6 +1615,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/404.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1563,6 +1628,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/frank.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1575,6 +1641,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/gsp.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1587,6 +1654,7 @@ export function runTests(ctx) {
             "srcRoute": "/gsp/fallback/[slug]",
             "dataRoute": "/_next/data/BUILD_ID/nl-NL/gsp/fallback/always.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1599,6 +1667,7 @@ export function runTests(ctx) {
             "srcRoute": "/gsp/no-fallback/[slug]",
             "dataRoute": "/_next/data/BUILD_ID/nl-NL/gsp/no-fallback/second.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1611,6 +1680,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/not-found.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1623,6 +1693,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/404.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1635,6 +1706,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/frank.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1647,6 +1719,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/gsp.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1659,6 +1732,7 @@ export function runTests(ctx) {
             "srcRoute": "/gsp/fallback/[slug]",
             "dataRoute": "/_next/data/BUILD_ID/nl/gsp/fallback/always.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1671,6 +1745,7 @@ export function runTests(ctx) {
             "srcRoute": null,
             "dataRoute": "/_next/data/BUILD_ID/not-found.json",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1697,6 +1772,7 @@ export function runTests(ctx) {
             "fallback": "/gsp/fallback/[slug].html",
             "dataRouteRegex": "^\\/_next\\/data\\/BUILD_ID\\/gsp\\/fallback\\/([^\\/]+?)\\.json$",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1710,6 +1786,7 @@ export function runTests(ctx) {
             "fallback": false,
             "dataRouteRegex": "^\\/_next\\/data\\/BUILD_ID\\/gsp\\/no\\-fallback\\/([^\\/]+?)\\.json$",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1723,6 +1800,7 @@ export function runTests(ctx) {
             "fallback": null,
             "dataRouteRegex": "^\\/_next\\/data\\/BUILD_ID\\/not\\-found\\/blocking\\-fallback\\/([^\\/]+?)\\.json$",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",
@@ -1736,6 +1814,7 @@ export function runTests(ctx) {
             "fallback": "/not-found/fallback/[slug].html",
             "dataRouteRegex": "^\\/_next\\/data\\/BUILD_ID\\/not\\-found\\/fallback\\/([^\\/]+?)\\.json$",
             "allowHeader": [
+              "host",
               "x-matched-path",
               "x-prerender-revalidate",
               "x-prerender-revalidate-if-generated",


### PR DESCRIPTION
The host header is necessary for determining the current domain locale for ISR so we need to ensure it's in the default allowed headers list. Without this header we aren't able to render links accurately during revalidations. 


x-ref: https://github.com/vercel/next.js/issues/71848
x-ref: NEXT-3842