### PR TITLE
[Segment Cache] Initial implementation

### DIFF
--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -65,7 +65,7 @@ export type RequestHeaders = {
   'Next-Test-Fetch-Priority'?: RequestInit['priority']
 }
 
-function urlToUrlWithoutFlightMarker(url: string): URL {
+export function urlToUrlWithoutFlightMarker(url: string): URL {
   const urlWithoutFlightParameters = new URL(url, location.origin)
   urlWithoutFlightParameters.searchParams.delete(NEXT_RSC_UNION_QUERY)
   if (process.env.NODE_ENV === 'production') {

--- a/packages/next/src/client/components/segment-cache/cache-key.ts
+++ b/packages/next/src/client/components/segment-cache/cache-key.ts
@@ -1,0 +1,43 @@
+// TypeScript trick to simulate opaque types, like in Flow.
+type Opaque<K, T> = T & { __brand: K }
+
+// Only functions in this module should be allowed to create CacheKeys.
+export type RouteCacheKeyId = Opaque<'RouteCacheKeyId', string>
+export type NormalizedHref = Opaque<'NormalizedHref', string>
+type NormalizedNextUrl = Opaque<'NormalizedNextUrl', string>
+
+export type RouteCacheKey = Opaque<
+  'RouteCacheKey',
+  {
+    id: RouteCacheKeyId
+    href: NormalizedHref
+    nextUrl: NormalizedNextUrl | null
+  }
+>
+
+export function createCacheKey(
+  originalHref: string,
+  nextUrl: string | null
+): RouteCacheKey {
+  const originalUrl = new URL(originalHref)
+
+  // TODO: As of now, we never include search params in the cache key because
+  // per-segment prefetch requests are always static, and cannot contain search
+  // params. But to support <Link prefetch={true}>, we will sometimes populate
+  // the cache with dynamic data, so this will have to change.
+  originalUrl.search = ''
+
+  const normalizedHref = originalUrl.href as NormalizedHref
+  const normalizedNextUrl = (
+    nextUrl !== null ? nextUrl : ''
+  ) as NormalizedNextUrl
+  const id = `|${normalizedHref}|${normalizedNextUrl}|` as RouteCacheKeyId
+
+  const cacheKey = {
+    id,
+    href: normalizedHref,
+    nextUrl: normalizedNextUrl,
+  } as RouteCacheKey
+
+  return cacheKey
+}

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -1,0 +1,471 @@
+import type {
+  TreePrefetch,
+  RootTreePrefetch,
+  SegmentPrefetch,
+} from '../../../server/app-render/collect-segment-data'
+import type { LoadingModuleData } from '../../../shared/lib/app-router-context.shared-runtime'
+import {
+  NEXT_ROUTER_PREFETCH_HEADER,
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+  NEXT_URL,
+  RSC_CONTENT_TYPE_HEADER,
+  RSC_HEADER,
+} from '../app-router-headers'
+import {
+  createFetch,
+  createFromNextReadableStream,
+  createUnclosingPrefetchStream,
+  urlToUrlWithoutFlightMarker,
+  type RequestHeaders,
+} from '../router-reducer/fetch-server-response'
+import {
+  trackPrefetchRequestBandwidth,
+  pingPrefetchTask,
+  type PrefetchTask,
+} from './scheduler'
+import { getAppBuildId } from '../../app-build-id'
+import { createHrefFromUrl } from '../router-reducer/create-href-from-url'
+import type { RouteCacheKey, RouteCacheKeyId } from './cache-key'
+
+// A note on async/await when working in the prefetch cache:
+//
+// Most async operations in the prefetch cache should *not* use async/await,
+// Instead, spawn a subtask that writes the results to a cache entry, and attach
+// a "ping" listener to notify the prefetch queue to try again.
+//
+// The reason is we need to be able to access the segment cache and traverse its
+// data structures synchronously. For example, if there's a synchronous update
+// we can take an immediate snapshot of the cache to produce something we can
+// render. Limiting the use of async/await also makes it easier to avoid race
+// conditions, which is especially important because is cache is mutable.
+//
+// Another reason is that while we're performing async work, it's possible for
+// existing entries to become stale, or for Link prefetches to be removed from
+// the queue. For optimal scheduling, we need to be able to "cancel" subtasks
+// that are no longer needed. So, when a segment is received from the server, we
+// restart from the root of the tree that's being prefetched, to confirm all the
+// parent segments are still cached. If the segment is no longer reachable from
+// the root, then it's effectively canceled. This is similar to the design of
+// Rust Futures, or React Suspense.
+
+type RouteCacheEntryShared = {
+  staleAt: number
+  couldBeIntercepted: boolean
+}
+
+export const enum EntryStatus {
+  Pending,
+  Rejected,
+  Fulfilled,
+}
+
+type PendingRouteCacheEntry = RouteCacheEntryShared & {
+  status: EntryStatus.Pending
+  canonicalUrl: null
+  tree: null
+  head: null
+}
+
+type RejectedRouteCacheEntry = RouteCacheEntryShared & {
+  status: EntryStatus.Rejected
+  canonicalUrl: null
+  tree: null
+  head: null
+}
+
+export type FulfilledRouteCacheEntry = RouteCacheEntryShared & {
+  status: EntryStatus.Fulfilled
+  canonicalUrl: string
+  tree: TreePrefetch
+  head: React.ReactNode | null
+}
+
+export type RouteCacheEntry =
+  | PendingRouteCacheEntry
+  | FulfilledRouteCacheEntry
+  | RejectedRouteCacheEntry
+
+type SegmentCacheEntryShared = {
+  staleAt: number
+}
+
+type PendingSegmentCacheEntry = SegmentCacheEntryShared & {
+  status: EntryStatus.Pending
+  rsc: null
+  loading: null
+  promise: null | PromiseWithResolvers<FulfilledSegmentCacheEntry | null>
+}
+
+type RejectedSegmentCacheEntry = SegmentCacheEntryShared & {
+  status: EntryStatus.Rejected
+  rsc: null
+  loading: null
+  promise: null
+}
+
+type FulfilledSegmentCacheEntry = SegmentCacheEntryShared & {
+  status: EntryStatus.Fulfilled
+  rsc: React.ReactNode | null
+  loading: LoadingModuleData | Promise<LoadingModuleData>
+  promise: null
+}
+
+export type SegmentCacheEntry =
+  | PendingSegmentCacheEntry
+  | RejectedSegmentCacheEntry
+  | FulfilledSegmentCacheEntry
+
+const routeCache = new Map<RouteCacheKeyId, RouteCacheEntry>()
+const segmentCache = new Map<string, SegmentCacheEntry>()
+
+export function readRouteCacheEntry(
+  now: number,
+  key: RouteCacheKey
+): RouteCacheEntry | null {
+  const existingEntry = routeCache.get(key.id)
+  if (existingEntry !== undefined) {
+    // Check if the entry is stale
+    if (existingEntry.staleAt > now) {
+      // Reuse the existing entry.
+      return existingEntry
+    } else {
+      // Evict the stale entry from the cache.
+      evictRouteCacheEntryFromCache(key)
+    }
+  }
+  return null
+}
+
+export function readSegmentCacheEntry(
+  now: number,
+  path: string
+): SegmentCacheEntry | null {
+  const existingEntry = segmentCache.get(path)
+  if (existingEntry !== undefined) {
+    // Check if the entry is stale
+    if (existingEntry.staleAt > now) {
+      // Reuse the existing entry.
+      return existingEntry
+    } else {
+      // Evict the stale entry from the cache.
+      evictSegmentEntryFromCache(existingEntry, path)
+    }
+  }
+  return null
+}
+
+export function waitForSegmentCacheEntry(
+  pendingEntry: PendingSegmentCacheEntry
+): Promise<FulfilledSegmentCacheEntry | null> {
+  // Because the entry is pending, there's already a in-progress request.
+  // Attach a promise to the entry that will resolve when the server responds.
+  let promiseWithResolvers = pendingEntry.promise
+  if (promiseWithResolvers === null) {
+    promiseWithResolvers = pendingEntry.promise =
+      createPromiseWithResolvers<FulfilledSegmentCacheEntry | null>()
+  } else {
+    // There's already a promise we can use
+  }
+  return promiseWithResolvers.promise
+}
+
+/**
+ * Reads the route cache for a matching entry *and* spawns a request if there's
+ * no match. Because this may issue a network request, it should only be called
+ * from within the context of a prefetch task.
+ */
+export function requestRouteCacheEntryFromCache(
+  now: number,
+  task: PrefetchTask
+): RouteCacheEntry {
+  const existingEntry = readRouteCacheEntry(now, task.key)
+  if (existingEntry !== null) {
+    return existingEntry
+  }
+  // Create a pending entry and spawn a request for its data.
+  const pendingEntry: PendingRouteCacheEntry = {
+    canonicalUrl: null,
+    status: EntryStatus.Pending,
+    tree: null,
+    head: null,
+    // If the request takes longer than a minute, a subsequent request should
+    // retry instead of waiting for this one.
+    //
+    // When the response is received, this value will be replaced by a new value
+    // based on the stale time sent from the server.
+    staleAt: now + 60 * 1000,
+    couldBeIntercepted: false,
+  }
+  const key = task.key
+  const requestPromise = fetchRouteOnCacheMiss(pendingEntry, key)
+  trackPrefetchRequestBandwidth(requestPromise)
+  routeCache.set(key.id, pendingEntry)
+  return pendingEntry
+}
+
+/**
+ * Reads the route cache for a matching entry *and* spawns a request if there's
+ * no match. Because this may issue a network request, it should only be called
+ * from within the context of a prefetch task.
+ */
+export function requestSegmentEntryFromCache(
+  now: number,
+  task: PrefetchTask,
+  route: FulfilledRouteCacheEntry,
+  path: string,
+  accessToken: string
+): SegmentCacheEntry {
+  const existingEntry = readSegmentCacheEntry(now, path)
+  if (existingEntry !== null) {
+    return existingEntry
+  }
+  // Create a pending entry and spawn a request for its data.
+  const pendingEntry: PendingSegmentCacheEntry = {
+    status: EntryStatus.Pending,
+    rsc: null,
+    loading: null,
+    staleAt: route.staleAt,
+    promise: null,
+  }
+  trackPrefetchRequestBandwidth(
+    fetchSegmentEntryOnCacheMiss(
+      route,
+      pendingEntry,
+      task.key,
+      path,
+      accessToken
+    )
+  )
+  segmentCache.set(path, pendingEntry)
+  return pendingEntry
+}
+
+function evictRouteCacheEntryFromCache(key: RouteCacheKey): void {
+  routeCache.delete(key.id)
+}
+
+function evictSegmentEntryFromCache(
+  entry: SegmentCacheEntry,
+  key: string
+): void {
+  segmentCache.delete(key)
+  if (entry.status === EntryStatus.Pending && entry.promise !== null) {
+    // There were listeners for this entry. Resolve them with `null` to indicate
+    // that the prefetch failed. It's up to the listener to decide how to handle
+    // this case.
+    // NOTE: We don't currently propagate the reason the prefetch was canceled
+    // but we could by accepting a `reason` argument.
+    entry.promise.resolve(null)
+    entry.promise = null
+  }
+}
+
+function fulfillRouteCacheEntry(
+  entry: PendingRouteCacheEntry,
+  tree: TreePrefetch,
+  head: React.ReactNode,
+  staleAt: number,
+  couldBeIntercepted: boolean,
+  canonicalUrl: string
+) {
+  const fulfilledEntry: FulfilledRouteCacheEntry = entry as any
+  fulfilledEntry.status = EntryStatus.Fulfilled
+  fulfilledEntry.tree = tree
+  fulfilledEntry.head = head
+  fulfilledEntry.staleAt = staleAt
+  fulfilledEntry.couldBeIntercepted = couldBeIntercepted
+  fulfilledEntry.canonicalUrl = canonicalUrl
+}
+
+function fulfillSegmentCacheEntry(
+  segmentCacheEntry: PendingSegmentCacheEntry,
+  rsc: React.ReactNode,
+  loading: LoadingModuleData | Promise<LoadingModuleData>,
+  staleAt: number
+) {
+  const fulfilledEntry: FulfilledSegmentCacheEntry = segmentCacheEntry as any
+  fulfilledEntry.status = EntryStatus.Fulfilled
+  fulfilledEntry.rsc = rsc
+  fulfilledEntry.loading = loading
+  fulfilledEntry.staleAt = staleAt
+  // Resolve any listeners that were waiting for this data.
+  if (segmentCacheEntry.promise !== null) {
+    segmentCacheEntry.promise.resolve(fulfilledEntry)
+    // Free the promise for garbage collection.
+    fulfilledEntry.promise = null
+  }
+}
+
+function rejectRouteCacheEntry(
+  entry: PendingRouteCacheEntry,
+  staleAt: number
+): void {
+  const rejectedEntry: RejectedRouteCacheEntry = entry as any
+  rejectedEntry.status = EntryStatus.Rejected
+  rejectedEntry.staleAt = staleAt
+}
+
+function rejectSegmentCacheEntry(
+  entry: PendingSegmentCacheEntry,
+  staleAt: number
+): void {
+  const rejectedEntry: RejectedSegmentCacheEntry = entry as any
+  rejectedEntry.status = EntryStatus.Rejected
+  rejectedEntry.staleAt = staleAt
+  if (entry.promise !== null) {
+    // NOTE: We don't currently propagate the reason the prefetch was canceled
+    // but we could by accepting a `reason` argument.
+    entry.promise.resolve(null)
+    entry.promise = null
+  }
+}
+
+async function fetchRouteOnCacheMiss(
+  entry: PendingRouteCacheEntry,
+  key: RouteCacheKey
+): Promise<void> {
+  // This function is allowed to use async/await because it contains the actual
+  // fetch that gets issued on a cache miss. Notice though that it does not
+  // return anything; it writes the result to the cache entry directly, then
+  // pings the scheduler to unblock the corresponding prefetch task.
+  const href = key.href
+  try {
+    const response = await fetchSegmentPrefetchResponse(href, '/_tree')
+    if (!response || !response.ok || !response.body) {
+      // Received an unexpected response.
+      rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
+      return
+    }
+    const serverData: RootTreePrefetch = await (createFromNextReadableStream(
+      response.body
+    ) as Promise<RootTreePrefetch>)
+    if (serverData.buildId !== getAppBuildId()) {
+      // The server build does not match the client. Treat as a 404. During
+      // an actual navigation, the router will trigger an MPA navigation.
+      // TODO: Consider moving the build ID to a response header so we can check
+      // it before decoding the response, and so there's one way of checking
+      // across all response types.
+      rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
+      return
+    }
+
+    // This is a bit convoluted but it's taken from router-reducer and
+    // fetch-server-response
+    const canonicalUrl = response.redirected
+      ? createHrefFromUrl(urlToUrlWithoutFlightMarker(response.url))
+      : href
+
+    // Check whether the response varies based on the Next-Url header.
+    const varyHeader = response.headers.get('vary')
+    const couldBeIntercepted = varyHeader
+      ? varyHeader.includes(NEXT_URL)
+      : false
+
+    fulfillRouteCacheEntry(
+      entry,
+      serverData.tree,
+      serverData.head,
+      Date.now() + serverData.staleTime,
+      couldBeIntercepted,
+      canonicalUrl
+    )
+  } catch (error) {
+    // Either the connection itself failed, or something bad happened while
+    // decoding the response.
+    rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
+    pingPrefetchTask(key)
+  } finally {
+    // The request for the route tree is was blocking this task from prefetching
+    // the segments. Now that the route tree is ready, notify the scheduler to
+    // unblock the prefetch task. We do this even if the request failed, so the
+    // scheduler can dispose of the task.
+    pingPrefetchTask(key)
+  }
+}
+
+async function fetchSegmentEntryOnCacheMiss(
+  route: FulfilledRouteCacheEntry,
+  segmentCacheEntry: PendingSegmentCacheEntry,
+  routeKey: RouteCacheKey,
+  segmentPath: string,
+  accessToken: string | null
+): Promise<void> {
+  // This function is allowed to use async/await because it contains the actual
+  // fetch that gets issued on a cache miss. Notice though that it does not
+  // return anything; it writes the result to the cache entry directly.
+  //
+  // Segment fetches are non-blocking so we don't need to ping the scheduler
+  // on completion.
+  const href = routeKey.href
+  try {
+    const response = await fetchSegmentPrefetchResponse(
+      href,
+      accessToken === '' ? segmentPath : `${segmentPath}.${accessToken}`
+    )
+    if (!response || !response.ok || !response.body) {
+      // Server responded with an error. We should still cache the response, but
+      // we can try again after 10 seconds.
+      rejectSegmentCacheEntry(segmentCacheEntry, Date.now() + 10 * 1000)
+      return
+    }
+    // Wrap the original stream in a new stream that never closes. That way the
+    // Flight client doesn't error if there's a hanging promise. See comment in
+    // createUnclosingPrefetchStream for more details.
+    const prefetchStream = createUnclosingPrefetchStream(response.body)
+    const serverData = await (createFromNextReadableStream(
+      prefetchStream
+    ) as Promise<SegmentPrefetch>)
+    if (serverData.buildId !== getAppBuildId()) {
+      // The server build does not match the client. Treat as a 404. During
+      // an actual navigation, the router will trigger an MPA navigation.
+      // TODO: Consider moving the build ID to a response header so we can check
+      // it before decoding the response, and so there's one way of checking
+      // across all response types.
+      rejectSegmentCacheEntry(segmentCacheEntry, Date.now() + 10 * 1000)
+      return
+    }
+    fulfillSegmentCacheEntry(
+      segmentCacheEntry,
+      serverData.rsc,
+      serverData.loading,
+      // TODO: The server does not currently provide per-segment stale time.
+      // So we use the stale time of the route.
+      route.staleAt
+    )
+  } catch (error) {
+    // Either the connection itself failed, or something bad happened while
+    // decoding the response.
+    rejectSegmentCacheEntry(segmentCacheEntry, Date.now() + 10 * 1000)
+  }
+}
+
+async function fetchSegmentPrefetchResponse(
+  href: string,
+  segmentPath: string
+): Promise<Response | null> {
+  const headers: RequestHeaders = {
+    [RSC_HEADER]: '1',
+    [NEXT_ROUTER_PREFETCH_HEADER]: '1',
+    [NEXT_ROUTER_SEGMENT_PREFETCH_HEADER]: segmentPath,
+  }
+  const fetchPriority = 'low'
+  const response = await createFetch(new URL(href), headers, fetchPriority)
+  const contentType = response.headers.get('content-type')
+  const isFlightResponse =
+    contentType && contentType.startsWith(RSC_CONTENT_TYPE_HEADER)
+  if (!response.ok || !isFlightResponse) {
+    return null
+  }
+  return response
+}
+
+function createPromiseWithResolvers<T>(): PromiseWithResolvers<T> {
+  // Shim of Stage 4 Promise.withResolvers proposal
+  let resolve: (value: T | PromiseLike<T>) => void
+  let reject: (reason: any) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { resolve: resolve!, reject: reject!, promise }
+}

--- a/packages/next/src/client/components/segment-cache/prefetch.ts
+++ b/packages/next/src/client/components/segment-cache/prefetch.ts
@@ -1,4 +1,6 @@
 import { createPrefetchURL } from '../../components/app-router'
+import { createCacheKey } from './cache-key'
+import { schedulePrefetchTask } from './scheduler'
 
 /**
  * Entrypoint for prefetching a URL into the Segment Cache.
@@ -12,5 +14,8 @@ export function prefetch(href: string) {
     return
   }
 
-  // TODO: Not yet implemented
+  // TODO: Interception routes not yet implemented in Segment Cache. Pass a
+  // Next-URL to createCacheKey.
+  const cacheKey = createCacheKey(url.href, null)
+  schedulePrefetchTask(cacheKey)
 }

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -1,0 +1,449 @@
+import type { TreePrefetch } from '../../../server/app-render/collect-segment-data'
+import {
+  requestRouteCacheEntryFromCache,
+  requestSegmentEntryFromCache,
+  EntryStatus,
+  type FulfilledRouteCacheEntry,
+  type RouteCacheEntry,
+} from './cache'
+import type { RouteCacheKey, RouteCacheKeyId } from './cache-key'
+
+const scheduleMicrotask =
+  typeof queueMicrotask === 'function'
+    ? queueMicrotask
+    : (fn: () => unknown) =>
+        Promise.resolve()
+          .then(fn)
+          .catch((error) =>
+            setTimeout(() => {
+              throw error
+            })
+          )
+
+export type PrefetchTask = {
+  key: RouteCacheKey
+
+  /**
+   * sortId is an incrementing counter
+   *
+   * Newer prefetches are prioritized over older ones, so that as new links
+   * enter the viewport, they are not starved by older links that are no
+   * longer relevant. In the future, we can add additional prioritization
+   * heuristics, like removing prefetches once a link leaves the viewport.
+   *
+   * The sortId is assigned when the prefetch is initiated, and reassigned if
+   * the same URL is prefetched again (effectively bumping it to the top of
+   * the queue).
+   *
+   * TODO: We can add additional fields here to indicate what kind of prefetch
+   * it is. For example, was it initiated by a link? Or was it an imperative
+   * call? If it was initiated by a link, we can remove it from the queue when
+   * the link leaves the viewport, but if it was an imperative call, then we
+   * should keep it in the queue until it's fulfilled.
+   *
+   * We can also add priority levels. For example, hovering over a link could
+   * increase the priority of its prefetch.
+   */
+  sortId: number
+
+  /**
+   * True if the prefetch is blocked by network data. We remove tasks from the
+   * queue once they are blocked, and add them back when they receive data.
+   *
+   * isBlocked also indicates whether the task is currently in the queue;
+   * tasks are removed from the queue (but not the map) when they are blocked.
+   * Use this to avoid queueing the same task multiple times.
+   */
+  isBlocked: boolean
+
+  /**
+   * The index of the task in the heap's backing array. Used to efficiently
+   * change the priority of a task by re-sifting it, which requires knowing
+   * where it is in the array. This is only used internally by the heap
+   * algorithm. The naive alternative is indexOf every time a task is queued,
+   * which has O(n) complexity.
+   */
+  _heapIndex: number
+}
+
+const enum PrefetchTaskExitStatus {
+  /**
+   * The task yielded because there are too many requests in progress.
+   */
+  InProgress,
+
+  /**
+   * The task is blocked. It needs more data before it can proceed.
+   *
+   * Currently the only reason this happens is we're still waiting to receive a
+   * route tree from the server, because we can't start prefetching the segments
+   * until we know what to prefetch.
+   */
+  Blocked,
+
+  /**
+   * There's nothing left to prefetch.
+   */
+  Done,
+}
+
+const taskHeap: Array<PrefetchTask> = []
+const taskMap: Map<RouteCacheKeyId, PrefetchTask> = new Map()
+
+// This is intentionally low so that when a navigation happens, the browser's
+// internal network queue is not already saturated with prefetch requests.
+const MAX_CONCURRENT_PREFETCH_REQUESTS = 3
+let inProgressRequests = 0
+
+let sortIdCounter = 0
+let didScheduleMicrotask = false
+
+/**
+ * Initiates a prefetch task for the given URL. If a prefetch for the same URL
+ * is already in progress, this will bump it to the top of the queue.
+ *
+ * This is not a user-facing function. By the time this is called, the href is
+ * expected to be validated and normalized.
+ *
+ * @param key The RouteCacheKey to prefetch.
+ */
+export function schedulePrefetchTask(key: RouteCacheKey): void {
+  const existingTask = taskMap.get(key.id)
+  if (existingTask !== undefined) {
+    // A task for this URL already exists, but we should bump it to the top of
+    // the queue by assigning a new sortId. However, if it already has the
+    // highest sortId that's been assigned, then we can bail out.
+    //
+    // Note that this check is not equivalent to checking if it's at the front
+    // of the queue, because there could be tasks that have a higher sortId but
+    // are not currently queued (because they are blocked).
+    if (existingTask.sortId === sortIdCounter) {
+      // No-op
+      return
+    }
+    existingTask.sortId = sortIdCounter++
+    heapSift(taskHeap, existingTask)
+    return
+  }
+
+  // Spawn a new prefetch task
+  const task: PrefetchTask = {
+    key,
+    sortId: sortIdCounter++,
+    isBlocked: false,
+    _heapIndex: -1,
+  }
+  heapPush(taskHeap, task)
+  taskMap.set(key.id, task)
+
+  // Schedule an async task to process the queue.
+  //
+  // The main reason we process the queue in an async task is for batching.
+  // It's common for a single JS task/event to trigger multiple prefetches.
+  // By deferring to a microtask, we only process the queue once per JS task.
+  // If they have different priorities, it also ensures they are processed in
+  // the optimal order.
+  ensureWorkIsScheduled()
+}
+
+function ensureWorkIsScheduled() {
+  if (didScheduleMicrotask || !hasNetworkBandwidth()) {
+    // Either we already scheduled a task to process the queue, or there are
+    // too many concurrent requests in progress. In the latter case, the
+    // queue will resume processing once more bandwidth is available.
+    return
+  }
+  didScheduleMicrotask = true
+  scheduleMicrotask(processQueueInMicrotask)
+}
+
+/**
+ * Checks if we've exceeded the maximum number of concurrent prefetch requests,
+ * to avoid saturating the browser's internal network queue. This is a
+ * cooperative limit — prefetch tasks should check this before issuing
+ * new requests.
+ */
+function hasNetworkBandwidth(): boolean {
+  // TODO: Also check if there's an in-progress navigation. We should never
+  // add prefetch requests to the network queue if an actual navigation is
+  // taking place, to ensure there's sufficient bandwidth for render-blocking
+  // data and resources.
+  return inProgressRequests < MAX_CONCURRENT_PREFETCH_REQUESTS
+}
+
+/**
+ * Notifies the scheduler of an in-progress prefetch request. This is used to
+ * control network bandwidth by limiting the number of concurrent requests.
+ *
+ * @param promise A promise that resolves when the request has finished.
+ */
+export function trackPrefetchRequestBandwidth(
+  promiseForServerData: Promise<unknown>
+) {
+  inProgressRequests++
+  promiseForServerData.then(
+    onPrefetchRequestCompletion,
+    onPrefetchRequestCompletion
+  )
+}
+
+function onPrefetchRequestCompletion(): void {
+  inProgressRequests--
+
+  // Notify the scheduler that we have more bandwidth, and can continue
+  // processing tasks.
+  ensureWorkIsScheduled()
+}
+
+/**
+ * Notify the scheduler that we've received new data for an in-progress
+ * prefetch. The corresponding task will be added back to the queue (unless the
+ * task has been canceled in the meantime).
+ */
+export function pingPrefetchTask(key: RouteCacheKey) {
+  // "Ping" a prefetch that's already in progress to notify it of new data.
+  const task = taskMap.get(key.id)
+  if (task === undefined) {
+    // There's no matching prefetch task, which means it must have either
+    // already completed or been canceled. This can also happen if an entry is
+    // read from the cache outside the context of a prefetch.
+    return
+  }
+  if (!task.isBlocked) {
+    // Prefetch is already queued.
+    return
+  }
+  // Unblock the task and requeue it.
+  task.isBlocked = false
+  heapPush(taskHeap, task)
+  ensureWorkIsScheduled()
+}
+
+function processQueueInMicrotask() {
+  didScheduleMicrotask = false
+
+  // We aim to minimize how often we read the current time. Since nearly all
+  // functions in the prefetch scheduler are synchronous, we can read the time
+  // once and pass it as an argument wherever it's needed.
+  const now = Date.now()
+
+  // Process the task queue until we run out of network bandwidth.
+  let task = heapPeek(taskHeap)
+  while (task !== null && hasNetworkBandwidth()) {
+    const route = requestRouteCacheEntryFromCache(now, task)
+    const exitStatus = pingRouteTree(now, task, route)
+    switch (exitStatus) {
+      case PrefetchTaskExitStatus.InProgress:
+        // The task yielded because there are too many requests in progress.
+        // Stop processing tasks until we have more bandwidth.
+        return
+      case PrefetchTaskExitStatus.Blocked:
+        // The task is blocked. It needs more data before it can proceed.
+        // Keep the task out of the queue until the server responds.
+        task.isBlocked = true
+
+        // Continue to the next task
+        task = heapPop(taskHeap)
+        continue
+      case PrefetchTaskExitStatus.Done:
+        // The prefetch is complete. Remove the task from the map so it can be
+        // garbage collected.
+        taskMap.delete(task.key.id)
+
+        // Continue to the next task
+        task = heapPop(taskHeap)
+        continue
+      default: {
+        const _exhaustiveCheck: never = exitStatus
+        return
+      }
+    }
+  }
+}
+
+function pingRouteTree(
+  now: number,
+  task: PrefetchTask,
+  route: RouteCacheEntry
+): PrefetchTaskExitStatus {
+  switch (route.status) {
+    case EntryStatus.Pending: {
+      // Still pending. We can't start prefetching the segments until the route
+      // tree has loaded.
+      return PrefetchTaskExitStatus.Blocked
+    }
+    case EntryStatus.Rejected: {
+      // Route tree failed to load. Treat as a 404.
+      return PrefetchTaskExitStatus.Done
+    }
+    case EntryStatus.Fulfilled: {
+      // Recursively fill in the segment tree.
+      if (!hasNetworkBandwidth()) {
+        // Stop prefetching segments until there's more bandwidth.
+        return PrefetchTaskExitStatus.InProgress
+      }
+      const tree = route.tree
+      requestSegmentEntryFromCache(now, task, route, tree.path, '')
+      return pingSegmentTree(now, task, route, tree)
+    }
+    default: {
+      const _exhaustiveCheck: never = route
+      return PrefetchTaskExitStatus.Done
+    }
+  }
+}
+
+function pingSegmentTree(
+  now: number,
+  task: PrefetchTask,
+  route: FulfilledRouteCacheEntry,
+  tree: TreePrefetch
+): PrefetchTaskExitStatus.InProgress | PrefetchTaskExitStatus.Done {
+  if (tree.slots !== null) {
+    // Recursively ping the children.
+    for (const parallelRouteKey in tree.slots) {
+      const childTree = tree.slots[parallelRouteKey]
+      if (!hasNetworkBandwidth()) {
+        // Stop prefetching segments until there's more bandwidth.
+        return PrefetchTaskExitStatus.InProgress
+      } else {
+        const childPath = childTree.path
+        const childToken = childTree.token
+        requestSegmentEntryFromCache(now, task, route, childPath, childToken)
+      }
+      const childExitStatus = pingSegmentTree(now, task, route, childTree)
+      if (childExitStatus === PrefetchTaskExitStatus.InProgress) {
+        // Child yielded without finishing.
+        return PrefetchTaskExitStatus.InProgress
+      }
+    }
+  }
+  // This segment and all its children have finished prefetching.
+  return PrefetchTaskExitStatus.Done
+}
+
+// -----------------------------------------------------------------------------
+// The remainider of the module is a MinHeap implementation. Try not to put any
+// logic below here unless it's related to the heap algorithm. We can extract
+// this to a separate module if/when we need multiple kinds of heaps.
+// -----------------------------------------------------------------------------
+
+function compareQueuePriority(a: PrefetchTask, b: PrefetchTask) {
+  // Since the queue is a MinHeap, this should return a positive number if b is
+  // higher priority than a, and a negative number if a is higher priority
+  // than b.
+  //
+  // sortId is an incrementing counter assigned to prefetches. We want to
+  // process the newest prefetches first.
+  return b.sortId - a.sortId
+}
+
+function heapPush(heap: Array<PrefetchTask>, node: PrefetchTask): void {
+  const index = heap.length
+  heap.push(node)
+  node._heapIndex = index
+  heapSiftUp(heap, node, index)
+}
+
+function heapPeek(heap: Array<PrefetchTask>): PrefetchTask | null {
+  return heap.length === 0 ? null : heap[0]
+}
+
+function heapPop(heap: Array<PrefetchTask>): PrefetchTask | null {
+  if (heap.length === 0) {
+    return null
+  }
+  const first = heap[0]
+  first._heapIndex = -1
+  const last = heap.pop() as PrefetchTask
+  if (last !== first) {
+    heap[0] = last
+    last._heapIndex = 0
+    heapSiftDown(heap, last, 0)
+  }
+  return first
+}
+
+function heapSift(heap: Array<PrefetchTask>, node: PrefetchTask) {
+  const index = node._heapIndex
+  if (index !== -1) {
+    const parentIndex = (index - 1) >>> 1
+    const parent = heap[parentIndex]
+    if (compareQueuePriority(parent, node) > 0) {
+      // The parent is larger. Sift up.
+      heapSiftUp(heap, node, index)
+    } else {
+      // The parent is smaller (or equal). Sift down.
+      heapSiftDown(heap, node, index)
+    }
+  }
+}
+
+function heapSiftUp(
+  heap: Array<PrefetchTask>,
+  node: PrefetchTask,
+  i: number
+): void {
+  let index = i
+  while (index > 0) {
+    const parentIndex = (index - 1) >>> 1
+    const parent = heap[parentIndex]
+    if (compareQueuePriority(parent, node) > 0) {
+      // The parent is larger. Swap positions.
+      heap[parentIndex] = node
+      node._heapIndex = parentIndex
+      heap[index] = parent
+      parent._heapIndex = index
+
+      index = parentIndex
+    } else {
+      // The parent is smaller. Exit.
+      return
+    }
+  }
+}
+
+function heapSiftDown(
+  heap: Array<PrefetchTask>,
+  node: PrefetchTask,
+  i: number
+): void {
+  let index = i
+  const length = heap.length
+  const halfLength = length >>> 1
+  while (index < halfLength) {
+    const leftIndex = (index + 1) * 2 - 1
+    const left = heap[leftIndex]
+    const rightIndex = leftIndex + 1
+    const right = heap[rightIndex]
+
+    // If the left or right node is smaller, swap with the smaller of those.
+    if (compareQueuePriority(left, node) < 0) {
+      if (rightIndex < length && compareQueuePriority(right, left) < 0) {
+        heap[index] = right
+        right._heapIndex = index
+        heap[rightIndex] = node
+        node._heapIndex = rightIndex
+
+        index = rightIndex
+      } else {
+        heap[index] = left
+        left._heapIndex = index
+        heap[leftIndex] = node
+        node._heapIndex = leftIndex
+
+        index = leftIndex
+      }
+    } else if (rightIndex < length && compareQueuePriority(right, node) < 0) {
+      heap[index] = right
+      right._heapIndex = index
+      heap[rightIndex] = node
+      node._heapIndex = rightIndex
+
+      index = rightIndex
+    } else {
+      // Neither child is smaller. Exit.
+      return
+    }
+  }
+}

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -96,7 +96,7 @@ export type CacheNodeSeedData = [
   parallelRoutes: {
     [parallelRouterKey: string]: CacheNodeSeedData | null
   },
-  loading: LoadingModuleData,
+  loading: LoadingModuleData | Promise<LoadingModuleData>,
 ]
 
 export type FlightDataSegment = [

--- a/test/e2e/app-dir/ppr-navigations/simple/per-segment-prefetching.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/simple/per-segment-prefetching.test.ts
@@ -52,11 +52,10 @@ describe('per segment prefetching', () => {
     expect(enResponseText).toEqual(frResponseText)
 
     // Now use the route tree to construct a request for the child segment.
-    const childSegmentPath = routeTree.tree.slots.children.key
-    const childToken = routeTree.tree.slots.children.token
+    const child = routeTree.tree.slots.children
 
     // The access token is appended to the end of the segment path.
-    const fullChildSegmentPath = `${childSegmentPath}.${childToken}`
+    const fullChildSegmentPath = `${child.path}.${child.token}`
     const childResponse = await prefetch('/en', fullChildSegmentPath)
     const childResponseText = await childResponse.text()
 

--- a/test/e2e/app-dir/segment-cache/basic/app/streaming-text.tsx
+++ b/test/e2e/app-dir/segment-cache/basic/app/streaming-text.tsx
@@ -14,13 +14,13 @@ export function StreamingText({
   dynamic: string
 }) {
   return (
-    <div data-streaming-text>
-      <div>{staticText}</div>
-      <div>
-        <Suspense fallback={`Loading... [${dynamic}]`}>
+    <div>
+      <div data-streaming-text-static={staticText}>{staticText}</div>
+      <Suspense fallback={<div>Loading... [{dynamic}]</div>}>
+        <div data-streaming-text-dynamic={dynamic}>
           <DynamicText text={dynamic} />
-        </Suspense>
-      </div>
+        </div>
+      </Suspense>
     </div>
   )
 }

--- a/test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
+++ b/test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import type { Page, Route } from 'playwright'
 
 describe('segment cache (basic tests)', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
@@ -10,19 +11,142 @@ describe('segment cache (basic tests)', () => {
     return
   }
 
-  it('basic navigation', async () => {
-    const browser = await next.browser('/')
+  it('navigate before any data has loaded into the prefetch cache', async () => {
+    // Before loading the page, block all prefetch requests from resolving so
+    // we can simulate what happens during a navigation if the cache does not
+    // have a matching prefetch entry.
+    const interceptor = createRequestInterceptor()
+    const prefetchLock = interceptor.lockPrefetches()
+
+    const browser = await next.browser('/', {
+      beforePageLoad(page: Page) {
+        page.route('**/*', async (route: Route) => {
+          await interceptor.interceptRoute(route)
+        })
+      },
+    })
 
     // Navigate to the test page
     const link = await browser.elementByCss('a')
     await link.click()
 
-    // Confirm that the content has streamed in and the URL has updated
-    // as expected
+    // The static and dynamic content appears simultaneously because everything
+    // was fetched as part of the same navigation request.
     const nav = await browser.elementById('nav')
     expect(await nav.innerHTML()).toMatchInlineSnapshot(
-      `"<div data-streaming-text="true"><div>Static in nav</div><div>Dynamic in nav</div></div>"`
+      `"<div><div data-streaming-text-static="Static in nav">Static in nav</div><div data-streaming-text-dynamic="Dynamic in nav">Dynamic in nav</div></div>"`
     )
-    expect(new URL(await browser.url()).pathname).toBe('/test')
+
+    await prefetchLock.release()
+  })
+
+  it('navigate with prefetched data', async () => {
+    const interceptor = createRequestInterceptor()
+    const browser = await next.browser('/', {
+      beforePageLoad(page: Page) {
+        page.route('**/*', async (route: Route) => {
+          await interceptor.interceptRoute(route)
+        })
+      },
+    })
+
+    // Rendering the link triggers a prefetch of the test page.
+    const link = await browser.elementByCss('a')
+
+    // Before navigating to the test page, block all navigation requests from
+    // resolving so we can simulate what happens on a slow connection when
+    // the cache has been populated with prefetched data.
+    const navigationsLock = interceptor.lockNavigations()
+
+    // Navigate to the test page
+    await link.click()
+
+    // Even though the navigation is blocked, we're able to immediately render
+    // the static content because it was prefetched.
+    const nav = await browser.elementById('nav')
+    expect(await nav.innerHTML()).toMatchInlineSnapshot(
+      `"<div><div data-streaming-text-static="Static in nav">Static in nav</div><div>Loading... [Dynamic in nav]</div></div>"`
+    )
+
+    // Unblocking the navigation request causes the dynamic content to
+    // stream in.
+    await navigationsLock.release()
+    await browser.elementByCss('[data-streaming-text-dynamic="Dynamic in nav"]')
+    expect(await nav.innerHTML()).toMatchInlineSnapshot(
+      `"<div><div data-streaming-text-static="Static in nav">Static in nav</div><div data-streaming-text-dynamic="Dynamic in nav">Dynamic in nav</div></div>"`
+    )
   })
 })
+
+function createRequestInterceptor() {
+  // Test utility for intercepting internal RSC requests so we can control the
+  // timing of when they resolve. We want to avoid relying on internals and
+  // implementation details as much as possible, so the only thing this does
+  // for now is let you block and release requests from happening based on
+  // their type (prefetch requests, navigation requests).
+  let pendingPrefetches: Set<Route> | null = null
+  let pendingNavigations: Set<Route> | null = null
+
+  return {
+    lockNavigations() {
+      if (pendingNavigations !== null) {
+        throw new Error('Navigations are already locked')
+      }
+      pendingNavigations = new Set()
+      return {
+        async release() {
+          if (pendingNavigations === null) {
+            throw new Error('This lock was already released')
+          }
+          const routes = pendingNavigations
+          pendingNavigations = null
+          for (const route of routes) {
+            route.continue()
+          }
+        },
+      }
+    },
+
+    lockPrefetches() {
+      if (pendingPrefetches !== null) {
+        throw new Error('Prefetches are already locked')
+      }
+      pendingPrefetches = new Set()
+      return {
+        release() {
+          if (pendingPrefetches === null) {
+            throw new Error('This lock was already released')
+          }
+          const routes = pendingPrefetches
+          pendingPrefetches = null
+          for (const route of routes) {
+            route.continue()
+          }
+        },
+      }
+    },
+
+    async interceptRoute(route: Route) {
+      const requestHeaders = await route.request().allHeaders()
+
+      if (requestHeaders['RSC'.toLowerCase()]) {
+        // This is an RSC request. Check if it's a prefetch or a navigation.
+        if (requestHeaders['Next-Router-Prefetch'.toLowerCase()]) {
+          // This is a prefetch request.
+          if (pendingPrefetches !== null) {
+            pendingPrefetches.add(route)
+            return
+          }
+        } else {
+          // This is a navigation request.
+          if (pendingNavigations !== null) {
+            pendingNavigations.add(route)
+            return
+          }
+        }
+      }
+
+      await route.continue()
+    },
+  }
+}


### PR DESCRIPTION
Based on:

- #72874 
- #72890 
- #72872 

---

This adds an initial implementation of the client Segment Cache, behind the experimental `clientSegmentCache` flag. (Note: It is not anywhere close to being ready for production use. It will take a while for it to reach parity with the existing implementation.)

I've discussed the motivation in previous PRs, but I'll share a brief summary here again:

The client Segment Cache is a rewrite of App Router's client caching implementation, designed with PPR and "use cache" in mind. Its main distinguishing feature from the current implementation is that it fetches/caches/expires data per route segment, rather than per full URL. An example of what this means in practical terms is that shared layouts are deduplicated in the cache, resulting in less bandwidth. There are other benefits we have in mind but that's the starting point.

I've tried to extract the work here into reasonably-sized commits (many of which have already landed) but this one here is sorta unavoidably large. Here are the main pieces:

- [segment-cache/cache.ts](https://github.com/acdlite/next.js/blob/initial-implementation-client-segment-cache/packages/next/src/client/components/segment-cache/cache.ts): This module is where the cache entries are maintained in memory. An important design principle is that you must be able to read from the cache synchronously without awaiting any promises. We avoid the use of async/await wherever possible; instead, async tasks write their results directly into the cache. This also helps to avoid race conditions.

Currently there's no eviction policy other than stale time, but eventually we'll use an LRU for memory management.

- [segment-cache/scheduler.ts](https://github.com/acdlite/next.js/blob/initial-implementation-client-segment-cache/packages/next/src/client/components/segment-cache/scheduler.ts): This module is primarily a task scheduler. It's also used to manage network bandwidth. The design is inspired by React Suspense and Rust Futures — tasks are pull-based, not push-based. The backing data structure is a MinHeap/PriorityQueue, to support efficient reprioritization of tasks.

- [segment-cache/navigation.ts](https://github.com/acdlite/next.js/blob/initial-implementation-client-segment-cache/packages/next/src/client/components/segment-cache/navigation.ts): This module is responsible for creating a snapshot of the cache at the time of a navigation. Right now it's mostly a bunch of glue code to interop with the data structures used by the rest of the App Router, like CacheNodeSeedData and FlightRouterState. The long term plan is to move everything to using the Segment Cache and refactoring those data structures.

Additional explanations are provided inline.