### PR TITLE
codemod(turbopack): Some more script-generated migrations to ResolvedVc

### DIFF
--- a/turbopack/crates/turbo-tasks-env/src/custom.rs
+++ b/turbopack/crates/turbo-tasks-env/src/custom.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 
 use crate::{case_insensitive_read, EnvMap, ProcessEnv};
 
@@ -8,14 +8,14 @@ use crate::{case_insensitive_read, EnvMap, ProcessEnv};
 /// envs if a key is not overridden.
 #[turbo_tasks::value]
 pub struct CustomProcessEnv {
-    prior: Vc<Box<dyn ProcessEnv>>,
-    custom: Vc<EnvMap>,
+    prior: ResolvedVc<Box<dyn ProcessEnv>>,
+    custom: ResolvedVc<EnvMap>,
 }
 
 #[turbo_tasks::value_impl]
 impl CustomProcessEnv {
     #[turbo_tasks::function]
-    pub fn new(prior: Vc<Box<dyn ProcessEnv>>, custom: Vc<EnvMap>) -> Vc<Self> {
+    pub fn new(prior: ResolvedVc<Box<dyn ProcessEnv>>, custom: ResolvedVc<EnvMap>) -> Vc<Self> {
         CustomProcessEnv { prior, custom }.cell()
     }
 }
@@ -34,7 +34,7 @@ impl ProcessEnv for CustomProcessEnv {
 
     #[turbo_tasks::function]
     async fn read(&self, name: RcStr) -> Result<Vc<Option<RcStr>>> {
-        let custom = case_insensitive_read(self.custom, name.clone());
+        let custom = case_insensitive_read(*self.custom, name.clone());
         match &*custom.await? {
             Some(_) => Ok(custom),
             None => Ok(self.prior.read(name)),

--- a/turbopack/crates/turbo-tasks-env/src/dotenv.rs
+++ b/turbopack/crates/turbo-tasks-env/src/dotenv.rs
@@ -13,7 +13,7 @@ use crate::{sorted_env_vars, EnvMap, ProcessEnv, GLOBAL_ENV_LOCK};
 #[turbo_tasks::value]
 pub struct DotenvProcessEnv {
     prior: Option<ResolvedVc<Box<dyn ProcessEnv>>>,
-    path: Vc<FileSystemPath>,
+    path: ResolvedVc<FileSystemPath>,
 }
 
 #[turbo_tasks::value_impl]
@@ -21,7 +21,7 @@ impl DotenvProcessEnv {
     #[turbo_tasks::function]
     pub fn new(
         prior: Option<ResolvedVc<Box<dyn ProcessEnv>>>,
-        path: Vc<FileSystemPath>,
+        path: ResolvedVc<FileSystemPath>,
     ) -> Vc<Self> {
         DotenvProcessEnv { prior, path }.cell()
     }

--- a/turbopack/crates/turbo-tasks-env/src/filter.rs
+++ b/turbopack/crates/turbo-tasks-env/src/filter.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, Vc};
+use turbo_tasks::{FxIndexMap, ResolvedVc, Vc};
 
 use crate::{EnvMap, ProcessEnv};
 
@@ -8,14 +8,14 @@ use crate::{EnvMap, ProcessEnv};
 /// filtering.
 #[turbo_tasks::value]
 pub struct FilterProcessEnv {
-    prior: Vc<Box<dyn ProcessEnv>>,
+    prior: ResolvedVc<Box<dyn ProcessEnv>>,
     filters: Vec<RcStr>,
 }
 
 #[turbo_tasks::value_impl]
 impl FilterProcessEnv {
     #[turbo_tasks::function]
-    pub fn new(prior: Vc<Box<dyn ProcessEnv>>, filters: Vec<RcStr>) -> Vc<Self> {
+    pub fn new(prior: ResolvedVc<Box<dyn ProcessEnv>>, filters: Vec<RcStr>) -> Vc<Self> {
         FilterProcessEnv {
             prior,
             filters: filters

--- a/turbopack/crates/turbo-tasks-fetch/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/lib.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{mark_session_dependent, Vc};
+use turbo_tasks::{mark_session_dependent, ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString};
 
@@ -104,7 +104,7 @@ pub enum FetchErrorKind {
 
 #[turbo_tasks::value(shared)]
 pub struct FetchError {
-    pub url: Vc<RcStr>,
+    pub url: ResolvedVc<RcStr>,
     pub kind: Vc<FetchErrorKind>,
     pub detail: Vc<StyledString>,
 }
@@ -123,7 +123,7 @@ impl FetchError {
 
         FetchError {
             detail: StyledString::Text(error.to_string().into()).cell(),
-            url: Vc::cell(url.into()),
+            url: ResolvedVc::cell(url.into()),
             kind: kind.into(),
         }
     }
@@ -134,14 +134,14 @@ impl FetchError {
     #[turbo_tasks::function]
     pub async fn to_issue(
         self: Vc<Self>,
-        severity: Vc<IssueSeverity>,
-        issue_context: Vc<FileSystemPath>,
+        severity: ResolvedVc<IssueSeverity>,
+        issue_context: ResolvedVc<FileSystemPath>,
     ) -> Result<Vc<FetchIssue>> {
         let this = &*self.await?;
         Ok(FetchIssue {
             issue_context,
             severity,
-            url: this.url,
+            url: *this.url,
             kind: this.kind,
             detail: this.detail,
         }
@@ -151,8 +151,8 @@ impl FetchError {
 
 #[turbo_tasks::value(shared)]
 pub struct FetchIssue {
-    pub issue_context: Vc<FileSystemPath>,
-    pub severity: Vc<IssueSeverity>,
+    pub issue_context: ResolvedVc<FileSystemPath>,
+    pub severity: ResolvedVc<IssueSeverity>,
     pub url: Vc<RcStr>,
     pub kind: Vc<FetchErrorKind>,
     pub detail: Vc<StyledString>,
@@ -162,12 +162,12 @@ pub struct FetchIssue {
 impl Issue for FetchIssue {
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        self.issue_context
+        *self.issue_context
     }
 
     #[turbo_tasks::function]
     fn severity(&self) -> Vc<IssueSeverity> {
-        self.severity
+        *self.severity
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-testing/tests/debug.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/debug.rs
@@ -91,7 +91,7 @@ async fn struct_unit_debug() {
 async fn struct_transparent_debug() {
     run(&REGISTRATION, || async {
         let a: Vc<StructWithTransparent> = StructWithTransparent {
-            transparent: Transparent(42).cell(),
+            transparent: Transparent(42).resolved_cell(),
         }
         .cell();
         assert_eq!(
@@ -172,7 +172,7 @@ struct StructUnit;
 
 #[turbo_tasks::value(shared)]
 struct StructWithTransparent {
-    transparent: Vc<Transparent>,
+    transparent: ResolvedVc<Transparent>,
 }
 
 #[turbo_tasks::value(shared)]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
@@ -17,8 +17,8 @@ use crate::{ecmascript::content::EcmascriptDevChunkContent, BrowserChunkingConte
 /// Development Ecmascript chunk.
 #[turbo_tasks::value(shared)]
 pub struct EcmascriptDevChunk {
-    chunking_context: Vc<BrowserChunkingContext>,
-    chunk: Vc<EcmascriptChunk>,
+    chunking_context: ResolvedVc<BrowserChunkingContext>,
+    chunk: ResolvedVc<EcmascriptChunk>,
 }
 
 #[turbo_tasks::value_impl]
@@ -26,8 +26,8 @@ impl EcmascriptDevChunk {
     /// Creates a new [`Vc<EcmascriptDevChunk>`].
     #[turbo_tasks::function]
     pub fn new(
-        chunking_context: Vc<BrowserChunkingContext>,
-        chunk: Vc<EcmascriptChunk>,
+        chunking_context: ResolvedVc<BrowserChunkingContext>,
+        chunk: ResolvedVc<EcmascriptChunk>,
     ) -> Vc<Self> {
         EcmascriptDevChunk {
             chunking_context,
@@ -68,7 +68,7 @@ impl EcmascriptDevChunk {
     async fn own_content(self: Vc<Self>) -> Result<Vc<EcmascriptDevChunkContent>> {
         let this = self.await?;
         Ok(EcmascriptDevChunkContent::new(
-            this.chunking_context,
+            *this.chunking_context,
             self,
             this.chunk.chunk_content(),
         ))
@@ -76,7 +76,7 @@ impl EcmascriptDevChunk {
 
     #[turbo_tasks::function]
     pub fn chunk(&self) -> Result<Vc<Box<dyn Chunk>>> {
-        Ok(Vc::upcast(self.chunk))
+        Ok(Vc::upcast(*self.chunk))
     }
 }
 
@@ -172,7 +172,7 @@ impl Introspectable for EcmascriptDevChunk {
     #[turbo_tasks::function]
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         let mut children = FxIndexSet::default();
-        let chunk = Vc::upcast::<Box<dyn Introspectable>>(self.chunk)
+        let chunk = Vc::upcast::<Box<dyn Introspectable>>(*self.chunk)
             .resolve()
             .await?;
         children.insert((Vc::cell("chunk".into()), chunk));

--- a/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
@@ -172,10 +172,8 @@ impl Introspectable for EcmascriptDevChunk {
     #[turbo_tasks::function]
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         let mut children = FxIndexSet::default();
-        let chunk = Vc::upcast::<Box<dyn Introspectable>>(*self.chunk)
-            .resolve()
-            .await?;
-        children.insert((Vc::cell("chunk".into()), chunk));
+        let chunk = ResolvedVc::upcast::<Box<dyn Introspectable>>(self.chunk);
+        children.insert((Vc::cell("chunk".into()), *chunk));
         Ok(Vc::cell(children))
     }
 }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use anyhow::{bail, Result};
 use indoc::writedoc;
 use turbo_rcstr::RcStr;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::File;
 use turbopack_core::{
     asset::AssetContent,
@@ -23,21 +23,21 @@ use crate::BrowserChunkingContext;
 
 #[turbo_tasks::value(serialization = "none")]
 pub struct EcmascriptDevChunkContent {
-    pub(super) entries: Vc<EcmascriptDevChunkContentEntries>,
-    pub(super) chunking_context: Vc<BrowserChunkingContext>,
-    pub(super) chunk: Vc<EcmascriptDevChunk>,
+    pub(super) entries: ResolvedVc<EcmascriptDevChunkContentEntries>,
+    pub(super) chunking_context: ResolvedVc<BrowserChunkingContext>,
+    pub(super) chunk: ResolvedVc<EcmascriptDevChunk>,
 }
 
 #[turbo_tasks::value_impl]
 impl EcmascriptDevChunkContent {
     #[turbo_tasks::function]
     pub(crate) async fn new(
-        chunking_context: Vc<BrowserChunkingContext>,
-        chunk: Vc<EcmascriptDevChunk>,
+        chunking_context: ResolvedVc<BrowserChunkingContext>,
+        chunk: ResolvedVc<EcmascriptDevChunk>,
         content: Vc<EcmascriptChunkContent>,
     ) -> Result<Vc<Self>> {
         let entries = EcmascriptDevChunkContentEntries::new(content)
-            .resolve()
+            .to_resolved()
             .await?;
         Ok(EcmascriptDevChunkContent {
             entries,
@@ -49,7 +49,7 @@ impl EcmascriptDevChunkContent {
 
     #[turbo_tasks::function]
     pub fn entries(&self) -> Vc<EcmascriptDevChunkContentEntries> {
-        self.entries
+        *self.entries
     }
 }
 
@@ -60,7 +60,7 @@ impl EcmascriptDevChunkContent {
         EcmascriptDevChunkVersion::new(
             self.chunking_context.output_root(),
             self.chunk.ident().path(),
-            self.entries,
+            *self.entries,
         )
     }
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content_entry.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content_entry.rs
@@ -2,7 +2,7 @@ use std::io::Write as _;
 
 use anyhow::Result;
 use tracing::{info_span, Instrument};
-use turbo_tasks::{FxIndexMap, ReadRef, TryJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{FxIndexMap, ReadRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 use turbopack_core::{
     chunk::{AsyncModuleInfo, ChunkItem, ChunkItemExt, ModuleId},
     code_builder::{Code, CodeBuilder},
@@ -22,8 +22,8 @@ use turbopack_ecmascript::chunk::{
 #[turbo_tasks::value]
 #[derive(Debug)]
 pub struct EcmascriptDevChunkContentEntry {
-    pub code: Vc<Code>,
-    pub hash: Vc<u64>,
+    pub code: ResolvedVc<Code>,
+    pub hash: ResolvedVc<u64>,
 }
 
 impl EcmascriptDevChunkContentEntry {
@@ -31,10 +31,10 @@ impl EcmascriptDevChunkContentEntry {
         chunk_item: Vc<Box<dyn EcmascriptChunkItem>>,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Self> {
-        let code = chunk_item.code(async_module_info).resolve().await?;
+        let code = chunk_item.code(async_module_info).to_resolved().await?;
         Ok(EcmascriptDevChunkContentEntry {
             code,
-            hash: code.source_code_hash().resolve().await?,
+            hash: code.source_code_hash().to_resolved().await?,
         })
     }
 }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -32,10 +32,10 @@ use crate::BrowserChunkingContext;
 /// * Evaluates a list of runtime entries.
 #[turbo_tasks::value(shared)]
 pub(crate) struct EcmascriptDevEvaluateChunk {
-    chunking_context: Vc<BrowserChunkingContext>,
-    ident: Vc<AssetIdent>,
-    other_chunks: Vc<OutputAssets>,
-    evaluatable_assets: Vc<EvaluatableAssets>,
+    chunking_context: ResolvedVc<BrowserChunkingContext>,
+    ident: ResolvedVc<AssetIdent>,
+    other_chunks: ResolvedVc<OutputAssets>,
+    evaluatable_assets: ResolvedVc<EvaluatableAssets>,
 }
 
 #[turbo_tasks::value_impl]
@@ -43,10 +43,10 @@ impl EcmascriptDevEvaluateChunk {
     /// Creates a new [`Vc<EcmascriptDevEvaluateChunk>`].
     #[turbo_tasks::function]
     pub fn new(
-        chunking_context: Vc<BrowserChunkingContext>,
-        ident: Vc<AssetIdent>,
-        other_chunks: Vc<OutputAssets>,
-        evaluatable_assets: Vc<EvaluatableAssets>,
+        chunking_context: ResolvedVc<BrowserChunkingContext>,
+        ident: ResolvedVc<AssetIdent>,
+        other_chunks: ResolvedVc<OutputAssets>,
+        evaluatable_assets: ResolvedVc<EvaluatableAssets>,
     ) -> Vc<Self> {
         EcmascriptDevEvaluateChunk {
             chunking_context,
@@ -59,7 +59,7 @@ impl EcmascriptDevEvaluateChunk {
 
     #[turbo_tasks::function]
     fn chunks_data(&self) -> Vc<ChunksData> {
-        ChunkData::from_assets(self.chunking_context.output_root(), self.other_chunks)
+        ChunkData::from_assets(self.chunking_context.output_root(), *self.other_chunks)
     }
 
     #[turbo_tasks::function]
@@ -101,7 +101,7 @@ impl EcmascriptDevEvaluateChunk {
                     {
                         Ok(Some(
                             placeable
-                                .as_chunk_item(Vc::upcast(chunking_context))
+                                .as_chunk_item(Vc::upcast(*chunking_context))
                                 .id()
                                 .await?,
                         ))

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Value, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkingContext, EvaluatableAssets},
@@ -25,10 +25,10 @@ use crate::BrowserChunkingContext;
 /// * changing a chunk's path.
 #[turbo_tasks::value(shared)]
 pub(crate) struct EcmascriptDevChunkList {
-    pub(super) chunking_context: Vc<BrowserChunkingContext>,
-    pub(super) ident: Vc<AssetIdent>,
-    pub(super) evaluatable_assets: Vc<EvaluatableAssets>,
-    pub(super) chunks: Vc<OutputAssets>,
+    pub(super) chunking_context: ResolvedVc<BrowserChunkingContext>,
+    pub(super) ident: ResolvedVc<AssetIdent>,
+    pub(super) evaluatable_assets: ResolvedVc<EvaluatableAssets>,
+    pub(super) chunks: ResolvedVc<OutputAssets>,
     pub(super) source: EcmascriptDevChunkListSource,
 }
 
@@ -37,10 +37,10 @@ impl EcmascriptDevChunkList {
     /// Creates a new [`Vc<EcmascriptDevChunkList>`].
     #[turbo_tasks::function]
     pub fn new(
-        chunking_context: Vc<BrowserChunkingContext>,
-        ident: Vc<AssetIdent>,
-        evaluatable_assets: Vc<EvaluatableAssets>,
-        chunks: Vc<OutputAssets>,
+        chunking_context: ResolvedVc<BrowserChunkingContext>,
+        ident: ResolvedVc<AssetIdent>,
+        evaluatable_assets: ResolvedVc<EvaluatableAssets>,
+        chunks: ResolvedVc<OutputAssets>,
         source: Value<EcmascriptDevChunkListSource>,
     ) -> Vc<Self> {
         EcmascriptDevChunkList {
@@ -113,7 +113,7 @@ impl OutputAsset for EcmascriptDevChunkList {
 
     #[turbo_tasks::function]
     fn references(&self) -> Vc<OutputAssets> {
-        self.chunks
+        *self.chunks
     }
 }
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/merged/update.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/merged/update.rs
@@ -245,7 +245,7 @@ pub(super) async fn update_ecmascript_merged_chunk(
 
                 if merged_module_map.get(id) != Some(hash) {
                     let entry =
-                        EcmascriptModuleEntry::from_code(id, entry.code, chunk_path).await?;
+                        EcmascriptModuleEntry::from_code(id, *entry.code, chunk_path).await?;
                     merged_update.entries.insert(id.clone(), entry);
                 }
             }

--- a/turbopack/crates/turbopack-browser/src/react_refresh.rs
+++ b/turbopack/crates/turbopack-browser/src/react_refresh.rs
@@ -45,16 +45,16 @@ impl ResolveReactRefreshResult {
 /// given path. Emits an issue if we can't.
 #[turbo_tasks::function]
 pub async fn assert_can_resolve_react_refresh(
-    path: Vc<FileSystemPath>,
+    path: ResolvedVc<FileSystemPath>,
     resolve_options_context: Vc<ResolveOptionsContext>,
 ) -> Result<Vc<ResolveReactRefreshResult>> {
     let resolve_options = apply_cjs_specific_options(turbopack_resolve::resolve::resolve_options(
-        path,
+        *path,
         resolve_options_context,
     ));
     for request in [react_refresh_request_in_next(), react_refresh_request()] {
         let result = turbopack_core::resolve::resolve(
-            path,
+            *path,
             Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
             request,
             resolve_options,
@@ -72,7 +72,7 @@ pub async fn assert_can_resolve_react_refresh(
 /// An issue that occurred while resolving the React Refresh runtime module.
 #[turbo_tasks::value(shared)]
 pub struct ReactRefreshResolvingIssue {
-    path: Vc<FileSystemPath>,
+    path: ResolvedVc<FileSystemPath>,
 }
 
 #[turbo_tasks::value_impl]
@@ -94,7 +94,7 @@ impl Issue for ReactRefreshResolvingIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        self.path
+        *self.path
     }
 
     #[turbo_tasks::function]


### PR DESCRIPTION
These changes are generated using https://github.com/vercel/turbopack-resolved-vc-codemod, using the fix to the logic that finds `Vc` field: https://github.com/vercel/turbopack-resolved-vc-codemod/commit/5c277f82024aff59d7dce6c7c623123c1db4ed10

This is a combination of applying compiler hints and an LLM to fix some easy cases.

Closes PACK-3499