### PR TITLE
refactor(turbopack): Use weak deps for side effects

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -240,7 +240,7 @@ impl Analyzer<'_> {
                         let state = self.vars.entry(id.clone()).or_default();
 
                         self.g.add_weak_deps(item_id, state.last_writes.iter());
-                        self.g.add_strong_deps(item_id, state.last_reads.iter());
+                        self.g.add_weak_deps(item_id, state.last_reads.iter());
                     }
                 }
 


### PR DESCRIPTION
### What?

Use `side_effect` flag instead of depending as a strong dependency

### Why?

This makes tree shaking produce less modules.

### How?

Closes NEXT-
Fixes #


Closes PACK-3482