### PR TITLE
Clarify how MDX plugins are supported in Turbopack

### DIFF
--- a/docs/01-app/02-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/02-building-your-application/07-configuring/05-mdx.mdx
@@ -650,7 +650,7 @@ export default withMDX(nextConfig)
 ### Using Plugins with Turbopack
 
 To use plugins with [Turbopack](/docs/architecture/turbopack), upgrade to the latest `@next/mdx` and specify plugin names using a string:
- 
+
 ```js filename="next.config.mjs"
 import createMDX from '@next/mdx'
 

--- a/docs/01-app/02-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/02-building-your-application/07-configuring/05-mdx.mdx
@@ -649,7 +649,7 @@ export default withMDX(nextConfig)
 
 > **Good to know**:
 >
-> remark and rehype plugins cannot be used with [Turbopack](/docs/architecture/turbopack) yet, due to [inability to pass JavaScript functions to Rust](https://github.com/vercel/next.js/issues/71819#issuecomment-2461802968)
+> remark and rehype plugins without serializable options cannot be used with [Turbopack](/docs/architecture/turbopack) yet, due to [inability to pass JavaScript functions to Rust](https://github.com/vercel/next.js/issues/71819#issuecomment-2461802968)
 
 ## Remote MDX
 

--- a/docs/01-app/02-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/02-building-your-application/07-configuring/05-mdx.mdx
@@ -670,7 +670,7 @@ export default withMDX(nextConfig)
 ```
 
 > **Good to know**:
-
+>
 > remark and rehype plugins without serializable options cannot be used yet with [Turbopack](/docs/architecture/turbopack), due to [inability to pass JavaScript functions to Rust](https://github.com/vercel/next.js/issues/71819#issuecomment-2461802968)
 
 ## Remote MDX

--- a/docs/01-app/02-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/02-building-your-application/07-configuring/05-mdx.mdx
@@ -647,9 +647,31 @@ const withMDX = createMDX({
 export default withMDX(nextConfig)
 ```
 
+### Using Plugins with Turbopack
+
+To use plugins with [Turbopack](/docs/architecture/turbopack), upgrade to the latest `@next/mdx` and specify plugin names using a string:
+ 
+```js filename="next.config.mjs"
+import createMDX from '@next/mdx'
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],
+}
+
+const withMDX = createMDX({
+  options: {
+    remarkPlugins: [],
+    rehypePlugins: [['rehype-katex', { strict: true, throwOnError: true }]],
+  },
+})
+
+export default withMDX(nextConfig)
+```
+
 > **Good to know**:
->
-> remark and rehype plugins without serializable options cannot be used with [Turbopack](/docs/architecture/turbopack) yet, due to [inability to pass JavaScript functions to Rust](https://github.com/vercel/next.js/issues/71819#issuecomment-2461802968)
+
+> remark and rehype plugins without serializable options cannot be used yet with [Turbopack](/docs/architecture/turbopack), due to [inability to pass JavaScript functions to Rust](https://github.com/vercel/next.js/issues/71819#issuecomment-2461802968)
 
 ## Remote MDX
 


### PR DESCRIPTION
Followup to https://github.com/vercel/next.js/pull/72241 and https://github.com/vercel/next.js/pull/72467

Documenting the new Turbopack support for MDX plugins (remark, rehype, recma plugins):

- https://github.com/vercel/next.js/issues/71819#issuecomment-2482774351

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

Clarify that MDX-related plugins (remark and rehype plugins) are supported when options are serializable, by using the new string name config format

### Why?

Support was added in 72802

- https://github.com/vercel/next.js/pull/72802

### How?

Add a new ["Using Plugins with Turbopack" docs section](https://nextjs.org/docs/canary/app/building-your-application/configuring/mdx#using-plugins-with-turbopack) about using plugins with Turbopack