### PR TITLE
Fix sourcemaps for internal client boundaries

### DIFF
--- a/packages/next/taskfile-swc.js
+++ b/packages/next/taskfile-swc.js
@@ -128,17 +128,6 @@ module.exports = function (task) {
       const output = yield transform(source, options)
       const ext = path.extname(file.base)
 
-      // Make sure the output content keeps the `"use client"` directive.
-      // TODO: Remove this once SWC fixes the issue.
-      if (/^['"]use client['"]/.test(source)) {
-        output.code =
-          '"use client";\n' +
-          output.code
-            .split('\n')
-            .map((l) => (/^['"]use client['"]/.test(l) ? '' : l))
-            .join('\n')
-      }
-
       // Replace `.ts|.tsx` with `.js` in files with an extension
       if (ext) {
         const extRegex = new RegExp(ext.replace('.', '\\.') + '$', 'i')

--- a/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
+++ b/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
@@ -68,7 +68,7 @@ describe('Dynamic IO Dev Errors', () => {
         `See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense` +
         '\n    at Page [Server] (<anonymous>)' +
         // TODO(veil): Should be ignore-listed. Feel free to adjust the component name since it's Next.js internals.
-        '\n    at InnerLayoutRouter (' +
+        '\n    at parallelRouterKey (' +
         (isTurbopack
           ? 'node_modules'
           : // TODO(veil): Why is this not pointing to n_m in Webpack?


### PR DESCRIPTION
We used to manually insert `use client` where SWC strips it.
This caused sourcemaps to be off by one line right from the start which can accumulate throughout the mappings to result in mappings being off by multiple lines.

The underlying issue in SWC is fixed so we can remove the workaround
and fix sourcemaps for internal files with a `use client` directive.