### PR TITLE
Do not add client entries for route handlers if `dynamicIO` is disabled

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1901,6 +1901,7 @@ export default async function getBaseWebpackConfig(
               dev,
               isEdgeServer,
               encryptionKey,
+              includeRouteHandlers: Boolean(config.experimental.dynamicIO),
             })),
       hasAppDir &&
         !isClient &&

--- a/packages/next/src/build/webpack/utils.ts
+++ b/packages/next/src/build/webpack/utils.ts
@@ -8,6 +8,7 @@ import type {
 } from 'webpack'
 import type { ModuleGraphConnection } from 'webpack'
 import { isMetadataRoute } from '../../lib/metadata/is-metadata-route'
+import { isAppRouteRoute } from '../../lib/is-app-route-route'
 
 export function traverseModules(
   compilation: Compilation,
@@ -42,15 +43,24 @@ export function traverseModules(
 }
 
 // Loop over all the entry modules.
-export function forEachEntryModule(
-  compilation: any,
+export function forEachEntryModule({
+  compilation,
+  includeRouteHandlers,
+  callback,
+}: {
+  compilation: any
+  includeRouteHandlers: boolean
   callback: ({ name, entryModule }: { name: string; entryModule: any }) => void
-) {
+}) {
   for (const [name, entry] of compilation.entries.entries()) {
     // Skip for entries under pages/
     if (
       name.startsWith('pages/') ||
-      // Skip for metadata route handlers
+      // Skip route handlers unless explicitly enabled.
+      (name.startsWith('app/') &&
+        isAppRouteRoute(name) &&
+        !includeRouteHandlers) ||
+      // In any case, skip metadata route handlers.
       (name.startsWith('app/') && isMetadataRoute(name))
     ) {
       continue


### PR DESCRIPTION
> [!NOTE]  
> This PR is best reviewed with hidden whitespace changes.

To enable `"use cache"` in route handlers, we started generating client reference manifests and client chunks for route handlers in #70897.

This is currently not required if `experimental.dynamicIO` is not enabled, so we can skip the additional work during builds.