### PR TITLE
Pass down ignored field to error overlay

### DIFF
--- a/packages/next/src/build/webpack/config/blocks/base.ts
+++ b/packages/next/src/build/webpack/config/blocks/base.ts
@@ -4,14 +4,7 @@ import { COMPILER_NAMES } from '../../../../shared/lib/constants'
 import type { ConfigurationContext } from '../utils'
 import DevToolsIgnorePlugin from '../../plugins/devtools-ignore-list-plugin'
 import EvalSourceMapDevToolPlugin from '../../plugins/eval-source-map-dev-tool-plugin'
-
-function shouldIgnorePath(modulePath: string): boolean {
-  return (
-    modulePath.includes('node_modules') ||
-    // Only relevant for when Next.js is symlinked e.g. in the Next.js monorepo
-    modulePath.includes('next/dist')
-  )
-}
+import { shouldIgnorePath } from '../ignore-list'
 
 export const base = curry(function base(
   ctx: ConfigurationContext,

--- a/packages/next/src/build/webpack/config/blocks/base.ts
+++ b/packages/next/src/build/webpack/config/blocks/base.ts
@@ -4,7 +4,14 @@ import { COMPILER_NAMES } from '../../../../shared/lib/constants'
 import type { ConfigurationContext } from '../utils'
 import DevToolsIgnorePlugin from '../../plugins/devtools-ignore-list-plugin'
 import EvalSourceMapDevToolPlugin from '../../plugins/eval-source-map-dev-tool-plugin'
-import { shouldIgnorePath } from '../ignore-list'
+
+function shouldIgnorePath(modulePath: string): boolean {
+  return (
+    modulePath.includes('node_modules') ||
+    // Only relevant for when Next.js is symlinked e.g. in the Next.js monorepo
+    modulePath.includes('next/dist')
+  )
+}
 
 export const base = curry(function base(
   ctx: ConfigurationContext,

--- a/packages/next/src/build/webpack/config/ignore-list.ts
+++ b/packages/next/src/build/webpack/config/ignore-list.ts
@@ -1,0 +1,7 @@
+export function shouldIgnorePath(modulePath: string): boolean {
+  return (
+    modulePath.includes('node_modules') ||
+    // Only relevant for when Next.js is symlinked e.g. in the Next.js monorepo
+    modulePath.includes('next/dist')
+  )
+}

--- a/packages/next/src/build/webpack/plugins/wellknown-errors-plugin/parseNotFoundError.ts
+++ b/packages/next/src/build/webpack/plugins/wellknown-errors-plugin/parseNotFoundError.ts
@@ -1,6 +1,9 @@
 import { bold, cyan, green, red, yellow } from '../../../../lib/picocolors'
 import { SimpleWebpackError } from './simpleWebpackError'
-import { createOriginalStackFrame } from '../../../../client/components/react-dev-overlay/server/middleware'
+import {
+  createOriginalStackFrame,
+  getIgnoredSources,
+} from '../../../../client/components/react-dev-overlay/server/middleware'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 
 // Based on https://github.com/webpack/webpack/blob/fcdd04a833943394bbb0a9eeb54a962a24cc7e41/lib/stats/DefaultStatsFactoryPlugin.js#L422-L431
@@ -62,6 +65,7 @@ async function getSourceFrame(
         source: {
           type: 'bundle',
           sourceMap,
+          ignoredSources: getIgnoredSources(sourceMap),
           compilation,
           moduleId,
           modulePath: fileName,

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/CallStackFrame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/CallStackFrame.tsx
@@ -37,7 +37,7 @@ export const CallStackFrame: React.FC<{
 
   return (
     <div data-nextjs-call-stack-frame>
-      <h3 data-nextjs-frame-expanded={Boolean(frame.expanded)}>
+      <h3 data-nextjs-frame-expanded={!frame.ignored}>
         <HotlinkedText text={formattedMethod} />
       </h3>
       <div

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
@@ -8,7 +8,7 @@ export interface OriginalStackFrame extends OriginalStackFrameResponse {
   error: boolean
   reason: string | null
   external: boolean
-  expanded: boolean
+  ignored: boolean
   sourceStackFrame: StackFrame
 }
 
@@ -49,20 +49,15 @@ function getOriginalStackFrame(
       error: false,
       reason: null,
       external: false,
-      expanded: !Boolean(
-        /* collapsed */
-        (source.file?.includes('node_modules') ||
-          body.originalStackFrame?.file?.includes('node_modules') ||
-          body.originalStackFrame?.file?.startsWith('[turbopack]/')) ??
-          true
-      ),
       sourceStackFrame: source,
       originalStackFrame: body.originalStackFrame,
       originalCodeFrame: body.originalCodeFrame || null,
       sourcePackage: body.sourcePackage,
+      ignored: body.originalStackFrame?.ignored || false,
     }
   }
 
+  // TODO: merge this section into ignoredList handling
   if (
     source.file === '<anonymous>' ||
     source.file === 'file://' ||
@@ -73,11 +68,11 @@ function getOriginalStackFrame(
       error: false,
       reason: null,
       external: true,
-      expanded: false,
       sourceStackFrame: source,
       originalStackFrame: null,
       originalCodeFrame: null,
       sourcePackage: null,
+      ignored: true,
     })
   }
 
@@ -85,11 +80,11 @@ function getOriginalStackFrame(
     error: true,
     reason: err?.message ?? err?.toString() ?? 'Unknown Error',
     external: false,
-    expanded: false,
     sourceStackFrame: source,
     originalStackFrame: null,
     originalCodeFrame: null,
     sourcePackage: null,
+    ignored: false,
   }))
 }
 

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
@@ -84,7 +84,7 @@ function getOriginalStackFrame(
     originalStackFrame: null,
     originalCodeFrame: null,
     sourcePackage: null,
-    ignored: true,
+    ignored: false,
   }))
 }
 

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
@@ -84,7 +84,7 @@ function getOriginalStackFrame(
     originalStackFrame: null,
     originalCodeFrame: null,
     sourcePackage: null,
-    ignored: false,
+    ignored: true,
   }))
 }
 

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
@@ -19,11 +19,13 @@ import type { Project, TurbopackStackFrame } from '../../../../build/swc/types'
 import { getSourceMapFromFile } from '../internal/helpers/get-source-map-from-file'
 import { findSourceMap } from 'node:module'
 
+type IgnorableStackFrame = StackFrame & { ignored: boolean }
+
 const currentSourcesByFile: Map<string, Promise<string | null>> = new Map()
 export async function batchedTraceSource(
   project: Project,
   frame: TurbopackStackFrame
-): Promise<{ frame: StackFrame; source: string | null } | undefined> {
+): Promise<{ frame: IgnorableStackFrame; source: string | null } | undefined> {
   const file = frame.file ? decodeURIComponent(frame.file) : undefined
   if (!file) return
 
@@ -31,10 +33,15 @@ export async function batchedTraceSource(
   if (!sourceFrame) return
 
   let source = null
+  let ignored = true
   // Don't look up source for node_modules or internals. These can often be large bundled files.
   if (
     sourceFrame.file &&
-    !(sourceFrame.file.includes('node_modules') || sourceFrame.isInternal)
+    !(
+      sourceFrame.file.includes('node_modules') ||
+      // isInternal means resource starts with turbopack://[turbopack]
+      sourceFrame.isInternal
+    )
   ) {
     let sourcePromise = currentSourcesByFile.get(sourceFrame.file)
     if (!sourcePromise) {
@@ -46,18 +53,22 @@ export async function batchedTraceSource(
         currentSourcesByFile.delete(sourceFrame.file!)
       }, 100)
     }
-
+    ignored = false
     source = await sourcePromise
   }
 
+  // TODO: get ignoredList from turbopack source map
+  const ignorableFrame = {
+    file: sourceFrame.file,
+    lineNumber: sourceFrame.line ?? 0,
+    column: sourceFrame.column ?? 0,
+    methodName: sourceFrame.methodName ?? frame.methodName ?? '<unknown>',
+    ignored,
+    arguments: [],
+  }
+
   return {
-    frame: {
-      file: sourceFrame.file,
-      lineNumber: sourceFrame.line ?? 0,
-      column: sourceFrame.column ?? 0,
-      methodName: sourceFrame.methodName ?? frame.methodName ?? '<unknown>',
-      arguments: [],
-    },
+    frame: ignorableFrame,
     source,
   }
 }

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware.ts
@@ -21,18 +21,36 @@ export { getSourceMapFromFile }
 
 import type { IncomingMessage, ServerResponse } from 'http'
 import type webpack from 'webpack'
-import type { RawSourceMap } from 'next/dist/compiled/source-map08'
+import type {
+  NullableMappedPosition,
+  RawSourceMap,
+} from 'next/dist/compiled/source-map08'
 import { formatFrameSourceFile } from '../internal/helpers/webpack-module-path'
+import { shouldIgnorePath } from '../../../../build/webpack/config/ignore-list'
+import type { MappedPosition } from 'source-map'
+
+interface ModernRawSourceMap extends RawSourceMap {
+  ignoreList?: number[]
+}
+
+export interface IgnorableStackFrame extends StackFrame {
+  ignored: boolean
+}
+
+type SourceAttributes = {
+  sourcePosition: NullableMappedPosition
+  sourceContent: string | null
+}
 
 type Source =
   | {
       type: 'file'
-      sourceMap: RawSourceMap
+      sourceMap: ModernRawSourceMap
       modulePath: string
     }
   | {
       type: 'bundle'
-      sourceMap: RawSourceMap
+      sourceMap: ModernRawSourceMap
       compilation: webpack.Compilation
       moduleId: string
       modulePath: string
@@ -56,9 +74,9 @@ function getSourcePath(source: string) {
 }
 
 async function findOriginalSourcePositionAndContent(
-  sourceMap: RawSourceMap,
+  sourceMap: ModernRawSourceMap,
   position: { line: number; column: number | null }
-) {
+): Promise<SourceAttributes | null> {
   const consumer = await new SourceMapConsumer(sourceMap)
   try {
     const sourcePosition = consumer.originalPositionFor({
@@ -85,9 +103,23 @@ async function findOriginalSourcePositionAndContent(
   }
 }
 
+function isIgnoredSource(
+  source: Source,
+  sourcePosition: MappedPosition | NullableMappedPosition
+) {
+  if (sourcePosition.source == null) {
+    return true
+  }
+  const sourceIndex = source.sourceMap.sources.indexOf(sourcePosition.source)
+  const ignored = source.sourceMap.ignoreList?.includes(sourceIndex) ?? false
+
+  return ignored
+}
+
 function createStackFrame(searchParams: URLSearchParams) {
+  const file = searchParams.get('file') as string
   return {
-    file: searchParams.get('file') as string,
+    file,
     methodName: searchParams.get('methodName') as string,
     lineNumber: parseInt(searchParams.get('lineNumber') ?? '0', 10) || 0,
     column: parseInt(searchParams.get('column') ?? '0', 10) || 0,
@@ -99,7 +131,7 @@ function findOriginalSourcePositionAndContentFromCompilation(
   moduleId: string | undefined,
   importedModule: string,
   compilation: webpack.Compilation
-) {
+): SourceAttributes | null {
   const module = getModuleById(moduleId, compilation)
   return module?.buildInfo?.importLocByPath?.get(importedModule) ?? null
 }
@@ -136,17 +168,22 @@ export async function createOriginalStackFrame({
     })
   })()
 
-  if (!result?.sourcePosition.source) {
+  if (!result) {
+    return null
+  }
+  const { sourcePosition, sourceContent } = result
+
+  if (!sourcePosition.source) {
     return null
   }
 
-  const { sourcePosition, sourceContent } = result
+  const ignored = isIgnoredSource(source, sourcePosition)
 
   const filePath = path.resolve(
     rootDirectory,
     getSourcePath(
       // When sourcePosition.source is the loader path the modulePath is generally better.
-      (sourcePosition.source.includes('|')
+      (sourcePosition.source!.includes('|')
         ? source.modulePath
         : sourcePosition.source) || source.modulePath
     )
@@ -156,7 +193,7 @@ export async function createOriginalStackFrame({
     ? path.relative(rootDirectory, filePath)
     : sourcePosition.source
 
-  const traced = {
+  const traced: IgnorableStackFrame = {
     file: resolvedFilePath,
     lineNumber: sourcePosition.line,
     column: (sourcePosition.column ?? 0) + 1,
@@ -168,7 +205,8 @@ export async function createOriginalStackFrame({
         ?.replace('__WEBPACK_DEFAULT_EXPORT__', 'default')
         ?.replace('__webpack_exports__.', ''),
     arguments: [],
-  } satisfies StackFrame
+    ignored,
+  }
 
   return {
     originalStackFrame: traced,
@@ -201,7 +239,7 @@ export async function getSourceMapFromCompilation(
   }
 }
 
-export async function getSource(
+async function getSource(
   filename: string,
   options: {
     getCompilations: () => webpack.Compilation[]
@@ -241,9 +279,30 @@ export async function getSource(
   for (const compilation of getCompilations()) {
     // TODO: `ignoreList`
     const sourceMap = await getSourceMapFromCompilation(moduleId, compilation)
+    const ignoreList = []
+    const moduleFilenames = sourceMap?.sources ?? []
+
+    // console.log('moduleFilenames', moduleFilenames)
+    for (let index = 0; index < moduleFilenames.length; index++) {
+      // bundlerFilePath case: webpack://./app/page.tsx
+      const bundlerFilePath = moduleFilenames[index]
+      // Format the path to the normal file path
+      const formattedFilePath = formatFrameSourceFile(bundlerFilePath)
+      if (shouldIgnorePath(formattedFilePath)) {
+        ignoreList.push(index)
+      }
+    }
 
     if (sourceMap) {
-      return { type: 'bundle', sourceMap, compilation, moduleId, modulePath }
+      const modernSourceMap = sourceMap as ModernRawSourceMap
+      modernSourceMap.ignoreList = ignoreList
+      return {
+        type: 'bundle',
+        sourceMap: modernSourceMap,
+        compilation,
+        moduleId,
+        modulePath,
+      }
     }
   }
 
@@ -270,24 +329,11 @@ export function getOverlayMiddleware(options: {
       const isEdgeServer = searchParams.get('isEdgeServer') === 'true'
       const isAppDirectory = searchParams.get('isAppDirectory') === 'true'
       const frame = createStackFrame(searchParams)
-
-      let sourcePackage = findSourcePackage(frame)
-
-      if (
-        !(
-          /^(rsc:\/\/React\/[^/]+\/)?(webpack-internal:\/\/\/|(file|webpack):\/\/)/.test(
-            frame.file
-          ) && frame.lineNumber
-        )
-      ) {
-        if (sourcePackage) return json(res, { sourcePackage })
-        return badRequest(res)
-      }
-
       const formattedFilePath = formatFrameSourceFile(frame.file)
       const filePath = path.join(rootDirectory, formattedFilePath)
       const isNextjsSource = filePath.startsWith(NEXT_PROJECT_ROOT)
 
+      let sourcePackage = findSourcePackage(frame)
       let source: Source | undefined
 
       if (isNextjsSource) {

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware.ts
@@ -110,7 +110,7 @@ async function findOriginalSourcePositionAndContent(
   }
 }
 
-function getIgnoredSources(sourceMap: RawSourceMap): IgnoredSources {
+export function getIgnoredSources(sourceMap: RawSourceMap): IgnoredSources {
   const ignoreList = new Set<number>()
   const moduleFilenames = sourceMap?.sources ?? []
 

--- a/packages/next/src/client/components/react-dev-overlay/server/shared.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/shared.ts
@@ -10,7 +10,7 @@ import isInternal, {
 export type SourcePackage = 'react' | 'next'
 
 export interface OriginalStackFrameResponse {
-  originalStackFrame?: StackFrame | null
+  originalStackFrame?: (StackFrame & { ignored: boolean }) | null
   originalCodeFrame?: string | null
   /** We use this to group frames in the error overlay */
   sourcePackage?: SourcePackage | null

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -69,6 +69,7 @@ import {
   getSourceMapFromCompilation,
   getSourceMapFromFile,
   parseStack,
+  getIgnoredSources,
 } from '../../../client/components/react-dev-overlay/server/middleware'
 import {
   batchedTraceSource,
@@ -1005,6 +1006,7 @@ async function startWatcher(opts: SetupOpts) {
                     type: 'bundle',
                     sourceMap,
                     compilation,
+                    ignoredSources: getIgnoredSources(sourceMap),
                     moduleId,
                     modulePath,
                   },


### PR DESCRIPTION
### What

Pass down a `ignored` field to stack frame on error overlay, which is going to be used for managing if a stack frame needs to be displayed or collapsed by default


Replace the `expanded` field of teh frame with `ignored` 

### Why

This is the preparation for the feature of `ignoreList`, where we display the user-land source frames and hide the 3rd-parties stack frames, to replace the current stack frame group only applied on "next" and "react"

Closes NDX-450