### PR TITLE
[Turbopack] concurrent write batches and little endian encoding

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -741,7 +741,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 persisted_storage_meta_log,
                 persisted_storage_data_log,
             ) {
-                println!("Persising failed: {:#?}", err);
+                println!("Persising failed: {}", err);
                 return None;
             }
         }

--- a/turbopack/crates/turbo-tasks-backend/src/database/fresh_db_optimization.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/fresh_db_optimization.rs
@@ -7,7 +7,10 @@ use std::{
 
 use anyhow::Result;
 
-use crate::database::key_value_database::{KeySpace, KeyValueDatabase, WriteBatch};
+use crate::database::{
+    key_value_database::{KeySpace, KeyValueDatabase},
+    write_batch::{BaseWriteBatch, ConcurrentWriteBatch, SerialWriteBatch, WriteBatch},
+};
 
 pub fn is_fresh(path: &Path) -> bool {
     fs::exists(path).map_or(false, |exists| !exists)
@@ -63,33 +66,42 @@ impl<T: KeyValueDatabase> KeyValueDatabase for FreshDbOptimization<T> {
         self.database.get(transaction, key_space, key)
     }
 
-    type WriteBatch<'l>
-        = FreshDbOptimizationWriteBatch<'l, T>
+    type SerialWriteBatch<'l>
+        = FreshDbOptimizationWriteBatch<'l, T::SerialWriteBatch<'l>>
     where
         Self: 'l;
 
-    fn write_batch(&self) -> Result<Self::WriteBatch<'_>> {
-        Ok(FreshDbOptimizationWriteBatch {
-            write_batch: self.database.write_batch()?,
-            fresh_db: &self.fresh_db,
+    type ConcurrentWriteBatch<'l>
+        = FreshDbOptimizationWriteBatch<'l, T::ConcurrentWriteBatch<'l>>
+    where
+        Self: 'l;
+
+    fn write_batch<'l>(
+        &'l self,
+    ) -> Result<WriteBatch<'l, Self::SerialWriteBatch<'l>, Self::ConcurrentWriteBatch<'l>>> {
+        Ok(match self.database.write_batch()? {
+            WriteBatch::Serial(write_batch) => WriteBatch::serial(FreshDbOptimizationWriteBatch {
+                write_batch,
+                fresh_db: &self.fresh_db,
+            }),
+            WriteBatch::Concurrent(write_batch, _) => {
+                WriteBatch::concurrent(FreshDbOptimizationWriteBatch {
+                    write_batch,
+                    fresh_db: &self.fresh_db,
+                })
+            }
         })
     }
 }
 
-pub struct FreshDbOptimizationWriteBatch<'a, T: KeyValueDatabase>
-where
-    T: 'a,
-{
-    write_batch: T::WriteBatch<'a>,
+pub struct FreshDbOptimizationWriteBatch<'a, B> {
+    write_batch: B,
     fresh_db: &'a AtomicBool,
 }
 
-impl<'a, T: KeyValueDatabase> WriteBatch<'a> for FreshDbOptimizationWriteBatch<'a, T>
-where
-    T: 'a,
-{
+impl<'a, B: BaseWriteBatch<'a>> BaseWriteBatch<'a> for FreshDbOptimizationWriteBatch<'a, B> {
     type ValueBuffer<'l>
-        = <T::WriteBatch<'a> as WriteBatch<'a>>::ValueBuffer<'l>
+        = B::ValueBuffer<'l>
     where
         Self: 'l,
         'a: 'l;
@@ -101,6 +113,13 @@ where
         self.write_batch.get(key_space, key)
     }
 
+    fn commit(self) -> Result<()> {
+        self.fresh_db.store(false, Ordering::Release);
+        self.write_batch.commit()
+    }
+}
+
+impl<'a, B: SerialWriteBatch<'a>> SerialWriteBatch<'a> for FreshDbOptimizationWriteBatch<'a, B> {
     fn put(&mut self, key_space: KeySpace, key: Cow<[u8]>, value: Cow<[u8]>) -> Result<()> {
         self.write_batch.put(key_space, key, value)
     }
@@ -108,9 +127,16 @@ where
     fn delete(&mut self, key_space: KeySpace, key: Cow<[u8]>) -> Result<()> {
         self.write_batch.delete(key_space, key)
     }
+}
 
-    fn commit(self) -> Result<()> {
-        self.fresh_db.store(false, Ordering::Release);
-        self.write_batch.commit()
+impl<'a, B: ConcurrentWriteBatch<'a>> ConcurrentWriteBatch<'a>
+    for FreshDbOptimizationWriteBatch<'a, B>
+{
+    fn put(&self, key_space: KeySpace, key: Cow<[u8]>, value: Cow<[u8]>) -> Result<()> {
+        self.write_batch.put(key_space, key, value)
+    }
+
+    fn delete(&self, key_space: KeySpace, key: Cow<[u8]>) -> Result<()> {
+        self.write_batch.delete(key_space, key)
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/fresh_db_optimization.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/fresh_db_optimization.rs
@@ -76,9 +76,9 @@ impl<T: KeyValueDatabase> KeyValueDatabase for FreshDbOptimization<T> {
     where
         Self: 'l;
 
-    fn write_batch<'l>(
-        &'l self,
-    ) -> Result<WriteBatch<'l, Self::SerialWriteBatch<'l>, Self::ConcurrentWriteBatch<'l>>> {
+    fn write_batch(
+        &self,
+    ) -> Result<WriteBatch<'_, Self::SerialWriteBatch<'_>, Self::ConcurrentWriteBatch<'_>>> {
         Ok(match self.database.write_batch()? {
             WriteBatch::Serial(write_batch) => WriteBatch::serial(FreshDbOptimizationWriteBatch {
                 write_batch,

--- a/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
@@ -44,7 +44,7 @@ pub trait KeyValueDatabase {
     where
         Self: 'l;
 
-    fn write_batch<'a>(
-        &'a self,
-    ) -> Result<WriteBatch<'a, Self::SerialWriteBatch<'a>, Self::ConcurrentWriteBatch<'a>>>;
+    fn write_batch(
+        &self,
+    ) -> Result<WriteBatch<'_, Self::SerialWriteBatch<'_>, Self::ConcurrentWriteBatch<'_>>>;
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
@@ -1,6 +1,8 @@
-use std::borrow::Cow;
-
 use anyhow::Result;
+
+use crate::database::write_batch::{
+    ConcurrentWriteBatch, SerialWriteBatch, UnimplementedWriteBatch, WriteBatch,
+};
 
 #[derive(Debug, Clone, Copy)]
 pub enum KeySpace {
@@ -9,20 +11,6 @@ pub enum KeySpace {
     TaskData,
     ForwardTaskCache,
     ReverseTaskCache,
-}
-
-pub trait WriteBatch<'a> {
-    type ValueBuffer<'l>: std::borrow::Borrow<[u8]>
-    where
-        Self: 'l,
-        'a: 'l;
-
-    fn get<'l>(&'l self, key_space: KeySpace, key: &[u8]) -> Result<Option<Self::ValueBuffer<'l>>>
-    where
-        'a: 'l;
-    fn put(&mut self, key_space: KeySpace, key: Cow<[u8]>, value: Cow<[u8]>) -> Result<()>;
-    fn delete(&mut self, key_space: KeySpace, key: Cow<[u8]>) -> Result<()>;
-    fn commit(self) -> Result<()>;
 }
 
 pub trait KeyValueDatabase {
@@ -47,8 +35,16 @@ pub trait KeyValueDatabase {
         key: &[u8],
     ) -> Result<Option<Self::ValueBuffer<'l>>>;
 
-    type WriteBatch<'l>: WriteBatch<'l>
+    type SerialWriteBatch<'l>: SerialWriteBatch<'l>
+        = UnimplementedWriteBatch
     where
         Self: 'l;
-    fn write_batch(&self) -> Result<Self::WriteBatch<'_>>;
+    type ConcurrentWriteBatch<'l>: ConcurrentWriteBatch<'l>
+        = UnimplementedWriteBatch
+    where
+        Self: 'l;
+
+    fn write_batch<'a>(
+        &'a self,
+    ) -> Result<WriteBatch<'a, Self::SerialWriteBatch<'a>, Self::ConcurrentWriteBatch<'a>>>;
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/lmdb/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/lmdb/mod.rs
@@ -6,7 +6,10 @@ use lmdb::{
     Transaction, WriteFlags,
 };
 
-use crate::database::key_value_database::{KeySpace, KeyValueDatabase, WriteBatch};
+use crate::database::{
+    key_value_database::{KeySpace, KeyValueDatabase},
+    write_batch::{BaseWriteBatch, SerialWriteBatch, WriteBatch},
+};
 
 mod extended_key;
 
@@ -111,16 +114,18 @@ impl KeyValueDatabase for LmbdKeyValueDatabase {
         Ok(Some(value))
     }
 
-    type WriteBatch<'l>
+    type SerialWriteBatch<'l>
         = LmbdWriteBatch<'l>
     where
         Self: 'l;
 
-    fn write_batch(&self) -> Result<Self::WriteBatch<'_>> {
-        Ok(LmbdWriteBatch {
+    fn write_batch<'a>(
+        &'a self,
+    ) -> Result<WriteBatch<'a, Self::SerialWriteBatch<'a>, Self::ConcurrentWriteBatch<'a>>> {
+        Ok(WriteBatch::serial(LmbdWriteBatch {
             tx: self.env.begin_rw_txn()?,
             this: self,
-        })
+        }))
     }
 }
 
@@ -129,28 +134,7 @@ pub struct LmbdWriteBatch<'l> {
     this: &'l LmbdKeyValueDatabase,
 }
 
-impl<'a> WriteBatch<'a> for LmbdWriteBatch<'a> {
-    fn put(&mut self, key_space: KeySpace, key: Cow<[u8]>, value: Cow<[u8]>) -> Result<()> {
-        extended_key::put(
-            &mut self.tx,
-            self.this.db(key_space),
-            &key,
-            &value,
-            WriteFlags::empty(),
-        )?;
-        Ok(())
-    }
-
-    fn delete(&mut self, key_space: KeySpace, key: Cow<[u8]>) -> Result<()> {
-        extended_key::delete(
-            &mut self.tx,
-            self.this.db(key_space),
-            &key,
-            WriteFlags::empty(),
-        )?;
-        Ok(())
-    }
-
+impl<'a> BaseWriteBatch<'a> for LmbdWriteBatch<'a> {
     type ValueBuffer<'l>
         = &'l [u8]
     where
@@ -175,6 +159,29 @@ impl<'a> WriteBatch<'a> for LmbdWriteBatch<'a> {
 
     fn commit(self) -> Result<()> {
         self.tx.commit()?;
+        Ok(())
+    }
+}
+
+impl<'a> SerialWriteBatch<'a> for LmbdWriteBatch<'a> {
+    fn put(&mut self, key_space: KeySpace, key: Cow<[u8]>, value: Cow<[u8]>) -> Result<()> {
+        extended_key::put(
+            &mut self.tx,
+            self.this.db(key_space),
+            &key,
+            &value,
+            WriteFlags::empty(),
+        )?;
+        Ok(())
+    }
+
+    fn delete(&mut self, key_space: KeySpace, key: Cow<[u8]>) -> Result<()> {
+        extended_key::delete(
+            &mut self.tx,
+            self.this.db(key_space),
+            &key,
+            WriteFlags::empty(),
+        )?;
         Ok(())
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/lmdb/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/lmdb/mod.rs
@@ -119,9 +119,9 @@ impl KeyValueDatabase for LmbdKeyValueDatabase {
     where
         Self: 'l;
 
-    fn write_batch<'a>(
-        &'a self,
-    ) -> Result<WriteBatch<'a, Self::SerialWriteBatch<'a>, Self::ConcurrentWriteBatch<'a>>> {
+    fn write_batch(
+        &self,
+    ) -> Result<WriteBatch<'_, Self::SerialWriteBatch<'_>, Self::ConcurrentWriteBatch<'_>>> {
         Ok(WriteBatch::serial(LmbdWriteBatch {
             tx: self.env.begin_rw_txn()?,
             this: self,

--- a/turbopack/crates/turbo-tasks-backend/src/database/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/mod.rs
@@ -6,6 +6,7 @@ pub mod lmdb;
 pub mod noop_kv;
 pub mod read_transaction_cache;
 mod startup_cache;
+pub mod write_batch;
 
 pub use db_versioning::handle_db_versioning;
 pub use fresh_db_optimization::{is_fresh, FreshDbOptimization};

--- a/turbopack/crates/turbo-tasks-backend/src/database/noop_kv.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/noop_kv.rs
@@ -2,7 +2,10 @@ use std::borrow::Cow;
 
 use anyhow::Result;
 
-use crate::database::key_value_database::{KeySpace, KeyValueDatabase, WriteBatch};
+use crate::database::{
+    key_value_database::{KeySpace, KeyValueDatabase},
+    write_batch::{BaseWriteBatch, ConcurrentWriteBatch, SerialWriteBatch, WriteBatch},
+};
 
 pub struct NoopKvDb;
 
@@ -36,23 +39,26 @@ impl KeyValueDatabase for NoopKvDb {
         Ok(None)
     }
 
-    type WriteBatch<'l>
+    type SerialWriteBatch<'l>
         = NoopWriteBatch
     where
         Self: 'l;
 
-    fn write_batch(&self) -> Result<Self::WriteBatch<'_>> {
-        Ok(NoopWriteBatch)
+    type ConcurrentWriteBatch<'l>
+        = NoopWriteBatch
+    where
+        Self: 'l;
+
+    fn write_batch<'l>(
+        &'l self,
+    ) -> Result<WriteBatch<'l, Self::SerialWriteBatch<'l>, Self::ConcurrentWriteBatch<'l>>> {
+        Ok(WriteBatch::concurrent(NoopWriteBatch))
     }
 }
 
 pub struct NoopWriteBatch;
 
-impl<'a> WriteBatch<'a> for NoopWriteBatch {
-    fn put(&mut self, _key_space: KeySpace, _key: Cow<[u8]>, _value: Cow<[u8]>) -> Result<()> {
-        Ok(())
-    }
-
+impl<'a> BaseWriteBatch<'a> for NoopWriteBatch {
     type ValueBuffer<'l>
         = &'l [u8]
     where
@@ -66,11 +72,27 @@ impl<'a> WriteBatch<'a> for NoopWriteBatch {
         Ok(None)
     }
 
-    fn delete(&mut self, _key_space: KeySpace, _key: Cow<[u8]>) -> Result<()> {
+    fn commit(self) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> SerialWriteBatch<'a> for NoopWriteBatch {
+    fn put(&mut self, _key_space: KeySpace, _key: Cow<[u8]>, _value: Cow<[u8]>) -> Result<()> {
         Ok(())
     }
 
-    fn commit(self) -> Result<()> {
+    fn delete(&mut self, _key_space: KeySpace, _key: Cow<[u8]>) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> ConcurrentWriteBatch<'a> for NoopWriteBatch {
+    fn put(&self, _key_space: KeySpace, _key: Cow<[u8]>, _value: Cow<[u8]>) -> Result<()> {
+        Ok(())
+    }
+
+    fn delete(&self, _key_space: KeySpace, _key: Cow<[u8]>) -> Result<()> {
         Ok(())
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/noop_kv.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/noop_kv.rs
@@ -49,9 +49,9 @@ impl KeyValueDatabase for NoopKvDb {
     where
         Self: 'l;
 
-    fn write_batch<'l>(
-        &'l self,
-    ) -> Result<WriteBatch<'l, Self::SerialWriteBatch<'l>, Self::ConcurrentWriteBatch<'l>>> {
+    fn write_batch(
+        &self,
+    ) -> Result<WriteBatch<'_, Self::SerialWriteBatch<'_>, Self::ConcurrentWriteBatch<'_>>> {
         Ok(WriteBatch::concurrent(NoopWriteBatch))
     }
 }
@@ -77,7 +77,7 @@ impl<'a> BaseWriteBatch<'a> for NoopWriteBatch {
     }
 }
 
-impl<'a> SerialWriteBatch<'a> for NoopWriteBatch {
+impl SerialWriteBatch<'_> for NoopWriteBatch {
     fn put(&mut self, _key_space: KeySpace, _key: Cow<[u8]>, _value: Cow<[u8]>) -> Result<()> {
         Ok(())
     }
@@ -87,7 +87,7 @@ impl<'a> SerialWriteBatch<'a> for NoopWriteBatch {
     }
 }
 
-impl<'a> ConcurrentWriteBatch<'a> for NoopWriteBatch {
+impl ConcurrentWriteBatch<'_> for NoopWriteBatch {
     fn put(&self, _key_space: KeySpace, _key: Cow<[u8]>, _value: Cow<[u8]>) -> Result<()> {
         Ok(())
     }

--- a/turbopack/crates/turbo-tasks-backend/src/database/read_transaction_cache.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/read_transaction_cache.rs
@@ -5,7 +5,10 @@ use arc_swap::ArcSwap;
 use smallvec::SmallVec;
 use thread_local::ThreadLocal;
 
-use crate::database::key_value_database::{KeyValueDatabase, WriteBatch};
+use crate::database::{
+    key_value_database::KeyValueDatabase,
+    write_batch::{BaseWriteBatch, ConcurrentWriteBatch, SerialWriteBatch, WriteBatch},
+};
 
 struct ThreadLocalReadTransactionsContainer<T: KeyValueDatabase + 'static>(
     UnsafeCell<SmallVec<[T::ReadTransaction<'static>; 4]>>,
@@ -86,12 +89,25 @@ impl<T: KeyValueDatabase + 'static> KeyValueDatabase for ReadTransactionCache<T>
             .get(transaction.tx.as_ref().unwrap(), key_space, key)
     }
 
-    type WriteBatch<'l> = ReadTransactionCacheWriteBatch<'l, T>;
+    type SerialWriteBatch<'l> = ReadTransactionCacheWriteBatch<'l, T, T::SerialWriteBatch<'l>>;
 
-    fn write_batch(&self) -> Result<Self::WriteBatch<'_>> {
-        Ok(ReadTransactionCacheWriteBatch {
-            write_batch: self.database.write_batch()?,
-            this: self,
+    type ConcurrentWriteBatch<'l> =
+        ReadTransactionCacheWriteBatch<'l, T, T::ConcurrentWriteBatch<'l>>;
+
+    fn write_batch<'l>(
+        &'l self,
+    ) -> Result<WriteBatch<'l, Self::SerialWriteBatch<'l>, Self::ConcurrentWriteBatch<'l>>> {
+        Ok(match self.database.write_batch()? {
+            WriteBatch::Serial(write_batch) => WriteBatch::serial(ReadTransactionCacheWriteBatch {
+                write_batch,
+                read_transactions_cache: &self.read_transactions_cache,
+            }),
+            WriteBatch::Concurrent(write_batch, _) => {
+                WriteBatch::concurrent(ReadTransactionCacheWriteBatch {
+                    write_batch,
+                    read_transactions_cache: &self.read_transactions_cache,
+                })
+            }
         })
     }
 }
@@ -122,34 +138,26 @@ impl<T: KeyValueDatabase> Drop for CachedReadTransaction<'_, T> {
     }
 }
 
-pub struct ReadTransactionCacheWriteBatch<'l, T: KeyValueDatabase + 'static> {
-    write_batch: T::WriteBatch<'l>,
-    this: &'l ReadTransactionCache<T>,
+pub struct ReadTransactionCacheWriteBatch<'l, T: KeyValueDatabase + 'static, B> {
+    write_batch: B,
+    read_transactions_cache: &'l ArcSwap<ThreadLocal<ThreadLocalReadTransactionsContainer<T>>>,
 }
 
-impl<'a, T: KeyValueDatabase> WriteBatch<'a> for ReadTransactionCacheWriteBatch<'a, T> {
+impl<'a, T: KeyValueDatabase + 'static, B: BaseWriteBatch<'a>> BaseWriteBatch<'a>
+    for ReadTransactionCacheWriteBatch<'a, T, B>
+{
     fn commit(self) -> anyhow::Result<()> {
         self.write_batch.commit()?;
         let _span = tracing::trace_span!("swap read transactions").entered();
         // This resets the thread local storage for read transactions, read transactions are
         // eventually dropped, allowing DB to free up unused storage.
-        self.this
-            .read_transactions_cache
+        self.read_transactions_cache
             .store(Arc::new(ThreadLocal::new()));
         Ok(())
     }
 
-    fn put(
-        &mut self,
-        key_space: super::key_value_database::KeySpace,
-        key: std::borrow::Cow<[u8]>,
-        value: std::borrow::Cow<[u8]>,
-    ) -> Result<()> {
-        self.write_batch.put(key_space, key, value)
-    }
-
     type ValueBuffer<'l>
-        = <T::WriteBatch<'a> as WriteBatch<'a>>::ValueBuffer<'l>
+        = B::ValueBuffer<'l>
     where
         Self: 'l,
         'a: 'l;
@@ -164,9 +172,41 @@ impl<'a, T: KeyValueDatabase> WriteBatch<'a> for ReadTransactionCacheWriteBatch<
     {
         self.write_batch.get(key_space, key)
     }
+}
 
+impl<'a, T: KeyValueDatabase, B: SerialWriteBatch<'a>> SerialWriteBatch<'a>
+    for ReadTransactionCacheWriteBatch<'a, T, B>
+{
+    fn put(
+        &mut self,
+        key_space: super::key_value_database::KeySpace,
+        key: std::borrow::Cow<[u8]>,
+        value: std::borrow::Cow<[u8]>,
+    ) -> Result<()> {
+        self.write_batch.put(key_space, key, value)
+    }
     fn delete(
         &mut self,
+        key_space: super::key_value_database::KeySpace,
+        key: std::borrow::Cow<[u8]>,
+    ) -> Result<()> {
+        self.write_batch.delete(key_space, key)
+    }
+}
+
+impl<'a, T: KeyValueDatabase, B: ConcurrentWriteBatch<'a>> ConcurrentWriteBatch<'a>
+    for ReadTransactionCacheWriteBatch<'a, T, B>
+{
+    fn put(
+        &self,
+        key_space: super::key_value_database::KeySpace,
+        key: std::borrow::Cow<[u8]>,
+        value: std::borrow::Cow<[u8]>,
+    ) -> Result<()> {
+        self.write_batch.put(key_space, key, value)
+    }
+    fn delete(
+        &self,
         key_space: super::key_value_database::KeySpace,
         key: std::borrow::Cow<[u8]>,
     ) -> Result<()> {

--- a/turbopack/crates/turbo-tasks-backend/src/database/read_transaction_cache.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/read_transaction_cache.rs
@@ -94,9 +94,9 @@ impl<T: KeyValueDatabase + 'static> KeyValueDatabase for ReadTransactionCache<T>
     type ConcurrentWriteBatch<'l> =
         ReadTransactionCacheWriteBatch<'l, T, T::ConcurrentWriteBatch<'l>>;
 
-    fn write_batch<'l>(
-        &'l self,
-    ) -> Result<WriteBatch<'l, Self::SerialWriteBatch<'l>, Self::ConcurrentWriteBatch<'l>>> {
+    fn write_batch(
+        &self,
+    ) -> Result<WriteBatch<'_, Self::SerialWriteBatch<'_>, Self::ConcurrentWriteBatch<'_>>> {
         Ok(match self.database.write_batch()? {
             WriteBatch::Serial(write_batch) => WriteBatch::serial(ReadTransactionCacheWriteBatch {
                 write_batch,

--- a/turbopack/crates/turbo-tasks-backend/src/database/startup_cache.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/startup_cache.rs
@@ -15,7 +15,8 @@ use rustc_hash::{FxHashMap, FxHasher};
 
 use crate::database::{
     by_key_space::ByKeySpace,
-    key_value_database::{KeySpace, KeyValueDatabase, WriteBatch},
+    key_value_database::{KeySpace, KeyValueDatabase},
+    write_batch::{BaseWriteBatch, ConcurrentWriteBatch, SerialWriteBatch, WriteBatch},
 };
 
 const CACHE_SIZE_LIMIT: usize = 100 * 1024 * 1024;
@@ -155,35 +156,49 @@ impl<T: KeyValueDatabase> KeyValueDatabase for StartupCacheLayer<T> {
         Ok(value)
     }
 
-    type WriteBatch<'l>
-        = StartupCacheWriteBatch<'l, T>
+    type SerialWriteBatch<'l>
+        = StartupCacheWriteBatch<'l, T::SerialWriteBatch<'l>>
     where
         Self: 'l;
 
-    fn write_batch(&self) -> Result<Self::WriteBatch<'_>> {
-        Ok(StartupCacheWriteBatch {
-            batch: self.database.write_batch()?,
-            this: self,
+    type ConcurrentWriteBatch<'l>
+        = StartupCacheWriteBatch<'l, T::ConcurrentWriteBatch<'l>>
+    where
+        Self: 'l;
+
+    fn write_batch<'l>(
+        &'l self,
+    ) -> Result<WriteBatch<'l, Self::SerialWriteBatch<'l>, Self::ConcurrentWriteBatch<'l>>> {
+        Ok(match self.database.write_batch()? {
+            WriteBatch::Serial(batch) => WriteBatch::serial(StartupCacheWriteBatch {
+                batch,
+                path: &self.path,
+                fresh_db: self.fresh_db,
+                cache: &self.cache,
+                restored_map: &self.restored_map,
+            }),
+            WriteBatch::Concurrent(batch, _) => WriteBatch::concurrent(StartupCacheWriteBatch {
+                batch,
+                path: &self.path,
+                fresh_db: self.fresh_db,
+                cache: &self.cache,
+                restored_map: &self.restored_map,
+            }),
         })
     }
 }
 
-pub struct StartupCacheWriteBatch<'a, T: KeyValueDatabase> {
-    batch: T::WriteBatch<'a>,
-    this: &'a StartupCacheLayer<T>,
+pub struct StartupCacheWriteBatch<'a, B> {
+    batch: B,
+    path: &'a PathBuf,
+    fresh_db: bool,
+    cache: &'a Cache,
+    restored_map: &'a ByKeySpace<FxHashMap<&'static [u8], &'static [u8]>>,
 }
 
-impl<'a, T: KeyValueDatabase> WriteBatch<'a> for StartupCacheWriteBatch<'a, T> {
-    fn put(&mut self, key_space: KeySpace, key: Cow<[u8]>, value: Cow<[u8]>) -> Result<()> {
-        if !self.this.fresh_db {
-            let cache = self.this.cache.get(key_space);
-            cache.insert(key.to_vec(), Some(value.to_vec()));
-        }
-        self.batch.put(key_space, key, value)
-    }
-
+impl<'a, B: BaseWriteBatch<'a>> BaseWriteBatch<'a> for StartupCacheWriteBatch<'a, B> {
     type ValueBuffer<'l>
-        = <T::WriteBatch<'a> as WriteBatch<'a>>::ValueBuffer<'l>
+        = B::ValueBuffer<'l>
     where
         Self: 'l,
         'a: 'l;
@@ -195,27 +210,19 @@ impl<'a, T: KeyValueDatabase> WriteBatch<'a> for StartupCacheWriteBatch<'a, T> {
         self.batch.get(key_space, key)
     }
 
-    fn delete(&mut self, key_space: KeySpace, key: Cow<[u8]>) -> Result<()> {
-        if !self.this.fresh_db {
-            let cache = self.this.cache.get(key_space);
-            cache.insert(key.to_vec(), None);
-        }
-        self.batch.delete(key_space, key)
-    }
-
     fn commit(self) -> Result<()> {
-        if !self.this.fresh_db {
+        if !self.fresh_db {
             // Remove file before writing the new snapshot to database to avoid inconsistency
-            let _ = fs::remove_file(&self.this.path);
+            let _ = fs::remove_file(&self.path);
         }
         self.batch.commit()?;
-        if !self.this.fresh_db {
+        if !self.fresh_db {
             // write cache to a temp file to avoid corrupted file
-            let temp_path = self.this.path.with_extension("cache.tmp");
+            let temp_path = self.path.with_extension("cache.tmp");
             let mut writer = BufWriter::new(File::create(&temp_path)?);
             let mut size_buffer = [0u8; 4];
             let mut pos = 0;
-            for (key_space, cache) in self.this.cache.iter() {
+            for (key_space, cache) in self.cache.iter() {
                 for entry in cache.iter() {
                     if let (key, Some(value)) = entry.pair() {
                         pos += write_key_value_pair(
@@ -228,8 +235,8 @@ impl<'a, T: KeyValueDatabase> WriteBatch<'a> for StartupCacheWriteBatch<'a, T> {
                     }
                 }
             }
-            for (key_space, map) in self.this.restored_map.iter() {
-                let cache = self.this.cache.get(key_space);
+            for (key_space, map) in self.restored_map.iter() {
+                let cache = self.cache.get(key_space);
                 for (key, value) in map.iter() {
                     if !cache.contains_key(*key) {
                         let size = key.len() + value.len() + PAIR_HEADER_SIZE;
@@ -250,9 +257,45 @@ impl<'a, T: KeyValueDatabase> WriteBatch<'a> for StartupCacheWriteBatch<'a, T> {
             }
 
             // move temp file to the final location
-            fs::rename(temp_path, &self.this.path)?;
+            fs::rename(temp_path, &self.path)?;
         }
         Ok(())
+    }
+}
+
+impl<'a, B: SerialWriteBatch<'a>> SerialWriteBatch<'a> for StartupCacheWriteBatch<'a, B> {
+    fn put(&mut self, key_space: KeySpace, key: Cow<[u8]>, value: Cow<[u8]>) -> Result<()> {
+        if !self.fresh_db {
+            let cache = self.cache.get(key_space);
+            cache.insert(key.to_vec(), Some(value.to_vec()));
+        }
+        self.batch.put(key_space, key, value)
+    }
+
+    fn delete(&mut self, key_space: KeySpace, key: Cow<[u8]>) -> Result<()> {
+        if !self.fresh_db {
+            let cache = self.cache.get(key_space);
+            cache.insert(key.to_vec(), None);
+        }
+        self.batch.delete(key_space, key)
+    }
+}
+
+impl<'a, B: ConcurrentWriteBatch<'a>> ConcurrentWriteBatch<'a> for StartupCacheWriteBatch<'a, B> {
+    fn put(&self, key_space: KeySpace, key: Cow<[u8]>, value: Cow<[u8]>) -> Result<()> {
+        if !self.fresh_db {
+            let cache = self.cache.get(key_space);
+            cache.insert(key.to_vec(), Some(value.to_vec()));
+        }
+        self.batch.put(key_space, key, value)
+    }
+
+    fn delete(&self, key_space: KeySpace, key: Cow<[u8]>) -> Result<()> {
+        if !self.fresh_db {
+            let cache = self.cache.get(key_space);
+            cache.insert(key.to_vec(), None);
+        }
+        self.batch.delete(key_space, key)
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/database/write_batch.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/write_batch.rs
@@ -140,7 +140,7 @@ where
     }
 }
 
-impl<'r, 'a, S, C> BaseWriteBatch<'a> for WriteBatchRef<'r, 'a, S, C>
+impl<'a, S, C> BaseWriteBatch<'a> for WriteBatchRef<'_, 'a, S, C>
 where
     S: SerialWriteBatch<'a>,
     C: ConcurrentWriteBatch<'a>,
@@ -169,7 +169,7 @@ where
     }
 }
 
-impl<'r, 'a, S, C> SerialWriteBatch<'a> for WriteBatchRef<'r, 'a, S, C>
+impl<'a, S, C> SerialWriteBatch<'a> for WriteBatchRef<'_, 'a, S, C>
 where
     S: SerialWriteBatch<'a>,
     C: ConcurrentWriteBatch<'a>,
@@ -209,7 +209,7 @@ impl<'a> BaseWriteBatch<'a> for UnimplementedWriteBatch {
     }
 }
 
-impl<'a> SerialWriteBatch<'a> for UnimplementedWriteBatch {
+impl SerialWriteBatch<'_> for UnimplementedWriteBatch {
     fn put(&mut self, _key_space: KeySpace, _key: Cow<[u8]>, _value: Cow<[u8]>) -> Result<()> {
         todo!()
     }
@@ -218,7 +218,7 @@ impl<'a> SerialWriteBatch<'a> for UnimplementedWriteBatch {
     }
 }
 
-impl<'a> ConcurrentWriteBatch<'a> for UnimplementedWriteBatch {
+impl ConcurrentWriteBatch<'_> for UnimplementedWriteBatch {
     fn put(&self, _key_space: KeySpace, _key: Cow<[u8]>, _value: Cow<[u8]>) -> Result<()> {
         todo!()
     }

--- a/turbopack/crates/turbo-tasks-backend/src/database/write_batch.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/write_batch.rs
@@ -1,0 +1,156 @@
+use std::{
+    borrow::{Borrow, Cow},
+    marker::PhantomData,
+};
+
+use anyhow::Result;
+
+use crate::database::key_value_database::KeySpace;
+
+pub trait BaseWriteBatch<'a> {
+    type ValueBuffer<'l>: std::borrow::Borrow<[u8]>
+    where
+        Self: 'l,
+        'a: 'l;
+
+    fn get<'l>(&'l self, key_space: KeySpace, key: &[u8]) -> Result<Option<Self::ValueBuffer<'l>>>
+    where
+        'a: 'l;
+    fn commit(self) -> Result<()>;
+}
+
+pub trait SerialWriteBatch<'a>: BaseWriteBatch<'a> {
+    fn put(&mut self, key_space: KeySpace, key: Cow<[u8]>, value: Cow<[u8]>) -> Result<()>;
+    fn delete(&mut self, key_space: KeySpace, key: Cow<[u8]>) -> Result<()>;
+}
+
+pub trait ConcurrentWriteBatch<'a>: BaseWriteBatch<'a> + Sync + Send {
+    fn put(&self, key_space: KeySpace, key: Cow<[u8]>, value: Cow<[u8]>) -> Result<()>;
+    fn delete(&self, key_space: KeySpace, key: Cow<[u8]>) -> Result<()>;
+}
+
+pub enum WriteBatch<'a, S, C>
+where
+    S: SerialWriteBatch<'a>,
+    C: ConcurrentWriteBatch<'a>,
+{
+    Serial(S),
+    Concurrent(C, PhantomData<&'a ()>),
+}
+
+pub enum WriteBatchValueBuffer<S: Borrow<[u8]>, C: Borrow<[u8]>> {
+    Serial(S),
+    Concurrent(C),
+}
+
+impl<S: Borrow<[u8]>, C: Borrow<[u8]>> Borrow<[u8]> for WriteBatchValueBuffer<S, C> {
+    fn borrow(&self) -> &[u8] {
+        match self {
+            WriteBatchValueBuffer::Serial(s) => s.borrow(),
+            WriteBatchValueBuffer::Concurrent(c) => c.borrow(),
+        }
+    }
+}
+
+impl<'a, S, C> WriteBatch<'a, S, C>
+where
+    S: SerialWriteBatch<'a>,
+    C: ConcurrentWriteBatch<'a>,
+{
+    pub fn serial(s: S) -> Self {
+        WriteBatch::Serial(s)
+    }
+
+    pub fn concurrent(c: C) -> Self {
+        WriteBatch::Concurrent(c, PhantomData)
+    }
+}
+
+impl<'a, S, C> BaseWriteBatch<'a> for WriteBatch<'a, S, C>
+where
+    S: SerialWriteBatch<'a>,
+    C: ConcurrentWriteBatch<'a>,
+{
+    type ValueBuffer<'l>
+        = WriteBatchValueBuffer<S::ValueBuffer<'l>, C::ValueBuffer<'l>>
+    where
+        Self: 'l,
+        'a: 'l;
+
+    fn get<'l>(&'l self, key_space: KeySpace, key: &[u8]) -> Result<Option<Self::ValueBuffer<'l>>>
+    where
+        'a: 'l,
+    {
+        Ok(match self {
+            WriteBatch::Serial(s) => s.get(key_space, key)?.map(WriteBatchValueBuffer::Serial),
+            WriteBatch::Concurrent(c, _) => c
+                .get(key_space, key)?
+                .map(WriteBatchValueBuffer::Concurrent),
+        })
+    }
+
+    fn commit(self) -> Result<()> {
+        match self {
+            WriteBatch::Serial(s) => s.commit(),
+            WriteBatch::Concurrent(c, _) => c.commit(),
+        }
+    }
+}
+
+impl<'a, S, C> SerialWriteBatch<'a> for WriteBatch<'a, S, C>
+where
+    S: SerialWriteBatch<'a>,
+    C: ConcurrentWriteBatch<'a>,
+{
+    fn put(&mut self, key_space: KeySpace, key: Cow<[u8]>, value: Cow<[u8]>) -> Result<()> {
+        match self {
+            WriteBatch::Serial(s) => s.put(key_space, key, value),
+            WriteBatch::Concurrent(c, _) => c.put(key_space, key, value),
+        }
+    }
+
+    fn delete(&mut self, key_space: KeySpace, key: Cow<[u8]>) -> Result<()> {
+        match self {
+            WriteBatch::Serial(s) => s.delete(key_space, key),
+            WriteBatch::Concurrent(c, _) => c.delete(key_space, key),
+        }
+    }
+}
+
+pub struct UnimplementedWriteBatch;
+
+impl<'a> BaseWriteBatch<'a> for UnimplementedWriteBatch {
+    type ValueBuffer<'l>
+        = &'l [u8]
+    where
+        Self: 'l,
+        'a: 'l;
+
+    fn get<'l>(&'l self, _key_space: KeySpace, _key: &[u8]) -> Result<Option<Self::ValueBuffer<'l>>>
+    where
+        'a: 'l,
+    {
+        todo!()
+    }
+    fn commit(self) -> Result<()> {
+        todo!()
+    }
+}
+
+impl<'a> SerialWriteBatch<'a> for UnimplementedWriteBatch {
+    fn put(&mut self, _key_space: KeySpace, _key: Cow<[u8]>, _value: Cow<[u8]>) -> Result<()> {
+        todo!()
+    }
+    fn delete(&mut self, _key_space: KeySpace, _key: Cow<[u8]>) -> Result<()> {
+        todo!()
+    }
+}
+
+impl<'a> ConcurrentWriteBatch<'a> for UnimplementedWriteBatch {
+    fn put(&self, _key_space: KeySpace, _key: Cow<[u8]>, _value: Cow<[u8]>) -> Result<()> {
+        todo!()
+    }
+    fn delete(&self, _key_space: KeySpace, _key: Cow<[u8]>) -> Result<()> {
+        todo!()
+    }
+}

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -128,7 +128,6 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorage
         data_updates: Vec<ChunkedVec<CachedDataUpdate>>,
     ) -> Result<()> {
         let _span = tracing::trace_span!("save snapshot", session_id = ?session_id, operations = operations.len());
-        let start = Instant::now();
         let mut batch = self.database.write_batch()?;
         let mut task_meta_items_result = Ok(Vec::new());
         let mut task_data_items_result = Ok(Vec::new());
@@ -323,8 +322,6 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorage
                 }
             }
         }
-
-        println!("Preparing data took {:?}", start.elapsed());
 
         {
             let _span = tracing::trace_span!("commit").entered();

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -3,7 +3,6 @@ use std::{
     cmp::max,
     collections::hash_map::Entry,
     sync::Arc,
-    time::Instant,
 };
 
 use anyhow::{anyhow, Context, Result};

--- a/turbopack/crates/turbo-tasks-backend/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(anonymous_lifetime_in_impl_trait)]
+#![feature(associated_type_defaults)]
 
 mod backend;
 mod backing_storage;


### PR DESCRIPTION
### What?

Allow KeyValueDatabase to implement to variants of WriteBatches

* Serial: It's not Send+Sync and writing takes a `&mut self`
* Concurrent: It's Send+Sync and writing takes a `&self`

When using the concurrent variant we can avoid buffering the intermediate results and write that directly to the write batch. But the database need to take care of handling concurrency.


Closes PACK-3508