### PR TITLE
docs: use relative urls

### DIFF
--- a/errors/deprecated-analyticsid.mdx
+++ b/errors/deprecated-analyticsid.mdx
@@ -16,5 +16,5 @@ To remove this warning, you must remove `analyticsId` from your `next.config.js`
 
 To keep tracking your Core Web Vitals, you could:
 
-- use `useReportWebVitals` hook as explained [here](https://nextjs.org/docs/app/api-reference/functions/use-report-web-vitals) and send the metrics to any backend of your choice.
+- use `useReportWebVitals` hook as explained [here](/docs/app/api-reference/functions/use-report-web-vitals) and send the metrics to any backend of your choice.
 - [install and use](https://vercel.com/docs/speed-insights/quickstart) `@vercel/speed-insights` package into your application

--- a/errors/invalid-use-server-value.mdx
+++ b/errors/invalid-use-server-value.mdx
@@ -6,7 +6,7 @@ title: 'Invalid "use server" Value'
 
 This error occurs when a `"use server"` file exports a value that is not an async function. It might happen when you unintentionally export something like a configuration object, an arbitrary value, or missed the `async` keyword in the exported function declaration.
 
-These functions are required to be defined as async, because `"use server"` marks them as [Server Actions](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations) and they can be invoked directly from the client through a network request.
+These functions are required to be defined as async, because `"use server"` marks them as [Server Actions](/docs/app/building-your-application/data-fetching/server-actions-and-mutations) and they can be invoked directly from the client through a network request.
 
 Examples of incorrect code:
 
@@ -39,5 +39,5 @@ Check all exported values in the `"use server"` file (including `export *`) and 
 
 ## Useful Links
 
-- [Server Actions and Mutations - Next.js](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations)
+- [Server Actions and Mutations - Next.js](/docs/app/building-your-application/data-fetching/server-actions-and-mutations)
 - ['use server' directive - React](https://react.dev/reference/react/use-server)

--- a/errors/missing-root-layout-tags.mdx
+++ b/errors/missing-root-layout-tags.mdx
@@ -26,4 +26,4 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 
 ## Useful Links
 
-- [Root Layout](https://nextjs.org/docs/app/building-your-application/routing/layouts-and-templates#root-layout-required)
+- [Root Layout](/docs/app/building-your-application/routing/layouts-and-templates#root-layout-required)

--- a/errors/missing-suspense-with-csr-bailout.mdx
+++ b/errors/missing-suspense-with-csr-bailout.mdx
@@ -74,4 +74,4 @@ This configuration option will be removed in a future major version.
 
 ## Useful Links
 
-- [`useSearchParams`](https://nextjs.org/docs/app/api-reference/functions/use-search-params)
+- [`useSearchParams`](/docs/app/api-reference/functions/use-search-params)

--- a/errors/next-dynamic-api-wrong-context.mdx
+++ b/errors/next-dynamic-api-wrong-context.mdx
@@ -39,5 +39,5 @@ export async function GET() {
 - [`headers()` function](/docs/app/api-reference/functions/headers)
 - [`cookies()` function](/docs/app/api-reference/functions/cookies)
 - [`draftMode()` function](/docs/app/api-reference/functions/draft-mode)
-- [`unstable_noStore()` function](/docs/app/api-reference/functions/unstable_nostore)
+- [`unstable_noStore()` function](/docs/app/api-reference/functions/unstable_noStore)
 - [`unstable_cache()` function](/docs/app/api-reference/functions/unstable_cache)

--- a/errors/next-dynamic-api-wrong-context.mdx
+++ b/errors/next-dynamic-api-wrong-context.mdx
@@ -36,8 +36,8 @@ export async function GET() {
 
 ## Useful Links
 
-- [`headers()` function](https://nextjs.org/docs/app/api-reference/functions/headers)
-- [`cookies()` function](https://nextjs.org/docs/app/api-reference/functions/cookies)
-- [`draftMode()` function](https://nextjs.org/docs/app/api-reference/functions/draft-mode)
-- [`unstable_noStore()` function](https://nextjs.org/docs/app/api-reference/functions/unstable_nostore)
-- [`unstable_cache()` function](https://nextjs.org/docs/app/api-reference/functions/unstable_cache)
+- [`headers()` function](/docs/app/api-reference/functions/headers)
+- [`cookies()` function](/docs/app/api-reference/functions/cookies)
+- [`draftMode()` function](/docs/app/api-reference/functions/draft-mode)
+- [`unstable_noStore()` function](/docs/app/api-reference/functions/unstable_nostore)
+- [`unstable_cache()` function](/docs/app/api-reference/functions/unstable_cache)

--- a/errors/next-prerender-crypto.mdx
+++ b/errors/next-prerender-crypto.mdx
@@ -93,7 +93,7 @@ export default async function Page() {
 
 ## Useful Links
 
-- [`connection` function](https://nextjs.org/docs/app/api-reference/functions/connection)
+- [`connection` function](/docs/app/api-reference/functions/connection)
 - [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API)
 - [Node Crypto API](https://nodejs.org/docs/latest/api/crypto.html)
 - [`Suspense` React API](https://react.dev/reference/react/Suspense)

--- a/errors/next-prerender-current-time.mdx
+++ b/errors/next-prerender-current-time.mdx
@@ -196,7 +196,7 @@ async function DynamicBanner() {
 
 - [`Date.now` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now)
 - [`Date constructor` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date)
-- [`connection` function](https://nextjs.org/docs/app/api-reference/functions/connection)
+- [`connection` function](/docs/app/api-reference/functions/connection)
 - [`performance` Web API](https://developer.mozilla.org/en-US/docs/Web/API/Performance)
 - [`Suspense` React API](https://react.dev/reference/react/Suspense)
 - [`useLayoutEffect` React Hook](https://react.dev/reference/react/useLayoutEffect)

--- a/errors/next-prerender-missing-suspense.mdx
+++ b/errors/next-prerender-missing-suspense.mdx
@@ -256,7 +256,7 @@ Alternatively you can add a Suspense boundary above the component that is access
 ## Useful Links
 
 - [`Suspense` React API](https://react.dev/reference/react/Suspense)
-- [`headers` function](https://nextjs.org/docs/app/api-reference/functions/headers)
-- [`cookies` function](https://nextjs.org/docs/app/api-reference/functions/cookies)
-- [`draftMode` function](https://nextjs.org/docs/app/api-reference/functions/draft-mode)
-- [`connection` function](https://nextjs.org/docs/app/api-reference/functions/connection)
+- [`headers` function](/docs/app/api-reference/functions/headers)
+- [`cookies` function](/docs/app/api-reference/functions/cookies)
+- [`draftMode` function](/docs/app/api-reference/functions/draft-mode)
+- [`connection` function](/docs/app/api-reference/functions/connection)

--- a/errors/next-prerender-random.mdx
+++ b/errors/next-prerender-random.mdx
@@ -47,5 +47,5 @@ async function DynamicProductsView() {
 
 ## Useful Links
 
-- [`connection` function](https://nextjs.org/docs/app/api-reference/functions/connection)
+- [`connection` function](/docs/app/api-reference/functions/connection)
 - [`Suspense` React API](https://react.dev/reference/react/Suspense)

--- a/errors/next-prerender-sync-headers.mdx
+++ b/errors/next-prerender-sync-headers.mdx
@@ -12,7 +12,7 @@ To support migrating to the async APIs Next.js 15 still supports accessing prope
 
 If you haven't already followed the Next.js 15 upgrade guide which includes running a codemod to auto-convert to the necessary async form of these APIs start there.
 
-[Next 15 Upgrade Guide](https://nextjs.org/docs/app/building-your-application/upgrading/version-15#async-request-apis-breaking-change)
+[Next 15 Upgrade Guide](/docs/app/building-your-application/upgrading/version-15#async-request-apis-breaking-change)
 
 If you have already run the codemod on your project look for instances of the string `@next-codemod-error` to see where the codemod was unable to convert to the async form. You will have to refactor your code manually here to make it compatible with the new result type.
 
@@ -90,8 +90,8 @@ Note that with `await connection()` and `dynamicIO` it is still required that th
 
 ## Useful Links
 
-- [`headers` function](https://nextjs.org/docs/app/api-reference/functions/headers)
-- [`cookies` function](https://nextjs.org/docs/app/api-reference/functions/cookies)
-- [`draftMode` function](https://nextjs.org/docs/app/api-reference/functions/draft-mode)
-- [`connection` function](https://nextjs.org/docs/app/api-reference/functions/connection)
+- [`headers` function](/docs/app/api-reference/functions/headers)
+- [`cookies` function](/docs/app/api-reference/functions/cookies)
+- [`draftMode` function](/docs/app/api-reference/functions/draft-mode)
+- [`connection` function](/docs/app/api-reference/functions/connection)
 - [`Suspense` React API](https://react.dev/reference/react/Suspense)

--- a/errors/next-prerender-sync-params.mdx
+++ b/errors/next-prerender-sync-params.mdx
@@ -12,7 +12,7 @@ To support migrating to the async `params` and `searchParams` Next.js 15 still s
 
 If you haven't already followed the Next.js 15 upgrade guide which includes running a codemod to auto-convert to the necessary async form of `params` and `searchParams` start there.
 
-[Next 15 Upgrade Guide](https://nextjs.org/docs/app/building-your-application/upgrading/version-15#async-request-apis-breaking-change)
+[Next 15 Upgrade Guide](/docs/app/building-your-application/upgrading/version-15#async-request-apis-breaking-change)
 
 If you have already run the codemod on your project look for instances of the string `@next-codemod-error` to see where the codemod was unable to convert to the async form. You will have to refactor your code manually here to make it compatible with the new result type.
 
@@ -56,6 +56,6 @@ It is unexpected that you would run the codemod and not successfully convert all
 
 ## Useful Links
 
-- [`page.js` file convention](https://nextjs.org/docs/app/api-reference/file-conventions/page)
-- [`layout.js` file convention](https://nextjs.org/docs/app/api-reference/file-conventions/layout)
-- [`route.js` file convention](https://nextjs.org/docs/app/api-reference/file-conventions/route)
+- [`page.js` file convention](/docs/app/api-reference/file-conventions/page)
+- [`layout.js` file convention](/docs/app/api-reference/file-conventions/layout)
+- [`route.js` file convention](/docs/app/api-reference/file-conventions/route)

--- a/errors/next-prerender-sync-request.mdx
+++ b/errors/next-prerender-sync-request.mdx
@@ -37,5 +37,5 @@ It is unexpected that you would run the codemod and not successfully convert all
 
 ## Useful Links
 
-- [`connection` function](https://nextjs.org/docs/app/api-reference/functions/connection)
-- [`route.js` file convention](https://nextjs.org/docs/app/api-reference/file-conventions/route)
+- [`connection` function](/docs/app/api-reference/functions/connection)
+- [`route.js` file convention](/docs/app/api-reference/file-conventions/route)

--- a/errors/next-request-in-use-cache.mdx
+++ b/errors/next-request-in-use-cache.mdx
@@ -46,6 +46,6 @@ export default async function Page() {
 
 ## Useful Links
 
-- [`headers()` function](https://nextjs.org/docs/app/api-reference/functions/headers)
-- [`cookies()` function](https://nextjs.org/docs/app/api-reference/functions/cookies)
-- [`draftMode()` function](https://nextjs.org/docs/app/api-reference/functions/draft-mode)
+- [`headers()` function](/docs/app/api-reference/functions/headers)
+- [`cookies()` function](/docs/app/api-reference/functions/cookies)
+- [`draftMode()` function](/docs/app/api-reference/functions/draft-mode)

--- a/errors/parallel-build-without-worker.mdx
+++ b/errors/parallel-build-without-worker.mdx
@@ -15,4 +15,4 @@ Build workers are enabled by default unless you have a custom webpack config. Yo
 
 ## Useful Links
 
-Also see https://nextjs.org/docs/messages/webpack-build-worker-opt-out
+- [Webpack Build Worker automatic opt-out](/docs/messages/webpack-build-worker-opt-out)

--- a/errors/react-hydration-error.mdx
+++ b/errors/react-hydration-error.mdx
@@ -21,7 +21,7 @@ Hydration errors can occur from:
 3. Using browser-only APIs like `window` or `localStorage` in your rendering logic
 4. Using time-dependent APIs such as the `Date()` constructor in your rendering logic
 5. [Browser extensions](https://github.com/facebook/react/issues/24430) modifying the HTML
-6. Incorrectly configured [CSS-in-JS libraries](https://nextjs.org/docs/app/building-your-application/styling/css-in-js)
+6. Incorrectly configured [CSS-in-JS libraries](/docs/app/building-your-application/styling/css-in-js)
    1. Ensure your code is following [our official examples](https://github.com/vercel/next.js/tree/canary/examples)
 7. Incorrectly configured Edge/CDN that attempts to modify the html response, such as Cloudflare [Auto Minify](https://developers.cloudflare.com/speed/optimization/content/troubleshooting/disable-auto-minify/)
 
@@ -51,7 +51,7 @@ During React hydration, `useEffect` is called. This means browser APIs like `win
 
 ### Solution 2: Disabling SSR on specific components
 
-Next.js allows you to [disable prerendering](https://nextjs.org/docs/app/building-your-application/optimizing/lazy-loading#skipping-ssr) on specific components, which can prevent hydration mismatches.
+Next.js allows you to [disable prerendering](/docs/app/building-your-application/optimizing/lazy-loading#skipping-ssr) on specific components, which can prevent hydration mismatches.
 
 ```jsx
 import dynamic from 'next/dynamic'


### PR DESCRIPTION
## Description
Follow up #52038.
Remove `https://nextjs.org` from URL in [error pages](https://github.com/vercel/next.js/tree/canary/errors). 

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide