### PR TITLE
docs: add the section titles to error page

### DIFF
--- a/errors/next-prerender-crypto.mdx
+++ b/errors/next-prerender-crypto.mdx
@@ -10,6 +10,8 @@ If the API used has an async version you can also switch to that in instead of u
 
 ## Possible Ways to Fix It
 
+### Cache the token value
+
 If you are generating a token to talk to a database that itself should be cached move the token generation inside the `"use cache"`.
 
 Before:
@@ -42,6 +44,8 @@ export default async function Page() {
 }
 ```
 
+### Use an async API at request-time
+
 If you require this random value to be unique per Request and an async version of the API exists switch to it instead. Also ensure that there is a parent Suspense boundary that defines a fallback UI Next.js can use while rendering this component on each Request.
 
 Before:
@@ -67,6 +71,8 @@ export default async function Page() {
   return ...
 }
 ```
+
+### Use `await connection()` at request-time
 
 If you require this random value to be unique per Request and an async version of the API does not exist, call `await connection()`. Also ensure that there is a parent Suspense boundary that defines a fallback UI Next.js can use while rendering this component on each Request.
 


### PR DESCRIPTION
## Summary
Add the paragraph name to [next-prerender-crypto](https://github.com/vercel/next.js/blob/canary/errors/next-prerender-crypto.mdx) error page like [other next-prerender pages](https://github.com/vercel/next.js/blob/canary/errors/next-prerender-current-time.mdx).

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide