### PR TITLE
docs: fix code block language in error pages

### DIFF
--- a/errors/edge-dynamic-code-evaluation.mdx
+++ b/errors/edge-dynamic-code-evaluation.mdx
@@ -33,7 +33,7 @@ export default async function middleware() {
 In rare cases, your code could contain (or import) some dynamic code evaluation statements which _can not be reached at runtime_ and which can not be removed by tree-shaking.
 You can relax the check to allow specific files with your Middleware [configuration](/docs/pages/api-reference/edge#unsupported-apis):
 
-```tsx filename="pages/api/example.ts"
+```ts filename="pages/api/example.ts"
 export const config = {
   unstable_allowDynamic: [
     '/lib/utilities.js', // allows a single file

--- a/errors/empty-configuration.mdx
+++ b/errors/empty-configuration.mdx
@@ -10,7 +10,7 @@ There is no object exported from next.config.js or the object is empty.
 
 Check if you correctly export configuration in `next.config.js` file:
 
-```
+```js filename="next.config.js"
 module.exports = {
   /* config options here */
 }

--- a/errors/get-initial-props-as-an-instance-method.mdx
+++ b/errors/get-initial-props-as-an-instance-method.mdx
@@ -10,7 +10,7 @@ title: '`getInitialProps` was defined as an instance method'
 
 Use the static keyword.
 
-```js filename="pages/example.js"
+```jsx filename="pages/example.js"
 export default class YourEntryComponent extends React.Component {
   static getInitialProps() {
     return {}
@@ -24,7 +24,7 @@ export default class YourEntryComponent extends React.Component {
 
 or
 
-```js filename="pages/example.js"
+```jsx filename="pages/example.js"
 const YourEntryComponent = function () {
   return 'foo'
 }

--- a/errors/link-multiple-children.mdx
+++ b/errors/link-multiple-children.mdx
@@ -8,7 +8,7 @@ In your application code multiple children were passed to `next/link` but only o
 
 For example:
 
-```js filename="example.js"
+```jsx filename="example.js"
 import Link from 'next/link'
 
 export default function Home() {
@@ -25,7 +25,7 @@ export default function Home() {
 
 Make sure only one child is used when using `<Link>`:
 
-```js filename="example.js"
+```jsx filename="example.js"
 import Link from 'next/link'
 
 export default function Home() {

--- a/errors/module-not-found.mdx
+++ b/errors/module-not-found.mdx
@@ -38,7 +38,7 @@ Make sure the casing of the file is correct.
 
 Example:
 
-```js filename="components/MyComponent.js"
+```jsx filename="components/MyComponent.js"
 export default function MyComponent() {
   return <h1>Hello</h1>
 }

--- a/errors/next-dynamic-modules.mdx
+++ b/errors/next-dynamic-modules.mdx
@@ -14,7 +14,7 @@ Migrate to using separate dynamic calls for each module.
 
 **Before**
 
-```js filename="example.js"
+```jsx filename="example.js"
 import dynamic from 'next/dynamic'
 
 const HelloBundle = dynamic({
@@ -44,7 +44,7 @@ export default DynamicBundle
 
 **After**
 
-```js filename="example.js"
+```jsx filename="example.js"
 import dynamic from 'next/dynamic'
 
 const Hello1 = dynamic(() => import('../components/hello1'))

--- a/errors/no-document-title.mdx
+++ b/errors/no-document-title.mdx
@@ -10,7 +10,7 @@ Adding `<title>` in `pages/_document.js` will lead to unexpected results with `n
 
 Set `<title>` in `pages/_app.js` instead:
 
-```js filename="pages/_app.js"
+```jsx filename="pages/_app.js"
 import React from 'react'
 import Head from 'next/head'
 

--- a/errors/opt-out-auto-static-optimization.mdx
+++ b/errors/opt-out-auto-static-optimization.mdx
@@ -17,7 +17,7 @@ Verify if you need to use `getInitialProps` in `pages/_app`. There are some vali
 
 The following `getInitialProps` can be removed:
 
-```js filename="pages/_app.js"
+```jsx filename="pages/_app.js"
 class MyApp extends App {
   // Remove me, I do nothing!
   static async getInitialProps({ Component, ctx }) {

--- a/errors/opt-out-automatic-prerendering.mdx
+++ b/errors/opt-out-automatic-prerendering.mdx
@@ -17,7 +17,7 @@ If you previously copied the [Custom `<App>`](/docs/pages/building-your-applicat
 
 The following `getInitialProps` does nothing and may be removed:
 
-```js filename="pages/_app.js"
+```jsx filename="pages/_app.js"
 class MyApp extends App {
   // Remove me, I do nothing!
   static async getInitialProps({ Component, ctx }) {

--- a/errors/sync-dynamic-apis.mdx
+++ b/errors/sync-dynamic-apis.mdx
@@ -16,7 +16,7 @@ In Next 15, these APIs have been made asynchronous. You can read more about this
 
 For example, the following code will issue a warning:
 
-```js filename="app/[id]/page.js"
+```jsx filename="app/[id]/page.js"
 function Page({ params }) {
   // direct access of `params.id`.
   return <p>ID: {params.id}</p>
@@ -42,7 +42,7 @@ The codemod cannot cover all cases, so you may need to manually adjust some code
 If the warning occured on the Server (e.g. a route handler, or a Server Component),
 you must `await` the dynamic API to access its properties:
 
-```js filename="app/[id]/page.js"
+```jsx filename="app/[id]/page.js"
 async function Page({ params }) {
   // asynchronous access of `params.id`.
   const { id } = await params
@@ -53,7 +53,7 @@ async function Page({ params }) {
 If the warning occured in a synchronous component (e.g. a Client component),
 you must use `React.use()` to unwrap the Promise first:
 
-```js filename="app/[id]/page.js"
+```jsx filename="app/[id]/page.js"
 'use client'
 import * as React from 'react'
 

--- a/errors/url-deprecated.mdx
+++ b/errors/url-deprecated.mdx
@@ -17,7 +17,7 @@ The `router` property that is injected will hold the same values as `url`, like 
 
 Here's an example of using `withRouter`:
 
-```js filename="pages/index.js"
+```jsx filename="pages/index.js"
 import { withRouter } from 'next/router'
 
 class Page extends React.Component {


### PR DESCRIPTION
## Summary
Update code block language in [error pages](https://github.com/vercel/next.js/tree/canary/errors).

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide