### PR TITLE
Support custom servers with minimal node modules

### DIFF
--- a/docs/01-app/02-building-your-application/07-configuring/10-custom-server.mdx
+++ b/docs/01-app/02-building-your-application/07-configuring/10-custom-server.mdx
@@ -87,16 +87,17 @@ const app = next({})
 
 The above `next` import is a function that receives an object with the following options:
 
-| Option       | Type               | Description                                                                         |
-| ------------ | ------------------ | ----------------------------------------------------------------------------------- |
-| `conf`       | `Object`           | The same object you would use in `next.config.js`. Defaults to `{}`                 |
-| `dev`        | `Boolean`          | (_Optional_) Whether or not to launch Next.js in dev mode. Defaults to `false`      |
-| `dir`        | `String`           | (_Optional_) Location of the Next.js project. Defaults to `'.'`                     |
-| `quiet`      | `Boolean`          | (_Optional_) Hide error messages containing server information. Defaults to `false` |
-| `hostname`   | `String`           | (_Optional_) The hostname the server is running behind                              |
-| `port`       | `Number`           | (_Optional_) The port the server is running behind                                  |
-| `httpServer` | `node:http#Server` | (_Optional_) The HTTP Server that Next.js is running behind                         |
-| `turbo`      | `Boolean`          | (_Optional_) Enable Turbopack                                                       |
+| Option            | Type                 | Description                                                                                                           |
+| ----------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `conf`            | `Object`             | The same object you would use in `next.config.js`. Defaults to `{}`                                                   |
+| `dev`             | `Boolean`            | (_Optional_) Whether or not to launch Next.js in dev mode. Defaults to `false`                                        |
+| `dir`             | `String`             | (_Optional_) Location of the Next.js project. Defaults to `'.'`                                                       |
+| `quiet`           | `Boolean`            | (_Optional_) Hide error messages containing server information. Defaults to `false`                                   |
+| `hostname`        | `String`             | (_Optional_) The hostname the server is running behind                                                                |
+| `port`            | `Number`             | (_Optional_) The port the server is running behind                                                                    |
+| `httpServer`      | `node:http#Server`   | (_Optional_) The HTTP Server that Next.js is running behind                                                           |
+| `turbo`           | `Boolean`            | (_Optional_) Enable Turbopack                                                                                         |
+| `preloadedConfig` | `NextConfigComplete` | (_Optional_) A preloaded config to be used instead of loading from `next.config.js`. Only works when `dev` is `false` |
 
 The returned `app` can then be used to let Next.js handle requests as required.
 


### PR DESCRIPTION
## Fixing a bug

### Related issues

fixes #64031

### Why is this change needed

Per the Next.js [docs](https://nextjs.org/docs/pages/api-reference/next-config-js/output)

> Next.js' production server is also traced for its needed files and output at .next/next-server.js.nft.json which can be leveraged in production.

When I tried doing this my [custom server](https://nextjs.org/docs/pages/building-your-application/configuring/custom-server) would crash on startup because of this codepath

https://github.com/vercel/next.js/blob/canary/packages/next/src/server/config.ts#L1022

My first attempt at fixing this involved changing

```
if (!process.env.__NEXT_PRIVATE_STANDALONE_CONFIG) {
```

to

```
if (phase === PHASE_PRODUCTION_SERVER) {
```

but this is not guaranteed to work because the next.config.js and it's required dependencies may not be present causing the server to use the default config

The best solution is to mimic standalone mode as closely as possible

### What does this change do

This change allows a custom server running in production with only required files to pass in a preloaded next config (most likely from `required-server-files.json`)

This is very similar to how the [standalone server works](https://github.com/vercel/next.js/blob/bc49287063d6afd50a7361566b14f1ab6c26b136/packages/next/src/build/utils.ts#L2142)

### Testing

I'd like to get an initial round of feedback from the next team before I dive into writing an integration test. I patched nextjs in my repo and this solution worked
