### PR TITLE
Allow method properties to be server functions

### DIFF
--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/53/input.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/53/input.js
@@ -1,0 +1,8 @@
+export const obj = {
+  async foo() {
+    'use cache'
+  },
+  async bar() {
+    'use server'
+  },
+}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/53/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/53/output.js
@@ -1,0 +1,13 @@
+/* __next_internal_action_entry_do_not_use__ {"0090b5db271335765a4b0eab01f044b381b5ebd5cd":"$$RSC_SERVER_ACTION_1","803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function foo() {});
+Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+    "value": "foo",
+    "writable": false
+});
+export const $$RSC_SERVER_ACTION_1 = async function bar() {};
+export const obj = {
+    foo: registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null),
+    bar: registerServerReference($$RSC_SERVER_ACTION_1, "0090b5db271335765a4b0eab01f044b381b5ebd5cd", null)
+};

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/54/input.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/54/input.js
@@ -1,0 +1,14 @@
+function createObj(n) {
+  const m = n + 1
+
+  return {
+    async foo() {
+      'use cache'
+      return n * m
+    },
+    async bar() {
+      'use server'
+      console.log(m)
+    },
+  }
+}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/54/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/54/output.js
@@ -1,0 +1,27 @@
+/* __next_internal_action_entry_do_not_use__ {"401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91":"$$RSC_SERVER_ACTION_2","c03128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", 2, async function foo([$$ACTION_ARG_0, $$ACTION_ARG_1]) {
+    return $$ACTION_ARG_0 * $$ACTION_ARG_1;
+});
+Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+    "value": "foo",
+    "writable": false
+});
+export const $$RSC_SERVER_ACTION_2 = async function bar($$ACTION_CLOSURE_BOUND) {
+    var [$$ACTION_ARG_0] = await decryptActionBoundArgs("401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", $$ACTION_CLOSURE_BOUND);
+    console.log($$ACTION_ARG_0);
+};
+function createObj(n) {
+    const m = n + 1;
+    return {
+        foo: $$RSC_SERVER_REF_1.bind(null, encryptActionBoundArgs("c03128060c414d59f8552e4788b846c0d2b7f74743", [
+            n,
+            m
+        ])),
+        bar: registerServerReference($$RSC_SERVER_ACTION_2, "401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null).bind(null, encryptActionBoundArgs("401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", [
+            m
+        ]))
+    };
+}
+var $$RSC_SERVER_REF_1 = registerServerReference($$RSC_SERVER_CACHE_0, "c03128060c414d59f8552e4788b846c0d2b7f74743", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/55/input.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/55/input.js
@@ -1,0 +1,9 @@
+export const api = {
+  product: {
+    async fetch() {
+      'use cache'
+
+      return fetch('https://example.com').then((res) => res.json())
+    },
+  },
+}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/55/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/55/output.js
@@ -1,0 +1,15 @@
+/* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function fetch1() {
+    return fetch('https://example.com').then((res)=>res.json());
+});
+Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+    "value": "fetch",
+    "writable": false
+});
+export const api = {
+    product: {
+        fetch: registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null)
+    }
+};

--- a/test/e2e/app-dir/use-cache/app/method-props/cached.ts
+++ b/test/e2e/app-dir/use-cache/app/method-props/cached.ts
@@ -1,0 +1,10 @@
+export function createCached(n: number) {
+  return {
+    async getRandomValue() {
+      'use cache'
+      const v = n + Math.random()
+      console.log(v)
+      return v
+    },
+  }
+}

--- a/test/e2e/app-dir/use-cache/app/method-props/form.tsx
+++ b/test/e2e/app-dir/use-cache/app/method-props/form.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useActionState } from 'react'
+
+export function Form({
+  id,
+  getRandomValue,
+}: {
+  id: string
+  getRandomValue: () => Promise<number>
+}) {
+  const [result, formAction, isPending] = useActionState(getRandomValue, -1)
+
+  return (
+    <form id={id} action={formAction}>
+      <button>Submit</button>
+      <p>{isPending ? 'loading...' : result}</p>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/use-cache/app/method-props/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/method-props/page.tsx
@@ -1,0 +1,14 @@
+import { createCached } from './cached'
+import { Form } from './form'
+
+export default function Page() {
+  const cached1 = createCached(1)
+  const cached2 = createCached(2)
+
+  return (
+    <main>
+      <Form id="form-1" getRandomValue={cached1.getRandomValue} />
+      <Form id="form-2" getRandomValue={cached2.getRandomValue} />
+    </main>
+  )
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -393,4 +393,42 @@ describe('use-cache', () => {
       expect(await browser.elementByCss('p').text()).toBe(value)
     })
   })
+
+  it('works with "use cache" in method props', async () => {
+    const browser = await next.browser('/method-props')
+
+    let [value1, value2] = await Promise.all([
+      browser.elementByCss('#form-1 p').text(),
+      browser.elementByCss('#form-2 p').text(),
+    ])
+
+    expect(value1).toBe('-1')
+    expect(value2).toBe('-1')
+
+    await browser.elementByCss('#form-1 button').click()
+
+    await retry(async () => {
+      value1 = await browser.elementByCss('#form-1 p').text()
+      expect(value1).toMatch(/1\.\d+/)
+    })
+
+    await browser.elementByCss('#form-2 button').click()
+
+    await retry(async () => {
+      value2 = await browser.elementByCss('#form-2 p').text()
+      expect(value2).toMatch(/2\.\d+/)
+    })
+
+    await browser.elementByCss('#form-1 button').click()
+
+    await retry(async () => {
+      expect(await browser.elementByCss('#form-1 p').text()).toBe(value1)
+    })
+
+    await browser.elementByCss('#form-2 button').click()
+
+    await retry(async () => {
+      expect(await browser.elementByCss('#form-2 p').text()).toBe(value2)
+    })
+  })
 })


### PR DESCRIPTION
With this PR, we are now allowing `"use server"` and `"use cache"` to be used in method properties, e.g.:

```js
export const obj = {
  async foo() {
    'use cache'

    return Math.random()
  },
  async bar() {
    'use server'

    console.log(42)
  },
}
```

Or, more realistically, something like this:

```js
export const api = {
  product: {
    async fetch() {
      'use cache'

      return fetch('https://example.com').then((res) => res.json())
    },
  },
}
```

Supporting this pattern is mostly done for convenience; it allows users to group server functions into a common object, using method properties. Notably, we will not support the usage of `this` and `super`, for which we will add build errors in a follow-up PR.