### PR TITLE
Extract existing `make_chunks` into a simple `ChunkingStrategy`

### DIFF
--- a/turbopack/crates/turbopack-core/src/chunk/chunking_strategies/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_strategies/mod.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+use turbo_rcstr::RcStr;
+use turbo_tasks::Vc;
+
+use super::{ChunkItemsWithAsyncModuleInfo, ChunkingContext, Chunks};
+use crate::output::OutputAssets;
+
+pub mod simple;
+
+#[turbo_tasks::value_trait]
+pub trait ChunkingStrategy {
+    async fn make_chunks(
+        self: Vc<Self>,
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+        chunk_items: Vc<ChunkItemsWithAsyncModuleInfo>,
+        key_prefix: RcStr,
+        referenced_output_assets: Vc<OutputAssets>,
+    ) -> Result<Vc<Chunks>>;
+}

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -1,8 +1,8 @@
 pub mod availability_info;
 pub mod available_chunk_items;
 pub mod chunk_group;
-pub mod chunking;
 pub(crate) mod chunking_context;
+pub mod chunking_strategies;
 pub(crate) mod containment_tree;
 pub(crate) mod data;
 pub(crate) mod evaluate;

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -9,6 +9,7 @@ use turbopack_core::{
     chunk::{
         availability_info::AvailabilityInfo,
         chunk_group::{make_chunk_group, MakeChunkGroupResult},
+        chunking_strategies::simple::SimpleChunkingStrategy,
         module_id_strategies::{DevModuleIdStrategy, ModuleIdStrategy},
         Chunk, ChunkGroupResult, ChunkItem, ChunkableModule, ChunkingContext,
         EntryChunkGroupResult, EvaluatableAssets, MinifyType, ModuleId,
@@ -297,6 +298,7 @@ impl ChunkingContext for NodeJsChunkingContext {
                 availability_info,
             } = make_chunk_group(
                 Vc::upcast(self),
+                Vc::upcast(SimpleChunkingStrategy::new()),
                 [Vc::upcast(module)],
                 availability_info.into_value(),
             )
@@ -337,6 +339,7 @@ impl ChunkingContext for NodeJsChunkingContext {
             availability_info,
         } = make_chunk_group(
             Vc::upcast(self),
+            Vc::upcast(SimpleChunkingStrategy::new()),
             once(module).chain(
                 evaluatable_assets
                     .await?


### PR DESCRIPTION
This:

- Implements a new trait, `ChunkingStrategy`, which is responsible for implementing the bulk of chunking.
- Extracts the existing `make_chunks` function into a `SimpleChunkingStrategy`, and uses it across existing `ChunkingContext`s.
- Allows `BrowserChunkingContext` to accept a different `ChunkingStrategy`. Soon, we’ll implement a more optimal strategy for browser code in production builds that shares code across routes.
- `NodeJsChunkingContext` continues to always use the existing `SimpleChunkingStrategy`.

Test Plan: No behavior change. CI.


Closes PACK-3955