### PR TITLE
docs: add second parameter `ctx` to get method in CacheHandler

### DIFF
--- a/docs/01-app/02-building-your-application/10-deploying/index.mdx
+++ b/docs/01-app/02-building-your-application/10-deploying/index.mdx
@@ -200,8 +200,9 @@ module.exports = class CacheHandler {
     this.options = options
   }
 
-  async get(key) {
+  async get(key /*, ctx */) {
     // This could be stored anywhere, like durable storage
+    // ctx can be used to customize the key if needed
     return cache.get(key)
   }
 


### PR DESCRIPTION
### Why?

The `CacheHandler` example's get method allows the use of `a second parameter, ctx`, but this is not documented. I am submitting this PR to request its inclusion.

The use of ctx is also supported in the **next-shared-cache library** recommended by Next.js.
ref: [next-shared-cache/cache-hanlder.ts](https://github.com/caching-tools/next-shared-cache/blob/canary/packages/cache-handler/src/cache-handler.ts#L613)