### PR TITLE
Include `debug` script in test directories

### DIFF
--- a/contributing/core/testing.md
+++ b/contributing/core/testing.md
@@ -84,7 +84,7 @@ these can be leveraged by prefixing the `pnpm test` command.
 
 - When investigating failures in isolated tests you can use
   `NEXT_TEST_SKIP_CLEANUP=1` to prevent deleting the temp folder created for the test,
-  then you can run `pnpm next` while inside the temp folder to debug the fully set-up test project.
+  then you can run `pnpm debug` while inside the temp folder to debug the fully set-up test project.
 - You can also use `NEXT_SKIP_ISOLATE=1` if the test doesn't need to be installed to debug,
   and it will run inside the Next.js repo instead of the temp directory,
   this can also reduce test times locally but is not compatible with all tests.

--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -130,12 +130,18 @@ async function createNextInstall({
         }, {}),
       }
 
+      const scripts = {
+        debug: `NEXT_PRIVATE_SKIP_CANARY_CHECK=1 NEXT_TELEMETRY_DISABLED=1 NEXT_TEST_NATIVE_DIR=${process.env.NEXT_TEST_NATIVE_DIR} node --inspect --trace-deprecation --enable-source-maps node_modules/next/dist/bin/next`,
+        ...packageJson.scripts,
+      }
+
       await fs.ensureDir(installDir)
       await fs.writeFile(
         path.join(installDir, 'package.json'),
         JSON.stringify(
           {
             ...packageJson,
+            scripts,
             dependencies: combinedDependencies,
             private: true,
             // Add resolutions if provided.


### PR DESCRIPTION
I commonly add a `debug` script that allows me to attach a debugger when running Next.js in the isolated test dirs. 

Now we always add it and make it work just like `debug` from the monorepo. So after the test you can `cd` into the created test directory and run `pnpm debug dev`. `debug` is just an alias for `next` with some additional configurations:
- tracing deprecations
- no telemetry
- no canary checks
- debugger attachable
- source maps

`debug` also ensures the SWC version that was used during the test is used. Previously it used the cached version which isn't necessarily the one built in this specific worktree.