### PR TITLE
Rename `waitForAndOpenRuntimeError` to `openRedbox`

### DIFF
--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -41,7 +41,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     )
     await session.evaluate(() => document.querySelector('a').click())
 
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
     expect(await session.getRedboxSource()).toMatchSnapshot()
   })
 
@@ -149,7 +149,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
       `export default function FunctionDefault() { throw new Error('no'); }`
     )
 
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
     expect(await session.getRedboxSource()).toMatchSnapshot()
     expect(
       await session.evaluate(() => document.querySelector('h2').textContent)
@@ -390,7 +390,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     )
 
     await session.evaluate(() => document.querySelector('button').click())
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
 
     const header = await session.getRedboxDescription()
     expect(header).toMatchSnapshot()
@@ -435,7 +435,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     )
 
     await session.evaluate(() => document.querySelector('button').click())
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
 
     const header2 = await session.getRedboxDescription()
     expect(header2).toMatchSnapshot()
@@ -480,7 +480,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     )
 
     await session.evaluate(() => document.querySelector('button').click())
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
 
     const header3 = await session.getRedboxDescription()
     expect(header3).toMatchSnapshot()
@@ -525,7 +525,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     )
 
     await session.evaluate(() => document.querySelector('button').click())
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
 
     const header4 = await session.getRedboxDescription()
     expect(header4).toEqual(

--- a/test/development/acceptance-app/error-message-url.test.ts
+++ b/test/development/acceptance-app/error-message-url.test.ts
@@ -49,7 +49,7 @@ describe('Error overlay - error message urls', () => {
       ])
     )
     const { session, browser } = sandbox
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
 
     const link = await browser.elementByCss('#nextjs__container_errors__link a')
     const text = await link.text()

--- a/test/development/acceptance-app/error-recovery.test.ts
+++ b/test/development/acceptance-app/error-recovery.test.ts
@@ -136,7 +136,7 @@ describe.each(['default', 'turbo'])('Error recovery app %s', () => {
       await session.evaluate(() => document.querySelector('p').textContent)
     ).toBe('1')
 
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
 
     expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
       "index.js (7:11) @ Index.useCallback[increment]
@@ -282,7 +282,7 @@ describe.each(['default', 'turbo'])('Error recovery app %s', () => {
     )
 
     await new Promise((resolve) => setTimeout(resolve, 1000))
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
     expect(await session.getRedboxSource()).not.toInclude(
       "Expected '}', got '<eof>'"
     )

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -71,9 +71,8 @@ describe('Error overlay for hydration errors in App router', () => {
       ])
     )
     const { session, browser } = sandbox
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
 
-    await session.assertHasRedbox()
     expect(await getRedboxTotalErrorCount(browser)).toBe(1)
 
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
@@ -153,9 +152,8 @@ describe('Error overlay for hydration errors in App router', () => {
       ])
     )
     const { session, browser } = sandbox
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
 
-    await session.assertHasRedbox()
     expect(await getRedboxTotalErrorCount(browser)).toBe(1)
 
     const pseudoHtml = await session.getRedboxComponentStack()
@@ -203,9 +201,8 @@ describe('Error overlay for hydration errors in App router', () => {
       ])
     )
     const { session, browser } = sandbox
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
 
-    await session.assertHasRedbox()
     expect(await getRedboxTotalErrorCount(browser)).toBe(1)
 
     const pseudoHtml = await session.getRedboxComponentStack()
@@ -239,9 +236,8 @@ describe('Error overlay for hydration errors in App router', () => {
       ])
     )
     const { session, browser } = sandbox
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
 
-    await session.assertHasRedbox()
     expect(await getRedboxTotalErrorCount(browser)).toBe(1)
 
     const pseudoHtml = await session.getRedboxComponentStack()
@@ -288,9 +284,8 @@ describe('Error overlay for hydration errors in App router', () => {
       ])
     )
     const { session, browser } = sandbox
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
 
-    await session.assertHasRedbox()
     expect(await getRedboxTotalErrorCount(browser)).toBe(1)
 
     const pseudoHtml = await session.getRedboxComponentStack()
@@ -330,9 +325,8 @@ describe('Error overlay for hydration errors in App router', () => {
       ])
     )
     const { session, browser } = sandbox
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
 
-    await session.assertHasRedbox()
     expect(await getRedboxTotalErrorCount(browser)).toBe(1)
 
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
@@ -378,9 +372,8 @@ describe('Error overlay for hydration errors in App router', () => {
       ])
     )
     const { session, browser } = sandbox
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
 
-    await session.assertHasRedbox()
     expect(await getRedboxTotalErrorCount(browser)).toBe(2)
 
     // FIXME: Should also have "text nodes cannot be a child of tr"
@@ -427,9 +420,8 @@ describe('Error overlay for hydration errors in App router', () => {
       ])
     )
     const { session, browser } = sandbox
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
 
-    await session.assertHasRedbox()
     expect(await getRedboxTotalErrorCount(browser)).toBe(1)
 
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
@@ -487,7 +479,7 @@ describe('Error overlay for hydration errors in App router', () => {
       ])
     )
     const { session } = sandbox
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
 
     const pseudoHtml = await session.getRedboxComponentStack()
     if (isTurbopack) {
@@ -572,9 +564,8 @@ describe('Error overlay for hydration errors in App router', () => {
     )
 
     const { session, browser } = sandbox
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
 
-    await session.assertHasRedbox()
     expect(await getRedboxTotalErrorCount(browser)).toBe(2)
 
     const description = await session.getRedboxDescription()
@@ -631,9 +622,8 @@ describe('Error overlay for hydration errors in App router', () => {
     )
 
     const { session, browser } = sandbox
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
 
-    await session.assertHasRedbox()
     expect(await getRedboxTotalErrorCount(browser)).toBe(2)
 
     const description = await session.getRedboxDescription()
@@ -670,9 +660,8 @@ describe('Error overlay for hydration errors in App router', () => {
     )
 
     const { session, browser } = sandbox
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
 
-    await session.assertHasRedbox()
     expect(await getRedboxTotalErrorCount(browser)).toBe(2)
 
     const description = await session.getRedboxDescription()
@@ -724,9 +713,8 @@ describe('Error overlay for hydration errors in App router', () => {
     )
 
     const { session, browser } = sandbox
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
 
-    await session.assertHasRedbox()
     expect(await getRedboxTotalErrorCount(browser)).toBe(2)
 
     const description = await session.getRedboxDescription()
@@ -796,9 +784,7 @@ describe('Error overlay for hydration errors in App router', () => {
       ])
     )
     const { session, browser } = sandbox
-    await session.waitForAndOpenRuntimeError()
-
-    await session.assertHasRedbox()
+    await session.openRedbox()
 
     retry(async () => {
       expect(await getRedboxTotalErrorCount(browser)).toBe(4)
@@ -868,9 +854,8 @@ describe('Error overlay for hydration errors in App router', () => {
       ])
     )
     const { session, browser } = sandbox
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
 
-    await session.assertHasRedbox()
     expect(await getRedboxTotalErrorCount(browser)).toBe(1)
 
     const pseudoHtml = await session.getRedboxComponentStack()

--- a/test/development/acceptance-app/version-staleness.test.ts
+++ b/test/development/acceptance-app/version-staleness.test.ts
@@ -45,7 +45,7 @@ describe('Error Overlay version staleness', () => {
       `
     )
 
-    await session.waitForAndOpenRuntimeError()
+    await session.openRedbox()
 
     if (process.env.TURBOPACK) {
       expect(await getStaleness(browser)).toMatchInlineSnapshot(

--- a/test/development/app-dir/capture-console-error-owner-stack/capture-console-error-owner-stack.test.ts
+++ b/test/development/app-dir/capture-console-error-owner-stack/capture-console-error-owner-stack.test.ts
@@ -1,12 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 import {
-  assertHasRedbox,
   getRedboxCallStack,
   getRedboxDescription,
   getRedboxTitle,
   getRedboxSource,
   getRedboxTotalErrorCount,
-  waitForAndOpenRuntimeError,
+  openRedbox,
 } from 'next-test-utils'
 
 async function getRedboxResult(browser: any) {
@@ -33,8 +32,7 @@ describe('app-dir - capture-console-error-owner-stack', () => {
     const browser = await next.browser('/browser/event')
     await browser.elementByCss('button').click()
 
-    await waitForAndOpenRuntimeError(browser)
-    await assertHasRedbox(browser)
+    await openRedbox(browser)
 
     const result = await getRedboxResult(browser)
 
@@ -82,8 +80,7 @@ describe('app-dir - capture-console-error-owner-stack', () => {
   it('should capture browser console error in render and dedupe if necessary', async () => {
     const browser = await next.browser('/browser/render')
 
-    await waitForAndOpenRuntimeError(browser)
-    await assertHasRedbox(browser)
+    await openRedbox(browser)
 
     const result = await getRedboxResult(browser)
 
@@ -129,8 +126,7 @@ describe('app-dir - capture-console-error-owner-stack', () => {
   it('should capture browser console error in render and dedupe when multi same errors logged', async () => {
     const browser = await next.browser('/browser/render')
 
-    await waitForAndOpenRuntimeError(browser)
-    await assertHasRedbox(browser)
+    await openRedbox(browser)
 
     const result = await getRedboxResult(browser)
 
@@ -176,8 +172,7 @@ describe('app-dir - capture-console-error-owner-stack', () => {
   it('should capture server replay string error from console error', async () => {
     const browser = await next.browser('/ssr')
 
-    await waitForAndOpenRuntimeError(browser)
-    await assertHasRedbox(browser)
+    await openRedbox(browser)
 
     const result = await getRedboxResult(browser)
 
@@ -223,8 +218,7 @@ describe('app-dir - capture-console-error-owner-stack', () => {
   it('should capture server replay error instance from console error', async () => {
     const browser = await next.browser('/ssr-error-instance')
 
-    await waitForAndOpenRuntimeError(browser)
-    await assertHasRedbox(browser)
+    await openRedbox(browser)
 
     const result = await getRedboxResult(browser)
 
@@ -270,8 +264,7 @@ describe('app-dir - capture-console-error-owner-stack', () => {
   it('should be able to capture rsc logged error', async () => {
     const browser = await next.browser('/rsc')
 
-    await waitForAndOpenRuntimeError(browser)
-    await assertHasRedbox(browser)
+    await openRedbox(browser)
 
     const result = await getRedboxResult(browser)
 

--- a/test/development/app-dir/capture-console-error/capture-console-error.test.ts
+++ b/test/development/app-dir/capture-console-error/capture-console-error.test.ts
@@ -1,12 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 import {
-  assertHasRedbox,
   getRedboxCallStack,
   getRedboxDescription,
   getRedboxTitle,
   getRedboxSource,
   getRedboxTotalErrorCount,
-  waitForAndOpenRuntimeError,
+  openRedbox,
 } from 'next-test-utils'
 
 async function getRedboxResult(browser: any) {
@@ -41,8 +40,7 @@ describe('app-dir - capture-console-error', () => {
     const browser = await next.browser('/browser/event')
     await browser.elementByCss('button').click()
 
-    await waitForAndOpenRuntimeError(browser)
-    await assertHasRedbox(browser)
+    await openRedbox(browser)
 
     const result = await getRedboxResult(browser)
 
@@ -88,8 +86,7 @@ describe('app-dir - capture-console-error', () => {
   it('should capture browser console error in render and dedupe if necessary', async () => {
     const browser = await next.browser('/browser/render')
 
-    await waitForAndOpenRuntimeError(browser)
-    await assertHasRedbox(browser)
+    await openRedbox(browser)
 
     const result = await getRedboxResult(browser)
 
@@ -135,8 +132,7 @@ describe('app-dir - capture-console-error', () => {
   it('should capture browser console error in render and dedupe when multi same errors logged', async () => {
     const browser = await next.browser('/browser/render')
 
-    await waitForAndOpenRuntimeError(browser)
-    await assertHasRedbox(browser)
+    await openRedbox(browser)
 
     const result = await getRedboxResult(browser)
 
@@ -182,8 +178,7 @@ describe('app-dir - capture-console-error', () => {
   it('should capture server replay string error from console error', async () => {
     const browser = await next.browser('/ssr')
 
-    await waitForAndOpenRuntimeError(browser)
-    await assertHasRedbox(browser)
+    await openRedbox(browser)
 
     const result = await getRedboxResult(browser)
 
@@ -229,8 +224,7 @@ describe('app-dir - capture-console-error', () => {
   it('should capture server replay error instance from console error', async () => {
     const browser = await next.browser('/ssr-error-instance')
 
-    await waitForAndOpenRuntimeError(browser)
-    await assertHasRedbox(browser)
+    await openRedbox(browser)
 
     const result = await getRedboxResult(browser)
 
@@ -276,8 +270,7 @@ describe('app-dir - capture-console-error', () => {
   it('should be able to capture rsc logged error', async () => {
     const browser = await next.browser('/rsc')
 
-    await waitForAndOpenRuntimeError(browser)
-    await assertHasRedbox(browser)
+    await openRedbox(browser)
 
     const result = await getRedboxResult(browser)
 

--- a/test/development/app-dir/dynamic-io-dev-cache-scope/dynamic-io-dev-cache-scope.test.ts
+++ b/test/development/app-dir/dynamic-io-dev-cache-scope/dynamic-io-dev-cache-scope.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 import {
   getRedboxDescription,
-  waitForAndOpenRuntimeError,
+  openRedbox,
   assertNoRedbox,
   retry,
 } from 'next-test-utils'
@@ -72,7 +72,7 @@ describe('Dynamic IO Dev Errors', () => {
     let desc
 
     const browser = await next.browser('/uncached')
-    await waitForAndOpenRuntimeError(browser)
+    await openRedbox(browser)
     desc = await getRedboxDescription(browser)
 
     expect(desc).toContain(
@@ -80,7 +80,7 @@ describe('Dynamic IO Dev Errors', () => {
     )
 
     await browser.refresh()
-    await waitForAndOpenRuntimeError(browser)
+    await openRedbox(browser)
     desc = await getRedboxDescription(browser)
 
     expect(desc).toContain(

--- a/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
+++ b/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
@@ -7,7 +7,7 @@ import {
   getRedboxDescription,
   hasErrorToast,
   retry,
-  waitForAndOpenRuntimeError,
+  openRedbox,
   getRedboxSource,
 } from 'next-test-utils'
 import { createSandbox } from 'development-sandbox'
@@ -21,15 +21,11 @@ describe('Dynamic IO Dev Errors', () => {
   it('should show a red box error on the SSR render', async () => {
     const browser = await next.browser('/error')
 
-    await retry(async () => {
-      expect(await hasErrorToast(browser)).toBe(true)
+    await openRedbox(browser)
 
-      await waitForAndOpenRuntimeError(browser)
-
-      expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
-        `"[ Server ] Error: Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random"`
-      )
-    })
+    expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
+      `"[ Server ] Error: Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random"`
+    )
   })
 
   it('should show a red box error on client navigations', async () => {
@@ -39,15 +35,11 @@ describe('Dynamic IO Dev Errors', () => {
 
     await browser.elementByCss("[href='/error']").click()
 
-    await retry(async () => {
-      expect(await hasErrorToast(browser)).toBe(true)
+    await openRedbox(browser)
 
-      await waitForAndOpenRuntimeError(browser)
-
-      expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
-        `"[ Server ] Error: Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random"`
-      )
-    })
+    expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
+      `"[ Server ] Error: Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random"`
+    )
   })
 
   // NOTE: when update this snapshot, use `pnpm build` in packages/next to avoid next source code get mapped to source.
@@ -55,11 +47,7 @@ describe('Dynamic IO Dev Errors', () => {
     const outputIndex = next.cliOutput.length
     const browser = await next.browser('/no-accessed-data')
 
-    await retry(async () => {
-      expect(await hasErrorToast(browser)).toBe(true)
-      await waitForAndOpenRuntimeError(browser)
-      await assertHasRedbox(browser)
-    })
+    await openRedbox(browser)
 
     expect(stripAnsi(next.cliOutput.slice(outputIndex))).toContain(
       `\nError: Route "/no-accessed-data": ` +

--- a/test/development/app-dir/hook-function-names/hook-function-names.test.ts
+++ b/test/development/app-dir/hook-function-names/hook-function-names.test.ts
@@ -1,9 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import {
-  assertHasRedbox,
-  getRedboxSource,
-  waitForAndOpenRuntimeError,
-} from 'next-test-utils'
+import { assertHasRedbox, getRedboxSource, openRedbox } from 'next-test-utils'
 
 describe('hook-function-names', () => {
   const { next, isTurbopack } = nextTestSetup({
@@ -15,7 +11,7 @@ describe('hook-function-names', () => {
 
     await browser.elementByCss('button').click()
 
-    await waitForAndOpenRuntimeError(browser)
+    await openRedbox(browser)
 
     if (isTurbopack) {
       expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`

--- a/test/development/app-dir/owner-stack-react-missing-key-prop/owner-stack-react-missing-key-prop.test.ts
+++ b/test/development/app-dir/owner-stack-react-missing-key-prop/owner-stack-react-missing-key-prop.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 import {
   getRedboxSource,
-  waitForAndOpenRuntimeError,
+  openRedbox,
   getStackFramesContent,
 } from 'next-test-utils'
 
@@ -19,7 +19,7 @@ const isOwnerStackEnabled =
 
     it('should catch invalid element from on rsc component', async () => {
       const browser = await next.browser('/rsc')
-      await waitForAndOpenRuntimeError(browser)
+      await openRedbox(browser)
 
       const stackFramesContent = await getStackFramesContent(browser)
       const source = await getRedboxSource(browser)
@@ -61,7 +61,7 @@ const isOwnerStackEnabled =
 
     it('should catch invalid element from on ssr client component', async () => {
       const browser = await next.browser('/ssr')
-      await waitForAndOpenRuntimeError(browser)
+      await openRedbox(browser)
 
       const stackFramesContent = await getStackFramesContent(browser)
       const source = await getRedboxSource(browser)

--- a/test/development/app-dir/owner-stack-react-missing-key-prop/react-missing-key-prop.test.ts
+++ b/test/development/app-dir/owner-stack-react-missing-key-prop/react-missing-key-prop.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { getRedboxSource, waitForAndOpenRuntimeError } from 'next-test-utils'
+import { getRedboxSource, openRedbox } from 'next-test-utils'
 
 // TODO: When owner stack is enabled by default, remove the condition and only keep one test
 const isOwnerStackEnabled =
@@ -60,7 +60,7 @@ async function getStackFramesContent(browser) {
 
     it('should catch invalid element from on rsc component', async () => {
       const browser = await next.browser('/rsc')
-      await waitForAndOpenRuntimeError(browser)
+      await openRedbox(browser)
 
       const stackFramesContent = await getStackFramesContent(browser)
       const source = await getRedboxSource(browser)
@@ -97,7 +97,7 @@ async function getStackFramesContent(browser) {
 
     it('should catch invalid element from on ssr client component', async () => {
       const browser = await next.browser('/ssr')
-      await waitForAndOpenRuntimeError(browser)
+      await openRedbox(browser)
 
       const stackFramesContent = await getStackFramesContent(browser)
       const source = await getRedboxSource(browser)

--- a/test/development/app-dir/owner-stack/owner-stack.test.ts
+++ b/test/development/app-dir/owner-stack/owner-stack.test.ts
@@ -2,7 +2,7 @@ import { nextTestSetup } from 'e2e-utils'
 import {
   assertHasRedbox,
   assertNoRedbox,
-  waitForAndOpenRuntimeError,
+  openRedbox,
   getRedboxDescription,
 } from 'next-test-utils'
 
@@ -123,7 +123,7 @@ describe('app-dir - owner-stack', () => {
       return log.message.includes('Error: browser error')
     }).message
 
-    await waitForAndOpenRuntimeError(browser)
+    await openRedbox(browser)
 
     const stackFramesContent = await getStackFramesContent(browser)
 
@@ -209,8 +209,7 @@ describe('app-dir - owner-stack', () => {
   it('should capture unhandled promise rejections', async () => {
     const browser = await next.browser('/browser/reject-promise')
 
-    await waitForAndOpenRuntimeError(browser)
-    await assertHasRedbox(browser)
+    await openRedbox(browser)
 
     const description = await getRedboxDescription(browser)
     expect(description).toMatchInlineSnapshot(`"string in rejected promise"`)

--- a/test/lib/development-sandbox.ts
+++ b/test/lib/development-sandbox.ts
@@ -8,7 +8,7 @@ import {
   assertHasRedbox,
   assertNoRedbox,
   waitFor,
-  waitForAndOpenRuntimeError,
+  openRedbox,
   getRedboxDescriptionWarning,
   toggleCollapseComponentStack,
   getRedboxErrorLink,
@@ -124,8 +124,8 @@ export async function createSandbox(
         async assertNoRedbox() {
           return assertNoRedbox(browser)
         },
-        async waitForAndOpenRuntimeError() {
-          return waitForAndOpenRuntimeError(browser)
+        async openRedbox() {
+          return openRedbox(browser)
         },
         async hasErrorToast() {
           return Boolean(await hasErrorToast(browser))

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -879,8 +879,19 @@ export async function hasErrorToast(
   })
 }
 
-export async function waitForAndOpenRuntimeError(browser: BrowserInterface) {
-  return browser.waitForElementByCss('[data-nextjs-toast]', 5000).click()
+/**
+ * Has retried version of {@link hasErrorToast} built-in.
+ * Success implies {@link assertHasRedbox}.
+ */
+export async function openRedbox(browser: BrowserInterface): Promise<void> {
+  try {
+    browser.waitForElementByCss('[data-nextjs-toast]', 5000).click()
+  } catch (cause) {
+    const error = new Error('No Redbox to open.', { cause })
+    Error.captureStackTrace(error, openRedbox)
+    throw error
+  }
+  await assertHasRedbox(browser)
 }
 
 export function getRedboxHeader(browser: BrowserInterface) {


### PR DESCRIPTION
"Redbox" is our internal name for the "issue overlay". "open runtime error" is no longer applicable now that we show console errors there.

Also cleaned up some usages where it was combined with `assertRedbox` (redundant) or a retried version of `hasErrorToast` which `openRedbox` already did.

