### PR TITLE
Remove unused `retry` around `browser.eval`

### DIFF
--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -896,23 +896,14 @@ export async function waitForAndOpenRuntimeError(browser: BrowserInterface) {
   return browser.waitForElementByCss('[data-nextjs-toast]', 5000).click()
 }
 
-export async function getRedboxHeader(browser: BrowserInterface) {
-  return retry(
-    () => {
-      return evaluate(browser, () => {
-        const portal = [].slice
-          .call(document.querySelectorAll('nextjs-portal'))
-          .find((p) =>
-            p.shadowRoot.querySelector('[data-nextjs-dialog-header]')
-          )
-        const root = portal?.shadowRoot
-        return root?.querySelector('[data-nextjs-dialog-header]')?.innerText
-      })
-    },
-    10000,
-    500,
-    'getRedboxHeader'
-  )
+export function getRedboxHeader(browser: BrowserInterface) {
+  return evaluate(browser, () => {
+    const portal = [].slice
+      .call(document.querySelectorAll('nextjs-portal'))
+      .find((p) => p.shadowRoot.querySelector('[data-nextjs-dialog-header]'))
+    const root = portal?.shadowRoot
+    return root?.querySelector('[data-nextjs-dialog-header]')?.innerText
+  })
 }
 
 export async function getRedboxTotalErrorCount(browser: BrowserInterface) {
@@ -920,112 +911,71 @@ export async function getRedboxTotalErrorCount(browser: BrowserInterface) {
   return parseInt(header.match(/\d+ of (\d+) error/)?.[1], 10)
 }
 
-export async function getRedboxSource(browser: BrowserInterface) {
-  return retry(
-    () =>
-      evaluate(browser, () => {
-        const portal = [].slice
-          .call(document.querySelectorAll('nextjs-portal'))
-          .find((p) =>
-            p.shadowRoot.querySelector(
-              '#nextjs__container_errors_label, #nextjs__container_errors_label'
-            )
-          )
-        const root = portal.shadowRoot
-        return root.querySelector(
-          '[data-nextjs-codeframe], [data-nextjs-terminal]'
-        ).innerText
-      }),
-    10000,
-    500,
-    'getRedboxSource'
-  )
+export function getRedboxSource(browser: BrowserInterface) {
+  return evaluate(browser, () => {
+    const portal = [].slice
+      .call(document.querySelectorAll('nextjs-portal'))
+      .find((p) =>
+        p.shadowRoot.querySelector(
+          '#nextjs__container_errors_label, #nextjs__container_errors_label'
+        )
+      )
+    const root = portal.shadowRoot
+    return root.querySelector('[data-nextjs-codeframe], [data-nextjs-terminal]')
+      .innerText
+  })
 }
 
-export async function getRedboxTitle(browser: BrowserInterface) {
-  return retry(
-    () =>
-      evaluate(browser, () => {
-        const portal = [].slice
-          .call(document.querySelectorAll('nextjs-portal'))
-          .find((p) =>
-            p.shadowRoot.querySelector('[data-nextjs-dialog-header]')
-          )
-        const root = portal.shadowRoot
-        return root.querySelector(
-          '[data-nextjs-dialog-header] .nextjs__container_errors__error_title'
-        ).innerText
-      }),
-    3000,
-    500,
-    'getRedboxTitle'
-  )
+export function getRedboxTitle(browser: BrowserInterface) {
+  return evaluate(browser, () => {
+    const portal = [].slice
+      .call(document.querySelectorAll('nextjs-portal'))
+      .find((p) => p.shadowRoot.querySelector('[data-nextjs-dialog-header]'))
+    const root = portal.shadowRoot
+    return root.querySelector(
+      '[data-nextjs-dialog-header] .nextjs__container_errors__error_title'
+    ).innerText
+  })
 }
 
-export async function getRedboxDescription(browser: BrowserInterface) {
-  return retry(
-    () =>
-      evaluate(browser, () => {
-        const portal = [].slice
-          .call(document.querySelectorAll('nextjs-portal'))
-          .find((p) =>
-            p.shadowRoot.querySelector('[data-nextjs-dialog-header]')
-          )
-        const root = portal.shadowRoot
-        const text = root.querySelector(
-          '#nextjs__container_errors_desc'
-        ).innerText
-        if (text === null) throw new Error('No redbox description found')
-        return text
-      }),
-    3000,
-    500,
-    'getRedboxDescription'
-  )
+export function getRedboxDescription(browser: BrowserInterface) {
+  return evaluate(browser, () => {
+    const portal = [].slice
+      .call(document.querySelectorAll('nextjs-portal'))
+      .find((p) => p.shadowRoot.querySelector('[data-nextjs-dialog-header]'))
+    const root = portal.shadowRoot
+    const text = root.querySelector('#nextjs__container_errors_desc').innerText
+    if (text === null) throw new Error('No redbox description found')
+    return text
+  })
 }
 
-export async function getRedboxDescriptionWarning(browser: BrowserInterface) {
-  return retry(
-    () =>
-      evaluate(browser, () => {
-        const portal = [].slice
-          .call(document.querySelectorAll('nextjs-portal'))
-          .find((p) =>
-            p.shadowRoot.querySelector('[data-nextjs-dialog-header]')
-          )
-        const root = portal.shadowRoot
-        const text = root.querySelector(
-          '#nextjs__container_errors__notes'
-        )?.innerText
-        return text
-      }),
-    3000,
-    500,
-    'getRedboxDescriptionWarning'
-  )
+export function getRedboxDescriptionWarning(browser: BrowserInterface) {
+  return evaluate(browser, () => {
+    const portal = [].slice
+      .call(document.querySelectorAll('nextjs-portal'))
+      .find((p) => p.shadowRoot.querySelector('[data-nextjs-dialog-header]'))
+    const root = portal.shadowRoot
+    const text = root.querySelector(
+      '#nextjs__container_errors__notes'
+    )?.innerText
+    return text
+  })
 }
 
-export async function getRedboxErrorLink(
+export function getRedboxErrorLink(
   browser: BrowserInterface
 ): Promise<string | undefined> {
-  return retry(
-    () =>
-      evaluate(browser, () => {
-        const portal = [].slice
-          .call(document.querySelectorAll('nextjs-portal'))
-          .find((p) =>
-            p.shadowRoot.querySelector('[data-nextjs-dialog-header]')
-          )
-        const root = portal.shadowRoot
-        const text = root.querySelector(
-          '#nextjs__container_errors__link'
-        )?.innerText
-        return text
-      }),
-    3000,
-    500,
-    'getRedboxDescriptionWarning'
-  )
+  return evaluate(browser, () => {
+    const portal = [].slice
+      .call(document.querySelectorAll('nextjs-portal'))
+      .find((p) => p.shadowRoot.querySelector('[data-nextjs-dialog-header]'))
+    const root = portal.shadowRoot
+    const text = root.querySelector(
+      '#nextjs__container_errors__link'
+    )?.innerText
+    return text
+  })
 }
 
 export function getBrowserBodyText(browser: BrowserInterface) {


### PR DESCRIPTION
`browser.eval` will not throw if the evaluated code throws.
Instead, it will return `null`.
