### PR TITLE
Revert "Support custom servers with minimal node modules"

### DIFF
--- a/docs/01-app/02-building-your-application/07-configuring/10-custom-server.mdx
+++ b/docs/01-app/02-building-your-application/07-configuring/10-custom-server.mdx
@@ -87,17 +87,16 @@ const app = next({})
 
 The above `next` import is a function that receives an object with the following options:
 
-| Option            | Type                 | Description                                                                                                           |
-| ----------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `conf`            | `Object`             | The same object you would use in `next.config.js`. Defaults to `{}`                                                   |
-| `dev`             | `Boolean`            | (_Optional_) Whether or not to launch Next.js in dev mode. Defaults to `false`                                        |
-| `dir`             | `String`             | (_Optional_) Location of the Next.js project. Defaults to `'.'`                                                       |
-| `quiet`           | `Boolean`            | (_Optional_) Hide error messages containing server information. Defaults to `false`                                   |
-| `hostname`        | `String`             | (_Optional_) The hostname the server is running behind                                                                |
-| `port`            | `Number`             | (_Optional_) The port the server is running behind                                                                    |
-| `httpServer`      | `node:http#Server`   | (_Optional_) The HTTP Server that Next.js is running behind                                                           |
-| `turbo`           | `Boolean`            | (_Optional_) Enable Turbopack                                                                                         |
-| `preloadedConfig` | `NextConfigComplete` | (_Optional_) A preloaded config to be used instead of loading from `next.config.js`. Only works when `dev` is `false` |
+| Option       | Type               | Description                                                                         |
+| ------------ | ------------------ | ----------------------------------------------------------------------------------- |
+| `conf`       | `Object`           | The same object you would use in `next.config.js`. Defaults to `{}`                 |
+| `dev`        | `Boolean`          | (_Optional_) Whether or not to launch Next.js in dev mode. Defaults to `false`      |
+| `dir`        | `String`           | (_Optional_) Location of the Next.js project. Defaults to `'.'`                     |
+| `quiet`      | `Boolean`          | (_Optional_) Hide error messages containing server information. Defaults to `false` |
+| `hostname`   | `String`           | (_Optional_) The hostname the server is running behind                              |
+| `port`       | `Number`           | (_Optional_) The port the server is running behind                                  |
+| `httpServer` | `node:http#Server` | (_Optional_) The HTTP Server that Next.js is running behind                         |
+| `turbo`      | `Boolean`          | (_Optional_) Enable Turbopack                                                       |
 
 The returned `app` can then be used to let Next.js handle requests as required.
 

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -25,7 +25,6 @@ import { getTracer } from './lib/trace/tracer'
 import { NextServerSpan } from './lib/trace/constants'
 import { formatUrl } from '../shared/lib/router/utils/format-url'
 import type { ServerFields } from './lib/router-utils/setup-dev-bundler'
-import type { NextConfigComplete } from './config-shared'
 
 let ServerImpl: typeof Server
 
@@ -41,9 +40,7 @@ export type NextServerOptions = Omit<
   // This is assigned in this server abstraction.
   'conf'
 > &
-  Partial<Pick<ServerOptions | DevServerOptions, 'conf'>> & {
-    preloadedConfig?: NextConfigComplete
-  }
+  Partial<Pick<ServerOptions | DevServerOptions, 'conf'>>
 
 export interface RequestHandler {
   (
@@ -69,18 +66,6 @@ export class NextServer {
 
   constructor(options: NextServerOptions) {
     this.options = options
-
-    // If we're in production mode and have a config that can be preloaded (from `next build`) then it's
-    // possible the server is running in an environment similar to standalone mode where only required node
-    // modules are present. Without setting the following environment variable multiple things can happen:
-    //   - The server will crash on startup from `loadWebpackConfig` in `loadConfig` because the files
-    //     are not available
-    //   - The server will load an incorrect config because the `next.config.js` file is not available
-    if (!this.options.dev && this.options.preloadedConfig) {
-      process.env.__NEXT_PRIVATE_STANDALONE_CONFIG = JSON.stringify(
-        this.options.preloadedConfig
-      )
-    }
   }
 
   get hostname() {
@@ -401,12 +386,6 @@ function createServer(
   if (options.dev && typeof options.dev !== 'boolean') {
     console.warn(
       "Warning: 'dev' is not a boolean which could introduce unexpected behavior. https://nextjs.org/docs/messages/invalid-server-options"
-    )
-  }
-
-  if (options.dev && options.preloadedConfig) {
-    log.warn(
-      '`dev` is set to true but `preloadedConfig` is provided. `preloadedConfig` will be ignored.'
     )
   }
 


### PR DESCRIPTION
Reverts vercel/next.js#72966

We would like to fix it by revisiting the path forward with `preloadedConfig`.
Since there is a [workaround](https://github.com/vercel/next.js/issues/64031#issuecomment-2078708340), we want to take time to think about the setup of custom server with minimal mode.
