### PR TITLE
remove inheritance from NextCustomServer

### DIFF
--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -2,7 +2,6 @@
 import type { WorkerRequestHandler, WorkerUpgradeHandler } from './types'
 import type { DevBundler, ServerFields } from './router-utils/setup-dev-bundler'
 import type { NextUrlWithParsedQuery, RequestMeta } from '../request-meta'
-import type { NextServer } from '../next'
 
 // This is required before other imports to ensure the require hook is setup.
 import '../node-environment'
@@ -47,6 +46,7 @@ import {
 } from '../dev/hot-reloader-types'
 import { normalizedAssetPrefix } from '../../shared/lib/normalized-asset-prefix'
 import { NEXT_PATCH_SYMBOL } from './patch-fetch'
+import type { ServerInitResult } from './render-server'
 
 const debug = setupDebug('next:router-server:main')
 const isNextFont = (pathname: string | null) =>
@@ -79,7 +79,7 @@ export async function initialize(opts: {
   experimentalHttpsServer?: boolean
   startServerSpan?: Span
   quiet?: boolean
-}): Promise<[WorkerRequestHandler, WorkerUpgradeHandler, NextServer]> {
+}): Promise<ServerInitResult> {
   if (!process.env.NODE_ENV) {
     // @ts-ignore not readonly
     process.env.NODE_ENV = opts.dev ? 'development' : 'production'
@@ -739,5 +739,5 @@ export async function initialize(opts: {
     }
   }
 
-  return [requestHandler, upgradeHandler, handlers.app]
+  return { requestHandler, upgradeHandler, server: handlers.server }
 }

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -334,8 +334,8 @@ export async function startServer(
           keepAliveTimeout,
           experimentalHttpsServer: !!selfSignedCertificate,
         })
-        requestHandler = initResult[0]
-        upgradeHandler = initResult[1]
+        requestHandler = initResult.requestHandler
+        upgradeHandler = initResult.upgradeHandler
 
         const startServerProcessDuration =
           performance.mark('next-start-end') &&

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -5,13 +5,14 @@ import type {
 } from './next-server'
 import type { UrlWithParsedQuery } from 'url'
 import type { IncomingMessage, ServerResponse } from 'http'
+import type { Duplex } from 'stream'
 import type { NextUrlWithParsedQuery } from './request-meta'
 import type { WorkerRequestHandler, WorkerUpgradeHandler } from './lib/types'
 
 import './require-hook'
 import './node-polyfill-crypto'
 
-import type { default as Server } from './next-server'
+import type { default as NextNodeServer } from './next-server'
 import * as log from '../build/output/log'
 import loadConfig from './config'
 import path, { resolve } from 'path'
@@ -26,7 +27,7 @@ import { NextServerSpan } from './lib/trace/constants'
 import { formatUrl } from '../shared/lib/router/utils/format-url'
 import type { ServerFields } from './lib/router-utils/setup-dev-bundler'
 
-let ServerImpl: typeof Server
+let ServerImpl: typeof NextNodeServer
 
 const getServerImpl = async () => {
   if (ServerImpl === undefined) {
@@ -42,25 +43,68 @@ export type NextServerOptions = Omit<
 > &
   Partial<Pick<ServerOptions | DevServerOptions, 'conf'>>
 
-export interface RequestHandler {
-  (
-    req: IncomingMessage,
-    res: ServerResponse,
-    parsedUrl?: NextUrlWithParsedQuery | undefined
-  ): Promise<void>
-}
+export type RequestHandler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  parsedUrl?: NextUrlWithParsedQuery | undefined
+) => Promise<void>
+
+export type UpgradeHandler = (
+  req: IncomingMessage,
+  socket: Duplex,
+  head: Buffer
+) => Promise<void>
 
 const SYMBOL_LOAD_CONFIG = Symbol('next.load_config')
 
-export class NextServer {
-  private serverPromise?: Promise<Server>
-  private server?: Server
+export interface NextWrapperServer {
+  // NOTE: the methods/properties here are the public API for custom servers.
+  // Consider backwards compatibilty when changing something here!
+
+  options: NextServerOptions
+  hostname: string | undefined
+  port: number | undefined
+
+  getRequestHandler(): RequestHandler
+  prepare(serverFields?: ServerFields): Promise<void>
+  setAssetPrefix(assetPrefix: string): void
+  close(): Promise<void>
+
+  // used internally
+  getUpgradeHandler(): UpgradeHandler
+
+  // legacy methods that we left exposed in the past
+
+  logError(...args: Parameters<NextNodeServer['logError']>): void
+
+  render(
+    ...args: Parameters<NextNodeServer['render']>
+  ): ReturnType<NextNodeServer['render']>
+
+  renderToHTML(
+    ...args: Parameters<NextNodeServer['renderToHTML']>
+  ): ReturnType<NextNodeServer['renderToHTML']>
+
+  renderError(
+    ...args: Parameters<NextNodeServer['renderError']>
+  ): ReturnType<NextNodeServer['renderError']>
+
+  renderErrorToHTML(
+    ...args: Parameters<NextNodeServer['renderErrorToHTML']>
+  ): ReturnType<NextNodeServer['renderErrorToHTML']>
+
+  render404(
+    ...args: Parameters<NextNodeServer['render404']>
+  ): ReturnType<NextNodeServer['render404']>
+}
+
+/** The wrapper server used by `next start` */
+export class NextServer implements NextWrapperServer {
+  private serverPromise?: Promise<NextNodeServer>
+  private server?: NextNodeServer
   private reqHandler?: NodeRequestHandler
   private reqHandlerPromise?: Promise<NodeRequestHandler>
   private preparedAssetPrefix?: string
-
-  protected cleanupListeners: (() => Promise<void>)[] = []
-  protected standaloneMode?: boolean
 
   public options: NextServerOptions
 
@@ -89,7 +133,7 @@ export class NextServer {
     }
   }
 
-  getUpgradeHandler() {
+  getUpgradeHandler(): UpgradeHandler {
     return async (req: IncomingMessage, socket: any, head: any) => {
       const server = await this.getServer()
       // @ts-expect-error we mark this as protected so it
@@ -106,40 +150,40 @@ export class NextServer {
     }
   }
 
-  logError(...args: Parameters<Server['logError']>) {
+  logError(...args: Parameters<NextWrapperServer['logError']>) {
     if (this.server) {
       this.server.logError(...args)
     }
   }
 
-  async render(...args: Parameters<Server['render']>) {
+  async render(...args: Parameters<NextWrapperServer['render']>) {
     const server = await this.getServer()
     return server.render(...args)
   }
 
-  async renderToHTML(...args: Parameters<Server['renderToHTML']>) {
+  async renderToHTML(...args: Parameters<NextWrapperServer['renderToHTML']>) {
     const server = await this.getServer()
     return server.renderToHTML(...args)
   }
 
-  async renderError(...args: Parameters<Server['renderError']>) {
+  async renderError(...args: Parameters<NextWrapperServer['renderError']>) {
     const server = await this.getServer()
     return server.renderError(...args)
   }
 
-  async renderErrorToHTML(...args: Parameters<Server['renderErrorToHTML']>) {
+  async renderErrorToHTML(
+    ...args: Parameters<NextWrapperServer['renderErrorToHTML']>
+  ) {
     const server = await this.getServer()
     return server.renderErrorToHTML(...args)
   }
 
-  async render404(...args: Parameters<Server['render404']>) {
+  async render404(...args: Parameters<NextWrapperServer['render404']>) {
     const server = await this.getServer()
     return server.render404(...args)
   }
 
   async prepare(serverFields?: ServerFields) {
-    if (this.standaloneMode) return
-
     const server = await this.getServer()
 
     if (serverFields) {
@@ -153,21 +197,16 @@ export class NextServer {
   }
 
   async close() {
-    await Promise.all(
-      [
-        async () => {
-          const server = await this.getServer()
-          await (server as any).close()
-        },
-        ...this.cleanupListeners,
-      ].map((f) => f())
-    )
+    if (this.server) {
+      // BaseServer.close() is protected
+      await this.server['close']()
+    }
   }
 
   private async createServer(
     options: ServerOptions | DevServerOptions
-  ): Promise<Server> {
-    let ServerImplementation: typeof Server
+  ): Promise<NextNodeServer> {
+    let ServerImplementation: typeof NextNodeServer
     if (options.dev) {
       ServerImplementation = require('./dev/next-dev-server')
         .default as typeof import('./dev/next-dev-server').default
@@ -214,10 +253,6 @@ export class NextServer {
   private async getServer() {
     if (!this.serverPromise) {
       this.serverPromise = this[SYMBOL_LOAD_CONFIG]().then(async (conf) => {
-        if (this.standaloneMode) {
-          process.env.__NEXT_PRIVATE_STANDALONE_CONFIG = JSON.stringify(conf)
-        }
-
         if (!this.options.dev) {
           if (conf.output === 'standalone') {
             if (!process.env.__NEXT_PRIVATE_STANDALONE_CONFIG) {
@@ -263,16 +298,49 @@ export class NextServer {
   }
 }
 
-class NextCustomServer extends NextServer {
-  protected standaloneMode = true
+/** The wrapper server used for `import next from "next" (in a custom server)` */
+class NextCustomServer implements NextWrapperServer {
   private didWebSocketSetup: boolean = false
+  protected cleanupListeners: (() => Promise<void>)[] = []
 
-  // @ts-expect-error These are initialized in prepare()
-  protected requestHandler: WorkerRequestHandler
-  // @ts-expect-error These are initialized in prepare()
-  protected upgradeHandler: WorkerUpgradeHandler
-  // @ts-expect-error These are initialized in prepare()
-  protected renderServer: NextServer
+  protected init?: {
+    requestHandler: WorkerRequestHandler
+    upgradeHandler: WorkerUpgradeHandler
+    renderServer: NextServer
+  }
+
+  public options: NextServerOptions
+
+  constructor(options: NextServerOptions) {
+    this.options = options
+  }
+
+  protected getInit() {
+    if (!this.init) {
+      throw new Error(
+        'prepare() must be called before performing this operation'
+      )
+    }
+    return this.init
+  }
+
+  protected get requestHandler() {
+    return this.getInit().requestHandler
+  }
+  protected get upgradeHandler() {
+    return this.getInit().upgradeHandler
+  }
+  protected get renderServer() {
+    return this.getInit().renderServer
+  }
+
+  get hostname() {
+    return this.options.hostname
+  }
+
+  get port() {
+    return this.options.port
+  }
 
   async prepare() {
     const { getRequestHandlers } =
@@ -287,9 +355,11 @@ class NextCustomServer extends NextServer {
       minimalMode: this.options.minimalMode,
       quiet: this.options.quiet,
     })
-    this.requestHandler = initResult[0]
-    this.upgradeHandler = initResult[1]
-    this.renderServer = initResult[2]
+    this.init = {
+      requestHandler: initResult[0],
+      upgradeHandler: initResult[1],
+      renderServer: initResult[2],
+    }
   }
 
   private setupWebSocketHandler(
@@ -308,7 +378,7 @@ class NextCustomServer extends NextServer {
     }
   }
 
-  getRequestHandler() {
+  getRequestHandler(): RequestHandler {
     return async (
       req: IncomingMessage,
       res: ServerResponse,
@@ -324,9 +394,9 @@ class NextCustomServer extends NextServer {
     }
   }
 
-  async render(...args: Parameters<Server['render']>) {
+  async render(...args: Parameters<NextWrapperServer['render']>) {
     let [req, res, pathname, query, parsedUrl] = args
-    this.setupWebSocketHandler(this.options.httpServer, req as any)
+    this.setupWebSocketHandler(this.options.httpServer, req as IncomingMessage)
 
     if (!pathname.startsWith('/')) {
       console.error(`Cannot render page with path "${pathname}"`)
@@ -340,13 +410,45 @@ class NextCustomServer extends NextServer {
       query,
     })
 
-    await this.requestHandler(req as any, res as any)
+    await this.requestHandler(req as IncomingMessage, res as ServerResponse)
     return
   }
 
   setAssetPrefix(assetPrefix: string): void {
-    super.setAssetPrefix(assetPrefix)
     this.renderServer.setAssetPrefix(assetPrefix)
+  }
+
+  getUpgradeHandler(): UpgradeHandler {
+    return this.renderServer.getUpgradeHandler()
+  }
+
+  logError(...args: Parameters<NextWrapperServer['logError']>) {
+    this.renderServer.logError(...args)
+  }
+
+  async renderToHTML(...args: Parameters<NextWrapperServer['renderToHTML']>) {
+    return this.renderServer.renderToHTML(...args)
+  }
+
+  async renderError(...args: Parameters<NextWrapperServer['renderError']>) {
+    return this.renderServer.renderError(...args)
+  }
+
+  async renderErrorToHTML(
+    ...args: Parameters<NextWrapperServer['renderErrorToHTML']>
+  ) {
+    return this.renderServer.renderErrorToHTML(...args)
+  }
+
+  async render404(...args: Parameters<NextWrapperServer['render404']>) {
+    return this.renderServer.render404(...args)
+  }
+
+  async close() {
+    await Promise.all([
+      this.init?.renderServer.close(),
+      ...this.cleanupListeners.map((f) => f()),
+    ])
   }
 }
 
@@ -356,7 +458,7 @@ function createServer(
     turbo?: boolean
     turbopack?: boolean
   }
-): NextServer {
+): NextWrapperServer {
   if (options && (options.turbo || options.turbopack)) {
     process.env.TURBOPACK = '1'
   }

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -57,7 +57,7 @@ export type UpgradeHandler = (
 
 const SYMBOL_LOAD_CONFIG = Symbol('next.load_config')
 
-export interface NextWrapperServer {
+interface NextWrapperServer {
   // NOTE: the methods/properties here are the public API for custom servers.
   // Consider backwards compatibilty when changing something here!
 

--- a/test/integration/custom-server/pages/404.js
+++ b/test/integration/custom-server/pages/404.js
@@ -1,0 +1,1 @@
+export default () => <p>made it to 404</p>

--- a/test/integration/custom-server/pages/500.js
+++ b/test/integration/custom-server/pages/500.js
@@ -1,0 +1,1 @@
+export default () => <p>made it to 500</p>

--- a/test/integration/custom-server/pages/dynamic-dashboard/index.js
+++ b/test/integration/custom-server/pages/dynamic-dashboard/index.js
@@ -1,0 +1,22 @@
+import { useRouter } from 'next/router'
+
+// NOTE: we want this page to be dynamic, otherwise the HTML won't contain search params
+export async function getServerSideProps() {
+  return { props: {} }
+}
+
+export default function Page() {
+  const router = useRouter()
+  const searchParam = router.query.q
+  return (
+    <p>
+      made it to dynamic dashboard
+      {!!searchParam && (
+        <>
+          <br />
+          query param: {searchParam}
+        </>
+      )}
+    </p>
+  )
+}

--- a/test/integration/custom-server/test/index.test.js
+++ b/test/integration/custom-server/test/index.test.js
@@ -318,71 +318,74 @@ describe.each([
     })
   })
 
-  describe.each(['development', 'production'])(
-    'legacy NextCustomServer methods - %s mode',
-    (mode) => {
-      const isNextDev = mode === 'development'
+  const modes = process.env.TURBOPACK_DEV
+    ? ['development']
+    : process.env.TURBOPACK_BUILD
+      ? ['production']
+      : ['development', 'production']
 
-      beforeAll(async () => {
-        if (!isNextDev) {
-          await nextBuild(appDir)
-        }
-        await startServer({ NODE_ENV: mode })
-      })
-      afterAll(() => killApp(server))
+  describe.each(modes)('legacy NextCustomServer methods - %s mode', (mode) => {
+    const isNextDev = mode === 'development'
 
-      it('NextCustomServer.renderToHTML', async () => {
-        const rawHTML = await renderViaHTTP(
-          nextUrl,
-          '/legacy-methods/render-to-html?q=2',
-          undefined,
-          { agent }
-        )
-        const $ = cheerio.load(rawHTML)
-        const text = $('p').text()
-        expect(text).toContain('made it to dynamic dashboard')
-        expect(text).toContain('query param: 1')
-      })
+    beforeAll(async () => {
+      if (!isNextDev) {
+        await nextBuild(appDir)
+      }
+      await startServer({ NODE_ENV: mode })
+    })
+    afterAll(() => killApp(server))
 
-      it('NextCustomServer.render404', async () => {
-        const html = await renderViaHTTP(
-          nextUrl,
-          '/legacy-methods/render404',
-          undefined,
-          { agent }
-        )
-        expect(html).toContain('made it to 404')
-      })
+    it('NextCustomServer.renderToHTML', async () => {
+      const rawHTML = await renderViaHTTP(
+        nextUrl,
+        '/legacy-methods/render-to-html?q=2',
+        undefined,
+        { agent }
+      )
+      const $ = cheerio.load(rawHTML)
+      const text = $('p').text()
+      expect(text).toContain('made it to dynamic dashboard')
+      expect(text).toContain('query param: 1')
+    })
 
-      it('NextCustomServer.renderError', async () => {
-        const html = await renderViaHTTP(
-          nextUrl,
-          '/legacy-methods/render-error',
-          undefined,
-          { agent }
-        )
-        if (isNextDev) {
-          // in dev, we always render error overlay + default error page, not /500
-          expect(html).toContain('Error: kaboom')
-        } else {
-          expect(html).toContain('made it to 500')
-        }
-      })
+    it('NextCustomServer.render404', async () => {
+      const html = await renderViaHTTP(
+        nextUrl,
+        '/legacy-methods/render404',
+        undefined,
+        { agent }
+      )
+      expect(html).toContain('made it to 404')
+    })
 
-      it('NextCustomServer.renderErrorToHTML', async () => {
-        const html = await renderViaHTTP(
-          nextUrl,
-          '/legacy-methods/render-error-to-html',
-          undefined,
-          { agent }
-        )
-        if (isNextDev) {
-          // in dev, we always render error overlay + default error page, not /500
-          expect(html).toContain('Error: kaboom')
-        } else {
-          expect(html).toContain('made it to 500')
-        }
-      })
-    }
-  )
+    it('NextCustomServer.renderError', async () => {
+      const html = await renderViaHTTP(
+        nextUrl,
+        '/legacy-methods/render-error',
+        undefined,
+        { agent }
+      )
+      if (isNextDev) {
+        // in dev, we always render error overlay + default error page, not /500
+        expect(html).toContain('Error: kaboom')
+      } else {
+        expect(html).toContain('made it to 500')
+      }
+    })
+
+    it('NextCustomServer.renderErrorToHTML', async () => {
+      const html = await renderViaHTTP(
+        nextUrl,
+        '/legacy-methods/render-error-to-html',
+        undefined,
+        { agent }
+      )
+      if (isNextDev) {
+        // in dev, we always render error overlay + default error page, not /500
+        expect(html).toContain('Error: kaboom')
+      } else {
+        expect(html).toContain('made it to 500')
+      }
+    })
+  })
 })

--- a/test/integration/filesystempublicroutes/server.js
+++ b/test/integration/filesystempublicroutes/server.js
@@ -13,7 +13,7 @@ app.prepare().then(() => {
     if (/setAssetPrefix/.test(req.url)) {
       app.setAssetPrefix(`http://127.0.0.1:${port}`)
     } else if (/setEmptyAssetPrefix/.test(req.url)) {
-      app.setAssetPrefix(null)
+      app.setAssetPrefix('')
     } else {
       // This is to support multi-zones support in localhost
       // and may be in staging deployments


### PR DESCRIPTION
### What

This PR changes `NextCustomServer` to no longer subclass `NextServer` and instead just delegate all methods to `this.renderServer`. I've also added an interface implemented by both `NextServer` and `NextCustomServer` to make it explicit what we're actually exposing. (Note that we're currently exposing too much for legacy reasons. we might want to decide to clean this up a bit, i've started that in https://github.com/vercel/next.js/pull/73021)

I've also cleaned up some random `(_ as any)`s and unnecessary indirections around the area.

### Why

currently, `NextCustomServer` is a subclass of `NextServer`, which makes it very confusing to reason about, because in  `prepare()` it creates *a nested `NextServer`* (stored in `this.renderServer`). this isn't immediately visible in the code, but that's what `getRequestHandlers` ends up doing.
https://github.com/vercel/next.js/blob/58b993c239689f22641682bbcb0d8dea6d85fdf1/packages/next/src/server/next.ts#L281
then, it delegates *some* methods to that (`render`, `getRequestHandler`, `setAssetPrefix`). But some methods (e.g. `render404`) *aren't* overridden/delegated and just run the implementation inherited from `NextServer`. And those implementations are unaware of `this.renderServer`, so they end up initializing a *second* `NextNodeServer` (`this.server` vs `this.renderServer.server`) and run against that instead. that's bad! and it's why e.g. #61676 was necessary -- we needed to update both servers! 

i think that this is a leftover of the old implementation where we ran a separate process for rendering. for historical context, see:
- #49805 which seems to have introduced this split (the proxy only overrides `prepare`, `getRequestHandler`, and `render`)
- #53523 which turned the proxy code into `NextCustomServer`

also apparently `render404` and others were broken in development (try running the tests in the first commit
I've changed `NextCustomServer` and see the server hang forever).