### PR TITLE
Track errors where frames are not sourcemapped properly in the Redbox

### DIFF
--- a/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
@@ -194,7 +194,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
       ])
     )
     const { session } = sandbox
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({ pageResponseCode: 500 })
 
     const source = await session.getRedboxSource()
     if (process.env.TURBOPACK) {

--- a/test/development/acceptance-app/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance-app/ReactRefreshRegression.test.ts
@@ -6,7 +6,7 @@ import { check } from 'next-test-utils'
 import { outdent } from 'outdent'
 
 describe('ReactRefreshRegression app', () => {
-  const { next } = nextTestSetup({
+  const { isTurbopack, next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
     dependencies: {
       'styled-components': '5.1.0',
@@ -277,7 +277,12 @@ describe('ReactRefreshRegression app', () => {
       `export default function () { throw new Error('boom'); }`
     )
 
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({
+      pageResponseCode: isTurbopack
+        ? 500
+        : // Webpack clears the console
+          undefined,
+    })
 
     const source = await session.getRedboxSource()
     expect(source.split(/\r?\n/g).slice(2).join('\n')).toMatchInlineSnapshot(`
@@ -295,7 +300,13 @@ describe('ReactRefreshRegression app', () => {
       `export default function Page() { throw new Error('boom'); }`
     )
 
-    await session.assertHasRedbox()
+    // webpack fail
+    await session.assertHasRedbox({
+      pageResponseCode: isTurbopack
+        ? 500
+        : // Webpack clears the console
+          undefined,
+    })
 
     const source = await session.getRedboxSource()
     expect(source.split(/\r?\n/g).slice(2).join('\n')).toMatchInlineSnapshot(`
@@ -316,7 +327,12 @@ describe('ReactRefreshRegression app', () => {
       `
     )
 
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({
+      pageResponseCode: isTurbopack
+        ? // Turbopack clears the console
+          undefined
+        : 500,
+    })
 
     const source = await session.getRedboxSource()
     expect(source.split(/\r?\n/g).slice(2).join('\n')).toMatchInlineSnapshot(`

--- a/test/development/acceptance-app/app-hmr-changes.test.ts
+++ b/test/development/acceptance-app/app-hmr-changes.test.ts
@@ -51,7 +51,12 @@ describe('Error overlay - RSC build errors', () => {
           await session.patch(pagePath, break2.replace('break 3', '<Hello />'))
 
           await session.patch(pagePath, break2)
-          await session.assertHasRedbox()
+          // TODO: remove try-catch
+          try {
+            await session.assertHasRedbox()
+          } catch (cause) {
+            throw new Error(`Failed attempt ${i}`, { cause })
+          }
 
           await session.patch(pagePath, break1)
 

--- a/test/development/acceptance-app/app-hmr-changes.test.ts
+++ b/test/development/acceptance-app/app-hmr-changes.test.ts
@@ -47,16 +47,14 @@ describe('Error overlay - RSC build errors', () => {
 
         await session.patch(pagePath, break2)
 
+        const pageResponseCode: number[] = []
         for (let i = 0; i < 5; i++) {
           await session.patch(pagePath, break2.replace('break 3', '<Hello />'))
 
           await session.patch(pagePath, break2)
-          // TODO: remove try-catch
-          try {
-            await session.assertHasRedbox()
-          } catch (cause) {
-            throw new Error(`Failed attempt ${i}`, { cause })
-          }
+          // TODO(veil): Why no 500 in initial?
+          await session.assertHasRedbox({ pageResponseCode })
+          pageResponseCode.push(500)
 
           await session.patch(pagePath, break1)
 

--- a/test/development/acceptance-app/dynamic-error.test.ts
+++ b/test/development/acceptance-app/dynamic-error.test.ts
@@ -30,7 +30,9 @@ describe('dynamic = "error" in devmode', () => {
       '/server'
     )
     const { session } = sandbox
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({
+      fixmeStackFramesHaveBrokenSourcemaps: true,
+    })
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
       `"[ Server ] Error: Route /server with \`dynamic = "error"\` couldn't be rendered statically because it used \`cookies\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering"`
     )

--- a/test/development/acceptance-app/error-recovery.test.ts
+++ b/test/development/acceptance-app/error-recovery.test.ts
@@ -6,7 +6,7 @@ import path from 'path'
 import { outdent } from 'outdent'
 
 describe.each(['default', 'turbo'])('Error recovery app %s', () => {
-  const { next } = nextTestSetup({
+  const { isTurbopack, next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
     skipStart: true,
   })
@@ -225,7 +225,9 @@ describe.each(['default', 'turbo'])('Error recovery app %s', () => {
         `
       )
 
-      await session.assertHasRedbox()
+      await session.assertHasRedbox({
+        pageResponseCode: isTurbopack || type === 'server' ? undefined : 500,
+      })
       expect(await session.getRedboxSource()).toInclude(
         'export default function Child()'
       )
@@ -359,7 +361,9 @@ describe.each(['default', 'turbo'])('Error recovery app %s', () => {
     )
 
     // We get an error because Foo didn't import React. Fair.
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({
+      pageResponseCode: isTurbopack ? undefined : 500,
+    })
     expect(await session.getRedboxSource()).toInclude(
       "return React.createElement('h1', null, 'Foo');"
     )
@@ -454,7 +458,9 @@ describe.each(['default', 'turbo'])('Error recovery app %s', () => {
         export default ClassDefault;
       `
     )
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({
+      pageResponseCode: isTurbopack ? undefined : 500,
+    })
 
     await expect(session.getRedboxSource()).resolves.toInclude('render() {')
 
@@ -469,7 +475,7 @@ describe.each(['default', 'turbo'])('Error recovery app %s', () => {
       new Map([['app/page.js', '{{{']])
     )
     const { session } = sandbox
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({ pageResponseCode: 500 })
     await expect(session.getRedboxSource(true)).resolves.toMatch(
       /Failed to compile/
     )

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -109,7 +109,7 @@ describe('Error overlay - RSC build errors', () => {
     await session.patch(pageFile, uncomment)
     await next.patchFile(pageFile, content)
 
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({ pageResponseCode: 500 })
     expect(await session.getRedboxSource()).toInclude(
       '"getStaticProps" is not supported in app/'
     )
@@ -218,7 +218,7 @@ describe('Error overlay - RSC build errors', () => {
         `/server-with-errors/react-apis/${api.toLowerCase()}`
       )
       const { session } = sandbox
-      await session.assertHasRedbox()
+      await session.assertHasRedbox({ pageResponseCode: 500 })
       expect(await session.getRedboxSource()).toInclude(
         // `Component` has a custom error message
         api === 'Component'
@@ -242,7 +242,7 @@ describe('Error overlay - RSC build errors', () => {
         `/server-with-errors/react-dom-apis/${api.toLowerCase()}`
       )
       const { session } = sandbox
-      await session.assertHasRedbox()
+      await session.assertHasRedbox({ pageResponseCode: 500 })
       expect(await session.getRedboxSource()).toInclude(
         `You're importing a component that needs \`${api}\`. This React hook only works in a client component. To fix, mark the file (or its parent) with the \`"use client"\` directive.`
       )
@@ -305,7 +305,9 @@ describe('Error overlay - RSC build errors', () => {
       'export default function Error() {}'
     )
 
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({
+      pageResponseCode: isTurbopack ? 500 : undefined,
+    })
     await expect(session.getRedboxSource()).resolves.toMatch(
       /must be a Client \n| Component/
     )
@@ -355,7 +357,9 @@ describe('Error overlay - RSC build errors', () => {
     // Empty file
     await session.patch('app/server-with-errors/error-file/error.js', '')
 
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({
+      pageResponseCode: isTurbopack ? undefined : 500,
+    })
     await expect(session.getRedboxSource()).resolves.toMatch(
       /Add the "use client"/
     )

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -305,9 +305,7 @@ describe('Error overlay - RSC build errors', () => {
       'export default function Error() {}'
     )
 
-    await session.assertHasRedbox({
-      pageResponseCode: isTurbopack ? 500 : undefined,
-    })
+    await session.assertHasRedbox()
     await expect(session.getRedboxSource()).resolves.toMatch(
       /must be a Client \n| Component/
     )
@@ -357,9 +355,7 @@ describe('Error overlay - RSC build errors', () => {
     // Empty file
     await session.patch('app/server-with-errors/error-file/error.js', '')
 
-    await session.assertHasRedbox({
-      pageResponseCode: isTurbopack ? undefined : 500,
-    })
+    await session.assertHasRedbox()
     await expect(session.getRedboxSource()).resolves.toMatch(
       /Add the "use client"/
     )

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -355,7 +355,9 @@ describe('Error overlay - RSC build errors', () => {
     // Empty file
     await session.patch('app/server-with-errors/error-file/error.js', '')
 
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({
+      pageResponseCode: isTurbopack ? undefined : 500,
+    })
     await expect(session.getRedboxSource()).resolves.toMatch(
       /Add the "use client"/
     )

--- a/test/development/acceptance-app/rsc-runtime-errors.test.ts
+++ b/test/development/acceptance-app/rsc-runtime-errors.test.ts
@@ -27,7 +27,9 @@ describe('Error overlay - RSC runtime errors', () => {
 
     const browser = await next.browser('/server')
 
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, {
+      fixmeStackFramesHaveBrokenSourcemaps: true,
+    })
     const errorDescription = await getRedboxDescription(browser)
 
     expect(errorDescription).toContain(
@@ -69,7 +71,9 @@ describe('Error overlay - RSC runtime errors', () => {
     )
 
     const browser = await next.browser('/server')
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, {
+      fixmeStackFramesHaveBrokenSourcemaps: true,
+    })
 
     const errorDescription = await getRedboxDescription(browser)
 
@@ -87,7 +91,9 @@ describe('Error overlay - RSC runtime errors', () => {
         `
     )
     const browser = await next.browser('/server')
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, {
+      fixmeStackFramesHaveBrokenSourcemaps: true,
+    })
 
     const source = await getRedboxSource(browser)
     // Can show the original source code
@@ -106,7 +112,9 @@ describe('Error overlay - RSC runtime errors', () => {
     )
     const browser = await next.browser('/server')
 
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, {
+      fixmeStackFramesHaveBrokenSourcemaps: true,
+    })
     const versionText = await getVersionCheckerText(browser)
     expect(versionText).toMatch(/Next.js \([\w.-]+\)/)
   })
@@ -122,7 +130,9 @@ describe('Error overlay - RSC runtime errors', () => {
     )
     const browser = await next.browser('/server')
 
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, {
+      fixmeStackFramesHaveBrokenSourcemaps: true,
+    })
     const source = await getRedboxSource(browser)
     expect(source).toContain('app/server/page.js')
     expect(source).not.toContain('//app/server/page.js')

--- a/test/development/acceptance-app/rsc-runtime-errors.test.ts
+++ b/test/development/acceptance-app/rsc-runtime-errors.test.ts
@@ -27,9 +27,7 @@ describe('Error overlay - RSC runtime errors', () => {
 
     const browser = await next.browser('/server')
 
-    await assertHasRedbox(browser, {
-      fixmeStackFramesHaveBrokenSourcemaps: true,
-    })
+    await assertHasRedbox(browser, { pageResponseCode: 500 })
     const errorDescription = await getRedboxDescription(browser)
 
     expect(errorDescription).toContain(
@@ -71,9 +69,7 @@ describe('Error overlay - RSC runtime errors', () => {
     )
 
     const browser = await next.browser('/server')
-    await assertHasRedbox(browser, {
-      fixmeStackFramesHaveBrokenSourcemaps: true,
-    })
+    await assertHasRedbox(browser, { pageResponseCode: 500 })
 
     const errorDescription = await getRedboxDescription(browser)
 
@@ -91,9 +87,7 @@ describe('Error overlay - RSC runtime errors', () => {
         `
     )
     const browser = await next.browser('/server')
-    await assertHasRedbox(browser, {
-      fixmeStackFramesHaveBrokenSourcemaps: true,
-    })
+    await assertHasRedbox(browser, { pageResponseCode: 500 })
 
     const source = await getRedboxSource(browser)
     // Can show the original source code

--- a/test/development/acceptance-app/server-components.test.ts
+++ b/test/development/acceptance-app/server-components.test.ts
@@ -520,7 +520,7 @@ describe('Error Overlay for server components', () => {
         ])
       )
       const { session } = sandbox
-      await session.assertHasRedbox()
+      await session.assertHasRedbox({ pageResponseCode: 500 })
       // In webpack when the message too long it gets truncated with `  | ` with new lines.
       // So we need to check for the first part of the message.
       const normalizedSource = await session.getRedboxSource()

--- a/test/development/acceptance-app/undefined-default-export.test.ts
+++ b/test/development/acceptance-app/undefined-default-export.test.ts
@@ -17,7 +17,10 @@ describe('Undefined default export', () => {
       '/specific-path/server'
     )
     const { session } = sandbox
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({
+      // TODO: Unclear why the test is navigating to the page twice
+      pageResponseCode: [500, 500],
+    })
     expect(await session.getRedboxDescription()).toInclude(
       'The default export is not a React Component in "/specific-path/server/page"'
     )
@@ -39,7 +42,9 @@ describe('Undefined default export', () => {
       '/will-not-found'
     )
     const { session } = sandbox
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({
+      pageResponseCode: 500,
+    })
     expect(await session.getRedboxDescription()).toInclude(
       'The default export is not a React Component in "/will-not-found/not-found"'
     )
@@ -55,7 +60,10 @@ describe('Undefined default export', () => {
     // Wait for the DOM node #__next to be present
     await browser.waitForElementByCss('#__next')
 
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({
+      // TODO: really?
+      fixmeStackFramesHaveBrokenSourcemaps: true,
+    })
     expect(await session.getRedboxDescription()).toInclude(
       'The default export is not a React Component in "/page"'
     )
@@ -73,7 +81,9 @@ describe('Undefined default export', () => {
       '/server-with-errors/page-export-initial-error'
     )
     const { session } = sandbox
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({
+      pageResponseCode: 500,
+    })
     expect(await session.getRedboxDescription()).toInclude(
       'The default export is not a React Component in "/server-with-errors/page-export-initial-error/page"'
     )

--- a/test/development/acceptance-app/undefined-default-export.test.ts
+++ b/test/development/acceptance-app/undefined-default-export.test.ts
@@ -61,7 +61,7 @@ describe('Undefined default export', () => {
     await browser.waitForElementByCss('#__next')
 
     await session.assertHasRedbox({
-      // TODO: really?
+      // Not actually broken. Just flaky 500 count
       fixmeStackFramesHaveBrokenSourcemaps: true,
     })
     expect(await session.getRedboxDescription()).toInclude(

--- a/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
@@ -18,7 +18,9 @@ describe.each(['default', 'turbo'])(
         new Map([['pages/_app.js', ``]])
       )
       const { session } = sandbox
-      await session.assertHasRedbox()
+      await session.assertHasRedbox({
+        pageResponseCode: 500,
+      })
       expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
         `"Error: The default export is not a React Component in page: "/_app""`
       )
@@ -41,7 +43,9 @@ describe.each(['default', 'turbo'])(
         new Map([['pages/_document.js', ``]])
       )
       const { session } = sandbox
-      await session.assertHasRedbox()
+      await session.assertHasRedbox({
+        pageResponseCode: 500,
+      })
       expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
         `"Error: The default export is not a React Component in page: "/_document""`
       )
@@ -92,7 +96,9 @@ describe.each(['default', 'turbo'])(
         ])
       )
       const { session } = sandbox
-      await session.assertHasRedbox()
+      await session.assertHasRedbox({
+        pageResponseCode: 500,
+      })
       const content = await session.getRedboxSource()
       const source = next.normalizeTestDirContent(content)
       if (process.env.TURBOPACK) {
@@ -178,7 +184,9 @@ describe.each(['default', 'turbo'])(
         ])
       )
       const { session } = sandbox
-      await session.assertHasRedbox()
+      await session.assertHasRedbox({
+        pageResponseCode: 500,
+      })
       const source = next.normalizeTestDirContent(
         await session.getRedboxSource()
       )

--- a/test/development/acceptance/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-builtins.test.ts
@@ -91,7 +91,10 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
       `
     )
 
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({
+      // TODO(veil)
+      pageResponseCode: process.env.CI ? 500 : undefined,
+    })
 
     const source = await session.getRedboxSource()
     if (process.env.TURBOPACK) {
@@ -198,7 +201,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
       ])
     )
     const { session } = sandbox
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({ pageResponseCode: 500 })
 
     const source = await session.getRedboxSource()
     if (process.env.TURBOPACK) {

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -83,7 +83,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
       `
     )
 
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({ pageResponseCode: 500 })
     expect(await session.getRedboxSource()).toMatchSnapshot()
   })
 
@@ -631,7 +631,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     ).toBe(null)
   })
 
-  test('non-Error errors are handled properly', async () => {
+  it('non-Error errors are handled properly', async () => {
     await using sandbox = await createSandbox(next)
     const { session } = sandbox
 
@@ -647,7 +647,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
       `
     )
 
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({ pageResponseCode: 500 })
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
       `"Error: {"a":1,"b":"x"}"`
     )
@@ -677,7 +677,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
         }
       `
     )
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({
+      pageResponseCode:
+        // Includes prior 500
+        [500, 500],
+    })
     expect(await session.getRedboxDescription()).toContain(
       `Error: class Hello {`
     )
@@ -705,7 +709,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
         }
       `
     )
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({
+      pageResponseCode:
+        // Includes prior 500s
+        [500, 500, 500],
+    })
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
       `"Error: string error"`
     )
@@ -733,7 +741,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
         }
       `
     )
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({
+      pageResponseCode:
+        // Includes prior 500s
+        [500, 500, 500, 500],
+    })
     expect(await session.getRedboxDescription()).toContain(
       `Error: A null error was thrown`
     )
@@ -791,7 +803,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
       ])
     )
     const { session, browser } = sandbox
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({ pageResponseCode: 500 })
     await toggleCollapseCallStackFrames(browser)
     let callStackFrames = await browser.elementsByCss(
       '[data-nextjs-call-stack-frame]'
@@ -820,7 +832,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
       ])
     )
     const { session, browser } = sandbox
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({ pageResponseCode: 500 })
 
     // Should still show the errored line in source code
     const source = await session.getRedboxSource()

--- a/test/development/acceptance/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance/ReactRefreshRegression.test.ts
@@ -281,7 +281,11 @@ describe('ReactRefreshRegression', () => {
     )
     expect(didNotReload).toBe(false)
 
-    await session.assertHasRedbox()
+    await session.assertHasRedbox({
+      pageResponseCode:
+        // TODO: Unclear why the test is navigating to the page twice
+        [500, 500],
+    })
 
     const source = await session.getRedboxSource()
     expect(source.split(/\r?\n/g).slice(2).join('\n')).toMatchInlineSnapshot(`

--- a/test/development/app-dir/dynamic-error-trace/index.test.ts
+++ b/test/development/app-dir/dynamic-error-trace/index.test.ts
@@ -18,7 +18,9 @@ describe('app dir - dynamic error trace', () => {
   it('should show the error trace', async () => {
     const browser = await next.browser('/')
 
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, {
+      fixmeStackFramesHaveBrokenSourcemaps: true,
+    })
 
     await expect(
       browser.hasElementByCssSelector(

--- a/test/development/app-dir/dynamic-error-trace/index.test.ts
+++ b/test/development/app-dir/dynamic-error-trace/index.test.ts
@@ -18,9 +18,7 @@ describe('app dir - dynamic error trace', () => {
   it('should show the error trace', async () => {
     const browser = await next.browser('/')
 
-    await assertHasRedbox(browser, {
-      fixmeStackFramesHaveBrokenSourcemaps: true,
-    })
+    await assertHasRedbox(browser, { pageResponseCode: 500 })
 
     await expect(
       browser.hasElementByCssSelector(

--- a/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
+++ b/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
@@ -100,7 +100,7 @@ describe('Dynamic IO Dev Errors', () => {
       ])
     )
     const { browser, session } = sandbox
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, { pageResponseCode: 500 })
     const redbox = {
       description: await getRedboxDescription(browser),
       source: await getRedboxSource(browser),

--- a/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
+++ b/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
@@ -23,7 +23,7 @@ describe('error-ignored-frames', () => {
 
   it('should be able to collapse ignored frames in server component', async () => {
     const browser = await next.browser('/')
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, { pageResponseCode: 500 })
 
     const defaultStack = await getStackFramesContent(browser)
     expect(defaultStack).toMatchInlineSnapshot(`""`)
@@ -50,7 +50,7 @@ describe('error-ignored-frames', () => {
 
   it('should be able to collapse ignored frames in client component', async () => {
     const browser = await next.browser('/client')
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, { pageResponseCode: 500 })
 
     const defaultStack = await getStackFramesContent(browser)
     expect(defaultStack).toMatchInlineSnapshot(`""`)
@@ -91,7 +91,7 @@ describe('error-ignored-frames', () => {
 
   it('should be able to collapse ignored frames in interleaved call stack', async () => {
     const browser = await next.browser('/interleaved')
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, { pageResponseCode: 500 })
 
     const defaultStack = await getStackFramesContent(browser)
     if (process.env.TURBOPACK) {
@@ -144,7 +144,7 @@ describe('error-ignored-frames', () => {
 
   it('should be able to collapse pages router ignored frames', async () => {
     const browser = await next.browser('/pages')
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, { pageResponseCode: 500 })
 
     const defaultStack = await getStackFramesContent(browser)
     expect(defaultStack).toMatchInlineSnapshot(`""`)

--- a/test/development/app-dir/next-after-app-invalid-usage/index.test.ts
+++ b/test/development/app-dir/next-after-app-invalid-usage/index.test.ts
@@ -25,7 +25,7 @@ describe('unstable_after() - invalid usages', () => {
   it('errors at compile time when used in a client module', async () => {
     const session = await next.browser('/invalid-in-client')
 
-    await assertHasRedbox(session)
+    await assertHasRedbox(session, { pageResponseCode: 500 })
     expect(await getRedboxSource(session)).toMatch(
       /You're importing a component that needs "?unstable_after"?\. That only works in a Server Component but one of its parents is marked with "use client", so it's a Client Component\./
     )

--- a/test/development/app-dir/owner-stack-invalid-element-type/invalid-element-type.test.ts
+++ b/test/development/app-dir/owner-stack-invalid-element-type/invalid-element-type.test.ts
@@ -59,7 +59,9 @@ const isOwnerStackEnabled =
     it('should catch invalid element from a rsc component', async () => {
       const browser = await next.browser('/rsc')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        pageResponseCode: 500,
+      })
       const stackFramesContent = await getStackFramesContent(browser)
       const source = await getRedboxSource(browser)
 
@@ -96,7 +98,9 @@ const isOwnerStackEnabled =
     it('should catch invalid element from on ssr client component', async () => {
       const browser = await next.browser('/ssr')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        pageResponseCode: 500,
+      })
 
       const stackFramesContent = await getStackFramesContent(browser)
       const source = await getRedboxSource(browser)

--- a/test/development/app-dir/owner-stack-invalid-element-type/owner-stack-invalid-element-type.test.ts
+++ b/test/development/app-dir/owner-stack-invalid-element-type/owner-stack-invalid-element-type.test.ts
@@ -64,7 +64,9 @@ const isOwnerStackEnabled =
     it('should catch invalid element from a rsc component', async () => {
       const browser = await next.browser('/rsc')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: true,
+      })
       const stackFramesContent = await getStackFramesContent(browser)
       const source = await getRedboxSource(browser)
 
@@ -106,7 +108,9 @@ const isOwnerStackEnabled =
     it('should catch invalid element from on ssr client component', async () => {
       const browser = await next.browser('/ssr')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: true,
+      })
 
       const stackFramesContent = await getStackFramesContent(browser)
       const source = await getRedboxSource(browser)

--- a/test/development/app-dir/owner-stack-invalid-element-type/owner-stack-invalid-element-type.test.ts
+++ b/test/development/app-dir/owner-stack-invalid-element-type/owner-stack-invalid-element-type.test.ts
@@ -64,9 +64,7 @@ const isOwnerStackEnabled =
     it('should catch invalid element from a rsc component', async () => {
       const browser = await next.browser('/rsc')
 
-      await assertHasRedbox(browser, {
-        fixmeStackFramesHaveBrokenSourcemaps: true,
-      })
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       const stackFramesContent = await getStackFramesContent(browser)
       const source = await getRedboxSource(browser)
 
@@ -108,9 +106,7 @@ const isOwnerStackEnabled =
     it('should catch invalid element from on ssr client component', async () => {
       const browser = await next.browser('/ssr')
 
-      await assertHasRedbox(browser, {
-        fixmeStackFramesHaveBrokenSourcemaps: true,
-      })
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
 
       const stackFramesContent = await getStackFramesContent(browser)
       const source = await getRedboxSource(browser)

--- a/test/development/app-dir/owner-stack/owner-stack.test.ts
+++ b/test/development/app-dir/owner-stack/owner-stack.test.ts
@@ -166,7 +166,7 @@ describe('app-dir - owner-stack', () => {
   it('should log stitched error for SSR errors', async () => {
     const browser = await next.browser('/ssr')
 
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, { pageResponseCode: 500 })
 
     const stackFramesContent = await getStackFramesContent(browser)
     if (process.env.TURBOPACK) {

--- a/test/development/app-dir/serialize-circular-error/serialize-circular-error.test.ts
+++ b/test/development/app-dir/serialize-circular-error/serialize-circular-error.test.ts
@@ -12,7 +12,7 @@ describe('serialize-circular-error', () => {
 
   it('should serialize the object from server component in console correctly', async () => {
     const browser = await next.browser('/')
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, { pageResponseCode: 500 })
 
     const description = await getRedboxDescription(browser)
     // React cannot serialize thrown objects with circular references

--- a/test/development/app-dir/server-component-next-dynamic-ssr-false/server-component-next-dynamic-ssr-false.test.ts
+++ b/test/development/app-dir/server-component-next-dynamic-ssr-false/server-component-next-dynamic-ssr-false.test.ts
@@ -12,7 +12,7 @@ describe('app-dir - server-component-next-dynamic-ssr-false', () => {
 
   it('should error when use dynamic ssr:false in server component', async () => {
     const browser = await next.browser('/')
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, { pageResponseCode: 500 })
     const redbox = {
       description: await getRedboxDescription(browser),
       source: await getRedboxSource(browser),

--- a/test/development/app-dir/server-navigation-error/server-navigation-error.test.ts
+++ b/test/development/app-dir/server-navigation-error/server-navigation-error.test.ts
@@ -82,7 +82,8 @@ describe('server-navigation-error', () => {
       // FIXME: the first request to middleware error load didn't show the redbox, need one more reload
       await browser.refresh()
       await assertHasRedbox(browser, {
-        fixmeStackFramesHaveBrokenSourcemaps: true,
+        // additional navigation due to refresh but why 3 instead of 2?
+        pageResponseCode: [500, 500, 500],
       })
       expect(await getRedboxDescription(browser)).toMatch(
         `Next.js navigation API is not allowed to be used in Middleware.`

--- a/test/development/app-dir/server-navigation-error/server-navigation-error.test.ts
+++ b/test/development/app-dir/server-navigation-error/server-navigation-error.test.ts
@@ -13,7 +13,7 @@ describe('server-navigation-error', () => {
   describe('pages router', () => {
     it('should error on navigation API redirect', async () => {
       const browser = await next.browser('/pages/redirect')
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       expect(await getRedboxDescription(browser)).toMatch(
         `Next.js navigation API is not allowed to be used in Pages Router.`
       )
@@ -45,7 +45,7 @@ describe('server-navigation-error', () => {
 
     it('should error on navigation API notFound', async () => {
       const browser = await next.browser('/pages/not-found')
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       expect(await getRedboxDescription(browser)).toMatch(
         `Next.js navigation API is not allowed to be used in Pages Router.`
       )
@@ -81,7 +81,9 @@ describe('server-navigation-error', () => {
       const browser = await next.browser('/middleware/redirect')
       // FIXME: the first request to middleware error load didn't show the redbox, need one more reload
       await browser.refresh()
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: true,
+      })
       expect(await getRedboxDescription(browser)).toMatch(
         `Next.js navigation API is not allowed to be used in Middleware.`
       )
@@ -115,7 +117,7 @@ describe('server-navigation-error', () => {
 
     it('should error on navigation API not-found', async () => {
       const browser = await next.browser('/middleware/not-found')
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       expect(await getRedboxDescription(browser)).toMatch(
         `Next.js navigation API is not allowed to be used in Middleware.`
       )

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -265,7 +265,7 @@ describe('react-dom/server in React Server environment', () => {
     )
 
     if (isTurbopack) {
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
     } else {
       // FIXME: why no redbox when there is an error?
       await assertNoRedbox(browser)
@@ -312,7 +312,7 @@ describe('react-dom/server in React Server environment', () => {
       '/exports/app-code/react-dom-server-node-explicit'
     )
 
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, { pageResponseCode: 500 })
     const redbox = {
       description: await getRedboxDescription(browser),
       source: await getRedboxSource(browser),
@@ -369,7 +369,7 @@ describe('react-dom/server in React Server environment', () => {
       '/exports/app-code/react-dom-server-node-implicit'
     )
 
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, { pageResponseCode: 500 })
     const redbox = {
       description: await getRedboxDescription(browser),
       source: await getRedboxSource(browser),
@@ -425,7 +425,7 @@ describe('react-dom/server in React Server environment', () => {
       '/exports/library-code/react-dom-server-browser-explicit'
     )
 
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, { pageResponseCode: 500 })
     const redbox = {
       description: await getRedboxDescription(browser),
       source: await getRedboxSource(browser),
@@ -723,7 +723,7 @@ describe('react-dom/server in React Server environment', () => {
       '/exports/library-code/react-dom-server-node-explicit'
     )
 
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, { pageResponseCode: 500 })
     const redbox = {
       description: await getRedboxDescription(browser),
       source: await getRedboxSource(browser),
@@ -780,7 +780,7 @@ describe('react-dom/server in React Server environment', () => {
       '/exports/library-code/react-dom-server-node-implicit'
     )
 
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, { pageResponseCode: 500 })
     const redbox = {
       description: await getRedboxDescription(browser),
       source: await getRedboxSource(browser),

--- a/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
+++ b/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
@@ -276,7 +276,8 @@ describe('GS(S)P Server-Side Change Reloading', () => {
 
     try {
       await next.patchFile(page, originalContent.replace('props:', 'propss:'))
-      await assertHasRedbox(browser)
+      // TODO: Unclear why two page navigations are triggered
+      await assertHasRedbox(browser, { pageResponseCode: [500, 500] })
       expect(await getRedboxHeader(browser)).toContain(
         'Additional keys were returned from'
       )
@@ -306,7 +307,8 @@ describe('GS(S)P Server-Side Change Reloading', () => {
           'throw new Error("custom oops"); const count'
         )
       )
-      await assertHasRedbox(browser)
+      // TODO: Unclear why two page navigations are triggered
+      await assertHasRedbox(browser, { pageResponseCode: [500, 500] })
       expect(await getRedboxHeader(browser)).toContain('custom oops')
 
       await next.patchFile(page, originalContent)

--- a/test/development/basic/hmr.test.ts
+++ b/test/development/basic/hmr.test.ts
@@ -507,7 +507,7 @@ describe.each([
 
       await next.patchFile(aboutPage, aboutContent.replace('</div>', 'div'))
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       const source = next.normalizeTestDirContent(
         await getRedboxSource(browser)
       )
@@ -610,7 +610,7 @@ describe.each([
 
           browser = await webdriver(next.url, basePath + '/hmr/contact')
 
-          await assertHasRedbox(browser)
+          await assertHasRedbox(browser, { pageResponseCode: 500 })
           expect(await getRedboxSource(browser)).toMatch(/Unexpected eof/)
 
           await next.patchFile(aboutPage, aboutContent)
@@ -650,7 +650,7 @@ describe.each([
           aboutContent.replace('export', 'aa=20;\nexport')
         )
 
-        await assertHasRedbox(browser)
+        await assertHasRedbox(browser, { pageResponseCode: 500 })
         expect(await getRedboxHeader(browser)).toMatch(/aa is not defined/)
 
         await next.patchFile(aboutPage, aboutContent)
@@ -680,7 +680,7 @@ describe.each([
           )
         )
 
-        await assertHasRedbox(browser)
+        await assertHasRedbox(browser, { pageResponseCode: 500 })
         expect(await getRedboxSource(browser)).toMatch(/an-expected-error/)
 
         await next.patchFile(aboutPage, aboutContent)
@@ -719,7 +719,7 @@ describe.each([
           )
         )
 
-        await assertHasRedbox(browser)
+        await assertHasRedbox(browser, { pageResponseCode: 500 })
         expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
           `"Error: The default export is not a React Component in page: "/hmr/about5""`
         )
@@ -761,7 +761,7 @@ describe.each([
           )
         )
 
-        await assertHasRedbox(browser)
+        await assertHasRedbox(browser, { pageResponseCode: 500 })
         // TODO: Replace this when webpack 5 is the default
         expect(await getRedboxHeader(browser)).toMatch(
           `Objects are not valid as a React child (found: [object RegExp]). If you meant to render a collection of children, use an array instead.`
@@ -805,7 +805,7 @@ describe.each([
           )
         )
 
-        await assertHasRedbox(browser)
+        await assertHasRedbox(browser, { pageResponseCode: 500 })
         expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
           `"Error: The default export is not a React Component in page: "/hmr/about7""`
         )
@@ -849,7 +849,7 @@ describe.each([
           )
         )
 
-        await assertHasRedbox(browser)
+        await assertHasRedbox(browser, { pageResponseCode: 500 })
         expect(await getRedboxHeader(browser)).toMatch('Failed to compile')
 
         if (process.env.TURBOPACK) {
@@ -915,7 +915,7 @@ describe.each([
           )
         )
 
-        await assertHasRedbox(browser)
+        await assertHasRedbox(browser, { pageResponseCode: 500 })
         expect(await getRedboxHeader(browser)).toMatch('Failed to compile')
         let redboxSource = await getRedboxSource(browser)
 
@@ -983,7 +983,7 @@ describe.each([
         browser = await webdriver(next.url, basePath + '/hmr')
         await browser.elementByCss('#error-in-gip-link').click()
 
-        await assertHasRedbox(browser)
+        await assertHasRedbox(browser, { pageResponseCode: 500 })
         expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
           `"Error: an-expected-error-in-gip"`
         )
@@ -1024,7 +1024,7 @@ describe.each([
       try {
         browser = await webdriver(next.url, basePath + '/hmr/error-in-gip')
 
-        await assertHasRedbox(browser)
+        await assertHasRedbox(browser, { pageResponseCode: 500 })
         expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
           `"Error: an-expected-error-in-gip"`
         )
@@ -1168,7 +1168,7 @@ describe.each([
         pageName,
         `import hello from 'non-existent'\n` + originalContent
       )
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       await waitFor(3000)
       await next.patchFile(pageName, originalContent)
       await check(() => next.cliOutput.substring(outputLength), /Compiled.*?/i)

--- a/test/development/basic/hmr.test.ts
+++ b/test/development/basic/hmr.test.ts
@@ -18,6 +18,8 @@ import { NextInstance } from 'e2e-utils'
 import { outdent } from 'outdent'
 import type { NextConfig } from 'next'
 
+const isTurbopack = Boolean(process.env.TURBOPACK)
+
 describe.each([
   { basePath: '', assetPrefix: '' },
   { basePath: '', assetPrefix: '/asset-prefix' },
@@ -507,7 +509,9 @@ describe.each([
 
       await next.patchFile(aboutPage, aboutContent.replace('</div>', 'div'))
 
-      await assertHasRedbox(browser, { pageResponseCode: 500 })
+      await assertHasRedbox(browser, {
+        pageResponseCode: isTurbopack ? undefined : 500,
+      })
       const source = next.normalizeTestDirContent(
         await getRedboxSource(browser)
       )
@@ -610,7 +614,9 @@ describe.each([
 
           browser = await webdriver(next.url, basePath + '/hmr/contact')
 
-          await assertHasRedbox(browser, { pageResponseCode: 500 })
+          await assertHasRedbox(browser, {
+            pageResponseCode: isTurbopack ? undefined : 500,
+          })
           expect(await getRedboxSource(browser)).toMatch(/Unexpected eof/)
 
           await next.patchFile(aboutPage, aboutContent)
@@ -650,7 +656,9 @@ describe.each([
           aboutContent.replace('export', 'aa=20;\nexport')
         )
 
-        await assertHasRedbox(browser, { pageResponseCode: 500 })
+        await assertHasRedbox(browser, {
+          pageResponseCode: isTurbopack ? undefined : 500,
+        })
         expect(await getRedboxHeader(browser)).toMatch(/aa is not defined/)
 
         await next.patchFile(aboutPage, aboutContent)
@@ -680,7 +688,9 @@ describe.each([
           )
         )
 
-        await assertHasRedbox(browser, { pageResponseCode: 500 })
+        await assertHasRedbox(browser, {
+          pageResponseCode: isTurbopack ? undefined : 500,
+        })
         expect(await getRedboxSource(browser)).toMatch(/an-expected-error/)
 
         await next.patchFile(aboutPage, aboutContent)
@@ -719,7 +729,9 @@ describe.each([
           )
         )
 
-        await assertHasRedbox(browser, { pageResponseCode: 500 })
+        await assertHasRedbox(browser, {
+          pageResponseCode: isTurbopack ? undefined : 500,
+        })
         expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
           `"Error: The default export is not a React Component in page: "/hmr/about5""`
         )
@@ -761,7 +773,9 @@ describe.each([
           )
         )
 
-        await assertHasRedbox(browser, { pageResponseCode: 500 })
+        await assertHasRedbox(browser, {
+          pageResponseCode: isTurbopack ? undefined : 500,
+        })
         // TODO: Replace this when webpack 5 is the default
         expect(await getRedboxHeader(browser)).toMatch(
           `Objects are not valid as a React child (found: [object RegExp]). If you meant to render a collection of children, use an array instead.`
@@ -805,7 +819,9 @@ describe.each([
           )
         )
 
-        await assertHasRedbox(browser, { pageResponseCode: 500 })
+        await assertHasRedbox(browser, {
+          pageResponseCode: isTurbopack ? undefined : 500,
+        })
         expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
           `"Error: The default export is not a React Component in page: "/hmr/about7""`
         )
@@ -849,7 +865,9 @@ describe.each([
           )
         )
 
-        await assertHasRedbox(browser, { pageResponseCode: 500 })
+        await assertHasRedbox(browser, {
+          pageResponseCode: isTurbopack ? undefined : 500,
+        })
         expect(await getRedboxHeader(browser)).toMatch('Failed to compile')
 
         if (process.env.TURBOPACK) {
@@ -915,7 +933,9 @@ describe.each([
           )
         )
 
-        await assertHasRedbox(browser, { pageResponseCode: 500 })
+        await assertHasRedbox(browser, {
+          pageResponseCode: isTurbopack ? undefined : 500,
+        })
         expect(await getRedboxHeader(browser)).toMatch('Failed to compile')
         let redboxSource = await getRedboxSource(browser)
 
@@ -983,7 +1003,9 @@ describe.each([
         browser = await webdriver(next.url, basePath + '/hmr')
         await browser.elementByCss('#error-in-gip-link').click()
 
-        await assertHasRedbox(browser, { pageResponseCode: 500 })
+        await assertHasRedbox(browser, {
+          pageResponseCode: isTurbopack ? undefined : 500,
+        })
         expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
           `"Error: an-expected-error-in-gip"`
         )
@@ -1024,7 +1046,9 @@ describe.each([
       try {
         browser = await webdriver(next.url, basePath + '/hmr/error-in-gip')
 
-        await assertHasRedbox(browser, { pageResponseCode: 500 })
+        await assertHasRedbox(browser, {
+          pageResponseCode: isTurbopack ? undefined : 500,
+        })
         expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
           `"Error: an-expected-error-in-gip"`
         )
@@ -1168,7 +1192,9 @@ describe.each([
         pageName,
         `import hello from 'non-existent'\n` + originalContent
       )
-      await assertHasRedbox(browser, { pageResponseCode: 500 })
+      await assertHasRedbox(browser, {
+        pageResponseCode: isTurbopack ? undefined : 500,
+      })
       await waitFor(3000)
       await next.patchFile(pageName, originalContent)
       await check(() => next.cliOutput.substring(outputLength), /Compiled.*?/i)

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -66,7 +66,7 @@ describe('middleware - development errors', () => {
 
     it('renders the error correctly and recovers', async () => {
       const browser = await next.browser('/')
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       await next.patchFile('middleware.js', `export default function () {}`)
       await assertNoRedbox(browser)
     })
@@ -194,7 +194,9 @@ describe('middleware - development errors', () => {
 
     it('renders the error correctly and recovers', async () => {
       const browser = await next.browser('/')
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        pageResponseCode: isTurbopack ? 500 : [500, 500],
+      })
 
       const lengthOfLogs = next.cliOutput.length
 
@@ -246,7 +248,7 @@ describe('middleware - development errors', () => {
 
     it('renders the error correctly and recovers', async () => {
       const browser = await next.browser('/')
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       const source = await getRedboxSource(browser)
       expect(source).toContain(`throw new Error('booooom!')`)
       expect(source).toContain('middleware.js')
@@ -351,7 +353,7 @@ describe('middleware - development errors', () => {
 
     it('renders the error correctly and recovers', async () => {
       const browser = await next.browser('/')
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       expect(
         await browser.elementByCss('#nextjs__container_errors_desc').text()
       ).toEqual('Failed to compile')

--- a/test/development/next-font/font-loader-in-document-error.test.ts
+++ b/test/development/next-font/font-loader-in-document-error.test.ts
@@ -18,7 +18,7 @@ describe('font-loader-in-document-error', () => {
 
   test('next/font inside _document', async () => {
     const browser = await webdriver(next.url, '/')
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, { pageResponseCode: 500 })
     if (process.env.TURBOPACK) {
       // TODO: Turbopack doesn't include pages/
       expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`

--- a/test/development/pages-dir/client-navigation/index.test.ts
+++ b/test/development/pages-dir/client-navigation/index.test.ts
@@ -58,7 +58,9 @@ describe('Client Navigation', () => {
 
     it('should have proper error when no children are provided', async () => {
       const browser = await webdriver(next.appPort, '/link-no-child')
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        pageResponseCode: 500,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         'No children were passed to <Link> with `href` of `/about` but one child is required'
       )

--- a/test/development/pages-dir/client-navigation/rendering.test.ts
+++ b/test/development/pages-dir/client-navigation/rendering.test.ts
@@ -135,7 +135,7 @@ describe('Client Navigation rendering', () => {
       const expectedErrorMessage =
         'Circular structure in "getInitialProps" result of page "/circular-json-error".'
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       const text = await getRedboxHeader(browser)
       expect(text).toContain(expectedErrorMessage)
     })
@@ -149,17 +149,17 @@ describe('Client Navigation rendering', () => {
       const expectedErrorMessage =
         '"InstanceInitialPropsPage.getInitialProps()" is defined as an instance method - visit https://nextjs.org/docs/messages/get-initial-props-as-an-instance-method for more information.'
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       const text = await getRedboxHeader(browser)
       expect(text).toContain(expectedErrorMessage)
     })
 
-    test('getInitialProps resolves to null', async () => {
+    it('getInitialProps resolves to null', async () => {
       const browser = await webdriver(next.appPort, '/empty-get-initial-props')
       const expectedErrorMessage =
         '"EmptyInitialPropsPage.getInitialProps()" should resolve to an object. But found "null" instead.'
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       const text = await getRedboxHeader(browser)
       expect(text).toContain(expectedErrorMessage)
     })
@@ -195,14 +195,14 @@ describe('Client Navigation rendering', () => {
 
     test('default export is not a React Component', async () => {
       const browser = await webdriver(next.appPort, '/no-default-export')
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       const text = await getRedboxHeader(browser)
       expect(text).toMatch(/The default export is not a React Component/)
     })
 
     test('error-inside-page', async () => {
       const browser = await webdriver(next.appPort, '/error-inside-page')
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       const text = await getRedboxHeader(browser)
       expect(text).toMatch(/This is an expected error/)
       // Sourcemaps are applied by react-error-overlay, so we can't check them on SSR.
@@ -213,7 +213,7 @@ describe('Client Navigation rendering', () => {
         next.appPort,
         '/error-in-the-global-scope'
       )
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       const text = await getRedboxHeader(browser)
       expect(text).toMatch(/aa is not defined/)
       // Sourcemaps are applied by react-error-overlay, so we can't check them on SSR.
@@ -313,7 +313,7 @@ describe('Client Navigation rendering', () => {
 
     it('should show a valid error when undefined is thrown', async () => {
       const browser = await webdriver(next.appPort, '/throw-undefined')
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       const text = await getRedboxHeader(browser)
 
       expect(text).toContain(

--- a/test/development/sass-error/index.test.ts
+++ b/test/development/sass-error/index.test.ts
@@ -21,7 +21,9 @@ describe('app dir - css', () => {
         it('should use original source points for sass errors', async () => {
           const browser = await next.browser('/sass-error')
 
-          await assertHasRedbox(browser)
+          await assertHasRedbox(browser, {
+            pageResponseCode: 500,
+          })
           const source = await getRedboxSource(browser)
 
           // css-loader does not report an error for this case

--- a/test/e2e/app-dir/dynamic-href/dynamic-href.test.ts
+++ b/test/e2e/app-dir/dynamic-href/dynamic-href.test.ts
@@ -19,8 +19,7 @@ describe('dynamic-href', () => {
     it('should error when using dynamic href.pathname in app dir', async () => {
       const browser = await next.browser('/object')
 
-      // Error should show up
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
         `"Error: Dynamic href \`/object/[slug]\` found in <Link> while using the \`/app\` router, this is not supported. Read more: https://nextjs.org/docs/messages/app-dir-dynamic-href"`
       )
@@ -47,8 +46,7 @@ describe('dynamic-href', () => {
     it('should error when using dynamic href in app dir', async () => {
       const browser = await next.browser('/string')
 
-      // Error should show up
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
         `"Error: Dynamic href \`/object/[slug]\` found in <Link> while using the \`/app\` router, this is not supported. Read more: https://nextjs.org/docs/messages/app-dir-dynamic-href"`
       )

--- a/test/e2e/app-dir/dynamic-io-segment-configs/dynamic-io-segment-configs.test.ts
+++ b/test/e2e/app-dir/dynamic-io-segment-configs/dynamic-io-segment-configs.test.ts
@@ -26,7 +26,7 @@ describe('dynamic-io-segment-configs', () => {
 
     if (isNextDev) {
       const browser = await next.browser('/revalidate')
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       const redbox = {
         description: await getRedboxDescription(browser),
         source: await getRedboxSource(browser),
@@ -79,7 +79,7 @@ describe('dynamic-io-segment-configs', () => {
 
         if (isNextDev) {
           const browser = await next.browser('/revalidate')
-          await assertHasRedbox(browser)
+          await assertHasRedbox(browser, { pageResponseCode: 500 })
           const redbox = {
             description: await getRedboxDescription(browser),
             source: await getRedboxSource(browser),

--- a/test/e2e/app-dir/error-on-next-codemod-comment/error-on-next-codemod-comment.test.ts
+++ b/test/e2e/app-dir/error-on-next-codemod-comment/error-on-next-codemod-comment.test.ts
@@ -21,7 +21,7 @@ describe('app-dir - error-on-next-codemod-comment', () => {
     it('should error with swc if you have codemod comments left', async () => {
       const browser = await next.browser('/')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
 
       if (process.env.TURBOPACK) {
         expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
@@ -67,7 +67,7 @@ describe('app-dir - error-on-next-codemod-comment', () => {
 
       const browser = await next.browser('/')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
 
       // Recover the original file content
       await next.patchFile('app/page.tsx', originFileContent)
@@ -76,7 +76,7 @@ describe('app-dir - error-on-next-codemod-comment', () => {
     it('should disappear the error when you rre the codemod comment', async () => {
       const browser = await next.browser('/')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
 
       let originFileContent
       await next.patchFile('app/page.tsx', (code) => {
@@ -98,7 +98,7 @@ describe('app-dir - error-on-next-codemod-comment', () => {
     it('should disappear the error when you replace with bypass comment', async () => {
       const browser = await next.browser('/')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
 
       let originFileContent
       await next.patchFile('app/page.tsx', (code) => {

--- a/test/e2e/app-dir/errors/index.test.ts
+++ b/test/e2e/app-dir/errors/index.test.ts
@@ -162,7 +162,7 @@ describe('app-dir - errors', () => {
       const browser = await next.browser('/global-error-boundary/server')
 
       if (isNextDev) {
-        await assertHasRedbox(browser)
+        await assertHasRedbox(browser, { pageResponseCode: 500 })
         expect(await getRedboxHeader(browser)).toMatch(/custom server error/)
       } else {
         expect(

--- a/test/e2e/app-dir/global-error/basic/index.test.ts
+++ b/test/e2e/app-dir/global-error/basic/index.test.ts
@@ -1,11 +1,6 @@
 import { assertHasRedbox, getRedboxHeader } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 
-async function testDev(browser, errorRegex) {
-  await assertHasRedbox(browser)
-  expect(await getRedboxHeader(browser)).toMatch(errorRegex)
-}
-
 describe('app dir - global error', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,
@@ -19,9 +14,9 @@ describe('app dir - global error', () => {
       .click()
 
     if (isNextDev) {
-      await testDev(browser, /Error: Client error/)
+      await assertHasRedbox(browser)
+      expect(await getRedboxHeader(browser)).toMatch(/Error: Client error/)
     } else {
-      await browser
       expect(await browser.elementByCss('#error').text()).toBe(
         'Global error: Client error'
       )
@@ -32,7 +27,8 @@ describe('app dir - global error', () => {
     const browser = await next.browser('/ssr/server')
 
     if (isNextDev) {
-      await testDev(browser, /Error: server page error/)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
+      expect(await getRedboxHeader(browser)).toMatch(/Error: server page error/)
     } else {
       expect(await browser.elementByCss('h1').text()).toBe('Global Error')
       expect(await browser.elementByCss('#error').text()).toBe(
@@ -46,7 +42,8 @@ describe('app dir - global error', () => {
     const browser = await next.browser('/ssr/client')
 
     if (isNextDev) {
-      await testDev(browser, /Error: client page error/)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
+      expect(await getRedboxHeader(browser)).toMatch(/Error: client page error/)
     } else {
       expect(await browser.elementByCss('h1').text()).toBe('Global Error')
       expect(await browser.elementByCss('#error').text()).toBe(
@@ -70,7 +67,8 @@ describe('app dir - global error', () => {
     const browser = await next.browser('/metadata-error-without-boundary')
 
     if (isNextDev) {
-      await testDev(browser, /Error: Metadata error/)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
+      expect(await getRedboxHeader(browser)).toMatch(/Error: Metadata error/)
     } else {
       expect(await browser.elementByCss('h1').text()).toBe('Global Error')
       expect(await browser.elementByCss('#error').text()).toBe(
@@ -82,7 +80,8 @@ describe('app dir - global error', () => {
   it('should catch the client error thrown in the nested routes', async () => {
     const browser = await next.browser('/nested/nested')
     if (isNextDev) {
-      await testDev(browser, /Error: nested error/)
+      await assertHasRedbox(browser)
+      expect(await getRedboxHeader(browser)).toMatch(/Error: nested error/)
     } else {
       expect(await browser.elementByCss('h1').text()).toBe('Global Error')
       expect(await browser.elementByCss('#error').text()).toBe(

--- a/test/e2e/app-dir/global-error/layout-error/index.test.ts
+++ b/test/e2e/app-dir/global-error/layout-error/index.test.ts
@@ -1,11 +1,6 @@
 import { assertHasRedbox, getRedboxHeader } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 
-async function testDev(browser, errorRegex) {
-  await assertHasRedbox(browser)
-  expect(await getRedboxHeader(browser)).toMatch(errorRegex)
-}
-
 describe('app dir - global error - layout error', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
@@ -20,7 +15,10 @@ describe('app dir - global error - layout error', () => {
     const browser = await next.browser('/')
 
     if (isNextDev) {
-      await testDev(browser, /Global error: layout error/)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
+      expect(await getRedboxHeader(browser)).toMatch(
+        /Global error: layout error/
+      )
     } else {
       expect(await browser.elementByCss('h1').text()).toBe('Global Error')
       expect(await browser.elementByCss('#error').text()).toBe(

--- a/test/e2e/app-dir/global-error/with-style-import/index.test.ts
+++ b/test/e2e/app-dir/global-error/with-style-import/index.test.ts
@@ -1,11 +1,6 @@
 import { assertHasRedbox, getRedboxHeader } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 
-async function testDev(browser, errorRegex) {
-  await assertHasRedbox(browser)
-  expect(await getRedboxHeader(browser)).toMatch(errorRegex)
-}
-
 describe('app dir - global error - with style import', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
@@ -20,7 +15,8 @@ describe('app dir - global error - with style import', () => {
     const browser = await next.browser('/')
 
     if (isNextDev) {
-      await testDev(browser, /Root Layout Error/)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
+      expect(await getRedboxHeader(browser)).toMatch(/Root Layout Error/)
       return
     }
 

--- a/test/e2e/app-dir/loader-file-named-export-custom-loader-error/loader-file-named-export-custom-loader-error.test.ts
+++ b/test/e2e/app-dir/loader-file-named-export-custom-loader-error/loader-file-named-export-custom-loader-error.test.ts
@@ -4,11 +4,6 @@ import { assertHasRedbox, getRedboxHeader } from 'next-test-utils'
 const errorMessage =
   'images.loaderFile detected but the file is missing default export.\nRead more: https://nextjs.org/docs/messages/invalid-images-config'
 
-async function testDev(browser, errorRegex) {
-  await assertHasRedbox(browser)
-  expect(await getRedboxHeader(browser)).toMatch(errorRegex)
-}
-
 describe('Error test if the loader file export a named function', () => {
   describe('in Development', () => {
     const { next, isNextDev } = nextTestSetup({
@@ -19,12 +14,14 @@ describe('Error test if the loader file export a named function', () => {
     ;(isNextDev ? describe : describe.skip)('development only', () => {
       it('should show the error when using `Image` component', async () => {
         const browser = await next.browser('/')
-        await testDev(browser, errorMessage)
+        await assertHasRedbox(browser, { pageResponseCode: 500 })
+        expect(await getRedboxHeader(browser)).toMatch(errorMessage)
       })
 
       it('should show the error when using `getImageProps` method', async () => {
         const browser = await next.browser('/get-img-props')
-        await testDev(browser, errorMessage)
+        await assertHasRedbox(browser, { pageResponseCode: 500 })
+        expect(await getRedboxHeader(browser)).toMatch(errorMessage)
       })
     })
   })

--- a/test/e2e/app-dir/next-after-app-static/generate-static-params-error/index.test.ts
+++ b/test/e2e/app-dir/next-after-app-static/generate-static-params-error/index.test.ts
@@ -18,7 +18,7 @@ describe('unstable_after() in generateStaticParams - thrown errors', () => {
     it('shows the error overlay if an error is thrown inside unstable_after', async () => {
       await next.start()
       const browser = await next.browser('/callback/1')
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       const route = '/callback/[myParam]'
       expect(await getRedboxDescription(browser)).toContain(
         `My cool error thrown inside unstable_after on route "${route}"`

--- a/test/e2e/app-dir/next-after-pages/index.test.ts
+++ b/test/e2e/app-dir/next-after-pages/index.test.ts
@@ -60,7 +60,7 @@ _describe('unstable_after() - pages', () => {
       ])('$title', async ({ path }) => {
         const browser = await next.browser(path)
 
-        await assertHasRedbox(browser)
+        await assertHasRedbox(browser, { pageResponseCode: 500 })
         expect(await getRedboxSource(browser)).toMatch(
           /You're importing a component that needs "?unstable_after"?\. That only works in a Server Component which is not supported in the pages\/ directory\./
         )

--- a/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
+++ b/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
@@ -79,7 +79,7 @@ describe('use-cache-unknown-cache-kind', () => {
     it('should show a build error', async () => {
       const browser = await next.browser('/')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
 
       const errorDescription = await getRedboxDescription(browser)
       const errorSource = await getRedboxSource(browser)
@@ -117,7 +117,7 @@ describe('use-cache-unknown-cache-kind', () => {
     it('should recover from the build error if the cache handler is defined', async () => {
       const browser = await next.browser('/')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
 
       await next.patchFile(
         'next.config.js',

--- a/test/e2e/app-dir/use-cache-without-dynamic-io/use-cache-without-dynamic-io.test.ts
+++ b/test/e2e/app-dir/use-cache-without-dynamic-io/use-cache-without-dynamic-io.test.ts
@@ -78,7 +78,7 @@ describe('use-cache-without-dynamic-io', () => {
     it('should show a build error', async () => {
       const browser = await next.browser('/')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
 
       const errorDescription = await getRedboxDescription(browser)
       const errorSource = await getRedboxSource(browser)
@@ -120,7 +120,7 @@ describe('use-cache-without-dynamic-io', () => {
     it('should recover from the build error if dynamicIO flag is set', async () => {
       const browser = await next.browser('/')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
 
       await next.patchFile(
         'next.config.js',

--- a/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
+++ b/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
@@ -28,7 +28,7 @@ describe('fetch failures have good stack traces in edge runtime', () => {
       // TODO(veil): Apply sourcemap
       expect(next.cliOutput).toContain('\n    at anotherFetcher (')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       const source = await getRedboxSource(browser)
 
       expect(source).toContain('async function anotherFetcher(...args)')

--- a/test/e2e/getserversideprops/test/index.test.ts
+++ b/test/e2e/getserversideprops/test/index.test.ts
@@ -19,6 +19,7 @@ import webdriver from 'next-webdriver'
 import { NextInstance } from 'e2e-utils'
 
 const appDir = join(__dirname, '../app')
+const isTurbopack = Boolean(process.env.TURBOPACK)
 
 let buildId
 let next: NextInstance
@@ -759,7 +760,10 @@ const runTests = (isDev = false, isDeploy = false) => {
       const browser = await webdriver(next.url, '/')
       await browser.elementByCss('#non-json').click()
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        pageResponseCode: 500,
+        fixmeStackFramesHaveBrokenSourcemaps: isTurbopack,
+      })
       await expect(getRedboxHeader(browser)).resolves.toMatch(
         /Error serializing `.time` returned from `getServerSideProps`/
       )

--- a/test/e2e/getserversideprops/test/index.test.ts
+++ b/test/e2e/getserversideprops/test/index.test.ts
@@ -759,9 +759,7 @@ const runTests = (isDev = false, isDeploy = false) => {
       const browser = await webdriver(next.url, '/')
       await browser.elementByCss('#non-json').click()
 
-      await assertHasRedbox(browser, {
-        fixmeStackFramesHaveBrokenSourcemaps: true,
-      })
+      await assertHasRedbox(browser, { pageResponseCode: [500, 500] })
       await expect(getRedboxHeader(browser)).resolves.toMatch(
         /Error serializing `.time` returned from `getServerSideProps`/
       )

--- a/test/e2e/getserversideprops/test/index.test.ts
+++ b/test/e2e/getserversideprops/test/index.test.ts
@@ -19,7 +19,6 @@ import webdriver from 'next-webdriver'
 import { NextInstance } from 'e2e-utils'
 
 const appDir = join(__dirname, '../app')
-const isTurbopack = Boolean(process.env.TURBOPACK)
 
 let buildId
 let next: NextInstance
@@ -761,8 +760,7 @@ const runTests = (isDev = false, isDeploy = false) => {
       await browser.elementByCss('#non-json').click()
 
       await assertHasRedbox(browser, {
-        pageResponseCode: 500,
-        fixmeStackFramesHaveBrokenSourcemaps: isTurbopack,
+        fixmeStackFramesHaveBrokenSourcemaps: true,
       })
       await expect(getRedboxHeader(browser)).resolves.toMatch(
         /Error serializing `.time` returned from `getServerSideProps`/

--- a/test/e2e/new-link-behavior/child-a-tag-error.test.ts
+++ b/test/e2e/new-link-behavior/child-a-tag-error.test.ts
@@ -30,7 +30,7 @@ describe('New Link Behavior with <a> child', () => {
 
     if (isNextDev) {
       expect(next.cliOutput).toContain(msg)
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       expect(await getRedboxDescription(browser)).toContain(msg)
       expect(link.length).toBe(0)
     } else {

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -1141,7 +1141,9 @@ describe('Prerender', () => {
             await browser.refresh()
 
             return retry(async () => {
-              await assertHasRedbox(browser)
+              await assertHasRedbox(browser, {
+                fixmeStackFramesHaveBrokenSourcemaps: true,
+              })
               const errOverlayContent = await getRedboxHeader(browser)
               const errorMsg = /oops from getStaticProps/
               expect(next.cliOutput).toMatch(errorMsg)
@@ -1271,7 +1273,9 @@ describe('Prerender', () => {
         // )
 
         // FIXME: disable this
-        await assertHasRedbox(browser)
+        await assertHasRedbox(browser, {
+          fixmeStackFramesHaveBrokenSourcemaps: true,
+        })
         expect(await getRedboxHeader(browser)).toMatch(
           /Failed to load static props/
         )
@@ -1287,7 +1291,9 @@ describe('Prerender', () => {
         // )
 
         // FIXME: disable this
-        await assertHasRedbox(browser)
+        await assertHasRedbox(browser, {
+          fixmeStackFramesHaveBrokenSourcemaps: true,
+        })
         expect(await getRedboxHeader(browser)).toMatch(
           /Failed to load static props/
         )

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -20,6 +20,7 @@ import webdriver from 'next-webdriver'
 import stripAnsi from 'strip-ansi'
 
 const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
+const isTurbopack = Boolean(process.env.TURBOPACK)
 
 describe('Prerender', () => {
   let next: NextInstance
@@ -1140,15 +1141,13 @@ describe('Prerender', () => {
             // we need to reload the page to trigger getStaticProps
             await browser.refresh()
 
-            return retry(async () => {
-              await assertHasRedbox(browser, {
-                fixmeStackFramesHaveBrokenSourcemaps: true,
-              })
-              const errOverlayContent = await getRedboxHeader(browser)
-              const errorMsg = /oops from getStaticProps/
-              expect(next.cliOutput).toMatch(errorMsg)
-              expect(errOverlayContent).toMatch(errorMsg)
+            await assertHasRedbox(browser, {
+              pageResponseCode: isTurbopack ? [500, 500, 500] : [500, 500],
             })
+            const errOverlayContent = await getRedboxHeader(browser)
+            const errorMsg = /oops from getStaticProps/
+            expect(next.cliOutput).toMatch(errorMsg)
+            expect(errOverlayContent).toMatch(errorMsg)
           }
         )
       })
@@ -1272,10 +1271,7 @@ describe('Prerender', () => {
         //   /Error serializing `.time` returned from `getStaticProps`/
         // )
 
-        // FIXME: disable this
-        await assertHasRedbox(browser, {
-          fixmeStackFramesHaveBrokenSourcemaps: true,
-        })
+        await assertHasRedbox(browser, { pageResponseCode: [500, 500, 500] })
         expect(await getRedboxHeader(browser)).toMatch(
           /Failed to load static props/
         )
@@ -1290,9 +1286,8 @@ describe('Prerender', () => {
         //   /Error serializing `.time` returned from `getStaticProps`/
         // )
 
-        // FIXME: disable this
         await assertHasRedbox(browser, {
-          fixmeStackFramesHaveBrokenSourcemaps: true,
+          pageResponseCode: [500, 500, 500, 500],
         })
         expect(await getRedboxHeader(browser)).toMatch(
           /Failed to load static props/

--- a/test/e2e/with-router/index.test.ts
+++ b/test/e2e/with-router/index.test.ts
@@ -65,7 +65,7 @@ describe('withRouter', () => {
     describe('SSR', () => {
       it('should show an error when trying to use router methods during SSR', async () => {
         const browser = await next.browser('/router-method-ssr')
-        await assertHasRedbox(browser)
+        await assertHasRedbox(browser, { pageResponseCode: 500 })
         expect(await getRedboxHeader(browser)).toMatch(
           `No router instance found. you should only use "next/router" inside the client side of your app. https://`
         )

--- a/test/integration/app-dir-export/test/utils.ts
+++ b/test/integration/app-dir-export/test/utils.ts
@@ -176,7 +176,10 @@ export async function runTests({
       if (isDev) {
         const url = dynamicPage ? '/another/first' : '/api/json'
         const browser = await webdriver(port, url)
-        await assertHasRedbox(browser)
+        await assertHasRedbox(browser, {
+          // Main issue here that a local run hits a Node.js bug: https://linear.app/vercel/issue/NDX-505
+          fixmeStackFramesHaveBrokenSourcemaps: true,
+        })
         const header = await getRedboxHeader(browser)
         const source = await getRedboxSource(browser)
         expect(`${header}\n${source}`).toContain(expectedErrMsg)

--- a/test/integration/config-output-export/test/index.test.ts
+++ b/test/integration/config-output-export/test/index.test.ts
@@ -221,7 +221,7 @@ describe('config-output-export', () => {
       await killApp(app).catch(() => {})
       fs.rmSync(blog)
     }
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, { pageResponseCode: 500 })
     expect(await getRedboxHeader(browser)).toContain(
       'ISR cannot be used with "output: export".'
     )
@@ -312,7 +312,7 @@ describe('config-output-export', () => {
       await killApp(app).catch(() => {})
       fs.rmSync(blog)
     }
-    await assertHasRedbox(browser)
+    await assertHasRedbox(browser, { pageResponseCode: 500 })
     expect(await getRedboxHeader(browser)).toContain(
       'getServerSideProps cannot be used with "output: export".'
     )
@@ -352,7 +352,7 @@ describe('config-output-export', () => {
         output: 'export',
       })
       browser = await webdriver(result.port, '/posts/one')
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       expect(await getRedboxHeader(browser)).toContain(
         'getStaticPaths with "fallback: true" cannot be used with "output: export".'
       )
@@ -396,7 +396,7 @@ describe('config-output-export', () => {
         output: 'export',
       })
       browser = await webdriver(result.port, '/posts/one')
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       expect(await getRedboxHeader(browser)).toContain(
         'getStaticPaths with "fallback: blocking" cannot be used with "output: export".'
       )

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -27,6 +27,8 @@ let buildId
 const appDir = join(__dirname, '../')
 const buildIdPath = join(appDir, '.next/BUILD_ID')
 
+const isTurbopack = Boolean(process.env.TURBOPACK)
+
 function runTests({ dev }) {
   if (!dev) {
     it('should have correct cache entries on prefetch', async () => {
@@ -1200,7 +1202,10 @@ function runTests({ dev }) {
         await browser
           .elementByCss('#view-post-1-interpolated-incorrectly')
           .click()
-        await assertHasRedbox(browser)
+        await assertHasRedbox(browser, {
+          // TODO(veil): This is odd. Should the bundler affect the response code?
+          pageResponseCode: isTurbopack ? undefined : 500,
+        })
         const header = await getRedboxHeader(browser)
         expect(header).toContain(
           'The provided `href` (/[name]?another=value) value is missing query values (name) to be interpolated properly.'

--- a/test/integration/invalid-href/test/index.test.js
+++ b/test/integration/invalid-href/test/index.test.js
@@ -20,6 +20,8 @@ let app
 let appPort
 const appDir = join(__dirname, '..')
 
+const isTurbopack = Boolean(process.env.TURBOPACK)
+
 // This test doesn't seem to benefit from retries, let's disable them until the test gets fixed
 // to prevent long running times
 jest.retryTimes(0)
@@ -49,7 +51,10 @@ const showsError = async (pathname, regex, click = false, isWarn = false) => {
         return warnLogs.join('\n')
       }, regex)
     } else {
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        // TODO(veil): This is odd. Should the bundler affect the response code?
+        pageResponseCode: isTurbopack ? undefined : 500,
+      })
       const errorContent = await getRedboxHeader(browser)
       expect(errorContent).toMatch(regex)
     }

--- a/test/integration/next-image-legacy/base-path/test/index.test.ts
+++ b/test/integration/next-image-legacy/base-path/test/index.test.ts
@@ -386,7 +386,10 @@ function runTests(mode) {
     it('should show invalid src error', async () => {
       const browser = await webdriver(appPort, '/docs/invalid-src')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        // Main issue here that a local run hits a Node.js bug: https://linear.app/vercel/issue/NDX-505
+        fixmeStackFramesHaveBrokenSourcemaps: true,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         'Invalid src prop (https://google.com/test.png) on `next/image`, hostname "google.com" is not configured under images in your `next.config.js`'
       )
@@ -398,7 +401,10 @@ function runTests(mode) {
         '/docs/invalid-src-proto-relative'
       )
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        // Main issue here that a local run hits a Node.js bug: https://linear.app/vercel/issue/NDX-505
+        fixmeStackFramesHaveBrokenSourcemaps: true,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         'Failed to parse src "//assets.example.com/img.jpg" on `next/image`, protocol-relative URL (//) must be changed to an absolute URL (http:// or https://)'
       )

--- a/test/integration/next-image-legacy/default/test/index.test.ts
+++ b/test/integration/next-image-legacy/default/test/index.test.ts
@@ -21,6 +21,7 @@ import { join } from 'path'
 import { existsSync } from 'fs'
 
 const appDir = join(__dirname, '../')
+const isTurbopack = Boolean(process.env.TURBOPACK)
 
 let appPort
 let app
@@ -824,7 +825,11 @@ function runTests(mode) {
     it('should show invalid src error', async () => {
       const browser = await webdriver(appPort, '/invalid-src')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        pageResponseCode: 500,
+        // Main issue here that a local run hits a Node.js bug: https://linear.app/vercel/issue/NDX-505
+        fixmeStackFramesHaveBrokenSourcemaps: !isTurbopack,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         'Invalid src prop (https://google.com/test.png) on `next/image`, hostname "google.com" is not configured under images in your `next.config.js`'
       )
@@ -833,7 +838,11 @@ function runTests(mode) {
     it('should show invalid src error when protocol-relative', async () => {
       const browser = await webdriver(appPort, '/invalid-src-proto-relative')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        pageResponseCode: 500,
+        // Main issue here that a local run hits a Node.js bug: https://linear.app/vercel/issue/NDX-505
+        fixmeStackFramesHaveBrokenSourcemaps: !isTurbopack,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         'Failed to parse src "//assets.example.com/img.jpg" on `next/image`, protocol-relative URL (//) must be changed to an absolute URL (http:// or https://)'
       )
@@ -842,7 +851,11 @@ function runTests(mode) {
     it('should show error when string src and placeholder=blur and blurDataURL is missing', async () => {
       const browser = await webdriver(appPort, '/invalid-placeholder-blur')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        pageResponseCode: 500,
+        // Main issue here that a local run hits a Node.js bug: https://linear.app/vercel/issue/NDX-505
+        fixmeStackFramesHaveBrokenSourcemaps: !isTurbopack,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/test.png" has "placeholder='blur'" property but is missing the "blurDataURL" property.`
       )
@@ -851,7 +864,11 @@ function runTests(mode) {
     it('should show error when not numeric string width or height', async () => {
       const browser = await webdriver(appPort, '/invalid-width-or-height')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        pageResponseCode: 500,
+        // Main issue here that a local run hits a Node.js bug: https://linear.app/vercel/issue/NDX-505
+        fixmeStackFramesHaveBrokenSourcemaps: !isTurbopack,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/test.jpg" has invalid "width" or "height" property. These should be numeric values.`
       )
@@ -863,7 +880,11 @@ function runTests(mode) {
         '/invalid-placeholder-blur-static'
       )
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        pageResponseCode: 500,
+        // Main issue here that a local run hits a Node.js bug: https://linear.app/vercel/issue/NDX-505
+        fixmeStackFramesHaveBrokenSourcemaps: !isTurbopack,
+      })
       expect(await getRedboxHeader(browser)).toMatch(
         /Image with src "(.*)bmp" has "placeholder='blur'" property but is missing the "blurDataURL" property/
       )

--- a/test/integration/next-image-new/app-dir-localpatterns/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir-localpatterns/test/index.test.ts
@@ -55,7 +55,9 @@ function runTests(mode: 'dev' | 'server') {
     const page = '/' + id
     const browser = await webdriver(appPort, page)
     if (mode === 'dev') {
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: true,
+      })
       expect(await getRedboxHeader(browser)).toMatch(
         /Invalid src prop (.+) on `next\/image` does not match `images.localPatterns` configured/g
       )

--- a/test/integration/next-image-new/app-dir/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir/test/index.test.ts
@@ -915,7 +915,9 @@ function runTests(mode: 'dev' | 'server') {
     it('should show invalid src error', async () => {
       const browser = await webdriver(appPort, '/invalid-src')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: true,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         'Invalid src prop (https://google.com/test.png) on `next/image`, hostname "google.com" is not configured under images in your `next.config.js`'
       )
@@ -924,7 +926,9 @@ function runTests(mode: 'dev' | 'server') {
     it('should show invalid src error when protocol-relative', async () => {
       const browser = await webdriver(appPort, '/invalid-src-proto-relative')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: true,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         'Failed to parse src "//assets.example.com/img.jpg" on `next/image`, protocol-relative URL (//) must be changed to an absolute URL (http:// or https://)'
       )
@@ -932,7 +936,9 @@ function runTests(mode: 'dev' | 'server') {
 
     it('should show invalid src with leading space', async () => {
       const browser = await webdriver(appPort, '/invalid-src-leading-space')
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: true,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         'Image with src " /test.jpg" cannot start with a space or control character.'
       )
@@ -940,7 +946,9 @@ function runTests(mode: 'dev' | 'server') {
 
     it('should show invalid src with trailing space', async () => {
       const browser = await webdriver(appPort, '/invalid-src-trailing-space')
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: true,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         'Image with src "/test.png " cannot end with a space or control character.'
       )
@@ -949,7 +957,9 @@ function runTests(mode: 'dev' | 'server') {
     it('should show error when string src and placeholder=blur and blurDataURL is missing', async () => {
       const browser = await webdriver(appPort, '/invalid-placeholder-blur')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: true,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/test.png" has "placeholder='blur'" property but is missing the "blurDataURL" property.`
       )
@@ -958,7 +968,9 @@ function runTests(mode: 'dev' | 'server') {
     it('should show error when invalid width prop', async () => {
       const browser = await webdriver(appPort, '/invalid-width')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: true,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/test.jpg" has invalid "width" property. Expected a numeric value in pixels but received "100%".`
       )
@@ -967,7 +979,9 @@ function runTests(mode: 'dev' | 'server') {
     it('should show error when invalid Infinity width prop', async () => {
       const browser = await webdriver(appPort, '/invalid-Infinity-width')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: true,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/test.jpg" has invalid "width" property. Expected a numeric value in pixels but received "Infinity".`
       )
@@ -976,7 +990,9 @@ function runTests(mode: 'dev' | 'server') {
     it('should show error when invalid height prop', async () => {
       const browser = await webdriver(appPort, '/invalid-height')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: true,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/test.jpg" has invalid "height" property. Expected a numeric value in pixels but received "50vh".`
       )
@@ -995,7 +1011,9 @@ function runTests(mode: 'dev' | 'server') {
     it('should show error when missing width prop', async () => {
       const browser = await webdriver(appPort, '/missing-width')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: true,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/test.jpg" is missing required "width" property.`
       )
@@ -1004,7 +1022,9 @@ function runTests(mode: 'dev' | 'server') {
     it('should show error when missing height prop', async () => {
       const browser = await webdriver(appPort, '/missing-height')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: true,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/test.jpg" is missing required "height" property.`
       )
@@ -1013,7 +1033,9 @@ function runTests(mode: 'dev' | 'server') {
     it('should show error when width prop on fill image', async () => {
       const browser = await webdriver(appPort, '/invalid-fill-width')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: true,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/wide.png" has both "width" and "fill" properties.`
       )
@@ -1022,7 +1044,9 @@ function runTests(mode: 'dev' | 'server') {
     it('should show error when CSS position changed on fill image', async () => {
       const browser = await webdriver(appPort, '/invalid-fill-position')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: true,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/wide.png" has both "fill" and "style.position" properties. Images with "fill" always use position absolute - it cannot be modified.`
       )
@@ -1034,7 +1058,9 @@ function runTests(mode: 'dev' | 'server') {
         '/invalid-placeholder-blur-static'
       )
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: true,
+      })
       expect(await getRedboxHeader(browser)).toMatch(
         /Image with src "(.*)bmp" has "placeholder='blur'" property but is missing the "blurDataURL" property/
       )

--- a/test/integration/next-image-new/base-path/test/index.test.js
+++ b/test/integration/next-image-new/base-path/test/index.test.js
@@ -20,6 +20,8 @@ const appDir = join(__dirname, '../')
 let appPort
 let app
 
+const isTurbopack = Boolean(process.env.TURBOPACK)
+
 async function hasImageMatchingUrl(browser, url) {
   const links = await browser.elementsByCss('img')
   let foundMatch = false
@@ -141,7 +143,11 @@ function runTests(mode) {
     it('should show invalid src error', async () => {
       const browser = await webdriver(appPort, '/docs/invalid-src')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        pageResponseCode: 500,
+        // Main issue here that a local run hits a Node.js bug: https://linear.app/vercel/issue/NDX-505
+        fixmeStackFramesHaveBrokenSourcemaps: !isTurbopack,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         'Invalid src prop (https://google.com/test.png) on `next/image`, hostname "google.com" is not configured under images in your `next.config.js`'
       )
@@ -153,7 +159,11 @@ function runTests(mode) {
         '/docs/invalid-src-proto-relative'
       )
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        pageResponseCode: 500,
+        // Main issue here that a local run hits a Node.js bug: https://linear.app/vercel/issue/NDX-505
+        fixmeStackFramesHaveBrokenSourcemaps: !isTurbopack,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         'Failed to parse src "//assets.example.com/img.jpg" on `next/image`, protocol-relative URL (//) must be changed to an absolute URL (http:// or https://)'
       )

--- a/test/integration/next-image-new/default/test/index.test.ts
+++ b/test/integration/next-image-new/default/test/index.test.ts
@@ -23,6 +23,7 @@ import fs from 'fs/promises'
 import { pathExists } from 'fs-extra'
 
 const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
+const isTurbopack = Boolean(process.env.TURBOPACK)
 
 const appDir = join(__dirname, '../')
 
@@ -917,7 +918,10 @@ function runTests(mode) {
     it('should show invalid src error', async () => {
       const browser = await webdriver(appPort, '/invalid-src')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: !isTurbopack,
+        pageResponseCode: 500,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         'Invalid src prop (https://google.com/test.png) on `next/image`, hostname "google.com" is not configured under images in your `next.config.js`'
       )
@@ -926,7 +930,10 @@ function runTests(mode) {
     it('should show invalid src error when protocol-relative', async () => {
       const browser = await webdriver(appPort, '/invalid-src-proto-relative')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: !isTurbopack,
+        pageResponseCode: 500,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         'Failed to parse src "//assets.example.com/img.jpg" on `next/image`, protocol-relative URL (//) must be changed to an absolute URL (http:// or https://)'
       )
@@ -934,7 +941,10 @@ function runTests(mode) {
 
     it('should show invalid src with leading space', async () => {
       const browser = await webdriver(appPort, '/invalid-src-leading-space')
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: !isTurbopack,
+        pageResponseCode: 500,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         'Image with src " /test.jpg" cannot start with a space or control character.'
       )
@@ -942,7 +952,10 @@ function runTests(mode) {
 
     it('should show invalid src with trailing space', async () => {
       const browser = await webdriver(appPort, '/invalid-src-trailing-space')
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: !isTurbopack,
+        pageResponseCode: 500,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         'Image with src "/test.png " cannot end with a space or control character.'
       )
@@ -951,7 +964,10 @@ function runTests(mode) {
     it('should show error when string src and placeholder=blur and blurDataURL is missing', async () => {
       const browser = await webdriver(appPort, '/invalid-placeholder-blur')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: !isTurbopack,
+        pageResponseCode: 500,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/test.png" has "placeholder='blur'" property but is missing the "blurDataURL" property.`
       )
@@ -960,7 +976,10 @@ function runTests(mode) {
     it('should show error when invalid width prop', async () => {
       const browser = await webdriver(appPort, '/invalid-width')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: !isTurbopack,
+        pageResponseCode: 500,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/test.jpg" has invalid "width" property. Expected a numeric value in pixels but received "100%".`
       )
@@ -969,7 +988,10 @@ function runTests(mode) {
     it('should show error when invalid Infinity width prop', async () => {
       const browser = await webdriver(appPort, '/invalid-Infinity-width')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: !isTurbopack,
+        pageResponseCode: 500,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/test.jpg" has invalid "width" property. Expected a numeric value in pixels but received "Infinity".`
       )
@@ -978,7 +1000,10 @@ function runTests(mode) {
     it('should show error when invalid height prop', async () => {
       const browser = await webdriver(appPort, '/invalid-height')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: !isTurbopack,
+        pageResponseCode: 500,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/test.jpg" has invalid "height" property. Expected a numeric value in pixels but received "50vh".`
       )
@@ -997,7 +1022,10 @@ function runTests(mode) {
     it('should show error when missing width prop', async () => {
       const browser = await webdriver(appPort, '/missing-width')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: !isTurbopack,
+        pageResponseCode: 500,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/test.jpg" is missing required "width" property.`
       )
@@ -1006,7 +1034,10 @@ function runTests(mode) {
     it('should show error when missing height prop', async () => {
       const browser = await webdriver(appPort, '/missing-height')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: !isTurbopack,
+        pageResponseCode: 500,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/test.jpg" is missing required "height" property.`
       )
@@ -1015,7 +1046,10 @@ function runTests(mode) {
     it('should show error when width prop on fill image', async () => {
       const browser = await webdriver(appPort, '/invalid-fill-width')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: !isTurbopack,
+        pageResponseCode: 500,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/wide.png" has both "width" and "fill" properties.`
       )
@@ -1024,7 +1058,10 @@ function runTests(mode) {
     it('should show error when CSS position changed on fill image', async () => {
       const browser = await webdriver(appPort, '/invalid-fill-position')
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: !isTurbopack,
+        pageResponseCode: 500,
+      })
       expect(await getRedboxHeader(browser)).toContain(
         `Image with src "/wide.png" has both "fill" and "style.position" properties. Images with "fill" always use position absolute - it cannot be modified.`
       )
@@ -1036,7 +1073,10 @@ function runTests(mode) {
         '/invalid-placeholder-blur-static'
       )
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, {
+        fixmeStackFramesHaveBrokenSourcemaps: !isTurbopack,
+        pageResponseCode: 500,
+      })
       expect(await getRedboxHeader(browser)).toMatch(
         /Image with src "(.*)bmp" has "placeholder='blur'" property but is missing the "blurDataURL" property/
       )

--- a/test/integration/next-image-new/export-config/test/index.test.ts
+++ b/test/integration/next-image-new/export-config/test/index.test.ts
@@ -35,7 +35,10 @@ describe('next/image with output export config', () => {
         const browser = await webdriver(appPort, '/')
         const msg =
           "Image Optimization using the default loader is not compatible with `{ output: 'export' }`."
-        await assertHasRedbox(browser)
+        await assertHasRedbox(browser, {
+          // Main issue here that a local run hits a Node.js bug: https://linear.app/vercel/issue/NDX-505
+          fixmeStackFramesHaveBrokenSourcemaps: true,
+        })
         expect(await getRedboxHeader(browser)).toContain(msg)
         expect(stderr).toContain(msg)
       })

--- a/test/integration/next-image-new/invalid-image-import/test/index.test.ts
+++ b/test/integration/next-image-new/invalid-image-import/test/index.test.ts
@@ -22,7 +22,7 @@ function runTests({ isDev }) {
   it('should show error', async () => {
     if (isDev) {
       const browser = await webdriver(appPort, '/')
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
       expect(await getRedboxHeader(browser)).toMatch('Failed to compile')
       const source = await getRedboxSource(browser)
       if (process.env.TURBOPACK) {

--- a/test/integration/server-side-dev-errors/test/index.test.js
+++ b/test/integration/server-side-dev-errors/test/index.test.js
@@ -89,7 +89,7 @@ describe('server-side dev errors', () => {
           '\n> 6 |   missingVar;return {'
       )
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
 
       expect(await getRedboxSource(browser)).toContain('missingVar')
       await fs.writeFile(gspPage, content, { flush: true })
@@ -142,7 +142,7 @@ describe('server-side dev errors', () => {
           '\n> 6 |   missingVar;return {'
       )
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
 
       expect(await getRedboxSource(browser)).toContain('missingVar')
       await fs.writeFile(gsspPage, content)
@@ -195,11 +195,11 @@ describe('server-side dev errors', () => {
           '\n> 6 |   missingVar;return {'
       )
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
 
       expect(await getRedboxSource(browser)).toContain('missingVar')
       await fs.writeFile(dynamicGsspPage, content)
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
     } finally {
       await fs.writeFile(dynamicGsspPage, content)
     }
@@ -248,11 +248,11 @@ describe('server-side dev errors', () => {
           "\n> 2 |   missingVar;res.status(200).json({ hello: 'world' })"
       )
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
 
       expect(await getRedboxSource(browser)).toContain('missingVar')
       await fs.writeFile(apiPage, content)
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
     } finally {
       await fs.writeFile(apiPage, content)
     }
@@ -303,11 +303,11 @@ describe('server-side dev errors', () => {
           '\n> 2 |   missingVar;res.status(200).json({ slug: req.query.slug })'
       )
 
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
 
       expect(await getRedboxSource(browser)).toContain('missingVar')
       await fs.writeFile(dynamicApiPage, content)
-      await assertHasRedbox(browser)
+      await assertHasRedbox(browser, { pageResponseCode: 500 })
     } finally {
       await fs.writeFile(dynamicApiPage, content)
     }

--- a/test/lib/development-sandbox.ts
+++ b/test/lib/development-sandbox.ts
@@ -5,9 +5,11 @@ import {
   getRedboxHeader,
   getRedboxSource,
   getVersionCheckerText,
+  type AssertHasRedboxOptions,
   assertHasRedbox,
   assertNoRedbox,
   waitFor,
+  type OpenRedboxOptions,
   openRedbox,
   getRedboxDescriptionWarning,
   toggleCollapseComponentStack,
@@ -118,14 +120,14 @@ export async function createSandbox(
             )
           }
         },
-        async assertHasRedbox() {
-          return assertHasRedbox(browser)
+        async assertHasRedbox(options?: AssertHasRedboxOptions) {
+          return assertHasRedbox(browser, options)
         },
         async assertNoRedbox() {
           return assertNoRedbox(browser)
         },
-        async openRedbox() {
-          return openRedbox(browser)
+        async openRedbox(options?: OpenRedboxOptions) {
+          return openRedbox(browser, options)
         },
         async hasErrorToast() {
           return Boolean(await hasErrorToast(browser))


### PR DESCRIPTION
We now check that every `assertHasRedbox` is not accompanied by any 500 errors in the console. While the error message is generic, all of them are caused by a failure to sourcemap in the dev middleware.

The assertion still passes when the `fixmeStackFramesHaveBrokenSourcemaps` option is passed e.g. `assertHasRedbox(browser, { fixmeStackFramesHaveBrokenSourcemaps: true })`. This helps us track these bugs since they may have different causes.

TODO:
- [x] go through remaining failures
- [x] double check each `fixmeStackFramesHaveBrokenSourcemaps: true` if it can be replaced with `pageResponseCode: 500` 