### PR TITLE
 examples(with-supabase): add new alias for hooks

### DIFF
--- a/examples/with-supabase/components.json
+++ b/examples/with-supabase/components.json
@@ -12,6 +12,7 @@
   },
   "aliases": {
     "components": "@/components",
+    "hooks": "@/hooks",
     "utils": "@/lib/utils"
   }
 }


### PR DESCRIPTION
I've encountered an issue when installing certain components of `shadcn/ui`.
For example, the Toast component ([documentation link](https://ui.shadcn.com/docs/components/toast)) seems to have installation problems.