### PR TITLE
Turbopack: more tracing spans

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1642,9 +1642,15 @@ impl Endpoint for AppEndpoint {
                 .clone_value();
 
             let client_relative_root = this.app_project.project().client_relative_path();
-            let client_paths = all_paths_in_root(output_assets, client_relative_root)
-                .await?
-                .clone_value();
+            let client_paths = async {
+                anyhow::Ok(
+                    all_paths_in_root(output_assets, client_relative_root)
+                        .await?
+                        .clone_value(),
+                )
+            }
+            .instrument(tracing::info_span!("client_paths"))
+            .await?;
 
             let written_endpoint = match *output {
                 AppEndpointOutput::NodeJs { rsc_chunk, .. } => WrittenEndpoint::NodeJs {

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1,3 +1,5 @@
+use std::future::IntoFuture;
+
 use anyhow::{Context, Result};
 use next_core::{
     all_assets_from_entries,
@@ -1642,15 +1644,11 @@ impl Endpoint for AppEndpoint {
                 .clone_value();
 
             let client_relative_root = this.app_project.project().client_relative_path();
-            let client_paths = async {
-                anyhow::Ok(
-                    all_paths_in_root(output_assets, client_relative_root)
-                        .await?
-                        .clone_value(),
-                )
-            }
-            .instrument(tracing::info_span!("client_paths"))
-            .await?;
+            let client_paths = all_paths_in_root(output_assets, client_relative_root)
+                .into_future()
+                .instrument(tracing::info_span!("client_paths"))
+                .await?
+                .clone_value();
 
             let written_endpoint = match *output {
                 AppEndpointOutput::NodeJs { rsc_chunk, .. } => WrittenEndpoint::NodeJs {

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -284,9 +284,15 @@ impl Endpoint for MiddlewareEndpoint {
 
             // Middleware could in theory have a client path (e.g. `new URL`).
             let client_relative_root = this.project.client_relative_path();
-            let client_paths = all_paths_in_root(output_assets, client_relative_root)
-                .await?
-                .clone_value();
+            let client_paths = async {
+                anyhow::Ok(
+                    all_paths_in_root(output_assets, client_relative_root)
+                        .await?
+                        .clone_value(),
+                )
+            }
+            .instrument(tracing::info_span!("client_paths"))
+            .await?;
 
             Ok(WrittenEndpoint::Edge {
                 server_paths,

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -1,3 +1,5 @@
+use std::future::IntoFuture;
+
 use anyhow::{bail, Context, Result};
 use next_core::{
     all_assets_from_entries,
@@ -284,15 +286,11 @@ impl Endpoint for MiddlewareEndpoint {
 
             // Middleware could in theory have a client path (e.g. `new URL`).
             let client_relative_root = this.project.client_relative_path();
-            let client_paths = async {
-                anyhow::Ok(
-                    all_paths_in_root(output_assets, client_relative_root)
-                        .await?
-                        .clone_value(),
-                )
-            }
-            .instrument(tracing::info_span!("client_paths"))
-            .await?;
+            let client_paths = all_paths_in_root(output_assets, client_relative_root)
+                .into_future()
+                .instrument(tracing::info_span!("client_paths"))
+                .await?
+                .clone_value();
 
             Ok(WrittenEndpoint::Edge {
                 server_paths,

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1278,9 +1278,15 @@ impl Endpoint for PageEndpoint {
                 .clone_value();
 
             let client_relative_root = this.pages_project.project().client_relative_path();
-            let client_paths = all_paths_in_root(output_assets, client_relative_root)
-                .await?
-                .clone_value();
+            let client_paths = async {
+                anyhow::Ok(
+                    all_paths_in_root(output_assets, client_relative_root)
+                        .await?
+                        .clone_value(),
+                )
+            }
+            .instrument(tracing::info_span!("client_paths"))
+            .await?;
 
             let node_root = &node_root.await?;
             let written_endpoint = match *output {

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1,3 +1,5 @@
+use std::future::IntoFuture;
+
 use anyhow::{bail, Context, Result};
 use next_core::{
     all_assets_from_entries, create_page_loader_entry_module, get_asset_path_from_pathname,
@@ -1278,15 +1280,11 @@ impl Endpoint for PageEndpoint {
                 .clone_value();
 
             let client_relative_root = this.pages_project.project().client_relative_path();
-            let client_paths = async {
-                anyhow::Ok(
-                    all_paths_in_root(output_assets, client_relative_root)
-                        .await?
-                        .clone_value(),
-                )
-            }
-            .instrument(tracing::info_span!("client_paths"))
-            .await?;
+            let client_paths = all_paths_in_root(output_assets, client_relative_root)
+                .into_future()
+                .instrument(tracing::info_span!("client_paths"))
+                .await?
+                .clone_value();
 
             let node_root = &node_root.await?;
             let written_endpoint = match *output {

--- a/crates/next-api/src/paths.rs
+++ b/crates/next-api/src/paths.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use next_core::{all_assets_from_entries, next_manifests::AssetBinding};
 use serde::{Deserialize, Serialize};
+use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{trace::TraceRawVcs, ResolvedVc, TryFlatJoinIterExt, Vc};
 use turbo_tasks_fs::FileSystemPath;
@@ -29,30 +30,35 @@ pub async fn all_server_paths(
     assets: Vc<OutputAssets>,
     node_root: Vc<FileSystemPath>,
 ) -> Result<Vc<ServerPaths>> {
-    let all_assets = all_assets_from_entries(assets).await?;
-    let node_root = &node_root.await?;
-    Ok(Vc::cell(
-        all_assets
-            .iter()
-            .map(|&asset| async move {
-                Ok(
-                    if let Some(path) = node_root.get_path_to(&*asset.ident().path().await?) {
-                        let content_hash = match *asset.content().await? {
-                            AssetContent::File(file) => *file.hash().await?,
-                            AssetContent::Redirect { .. } => 0,
-                        };
-                        Some(ServerPath {
-                            path: path.to_string(),
-                            content_hash,
-                        })
-                    } else {
-                        None
-                    },
-                )
-            })
-            .try_flat_join()
-            .await?,
-    ))
+    let span = tracing::info_span!("all_server_paths");
+    async move {
+        let all_assets = all_assets_from_entries(assets).await?;
+        let node_root = &node_root.await?;
+        Ok(Vc::cell(
+            all_assets
+                .iter()
+                .map(|&asset| async move {
+                    Ok(
+                        if let Some(path) = node_root.get_path_to(&*asset.ident().path().await?) {
+                            let content_hash = match *asset.content().await? {
+                                AssetContent::File(file) => *file.hash().await?,
+                                AssetContent::Redirect { .. } => 0,
+                            };
+                            Some(ServerPath {
+                                path: path.to_string(),
+                                content_hash,
+                            })
+                        } else {
+                            None
+                        },
+                    )
+                })
+                .try_flat_join()
+                .await?,
+        ))
+    }
+    .instrument(span)
+    .await
 }
 
 /// Return a list of relative paths to `root` for all output assets references

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, io::Write, iter::once};
+use std::{collections::BTreeMap, future::Future, io::Write, iter::once};
 
 use anyhow::{bail, Context, Result};
 use indexmap::map::Entry;
@@ -16,11 +16,11 @@ use swc_core::{
         utils::find_pat_ids,
     },
 };
-use tracing::Instrument;
+use tracing::{Instrument, Level};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    graph::{GraphTraversal, NonDeterministic},
-    FxIndexMap, ResolvedVc, TryFlatJoinIterExt, Value, ValueToString, Vc,
+    graph::{GraphTraversal, NonDeterministic, VisitControlFlow},
+    FxIndexMap, ReadRef, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Value, ValueToString, Vc,
 };
 use turbo_tasks_fs::{self, rope::RopeBuilder, File, FileSystemPath};
 use turbopack_core::{
@@ -65,7 +65,7 @@ pub(crate) async fn create_server_actions_manifest(
     asset_context: Vc<Box<dyn AssetContext>>,
     chunking_context: Vc<Box<dyn ChunkingContext>>,
 ) -> Result<Vc<ServerActionsManifest>> {
-    let actions = get_actions(rsc_entry, server_reference_modules, asset_context);
+    let actions = find_actions(rsc_entry, server_reference_modules, asset_context);
     let loader =
         build_server_actions_loader(project_path, page_name.clone(), actions, asset_context);
     let evaluable = Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(loader)
@@ -185,7 +185,7 @@ async fn build_manifest(
 /// comment which identifies server actions. Every found server action will be
 /// returned along with the module which exports that action.
 #[turbo_tasks::function]
-async fn get_actions(
+async fn find_actions(
     rsc_entry: ResolvedVc<Box<dyn Module>>,
     server_reference_modules: Vc<Modules>,
     asset_context: Vc<Box<dyn AssetContext>>,
@@ -194,13 +194,22 @@ async fn get_actions(
         let actions = NonDeterministic::new()
             .skip_duplicates()
             .visit(
-                once((ActionLayer::Rsc, rsc_entry)).chain(
+                once((
+                    ActionLayer::Rsc,
+                    rsc_entry,
+                    rsc_entry.ident().to_string().await?,
+                ))
+                .chain(
                     server_reference_modules
                         .await?
                         .iter()
-                        .map(|m| (ActionLayer::ActionBrowser, *m)),
+                        .map(|m| async move {
+                            Ok((ActionLayer::ActionBrowser, *m, m.ident().to_string().await?))
+                        })
+                        .try_join()
+                        .await?,
                 ),
-                get_referenced_modules,
+                FindActionsVisit {},
             )
             .await
             .completed()?
@@ -214,7 +223,7 @@ async fn get_actions(
         // to use the RSC layer's module. We do that by merging the hashes (which match
         // in both layers) and preferring the RSC layer's action.
         let mut all_actions: HashToLayerNameModule = FxIndexMap::default();
-        for ((layer, module), actions_map) in actions.iter() {
+        for ((layer, module, _), actions_map) in actions.iter() {
             let module = if *layer == ActionLayer::Rsc {
                 *module
             } else {
@@ -242,6 +251,46 @@ async fn get_actions(
     .await
 }
 
+type FindActionsNode = (ActionLayer, ResolvedVc<Box<dyn Module>>, ReadRef<RcStr>);
+struct FindActionsVisit {}
+impl turbo_tasks::graph::Visit<FindActionsNode> for FindActionsVisit {
+    type Edge = FindActionsNode;
+    type EdgesIntoIter = impl Iterator<Item = FindActionsNode>;
+    type EdgesFuture = impl Future<Output = Result<Self::EdgesIntoIter>>;
+
+    fn visit(&mut self, edge: Self::Edge) -> VisitControlFlow<Self::Edge> {
+        VisitControlFlow::Continue(edge)
+    }
+
+    fn edges(&mut self, node: &Self::Edge) -> Self::EdgesFuture {
+        get_referenced_modules(node.clone())
+    }
+
+    fn span(&mut self, node: &Self::Edge) -> tracing::Span {
+        let (_, _, name) = node;
+        tracing::span!(
+            Level::INFO,
+            "find server actions visit",
+            name = display(name)
+        )
+    }
+}
+
+/// Our graph traversal visitor, which finds the primary modules directly
+/// referenced by parent.
+async fn get_referenced_modules(
+    (layer, module, _): FindActionsNode,
+) -> Result<impl Iterator<Item = FindActionsNode> + Send> {
+    let modules = primary_referenced_modules(*module).await?;
+
+    Ok(modules
+        .into_iter()
+        .map(move |&m| async move { Ok((layer, m, m.ident().to_string().await?)) })
+        .try_join()
+        .await?
+        .into_iter())
+}
+
 /// The ActionBrowser layer's module is in the Client context, and we need to
 /// bring it into the RSC context.
 async fn to_rsc_context(
@@ -260,16 +309,6 @@ async fn to_rsc_context(
         .to_resolved()
         .await?;
     Ok(module)
-}
-
-/// Our graph traversal visitor, which finds the primary modules directly
-/// referenced by parent.
-async fn get_referenced_modules(
-    (layer, module): (ActionLayer, ResolvedVc<Box<dyn Module>>),
-) -> Result<impl Iterator<Item = (ActionLayer, ResolvedVc<Box<dyn Module>>)> + Send> {
-    primary_referenced_modules(*module)
-        .await
-        .map(|modules| modules.into_iter().map(move |&m| (layer, m)))
 }
 
 /// Parses the Server Actions comment for all exported action function names.
@@ -417,12 +456,12 @@ fn all_export_names(program: &Program) -> Vec<Atom> {
 /// Converts our cached [parse_actions] call into a data type suitable for
 /// collecting into a flat-mapped [FxIndexMap].
 async fn parse_actions_filter_map(
-    (layer, module): (ActionLayer, ResolvedVc<Box<dyn Module>>),
-) -> Result<Option<((ActionLayer, ResolvedVc<Box<dyn Module>>), Vc<ActionMap>)>> {
+    (layer, module, name): FindActionsNode,
+) -> Result<Option<(FindActionsNode, Vc<ActionMap>)>> {
     parse_actions(*module).await.map(|option_action_map| {
         option_action_map
             .clone_value()
-            .map(|action_map| ((layer, module), action_map))
+            .map(|action_map| ((layer, module, name), action_map))
     })
 }
 


### PR DESCRIPTION
- adds per-module tracing for `find server actions` (it's implemented in the same way for next/dynamic and client references). Now, `find server actions` isn't just a single blob anymore.
	- ![Bildschirmfoto 2024-11-20 um 18 17 47](https://github.com/user-attachments/assets/296ab575-410e-436f-ae61-5c555c91b3e4)
- add a tracing span for `all_server_paths`
	- Before: ![Bildschirmfoto 2024-11-20 um 14 47 13](https://github.com/user-attachments/assets/1dd2de3f-c785-4306-83a4-b051e5b06edc)
	- What's actually there: ![Bildschirmfoto 2024-11-20 um 14 50 48](https://github.com/user-attachments/assets/80556b5e-0327-4248-8894-c241e696f836)


Closes PACK-3529