### PR TITLE
Disallow multiple server directives at the same level (file or function)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -23,6 +23,7 @@ crates/next-custom-transforms/tests/errors/react-server-components/client-graph/
 crates/next-custom-transforms/tests/errors/react-server-components/server-graph/fake-client-entry/input.js
 crates/next-custom-transforms/tests/errors/server-actions/server-graph/8/input.js
 crates/next-custom-transforms/tests/errors/server-actions/server-graph/9/input.js
+crates/next-custom-transforms/tests/errors/server-actions/server-graph/18/input.js
 crates/next-custom-transforms/tests/fixture/optimize-barrel/normal/4/input.js
 crates/next-custom-transforms/tests/fixture/react-server-components/client-graph/client-entry/input.js
 crates/next-custom-transforms/tests/fixture/react-server-components/server-graph/client-entry/input.js

--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -479,7 +479,7 @@ impl<C: Comments> ServerActions<C> {
 
             body.stmts.retain(|stmt| {
                 let found_directive = self.get_directive_for_stmt(
-                    &stmt,
+                    stmt,
                     &mut directive,
                     DirectiveLocation::FunctionBody,
                     &mut is_allowed_position,
@@ -504,7 +504,7 @@ impl<C: Comments> ServerActions<C> {
         stmts.retain(|item| {
             if let ModuleItem::Stmt(stmt) = item {
                 let found_directive = self.get_directive_for_stmt(
-                    &stmt,
+                    stmt,
                     &mut directive,
                     DirectiveLocation::Module,
                     &mut is_allowed_position,

--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -329,7 +329,7 @@ impl<C: Comments> ServerActions<C> {
             let directive_visitor = &mut DirectiveVisitor {
                 config: &self.config,
                 directive: None,
-                file_directive: &self.file_directive,
+                has_file_directive: self.file_directive.is_some(),
                 is_allowed_position: true,
                 location: DirectiveLocation::FunctionBody,
             };
@@ -355,7 +355,7 @@ impl<C: Comments> ServerActions<C> {
         let directive_visitor = &mut DirectiveVisitor {
             config: &self.config,
             directive: None,
-            file_directive: &self.file_directive,
+            has_file_directive: false,
             is_allowed_position: true,
             location: DirectiveLocation::Module,
         };
@@ -2444,9 +2444,9 @@ fn collect_decl_idents_in_stmt(stmt: &Stmt, idents: &mut Vec<Ident>) {
 
 struct DirectiveVisitor<'a> {
     config: &'a Config,
-    file_directive: &'a Option<Directive>,
     location: DirectiveLocation,
     directive: Option<Directive>,
+    has_file_directive: bool,
     is_allowed_position: bool,
 }
 
@@ -2457,7 +2457,7 @@ impl DirectiveVisitor<'_> {
      */
     fn visit_stmt(&mut self, stmt: &Stmt) -> bool {
         let in_fn_body = matches!(self.location, DirectiveLocation::FunctionBody);
-        let allow_inline = self.config.is_react_server_layer || self.file_directive.is_some();
+        let allow_inline = self.config.is_react_server_layer || self.has_file_directive;
 
         match stmt {
             Stmt::Expr(ExprStmt {

--- a/crates/next-custom-transforms/tests/errors/server-actions/client-graph/1/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/client-graph/1/output.js
@@ -1,4 +1,6 @@
 /* __next_internal_client_entry_do_not_use__ default auto */ export default function App() {
-    async function fn() {}
+    async function fn() {
+        'use server';
+    }
     return <div>App</div>;
 }

--- a/crates/next-custom-transforms/tests/errors/server-actions/client-graph/2/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/client-graph/2/output.js
@@ -1,4 +1,6 @@
 /* __next_internal_client_entry_do_not_use__ default auto */ export default function App() {
-    async function fn() {}
+    async function fn() {
+        'use cache';
+    }
     return <div>App</div>;
 }

--- a/crates/next-custom-transforms/tests/errors/server-actions/client-graph/2/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/client-graph/2/output.stderr
@@ -2,10 +2,9 @@
   | To use "use cache" functions in a Client Component, you can either export them from a separate file with "use cache" or "use server" at the top, or pass them down through props from a Server
   | Component.
   | 
-   ,-[input.js:4:1]
- 3 |     export default function App() {
- 4 | ,->   async function fn() {
- 5 | |       'use cache'
- 6 | `->   }
- 7 |       return <div>App</div>
+   ,-[input.js:5:1]
+ 4 |   async function fn() {
+ 5 |     'use cache'
+   :     ^^^^^^^^^^^
+ 6 |   }
    `----

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/10/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/10/output.stderr
@@ -1,0 +1,6 @@
+  x Did you mean "use server"? "use sevrer" is not a supported directive name."
+  | 
+   ,-[input.js:1:1]
+ 1 | 'use sevrer'
+   : ^^^^^^^^^^^^
+   `----

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/18/input.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/18/input.js
@@ -1,0 +1,3 @@
+export async function fn() {
+  ('use cache')
+}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/18/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/18/output.js
@@ -1,0 +1,3 @@
+export async function fn() {
+    'use cache';
+}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/18/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/18/output.stderr
@@ -1,0 +1,8 @@
+  x The "use cache" directive cannot be wrapped in parentheses.
+  | 
+   ,-[input.js:2:1]
+ 1 | export async function fn() {
+ 2 |   ('use cache')
+   :   ^^^^^^^^^^^^^
+ 3 | }
+   `----

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/19/input.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/19/input.js
@@ -1,0 +1,4 @@
+export async function fn() {
+  console.log('foo')
+  ;('use cache')
+}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/19/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/19/output.js
@@ -1,0 +1,4 @@
+export async function fn() {
+    console.log('foo');
+    'use cache';
+}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/19/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/19/output.stderr
@@ -1,0 +1,8 @@
+  x The "use cache" directive must be at the top of the function body, and cannot be wrapped in parentheses.
+  | 
+   ,-[input.js:3:1]
+ 2 |   console.log('foo')
+ 3 |   ;('use cache')
+   :    ^^^^^^^^^^^^^
+ 4 | }
+   `----

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/20/input.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/20/input.js
@@ -1,0 +1,4 @@
+export async function fn() {
+  'use cache'
+  'use server'
+}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/20/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/20/output.js
@@ -1,0 +1,11 @@
+/* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ async function fn() {
+    'use server';
+});
+Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+    "value": "fn",
+    "writable": false
+});
+export var fn = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/20/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/20/output.stderr
@@ -1,0 +1,8 @@
+  x Conflicting directives "use server" and "use cache" found in the same function body. You cannot place both directives at the top of a function body. Please remove one of them.
+  | 
+   ,-[input.js:3:1]
+ 2 |   'use cache'
+ 3 |   'use server'
+   :   ^^^^^^^^^^^^
+ 4 | }
+   `----

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/21/input.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/21/input.js
@@ -1,0 +1,4 @@
+'use cache'
+'use server'
+
+export async function fn() {}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/21/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/21/output.js
@@ -1,0 +1,10 @@
+/* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
+'use server';
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ async function fn() {});
+Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+    "value": "fn",
+    "writable": false
+});
+export var fn = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/21/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/21/output.stderr
@@ -1,0 +1,7 @@
+  x Conflicting directives "use server" and "use cache" found in the same file. You cannot place both directives at the top of a file. Please remove one of them.
+  | 
+   ,-[input.js:2:1]
+ 1 | 'use cache'
+ 2 | 'use server'
+   : ^^^^^^^^^^^^
+   `----


### PR DESCRIPTION
This PR has two main goals:

- **Consolidate the detection of server directives in modules and function bodies.** Previously, these were two separate implementations with significant overlap, but also some [questionable discrepancies](https://github.com/vercel/next.js/pull/72811#discussion_r1843660381).
- **Model the current directive (in a file or function) using an enum instead of two separate booleans.** This change prevents any confusion that both directives might be present simultaneously. Additionally, we're now emitting an error if multiple directives (`"use server"` and `"use cache"`) are defined in the same location (at the top of a file or function body).

A mixed usage of `"use server"` and `"use cache"` _across different locations_ is still allowed, e.g. `"use cache"` at the top of a file, and `"use server"` in a function.

> [!NOTE]  
> The diff may be tricky to review because chunks from two different functions are combined into a single function. Fortunately, we have comprehensive test coverage for the transforms, which instills high confidence that these changes are correct.