### PR TITLE
remove unnecessary handling in forked Link components

### DIFF
--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -13,15 +13,10 @@ import { formatUrl } from '../shared/lib/router/utils/format-url'
 import { isAbsoluteUrl } from '../shared/lib/utils'
 import { addLocale } from './add-locale'
 import { RouterContext } from '../shared/lib/router-context.shared-runtime'
-import { AppRouterContext } from '../shared/lib/app-router-context.shared-runtime'
-import type {
-  AppRouterInstance,
-  PrefetchOptions as AppRouterPrefetchOptions,
-} from '../shared/lib/app-router-context.shared-runtime'
+import type { AppRouterInstance } from '../shared/lib/app-router-context.shared-runtime'
 import { useIntersection } from './use-intersection'
 import { getDomainLocale } from './get-domain-locale'
 import { addBasePath } from './add-base-path'
-import { PrefetchKind } from './components/router-reducer/router-reducer-types'
 import { useMergedRef } from './use-merged-ref'
 
 type Url = string | UrlObject
@@ -131,28 +126,22 @@ type PrefetchOptions = RouterPrefetchOptions & {
 }
 
 function prefetch(
-  router: NextRouter | AppRouterInstance,
+  router: NextRouter,
   href: string,
   as: string,
-  options: PrefetchOptions,
-  appOptions: AppRouterPrefetchOptions,
-  isAppRouter: boolean
+  options: PrefetchOptions
 ): void {
   if (typeof window === 'undefined') {
     return
   }
 
-  // app-router supports external urls out of the box so it shouldn't short-circuit here as support for e.g. `replace` is added in the app-router.
-  if (!isAppRouter && !isLocalURL(href)) {
+  if (!isLocalURL(href)) {
     return
   }
 
   // We should only dedupe requests when experimental.optimisticClientCache is
-  // disabled & when we're not using the app router. App router handles
-  // reusing an existing prefetch entry (if it exists) for the same URL.
-  // If we dedupe in here, we will cause a race where different prefetch kinds
-  // to the same URL (ie auto vs true) will cause one to be ignored.
-  if (!options.bypassPrefetchedCheck && !isAppRouter) {
+  // disabled.
+  if (!options.bypassPrefetchedCheck) {
     const locale =
       // Let the link's locale prop override the default router locale.
       typeof options.locale !== 'undefined'
@@ -173,21 +162,11 @@ function prefetch(
     prefetched.add(prefetchedKey)
   }
 
-  const doPrefetch = async () => {
-    if (isAppRouter) {
-      // note that `appRouter.prefetch()` is currently sync,
-      // so we have to wrap this call in an async function to be able to catch() errors below.
-      return (router as AppRouterInstance).prefetch(href, appOptions)
-    } else {
-      return (router as NextRouter).prefetch(href, as, options)
-    }
-  }
-
   // Prefetch the JSON page if asked (only in the client)
   // We need to handle a prefetch error here since we may be
   // loading with priority which can reject but we don't
   // want to force navigation since this is only a prefetch
-  doPrefetch().catch((err) => {
+  router.prefetch(href, as, options).catch((err) => {
     if (process.env.NODE_ENV !== 'production') {
       // rethrow to show invalid URL errors
       throw err
@@ -216,20 +195,14 @@ function linkClicked(
   replace?: boolean,
   shallow?: boolean,
   scroll?: boolean,
-  locale?: string | false,
-  isAppRouter?: boolean
+  locale?: string | false
 ): void {
   const { nodeName } = e.currentTarget
 
   // anchors inside an svg have a lowercase nodeName
   const isAnchorNodeName = nodeName.toUpperCase() === 'A'
 
-  if (
-    isAnchorNodeName &&
-    (isModifiedEvent(e) ||
-      // app-router supports external urls out of the box so it shouldn't short-circuit here as support for e.g. `replace` is added in the app-router.
-      (!isAppRouter && !isLocalURL(href)))
-  ) {
+  if (isAnchorNodeName && (isModifiedEvent(e) || !isLocalURL(href))) {
     // ignore click for browser’s default behavior
     return
   }
@@ -252,11 +225,7 @@ function linkClicked(
     }
   }
 
-  if (isAppRouter) {
-    React.startTransition(navigate)
-  } else {
-    navigate()
-  }
+  navigate()
 }
 
 type LinkPropsReal = React.PropsWithChildren<
@@ -310,22 +279,9 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
       children = <a>{children}</a>
     }
 
-    const pagesRouter = React.useContext(RouterContext)
-    const appRouter = React.useContext(AppRouterContext)
-    const router = pagesRouter ?? appRouter
-
-    // We're in the app directory if there is no pages router.
-    const isAppRouter = !pagesRouter
+    const router = React.useContext(RouterContext)
 
     const prefetchEnabled = prefetchProp !== false
-    /**
-     * The possible states for prefetch are:
-     * - null: this is the default "auto" mode, where we will prefetch partially if the link is in the viewport
-     * - true: we will prefetch if the link is visible and prefetch the full page, not just partially
-     * - false: we will not prefetch if in the viewport at all
-     */
-    const appPrefetchKind =
-      prefetchProp === null ? PrefetchKind.AUTO : PrefetchKind.FULL
 
     if (process.env.NODE_ENV !== 'production') {
       function createPropError(args: {
@@ -438,34 +394,8 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
       })
     }
 
-    if (process.env.NODE_ENV !== 'production') {
-      if (isAppRouter && !asProp) {
-        let href: string | undefined
-        if (typeof hrefProp === 'string') {
-          href = hrefProp
-        } else if (
-          typeof hrefProp === 'object' &&
-          typeof hrefProp.pathname === 'string'
-        ) {
-          href = hrefProp.pathname
-        }
-
-        if (href) {
-          const hasDynamicSegment = href
-            .split('/')
-            .some((segment) => segment.startsWith('[') && segment.endsWith(']'))
-
-          if (hasDynamicSegment) {
-            throw new Error(
-              `Dynamic href \`${href}\` found in <Link> while using the \`/app\` router, this is not supported. Read more: https://nextjs.org/docs/messages/app-dir-dynamic-href`
-            )
-          }
-        }
-      }
-    }
-
     const { href, as } = React.useMemo(() => {
-      if (!pagesRouter) {
+      if (!router) {
         const resolvedHref = formatStringOrUrl(hrefProp)
         return {
           href: resolvedHref,
@@ -473,19 +403,13 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
         }
       }
 
-      const [resolvedHref, resolvedAs] = resolveHref(
-        pagesRouter,
-        hrefProp,
-        true
-      )
+      const [resolvedHref, resolvedAs] = resolveHref(router, hrefProp, true)
 
       return {
         href: resolvedHref,
-        as: asProp
-          ? resolveHref(pagesRouter, asProp)
-          : resolvedAs || resolvedHref,
+        as: asProp ? resolveHref(router, asProp) : resolvedAs || resolvedHref,
       }
-    }, [pagesRouter, hrefProp, asProp])
+    }, [router, hrefProp, asProp])
 
     const previousHref = React.useRef<string>(href)
     const previousAs = React.useRef<string>(as)
@@ -573,27 +497,8 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
       }
 
       // Prefetch the URL.
-      prefetch(
-        router,
-        href,
-        as,
-        { locale },
-        {
-          kind: appPrefetchKind,
-        },
-        isAppRouter
-      )
-    }, [
-      as,
-      href,
-      isVisible,
-      locale,
-      prefetchEnabled,
-      pagesRouter?.locale,
-      router,
-      isAppRouter,
-      appPrefetchKind,
-    ])
+      prefetch(router, href, as, { locale })
+    }, [as, href, isVisible, locale, prefetchEnabled, router?.locale, router])
 
     const childProps: {
       onTouchStart?: React.TouchEventHandler<HTMLAnchorElement>
@@ -632,17 +537,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
           return
         }
 
-        linkClicked(
-          e,
-          router,
-          href,
-          as,
-          replace,
-          shallow,
-          scroll,
-          locale,
-          isAppRouter
-        )
+        linkClicked(e, router, href, as, replace, shallow, scroll, locale)
       },
       onMouseEnter(e) {
         if (!legacyBehavior && typeof onMouseEnterProp === 'function') {
@@ -661,28 +556,12 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
           return
         }
 
-        if (
-          (!prefetchEnabled || process.env.NODE_ENV === 'development') &&
-          isAppRouter
-        ) {
-          return
-        }
-
-        prefetch(
-          router,
-          href,
-          as,
-          {
-            locale,
-            priority: true,
-            // @see {https://github.com/vercel/next.js/discussions/40268?sort=top#discussioncomment-3572642}
-            bypassPrefetchedCheck: true,
-          },
-          {
-            kind: appPrefetchKind,
-          },
-          isAppRouter
-        )
+        prefetch(router, href, as, {
+          locale,
+          priority: true,
+          // @see {https://github.com/vercel/next.js/discussions/40268?sort=top#discussioncomment-3572642}
+          bypassPrefetchedCheck: true,
+        })
       },
       onTouchStart: process.env.__NEXT_LINK_NO_TOUCH_START
         ? undefined
@@ -703,25 +582,12 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
               return
             }
 
-            if (!prefetchEnabled && isAppRouter) {
-              return
-            }
-
-            prefetch(
-              router,
-              href,
-              as,
-              {
-                locale,
-                priority: true,
-                // @see {https://github.com/vercel/next.js/discussions/40268?sort=top#discussioncomment-3572642}
-                bypassPrefetchedCheck: true,
-              },
-              {
-                kind: appPrefetchKind,
-              },
-              isAppRouter
-            )
+            prefetch(router, href, as, {
+              locale,
+              priority: true,
+              // @see {https://github.com/vercel/next.js/discussions/40268?sort=top#discussioncomment-3572642}
+              bypassPrefetchedCheck: true,
+            })
           },
     }
 
@@ -735,23 +601,17 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
       passHref ||
       (child.type === 'a' && !('href' in child.props))
     ) {
-      const curLocale =
-        typeof locale !== 'undefined' ? locale : pagesRouter?.locale
+      const curLocale = typeof locale !== 'undefined' ? locale : router?.locale
 
       // we only render domain locales if we are currently on a domain locale
       // so that locale links are still visitable in development/preview envs
       const localeDomain =
-        pagesRouter?.isLocaleDomain &&
-        getDomainLocale(
-          as,
-          curLocale,
-          pagesRouter?.locales,
-          pagesRouter?.domainLocales
-        )
+        router?.isLocaleDomain &&
+        getDomainLocale(as, curLocale, router?.locales, router?.domainLocales)
 
       childProps.href =
         localeDomain ||
-        addBasePath(addLocale(as, curLocale, pagesRouter?.defaultLocale))
+        addBasePath(addLocale(as, curLocale, router?.defaultLocale))
     }
 
     return legacyBehavior ? (


### PR DESCRIPTION
This follows up the work from #73019 to update the implementations for the forked Link components to remove Pages specific handling in the App link, and App specific handling in the Pages link.