### PR TITLE
docs(sitemap): remove extra 's'

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/sitemap.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/sitemap.mdx
@@ -41,7 +41,7 @@ For smaller applications, you can create a `sitemap.xml` file and place it in th
 
 You can use the `sitemap.(js|ts)` file convention to programmatically **generate** a sitemap by exporting a default function that returns an array of URLs. If using TypeScript, a [`Sitemap`](#returns) type is available.
 
-> **Good to know**: `sitemap.js` is a special Route Handlers that is cached by default unless it uses a [Dynamic API](/docs/app/building-your-application/caching#dynamic-apis) or [dynamic config](/docs/app/building-your-application/caching#segment-config-options) option.
+> **Good to know**: `sitemap.js` is a special Route Handler that is cached by default unless it uses a [Dynamic API](/docs/app/building-your-application/caching#dynamic-apis) or [dynamic config](/docs/app/building-your-application/caching#segment-config-options) option.
 
 ```ts filename="app/sitemap.ts" switcher
 import type { MetadataRoute } from 'next'


### PR DESCRIPTION
## Why?

There's a typo in the note—Route Handler should be singular.