### PR TITLE
Turbopack: don't compute all paths for builds

### DIFF
--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -252,10 +252,14 @@ impl Endpoint for InstrumentationEndpoint {
             let _ = output_assets.resolve().await?;
             let _ = this.project.emit_all_output_assets(Vc::cell(output_assets));
 
-            let node_root = this.project.node_root();
-            let server_paths = all_server_paths(output_assets, node_root)
-                .await?
-                .clone_value();
+            let server_paths = if this.project.next_mode().await?.is_development() {
+                let node_root = this.project.node_root();
+                all_server_paths(output_assets, node_root)
+                    .await?
+                    .clone_value()
+            } else {
+                vec![]
+            };
 
             Ok(WrittenEndpoint::Edge {
                 server_paths,

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -279,18 +279,23 @@ impl Endpoint for MiddlewareEndpoint {
             let _ = output_assets.resolve().await?;
             let _ = this.project.emit_all_output_assets(Vc::cell(output_assets));
 
-            let node_root = this.project.node_root();
-            let server_paths = all_server_paths(output_assets, node_root)
-                .await?
-                .clone_value();
+            let (server_paths, client_paths) = if this.project.next_mode().await?.is_development() {
+                let node_root = this.project.node_root();
+                let server_paths = all_server_paths(output_assets, node_root)
+                    .await?
+                    .clone_value();
 
-            // Middleware could in theory have a client path (e.g. `new URL`).
-            let client_relative_root = this.project.client_relative_path();
-            let client_paths = all_paths_in_root(output_assets, client_relative_root)
-                .into_future()
-                .instrument(tracing::info_span!("client_paths"))
-                .await?
-                .clone_value();
+                // Middleware could in theory have a client path (e.g. `new URL`).
+                let client_relative_root = this.project.client_relative_path();
+                let client_paths = all_paths_in_root(output_assets, client_relative_root)
+                    .into_future()
+                    .instrument(tracing::info_span!("client_paths"))
+                    .await?
+                    .clone_value();
+                (server_paths, client_paths)
+            } else {
+                (vec![], vec![])
+            };
 
             Ok(WrittenEndpoint::Edge {
                 server_paths,

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1275,16 +1275,28 @@ impl Endpoint for PageEndpoint {
                 .emit_all_output_assets(Vc::cell(output_assets));
 
             let node_root = this.pages_project.project().node_root();
-            let server_paths = all_server_paths(output_assets, node_root)
-                .await?
-                .clone_value();
 
-            let client_relative_root = this.pages_project.project().client_relative_path();
-            let client_paths = all_paths_in_root(output_assets, client_relative_root)
-                .into_future()
-                .instrument(tracing::info_span!("client_paths"))
+            let (server_paths, client_paths) = if this
+                .pages_project
+                .project()
+                .next_mode()
                 .await?
-                .clone_value();
+                .is_development()
+            {
+                let server_paths = all_server_paths(output_assets, node_root)
+                    .await?
+                    .clone_value();
+
+                let client_relative_root = this.pages_project.project().client_relative_path();
+                let client_paths = all_paths_in_root(output_assets, client_relative_root)
+                    .into_future()
+                    .instrument(tracing::info_span!("client_paths"))
+                    .await?
+                    .clone_value();
+                (server_paths, client_paths)
+            } else {
+                (vec![], vec![])
+            };
 
             let node_root = &node_root.await?;
             let written_endpoint = match *output {


### PR DESCRIPTION
Depends on https://github.com/vercel/next.js/pull/73010

A very small speedup, mostly noticeable in cpu time, not really in wall time
```
before:
    504.86s user 73.31s system 792% cpu 1:12.93 total
    522.09s user 76.70s system 778% cpu 1:16.94 total
    503.73s user 68.78s system 818% cpu 1:09.92 total
after: 
    471.20s user 61.73s system 757% cpu 1:10.33 total
    481.69s user 69.05s system 805% cpu 1:08.33 total
```

Closes PACK-3541