### PR TITLE
docs: missing `await` when using params

### DIFF
--- a/docs/01-app/02-building-your-application/02-data-fetching/04-incremental-static-regeneration.mdx
+++ b/docs/01-app/02-building-your-application/02-data-fetching/04-incremental-static-regeneration.mdx
@@ -48,7 +48,12 @@ export async function generateStaticParams() {
   }))
 }
 
-export default async function Page({ params }: { params: { id: string } }) {
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const id = (await params).id
   const post: Post = await fetch(
     `https://api.vercel.app/blog/${params.id}`
   ).then((res) => res.json())


### PR DESCRIPTION
Hi, Team.
I'm adding `await` when using params as it will cause build to fail.

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide
