### PR TITLE
docs: incorrect `params.id`

### DIFF
--- a/docs/01-app/02-building-your-application/02-data-fetching/04-incremental-static-regeneration.mdx
+++ b/docs/01-app/02-building-your-application/02-data-fetching/04-incremental-static-regeneration.mdx
@@ -54,9 +54,9 @@ export default async function Page({
   params: Promise<{ id: string }>
 }) {
   const id = (await params).id
-  const post: Post = await fetch(
-    `https://api.vercel.app/blog/${params.id}`
-  ).then((res) => res.json())
+  const post: Post = await fetch(`https://api.vercel.app/blog/${id}`).then(
+    (res) => res.json()
+  )
   return (
     <main>
       <h1>{post.title}</h1>


### PR DESCRIPTION
Following https://github.com/vercel/next.js/pull/73044
I just found that `params.id` is not correct.
Thank you!