### PR TITLE
Turbopack: find_actions layout segment optimization

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1642,9 +1642,15 @@ impl Endpoint for AppEndpoint {
                 .clone_value();
 
             let client_relative_root = this.app_project.project().client_relative_path();
-            let client_paths = all_paths_in_root(output_assets, client_relative_root)
-                .await?
-                .clone_value();
+            let client_paths = async {
+                anyhow::Ok(
+                    all_paths_in_root(output_assets, client_relative_root)
+                        .await?
+                        .clone_value(),
+                )
+            }
+            .instrument(tracing::info_span!("client_paths"))
+            .await?;
 
             let written_endpoint = match *output {
                 AppEndpointOutput::NodeJs { rsc_chunk, .. } => WrittenEndpoint::NodeJs {

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -252,10 +252,14 @@ impl Endpoint for InstrumentationEndpoint {
             let _ = output_assets.resolve().await?;
             let _ = this.project.emit_all_output_assets(Vc::cell(output_assets));
 
-            let node_root = this.project.node_root();
-            let server_paths = all_server_paths(output_assets, node_root)
-                .await?
-                .clone_value();
+            let server_paths = if this.project.next_mode().await?.is_development() {
+                let node_root = this.project.node_root();
+                all_server_paths(output_assets, node_root)
+                    .await?
+                    .clone_value()
+            } else {
+                vec![]
+            };
 
             Ok(WrittenEndpoint::Edge {
                 server_paths,

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -277,22 +277,27 @@ impl Endpoint for MiddlewareEndpoint {
             let _ = output_assets.resolve().await?;
             let _ = this.project.emit_all_output_assets(Vc::cell(output_assets));
 
-            let node_root = this.project.node_root();
-            let server_paths = all_server_paths(output_assets, node_root)
-                .await?
-                .clone_value();
+            let (server_paths, client_paths) = if this.project.next_mode().await?.is_development() {
+                let node_root = this.project.node_root();
+                let server_paths = all_server_paths(output_assets, node_root)
+                    .await?
+                    .clone_value();
 
-            // Middleware could in theory have a client path (e.g. `new URL`).
-            let client_relative_root = this.project.client_relative_path();
-            let client_paths = async {
-                anyhow::Ok(
-                    all_paths_in_root(output_assets, client_relative_root)
-                        .await?
-                        .clone_value(),
-                )
-            }
-            .instrument(tracing::info_span!("client_paths"))
-            .await?;
+                // Middleware could in theory have a client path (e.g. `new URL`).
+                let client_relative_root = this.project.client_relative_path();
+                let client_paths = async {
+                    anyhow::Ok(
+                        all_paths_in_root(output_assets, client_relative_root)
+                            .await?
+                            .clone_value(),
+                    )
+                }
+                .instrument(tracing::info_span!("client_paths"))
+                .await?;
+                (server_paths, client_paths)
+            } else {
+                (vec![], vec![])
+            };
 
             Ok(WrittenEndpoint::Edge {
                 server_paths,

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -284,9 +284,15 @@ impl Endpoint for MiddlewareEndpoint {
 
             // Middleware could in theory have a client path (e.g. `new URL`).
             let client_relative_root = this.project.client_relative_path();
-            let client_paths = all_paths_in_root(output_assets, client_relative_root)
-                .await?
-                .clone_value();
+            let client_paths = async {
+                anyhow::Ok(
+                    all_paths_in_root(output_assets, client_relative_root)
+                        .await?
+                        .clone_value(),
+                )
+            }
+            .instrument(tracing::info_span!("client_paths"))
+            .await?;
 
             Ok(WrittenEndpoint::Edge {
                 server_paths,

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1278,9 +1278,15 @@ impl Endpoint for PageEndpoint {
                 .clone_value();
 
             let client_relative_root = this.pages_project.project().client_relative_path();
-            let client_paths = all_paths_in_root(output_assets, client_relative_root)
-                .await?
-                .clone_value();
+            let client_paths = async {
+                anyhow::Ok(
+                    all_paths_in_root(output_assets, client_relative_root)
+                        .await?
+                        .clone_value(),
+                )
+            }
+            .instrument(tracing::info_span!("client_paths"))
+            .await?;
 
             let node_root = &node_root.await?;
             let written_endpoint = match *output {

--- a/crates/next-api/src/paths.rs
+++ b/crates/next-api/src/paths.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use next_core::{all_assets_from_entries, next_manifests::AssetBinding};
 use serde::{Deserialize, Serialize};
+use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{trace::TraceRawVcs, ResolvedVc, TryFlatJoinIterExt, Vc};
 use turbo_tasks_fs::FileSystemPath;
@@ -29,30 +30,35 @@ pub async fn all_server_paths(
     assets: Vc<OutputAssets>,
     node_root: Vc<FileSystemPath>,
 ) -> Result<Vc<ServerPaths>> {
-    let all_assets = all_assets_from_entries(assets).await?;
-    let node_root = &node_root.await?;
-    Ok(Vc::cell(
-        all_assets
-            .iter()
-            .map(|&asset| async move {
-                Ok(
-                    if let Some(path) = node_root.get_path_to(&*asset.ident().path().await?) {
-                        let content_hash = match *asset.content().await? {
-                            AssetContent::File(file) => *file.hash().await?,
-                            AssetContent::Redirect { .. } => 0,
-                        };
-                        Some(ServerPath {
-                            path: path.to_string(),
-                            content_hash,
-                        })
-                    } else {
-                        None
-                    },
-                )
-            })
-            .try_flat_join()
-            .await?,
-    ))
+    let span = tracing::info_span!("all_server_paths");
+    async move {
+        let all_assets = all_assets_from_entries(assets).await?;
+        let node_root = &node_root.await?;
+        Ok(Vc::cell(
+            all_assets
+                .iter()
+                .map(|&asset| async move {
+                    Ok(
+                        if let Some(path) = node_root.get_path_to(&*asset.ident().path().await?) {
+                            let content_hash = match *asset.content().await? {
+                                AssetContent::File(file) => *file.hash().await?,
+                                AssetContent::Redirect { .. } => 0,
+                            };
+                            Some(ServerPath {
+                                path: path.to_string(),
+                                content_hash,
+                            })
+                        } else {
+                            None
+                        },
+                    )
+                })
+                .try_flat_join()
+                .await?,
+        ))
+    }
+    .instrument(span)
+    .await
 }
 
 /// Return a list of relative paths to `root` for all output assets references

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, io::Write, iter::once};
+use std::{collections::BTreeMap, future::Future, io::Write, iter::once};
 
 use anyhow::{bail, Context, Result};
 use indexmap::map::Entry;
@@ -16,11 +16,11 @@ use swc_core::{
         utils::find_pat_ids,
     },
 };
-use tracing::Instrument;
+use tracing::{Instrument, Level};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    graph::{GraphTraversal, NonDeterministic},
-    FxIndexMap, ResolvedVc, TryFlatJoinIterExt, Value, ValueToString, Vc,
+    graph::{GraphTraversal, NonDeterministic, VisitControlFlow},
+    FxIndexMap, ReadRef, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Value, ValueToString, Vc,
 };
 use turbo_tasks_fs::{self, rope::RopeBuilder, File, FileSystemPath};
 use turbopack_core::{
@@ -65,7 +65,7 @@ pub(crate) async fn create_server_actions_manifest(
     asset_context: Vc<Box<dyn AssetContext>>,
     chunking_context: Vc<Box<dyn ChunkingContext>>,
 ) -> Result<Vc<ServerActionsManifest>> {
-    let actions = get_actions(rsc_entry, server_reference_modules, asset_context);
+    let actions = find_actions(rsc_entry, server_reference_modules, asset_context);
     let loader =
         build_server_actions_loader(project_path, page_name.clone(), actions, asset_context);
     let evaluable = Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(loader)
@@ -185,7 +185,7 @@ async fn build_manifest(
 /// comment which identifies server actions. Every found server action will be
 /// returned along with the module which exports that action.
 #[turbo_tasks::function]
-async fn get_actions(
+async fn find_actions(
     rsc_entry: ResolvedVc<Box<dyn Module>>,
     server_reference_modules: Vc<Modules>,
     asset_context: Vc<Box<dyn AssetContext>>,
@@ -194,13 +194,22 @@ async fn get_actions(
         let actions = NonDeterministic::new()
             .skip_duplicates()
             .visit(
-                once((ActionLayer::Rsc, rsc_entry)).chain(
+                once((
+                    ActionLayer::Rsc,
+                    rsc_entry,
+                    rsc_entry.ident().to_string().await?,
+                ))
+                .chain(
                     server_reference_modules
                         .await?
                         .iter()
-                        .map(|m| (ActionLayer::ActionBrowser, *m)),
+                        .map(|m| async move {
+                            Ok((ActionLayer::ActionBrowser, *m, m.ident().to_string().await?))
+                        })
+                        .try_join()
+                        .await?,
                 ),
-                get_referenced_modules,
+                FindActionsVisit {},
             )
             .await
             .completed()?
@@ -214,7 +223,7 @@ async fn get_actions(
         // to use the RSC layer's module. We do that by merging the hashes (which match
         // in both layers) and preferring the RSC layer's action.
         let mut all_actions: HashToLayerNameModule = FxIndexMap::default();
-        for ((layer, module), actions_map) in actions.iter() {
+        for ((layer, module, _), actions_map) in actions.iter() {
             let module = if *layer == ActionLayer::Rsc {
                 *module
             } else {
@@ -242,6 +251,46 @@ async fn get_actions(
     .await
 }
 
+type FindActionsNode = (ActionLayer, ResolvedVc<Box<dyn Module>>, ReadRef<RcStr>);
+struct FindActionsVisit {}
+impl turbo_tasks::graph::Visit<FindActionsNode> for FindActionsVisit {
+    type Edge = FindActionsNode;
+    type EdgesIntoIter = impl Iterator<Item = FindActionsNode>;
+    type EdgesFuture = impl Future<Output = Result<Self::EdgesIntoIter>>;
+
+    fn visit(&mut self, edge: Self::Edge) -> VisitControlFlow<Self::Edge> {
+        VisitControlFlow::Continue(edge)
+    }
+
+    fn edges(&mut self, node: &Self::Edge) -> Self::EdgesFuture {
+        get_referenced_modules(node.clone())
+    }
+
+    fn span(&mut self, node: &Self::Edge) -> tracing::Span {
+        let (_, _, name) = node;
+        tracing::span!(
+            Level::INFO,
+            "find server actions visit",
+            name = display(name)
+        )
+    }
+}
+
+/// Our graph traversal visitor, which finds the primary modules directly
+/// referenced by parent.
+async fn get_referenced_modules(
+    (layer, module, _): FindActionsNode,
+) -> Result<impl Iterator<Item = FindActionsNode> + Send> {
+    let modules = primary_referenced_modules(*module).await?;
+
+    Ok(modules
+        .into_iter()
+        .map(move |&m| async move { Ok((layer, m, m.ident().to_string().await?)) })
+        .try_join()
+        .await?
+        .into_iter())
+}
+
 /// The ActionBrowser layer's module is in the Client context, and we need to
 /// bring it into the RSC context.
 async fn to_rsc_context(
@@ -260,16 +309,6 @@ async fn to_rsc_context(
         .to_resolved()
         .await?;
     Ok(module)
-}
-
-/// Our graph traversal visitor, which finds the primary modules directly
-/// referenced by parent.
-async fn get_referenced_modules(
-    (layer, module): (ActionLayer, ResolvedVc<Box<dyn Module>>),
-) -> Result<impl Iterator<Item = (ActionLayer, ResolvedVc<Box<dyn Module>>)> + Send> {
-    primary_referenced_modules(*module)
-        .await
-        .map(|modules| modules.into_iter().map(move |&m| (layer, m)))
 }
 
 /// Parses the Server Actions comment for all exported action function names.
@@ -417,12 +456,12 @@ fn all_export_names(program: &Program) -> Vec<Atom> {
 /// Converts our cached [parse_actions] call into a data type suitable for
 /// collecting into a flat-mapped [FxIndexMap].
 async fn parse_actions_filter_map(
-    (layer, module): (ActionLayer, ResolvedVc<Box<dyn Module>>),
-) -> Result<Option<((ActionLayer, ResolvedVc<Box<dyn Module>>), Vc<ActionMap>)>> {
+    (layer, module, name): FindActionsNode,
+) -> Result<Option<(FindActionsNode, Vc<ActionMap>)>> {
     parse_actions(*module).await.map(|option_action_map| {
         option_action_map
             .clone_value()
-            .map(|action_map| ((layer, module), action_map))
+            .map(|action_map| ((layer, module, name), action_map))
     })
 }
 

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -97,7 +97,7 @@ pub(crate) async fn create_server_actions_manifest(
 
         for module in server_component_entries {
             let refs = client_references_by_server_component
-                .get(&None)
+                .get(&Some(*module))
                 .map_or(&[] as &[_], |vec| vec.as_slice())
                 .iter()
                 .map(|r| async move { Ok(Vc::upcast(*r.await?.ssr_module)) })

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -100,7 +100,7 @@ pub(crate) async fn create_server_actions_manifest(
                 .get(&Some(*module))
                 .map_or(&[] as &[_], |vec| vec.as_slice())
                 .iter()
-                .map(|r| async move { Ok(Vc::upcast(*r.await?.ssr_module)) })
+                .map(|r| async move { Ok(Vc::upcast(*r.await?.client_module)) })
                 .try_join()
                 .await?;
             let current_actions = find_actions(

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -6,7 +6,7 @@ use turbo_tasks::{
 };
 use turbopack_core::{
     chunk::{availability_info::AvailabilityInfo, ChunkingContext, ChunkingContextExt},
-    module::{Module, Modules},
+    module::Module,
     output::OutputAssets,
 };
 
@@ -14,7 +14,6 @@ use super::include_modules_module::IncludeModulesModule;
 use crate::{
     next_client_reference::{
         visit_client_reference::ClientReferenceGraphResult, ClientReferenceType,
-        ClientReferenceTypes,
     },
     next_server_component::server_component_module::NextServerComponentModule,
 };
@@ -315,36 +314,4 @@ pub async fn get_app_client_references_chunks(
     }
     .instrument(tracing::info_span!("process client references"))
     .await
-}
-
-/// Crawls all modules emitted in the client transition, returning a list of all
-/// client JS modules.
-#[turbo_tasks::function]
-pub async fn get_app_server_reference_modules(
-    app_client_reference_types: Vc<ClientReferenceTypes>,
-) -> Result<Vc<Modules>> {
-    Ok(Vc::cell(
-        app_client_reference_types
-            .await?
-            .iter()
-            .map(|client_reference_ty| async move {
-                Ok(match client_reference_ty {
-                    ClientReferenceType::EcmascriptClientReference {
-                        module: ecmascript_client_reference,
-                        ..
-                    } => {
-                        let ecmascript_client_reference_ref = ecmascript_client_reference.await?;
-                        Some(ResolvedVc::upcast(
-                            ecmascript_client_reference_ref
-                                .client_module
-                                .to_resolved()
-                                .await?,
-                        ))
-                    }
-                    _ => None,
-                })
-            })
-            .try_flat_join()
-            .await?,
-    ))
 }

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -53,10 +53,8 @@ pub enum ClientReferenceType {
 #[derive(Clone, Debug)]
 pub struct ClientReferenceGraphResult {
     pub client_references: Vec<ClientReference>,
-    /// Only the [`ClientReferenceType::EcmascriptClientReference`]s are listed in this map.
-    #[allow(clippy::type_complexity)]
     pub client_references_by_server_component:
-        FxIndexMap<Option<Vc<NextServerComponentModule>>, Vec<Vc<Box<dyn Module>>>>,
+        FxIndexMap<Option<Vc<NextServerComponentModule>>, Vec<Vc<EcmascriptClientReferenceModule>>>,
     pub server_component_entries: Vec<Vc<NextServerComponentModule>>,
     pub server_utils: Vec<Vc<Box<dyn Module>>>,
     pub visited_nodes: Vc<VisitedClientReferenceGraphNodes>,
@@ -187,9 +185,7 @@ pub async fn client_reference_graph(
                         client_references_by_server_component
                             .entry(client_reference.server_component)
                             .or_insert_with(Vec::new)
-                            .push(*ResolvedVc::upcast::<Box<dyn Module>>(
-                                entry.await?.ssr_module,
-                            ));
+                            .push(entry);
                     }
                 }
                 VisitClientReferenceNodeType::ServerUtilEntry(server_util, _) => {


### PR DESCRIPTION
Depends on https://github.com/vercel/next.js/pull/73036

Testing using vercel-marketing:
```
before:
    416.31s user 54.20s system 700% cpu 1:07.13 total    
    423.41s user 55.50s system 762% cpu 1:02.80 total
    397.76s user 56.07s system 856% cpu 52.968 total
    410.00s user 58.71s system 796% cpu 58.852 total
after:
    386.88s user 53.57s system 824% cpu 53.410 total
    390.92s user 61.66s system 724% cpu 1:02.48 total
    395.85s user 62.64s system 656% cpu 1:09.84
    389.90s user 52.85s system 802% cpu 55.164 total
```
So about 2.5% faster in CPU time

Closes PACK-3598