### PR TITLE
remove locale from app link

### DIFF
--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -83,6 +83,7 @@ type InternalLinkProps = {
   /**
    * The active locale is automatically prepended. `locale` allows for providing a different locale.
    * When `false` `href` has to include the locale as the default behavior is disabled.
+   * Note: This is only available in the Pages Router.
    */
   locale?: string | false
   /**

--- a/test/e2e/app-dir/navigation/app/locale-app/page.js
+++ b/test/e2e/app-dir/navigation/app/locale-app/page.js
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <>
+      <Link href="/about" locale="en">
+        Link 1
+      </Link>
+      <Link href="/about" locale="fr">
+        Link 2
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -974,4 +974,27 @@ describe('app dir - navigation', () => {
       )
     })
   })
+
+  if (isNextDev) {
+    describe('locale warnings', () => {
+      it('should warn about using the `locale` prop with `next/link` in app router', async () => {
+        const browser = await next.browser('/locale-app')
+        const logs = await browser.log()
+        expect(logs).toContainEqual(
+          expect.objectContaining({
+            message: expect.stringContaining(
+              'The `locale` prop is not supported in `next/link` while using the `app` router.'
+            ),
+            source: 'warning',
+          })
+        )
+      })
+
+      it('should have no warnings in pages router', async () => {
+        const browser = await next.browser('/locale-pages')
+        const logs = await browser.log()
+        expect(logs.filter((log) => log.source === 'warning')).toHaveLength(0)
+      })
+    })
+  }
 })

--- a/test/e2e/app-dir/navigation/pages/locale-pages.js
+++ b/test/e2e/app-dir/navigation/pages/locale-pages.js
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <>
+      <Link href="/about" locale="en">
+        Link 1
+      </Link>
+      <Link href="/about" locale="fr">
+        Link 2
+      </Link>
+    </>
+  )
+}


### PR DESCRIPTION
This prop is a no-op in app router. This removes the code that handled it for the App Router link, and adds a warning for apps that are attempting to use it in an app router context. 