### PR TITLE
Revert "docs: add Fleek's Next.js template"

### DIFF
--- a/docs/01-app/02-building-your-application/10-deploying/index.mdx
+++ b/docs/01-app/02-building-your-application/10-deploying/index.mdx
@@ -37,7 +37,6 @@ We have community maintained deployment examples with the following providers:
 
 - [Deno](https://github.com/nextjs/deploy-deno)
 - [DigitalOcean](https://github.com/nextjs/deploy-digitalocean)
-- [Fleek](https://github.com/fleek-tools/fleek-nextjs-boilerplate)
 - [Flightcontrol](https://github.com/nextjs/deploy-flightcontrol)
 - [Fly.io](https://github.com/nextjs/deploy-fly)
 - [GitHub Pages](https://github.com/nextjs/deploy-github-pages)


### PR DESCRIPTION
Reverts vercel/next.js#72988

Right now, we're focused on making sure the examples linked are guaranteed to work and placed inside the Next.js community GitHub organization.