### PR TITLE
Method/function props of exported objects are not server functions

### DIFF
--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/56/input.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/56/input.js
@@ -1,0 +1,13 @@
+'use cache'
+
+// No method nor function property should be considered a cache function.
+export const obj = {
+  foo() {
+    return 1
+  },
+  async bar() {
+    return 2
+  },
+  baz: () => 2,
+  qux: async () => 3,
+}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/56/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/56/output.js
@@ -1,0 +1,14 @@
+/* __next_internal_action_entry_do_not_use__ {} */ import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
+// No method nor function property should be considered a cache function.
+export const obj = {
+    foo () {
+        return 1;
+    },
+    async bar () {
+        return 2;
+    },
+    baz: ()=>2,
+    qux: async ()=>3
+};


### PR DESCRIPTION
This is a follow-up fix for #72969. Method or function properties of exported objects in `"use cache"` or `"use server"` files must not be compiled into server functions, unless they have an inline server directive.