### PR TITLE
Forbid `this` and `arguments` in server functions

### DIFF
--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -2854,7 +2854,7 @@ fn emit_error(error_kind: ServerActionsErrorKind) {
             span,
             formatdoc! {
                 r#"
-                    {subject} can not use `{expr}`.
+                    {subject} cannot use `{expr}`.
                 "#,
                 subject = if let Directive::UseServer = directive {
                     "Server Actions"

--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -1275,7 +1275,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
     fn visit_mut_call_expr(&mut self, n: &mut CallExpr) {
         if let Callee::Expr(box Expr::Ident(Ident { sym, .. })) = &mut n.callee {
             if sym == "jsxDEV" || sym == "_jsxDEV" {
-                // Do not visit the 6th arg in a generated jsxDEV call, which is a `this` exression,
+                // Do not visit the 6th arg in a generated jsxDEV call, which is a `this` expression,
                 // to avoid emitting an error for using `this` if it's inside of a server function.
                 // https://github.com/facebook/react/blob/9106107/packages/react/src/jsx/ReactJSXElement.js#L429
                 if n.args.len() > 4 {

--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -47,10 +47,21 @@ enum DirectiveLocation {
 }
 
 #[derive(Clone, Debug)]
+enum ThisStatus {
+    Allowed,
+    Forbidden { directive: Directive },
+}
+
+#[derive(Clone, Debug)]
 enum ServerActionsErrorKind {
     ExportedSyncFunction {
         span: Span,
         in_action_file: bool,
+    },
+    ForbiddenExpression {
+        span: Span,
+        expr: String,
+        directive: Directive,
     },
     InlineSyncFunction {
         span: Span,
@@ -113,6 +124,7 @@ pub fn server_actions<C: Comments>(file_name: &FileName, config: Config, comment
         in_callee: false,
         has_action: false,
         has_cache: false,
+        this_status: ThisStatus::Allowed,
 
         reference_index: 0,
         in_module_level: true,
@@ -163,6 +175,7 @@ struct ServerActions<C: Comments> {
     in_callee: bool,
     has_action: bool,
     has_cache: bool,
+    this_status: ThisStatus,
 
     reference_index: u32,
     in_module_level: bool,
@@ -931,6 +944,12 @@ impl<C: Comments> VisitMut for ServerActions<C> {
         let declared_idents_until = self.declared_idents.len();
         let current_names = take(&mut self.names);
 
+        if let Some(directive) = &directive {
+            self.this_status = ThisStatus::Forbidden {
+                directive: directive.clone(),
+            };
+        }
+
         // Visit children
         {
             let old_in_module = self.in_module_level;
@@ -1070,12 +1089,15 @@ impl<C: Comments> VisitMut for ServerActions<C> {
     }
 
     fn visit_mut_fn_decl(&mut self, f: &mut FnDecl) {
+        let old_this_status = self.this_status.clone();
+        self.this_status = ThisStatus::Allowed;
         let old_in_exported_expr = self.in_exported_expr;
         if self.in_module_level && self.exported_local_ids.contains(&f.ident.to_id()) {
             self.in_exported_expr = true
         }
         let old_fn_decl_ident = self.fn_decl_ident.replace(f.ident.clone());
         f.visit_mut_children_with(self);
+        self.this_status = old_this_status;
         self.in_exported_expr = old_in_exported_expr;
         self.fn_decl_ident = old_fn_decl_ident;
     }
@@ -1090,6 +1112,12 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                 None
             },
         );
+
+        if let Some(directive) = &directive {
+            self.this_status = ThisStatus::Forbidden {
+                directive: directive.clone(),
+            };
+        }
 
         let declared_idents_until = self.declared_idents.len();
         let current_names = take(&mut self.names);
@@ -1203,13 +1231,19 @@ impl<C: Comments> VisitMut for ServerActions<C> {
             }
             PropOrSpread::Prop(box Prop::Method(MethodProp { key, .. })) => {
                 let key = key.clone();
+
                 if let PropName::Ident(ident_name) = &key {
                     self.arrow_or_fn_expr_ident = Some(ident_name.clone().into());
                 }
+
+                let old_this_status = self.this_status.clone();
+                self.this_status = ThisStatus::Allowed;
                 self.rewrite_expr_to_proxy_expr = None;
                 self.in_exported_expr = false;
                 n.visit_mut_children_with(self);
                 self.in_exported_expr = old_in_exported_expr;
+                self.this_status = old_this_status;
+
                 if let Some(expr) = &self.rewrite_expr_to_proxy_expr {
                     *n = PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
                         key,
@@ -1217,6 +1251,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                     })));
                     self.rewrite_expr_to_proxy_expr = None;
                 }
+
                 return;
             }
             _ => {}
@@ -2027,6 +2062,28 @@ impl<C: Comments> VisitMut for ServerActions<C> {
         self.arrow_or_fn_expr_ident = old_arrow_or_fn_expr_ident;
     }
 
+    fn visit_mut_this_expr(&mut self, n: &mut ThisExpr) {
+        if let ThisStatus::Forbidden { directive } = &self.this_status {
+            emit_error(ServerActionsErrorKind::ForbiddenExpression {
+                span: n.span,
+                expr: "this".into(),
+                directive: directive.clone(),
+            });
+        }
+    }
+
+    fn visit_mut_ident(&mut self, n: &mut Ident) {
+        if n.sym == *"arguments" {
+            if let ThisStatus::Forbidden { directive } = &self.this_status {
+                emit_error(ServerActionsErrorKind::ForbiddenExpression {
+                    span: n.span,
+                    expr: "arguments".into(),
+                    directive: directive.clone(),
+                });
+            }
+        }
+    }
+
     noop_visit_mut_type!();
 }
 
@@ -2768,6 +2825,23 @@ fn emit_error(error_kind: ServerActionsErrorKind) {
                     "\"use server\""
                 } else {
                     "\"use cache\""
+                }
+            },
+        ),
+        ServerActionsErrorKind::ForbiddenExpression {
+            span,
+            expr,
+            directive,
+        } => (
+            span,
+            formatdoc! {
+                r#"
+                    {subject} can not use `{expr}`.
+                "#,
+                subject = if let Directive::UseServer = directive {
+                    "Server Actions"
+                } else {
+                    "\"use cache\" functions"
                 }
             },
         ),

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/22/input.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/22/input.js
@@ -1,0 +1,50 @@
+async function a() {
+  'use cache'
+  // this is not allowed here
+  this.foo()
+  // arguments is not allowed here
+  console.log(arguments)
+
+  const b = async () => {
+    // this is not allowed here
+    this.foo()
+    // arguments is not allowed here
+    console.log(arguments)
+  }
+
+  function c() {
+    // this is allowed here
+    this.foo()
+    // arguments is allowed here
+    console.log(arguments)
+
+    const d = () => {
+      // this is allowed here
+      this.foo()
+      // arguments is allowed here
+      console.log(arguments)
+    }
+
+    const e = async () => {
+      'use server'
+      // this is not allowed here
+      this.foo()
+      // arguments is not allowed here
+      console.log(arguments)
+    }
+  }
+}
+
+export const api = {
+  result: null,
+  product: {
+    async fetch() {
+      'use cache'
+
+      // this is not allowed here
+      this.result = await fetch('https://example.com').then((res) => res.json())
+      // arguments is not allowed here
+      console.log(arguments)
+    },
+  },
+}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/22/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/22/output.js
@@ -1,0 +1,55 @@
+/*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ /* __next_internal_action_entry_do_not_use__ {"006a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0","8069348c79fce073bae2f70f139565a2fda1c74c74":"$$RSC_SERVER_CACHE_2","80951c375b4a6a6e89d67b743ec5808127cfde405d":"$$RSC_SERVER_CACHE_1"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
+export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_0 = async function e() {
+    // this is not allowed here
+    this.foo();
+    // arguments is not allowed here
+    console.log(arguments);
+};
+export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", 0, async function a() {
+    // this is not allowed here
+    this.foo();
+    // arguments is not allowed here
+    console.log(arguments);
+    const b = async ()=>{
+        // this is not allowed here
+        this.foo();
+        // arguments is not allowed here
+        console.log(arguments);
+    };
+    function c() {
+        // this is allowed here
+        this.foo();
+        // arguments is allowed here
+        console.log(arguments);
+        const d = ()=>{
+            // this is allowed here
+            this.foo();
+            // arguments is allowed here
+            console.log(arguments);
+        };
+        const e = registerServerReference($$RSC_SERVER_ACTION_0, "006a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null);
+    }
+});
+Object.defineProperty($$RSC_SERVER_CACHE_1, "name", {
+    "value": "a",
+    "writable": false
+});
+var a = registerServerReference($$RSC_SERVER_CACHE_1, "80951c375b4a6a6e89d67b743ec5808127cfde405d", null);
+export var $$RSC_SERVER_CACHE_2 = $$cache__("default", "8069348c79fce073bae2f70f139565a2fda1c74c74", 0, /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ async function fetch1() {
+    // this is not allowed here
+    this.result = await fetch('https://example.com').then((res)=>res.json());
+    // arguments is not allowed here
+    console.log(arguments);
+});
+Object.defineProperty($$RSC_SERVER_CACHE_2, "name", {
+    "value": "fetch",
+    "writable": false
+});
+export const api = {
+    result: null,
+    product: {
+        fetch: registerServerReference($$RSC_SERVER_CACHE_2, "8069348c79fce073bae2f70f139565a2fda1c74c74", null)
+    }
+};

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/22/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/22/output.stderr
@@ -1,0 +1,63 @@
+  x "use cache" functions can not use `this`.
+  | 
+   ,-[input.js:4:1]
+ 3 |   // this is not allowed here
+ 4 |   this.foo()
+   :   ^^^^
+ 5 |   // arguments is not allowed here
+   `----
+  x "use cache" functions can not use `arguments`.
+  | 
+   ,-[input.js:6:1]
+ 5 |   // arguments is not allowed here
+ 6 |   console.log(arguments)
+   :               ^^^^^^^^^
+   `----
+  x "use cache" functions can not use `this`.
+  | 
+    ,-[input.js:10:1]
+  9 |     // this is not allowed here
+ 10 |     this.foo()
+    :     ^^^^
+ 11 |     // arguments is not allowed here
+    `----
+  x "use cache" functions can not use `arguments`.
+  | 
+    ,-[input.js:12:1]
+ 11 |     // arguments is not allowed here
+ 12 |     console.log(arguments)
+    :                 ^^^^^^^^^
+ 13 |   }
+    `----
+  x Server Actions can not use `this`.
+  | 
+    ,-[input.js:31:1]
+ 30 |       // this is not allowed here
+ 31 |       this.foo()
+    :       ^^^^
+ 32 |       // arguments is not allowed here
+    `----
+  x Server Actions can not use `arguments`.
+  | 
+    ,-[input.js:33:1]
+ 32 |       // arguments is not allowed here
+ 33 |       console.log(arguments)
+    :                   ^^^^^^^^^
+ 34 |     }
+    `----
+  x "use cache" functions can not use `this`.
+  | 
+    ,-[input.js:45:1]
+ 44 |       // this is not allowed here
+ 45 |       this.result = await fetch('https://example.com').then((res) => res.json())
+    :       ^^^^
+ 46 |       // arguments is not allowed here
+    `----
+  x "use cache" functions can not use `arguments`.
+  | 
+    ,-[input.js:47:1]
+ 46 |       // arguments is not allowed here
+ 47 |       console.log(arguments)
+    :                   ^^^^^^^^^
+ 48 |     },
+    `----

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/22/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/22/output.stderr
@@ -1,4 +1,4 @@
-  x "use cache" functions can not use `this`.
+  x "use cache" functions cannot use `this`.
   | 
    ,-[input.js:4:1]
  3 |   // this is not allowed here
@@ -6,14 +6,14 @@
    :   ^^^^
  5 |   // arguments is not allowed here
    `----
-  x "use cache" functions can not use `arguments`.
+  x "use cache" functions cannot use `arguments`.
   | 
    ,-[input.js:6:1]
  5 |   // arguments is not allowed here
  6 |   console.log(arguments)
    :               ^^^^^^^^^
    `----
-  x "use cache" functions can not use `this`.
+  x "use cache" functions cannot use `this`.
   | 
     ,-[input.js:10:1]
   9 |     // this is not allowed here
@@ -21,7 +21,7 @@
     :     ^^^^
  11 |     // arguments is not allowed here
     `----
-  x "use cache" functions can not use `arguments`.
+  x "use cache" functions cannot use `arguments`.
   | 
     ,-[input.js:12:1]
  11 |     // arguments is not allowed here
@@ -29,7 +29,7 @@
     :                 ^^^^^^^^^
  13 |   }
     `----
-  x Server Actions can not use `this`.
+  x Server Actions cannot use `this`.
   | 
     ,-[input.js:31:1]
  30 |       // this is not allowed here
@@ -37,7 +37,7 @@
     :       ^^^^
  32 |       // arguments is not allowed here
     `----
-  x Server Actions can not use `arguments`.
+  x Server Actions cannot use `arguments`.
   | 
     ,-[input.js:33:1]
  32 |       // arguments is not allowed here
@@ -45,7 +45,7 @@
     :                   ^^^^^^^^^
  34 |     }
     `----
-  x "use cache" functions can not use `this`.
+  x "use cache" functions cannot use `this`.
   | 
     ,-[input.js:45:1]
  44 |       // this is not allowed here
@@ -53,7 +53,7 @@
     :       ^^^^
  46 |       // arguments is not allowed here
     `----
-  x "use cache" functions can not use `arguments`.
+  x "use cache" functions cannot use `arguments`.
   | 
     ,-[input.js:47:1]
  46 |       // arguments is not allowed here

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/23/input.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/23/input.js
@@ -1,0 +1,29 @@
+'use cache'
+
+// not exported!
+async function a() {
+  // this is allowed here
+  this.foo()
+  // arguments is allowed here
+  console.log(arguments)
+
+  const b = async () => {
+    'use server'
+    // this is not allowed here
+    this.foo()
+    // arguments is not allowed here
+    console.log(arguments)
+  }
+}
+
+export const obj = {
+  foo() {
+    return 42
+  },
+  bar() {
+    // this is allowed here
+    this.foo()
+    // arguments is allowed here
+    console.log(arguments)
+  },
+}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/23/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/23/output.js
@@ -1,0 +1,28 @@
+/* __next_internal_action_entry_do_not_use__ {"006a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
+export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_0 = async function b() {
+    // this is not allowed here
+    this.foo();
+    // arguments is not allowed here
+    console.log(arguments);
+};
+// not exported!
+async function a() {
+    // this is allowed here
+    this.foo();
+    // arguments is allowed here
+    console.log(arguments);
+    const b = registerServerReference($$RSC_SERVER_ACTION_0, "006a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null);
+}
+export const obj = {
+    foo () {
+        return 42;
+    },
+    bar () {
+        // this is allowed here
+        this.foo();
+        // arguments is allowed here
+        console.log(arguments);
+    }
+};

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/23/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/23/output.stderr
@@ -1,4 +1,4 @@
-  x Server Actions can not use `this`.
+  x Server Actions cannot use `this`.
   | 
     ,-[input.js:13:1]
  12 |     // this is not allowed here
@@ -6,7 +6,7 @@
     :     ^^^^
  14 |     // arguments is not allowed here
     `----
-  x Server Actions can not use `arguments`.
+  x Server Actions cannot use `arguments`.
   | 
     ,-[input.js:15:1]
  14 |     // arguments is not allowed here

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/23/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/23/output.stderr
@@ -1,0 +1,16 @@
+  x Server Actions can not use `this`.
+  | 
+    ,-[input.js:13:1]
+ 12 |     // this is not allowed here
+ 13 |     this.foo()
+    :     ^^^^
+ 14 |     // arguments is not allowed here
+    `----
+  x Server Actions can not use `arguments`.
+  | 
+    ,-[input.js:15:1]
+ 14 |     // arguments is not allowed here
+ 15 |     console.log(arguments)
+    :                 ^^^^^^^^^
+ 16 |   }
+    `----

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/24/input.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/24/input.js
@@ -1,0 +1,38 @@
+'use cache'
+
+// exported!
+export async function a() {
+  // this is not allowed here
+  this.foo()
+  // arguments is not allowed here
+  console.log(arguments)
+
+  const b = async () => {
+    // this is not allowed here
+    this.foo()
+    // arguments is not allowed here
+    console.log(arguments)
+  }
+
+  function c() {
+    // this is allowed here
+    this.foo()
+    // arguments is allowed here
+    console.log(arguments)
+
+    const d = () => {
+      // this is allowed here
+      this.foo()
+      // arguments is allowed here
+      console.log(arguments)
+    }
+
+    const e = async () => {
+      'use server'
+      // this is not allowed here
+      this.foo()
+      // arguments is not allowed here
+      console.log(arguments)
+    }
+  }
+}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/24/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/24/output.js
@@ -1,0 +1,40 @@
+/* __next_internal_action_entry_do_not_use__ {"006a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0","80951c375b4a6a6e89d67b743ec5808127cfde405d":"$$RSC_SERVER_CACHE_1"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
+export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_0 = async function e() {
+    // this is not allowed here
+    this.foo();
+    // arguments is not allowed here
+    console.log(arguments);
+};
+export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", 0, /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ async function a() {
+    // this is not allowed here
+    this.foo();
+    // arguments is not allowed here
+    console.log(arguments);
+    const b = async ()=>{
+        // this is not allowed here
+        this.foo();
+        // arguments is not allowed here
+        console.log(arguments);
+    };
+    function c() {
+        // this is allowed here
+        this.foo();
+        // arguments is allowed here
+        console.log(arguments);
+        const d = ()=>{
+            // this is allowed here
+            this.foo();
+            // arguments is allowed here
+            console.log(arguments);
+        };
+        const e = registerServerReference($$RSC_SERVER_ACTION_0, "006a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null);
+    }
+});
+Object.defineProperty($$RSC_SERVER_CACHE_1, "name", {
+    "value": "a",
+    "writable": false
+});
+// exported!
+export var a = registerServerReference($$RSC_SERVER_CACHE_1, "80951c375b4a6a6e89d67b743ec5808127cfde405d", null);

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/24/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/24/output.stderr
@@ -1,0 +1,47 @@
+  x "use cache" functions can not use `this`.
+  | 
+   ,-[input.js:6:1]
+ 5 |   // this is not allowed here
+ 6 |   this.foo()
+   :   ^^^^
+ 7 |   // arguments is not allowed here
+   `----
+  x "use cache" functions can not use `arguments`.
+  | 
+   ,-[input.js:8:1]
+ 7 |   // arguments is not allowed here
+ 8 |   console.log(arguments)
+   :               ^^^^^^^^^
+   `----
+  x "use cache" functions can not use `this`.
+  | 
+    ,-[input.js:12:1]
+ 11 |     // this is not allowed here
+ 12 |     this.foo()
+    :     ^^^^
+ 13 |     // arguments is not allowed here
+    `----
+  x "use cache" functions can not use `arguments`.
+  | 
+    ,-[input.js:14:1]
+ 13 |     // arguments is not allowed here
+ 14 |     console.log(arguments)
+    :                 ^^^^^^^^^
+ 15 |   }
+    `----
+  x Server Actions can not use `this`.
+  | 
+    ,-[input.js:33:1]
+ 32 |       // this is not allowed here
+ 33 |       this.foo()
+    :       ^^^^
+ 34 |       // arguments is not allowed here
+    `----
+  x Server Actions can not use `arguments`.
+  | 
+    ,-[input.js:35:1]
+ 34 |       // arguments is not allowed here
+ 35 |       console.log(arguments)
+    :                   ^^^^^^^^^
+ 36 |     }
+    `----

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/24/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/24/output.stderr
@@ -1,4 +1,4 @@
-  x "use cache" functions can not use `this`.
+  x "use cache" functions cannot use `this`.
   | 
    ,-[input.js:6:1]
  5 |   // this is not allowed here
@@ -6,14 +6,14 @@
    :   ^^^^
  7 |   // arguments is not allowed here
    `----
-  x "use cache" functions can not use `arguments`.
+  x "use cache" functions cannot use `arguments`.
   | 
    ,-[input.js:8:1]
  7 |   // arguments is not allowed here
  8 |   console.log(arguments)
    :               ^^^^^^^^^
    `----
-  x "use cache" functions can not use `this`.
+  x "use cache" functions cannot use `this`.
   | 
     ,-[input.js:12:1]
  11 |     // this is not allowed here
@@ -21,7 +21,7 @@
     :     ^^^^
  13 |     // arguments is not allowed here
     `----
-  x "use cache" functions can not use `arguments`.
+  x "use cache" functions cannot use `arguments`.
   | 
     ,-[input.js:14:1]
  13 |     // arguments is not allowed here
@@ -29,7 +29,7 @@
     :                 ^^^^^^^^^
  15 |   }
     `----
-  x Server Actions can not use `this`.
+  x Server Actions cannot use `this`.
   | 
     ,-[input.js:33:1]
  32 |       // this is not allowed here
@@ -37,7 +37,7 @@
     :       ^^^^
  34 |       // arguments is not allowed here
     `----
-  x Server Actions can not use `arguments`.
+  x Server Actions cannot use `arguments`.
   | 
     ,-[input.js:35:1]
  34 |       // arguments is not allowed here


### PR DESCRIPTION
Accessing `this` or `arguments` in server functions is not allowed. With this PR, we are now emitting build errors in this case.