### PR TITLE
Handle server function directives in class methods

### DIFF
--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/25/input.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/25/input.js
@@ -1,0 +1,12 @@
+export class MyClass {
+  async foo() {
+    'use cache'
+
+    return fetch('https://example.com').then((res) => res.json())
+  }
+  async bar() {
+    'use server'
+
+    console.log(42)
+  }
+}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/25/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/25/output.js
@@ -1,0 +1,10 @@
+export class MyClass {
+    async foo() {
+        'use cache';
+        return fetch('https://example.com').then((res)=>res.json());
+    }
+    async bar() {
+        'use server';
+        console.log(42);
+    }
+}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/25/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/25/output.stderr
@@ -1,0 +1,24 @@
+  x It is not allowed to define inline "use cache" annotated class instance methods.
+  | To define cached functions, use functions, object method properties, or static class methods instead.
+  | 
+   ,-[input.js:2:1]
+ 1 |     export class MyClass {
+ 2 | ,->   async foo() {
+ 3 | |       'use cache'
+ 4 | |   
+ 5 | |       return fetch('https://example.com').then((res) => res.json())
+ 6 | `->   }
+ 7 |       async bar() {
+   `----
+  x It is not allowed to define inline "use server" annotated class instance methods.
+  | To define Server Actions, use functions, object method properties, or static class methods instead.
+  | 
+    ,-[input.js:7:1]
+  6 |       }
+  7 | ,->   async bar() {
+  8 | |       'use server'
+  9 | |   
+ 10 | |       console.log(42)
+ 11 | `->   }
+ 12 |     }
+    `----

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/26/input.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/26/input.js
@@ -1,0 +1,13 @@
+export class MyClass {
+  static async foo() {
+    return fetch('https://example.com').then((res) => res.json())
+  }
+  static async bar() {
+    'use cache'
+
+    // arguments is not allowed here
+    console.log(arguments)
+    // this is not allowed here
+    return this.foo()
+  }
+}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/26/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/26/output.js
@@ -1,0 +1,19 @@
+/* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ async function bar() {
+    // arguments is not allowed here
+    console.log(arguments);
+    // this is not allowed here
+    return this.foo();
+});
+Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+    "value": "bar",
+    "writable": false
+});
+export class MyClass {
+    static async foo() {
+        return fetch('https://example.com').then((res)=>res.json());
+    }
+    static bar = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
+}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/26/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/26/output.stderr
@@ -1,0 +1,16 @@
+  x "use cache" functions cannot use `arguments`.
+  | 
+    ,-[input.js:9:1]
+  8 |     // arguments is not allowed here
+  9 |     console.log(arguments)
+    :                 ^^^^^^^^^
+ 10 |     // this is not allowed here
+    `----
+  x "use cache" functions cannot use `this`.
+  | 
+    ,-[input.js:11:1]
+ 10 |     // this is not allowed here
+ 11 |     return this.foo()
+    :            ^^^^
+ 12 |   }
+    `----

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/57/input.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/57/input.js
@@ -1,0 +1,12 @@
+export class MyClass {
+  static async foo() {
+    'use cache'
+
+    return fetch('https://example.com').then((res) => res.json())
+  }
+  static async bar() {
+    'use server'
+
+    console.log(42)
+  }
+}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/57/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/57/output.js
@@ -1,0 +1,17 @@
+/* __next_internal_action_entry_do_not_use__ {"0090b5db271335765a4b0eab01f044b381b5ebd5cd":"$$RSC_SERVER_ACTION_1","803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ async function foo() {
+    return fetch('https://example.com').then((res)=>res.json());
+});
+Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+    "value": "foo",
+    "writable": false
+});
+export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_1 = async function bar() {
+    console.log(42);
+};
+export class MyClass {
+    static foo = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
+    static bar = registerServerReference($$RSC_SERVER_ACTION_1, "0090b5db271335765a4b0eab01f044b381b5ebd5cd", null);
+}

--- a/test/e2e/app-dir/use-cache/app/static-class-method/cached.ts
+++ b/test/e2e/app-dir/use-cache/app/static-class-method/cached.ts
@@ -1,0 +1,8 @@
+export class Cached {
+  static async getRandomValue() {
+    'use cache'
+    const v = Math.random()
+    console.log(v)
+    return v
+  }
+}

--- a/test/e2e/app-dir/use-cache/app/static-class-method/form.tsx
+++ b/test/e2e/app-dir/use-cache/app/static-class-method/form.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { useActionState } from 'react'
+
+export function Form({
+  getRandomValue,
+}: {
+  getRandomValue: () => Promise<number>
+}) {
+  const [result, formAction, isPending] = useActionState(getRandomValue, -1)
+
+  return (
+    <form action={formAction}>
+      <button>Submit</button>
+      <p>{isPending ? 'loading...' : result}</p>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/use-cache/app/static-class-method/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/static-class-method/page.tsx
@@ -1,0 +1,6 @@
+import { Cached } from './cached'
+import { Form } from './form'
+
+export default function Page() {
+  return <Form getRandomValue={Cached.getRandomValue} />
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -431,4 +431,25 @@ describe('use-cache', () => {
       expect(await browser.elementByCss('#form-2 p').text()).toBe(value2)
     })
   })
+
+  it('works with "use cache" in static class methods', async () => {
+    const browser = await next.browser('/static-class-method')
+
+    let value = await browser.elementByCss('p').text()
+
+    expect(value).toBe('-1')
+
+    await browser.elementByCss('button').click()
+
+    await retry(async () => {
+      value = await browser.elementByCss('p').text()
+      expect(value).toMatch(/\d\.\d+/)
+    })
+
+    await browser.elementByCss('button').click()
+
+    await retry(async () => {
+      expect(await browser.elementByCss('p').text()).toBe(value)
+    })
+  })
 })


### PR DESCRIPTION
With this PR, we are allowing _static_ class methods to be annotated with `"use cache"` or `"use server"`.

Class _instance_ methods on the other hand are not allowed as server functions.