### PR TITLE
Forbid `super` in static class methods with server function directives

### DIFF
--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -2141,6 +2141,16 @@ impl<C: Comments> VisitMut for ServerActions<C> {
         }
     }
 
+    fn visit_mut_super(&mut self, n: &mut Super) {
+        if let ThisStatus::Forbidden { directive } = &self.this_status {
+            emit_error(ServerActionsErrorKind::ForbiddenExpression {
+                span: n.span,
+                expr: "super".into(),
+                directive: directive.clone(),
+            });
+        }
+    }
+
     fn visit_mut_ident(&mut self, n: &mut Ident) {
         if n.sym == *"arguments" {
             if let ThisStatus::Forbidden { directive } = &self.this_status {

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/26/input.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/26/input.js
@@ -1,9 +1,19 @@
-export class MyClass {
+import { BaseClass } from './base'
+
+export class MyClass extends BaseClass {
   static async foo() {
+    // super is allowed here
+    super.foo()
+
     return fetch('https://example.com').then((res) => res.json())
   }
   static async bar() {
     'use cache'
+
+    if (Math.random() > 0.5) {
+      // super is not allowed here
+      return [super.bar()]
+    }
 
     // arguments is not allowed here
     console.log(arguments)

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/26/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/26/output.js
@@ -1,8 +1,17 @@
-export class MyClass {
+import { BaseClass } from './base';
+export class MyClass extends BaseClass {
     static async foo() {
+        // super is allowed here
+        super.foo();
         return fetch('https://example.com').then((res)=>res.json());
     }
     static async bar() {
+        if (Math.random() > 0.5) {
+            // super is not allowed here
+            return [
+                super.bar()
+            ];
+        }
         // arguments is not allowed here
         console.log(arguments);
         // this is not allowed here

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/26/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/26/output.stderr
@@ -1,16 +1,24 @@
+  x "use cache" functions cannot use `super`.
+  | 
+    ,-[input.js:15:1]
+ 14 |       // super is not allowed here
+ 15 |       return [super.bar()]
+    :               ^^^^^
+ 16 |     }
+    `----
   x "use cache" functions cannot use `arguments`.
   | 
-    ,-[input.js:9:1]
-  8 |     // arguments is not allowed here
-  9 |     console.log(arguments)
+    ,-[input.js:19:1]
+ 18 |     // arguments is not allowed here
+ 19 |     console.log(arguments)
     :                 ^^^^^^^^^
- 10 |     // this is not allowed here
+ 20 |     // this is not allowed here
     `----
   x "use cache" functions cannot use `this`.
   | 
-    ,-[input.js:11:1]
- 10 |     // this is not allowed here
- 11 |     return this.foo()
+    ,-[input.js:21:1]
+ 20 |     // this is not allowed here
+ 21 |     return this.foo()
     :            ^^^^
- 12 |   }
+ 22 |   }
     `----


### PR DESCRIPTION
Static class methods that are annotated with `"use cache"` or `"use
server"` must not call `super`.