### PR TITLE
perf(turbopack): Use `ResolvedVc` for `turbopack-core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,17 +446,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.58",
-]
-
-[[package]]
 name = "async-signal"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8772,7 +8761,6 @@ name = "turbopack-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-recursion",
  "async-trait",
  "auto-hash-map",
  "browserslist-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "async-signal"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8761,6 +8772,7 @@ name = "turbopack-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-recursion",
  "async-trait",
  "auto-hash-map",
  "browserslist-rs",

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -124,7 +124,7 @@ async fn build_server_actions_loader(
     let module = asset_context
         .process(
             Vc::upcast(source),
-            Value::new(ReferenceType::Internal(Vc::cell(import_map))),
+            Value::new(ReferenceType::Internal(ResolvedVc::cell(import_map))),
         )
         .module();
 

--- a/crates/next-core/src/bootstrap.rs
+++ b/crates/next-core/src/bootstrap.rs
@@ -89,7 +89,9 @@ pub async fn bootstrap(
                     .into(),
                 ),
             )),
-            Value::new(ReferenceType::Internal(InnerAssets::empty())),
+            Value::new(ReferenceType::Internal(
+                InnerAssets::empty().to_resolved().await?,
+            )),
         )
         .module()
         .to_resolved()
@@ -102,7 +104,7 @@ pub async fn bootstrap(
     let asset = asset_context
         .process(
             bootstrap_asset,
-            Value::new(ReferenceType::Internal(Vc::cell(inner_assets))),
+            Value::new(ReferenceType::Internal(ResolvedVc::cell(inner_assets))),
         )
         .module()
         .to_resolved()

--- a/crates/next-core/src/middleware.rs
+++ b/crates/next-core/src/middleware.rs
@@ -49,7 +49,7 @@ pub async fn get_middleware_module(
     let module = asset_context
         .process(
             source,
-            Value::new(ReferenceType::Internal(Vc::cell(inner_assets))),
+            Value::new(ReferenceType::Internal(ResolvedVc::cell(inner_assets))),
         )
         .module();
 

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -114,7 +114,7 @@ pub async fn get_app_page_entry(
     let mut rsc_entry = module_asset_context
         .process(
             Vc::upcast(source),
-            Value::new(ReferenceType::Internal(Vc::cell(inner_assets))),
+            Value::new(ReferenceType::Internal(ResolvedVc::cell(inner_assets))),
         )
         .module();
 
@@ -194,7 +194,7 @@ async fn wrap_edge_page(
     let wrapped = asset_context
         .process(
             Vc::upcast(source),
-            Value::new(ReferenceType::Internal(Vc::cell(inner_assets))),
+            Value::new(ReferenceType::Internal(ResolvedVc::cell(inner_assets))),
         )
         .module();
 

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -106,7 +106,7 @@ pub async fn get_app_route_entry(
     let mut rsc_entry = module_asset_context
         .process(
             Vc::upcast(virtual_source),
-            Value::new(ReferenceType::Internal(Vc::cell(inner_assets))),
+            Value::new(ReferenceType::Internal(ResolvedVc::cell(inner_assets))),
         )
         .module();
 
@@ -162,7 +162,7 @@ async fn wrap_edge_route(
     let wrapped = asset_context
         .process(
             Vc::upcast(source),
-            Value::new(ReferenceType::Internal(Vc::cell(inner_assets))),
+            Value::new(ReferenceType::Internal(ResolvedVc::cell(inner_assets))),
         )
         .module();
 

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -113,7 +113,7 @@ async fn next_client_free_vars(define_env: Vc<EnvMap>) -> Result<Vc<FreeVarRefer
 pub async fn get_client_compile_time_info(
     browserslist_query: RcStr,
     define_env: Vc<EnvMap>,
-) -> Vc<CompileTimeInfo> {
+) -> Result<Vc<CompileTimeInfo>> {
     CompileTimeInfo::builder(
         Environment::new(Value::new(ExecutionEnvironment::Browser(
             BrowserEnvironment {

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -127,8 +127,8 @@ pub async fn get_client_compile_time_info(
         .to_resolved()
         .await?,
     )
-    .defines(next_client_defines(define_env))
-    .free_var_references(next_client_free_vars(define_env))
+    .defines(next_client_defines(define_env).to_resolved().await?)
+    .free_var_references(next_client_free_vars(define_env).to_resolved().await?)
     .cell()
     .await
 }

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -122,7 +122,7 @@ pub async fn get_client_compile_time_info(
                 service_worker: false,
                 browserslist_query: browserslist_query.to_owned(),
             }
-            .into(),
+            .resolved_cell(),
         )))
         .to_resolved()
         .await?,

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -110,22 +110,27 @@ async fn next_client_free_vars(define_env: Vc<EnvMap>) -> Result<Vc<FreeVarRefer
 }
 
 #[turbo_tasks::function]
-pub fn get_client_compile_time_info(
+pub async fn get_client_compile_time_info(
     browserslist_query: RcStr,
     define_env: Vc<EnvMap>,
 ) -> Vc<CompileTimeInfo> {
-    CompileTimeInfo::builder(Environment::new(Value::new(ExecutionEnvironment::Browser(
-        BrowserEnvironment {
-            dom: true,
-            web_worker: false,
-            service_worker: false,
-            browserslist_query: browserslist_query.to_owned(),
-        }
-        .into(),
-    ))))
+    CompileTimeInfo::builder(
+        Environment::new(Value::new(ExecutionEnvironment::Browser(
+            BrowserEnvironment {
+                dom: true,
+                web_worker: false,
+                service_worker: false,
+                browserslist_query: browserslist_query.to_owned(),
+            }
+            .into(),
+        )))
+        .to_resolved()
+        .await?,
+    )
     .defines(next_client_defines(define_env))
     .free_var_references(next_client_free_vars(define_env))
     .cell()
+    .await
 }
 
 #[turbo_tasks::value(shared, serialization = "auto_for_input")]

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -82,7 +82,7 @@ pub async fn get_edge_compile_time_info(
 ) -> Result<Vc<CompileTimeInfo>> {
     CompileTimeInfo::builder(
         Environment::new(Value::new(ExecutionEnvironment::EdgeWorker(
-            EdgeWorkerEnvironment {}.into(),
+            EdgeWorkerEnvironment {}.resolved_cell(),
         )))
         .to_resolved()
         .await?,

--- a/crates/next-core/src/next_edge/entry.rs
+++ b/crates/next-core/src/next_edge/entry.rs
@@ -56,7 +56,7 @@ pub async fn wrap_edge_entry(
     asset_context
         .process(
             Vc::upcast(virtual_source),
-            Value::new(ReferenceType::Internal(Vc::cell(inner_assets))),
+            Value::new(ReferenceType::Internal(ResolvedVc::cell(inner_assets))),
         )
         .module()
 }

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -170,7 +170,7 @@ impl ImportMappingReplacement for NextFontGoogleReplacer {
         };
 
         let this = &*self.await?;
-        if can_use_next_font(this.project_path, *query).await? {
+        if can_use_next_font(this.project_path, **query).await? {
             Ok(self.import_map_result(query.await?.as_str().into()))
         } else {
             Ok(ImportMapResult::NoEntry.into())
@@ -357,7 +357,7 @@ impl ImportMappingReplacement for NextFontGoogleFontFileReplacer {
             url,
             preload,
             has_size_adjust: size_adjust,
-        } = font_file_options_from_query_map(*query_vc).await?;
+        } = font_file_options_from_query_map(*q * uery_vc).await?;
 
         let (filename, ext) = split_extension(&url);
         let ext = ext.with_context(|| format!("font url {} is missing an extension", &url))?;

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -357,7 +357,7 @@ impl ImportMappingReplacement for NextFontGoogleFontFileReplacer {
             url,
             preload,
             has_size_adjust: size_adjust,
-        } = font_file_options_from_query_map(*q * uery_vc).await?;
+        } = font_file_options_from_query_map(**query_vc).await?;
 
         let (filename, ext) = split_extension(&url);
         let ext = ext.with_context(|| format!("font url {} is missing an extension", &url))?;
@@ -685,7 +685,9 @@ async fn get_mock_stylesheet(
                     .into(),
                 ),
             )),
-            Value::new(ReferenceType::Internal(InnerAssets::empty())),
+            Value::new(ReferenceType::Internal(
+                InnerAssets::empty().to_resolved().await?,
+            )),
         )
         .module();
 

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -186,7 +186,7 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
             "@vercel/turbopack-next/internal/font/local/cssmodule.module.css" => {
                 let query = query_vc.await?.to_string();
                 let request_hash = get_request_hash(&query).await?;
-                let options = font_options_from_query_map(*query_vc);
+                let options = font_options_from_query_map(**query_vc);
                 let css_virtual_path = lookup_path.join(
                     format!(
                         "/{}.module.css",

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -98,14 +98,14 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
 
         match request_key.as_str() {
             "next/font/local/target.css" => {
-                if !can_use_next_font(this.root, *query_vc).await? {
+                if !can_use_next_font(this.root, **query_vc).await? {
                     return Ok(ResolveResultOption::none());
                 }
 
                 let query = query_vc.await?.to_string();
                 let request_hash = get_request_hash(&query).await?;
                 let qstr = qstring::QString::from(query.as_str());
-                let options_vc = font_options_from_query_map(*query_vc);
+                let options_vc = font_options_from_query_map(**query_vc);
                 let font_fallbacks = get_font_fallbacks(lookup_path, options_vc);
                 let properties = get_font_css_properties(options_vc, font_fallbacks).await;
 
@@ -197,7 +197,7 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                 let fallback = get_font_fallbacks(lookup_path, options);
 
                 let stylesheet = build_stylesheet(
-                    font_options_from_query_map(*query_vc),
+                    font_options_from_query_map(**query_vc),
                     fallback,
                     get_font_css_properties(options, fallback),
                 )
@@ -219,7 +219,7 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                     path,
                     preload,
                     has_size_adjust: size_adjust,
-                } = font_file_options_from_query_map(*query_vc).await?;
+                } = font_file_options_from_query_map(**query_vc).await?;
 
                 let (filename, ext) = split_extension(&path);
                 let ext = ext.with_context(|| format!("font {} needs an extension", &path))?;

--- a/crates/next-core/src/next_image/module.rs
+++ b/crates/next-core/src/next_image/module.rs
@@ -52,7 +52,7 @@ impl StructuredImageModuleType {
                     }
                     .cell(),
                 ),
-                Value::new(ReferenceType::Internal(Vc::cell(fxindexmap!(
+                Value::new(ReferenceType::Internal(ResolvedVc::cell(fxindexmap!(
                     "IMAGE".into() => ResolvedVc::upcast(static_asset)
                 )))),
             )

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -142,7 +142,7 @@ pub async fn create_page_ssr_entry_module(
     let mut ssr_module = ssr_module_context
         .process(
             source,
-            Value::new(ReferenceType::Internal(Vc::cell(inner_assets))),
+            Value::new(ReferenceType::Internal(ResolvedVc::cell(inner_assets))),
         )
         .module();
 
@@ -262,7 +262,7 @@ async fn wrap_edge_page(
     let wrapped = asset_context
         .process(
             Vc::upcast(source),
-            Value::new(ReferenceType::Internal(Vc::cell(inner_assets))),
+            Value::new(ReferenceType::Internal(ResolvedVc::cell(inner_assets))),
         )
         .module();
 

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -376,18 +376,20 @@ pub async fn get_server_compile_time_info(
     define_env: Vc<EnvMap>,
     cwd: RcStr,
 ) -> Result<Vc<CompileTimeInfo>> {
-    CompileTimeInfo::builder(Environment::new(Value::new(
-        ExecutionEnvironment::NodeJsLambda(
+    CompileTimeInfo::builder(
+        Environment::new(Value::new(ExecutionEnvironment::NodeJsLambda(
             NodeJsEnvironment {
-                compile_target: CompileTarget::current(),
+                compile_target: CompileTarget::current().to_resolved(),
                 node_version: NodeJsVersion::cell(NodeJsVersion::Current(
                     process_env.to_resolved().await?,
                 )),
                 cwd: ResolvedVc::cell(Some(cwd)),
             }
             .resolved_cell(),
-        ),
-    )))
+        )))
+        .to_resolved()
+        .await?,
+    )
     .defines(next_server_defines(define_env).to_resolved().await?)
     .free_var_references(next_server_free_vars(define_env).to_resolved().await?)
     .cell()

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -376,21 +376,22 @@ pub async fn get_server_compile_time_info(
     define_env: Vc<EnvMap>,
     cwd: RcStr,
 ) -> Result<Vc<CompileTimeInfo>> {
-    Ok(CompileTimeInfo::builder(Environment::new(Value::new(
+    CompileTimeInfo::builder(Environment::new(Value::new(
         ExecutionEnvironment::NodeJsLambda(
             NodeJsEnvironment {
                 compile_target: CompileTarget::current(),
                 node_version: NodeJsVersion::cell(NodeJsVersion::Current(
                     process_env.to_resolved().await?,
                 )),
-                cwd: Vc::cell(Some(cwd)),
+                cwd: ResolvedVc::cell(Some(cwd)),
             }
-            .cell(),
+            .resolved_cell(),
         ),
     )))
-    .defines(next_server_defines(define_env))
-    .free_var_references(next_server_free_vars(define_env))
-    .cell())
+    .defines(next_server_defines(define_env).to_resolved().await?)
+    .free_var_references(next_server_free_vars(define_env).to_resolved().await?)
+    .cell()
+    .await
 }
 
 /// Determins if the module is an internal asset (i.e overlay, fallback) coming

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -379,8 +379,8 @@ pub async fn get_server_compile_time_info(
     CompileTimeInfo::builder(
         Environment::new(Value::new(ExecutionEnvironment::NodeJsLambda(
             NodeJsEnvironment {
-                compile_target: CompileTarget::current().to_resolved(),
-                node_version: NodeJsVersion::cell(NodeJsVersion::Current(
+                compile_target: CompileTarget::current().to_resolved().await?,
+                node_version: NodeJsVersion::resolved_cell(NodeJsVersion::Current(
                     process_env.to_resolved().await?,
                 )),
                 cwd: ResolvedVc::cell(Some(cwd)),

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use anyhow::{bail, Result};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{fxindexmap, TryJoinIterExt, Value, Vc};
+use turbo_tasks::{fxindexmap, ResolvedVc, TryJoinIterExt, Value, Vc};
 use turbo_tasks_fs::{
     self, rope::RopeBuilder, File, FileContent, FileSystemPath, FileSystemPathOption,
 };
@@ -62,7 +62,7 @@ pub async fn create_page_loader_entry_module(
     let module = client_context
         .process(
             virtual_source,
-            Value::new(ReferenceType::Internal(Vc::cell(fxindexmap! {
+            Value::new(ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
                 "PAGE".into() => module,
             }))),
         )

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -177,7 +177,7 @@ async fn build_internal(
             service_worker: false,
             browserslist_query: browserslist_query.clone(),
         }
-        .into(),
+        .resolved_cell(),
     )));
     let output_fs = output_fs(project_dir.clone());
     let project_fs = project_fs(root_dir.clone());

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -221,18 +221,20 @@ pub async fn get_client_compile_time_info(
     browserslist_query: RcStr,
     node_env: Vc<NodeEnv>,
 ) -> Result<Vc<CompileTimeInfo>> {
-    Ok(
-        CompileTimeInfo::builder(Environment::new(Value::new(ExecutionEnvironment::Browser(
+    CompileTimeInfo::builder(
+        Environment::new(Value::new(ExecutionEnvironment::Browser(
             BrowserEnvironment {
                 dom: true,
                 web_worker: false,
                 service_worker: false,
                 browserslist_query,
             }
-            .into(),
-        ))))
-        .defines(client_defines(&*node_env.await?))
-        .cell()
+            .resolved_cell(),
+        )))
+        .to_resolved()
         .await?,
     )
+    .defines(client_defines(&*node_env.await?).to_resolved().await?)
+    .cell()
+    .await
 }

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -232,6 +232,7 @@ pub async fn get_client_compile_time_info(
             .into(),
         ))))
         .defines(client_defines(&*node_env.await?))
-        .cell(),
+        .cell()
+        .await?,
     )
 }

--- a/turbopack/crates/turbopack-core/Cargo.toml
+++ b/turbopack/crates/turbopack-core/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-async-recursion = "1.1.1"
 async-trait = { workspace = true }
 auto-hash-map = { workspace = true }
 browserslist-rs = { workspace = true }

--- a/turbopack/crates/turbopack-core/Cargo.toml
+++ b/turbopack/crates/turbopack-core/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+async-recursion = "1.1.1"
 async-trait = { workspace = true }
 auto-hash-map = { workspace = true }
 browserslist-rs = { workspace = true }

--- a/turbopack/crates/turbopack-core/src/chunk/availability_info.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/availability_info.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 
 use super::available_chunk_items::{AvailableChunkItemInfoMap, AvailableChunkItems};
 
@@ -12,7 +12,7 @@ pub enum AvailabilityInfo {
     Root,
     /// There are modules already available.
     Complete {
-        available_chunk_items: Vc<AvailableChunkItems>,
+        available_chunk_items: ResolvedVc<AvailableChunkItems>,
     },
 }
 

--- a/turbopack/crates/turbopack-core/src/chunk/availability_info.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/availability_info.rs
@@ -24,7 +24,7 @@ impl AvailabilityInfo {
             Self::Complete {
                 available_chunk_items,
                 ..
-            } => Some(*available_chunk_items),
+            } => Some(**available_chunk_items),
         }
     }
 
@@ -35,14 +35,14 @@ impl AvailabilityInfo {
         Ok(match self {
             AvailabilityInfo::Untracked => AvailabilityInfo::Untracked,
             AvailabilityInfo::Root => AvailabilityInfo::Complete {
-                available_chunk_items: AvailableChunkItems::new(chunk_items).resolve().await?,
+                available_chunk_items: AvailableChunkItems::new(chunk_items).to_resolved().await?,
             },
             AvailabilityInfo::Complete {
                 available_chunk_items,
             } => AvailabilityInfo::Complete {
                 available_chunk_items: available_chunk_items
                     .with_chunk_items(chunk_items)
-                    .resolve()
+                    .to_resolved()
                     .await?,
             },
         })

--- a/turbopack/crates/turbopack-core/src/chunk/available_chunk_items.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/available_chunk_items.rs
@@ -27,7 +27,7 @@ pub struct AvailableChunkItemInfoMap(
 #[turbo_tasks::value]
 pub struct AvailableChunkItems {
     parent: Option<ResolvedVc<AvailableChunkItems>>,
-    chunk_items: Vc<AvailableChunkItemInfoMap>,
+    chunk_items: ResolvedVc<AvailableChunkItemInfoMap>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-core/src/chunk/available_chunk_items.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/available_chunk_items.rs
@@ -33,7 +33,7 @@ pub struct AvailableChunkItems {
 #[turbo_tasks::value_impl]
 impl AvailableChunkItems {
     #[turbo_tasks::function]
-    pub fn new(chunk_items: Vc<AvailableChunkItemInfoMap>) -> Vc<Self> {
+    pub fn new(chunk_items: ResolvedVc<AvailableChunkItemInfoMap>) -> Vc<Self> {
         AvailableChunkItems {
             parent: None,
             chunk_items,
@@ -44,7 +44,7 @@ impl AvailableChunkItems {
     #[turbo_tasks::function]
     pub async fn with_chunk_items(
         self: ResolvedVc<Self>,
-        chunk_items: Vc<AvailableChunkItemInfoMap>,
+        chunk_items: ResolvedVc<AvailableChunkItemInfoMap>,
     ) -> Result<Vc<Self>> {
         let chunk_items = chunk_items
             .await?
@@ -60,7 +60,7 @@ impl AvailableChunkItems {
             .await?;
         Ok(AvailableChunkItems {
             parent: Some(self),
-            chunk_items: Vc::cell(chunk_items.into_iter().collect()),
+            chunk_items: ResolvedVc::cell(chunk_items.into_iter().collect()),
         }
         .cell())
     }

--- a/turbopack/crates/turbopack-core/src/chunk/data.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/data.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ReadRef, TryJoinIterExt, Vc};
+use turbo_tasks::{ReadRef, ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
@@ -14,7 +14,7 @@ pub struct ChunkData {
     pub included: Vec<ReadRef<ModuleId>>,
     pub excluded: Vec<ReadRef<ModuleId>>,
     pub module_chunks: Vec<String>,
-    pub references: Vc<OutputAssets>,
+    pub references: ResolvedVc<OutputAssets>,
 }
 
 #[turbo_tasks::value(transparent)]

--- a/turbopack/crates/turbopack-core/src/chunk/data.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/data.rs
@@ -57,7 +57,7 @@ impl ChunkData {
                     included: Vec::new(),
                     excluded: Vec::new(),
                     module_chunks: Vec::new(),
-                    references: OutputAssets::empty(),
+                    references: OutputAssets::empty().to_resolved().await?,
                 }
                 .cell(),
             )));
@@ -112,7 +112,7 @@ impl ChunkData {
                 included,
                 excluded,
                 module_chunks,
-                references: Vc::cell(module_chunks_references),
+                references: ResolvedVc::cell(module_chunks_references),
             }
             .cell(),
         )))
@@ -139,6 +139,6 @@ impl ChunkData {
     /// Returns [`OutputAsset`]s that this chunk data references.
     #[turbo_tasks::function]
     pub fn references(&self) -> Vc<OutputAssets> {
-        self.references
+        *self.references
     }
 }

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -297,7 +297,7 @@ impl CompileTimeInfo {
 
     #[turbo_tasks::function]
     pub fn environment(&self) -> Vc<Environment> {
-        self.environment
+        *self.environment
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -321,18 +321,22 @@ impl CompileTimeInfoBuilder {
         self
     }
 
-    pub fn build(self) -> CompileTimeInfo {
-        CompileTimeInfo {
+    pub async fn build(self) -> Result<CompileTimeInfo> {
+        Ok(CompileTimeInfo {
             environment: self.environment,
-            defines: self.defines.unwrap_or_else(CompileTimeDefines::empty),
-            free_var_references: self
-                .free_var_references
-                .unwrap_or_else(FreeVarReferences::empty),
-        }
+            defines: match self.defines {
+                Some(defines) => defines,
+                None => CompileTimeDefines::empty().to_resolved().await?,
+            },
+            free_var_references: match self.free_var_references {
+                Some(free_var_references) => free_var_references,
+                None => FreeVarReferences::empty().to_resolved().await?,
+            },
+        })
     }
 
-    pub fn cell(self) -> Vc<CompileTimeInfo> {
-        self.build().cell()
+    pub async fn cell(self) -> Result<Vc<CompileTimeInfo>> {
+        Ok(self.build().await?.cell())
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -267,9 +267,9 @@ impl FreeVarReferences {
 #[turbo_tasks::value(shared)]
 #[derive(Debug, Clone)]
 pub struct CompileTimeInfo {
-    pub environment: Vc<Environment>,
-    pub defines: Vc<CompileTimeDefines>,
-    pub free_var_references: Vc<FreeVarReferences>,
+    pub environment: ResolvedVc<Environment>,
+    pub defines: ResolvedVc<CompileTimeDefines>,
+    pub free_var_references: ResolvedVc<FreeVarReferences>,
 }
 
 impl CompileTimeInfo {

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -236,7 +236,7 @@ pub struct NodeJsEnvironment {
 impl Default for NodeJsEnvironment {
     fn default() -> Self {
         NodeJsEnvironment {
-            compile_target: CompileTarget::default().resolved_cell(),
+            compile_target: CompileTarget::current_raw().resolved_cell(),
             node_version: NodeJsVersion::default().resolved_cell(),
             cwd: ResolvedVc::cell(None),
         }

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -233,16 +233,6 @@ pub struct NodeJsEnvironment {
     pub cwd: ResolvedVc<Option<RcStr>>,
 }
 
-impl Default for NodeJsEnvironment {
-    fn default() -> Self {
-        NodeJsEnvironment {
-            compile_target: CompileTarget::current(),
-            node_version: NodeJsVersion::default().cell(),
-            cwd: Vc::cell(None),
-        }
-    }
-}
-
 #[turbo_tasks::value_impl]
 impl NodeJsEnvironment {
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -227,10 +227,10 @@ pub enum NodeEnvironmentType {
 
 #[turbo_tasks::value(shared)]
 pub struct NodeJsEnvironment {
-    pub compile_target: Vc<CompileTarget>,
-    pub node_version: Vc<NodeJsVersion>,
+    pub compile_target: ResolvedVc<CompileTarget>,
+    pub node_version: ResolvedVc<NodeJsVersion>,
     // user specified process.cwd
-    pub cwd: Vc<Option<RcStr>>,
+    pub cwd: ResolvedVc<Option<RcStr>>,
 }
 
 impl Default for NodeJsEnvironment {

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -56,10 +56,10 @@ impl Environment {
 #[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(Debug, Hash, Clone, Copy)]
 pub enum ExecutionEnvironment {
-    NodeJsBuildTime(Vc<NodeJsEnvironment>),
-    NodeJsLambda(Vc<NodeJsEnvironment>),
-    EdgeWorker(Vc<EdgeWorkerEnvironment>),
-    Browser(Vc<BrowserEnvironment>),
+    NodeJsBuildTime(ResolvedVc<NodeJsEnvironment>),
+    NodeJsLambda(ResolvedVc<NodeJsEnvironment>),
+    EdgeWorker(ResolvedVc<EdgeWorkerEnvironment>),
+    Browser(ResolvedVc<BrowserEnvironment>),
     // TODO allow custom trait here
     Custom(u8),
 }
@@ -231,6 +231,16 @@ pub struct NodeJsEnvironment {
     pub node_version: ResolvedVc<NodeJsVersion>,
     // user specified process.cwd
     pub cwd: ResolvedVc<Option<RcStr>>,
+}
+
+impl Default for NodeJsEnvironment {
+    fn default() -> Self {
+        NodeJsEnvironment {
+            compile_target: CompileTarget::default().resolved_cell(),
+            node_version: NodeJsVersion::default().resolved_cell(),
+            cwd: ResolvedVc::cell(None),
+        }
+    }
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -262,12 +262,14 @@ impl NodeJsEnvironment {
     }
 
     #[turbo_tasks::function]
-    pub fn current(process_env: ResolvedVc<Box<dyn ProcessEnv>>) -> Vc<Self> {
-        Self::cell(NodeJsEnvironment {
-            compile_target: CompileTarget::current(),
-            node_version: NodeJsVersion::cell(NodeJsVersion::Current(process_env)),
-            cwd: Vc::cell(None),
-        })
+    pub async fn current(process_env: ResolvedVc<Box<dyn ProcessEnv>>) -> Result<Vc<Self>> {
+        Ok(Self::cell(NodeJsEnvironment {
+            compile_target: CompileTarget::current().to_resolved().await?,
+            node_version: NodeJsVersion::cell(NodeJsVersion::Current(process_env))
+                .to_resolved()
+                .await?,
+            cwd: ResolvedVc::cell(None),
+        }))
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -70,7 +70,7 @@ impl Environment {
     pub async fn compile_target(&self) -> Result<Vc<CompileTarget>> {
         Ok(match self.execution {
             ExecutionEnvironment::NodeJsBuildTime(node_env, ..)
-            | ExecutionEnvironment::NodeJsLambda(node_env) => node_env.await?.compile_target,
+            | ExecutionEnvironment::NodeJsLambda(node_env) => *node_env.await?.compile_target,
             ExecutionEnvironment::Browser(_) => CompileTarget::unknown(),
             ExecutionEnvironment::EdgeWorker(_) => CompileTarget::unknown(),
             ExecutionEnvironment::Custom(_) => todo!(),
@@ -189,7 +189,7 @@ impl Environment {
         let env = self;
         Ok(match env.execution {
             ExecutionEnvironment::NodeJsBuildTime(env)
-            | ExecutionEnvironment::NodeJsLambda(env) => env.await?.cwd,
+            | ExecutionEnvironment::NodeJsLambda(env) => *env.await?.cwd,
             _ => Vc::cell(None),
         })
     }

--- a/turbopack/crates/turbopack-core/src/file_source.rs
+++ b/turbopack/crates/turbopack-core/src/file_source.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{FileContent, FileSystemEntryType, FileSystemPath, LinkContent};
 
 use crate::{
@@ -13,8 +13,8 @@ use crate::{
 /// references to other [Source]s.
 #[turbo_tasks::value]
 pub struct FileSource {
-    pub path: Vc<FileSystemPath>,
-    pub query: Vc<RcStr>,
+    pub path: ResolvedVc<FileSystemPath>,
+    pub query: ResolvedVc<RcStr>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-core/src/file_source.rs
+++ b/turbopack/crates/turbopack-core/src/file_source.rs
@@ -20,15 +20,15 @@ pub struct FileSource {
 #[turbo_tasks::value_impl]
 impl FileSource {
     #[turbo_tasks::function]
-    pub fn new(path: Vc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(path: ResolvedVc<FileSystemPath>) -> Vc<Self> {
         Self::cell(FileSource {
             path,
-            query: Vc::<RcStr>::default(),
+            query: RcStr::default().resolved_cell(),
         })
     }
 
     #[turbo_tasks::function]
-    pub fn new_with_query(path: Vc<FileSystemPath>, query: Vc<RcStr>) -> Vc<Self> {
+    pub fn new_with_query(path: ResolvedVc<FileSystemPath>, query: ResolvedVc<RcStr>) -> Vc<Self> {
         Self::cell(FileSource { path, query })
     }
 }
@@ -37,7 +37,7 @@ impl FileSource {
 impl Source for FileSource {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(self.path).with_query(self.query)
+        AssetIdent::from_path(*self.path).with_query(*self.query)
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/file_source.rs
+++ b/turbopack/crates/turbopack-core/src/file_source.rs
@@ -23,7 +23,7 @@ impl FileSource {
     pub fn new(path: ResolvedVc<FileSystemPath>) -> Vc<Self> {
         Self::cell(FileSource {
             path,
-            query: RcStr::default().resolved_cell(),
+            query: ResolvedVc::cell(RcStr::default()),
         })
     }
 

--- a/turbopack/crates/turbopack-core/src/issue/analyze.rs
+++ b/turbopack/crates/turbopack-core/src/issue/analyze.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use super::{
@@ -11,12 +11,12 @@ use crate::ident::AssetIdent;
 
 #[turbo_tasks::value(shared)]
 pub struct AnalyzeIssue {
-    pub severity: Vc<IssueSeverity>,
-    pub source_ident: Vc<AssetIdent>,
-    pub title: Vc<RcStr>,
-    pub message: Vc<StyledString>,
+    pub severity: ResolvedVc<IssueSeverity>,
+    pub source_ident: ResolvedVc<AssetIdent>,
+    pub title: ResolvedVc<RcStr>,
+    pub message: ResolvedVc<StyledString>,
     pub code: Option<RcStr>,
-    pub source: Option<Vc<IssueSource>>,
+    pub source: Option<ResolvedVc<IssueSource>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-core/src/issue/analyze.rs
+++ b/turbopack/crates/turbopack-core/src/issue/analyze.rs
@@ -23,7 +23,7 @@ pub struct AnalyzeIssue {
 impl Issue for AnalyzeIssue {
     #[turbo_tasks::function]
     fn severity(&self) -> Vc<IssueSeverity> {
-        self.severity
+        *self.severity
     }
 
     #[turbo_tasks::function]
@@ -53,7 +53,7 @@ impl Issue for AnalyzeIssue {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(self.message))
+        Vc::cell(Some(*self.message))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/issue/analyze.rs
+++ b/turbopack/crates/turbopack-core/src/issue/analyze.rs
@@ -12,11 +12,11 @@ use crate::ident::AssetIdent;
 #[turbo_tasks::value(shared)]
 pub struct AnalyzeIssue {
     pub severity: ResolvedVc<IssueSeverity>,
-    pub source_ident: ResolvedVc<AssetIdent>,
+    pub source_ident: Vc<AssetIdent>,
     pub title: ResolvedVc<RcStr>,
     pub message: ResolvedVc<StyledString>,
     pub code: Option<RcStr>,
-    pub source: Option<ResolvedVc<IssueSource>>,
+    pub source: Option<Vc<IssueSource>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-core/src/issue/module.rs
+++ b/turbopack/crates/turbopack-core/src/issue/module.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use super::{Issue, IssueStage, OptionStyledString, StyledString};
@@ -6,9 +6,9 @@ use crate::{ident::AssetIdent, issue::IssueExt, source::Source};
 
 #[turbo_tasks::value(shared)]
 pub struct ModuleIssue {
-    pub ident: Vc<AssetIdent>,
-    pub title: Vc<StyledString>,
-    pub description: Vc<StyledString>,
+    pub ident: ResolvedVc<AssetIdent>,
+    pub title: ResolvedVc<StyledString>,
+    pub description: ResolvedVc<StyledString>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-core/src/issue/module.rs
+++ b/turbopack/crates/turbopack-core/src/issue/module.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 
 use super::{Issue, IssueStage, OptionStyledString, StyledString};
@@ -6,9 +6,9 @@ use crate::{ident::AssetIdent, issue::IssueExt, source::Source};
 
 #[turbo_tasks::value(shared)]
 pub struct ModuleIssue {
-    pub ident: ResolvedVc<AssetIdent>,
-    pub title: ResolvedVc<StyledString>,
-    pub description: ResolvedVc<StyledString>,
+    pub ident: Vc<AssetIdent>,
+    pub title: Vc<StyledString>,
+    pub description: Vc<StyledString>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-core/src/issue/resolve.rs
+++ b/turbopack/crates/turbopack-core/src/issue/resolve.rs
@@ -56,7 +56,7 @@ impl Issue for ResolvingIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        self.file_path
+        *self.file_path
     }
 
     #[turbo_tasks::function]
@@ -68,12 +68,12 @@ impl Issue for ResolvingIssue {
         let request_value = self.request.await?;
         let request_parts = match &*request_value {
             Request::Alternatives { requests } => requests.as_slice(),
-            _ => &[self.request],
+            _ => &[*self.request],
         };
 
         if let Some(import_map) = &self.resolve_options.await?.import_map {
             for request in request_parts {
-                match lookup_import_map(**import_map, self.file_path, *request).await {
+                match lookup_import_map(**import_map, *self.file_path, *request).await {
                     Ok(None) => {}
                     Ok(Some(str)) => writeln!(description, "Import map: {}", str)?,
                     Err(err) => {

--- a/turbopack/crates/turbopack-core/src/issue/resolve.rs
+++ b/turbopack/crates/turbopack-core/src/issue/resolve.rs
@@ -68,12 +68,12 @@ impl Issue for ResolvingIssue {
         let request_value = self.request.await?;
         let request_parts = match &*request_value {
             Request::Alternatives { requests } => requests.as_slice(),
-            _ => &[*self.request],
+            _ => &[self.request],
         };
 
         if let Some(import_map) = &self.resolve_options.await?.import_map {
             for request in request_parts {
-                match lookup_import_map(**import_map, *self.file_path, *request).await {
+                match lookup_import_map(**import_map, *self.file_path, **request).await {
                     Ok(None) => {}
                     Ok(Some(str)) => writeln!(description, "Import map: {}", str)?,
                     Err(err) => {

--- a/turbopack/crates/turbopack-core/src/issue/resolve.rs
+++ b/turbopack/crates/turbopack-core/src/issue/resolve.rs
@@ -30,7 +30,7 @@ pub struct ResolvingIssue {
 impl Issue for ResolvingIssue {
     #[turbo_tasks::function]
     fn severity(&self) -> Vc<IssueSeverity> {
-        self.severity
+        *self.severity
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/issue/resolve.rs
+++ b/turbopack/crates/turbopack-core/src/issue/resolve.rs
@@ -17,11 +17,11 @@ use crate::{
 
 #[turbo_tasks::value(shared)]
 pub struct ResolvingIssue {
-    pub severity: Vc<IssueSeverity>,
+    pub severity: ResolvedVc<IssueSeverity>,
     pub request_type: String,
-    pub request: Vc<Request>,
-    pub file_path: Vc<FileSystemPath>,
-    pub resolve_options: Vc<ResolveOptions>,
+    pub request: ResolvedVc<Request>,
+    pub file_path: ResolvedVc<FileSystemPath>,
+    pub resolve_options: ResolvedVc<ResolveOptions>,
     pub error_message: Option<String>,
     pub source: Option<ResolvedVc<IssueSource>>,
 }

--- a/turbopack/crates/turbopack-core/src/issue/resolve.rs
+++ b/turbopack/crates/turbopack-core/src/issue/resolve.rs
@@ -120,7 +120,7 @@ impl Issue for ResolvingIssue {
 
     #[turbo_tasks::function]
     fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(self.source.map(|s| s.resolve_source_map(self.file_path)))
+        Vc::cell(self.source.map(|s| s.resolve_source_map(*self.file_path)))
     }
 
     // TODO add sub_issue for a description of resolve_options

--- a/turbopack/crates/turbopack-core/src/raw_output.rs
+++ b/turbopack/crates/turbopack-core/src/raw_output.rs
@@ -20,7 +20,7 @@ pub struct RawOutput {
 impl OutputAsset for RawOutput {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(self.path)
+        AssetIdent::from_path(*self.path)
     }
 }
 
@@ -35,7 +35,10 @@ impl Asset for RawOutput {
 #[turbo_tasks::value_impl]
 impl RawOutput {
     #[turbo_tasks::function]
-    pub fn new(path: Vc<FileSystemPath>, source: Vc<Box<dyn Source>>) -> Vc<RawOutput> {
+    pub fn new(
+        path: ResolvedVc<FileSystemPath>,
+        source: ResolvedVc<Box<dyn Source>>,
+    ) -> Vc<RawOutput> {
         RawOutput { path, source }.cell()
     }
 }

--- a/turbopack/crates/turbopack-core/src/raw_output.rs
+++ b/turbopack/crates/turbopack-core/src/raw_output.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
@@ -12,8 +12,8 @@ use crate::{
 /// This module has no references to other modules.
 #[turbo_tasks::value]
 pub struct RawOutput {
-    path: Vc<FileSystemPath>,
-    source: Vc<Box<dyn Source>>,
+    path: ResolvedVc<FileSystemPath>,
+    source: ResolvedVc<Box<dyn Source>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-core/src/reference/source_map.rs
+++ b/turbopack/crates/turbopack-core/src/reference/source_map.rs
@@ -13,8 +13,8 @@ use crate::{
 
 #[turbo_tasks::value]
 pub struct SourceMapReference {
-    from: Vc<FileSystemPath>,
-    file: Vc<FileSystemPath>,
+    from: ResolvedVc<FileSystemPath>,
+    file: ResolvedVc<FileSystemPath>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-core/src/reference/source_map.rs
+++ b/turbopack/crates/turbopack-core/src/reference/source_map.rs
@@ -20,7 +20,7 @@ pub struct SourceMapReference {
 #[turbo_tasks::value_impl]
 impl SourceMapReference {
     #[turbo_tasks::function]
-    pub fn new(from: Vc<FileSystemPath>, file: Vc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(from: ResolvedVc<FileSystemPath>, file: ResolvedVc<FileSystemPath>) -> Vc<Self> {
         Self::cell(SourceMapReference { from, file })
     }
 }
@@ -30,7 +30,7 @@ impl SourceMapReference {
         let file_type = self.file.get_type().await;
         if let Ok(file_type_result) = file_type.as_ref() {
             if let FileSystemEntryType::File = &**file_type_result {
-                return Some(self.file);
+                return Some(*self.file);
             }
         }
         None

--- a/turbopack/crates/turbopack-core/src/reference_type.rs
+++ b/turbopack/crates/turbopack-core/src/reference_type.rs
@@ -166,7 +166,7 @@ impl ImportContext {
 #[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(Debug, Clone, Hash)]
 pub enum CssReferenceSubType {
-    AtImport(Option<Vc<ImportContext>>),
+    AtImport(Option<ResolvedVc<ImportContext>>),
     Compose,
     /// Reference from any asset to a CSS-parseable asset.
     ///
@@ -233,7 +233,7 @@ pub enum ReferenceType {
     Worker(WorkerReferenceSubType),
     Entry(EntryReferenceSubType),
     Runtime,
-    Internal(Vc<InnerAssets>),
+    Internal(ResolvedVc<InnerAssets>),
     Custom(u8),
     Undefined,
 }

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1726,7 +1726,7 @@ async fn resolve_internal_inline(
             Request::Alternatives { requests } => {
                 let results = requests
                     .iter()
-                    .map(|&req| async { resolve_internal_inline(lookup_path, *req, options).await })
+                    .map(|req| async { resolve_internal_inline(lookup_path, **req, options).await })
                     .try_join()
                     .await?;
 
@@ -1784,13 +1784,13 @@ async fn resolve_internal_inline(
                 if !fragment.await?.is_empty() {
                     if let Ok(result) = resolve_relative_request(
                         lookup_path,
-                        *request,
+                        request,
                         options,
                         options_value,
                         path,
                         **query,
                         *force_in_lookup_dir,
-                        *fragment,
+                        **fragment,
                     )
                     .await
                     {
@@ -1800,7 +1800,7 @@ async fn resolve_internal_inline(
                 // Resolve without fragment
                 resolve_relative_request(
                     lookup_path,
-                    *request,
+                    request,
                     options,
                     options_value,
                     path,
@@ -1818,7 +1818,7 @@ async fn resolve_internal_inline(
             } => {
                 resolve_module_request(
                     lookup_path,
-                    *request,
+                    request,
                     options,
                     options_value,
                     module,
@@ -2142,7 +2142,7 @@ async fn resolve_relative_request(
 
     let mut results = Vec::new();
     let matches = read_matches(
-        *lookup_path,
+        lookup_path,
         "".into(),
         force_in_lookup_dir,
         Pattern::new(new_path).resolve().await?,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -2804,7 +2804,7 @@ async fn handle_exports_imports_field(
             .await?;
 
             let resolve_result =
-                Box::pin(resolve_internal_inline(package_path, request, options)).await?;
+                Box::pin(resolve_internal_inline(package_path, *request, options)).await?;
             if conditions.is_empty() {
                 resolved_results.push(resolve_result.with_request(path.into()));
             } else {
@@ -2862,7 +2862,7 @@ async fn resolve_package_internal_with_imports_field(
     };
 
     handle_exports_imports_field(
-        package_json_path.parent().to_resolved().await?,
+        package_json_path.parent(),
         *package_json_path,
         resolve_options,
         imports,
@@ -2964,9 +2964,9 @@ pub async fn handle_resolve_source_error(
 
 async fn emit_resolve_error_issue(
     is_optional: bool,
-    origin_path: ResolvedVc<FileSystemPath>,
+    origin_path: Vc<FileSystemPath>,
     reference_type: Value<ReferenceType>,
-    request: ResolvedVc<Request>,
+    request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
     err: anyhow::Error,
     source: Option<ResolvedVc<IssueSource>>,
@@ -2978,10 +2978,10 @@ async fn emit_resolve_error_issue(
     };
     ResolvingIssue {
         severity,
-        file_path: origin_path,
+        file_path: origin_path.to_resolved().await?,
         request_type: format!("{} request", reference_type.into_value()),
         request,
-        resolve_options,
+        resolve_options: resolve_options.to_resolved().await?,
         error_message: Some(format!("{}", PrettyPrintError(&err))),
         source,
     }

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1518,7 +1518,7 @@ pub async fn resolve_inline(
 #[turbo_tasks::function]
 pub async fn url_resolve(
     origin: Vc<Box<dyn ResolveOrigin>>,
-    request: ResolvedVc<Request>,
+    request: Vc<Request>,
     reference_type: Value<ReferenceType>,
     issue_source: Option<ResolvedVc<IssueSource>>,
     is_optional: bool,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1531,12 +1531,12 @@ pub async fn url_resolve(
         rel_request,
         resolve_options,
     );
-    let result = if *rel_result.is_unresolvable().await? && rel_request.resolve().await? != *request
+    let result = if *rel_result.is_unresolvable().await? && rel_request.resolve().await? != request
     {
         resolve(
             origin.origin_path().parent(),
             reference_type.clone(),
-            *request,
+            request,
             resolve_options,
         )
         .with_affecting_sources(
@@ -2893,8 +2893,8 @@ pub async fn handle_resolve_error(
                     is_optional,
                     origin_path,
                     reference_type,
-                    request.to_resolved().await?,
-                    resolve_options.to_resolved().await?,
+                    request,
+                    resolve_options,
                     source,
                 )
                 .await?;

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -2256,8 +2256,8 @@ async fn resolve_relative_request(
 
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn apply_in_package(
-    lookup_path: Vc<FileSystemPath>,
-    options: Vc<ResolveOptions>,
+    lookup_path: ResolvedVc<FileSystemPath>,
+    options: ResolvedVc<ResolveOptions>,
     options_value: &ResolveOptions,
     get_request: impl Fn(&FileSystemPath) -> Option<RcStr>,
     query: Vc<RcStr>,
@@ -2338,9 +2338,11 @@ async fn apply_in_package(
 
         ResolvingIssue {
             severity: error_severity(options).await?,
-            file_path: **package_json_path,
+            file_path: *package_json_path,
             request_type: format!("alias field ({field})"),
-            request: Request::parse(Value::new(Pattern::Constant(request))),
+            request: Request::parse(Value::new(Pattern::Constant(request)))
+                .to_resolved()
+                .await?,
             resolve_options: options,
             error_message: Some(format!("invalid alias field value: {}", value)),
             source: None,
@@ -2600,7 +2602,7 @@ async fn resolve_import_map_result(
     lookup_path: ResolvedVc<FileSystemPath>,
     original_lookup_path: ResolvedVc<FileSystemPath>,
     original_request: ResolvedVc<Request>,
-    options: Vc<ResolveOptions>,
+    options: ResolvedVc<ResolveOptions>,
     query: Vc<RcStr>,
 ) -> Result<Option<Vc<ResolveResult>>> {
     Ok(match result {

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -2723,12 +2723,12 @@ async fn resolved(
 
     if let Some(resolved_map) = options_value.resolved_map {
         let result = resolved_map
-            .lookup(**path, *original_context, *original_request)
+            .lookup(**path, original_context, original_request)
             .await?;
 
         let resolved_result = resolve_import_map_result(
             &result,
-            path.parent().to_resolved().await?,
+            path.parent(),
             original_context,
             original_request,
             options,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -2924,15 +2924,15 @@ pub async fn handle_resolve_error(
 }
 
 pub async fn handle_resolve_source_error(
-    result: Vc<ResolveResult>,
+    result: ResolvedVc<ResolveResult>,
     reference_type: Value<ReferenceType>,
-    origin_path: Vc<FileSystemPath>,
-    request: Vc<Request>,
-    resolve_options: Vc<ResolveOptions>,
+    origin_path: ResolvedVc<FileSystemPath>,
+    request: ResolvedVc<Request>,
+    resolve_options: ResolvedVc<ResolveOptions>,
     is_optional: bool,
     source: Option<ResolvedVc<IssueSource>>,
 ) -> Result<Vc<ResolveResult>> {
-    async fn is_unresolvable(result: Vc<ResolveResult>) -> Result<bool> {
+    async fn is_unresolvable(result: ResolvedVc<ResolveResult>) -> Result<bool> {
         Ok(*result.resolve().await?.is_unresolvable().await?)
     }
     Ok(match is_unresolvable(result).await {
@@ -2969,10 +2969,10 @@ pub async fn handle_resolve_source_error(
 
 async fn emit_resolve_error_issue(
     is_optional: bool,
-    origin_path: Vc<FileSystemPath>,
+    origin_path: ResolvedVc<FileSystemPath>,
     reference_type: Value<ReferenceType>,
-    request: Vc<Request>,
-    resolve_options: Vc<ResolveOptions>,
+    request: ResolvedVc<Request>,
+    resolve_options: ResolvedVc<ResolveOptions>,
     err: anyhow::Error,
     source: Option<ResolvedVc<IssueSource>>,
 ) -> Result<()> {

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1932,9 +1932,9 @@ async fn resolve_internal_inline(
                     ResolvingIssue {
                         severity: error_severity(options).await?,
                         request_type: format!("unknown import: `{}`", path),
-                        request,
-                        file_path: lookup_path,
-                        resolve_options: options,
+                        request: request.to_resolved().await?,
+                        file_path: lookup_path.to_resolved().await?,
+                        resolve_options: options.to_resolved().await?,
                         error_message: None,
                         source: None,
                     }
@@ -2002,7 +2002,7 @@ async fn resolve_into_folder(
                         } else {
                             options
                         };
-                        let result = &*resolve_internal_inline(package_path, request, options)
+                        let result = &*resolve_internal_inline(*package_path, *request, options)
                             .await?
                             .await?;
                         // we are not that strict when a main field fails to resolve
@@ -2039,11 +2039,9 @@ async fn resolve_into_folder(
 
     let request = Request::parse(Value::new(pattern));
 
-    Ok(
-        resolve_internal_inline(package_path, request.to_resolved().await?, options)
-            .await?
-            .with_request(".".into()),
-    )
+    Ok(resolve_internal_inline(*package_path, request, options)
+        .await?
+        .with_request(".".into()))
 }
 
 #[tracing::instrument(level = Level::TRACE, skip_all)]

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1702,7 +1702,7 @@ async fn resolve_internal_inline(
                         lookup_path,
                         lookup_path,
                         request.to_resolved().await?,
-                        *options,
+                        options,
                         request.query(),
                     )
                     .await?;
@@ -1760,7 +1760,7 @@ async fn resolve_internal_inline(
                                     lookup_path,
                                     request,
                                     options_value,
-                                    options,
+                                    *options,
                                     *query,
                                     *fragment,
                                 )
@@ -1769,7 +1769,7 @@ async fn resolve_internal_inline(
                         }
                         PatternMatch::Directory(matched_pattern, path) => {
                             results.push(
-                                resolve_into_folder(*path, options)
+                                resolve_into_folder(*path, *options)
                                     .with_request(matched_pattern.clone()),
                             );
                         }
@@ -1844,8 +1844,8 @@ async fn resolve_internal_inline(
                     ResolvingIssue {
                         severity: error_severity(options).await?,
                         request_type: "server relative import: not implemented yet".to_string(),
-                        request: *request,
-                        file_path: *lookup_path,
+                        request,
+                        file_path: lookup_path,
                         resolve_options: options,
                         error_message: Some(
                             "server relative imports are not implemented yet. Please try an \

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1694,14 +1694,14 @@ async fn resolve_internal_inline(
                 _ => &[*request],
             };
             for request in request_parts {
-                let result = import_map.await?.lookup(*lookup_path, *request).await?;
+                let result = import_map.await?.lookup(lookup_path, *request).await?;
                 if !matches!(result, ImportMapResult::NoEntry) {
                     has_alias = true;
                     let resolved_result = resolve_import_map_result(
                         &result,
                         lookup_path,
                         lookup_path,
-                        request.to_resolved().await?,
+                        request,
                         options,
                         request.query(),
                     )
@@ -1743,7 +1743,7 @@ async fn resolve_internal_inline(
             } => {
                 let mut results = Vec::new();
                 let matches = read_matches(
-                    *lookup_path,
+                    lookup_path,
                     "".into(),
                     *force_in_lookup_dir,
                     Pattern::new(path.clone()).resolve().await?,
@@ -1756,12 +1756,12 @@ async fn resolve_internal_inline(
                             results.push(
                                 resolved(
                                     RequestKey::new(matched_pattern.clone()),
-                                    *path,
+                                    path,
                                     lookup_path,
                                     request,
                                     options_value,
-                                    *options,
-                                    *query,
+                                    options,
+                                    query,
                                     *fragment,
                                 )
                                 .await?,
@@ -2257,7 +2257,7 @@ async fn resolve_relative_request(
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn apply_in_package(
     lookup_path: ResolvedVc<FileSystemPath>,
-    options: ResolvedVc<ResolveOptions>,
+    options: Vc<ResolveOptions>,
     options_value: &ResolveOptions,
     get_request: impl Fn(&FileSystemPath) -> Option<RcStr>,
     query: Vc<RcStr>,
@@ -2403,8 +2403,8 @@ async fn resolve_module_request(
 ) -> Result<Vc<ResolveResult>> {
     // Check alias field for module aliases first
     if let Some(result) = apply_in_package(
-        *lookup_path,
-        *options,
+        lookup_path,
+        options,
         options_value,
         |_| {
             let full_pattern = Pattern::concat([RcStr::from(module).into(), path.clone()]);
@@ -2599,10 +2599,10 @@ async fn resolve_into_package(
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn resolve_import_map_result(
     result: &ImportMapResult,
-    lookup_path: ResolvedVc<FileSystemPath>,
+    lookup_path: Vc<FileSystemPath>,
     original_lookup_path: ResolvedVc<FileSystemPath>,
     original_request: ResolvedVc<Request>,
-    options: ResolvedVc<ResolveOptions>,
+    options: Vc<ResolveOptions>,
     query: Vc<RcStr>,
 ) -> Result<Option<Vc<ResolveResult>>> {
     Ok(match result {

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -2834,7 +2834,7 @@ async fn handle_exports_imports_field(
 async fn resolve_package_internal_with_imports_field(
     file_path: ResolvedVc<FileSystemPath>,
     request: ResolvedVc<Request>,
-    resolve_options: Vc<ResolveOptions>,
+    resolve_options: ResolvedVc<ResolveOptions>,
     pattern: &Pattern,
     conditions: &BTreeMap<RcStr, ConditionValue>,
     unspecified_conditions: &ConditionValue,
@@ -2846,9 +2846,9 @@ async fn resolve_package_internal_with_imports_field(
     if specifier == "#" || specifier.starts_with("#/") || specifier.ends_with('/') {
         ResolvingIssue {
             severity: error_severity(resolve_options).await?,
-            file_path: *file_path,
+            file_path,
             request_type: format!("package imports request: `{specifier}`"),
-            request: *request,
+            request,
             resolve_options,
             error_message: None,
             source: None,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -2404,7 +2404,7 @@ async fn resolve_module_request(
     // Check alias field for module aliases first
     if let Some(result) = apply_in_package(
         *lookup_path,
-        options,
+        *options,
         options_value,
         |_| {
             let full_pattern = Pattern::concat([RcStr::from(module).into(), path.clone()]);
@@ -2977,9 +2977,9 @@ async fn emit_resolve_error_issue(
     source: Option<ResolvedVc<IssueSource>>,
 ) -> Result<()> {
     let severity = if is_optional || resolve_options.await?.loose_errors {
-        IssueSeverity::Warning.cell()
+        IssueSeverity::Warning.resolved_cell()
     } else {
-        IssueSeverity::Error.cell()
+        IssueSeverity::Error.resolved_cell()
     };
     ResolvingIssue {
         severity,
@@ -2997,10 +2997,10 @@ async fn emit_resolve_error_issue(
 
 async fn emit_unresolvable_issue(
     is_optional: bool,
-    origin_path: Vc<FileSystemPath>,
+    origin_path: ResolvedVc<FileSystemPath>,
     reference_type: Value<ReferenceType>,
-    request: Vc<Request>,
-    resolve_options: Vc<ResolveOptions>,
+    request: ResolvedVc<Request>,
+    resolve_options: ResolvedVc<ResolveOptions>,
     source: Option<ResolvedVc<IssueSource>>,
 ) -> Result<()> {
     let severity = if is_optional || resolve_options.await?.loose_errors {

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1701,7 +1701,7 @@ async fn resolve_internal_inline(
                         &result,
                         lookup_path,
                         lookup_path,
-                        request,
+                        *request,
                         options,
                         request.query(),
                     )
@@ -2600,8 +2600,8 @@ async fn resolve_into_package(
 async fn resolve_import_map_result(
     result: &ImportMapResult,
     lookup_path: Vc<FileSystemPath>,
-    original_lookup_path: ResolvedVc<FileSystemPath>,
-    original_request: ResolvedVc<Request>,
+    original_lookup_path: Vc<FileSystemPath>,
+    original_request: Vc<Request>,
     options: Vc<ResolveOptions>,
     query: Vc<RcStr>,
 ) -> Result<Option<Vc<ResolveResult>>> {

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1769,7 +1769,7 @@ async fn resolve_internal_inline(
                         }
                         PatternMatch::Directory(matched_pattern, path) => {
                             results.push(
-                                resolve_into_folder(*path, *options)
+                                resolve_into_folder(*path, options)
                                     .with_request(matched_pattern.clone()),
                             );
                         }
@@ -1787,8 +1787,8 @@ async fn resolve_internal_inline(
                 if !fragment.await?.is_empty() {
                     if let Ok(result) = resolve_relative_request(
                         lookup_path,
-                        request,
-                        *options,
+                        *request,
+                        options,
                         options_value,
                         path,
                         *query,
@@ -2048,8 +2048,8 @@ async fn resolve_into_folder(
 
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn resolve_relative_request(
-    lookup_path: ResolvedVc<FileSystemPath>,
-    request: ResolvedVc<Request>,
+    lookup_path: Vc<FileSystemPath>,
+    request: Vc<Request>,
     options: Vc<ResolveOptions>,
     options_value: &ResolveOptions,
     path_pattern: &Pattern,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1838,7 +1838,7 @@ async fn resolve_internal_inline(
             } => {
                 let mut new_pat = path.clone();
                 new_pat.push_front(RcStr::from(".").into());
-                let relative = Request::relative(Value::new(new_pat), **query, *fragment, true);
+                let relative = Request::relative(Value::new(new_pat), **query, **fragment, true);
 
                 if !has_alias {
                     ResolvingIssue {
@@ -1948,7 +1948,7 @@ async fn resolve_internal_inline(
         // Apply fallback import mappings if provided
         if let Some(import_map) = &options_value.fallback_import_map {
             if *result.is_unresolvable().await? {
-                let result = import_map.await?.lookup(*lookup_path, *request).await?;
+                let result = import_map.await?.lookup(lookup_path, request).await?;
                 let resolved_result = resolve_import_map_result(
                     &result,
                     lookup_path,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1788,7 +1788,7 @@ async fn resolve_internal_inline(
                         options,
                         options_value,
                         path,
-                        *query,
+                        **query,
                         *force_in_lookup_dir,
                         *fragment,
                     )
@@ -1804,7 +1804,7 @@ async fn resolve_internal_inline(
                     options,
                     options_value,
                     path,
-                    *query,
+                    **query,
                     *force_in_lookup_dir,
                     Vc::cell(RcStr::default()),
                 )
@@ -1823,8 +1823,8 @@ async fn resolve_internal_inline(
                     options_value,
                     module,
                     path,
-                    *query,
-                    *fragment,
+                    **query,
+                    **fragment,
                 )
                 .await?
             }

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1874,8 +1874,8 @@ async fn resolve_internal_inline(
                     ResolvingIssue {
                         severity: error_severity(options).await?,
                         request_type: "windows import: not implemented yet".to_string(),
-                        request: *request,
-                        file_path: *lookup_path,
+                        request,
+                        file_path: lookup_path,
                         resolve_options: options,
                         error_message: Some("windows imports are not implemented yet".to_string()),
                         source: None,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1693,8 +1693,8 @@ async fn resolve_internal_inline(
                 Request::Alternatives { requests } => requests.as_slice(),
                 _ => &[request.to_resolved().await?],
             };
-            for request in request_parts {
-                let result = import_map.await?.lookup(lookup_path, request).await?;
+            for &request in request_parts {
+                let result = import_map.await?.lookup(lookup_path, *request).await?;
                 if !matches!(result, ImportMapResult::NoEntry) {
                     has_alias = true;
                     let resolved_result = resolve_import_map_result(
@@ -1726,10 +1726,7 @@ async fn resolve_internal_inline(
             Request::Alternatives { requests } => {
                 let results = requests
                     .iter()
-                    .map(|req| async {
-                        resolve_internal_inline(lookup_path, req.to_resolved().await?, options)
-                            .await
-                    })
+                    .map(|&req| async { resolve_internal_inline(lookup_path, *req, options).await })
                     .try_join()
                     .await?;
 
@@ -1758,11 +1755,11 @@ async fn resolve_internal_inline(
                                     RequestKey::new(matched_pattern.clone()),
                                     *path,
                                     lookup_path,
-                                    *request,
+                                    request,
                                     options_value,
                                     options,
-                                    *query,
-                                    *fragment,
+                                    **query,
+                                    **fragment,
                                 )
                                 .await?,
                             );

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -3002,9 +3002,9 @@ async fn emit_unresolvable_issue(
     source: Option<ResolvedVc<IssueSource>>,
 ) -> Result<()> {
     let severity = if is_optional || resolve_options.await?.loose_errors {
-        IssueSeverity::Warning.cell()
+        IssueSeverity::Warning.resolved_cell()
     } else {
-        IssueSeverity::Error.cell()
+        IssueSeverity::Error.resolved_cell()
     };
     ResolvingIssue {
         severity,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1756,12 +1756,12 @@ async fn resolve_internal_inline(
                             results.push(
                                 resolved(
                                     RequestKey::new(matched_pattern.clone()),
-                                    path,
+                                    *path,
                                     lookup_path,
-                                    request,
+                                    *request,
                                     options_value,
                                     options,
-                                    query,
+                                    *query,
                                     *fragment,
                                 )
                                 .await?,
@@ -2256,7 +2256,7 @@ async fn resolve_relative_request(
 
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn apply_in_package(
-    lookup_path: ResolvedVc<FileSystemPath>,
+    lookup_path: Vc<FileSystemPath>,
     options: Vc<ResolveOptions>,
     options_value: &ResolveOptions,
     get_request: impl Fn(&FileSystemPath) -> Option<RcStr>,
@@ -2702,8 +2702,8 @@ async fn resolve_import_map_result(
 async fn resolved(
     request_key: RequestKey,
     fs_path: Vc<FileSystemPath>,
-    original_context: ResolvedVc<FileSystemPath>,
-    original_request: ResolvedVc<Request>,
+    original_context: Vc<FileSystemPath>,
+    original_request: Vc<Request>,
     options_value: &ResolveOptions,
     options: Vc<ResolveOptions>,
     query: Vc<RcStr>,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -2058,7 +2058,7 @@ async fn resolve_relative_request(
     // Check alias field for aliases first
     let lookup_path_ref = &*lookup_path.await?;
     if let Some(result) = apply_in_package(
-        *lookup_path,
+        lookup_path,
         options,
         options_value,
         |package_path| {
@@ -2420,7 +2420,7 @@ async fn resolve_module_request(
     // module. This should match only using the exports field and no other
     // fields/fallbacks.
     if let FindSelfReferencePackageResult::Found { name, package_path } =
-        &*find_self_reference(*lookup_path).await?
+        &*find_self_reference(lookup_path).await?
     {
         if name == module {
             let result = resolve_into_package(
@@ -2437,7 +2437,7 @@ async fn resolve_module_request(
     }
 
     let result = find_package(
-        *lookup_path,
+        lookup_path,
         module.into(),
         resolve_modules_options(options).resolve().await?,
     )
@@ -2502,7 +2502,7 @@ async fn resolve_module_request(
             .to_resolved()
             .await?;
         let relative_result =
-            Box::pin(resolve_internal_inline(lookup_path, relative, options)).await?;
+            Box::pin(resolve_internal_inline(lookup_path, *relative, options)).await?;
         let relative_result = relative_result
             .with_replaced_request_key(module_prefix, Value::new(RequestKey::new(module.into())));
 
@@ -2554,9 +2554,9 @@ async fn resolve_into_package(
 
                 results.push(
                     handle_exports_imports_field(
-                        package_path,
+                        *package_path,
                         package_json_path,
-                        options,
+                        *options,
                         exports_field,
                         &path,
                         conditions,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1803,7 +1803,7 @@ async fn resolve_internal_inline(
                 // Resolve without fragment
                 resolve_relative_request(
                     lookup_path,
-                    request,
+                    *request,
                     options,
                     options_value,
                     path,
@@ -1821,7 +1821,7 @@ async fn resolve_internal_inline(
             } => {
                 resolve_module_request(
                     lookup_path,
-                    request,
+                    *request,
                     options,
                     options_value,
                     module,
@@ -1845,8 +1845,8 @@ async fn resolve_internal_inline(
                         severity: error_severity(options).await?,
                         request_type: "server relative import: not implemented yet".to_string(),
                         request,
-                        file_path: lookup_path,
-                        resolve_options: options,
+                        file_path: lookup_path.to_resolved().await?,
+                        resolve_options: options.to_resolved().await?,
                         error_message: Some(
                             "server relative imports are not implemented yet. Please try an \
                              import relative to the file you are importing from."
@@ -2392,8 +2392,8 @@ async fn find_self_reference(
 
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn resolve_module_request(
-    lookup_path: ResolvedVc<FileSystemPath>,
-    request: ResolvedVc<Request>,
+    lookup_path: Vc<FileSystemPath>,
+    request: Vc<Request>,
     options: Vc<ResolveOptions>,
     options_value: &ResolveOptions,
     module: &str,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -2878,7 +2878,7 @@ pub async fn handle_resolve_error(
     result: Vc<ModuleResolveResult>,
     reference_type: Value<ReferenceType>,
     origin_path: Vc<FileSystemPath>,
-    request: ResolvedVc<Request>,
+    request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
     is_optional: bool,
     source: Option<ResolvedVc<IssueSource>>,
@@ -2893,8 +2893,8 @@ pub async fn handle_resolve_error(
                     is_optional,
                     origin_path,
                     reference_type,
-                    request,
-                    resolve_options,
+                    request.to_resolved().await?,
+                    resolve_options.to_resolved().await?,
                     source,
                 )
                 .await?;
@@ -2919,15 +2919,15 @@ pub async fn handle_resolve_error(
 }
 
 pub async fn handle_resolve_source_error(
-    result: ResolvedVc<ResolveResult>,
+    result: Vc<ResolveResult>,
     reference_type: Value<ReferenceType>,
-    origin_path: ResolvedVc<FileSystemPath>,
-    request: ResolvedVc<Request>,
-    resolve_options: ResolvedVc<ResolveOptions>,
+    origin_path: Vc<FileSystemPath>,
+    request: Vc<Request>,
+    resolve_options: Vc<ResolveOptions>,
     is_optional: bool,
     source: Option<ResolvedVc<IssueSource>>,
 ) -> Result<Vc<ResolveResult>> {
-    async fn is_unresolvable(result: ResolvedVc<ResolveResult>) -> Result<bool> {
+    async fn is_unresolvable(result: Vc<ResolveResult>) -> Result<bool> {
         Ok(*result.resolve().await?.is_unresolvable().await?)
     }
     Ok(match is_unresolvable(result).await {
@@ -2944,7 +2944,7 @@ pub async fn handle_resolve_source_error(
                 .await?;
             }
 
-            *result
+            result
         }
         Err(err) => {
             emit_resolve_error_issue(
@@ -2980,7 +2980,7 @@ async fn emit_resolve_error_issue(
         severity,
         file_path: origin_path.to_resolved().await?,
         request_type: format!("{} request", reference_type.into_value()),
-        request,
+        request: request.to_resolved().await?,
         resolve_options: resolve_options.to_resolved().await?,
         error_message: Some(format!("{}", PrettyPrintError(&err))),
         source,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -2518,7 +2518,7 @@ async fn resolve_into_package(
     package_path: ResolvedVc<FileSystemPath>,
     query: Vc<RcStr>,
     fragment: Vc<RcStr>,
-    options: Vc<ResolveOptions>,
+    options: ResolvedVc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
     let path = path.into_value();
     let options_value = options.await?;
@@ -2767,7 +2767,7 @@ async fn resolved(
 async fn handle_exports_imports_field(
     package_path: ResolvedVc<FileSystemPath>,
     package_json_path: Vc<FileSystemPath>,
-    options: Vc<ResolveOptions>,
+    options: ResolvedVc<ResolveOptions>,
     exports_imports_field: &AliasMap<SubpathValue>,
     path: &str,
     conditions: &BTreeMap<RcStr, ConditionValue>,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -3020,11 +3020,11 @@ async fn emit_unresolvable_issue(
     Ok(())
 }
 
-async fn error_severity(resolve_options: Vc<ResolveOptions>) -> Result<Vc<IssueSeverity>> {
+async fn error_severity(resolve_options: Vc<ResolveOptions>) -> Result<ResolvedVc<IssueSeverity>> {
     Ok(if resolve_options.await?.loose_errors {
-        IssueSeverity::Warning.cell()
+        IssueSeverity::Warning.resolved_cell()
     } else {
-        IssueSeverity::Error.cell()
+        IssueSeverity::Error.resolved_cell()
     })
 }
 

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -2900,7 +2900,7 @@ pub async fn handle_resolve_error(
                 .await?;
             }
 
-            *result
+            result
         }
         Err(err) => {
             emit_resolve_error_issue(
@@ -2994,7 +2994,7 @@ async fn emit_unresolvable_issue(
     is_optional: bool,
     origin_path: Vc<FileSystemPath>,
     reference_type: Value<ReferenceType>,
-    request: ResolvedVc<Request>,
+    request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
     source: Option<ResolvedVc<IssueSource>>,
 ) -> Result<()> {
@@ -3007,7 +3007,7 @@ async fn emit_unresolvable_issue(
         severity,
         file_path: origin_path.to_resolved().await?,
         request_type: format!("{} request", reference_type.into_value()),
-        request,
+        request: request.to_resolved().await?,
         resolve_options: resolve_options.to_resolved().await?,
         error_message: None,
         source,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1663,7 +1663,7 @@ async fn handle_after_resolve_plugins(
 async fn resolve_internal(
     lookup_path: ResolvedVc<FileSystemPath>,
     request: ResolvedVc<Request>,
-    options: Vc<ResolveOptions>,
+    options: ResolvedVc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
     resolve_internal_inline(lookup_path, request, options).await
 }
@@ -1671,7 +1671,7 @@ async fn resolve_internal(
 async fn resolve_internal_inline(
     lookup_path: ResolvedVc<FileSystemPath>,
     request: ResolvedVc<Request>,
-    options: Vc<ResolveOptions>,
+    options: ResolvedVc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
     let span = {
         let lookup_path = lookup_path.to_string().await?.to_string();
@@ -1702,7 +1702,7 @@ async fn resolve_internal_inline(
                         lookup_path,
                         lookup_path,
                         request.to_resolved().await?,
-                        options,
+                        *options,
                         request.query(),
                     )
                     .await?;
@@ -1932,8 +1932,8 @@ async fn resolve_internal_inline(
                     ResolvingIssue {
                         severity: error_severity(options).await?,
                         request_type: format!("unknown import: `{}`", path),
-                        request: *request,
-                        file_path: *lookup_path,
+                        request,
+                        file_path: lookup_path,
                         resolve_options: options,
                         error_message: None,
                         source: None,

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -208,7 +208,7 @@ impl Request {
             Pattern::Concatenation(list) => {
                 let mut iter = list.into_iter();
                 if let Some(first) = iter.next() {
-                    let mut result = Self::parse_ref(first).await?;
+                    let mut result = Box::pin(Self::parse_ref(first)).await?;
                     match &mut result {
                         Request::Raw { path, .. } => {
                             path.extend(iter);
@@ -227,7 +227,8 @@ impl Request {
                         }
                         Request::Empty => {
                             result =
-                                Request::parse_ref(Pattern::Concatenation(iter.collect())).await?;
+                                Box::pin(Self::parse_ref(Pattern::Concatenation(iter.collect())))
+                                    .await?;
                         }
                         Request::PackageInternal { path } => {
                             path.extend(iter);

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -127,7 +127,6 @@ impl Request {
         })
     }
 
-    #[async_recursion::async_recursion]
     pub async fn parse_ref(mut request: Pattern) -> Result<Self> {
         request.normalize();
         Ok(match request {

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -444,7 +444,7 @@ impl Request {
                 path: path.clone(),
                 query: *query,
                 force_in_lookup_dir: *force_in_lookup_dir,
-                fragment,
+                fragment: fragment.to_resolved().await?,
             }
             .cell(),
             Request::Relative {
@@ -456,7 +456,7 @@ impl Request {
                 path: path.clone(),
                 query: *query,
                 force_in_lookup_dir: *force_in_lookup_dir,
-                fragment,
+                fragment: fragment.to_resolved().await?,
             }
             .cell(),
             Request::Module {
@@ -468,7 +468,7 @@ impl Request {
                 module: module.clone(),
                 path: path.clone(),
                 query: *query,
-                fragment,
+                fragment: fragment.to_resolved().await?,
             }
             .cell(),
             Request::ServerRelative {
@@ -478,7 +478,7 @@ impl Request {
             } => Request::ServerRelative {
                 path: path.clone(),
                 query: *query,
-                fragment,
+                fragment: fragment.to_resolved().await?,
             }
             .cell(),
             Request::Windows {
@@ -488,7 +488,7 @@ impl Request {
             } => Request::Windows {
                 path: path.clone(),
                 query: *query,
-                fragment,
+                fragment: fragment.to_resolved().await?,
             }
             .cell(),
             Request::Empty => self,

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -139,8 +139,8 @@ impl Request {
 
                     Request::ServerRelative {
                         path,
-                        query,
-                        fragment,
+                        query: query.to_resolved().await?,
+                        fragment: fragment.to_resolved().await?,
                     }
                 } else if r.starts_with('#') {
                     Request::PackageInternal {
@@ -152,8 +152,8 @@ impl Request {
                     Request::Relative {
                         path,
                         force_in_lookup_dir: false,
-                        query,
-                        fragment,
+                        query: query.to_resolved().await?,
+                        fragment: fragment.to_resolved().await?,
                     }
                 } else {
                     lazy_static! {
@@ -168,8 +168,8 @@ impl Request {
 
                         return Request::Windows {
                             path,
-                            query,
-                            fragment,
+                            query: query.to_resolved().await?,
+                            fragment: fragment.to_resolved().await?,
                         };
                     }
 
@@ -608,11 +608,11 @@ impl Request {
     #[turbo_tasks::function]
     pub fn query(&self) -> Vc<RcStr> {
         match self {
-            Request::Raw { query, .. } => *query,
-            Request::Relative { query, .. } => *query,
-            Request::Module { query, .. } => *query,
-            Request::ServerRelative { query, .. } => *query,
-            Request::Windows { query, .. } => *query,
+            Request::Raw { query, .. } => **query,
+            Request::Relative { query, .. } => **query,
+            Request::Module { query, .. } => **query,
+            Request::ServerRelative { query, .. } => **query,
+            Request::Windows { query, .. } => **query,
             Request::Empty => Vc::<RcStr>::default(),
             Request::PackageInternal { .. } => Vc::<RcStr>::default(),
             Request::Uri { .. } => Vc::<RcStr>::default(),

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -259,13 +259,13 @@ impl Request {
 #[turbo_tasks::value_impl]
 impl Request {
     #[turbo_tasks::function]
-    pub fn parse(request: Value<Pattern>) -> Vc<Self> {
-        Self::cell(Request::parse_ref(request.into_value()))
+    pub async fn parse(request: Value<Pattern>) -> Result<Vc<Self>> {
+        Ok(Self::cell(Request::parse_ref(request.into_value()).await?))
     }
 
     #[turbo_tasks::function]
-    pub fn parse_string(request: RcStr) -> Vc<Self> {
-        Self::cell(Request::parse_ref(request.into()))
+    pub async fn parse_string(request: RcStr) -> Result<Vc<Self>> {
+        Ok(Self::cell(Request::parse_ref(request.into().await?)))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -208,7 +208,7 @@ impl Request {
             Pattern::Concatenation(list) => {
                 let mut iter = list.into_iter();
                 if let Some(first) = iter.next() {
-                    let mut result = Self::parse_ref(first);
+                    let mut result = Self::parse_ref(first).await?;
                     match &mut result {
                         Request::Raw { path, .. } => {
                             path.extend(iter);
@@ -226,7 +226,8 @@ impl Request {
                             path.extend(iter);
                         }
                         Request::Empty => {
-                            result = Request::parse_ref(Pattern::Concatenation(iter.collect()))
+                            result =
+                                Request::parse_ref(Pattern::Concatenation(iter.collect())).await?;
                         }
                         Request::PackageInternal { path } => {
                             path.extend(iter);

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -166,22 +166,22 @@ impl Request {
                     if WINDOWS_PATH.is_match(&r) {
                         let (path, query, fragment) = split_off_query_fragment(r);
 
-                        return Request::Windows {
+                        return Ok(Request::Windows {
                             path,
                             query: query.to_resolved().await?,
                             fragment: fragment.to_resolved().await?,
-                        };
+                        });
                     }
 
                     if let Some(caps) = URI_PATH.captures(&r) {
                         if let (Some(protocol), Some(remainder)) = (caps.get(1), caps.get(2)) {
                             // TODO data uri
-                            return Request::Uri {
+                            return Ok(Request::Uri {
                                 protocol: protocol.as_str().to_string(),
                                 remainder: remainder.as_str().to_string(),
                                 query: ResolvedVc::cell(RcStr::default()),
                                 fragment: ResolvedVc::cell(RcStr::default()),
-                            };
+                            });
                         }
                     }
 
@@ -192,12 +192,12 @@ impl Request {
                         let (path, query, fragment) =
                             split_off_query_fragment(path.as_str().into());
 
-                        return Request::Module {
+                        return Ok(Request::Module {
                             module: module.as_str().into(),
                             path,
                             query: query.to_resolved().await?,
                             fragment: fragment.to_resolved().await?,
-                        };
+                        });
                     }
 
                     Request::Unknown {

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use lazy_static::lazy_static;
 use regex::Regex;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{TryJoinIterExt, Value, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, ValueToString, Vc};
 
 use super::pattern::Pattern;
 
@@ -11,31 +11,31 @@ use super::pattern::Pattern;
 pub enum Request {
     Raw {
         path: Pattern,
-        query: Vc<RcStr>,
+        query: ResolvedVc<RcStr>,
         force_in_lookup_dir: bool,
-        fragment: Vc<RcStr>,
+        fragment: ResolvedVc<RcStr>,
     },
     Relative {
         path: Pattern,
-        query: Vc<RcStr>,
+        query: ResolvedVc<RcStr>,
         force_in_lookup_dir: bool,
-        fragment: Vc<RcStr>,
+        fragment: ResolvedVc<RcStr>,
     },
     Module {
         module: RcStr,
         path: Pattern,
-        query: Vc<RcStr>,
-        fragment: Vc<RcStr>,
+        query: ResolvedVc<RcStr>,
+        fragment: ResolvedVc<RcStr>,
     },
     ServerRelative {
         path: Pattern,
-        query: Vc<RcStr>,
-        fragment: Vc<RcStr>,
+        query: ResolvedVc<RcStr>,
+        fragment: ResolvedVc<RcStr>,
     },
     Windows {
         path: Pattern,
-        query: Vc<RcStr>,
-        fragment: Vc<RcStr>,
+        query: ResolvedVc<RcStr>,
+        fragment: ResolvedVc<RcStr>,
     },
     Empty,
     PackageInternal {
@@ -44,15 +44,15 @@ pub enum Request {
     Uri {
         protocol: String,
         remainder: String,
-        query: Vc<RcStr>,
-        fragment: Vc<RcStr>,
+        query: ResolvedVc<RcStr>,
+        fragment: ResolvedVc<RcStr>,
     },
     Unknown {
         path: Pattern,
     },
     Dynamic,
     Alternatives {
-        requests: Vec<Vc<Request>>,
+        requests: Vec<ResolvedVc<Request>>,
     },
 }
 

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -538,7 +538,7 @@ impl Request {
             } => {
                 let mut pat = Pattern::concat([path.clone(), suffix.into()]);
                 pat.normalize();
-                Self::module(module.clone(), Value::new(pat), *query, *fragment)
+                Self::module(module.clone(), Value::new(pat), **query, **fragment)
             }
             Request::ServerRelative {
                 path,
@@ -650,7 +650,7 @@ impl Request {
             Request::Alternatives { requests } => Pattern::Alternatives(
                 requests
                     .iter()
-                    .map(async |r: &Vc<Request>| -> Result<Pattern> {
+                    .map(async |r: &ResolvedVc<Request>| -> Result<Pattern> {
                         Ok(r.request_pattern().await?.clone_value())
                     })
                     .try_join()

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -269,48 +269,48 @@ impl Request {
     }
 
     #[turbo_tasks::function]
-    pub fn raw(
+    pub async fn raw(
         request: Value<Pattern>,
         query: Vc<RcStr>,
         fragment: Vc<RcStr>,
         force_in_lookup_dir: bool,
-    ) -> Vc<Self> {
-        Self::cell(Request::Raw {
+    ) -> Result<Vc<Self>> {
+        Ok(Self::cell(Request::Raw {
             path: request.into_value(),
             force_in_lookup_dir,
-            query,
-            fragment,
-        })
+            query: query.to_resolved().await?,
+            fragment: fragment.to_resolved().await?,
+        }))
     }
 
     #[turbo_tasks::function]
-    pub fn relative(
+    pub async fn relative(
         request: Value<Pattern>,
         query: Vc<RcStr>,
         fragment: Vc<RcStr>,
         force_in_lookup_dir: bool,
-    ) -> Vc<Self> {
-        Self::cell(Request::Relative {
+    ) -> Result<Vc<Self>> {
+        Ok(Self::cell(Request::Relative {
             path: request.into_value(),
             force_in_lookup_dir,
-            query,
-            fragment,
-        })
+            query: query.to_resolved().await?,
+            fragment: fragment.to_resolved().await?,
+        }))
     }
 
     #[turbo_tasks::function]
-    pub fn module(
+    pub async fn module(
         module: RcStr,
         path: Value<Pattern>,
         query: Vc<RcStr>,
         fragment: Vc<RcStr>,
-    ) -> Vc<Self> {
-        Self::cell(Request::Module {
+    ) -> Result<Vc<Self>> {
+        Ok(Self::cell(Request::Module {
             module,
             path: path.into_value(),
-            query,
-            fragment,
-        })
+            query: query.to_resolved().await?,
+            fragment: fragment.to_resolved().await?,
+        }))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -518,7 +518,7 @@ impl Request {
             } => {
                 let mut pat = Pattern::concat([path.clone(), suffix.into()]);
                 pat.normalize();
-                Self::raw(Value::new(pat), *query, *fragment, *force_in_lookup_dir)
+                Self::raw(Value::new(pat), **query, **fragment, *force_in_lookup_dir)
             }
             Request::Relative {
                 path,
@@ -528,7 +528,7 @@ impl Request {
             } => {
                 let mut pat = Pattern::concat([path.clone(), suffix.into()]);
                 pat.normalize();
-                Self::relative(Value::new(pat), *query, *fragment, *force_in_lookup_dir)
+                Self::relative(Value::new(pat), **query, **fragment, *force_in_lookup_dir)
             }
             Request::Module {
                 module,

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -367,7 +367,7 @@ impl Request {
                 fragment,
             } => Request::Raw {
                 path: path.clone(),
-                query,
+                query: query.to_resolved().await?,
                 force_in_lookup_dir: *force_in_lookup_dir,
                 fragment: *fragment,
             }
@@ -379,7 +379,7 @@ impl Request {
                 fragment,
             } => Request::Relative {
                 path: path.clone(),
-                query,
+                query: query.to_resolved().await?,
                 force_in_lookup_dir: *force_in_lookup_dir,
                 fragment: *fragment,
             }
@@ -392,7 +392,7 @@ impl Request {
             } => Request::Module {
                 module: module.clone(),
                 path: path.clone(),
-                query,
+                query: query.to_resolved().await?,
                 fragment: *fragment,
             }
             .cell(),
@@ -402,7 +402,7 @@ impl Request {
                 fragment,
             } => Request::ServerRelative {
                 path: path.clone(),
-                query,
+                query: query.to_resolved().await?,
                 fragment: *fragment,
             }
             .cell(),
@@ -412,7 +412,7 @@ impl Request {
                 fragment,
             } => Request::Windows {
                 path: path.clone(),
-                query,
+                query: query.to_resolved().await?,
                 fragment: *fragment,
             }
             .cell(),

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -346,7 +346,12 @@ impl Request {
                 Self::parse(Value::new(pat))
             }
             Request::Alternatives { requests } => {
-                let requests = requests.iter().copied().map(Request::as_relative).collect();
+                let requests = requests
+                    .iter()
+                    .copied()
+                    .map(|v| *v)
+                    .map(Request::as_relative)
+                    .collect();
                 Request::Alternatives { requests }.cell()
             }
         })

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -265,7 +265,7 @@ impl Request {
 
     #[turbo_tasks::function]
     pub async fn parse_string(request: RcStr) -> Result<Vc<Self>> {
-        Ok(Self::cell(Request::parse_ref(request.into().await?)))
+        Ok(Self::cell(Request::parse_ref(request.into()).await?))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -40,7 +40,7 @@ impl Asset for SourceMapAsset {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<AssetContent>> {
         let Some(generate_source_map) =
-            Vc::try_resolve_sidecast::<Box<dyn GenerateSourceMap>>(self.asset).await?
+            ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(self.asset).await?
         else {
             bail!("asset does not support generating source maps")
         };

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexSet, ValueToString, Vc};
+use turbo_tasks::{FxIndexSet, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::File;
 
 use crate::{
@@ -14,7 +14,7 @@ use crate::{
 /// Represents the source map of an ecmascript asset.
 #[turbo_tasks::value]
 pub struct SourceMapAsset {
-    asset: Vc<Box<dyn OutputAsset>>,
+    asset: ResolvedVc<Box<dyn OutputAsset>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -86,7 +86,7 @@ impl Introspectable for SourceMapAsset {
         let mut children = FxIndexSet::default();
         if let Some(asset) = ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.asset).await?
         {
-            children.insert((Vc::cell("asset".into()), asset));
+            children.insert((Vc::cell("asset".into()), *asset));
         }
         Ok(Vc::cell(children))
     }

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -84,7 +84,7 @@ impl Introspectable for SourceMapAsset {
     #[turbo_tasks::function]
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         let mut children = FxIndexSet::default();
-        if let Some(asset) = Vc::try_resolve_sidecast::<Box<dyn Introspectable>>(self.asset).await?
+        if let Some(asset) = ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.asset).await?
         {
             children.insert((Vc::cell("asset".into()), asset));
         }

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -20,7 +20,7 @@ pub struct SourceMapAsset {
 #[turbo_tasks::value_impl]
 impl SourceMapAsset {
     #[turbo_tasks::function]
-    pub fn new(asset: Vc<Box<dyn OutputAsset>>) -> Vc<Self> {
+    pub fn new(asset: ResolvedVc<Box<dyn OutputAsset>>) -> Vc<Self> {
         SourceMapAsset { asset }.cell()
     }
 }

--- a/turbopack/crates/turbopack-core/src/target.rs
+++ b/turbopack/crates/turbopack-core/src/target.rs
@@ -30,12 +30,7 @@ impl Default for CompileTarget {
 impl CompileTarget {
     #[turbo_tasks::function]
     pub fn current() -> Vc<Self> {
-        Self::cell(CompileTarget {
-            arch: CompileTarget::current_arch(),
-            platform: CompileTarget::current_platform(),
-            endianness: CompileTarget::current_endianness(),
-            libc: CompileTarget::current_libc(),
-        })
+        Self::cell(Self::current_raw())
     }
 
     #[turbo_tasks::function]
@@ -56,6 +51,15 @@ impl Display for CompileTarget {
 }
 
 impl CompileTarget {
+    pub fn current_raw() -> Self {
+        CompileTarget {
+            arch: CompileTarget::current_arch(),
+            platform: CompileTarget::current_platform(),
+            endianness: CompileTarget::current_endianness(),
+            libc: CompileTarget::current_libc(),
+        }
+    }
+
     pub fn dylib_ext(&self) -> &'static str {
         let platform = self.platform;
         match platform {

--- a/turbopack/crates/turbopack-core/src/target.rs
+++ b/turbopack/crates/turbopack-core/src/target.rs
@@ -15,6 +15,17 @@ pub struct CompileTarget {
     pub libc: Libc,
 }
 
+impl Default for CompileTarget {
+    fn default() -> Self {
+        CompileTarget {
+            arch: Arch::Unknown,
+            platform: Platform::Unknown,
+            endianness: Endianness::Big,
+            libc: Libc::Unknown,
+        }
+    }
+}
+
 #[turbo_tasks::value_impl]
 impl CompileTarget {
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/virtual_output.rs
+++ b/turbopack/crates/turbopack-core/src/virtual_output.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
@@ -11,8 +11,8 @@ use crate::{
 /// to other assets.
 #[turbo_tasks::value]
 pub struct VirtualOutputAsset {
-    pub path: Vc<FileSystemPath>,
-    pub content: Vc<AssetContent>,
+    pub path: ResolvedVc<FileSystemPath>,
+    pub content: ResolvedVc<AssetContent>,
     pub references: Vc<OutputAssets>,
 }
 

--- a/turbopack/crates/turbopack-core/src/virtual_output.rs
+++ b/turbopack/crates/turbopack-core/src/virtual_output.rs
@@ -32,7 +32,7 @@ impl VirtualOutputAsset {
     pub fn new_with_references(
         path: ResolvedVc<FileSystemPath>,
         content: ResolvedVc<AssetContent>,
-        references: ResolvedVc<OutputAssets>,
+        references: Vc<OutputAssets>,
     ) -> Vc<Self> {
         VirtualOutputAsset {
             path,

--- a/turbopack/crates/turbopack-core/src/virtual_output.rs
+++ b/turbopack/crates/turbopack-core/src/virtual_output.rs
@@ -19,7 +19,7 @@ pub struct VirtualOutputAsset {
 #[turbo_tasks::value_impl]
 impl VirtualOutputAsset {
     #[turbo_tasks::function]
-    pub fn new(path: Vc<FileSystemPath>, content: Vc<AssetContent>) -> Vc<Self> {
+    pub fn new(path: ResolvedVc<FileSystemPath>, content: ResolvedVc<AssetContent>) -> Vc<Self> {
         VirtualOutputAsset {
             path,
             content,
@@ -30,9 +30,9 @@ impl VirtualOutputAsset {
 
     #[turbo_tasks::function]
     pub fn new_with_references(
-        path: Vc<FileSystemPath>,
-        content: Vc<AssetContent>,
-        references: Vc<OutputAssets>,
+        path: ResolvedVc<FileSystemPath>,
+        content: ResolvedVc<AssetContent>,
+        references: ResolvedVc<OutputAssets>,
     ) -> Vc<Self> {
         VirtualOutputAsset {
             path,
@@ -47,7 +47,7 @@ impl VirtualOutputAsset {
 impl OutputAsset for VirtualOutputAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(self.path)
+        AssetIdent::from_path(*self.path)
     }
 
     #[turbo_tasks::function]
@@ -60,6 +60,6 @@ impl OutputAsset for VirtualOutputAsset {
 impl Asset for VirtualOutputAsset {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
-        self.content
+        *self.content
     }
 }

--- a/turbopack/crates/turbopack-core/src/virtual_source.rs
+++ b/turbopack/crates/turbopack-core/src/virtual_source.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
@@ -10,8 +10,8 @@ use crate::{
 /// A [Source] that is created from some passed source code.
 #[turbo_tasks::value]
 pub struct VirtualSource {
-    pub ident: Vc<AssetIdent>,
-    pub content: Vc<AssetContent>,
+    pub ident: ResolvedVc<AssetIdent>,
+    pub content: ResolvedVc<AssetContent>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-core/src/virtual_source.rs
+++ b/turbopack/crates/turbopack-core/src/virtual_source.rs
@@ -17,7 +17,7 @@ pub struct VirtualSource {
 #[turbo_tasks::value_impl]
 impl VirtualSource {
     #[turbo_tasks::function]
-    pub fn new(path: Vc<FileSystemPath>, content: Vc<AssetContent>) -> Vc<Self> {
+    pub fn new(path: Vc<FileSystemPath>, content: ResolvedVc<AssetContent>) -> Vc<Self> {
         Self::cell(VirtualSource {
             ident: AssetIdent::from_path(path),
             content,
@@ -25,7 +25,10 @@ impl VirtualSource {
     }
 
     #[turbo_tasks::function]
-    pub fn new_with_ident(ident: Vc<AssetIdent>, content: Vc<AssetContent>) -> Vc<Self> {
+    pub fn new_with_ident(
+        ident: ResolvedVc<AssetIdent>,
+        content: ResolvedVc<AssetContent>,
+    ) -> Vc<Self> {
         Self::cell(VirtualSource { ident, content })
     }
 }
@@ -34,7 +37,7 @@ impl VirtualSource {
 impl Source for VirtualSource {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        self.ident
+        *self.ident
     }
 }
 
@@ -42,6 +45,6 @@ impl Source for VirtualSource {
 impl Asset for VirtualSource {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
-        self.content
+        *self.content
     }
 }

--- a/turbopack/crates/turbopack-core/src/virtual_source.rs
+++ b/turbopack/crates/turbopack-core/src/virtual_source.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
@@ -17,11 +18,14 @@ pub struct VirtualSource {
 #[turbo_tasks::value_impl]
 impl VirtualSource {
     #[turbo_tasks::function]
-    pub fn new(path: Vc<FileSystemPath>, content: ResolvedVc<AssetContent>) -> Vc<Self> {
-        Self::cell(VirtualSource {
-            ident: AssetIdent::from_path(path),
+    pub async fn new(
+        path: Vc<FileSystemPath>,
+        content: ResolvedVc<AssetContent>,
+    ) -> Result<Vc<Self>> {
+        Ok(Self::cell(VirtualSource {
+            ident: AssetIdent::from_path(path).to_resolved().await?,
             content,
-        })
+        }))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/references/import.rs
+++ b/turbopack/crates/turbopack-css/src/references/import.rs
@@ -118,6 +118,8 @@ impl ModuleReference for ImportAssetReference {
             let own_attrs = (*self.attributes.await?).as_reference_import_attributes();
             self.import_context
                 .add_attributes(own_attrs.layer, own_attrs.media, own_attrs.supports)
+                .to_resolved()
+                .await?
         };
 
         Ok(css_resolve(

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/asset_context.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/asset_context.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::Vc;
+use turbo_tasks::{Result, Vc};
 use turbopack::{
     module_options::{EcmascriptOptionsContext, ModuleOptionsContext, TypescriptTransformOptions},
     ModuleAssetContext,
@@ -9,7 +9,9 @@ use turbopack_core::{
 use turbopack_ecmascript::TreeShakingMode;
 
 /// Returns the runtime asset context to use to process runtime code assets.
-pub fn get_runtime_asset_context(environment: Vc<Environment>) -> Vc<Box<dyn AssetContext>> {
+pub async fn get_runtime_asset_context(
+    environment: Vc<Environment>,
+) -> Result<Vc<Box<dyn AssetContext>>> {
     let module_options_context = ModuleOptionsContext {
         ecmascript: EcmascriptOptionsContext {
             enable_typescript_transform: Some(
@@ -23,7 +25,9 @@ pub fn get_runtime_asset_context(environment: Vc<Environment>) -> Vc<Box<dyn Ass
         ..Default::default()
     }
     .cell();
-    let compile_time_info = CompileTimeInfo::builder(environment).cell();
+    let compile_time_info = CompileTimeInfo::builder(environment.to_resolved().await?)
+        .cell()
+        .await?;
 
     let asset_context: Vc<Box<dyn AssetContext>> = Vc::upcast(ModuleAssetContext::new(
         Default::default(),
@@ -33,5 +37,5 @@ pub fn get_runtime_asset_context(environment: Vc<Environment>) -> Vc<Box<dyn Ass
         Vc::cell("runtime".into()),
     ));
 
-    asset_context
+    Ok(asset_context)
 }

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/browser_runtime.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/browser_runtime.rs
@@ -21,7 +21,7 @@ pub async fn get_browser_runtime_code(
     runtime_type: Value<RuntimeType>,
     output_root: Vc<RcStr>,
 ) -> Result<Vc<Code>> {
-    let asset_context = get_runtime_asset_context(environment);
+    let asset_context = get_runtime_asset_context(environment).await?;
 
     let shared_runtime_utils_code =
         embed_static_code(asset_context, "shared/runtime-utils.ts".into());

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/nodejs_runtime.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/nodejs_runtime.rs
@@ -10,7 +10,7 @@ use crate::{asset_context::get_runtime_asset_context, embed_js::embed_static_cod
 /// Returns the code for the Node.js production ECMAScript runtime.
 #[turbo_tasks::function]
 pub async fn get_nodejs_runtime_code(environment: Vc<Environment>) -> Result<Vc<Code>> {
-    let asset_context = get_runtime_asset_context(environment);
+    let asset_context = get_runtime_asset_context(environment).await?;
 
     let shared_runtime_utils_code =
         embed_static_code(asset_context, "shared/runtime-utils.ts".into());

--- a/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
@@ -10,7 +10,7 @@ use swc_core::{
         visit::VisitMutWith,
     },
 };
-use turbo_tasks::Value;
+use turbo_tasks::{ResolvedVc, Value};
 use turbo_tasks_testing::VcStorage;
 use turbopack_core::{
     compile_time_info::CompileTimeInfo,
@@ -95,16 +95,18 @@ fn bench_link(b: &mut Bencher, input: &BenchInput) {
     b.to_async(rt).iter(|| async {
         for val in input.var_graph.values.values() {
             VcStorage::with(async {
-                let compile_time_info = CompileTimeInfo::builder(Environment::new(Value::new(
-                    ExecutionEnvironment::NodeJsLambda(
+                let compile_time_info = CompileTimeInfo::builder(
+                    Environment::new(Value::new(ExecutionEnvironment::NodeJsLambda(
                         NodeJsEnvironment {
-                            compile_target: CompileTarget::unknown(),
+                            compile_target: CompileTarget::unknown().to_resolved().await?,
                             node_version: NodeJsVersion::default().resolved_cell(),
                             cwd: ResolvedVc::cell(None),
                         }
                         .into(),
-                    ),
-                )))
+                    )))
+                    .to_resolved()
+                    .await?,
+                )
                 .cell()
                 .await?;
                 link(

--- a/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
@@ -14,7 +14,7 @@ use turbo_tasks::Value;
 use turbo_tasks_testing::VcStorage;
 use turbopack_core::{
     compile_time_info::CompileTimeInfo,
-    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
+    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion},
     target::CompileTarget,
 };
 use turbopack_ecmascript::analyzer::{
@@ -99,12 +99,14 @@ fn bench_link(b: &mut Bencher, input: &BenchInput) {
                     ExecutionEnvironment::NodeJsLambda(
                         NodeJsEnvironment {
                             compile_target: CompileTarget::unknown(),
-                            ..Default::default()
+                            node_version: NodeJsVersion::default().resolved_cell(),
+                            cwd: ResolvedVc::cell(None),
                         }
                         .into(),
                     ),
                 )))
-                .cell();
+                .cell()
+                .await?;
                 link(
                     &input.var_graph,
                     val.clone(),

--- a/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
@@ -102,7 +102,7 @@ fn bench_link(b: &mut Bencher, input: &BenchInput) {
                             node_version: NodeJsVersion::default().resolved_cell(),
                             cwd: ResolvedVc::cell(None),
                         }
-                        .into(),
+                        .resolved_cell(),
                     )))
                     .to_resolved()
                     .await?,

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -3986,10 +3986,10 @@ mod tests {
         },
         testing::{fixture, run_test, NormalizedOutput},
     };
-    use turbo_tasks::{util::FormatDuration, Value};
+    use turbo_tasks::{util::FormatDuration, ResolvedVc, Value};
     use turbopack_core::{
         compile_time_info::CompileTimeInfo,
-        environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
+        environment::{Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion},
         target::{Arch, CompileTarget, Endianness, Libc, Platform},
     };
 
@@ -4314,8 +4314,8 @@ mod tests {
 
     async fn resolve(var_graph: &VarGraph, val: JsValue, attributes: &ImportAttributes) -> JsValue {
         turbo_tasks_testing::VcStorage::with(async {
-            let compile_time_info = CompileTimeInfo::builder(Environment::new(Value::new(
-                ExecutionEnvironment::NodeJsLambda(
+            let compile_time_info = CompileTimeInfo::builder(
+                Environment::new(Value::new(ExecutionEnvironment::NodeJsLambda(
                     NodeJsEnvironment {
                         compile_target: CompileTarget {
                             arch: Arch::X64,
@@ -4323,12 +4323,15 @@ mod tests {
                             endianness: Endianness::Little,
                             libc: Libc::Glibc,
                         }
-                        .into(),
-                        ..Default::default()
+                        .resolved_cell(),
+                        node_version: NodeJsVersion::default().resolved_cell(),
+                        cwd: ResolvedVc::cell(None),
                     }
                     .into(),
-                ),
-            )))
+                )))
+                .to_resolved()
+                .await?,
+            )
             .cell()
             .await?;
             link(

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -4329,7 +4329,8 @@ mod tests {
                     .into(),
                 ),
             )))
-            .cell();
+            .cell()
+            .await?;
             link(
                 var_graph,
                 val,

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -4327,7 +4327,7 @@ mod tests {
                         node_version: NodeJsVersion::default().resolved_cell(),
                         cwd: ResolvedVc::cell(None),
                     }
-                    .into(),
+                    .resolved_cell(),
                 )))
                 .to_resolved()
                 .await?,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -403,11 +403,11 @@ pub async fn expand_star_exports(
 fn emit_star_exports_issue(source_ident: Vc<AssetIdent>, message: RcStr) {
     AnalyzeIssue {
         code: None,
-        message: StyledString::Text(message).cell(),
+        message: StyledString::Text(message).resolved_cell(),
         source_ident,
-        severity: IssueSeverity::Warning.into(),
+        severity: IssueSeverity::Warning.resolved_cell(),
         source: None,
-        title: Vc::cell("unexpected export *".into()),
+        title: ResolvedVc::cell("unexpected export *".into()),
     }
     .cell()
     .emit();

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1288,7 +1288,7 @@ async fn compile_time_info_for_module_type(
     Ok(CompileTimeInfo {
         environment: compile_time_info.environment,
         defines: compile_time_info.defines,
-        free_var_references: FreeVarReferences(free_var_references).cell(),
+        free_var_references: FreeVarReferences(free_var_references).resolved_cell(),
     }
     .cell())
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -832,11 +832,11 @@ pub(crate) async fn analyse_ecmascript_module_internal(
         AnalyzeIssue {
             code: None,
             message: StyledString::Text("top level await is only supported in ESM modules.".into())
-                .cell(),
+                .resolved_cell(),
             source_ident: source.ident(),
             severity: IssueSeverity::Error.into(),
             source: Some(issue_source(*source, span)),
-            title: Vc::cell("unexpected top level await".into()),
+            title: ResolvedVc::cell("unexpected top level await".into()),
         }
         .cell()
         .emit();

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -834,7 +834,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
             message: StyledString::Text("top level await is only supported in ESM modules.".into())
                 .resolved_cell(),
             source_ident: source.ident(),
-            severity: IssueSeverity::Error.into(),
+            severity: IssueSeverity::Error.resolved_cell(),
             source: Some(issue_source(*source, span)),
             title: ResolvedVc::cell("unexpected top level await".into()),
         }

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -96,7 +96,9 @@ async fn emit_evaluate_pool_assets(
     let runtime_asset = asset_context
         .process(
             Vc::upcast(FileSource::new(embed_file_path("ipc/evaluate.ts".into()))),
-            Value::new(ReferenceType::Internal(InnerAssets::empty())),
+            Value::new(ReferenceType::Internal(
+                InnerAssets::empty().to_resolved().await?,
+            )),
         )
         .module()
         .to_resolved()
@@ -120,7 +122,7 @@ async fn emit_evaluate_pool_assets(
                     File::from("import { run } from 'RUNTIME'; run(() => import('INNER'))").into(),
                 ),
             )),
-            Value::new(ReferenceType::Internal(Vc::cell(fxindexmap! {
+            Value::new(ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
                 "INNER".into() => module_asset,
                 "RUNTIME".into() => runtime_asset
             }))),
@@ -131,7 +133,9 @@ async fn emit_evaluate_pool_assets(
         let globals_module = asset_context
             .process(
                 Vc::upcast(FileSource::new(embed_file_path("globals.ts".into()))),
-                Value::new(ReferenceType::Internal(InnerAssets::empty())),
+                Value::new(ReferenceType::Internal(
+                    InnerAssets::empty().to_resolved().await?,
+                )),
             )
             .module();
 

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -172,19 +172,21 @@ struct ProcessPostCssResult {
 async fn config_changed(
     asset_context: Vc<Box<dyn AssetContext>>,
     postcss_config_path: Vc<FileSystemPath>,
-) -> Vc<Completion> {
+) -> Result<Vc<Completion>> {
     let config_asset = asset_context
         .process(
             Vc::upcast(FileSource::new(postcss_config_path)),
-            Value::new(ReferenceType::Internal(InnerAssets::empty())),
+            Value::new(ReferenceType::Internal(
+                InnerAssets::empty().to_resolved().await?,
+            )),
         )
         .module();
 
-    Vc::<Completions>::cell(vec![
+    Ok(Vc::<Completions>::cell(vec![
         any_content_changed_of_module(config_asset),
         extra_configs_changed(asset_context, postcss_config_path),
     ])
-    .completed()
+    .completed())
 }
 
 #[turbo_tasks::function]
@@ -208,7 +210,9 @@ async fn extra_configs_changed(
                     asset_context
                         .process(
                             Vc::upcast(FileSource::new(path)),
-                            Value::new(ReferenceType::Internal(InnerAssets::empty())),
+                            Value::new(ReferenceType::Internal(
+                                InnerAssets::empty().to_resolved().await?,
+                            )),
                         )
                         .try_into_module()
                         .await?
@@ -383,7 +387,7 @@ async fn postcss_executor(
             )
             .cell(),
         )),
-        Value::new(ReferenceType::Internal(Vc::cell(fxindexmap! {
+        Value::new(ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
             "CONFIG".into() => config_asset
         }))),
     ))

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -176,13 +176,17 @@ struct ProcessWebpackLoadersResult {
 }
 
 #[turbo_tasks::function]
-fn webpack_loaders_executor(evaluate_context: Vc<Box<dyn AssetContext>>) -> Vc<ProcessResult> {
-    evaluate_context.process(
+async fn webpack_loaders_executor(
+    evaluate_context: Vc<Box<dyn AssetContext>>,
+) -> Result<Vc<ProcessResult>> {
+    Ok(evaluate_context.process(
         Vc::upcast(FileSource::new(embed_file_path(
             "transforms/webpack-loaders.ts".into(),
         ))),
-        Value::new(ReferenceType::Internal(InnerAssets::empty())),
-    )
+        Value::new(ReferenceType::Internal(
+            InnerAssets::empty().to_resolved().await?,
+        )),
+    ))
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-swc-utils/src/emitter.rs
+++ b/turbopack/crates/turbopack-swc-utils/src/emitter.rs
@@ -6,7 +6,7 @@ use swc_core::common::{
     SourceMap,
 };
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::ResolvedVc;
 use turbopack_core::{
     issue::{analyze::AnalyzeIssue, IssueExt, IssueSeverity, IssueSource, StyledString},
     source::Source,

--- a/turbopack/crates/turbopack-swc-utils/src/emitter.rs
+++ b/turbopack/crates/turbopack-swc-utils/src/emitter.rs
@@ -6,7 +6,7 @@ use swc_core::common::{
     SourceMap,
 };
 use turbo_rcstr::RcStr;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::{
     issue::{analyze::AnalyzeIssue, IssueExt, IssueSeverity, IssueSource, StyledString},
     source::Source,
@@ -67,7 +67,7 @@ impl Emitter for IssueEmitter {
                 Level::FailureNote => IssueSeverity::Note,
             }
         })
-        .cell();
+        .resolved_cell();
 
         let title;
         if let Some(t) = self.title.as_ref() {
@@ -86,8 +86,8 @@ impl Emitter for IssueEmitter {
         let issue = AnalyzeIssue {
             severity,
             source_ident: self.source.ident(),
-            title: Vc::cell(title),
-            message: StyledString::Text(message.into()).cell(),
+            title: ResolvedVc::cell(title),
+            message: StyledString::Text(message.into()).resolved_cell(),
             code,
             source,
         }

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -73,7 +73,7 @@ impl WebAssemblyModuleAsset {
 
         let module = this.asset_context.process(
             loader_source,
-            Value::new(ReferenceType::Internal(Vc::cell(fxindexmap! {
+            Value::new(ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
                 "WASM_PATH".into() => ResolvedVc::upcast(RawWebAssemblyModuleAsset::new(this.source, this.asset_context).to_resolved().await?),
             }))),
         ).module();

--- a/turbopack/crates/turbopack/benches/node_file_trace.rs
+++ b/turbopack/crates/turbopack/benches/node_file_trace.rs
@@ -83,10 +83,15 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
                 let output_dir = output_fs.root();
 
                 let source = FileSource::new(input);
-                let compile_time_info = CompileTimeInfo::builder(Environment::new(Value::new(
-                    ExecutionEnvironment::NodeJsLambda(NodeJsEnvironment::default().into()),
-                )))
-                .cell();
+                let compile_time_info = CompileTimeInfo::builder(
+                    Environment::new(Value::new(ExecutionEnvironment::NodeJsLambda(
+                        NodeJsEnvironment::default().resolved_cell(),
+                    )))
+                    .to_resolved()
+                    .await?,
+                )
+                .cell()
+                .await?;
                 let module_asset_context = ModuleAssetContext::new(
                     Default::default(),
                     compile_time_info,

--- a/turbopack/crates/turbopack/examples/turbopack.rs
+++ b/turbopack/crates/turbopack/examples/turbopack.rs
@@ -46,7 +46,9 @@ async fn main() -> Result<()> {
             let module_asset_context = turbopack::ModuleAssetContext::new(
                 Default::default(),
                 CompileTimeInfo::new(Environment::new(Value::new(
-                    ExecutionEnvironment::NodeJsLambda(NodeJsEnvironment::default().into()),
+                    ExecutionEnvironment::NodeJsLambda(
+                        NodeJsEnvironment::default().resolved_cell(),
+                    ),
                 ))),
                 Default::default(),
                 ResolveOptionsContext {

--- a/turbopack/crates/turbopack/src/evaluate_context.rs
+++ b/turbopack/crates/turbopack/src/evaluate_context.rs
@@ -24,7 +24,7 @@ use crate::{
 #[turbo_tasks::function]
 pub fn node_build_environment() -> Vc<Environment> {
     Environment::new(Value::new(ExecutionEnvironment::NodeJsBuildTime(
-        NodeJsEnvironment::default().cell(),
+        NodeJsEnvironment::default().celll(),
     )))
 }
 
@@ -91,16 +91,17 @@ pub async fn node_evaluate_asset_context(
 
     Ok(Vc::upcast(ModuleAssetContext::new(
         transitions.unwrap_or_default(),
-        CompileTimeInfo::builder(node_build_environment())
+        CompileTimeInfo::builder(node_build_environment().to_resolved().await?)
             .defines(
                 compile_time_defines!(
                     process.turbopack = true,
                     process.env.NODE_ENV = node_env.into_owned(),
                     process.env.TURBOPACK = true
                 )
-                .cell(),
+                .resolved_cell(),
             )
-            .cell(),
+            .cell()
+            .await?,
         ModuleOptionsContext {
             tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
             ecmascript: EcmascriptOptionsContext {

--- a/turbopack/crates/turbopack/src/evaluate_context.rs
+++ b/turbopack/crates/turbopack/src/evaluate_context.rs
@@ -24,7 +24,7 @@ use crate::{
 #[turbo_tasks::function]
 pub fn node_build_environment() -> Vc<Environment> {
     Environment::new(Value::new(ExecutionEnvironment::NodeJsBuildTime(
-        NodeJsEnvironment::default().celll(),
+        NodeJsEnvironment::default().resolved_cell(),
     )))
 }
 

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -246,7 +246,7 @@ async fn apply_module_type(
                 if let ReferenceType::Css(CssReferenceSubType::AtImport(import)) =
                     reference_type.into_value()
                 {
-                    import
+                    import.map(|v| *v)
                 } else {
                     None
                 },
@@ -639,7 +639,7 @@ async fn process_default_internal(
 #[turbo_tasks::function]
 async fn externals_tracing_module_context(ty: ExternalType) -> Result<Vc<ModuleAssetContext>> {
     let env = Environment::new(Value::new(ExecutionEnvironment::NodeJsLambda(
-        NodeJsEnvironment::default().cell(),
+        NodeJsEnvironment::default().resolved_cell(),
     )))
     .to_resolved()
     .await?;

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -631,7 +631,7 @@ async fn process_default_internal(
         module_type.cell(),
         Value::new(reference_type.clone()),
         part,
-        inner_assets,
+        inner_assets.map(|v| *v),
         matches!(reference_type, ReferenceType::Runtime),
     ))
 }
@@ -645,7 +645,7 @@ async fn externals_tracing_module_context(ty: ExternalType) -> Result<Vc<ModuleA
     .await?;
 
     let resolve_options = ResolveOptionsContext {
-        emulate_environment: Some(env.to_resolved().await?),
+        emulate_environment: Some(env),
         loose_errors: true,
         custom_conditions: match ty {
             ExternalType::CommonJs => vec!["require".into()],
@@ -657,7 +657,7 @@ async fn externals_tracing_module_context(ty: ExternalType) -> Result<Vc<ModuleA
 
     Ok(ModuleAssetContext::new_without_replace_externals(
         Default::default(),
-        CompileTimeInfo::builder(*env).cell(),
+        CompileTimeInfo::builder(env).cell().await?,
         ModuleOptionsContext::default().cell(),
         resolve_options.cell(),
         Vc::cell("externals-tracing".into()),

--- a/turbopack/crates/turbopack/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack/tests/node-file-trace.rs
@@ -429,7 +429,9 @@ fn node_file_trace<B: Backend + 'static>(
                     // binary. TODO These test cases should move into the
                     // `node-file-trace` crate and use the same config.
                     CompileTimeInfo::new(Environment::new(Value::new(
-                        ExecutionEnvironment::NodeJsLambda(NodeJsEnvironment::default().into()),
+                        ExecutionEnvironment::NodeJsLambda(
+                            NodeJsEnvironment::default().resolved_cell(),
+                        ),
                     ))),
                     ModuleOptionsContext {
                         ecmascript: EcmascriptOptionsContext {


### PR DESCRIPTION
### What?

Use `ResolvedVc<T>` instead of `Vc<T>` for struct fields in `turbopack-core`

### Why?

### How?


Closes PACK-3545