### PR TITLE
docs(next-config): add experimental inline css docs

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/inlineCss.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/inlineCss.mdx
@@ -1,0 +1,30 @@
+---
+title: inlineCss
+description: Enable inline CSS support.
+version: experimental
+---
+
+Experimental support for inlining CSS in the `<head>`. When this flag is enabled, all places where we normally generate a `<link>` tag will instead have a generated `<style>` tag.
+
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    inlineCss: true,
+  },
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" switcher
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    inlineCss: true,
+  },
+}
+
+module.exports = nextConfig
+```


### PR DESCRIPTION
## Why?

Add documentation for experimental `inlineCss`.

```
import type { NextConfig } from 'next'

const nextConfig: NextConfig = {
  experimental: {
    inlineCss: true,
  },
}
```

- x-ref: https://github.com/vercel/next.js/pull/72195