### PR TITLE
docs: update tags when upgrading from 13 to 14

### DIFF
--- a/docs/01-app/02-building-your-application/11-upgrading/03-version-14.mdx
+++ b/docs/01-app/02-building-your-application/11-upgrading/03-version-14.mdx
@@ -10,19 +10,19 @@ description: Upgrade your Next.js Application from Version 13 to 14.
 To update to Next.js version 14, run the following command using your preferred package manager:
 
 ```bash filename="Terminal"
-npm i next@latest react@latest react-dom@latest eslint-config-next@latest
+npm i next@next-14 react@latest react-dom@latest && npm i eslint-config-next@next-14 -D
 ```
 
 ```bash filename="Terminal"
-yarn add next@latest react@latest react-dom@latest eslint-config-next@latest
+yarn add next@next-14 react@latest react-dom@latest && yarn add eslint-config-next@next-14 -D
 ```
 
 ```bash filename="Terminal"
-pnpm up next react react-dom eslint-config-next --latest
+pnpm i next@next-14 react@latest react-dom@latest && pnpm i eslint-config-next@next-14 -D
 ```
 
 ```bash filename="Terminal"
-bun add next@latest react@latest react-dom@latest eslint-config-next@latest
+bun add next@next-14 react@latest react-dom@latest && bun add eslint-config-next@next-14 -D
 ```
 
 > **Good to know:** If you are using TypeScript, ensure you also upgrade `@types/react` and `@types/react-dom` to their latest versions.


### PR DESCRIPTION
## Why?

The `latest` tag currently points to v15, so we need to update the tag to `next-14`.