### PR TITLE
Align navigation digest with message

### DIFF
--- a/packages/next/src/client/components/forbidden.ts
+++ b/packages/next/src/client/components/forbidden.ts
@@ -16,6 +16,9 @@ import {
  *
  * Read more: [Next.js Docs: `forbidden`](https://nextjs.org/docs/app/api-reference/functions/forbidden)
  */
+
+const DIGEST = `${HTTP_ERROR_FALLBACK_ERROR_CODE};403`
+
 export function forbidden(): never {
   if (!process.env.__NEXT_EXPERIMENTAL_AUTH_INTERRUPTS) {
     throw new Error(
@@ -24,10 +27,7 @@ export function forbidden(): never {
   }
 
   // eslint-disable-next-line no-throw-literal
-  const error = new Error(
-    HTTP_ERROR_FALLBACK_ERROR_CODE
-  ) as HTTPAccessFallbackError
-  ;(error as HTTPAccessFallbackError).digest =
-    `${HTTP_ERROR_FALLBACK_ERROR_CODE};403`
+  const error = new Error(DIGEST) as HTTPAccessFallbackError
+  ;(error as HTTPAccessFallbackError).digest = DIGEST
   throw error
 }

--- a/packages/next/src/client/components/is-next-router-error.test.ts
+++ b/packages/next/src/client/components/is-next-router-error.test.ts
@@ -1,0 +1,14 @@
+import { isNextRouterError } from './is-next-router-error'
+import { notFound } from './not-found'
+
+describe('isNextRouterError', () => {
+  it('returns true for a navigation error', () => {
+    let caught
+    try {
+      notFound()
+    } catch (error) {
+      caught = error
+    }
+    expect(isNextRouterError(caught)).toBe(true)
+  })
+})

--- a/packages/next/src/client/components/not-found.ts
+++ b/packages/next/src/client/components/not-found.ts
@@ -17,12 +17,13 @@ import {
  *
  * Read more: [Next.js Docs: `notFound`](https://nextjs.org/docs/app/api-reference/functions/not-found)
  */
+
+const DIGEST = `${HTTP_ERROR_FALLBACK_ERROR_CODE};404`
+
 export function notFound(): never {
   // eslint-disable-next-line no-throw-literal
-  const error = new Error(
-    HTTP_ERROR_FALLBACK_ERROR_CODE
-  ) as HTTPAccessFallbackError
-  ;(error as HTTPAccessFallbackError).digest =
-    `${HTTP_ERROR_FALLBACK_ERROR_CODE};404`
+  const error = new Error(DIGEST) as HTTPAccessFallbackError
+  ;(error as HTTPAccessFallbackError).digest = DIGEST
+
   throw error
 }

--- a/packages/next/src/client/components/unauthorized.ts
+++ b/packages/next/src/client/components/unauthorized.ts
@@ -17,6 +17,9 @@ import {
  *
  * Read more: [Next.js Docs: `unauthorized`](https://nextjs.org/docs/app/api-reference/functions/unauthorized)
  */
+
+const DIGEST = `${HTTP_ERROR_FALLBACK_ERROR_CODE};401`
+
 export function unauthorized(): never {
   if (!process.env.__NEXT_EXPERIMENTAL_AUTH_INTERRUPTS) {
     throw new Error(
@@ -25,10 +28,7 @@ export function unauthorized(): never {
   }
 
   // eslint-disable-next-line no-throw-literal
-  const error = new Error(
-    HTTP_ERROR_FALLBACK_ERROR_CODE
-  ) as HTTPAccessFallbackError
-  ;(error as HTTPAccessFallbackError).digest =
-    `${HTTP_ERROR_FALLBACK_ERROR_CODE};401`
+  const error = new Error(DIGEST) as HTTPAccessFallbackError
+  ;(error as HTTPAccessFallbackError).digest = DIGEST
   throw error
 }


### PR DESCRIPTION
### What

Ensure the `error.digest` property is aligned with the `error.message` for navigation errors, so they can be test with navigation helpers

Follow up for #72785 