### PR TITLE
port turbopack-node to ResolvedVc

### DIFF
--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -291,7 +291,7 @@ pub trait EvaluateContext {
     fn keep_alive(&self) -> bool {
         false
     }
-    fn args(&self) -> &[Vc<JsonValue>];
+    fn args(&self) -> &[ResolvedVc<JsonValue>];
     fn cwd(&self) -> Vc<FileSystemPath>;
     async fn emit_error(&self, error: StructuredError, pool: &NodeJsPool) -> Result<()>;
     async fn info(
@@ -366,7 +366,7 @@ pub fn evaluate(
     asset_context: ResolvedVc<Box<dyn AssetContext>>,
     chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     runtime_entries: Option<ResolvedVc<EvaluatableAssets>>,
-    args: Vec<Vc<JsonValue>>,
+    args: Vec<ResolvedVc<JsonValue>>,
     additional_invalidation: ResolvedVc<Completion>,
     debug: bool,
 ) -> Vc<JavaScriptEvaluation> {
@@ -547,7 +547,7 @@ struct BasicEvaluateContext {
     asset_context: ResolvedVc<Box<dyn AssetContext>>,
     chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     runtime_entries: Option<ResolvedVc<EvaluatableAssets>>,
-    args: Vec<Vc<JsonValue>>,
+    args: Vec<ResolvedVc<JsonValue>>,
     additional_invalidation: ResolvedVc<Completion>,
     debug: bool,
 }
@@ -576,7 +576,7 @@ impl EvaluateContext for BasicEvaluateContext {
         )
     }
 
-    fn args(&self) -> &[Vc<serde_json::Value>] {
+    fn args(&self) -> &[ResolvedVc<serde_json::Value>] {
         &self.args
     }
 

--- a/turbopack/crates/turbopack-node/src/node_entry.rs
+++ b/turbopack/crates/turbopack-node/src/node_entry.rs
@@ -16,6 +16,8 @@ pub struct NodeRenderingEntry {
     pub project_dir: ResolvedVc<FileSystemPath>,
 }
 
+// TODO(ResolvedVc): this struct seems to be trivially used in this trait which returns a Vc
+//                   so perhaps it should remain a Vc?
 #[turbo_tasks::value(transparent)]
 pub struct NodeRenderingEntries(Vec<Vc<NodeRenderingEntry>>);
 

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -507,7 +507,10 @@ impl PostCssTransformedAsset {
             asset_context: evaluate_context,
             chunking_context: *chunking_context,
             resolve_options_context: None,
-            args: vec![Vc::cell(content.into()), Vc::cell(css_path.into())],
+            args: vec![
+                ResolvedVc::cell(content.into()),
+                ResolvedVc::cell(css_path.into()),
+            ],
             additional_invalidation: config_changed,
         })
         .await?;

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -3,6 +3,7 @@ use std::mem::take;
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use either::Either;
+use futures::future::try_join_all;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
 use serde_with::serde_as;
@@ -172,7 +173,7 @@ impl GenerateSourceMap for WebpackLoadersProcessedAsset {
 struct ProcessWebpackLoadersResult {
     content: ResolvedVc<AssetContent>,
     source_map: Option<ResolvedVc<SourceMap>>,
-    assets: Vec<Vc<VirtualSource>>,
+    assets: Vec<ResolvedVc<VirtualSource>>,
 }
 
 #[turbo_tasks::function]
@@ -238,11 +239,11 @@ impl WebpackLoadersProcessedAsset {
             chunking_context,
             resolve_options_context: Some(transform.resolve_options_context),
             args: vec![
-                Vc::cell(content.into()),
+                ResolvedVc::cell(content.into()),
                 // We need to pass the query string to the loader
-                Vc::cell(resource_path.to_string().into()),
-                Vc::cell(this.source.ident().query().await?.to_string().into()),
-                Vc::cell(json!(*loaders)),
+                ResolvedVc::cell(resource_path.to_string().into()),
+                ResolvedVc::cell(this.source.ident().query().await?.to_string().into()),
+                ResolvedVc::cell(json!(*loaders)),
             ],
             additional_invalidation: Completion::immutable().to_resolved().await?,
         })
@@ -274,11 +275,14 @@ impl WebpackLoadersProcessedAsset {
             Either::Left(str) => File::from(str),
             Either::Right(bytes) => File::from(bytes.binary),
         };
-        let assets = emitted_assets_to_virtual_sources(processed.assets)
-            .await?
-            .into_iter()
-            .map(|asset| *asset)
-            .collect();
+        let assets = try_join_all(
+            emitted_assets_to_virtual_sources(processed.assets)
+                .await?
+                .into_iter()
+                .map(|v| v.to_resolved()),
+        )
+        .await?;
+
         let content =
             AssetContent::File(FileContent::Content(file).resolved_cell()).resolved_cell();
         Ok(ProcessWebpackLoadersResult {
@@ -393,7 +397,7 @@ pub struct WebpackLoaderContext {
     pub asset_context: ResolvedVc<Box<dyn AssetContext>>,
     pub chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     pub resolve_options_context: Option<ResolvedVc<ResolveOptionsContext>>,
-    pub args: Vec<Vc<JsonValue>>,
+    pub args: Vec<ResolvedVc<JsonValue>>,
     pub additional_invalidation: ResolvedVc<Completion>,
 }
 
@@ -421,7 +425,7 @@ impl EvaluateContext for WebpackLoaderContext {
         )
     }
 
-    fn args(&self) -> &[Vc<serde_json::Value>] {
+    fn args(&self) -> &[ResolvedVc<serde_json::Value>] {
         &self.args
     }
 


### PR DESCRIPTION
Does what it says on the tin.

One struct seems to be trivially used in a trait which requires it to be a Vc so I left it with a comment. @bgw perhaps we can set up some lint + disabling comment for all the cases in this doc?

Would be handy to ensure we are continuing to follow the heuristic in the future also.

Closes PACK-3553