### PR TITLE
Docs: Add canary tags to `expirePath` and `expireTag`

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/expirePath.mdx
+++ b/docs/01-app/03-api-reference/04-functions/expirePath.mdx
@@ -1,6 +1,7 @@
 ---
 title: expirePath
 description: API Reference for the expirePath function.
+version: canary
 ---
 
 `expirePath` allows you to purge [cached data](/docs/app/building-your-application/caching) on-demand for a specific path.

--- a/docs/01-app/03-api-reference/04-functions/expireTag.mdx
+++ b/docs/01-app/03-api-reference/04-functions/expireTag.mdx
@@ -1,6 +1,7 @@
 ---
 title: expireTag
 description: API Reference for the expireTag function.
+version: canary
 ---
 
 `expireTag` allows you to purge [cached data](/docs/app/building-your-application/caching) on-demand for a specific cache tag.


### PR DESCRIPTION
- `expirePath` and `expireTag` are not yet available in a stable version, so we don't want these APIs leaking into stable docs.
