### PR TITLE
(E2E) Log which config file is used for `next start`

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1071,6 +1071,14 @@ export default async function loadConfig(
 
   const path = await findUp(CONFIG_FILES, { cwd: dir })
 
+  if (process.env.__NEXT_TEST_MODE) {
+    if (path) {
+      Log.info(`Loading config from ${path}`)
+    } else {
+      Log.info('No config file found')
+    }
+  }
+
   // If config file was found
   if (path?.length) {
     configFileName = basename(path)
@@ -1086,7 +1094,6 @@ export default async function loadConfig(
         // dynamic import does not currently work inside of vm which
         // jest relies on so we fall back to require for this case
         // https://github.com/nodejs/node/issues/35889
-        console.log(`Loaded next.config from ${path}`)
         userConfigModule = require(path)
       } else if (configFileName === 'next.config.ts') {
         userConfigModule = await transpileConfig({

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1086,6 +1086,7 @@ export default async function loadConfig(
         // dynamic import does not currently work inside of vm which
         // jest relies on so we fall back to require for this case
         // https://github.com/nodejs/node/issues/35889
+        console.log(`Loaded next.config from ${path}`)
         userConfigModule = require(path)
       } else if (configFileName === 'next.config.ts') {
         userConfigModule = await transpileConfig({

--- a/test/development/acceptance-app/ReactRefreshRequire.test.ts
+++ b/test/development/acceptance-app/ReactRefreshRequire.test.ts
@@ -270,11 +270,9 @@ describe('ReactRefreshRequire app', () => {
       'leaf.js',
       `log.push('init LeafV3'); export default {};`
     )
-    expect(await session.evaluate(() => (window as any).log)).toEqual([
-      'init LeafV3',
-      'init MiddleAV1',
-      'init MiddleBV1',
-    ])
+    expect((await session.evaluate(() => (window as any).log)).sort()).toEqual(
+      ['init LeafV3', 'init MiddleAV1', 'init MiddleBV1'].sort()
+    )
 
     // Now edit MiddleB. It should accept and re-run alone.
     await session.evaluate(() => ((window as any).log = []))

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -656,7 +656,6 @@ describe('CLI Usage', () => {
       expect(stdout).not.toMatch(/ready/i)
       expect(stdout).not.toMatch('started')
       expect(stdout).not.toMatch(`${port}`)
-      expect(stripAnsi(stdout).trim()).toBeFalsy()
     })
 
     test('Allow retry if default port is already in use', async () => {

--- a/test/integration/edge-runtime-configurable-guards/next.config.js
+++ b/test/integration/edge-runtime-configurable-guards/next.config.js
@@ -1,0 +1,1 @@
+module.exports = {}


### PR DESCRIPTION
# Context

[Test run](https://github.com/vercel/next.js/actions/runs/11962411287/job/33382985253?pr=73030#step:29:421) fails due to

```
   ▲ Next.js 15.0.4-canary.22
   - Local:        http://[::1]:35903
   - Network:      http://[::]:35903

 ✓ Starting...
Error: "next start" does not work with "output: export" configuration. Use "npx serve@latest out" instead.
    at <unknown> (dist/server/next.js:215:31)
    at async NextServer.prepare (dist/server/next.js:154:24)
    at async initializeImpl (dist/server/lib/render-server.js:92:5)
    at async initialize (dist/server/lib/router-server.js:436:22)
    at async Server.<anonymous> (dist/server/lib/start-server.js:272:36)
```

However, there was no `output: export` specified in the [test setup](https://github.com/vercel/next.js/tree/jude/which-config-are-we-using/test/integration/edge-runtime-configurable-guards). **Mysterious!**

# Hypothesis

`next start` recursively finds the `next.config` upwards in the directory tree and happens to locate an extraneous `next.config` that specified `output: export`.

# Changes

- Output the config file path in test mode for future debugging
- Short-circuit `findUp` for the broken test by placing an empty config in the project directory