### PR TITLE
[Turbopack] instead of depending on all env vars, track them via Proxy in webpack loaders

### DIFF
--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -551,6 +551,13 @@ where
     pub fn strongly_consistent(self) -> ReadVcFuture<T> {
         self.node.into_strongly_consistent_read().into()
     }
+
+    /// Returns a untracked read of the value. This will not invalidate the current function when
+    /// the read value changed.
+    #[must_use]
+    pub fn untracked(self) -> ReadVcFuture<T> {
+        self.node.into_read_untracked().into()
+    }
 }
 
 impl<T> Unpin for Vc<T> where T: ?Sized {}

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -47,8 +47,8 @@ use crate::{
     debug::should_debug,
     embed_js::embed_file_path,
     evaluate::{
-        compute, custom_evaluate, get_evaluate_pool, EvaluateContext, EvaluationIssue,
-        JavaScriptEvaluation, JavaScriptStreamSender,
+        compute, custom_evaluate, get_evaluate_pool, EnvVarTracking, EvaluateContext,
+        EvaluationIssue, JavaScriptEvaluation, JavaScriptStreamSender,
     },
     execution_context::ExecutionContext,
     pool::{FormattingMode, NodeJsPool},
@@ -432,7 +432,7 @@ impl EvaluateContext for WebpackLoaderContext {
             // Env vars are read untracked, since we want a more granular dependency on certain env
             // vars only. So the runtime code tracks which env vars are read and send a dependency
             // message for them.
-            true,
+            EnvVarTracking::Untracked,
         )
     }
 


### PR DESCRIPTION
### What?

* instead of depending on all env vars, track them via Proxy in webpack loaders
* fix invalidation of evaluate pool after persistent cache restore


Closes PACK-3560