### PR TITLE
docs: clarify Switching to Dynamic Rendering section

### DIFF
--- a/docs/01-app/02-building-your-application/03-rendering/01-server-components.mdx
+++ b/docs/01-app/02-building-your-application/03-rendering/01-server-components.mdx
@@ -82,7 +82,7 @@ Dynamic rendering is useful when a route has data that is personalized to the us
 
 #### Switching to Dynamic Rendering
 
-During rendering, if a [Dynamic API](#dynamic-apis) or uncached data request is discovered, Next.js will switch to dynamically rendering the whole route. This table summarizes how Dynamic APIs and data caching affect whether a route is statically or dynamically rendered:
+During rendering, if a [Dynamic API](#dynamic-apis) or a [fetch](/docs/app/api-reference/functions/fetch) option of `{ cache: 'no-store' }` is discovered, Next.js will switch to dynamically rendering the whole route. This table summarizes how Dynamic APIs and data caching affect whether a route is statically or dynamically rendered:
 
 | Dynamic APIs | Data       | Route                |
 | ------------ | ---------- | -------------------- |


### PR DESCRIPTION
## Why?

The default config of fetch, which is `auto no cache`, is slightly different from the fetch option `{ cache: 'no-store' }` (this opts the whole route out of statically prerendering), so we need to clarify that further.

- https://nextjs.org/docs/canary/app/api-reference/functions/fetch#optionscache
- x-ref: https://github.com/vercel/next.js/pull/72982
- Fixes https://github.com/vercel/next.js/issues/73109