### PR TITLE
Increase max cache tags to 128

### DIFF
--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -27,7 +27,7 @@ export const NEXT_RESUME_HEADER = 'next-resume'
 
 // if these change make sure we update the related
 // documentation as well
-export const NEXT_CACHE_TAG_MAX_ITEMS = 64
+export const NEXT_CACHE_TAG_MAX_ITEMS = 128
 export const NEXT_CACHE_TAG_MAX_LENGTH = 256
 export const NEXT_CACHE_SOFT_TAG_MAX_LENGTH = 1024
 export const NEXT_CACHE_IMPLICIT_TAG_ID = '_N_T_'

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -128,7 +128,7 @@ describe('app-dir static/dynamic handling', () => {
       expect(res.status).toBe(200)
       await retry(() => {
         expect(next.cliOutput).toContain('exceeded max tag count for')
-        expect(next.cliOutput).toContain('tag-65')
+        expect(next.cliOutput).toContain('tag-129')
       })
     })
   }

--- a/test/e2e/app-dir/app-static/app/too-many-cache-tags/page.tsx
+++ b/test/e2e/app-dir/app-static/app/too-many-cache-tags/page.tsx
@@ -3,7 +3,7 @@ export const revalidate = 0
 export default async function Page() {
   const tags: string[] = []
 
-  for (let i = 0; i < 96; i++) {
+  for (let i = 0; i < 130; i++) {
     tags.push(`tag-${i}`)
   }
   const data = await fetch(


### PR DESCRIPTION
As discussed this increases the max tags allowed per fetch cache entry from 64 to 128. 

x-ref: [slack thread](https://vercel.slack.com/archives/C02K2HCH5V4/p1732310630701619?thread_ts=1731423151.720739&cid=C02K2HCH5V4)