### PR TITLE
[backport] Increase max cache tags to 128

### DIFF
--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -21,7 +21,7 @@ export const NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER =
 
 // if these change make sure we update the related
 // documentation as well
-export const NEXT_CACHE_TAG_MAX_ITEMS = 64
+export const NEXT_CACHE_TAG_MAX_ITEMS = 128
 export const NEXT_CACHE_TAG_MAX_LENGTH = 256
 export const NEXT_CACHE_SOFT_TAG_MAX_LENGTH = 1024
 export const NEXT_CACHE_IMPLICIT_TAG_ID = '_N_T_'

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -64,7 +64,7 @@ describe('app-dir static/dynamic handling', () => {
     expect(res.status).toBe(200)
     await retry(() => {
       expect(next.cliOutput).toContain('exceeded max tag count for')
-      expect(next.cliOutput).toContain('tag-65')
+      expect(next.cliOutput).toContain('tag-129')
     })
   })
 

--- a/test/e2e/app-dir/app-static/app/too-many-cache-tags/page.tsx
+++ b/test/e2e/app-dir/app-static/app/too-many-cache-tags/page.tsx
@@ -3,7 +3,7 @@ export const revalidate = 0
 export default async function Page() {
   const tags: string[] = []
 
-  for (let i = 0; i < 96; i++) {
+  for (let i = 0; i < 130; i++) {
     tags.push(`tag-${i}`)
   }
   const data = await fetch(


### PR DESCRIPTION
backports https://github.com/vercel/next.js/pull/73124 to v14 releases. 