### PR TITLE
Revert "ensure webpack worker exits bubble to parent process (#72921)"

### DIFF
--- a/packages/next/src/build/webpack-build/index.ts
+++ b/packages/next/src/build/webpack-build/index.ts
@@ -2,8 +2,9 @@ import type { COMPILER_INDEXES } from '../../shared/lib/constants'
 import * as Log from '../output/log'
 import { NextBuildContext } from '../build-context'
 import type { BuildTraceContext } from '../webpack/plugins/next-trace-entrypoints-plugin'
-import { Worker } from '../../lib/worker'
+import { Worker } from 'next/dist/compiled/jest-worker'
 import origDebug from 'next/dist/compiled/debug'
+import type { ChildProcess } from 'child_process'
 import path from 'path'
 import { exportTraceState, recordTraceEvents } from '../../trace'
 
@@ -37,17 +38,35 @@ async function webpackBuildWithWorker(
 
   prunedBuildContext.pluginState = pluginState
 
-  const worker = new Worker(path.join(__dirname, 'impl.js'), {
-    exposedMethods: ['workerMain'],
-    numWorkers: 1,
-    maxRetries: 0,
-    forkOptions: {
-      env: {
-        ...process.env,
-        NEXT_PRIVATE_BUILD_WORKER: '1',
+  const getWorker = (compilerName: string) => {
+    const _worker = new Worker(path.join(__dirname, 'impl.js'), {
+      exposedMethods: ['workerMain'],
+      numWorkers: 1,
+      maxRetries: 0,
+      forkOptions: {
+        env: {
+          ...process.env,
+          NEXT_PRIVATE_BUILD_WORKER: '1',
+        },
       },
-    },
-  }) as Worker & typeof import('./impl')
+    }) as Worker & typeof import('./impl')
+    _worker.getStderr().pipe(process.stderr)
+    _worker.getStdout().pipe(process.stdout)
+
+    for (const worker of ((_worker as any)._workerPool?._workers || []) as {
+      _child: ChildProcess
+    }[]) {
+      worker._child.on('exit', (code, signal) => {
+        if (code || (signal && signal !== 'SIGINT')) {
+          debug(
+            `Compiler ${compilerName} unexpectedly exited with code: ${code} and signal: ${signal}`
+          )
+        }
+      })
+    }
+
+    return _worker
+  }
 
   const combinedResult = {
     duration: 0,
@@ -55,6 +74,8 @@ async function webpackBuildWithWorker(
   }
 
   for (const compilerName of compilerNames) {
+    const worker = getWorker(compilerName)
+
     const curResult = await worker.workerMain({
       buildContext: prunedBuildContext,
       compilerName,
@@ -67,6 +88,8 @@ async function webpackBuildWithWorker(
     if (nextBuildSpan && curResult.debugTraceEvents) {
       recordTraceEvents(curResult.debugTraceEvents)
     }
+    // destroy worker so it's not sticking around using memory
+    await worker.end()
 
     // Update plugin state
     pluginState = deepMerge(pluginState, curResult.pluginState)
@@ -101,9 +124,6 @@ async function webpackBuildWithWorker(
       }
     }
   }
-
-  // destroy worker so it's not sticking around using memory
-  worker.end()
 
   if (compilerNames.length === 3) {
     Log.event('Compiled successfully')


### PR DESCRIPTION
This reverts commit df2c4a302a03d28239da86338941c5203e5f697c.

We saw some OOMs during `next build` in internal repos. Confirming that this is the cause.
