### PR TITLE
Reapply "ensure webpack worker exits bubble to parent process (#72921)"

### DIFF
--- a/packages/next/src/build/webpack-build/index.ts
+++ b/packages/next/src/build/webpack-build/index.ts
@@ -2,11 +2,14 @@ import type { COMPILER_INDEXES } from '../../shared/lib/constants'
 import * as Log from '../output/log'
 import { NextBuildContext } from '../build-context'
 import type { BuildTraceContext } from '../webpack/plugins/next-trace-entrypoints-plugin'
-import { Worker } from 'next/dist/compiled/jest-worker'
+import { Worker } from '../../lib/worker'
 import origDebug from 'next/dist/compiled/debug'
-import type { ChildProcess } from 'child_process'
 import path from 'path'
 import { exportTraceState, recordTraceEvents } from '../../trace'
+import {
+  formatNodeOptions,
+  getParsedNodeOptionsWithoutInspect,
+} from '../../server/lib/utils'
 
 const debug = origDebug('next:build:webpack-build')
 
@@ -38,8 +41,15 @@ async function webpackBuildWithWorker(
 
   prunedBuildContext.pluginState = pluginState
 
-  const getWorker = (compilerName: string) => {
-    const _worker = new Worker(path.join(__dirname, 'impl.js'), {
+  const combinedResult = {
+    duration: 0,
+    buildTraceContext: {} as BuildTraceContext,
+  }
+
+  const nodeOptions = getParsedNodeOptionsWithoutInspect()
+
+  for (const compilerName of compilerNames) {
+    const worker = new Worker(path.join(__dirname, 'impl.js'), {
       exposedMethods: ['workerMain'],
       numWorkers: 1,
       maxRetries: 0,
@@ -47,34 +57,10 @@ async function webpackBuildWithWorker(
         env: {
           ...process.env,
           NEXT_PRIVATE_BUILD_WORKER: '1',
+          NODE_OPTIONS: formatNodeOptions(nodeOptions),
         },
       },
     }) as Worker & typeof import('./impl')
-    _worker.getStderr().pipe(process.stderr)
-    _worker.getStdout().pipe(process.stdout)
-
-    for (const worker of ((_worker as any)._workerPool?._workers || []) as {
-      _child: ChildProcess
-    }[]) {
-      worker._child.on('exit', (code, signal) => {
-        if (code || (signal && signal !== 'SIGINT')) {
-          debug(
-            `Compiler ${compilerName} unexpectedly exited with code: ${code} and signal: ${signal}`
-          )
-        }
-      })
-    }
-
-    return _worker
-  }
-
-  const combinedResult = {
-    duration: 0,
-    buildTraceContext: {} as BuildTraceContext,
-  }
-
-  for (const compilerName of compilerNames) {
-    const worker = getWorker(compilerName)
 
     const curResult = await worker.workerMain({
       buildContext: prunedBuildContext,

--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -1,9 +1,5 @@
 import type { ChildProcess } from 'child_process'
 import { Worker as JestWorker } from 'next/dist/compiled/jest-worker'
-import {
-  getParsedNodeOptionsWithoutInspect,
-  formatNodeOptions,
-} from '../server/lib/utils'
 import { Transform } from 'stream'
 
 type FarmOptions = ConstructorParameters<typeof JestWorker>[1]
@@ -47,12 +43,6 @@ export class Worker {
     })
 
     const createWorker = () => {
-      // Get the node options without inspect and also remove the
-      // --max-old-space-size flag as it can cause memory issues.
-      const nodeOptions = getParsedNodeOptionsWithoutInspect()
-      delete nodeOptions['max-old-space-size']
-      delete nodeOptions['max_old_space_size']
-
       this._worker = new JestWorker(workerPath, {
         ...farmOptions,
         forkOptions: {
@@ -60,7 +50,6 @@ export class Worker {
           env: {
             ...((farmOptions.forkOptions?.env || {}) as any),
             ...process.env,
-            NODE_OPTIONS: formatNodeOptions(nodeOptions),
           } as any,
         },
         maxRetries: 0,


### PR DESCRIPTION
This relands #72921 to be a more minimal refactor. This re-applies the core change to use the existing worker that has proper error bubbling handling without changing the worker lifecycle. 

For the purposes of the internal OOM we were seeing, this ensures that any custom `max-old-space-size` flags are preserved during the webpack build step, even when using the shared worker. Instead, I moved it to `createStaticWorker`, as that was where it was intended to be respected when it landed in #46705.

Closes NDX-485