### PR TITLE
Omit unnecessary cache wrapper import

### DIFF
--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/23/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/23/output.js
@@ -1,6 +1,5 @@
 /* __next_internal_action_entry_do_not_use__ {"006a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_0 = async function b() {
     // this is not allowed here
     this.foo();

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/51/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/51/output.js
@@ -1,6 +1,5 @@
 /* __next_internal_action_entry_do_not_use__ {"601c36b06e398c97abe5d5d7ae8c672bfddf4e1b91":"$$RSC_SERVER_ACTION_2","609ed0cc47abc4e1c64320cf42b74ae60b58c40f00":"$$RSC_SERVER_ACTION_3","7090b5db271335765a4b0eab01f044b381b5ebd5cd":"$$RSC_SERVER_ACTION_1"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_1 = async function $$RSC_SERVER_ACTION_0(a, b, c) {
     return <div>
       {a}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/56/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/56/output.js
@@ -1,6 +1,3 @@
-/* __next_internal_action_entry_do_not_use__ {} */ import { registerServerReference } from "private-next-rsc-server-reference";
-import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 // No method nor function property should be considered a cache function.
 export const obj = {
     foo () {


### PR DESCRIPTION
When a `"use cache"` module has no exported or annotated cache function, we can omit the import statement for the cache wrapper function.