### PR TITLE
feat: Update `lightningcss` to `v1.0.0-alpha.61`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3402,9 +3402,9 @@ dependencies = [
 
 [[package]]
 name = "lightningcss"
-version = "1.0.0-alpha.60"
+version = "1.0.0-alpha.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3aad0f3d9105ab72b02caf1b2a998a6d549f3fff8cca0c558e590c3245edfd"
+checksum = "20c9e1f991b3861d25bf872ecca2eb6a73f7a9fe671da047cd1f9b49c65cbc40"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.5.0",
@@ -3414,6 +3414,7 @@ dependencies = [
  "dashmap 5.5.3",
  "data-encoding",
  "getrandom",
+ "indexmap 2.5.0",
  "itertools 0.10.5",
  "lazy_static",
  "lightningcss-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ indoc = "2.0.0"
 itertools = "0.10.5"
 lazy_static = "1.4.0"
 log = "0.4.17"
-lightningcss = { version = "1.0.0-alpha.60", features = [
+lightningcss = { version = "1.0.0-alpha.61", features = [
   "serde",
   "visitor",
   "into_owned",


### PR DESCRIPTION
### What?

Update `lightningcss` to the latest. 

 - https://github.com/parcel-bundler/lightningcss/releases/tag/v1.28.2

### Why?

It's released.

### How?


Closes PACK-3525