### PR TITLE
CNA: replace `.eslintrc.json` with `eslint.config.mjs`

### DIFF
--- a/packages/create-next-app/templates/app-empty/js/eslint.config.mjs
+++ b/packages/create-next-app/templates/app-empty/js/eslint.config.mjs
@@ -1,0 +1,14 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [...compat.extends("next/core-web-vitals")];
+
+export default eslintConfig;

--- a/packages/create-next-app/templates/app-empty/js/eslintrc.json
+++ b/packages/create-next-app/templates/app-empty/js/eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}

--- a/packages/create-next-app/templates/app-empty/ts/eslint.config.mjs
+++ b/packages/create-next-app/templates/app-empty/ts/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
+];
+
+export default eslintConfig;

--- a/packages/create-next-app/templates/app-empty/ts/eslintrc.json
+++ b/packages/create-next-app/templates/app-empty/ts/eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["next/core-web-vitals", "next/typescript"]
-}

--- a/packages/create-next-app/templates/app-tw-empty/js/eslint.config.mjs
+++ b/packages/create-next-app/templates/app-tw-empty/js/eslint.config.mjs
@@ -1,0 +1,14 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [...compat.extends("next/core-web-vitals")];
+
+export default eslintConfig;

--- a/packages/create-next-app/templates/app-tw-empty/js/eslintrc.json
+++ b/packages/create-next-app/templates/app-tw-empty/js/eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}

--- a/packages/create-next-app/templates/app-tw-empty/ts/eslint.config.mjs
+++ b/packages/create-next-app/templates/app-tw-empty/ts/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
+];
+
+export default eslintConfig;

--- a/packages/create-next-app/templates/app-tw-empty/ts/eslintrc.json
+++ b/packages/create-next-app/templates/app-tw-empty/ts/eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["next/core-web-vitals", "next/typescript"]
-}

--- a/packages/create-next-app/templates/app-tw/js/eslint.config.mjs
+++ b/packages/create-next-app/templates/app-tw/js/eslint.config.mjs
@@ -1,0 +1,14 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [...compat.extends("next/core-web-vitals")];
+
+export default eslintConfig;

--- a/packages/create-next-app/templates/app-tw/js/eslintrc.json
+++ b/packages/create-next-app/templates/app-tw/js/eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}

--- a/packages/create-next-app/templates/app-tw/ts/eslint.config.mjs
+++ b/packages/create-next-app/templates/app-tw/ts/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
+];
+
+export default eslintConfig;

--- a/packages/create-next-app/templates/app-tw/ts/eslintrc.json
+++ b/packages/create-next-app/templates/app-tw/ts/eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["next/core-web-vitals", "next/typescript"]
-}

--- a/packages/create-next-app/templates/app/js/eslint.config.mjs
+++ b/packages/create-next-app/templates/app/js/eslint.config.mjs
@@ -1,0 +1,14 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [...compat.extends("next/core-web-vitals")];
+
+export default eslintConfig;

--- a/packages/create-next-app/templates/app/js/eslintrc.json
+++ b/packages/create-next-app/templates/app/js/eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}

--- a/packages/create-next-app/templates/app/ts/eslint.config.mjs
+++ b/packages/create-next-app/templates/app/ts/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
+];
+
+export default eslintConfig;

--- a/packages/create-next-app/templates/app/ts/eslintrc.json
+++ b/packages/create-next-app/templates/app/ts/eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["next/core-web-vitals", "next/typescript"]
-}

--- a/packages/create-next-app/templates/default-empty/js/eslint.config.mjs
+++ b/packages/create-next-app/templates/default-empty/js/eslint.config.mjs
@@ -1,0 +1,14 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [...compat.extends("next/core-web-vitals")];
+
+export default eslintConfig;

--- a/packages/create-next-app/templates/default-empty/js/eslintrc.json
+++ b/packages/create-next-app/templates/default-empty/js/eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}

--- a/packages/create-next-app/templates/default-empty/ts/eslint.config.mjs
+++ b/packages/create-next-app/templates/default-empty/ts/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
+];
+
+export default eslintConfig;

--- a/packages/create-next-app/templates/default-empty/ts/eslintrc.json
+++ b/packages/create-next-app/templates/default-empty/ts/eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["next/core-web-vitals", "next/typescript"]
-}

--- a/packages/create-next-app/templates/default-tw-empty/js/eslint.config.mjs
+++ b/packages/create-next-app/templates/default-tw-empty/js/eslint.config.mjs
@@ -1,0 +1,14 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [...compat.extends("next/core-web-vitals")];
+
+export default eslintConfig;

--- a/packages/create-next-app/templates/default-tw-empty/js/eslintrc.json
+++ b/packages/create-next-app/templates/default-tw-empty/js/eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}

--- a/packages/create-next-app/templates/default-tw-empty/ts/eslint.config.mjs
+++ b/packages/create-next-app/templates/default-tw-empty/ts/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
+];
+
+export default eslintConfig;

--- a/packages/create-next-app/templates/default-tw-empty/ts/eslintrc.json
+++ b/packages/create-next-app/templates/default-tw-empty/ts/eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["next/core-web-vitals", "next/typescript"]
-}

--- a/packages/create-next-app/templates/default-tw/js/eslint.config.mjs
+++ b/packages/create-next-app/templates/default-tw/js/eslint.config.mjs
@@ -1,0 +1,14 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [...compat.extends("next/core-web-vitals")];
+
+export default eslintConfig;

--- a/packages/create-next-app/templates/default-tw/js/eslintrc.json
+++ b/packages/create-next-app/templates/default-tw/js/eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}

--- a/packages/create-next-app/templates/default-tw/ts/eslint.config.mjs
+++ b/packages/create-next-app/templates/default-tw/ts/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
+];
+
+export default eslintConfig;

--- a/packages/create-next-app/templates/default-tw/ts/eslintrc.json
+++ b/packages/create-next-app/templates/default-tw/ts/eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["next/core-web-vitals", "next/typescript"]
-}

--- a/packages/create-next-app/templates/default/js/eslint.config.mjs
+++ b/packages/create-next-app/templates/default/js/eslint.config.mjs
@@ -1,0 +1,14 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [...compat.extends("next/core-web-vitals")];
+
+export default eslintConfig;

--- a/packages/create-next-app/templates/default/js/eslintrc.json
+++ b/packages/create-next-app/templates/default/js/eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}

--- a/packages/create-next-app/templates/default/ts/eslint.config.mjs
+++ b/packages/create-next-app/templates/default/ts/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
+];
+
+export default eslintConfig;

--- a/packages/create-next-app/templates/default/ts/eslintrc.json
+++ b/packages/create-next-app/templates/default/ts/eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["next/core-web-vitals", "next/typescript"]
-}

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -53,7 +53,7 @@ export const installTemplate = async ({
   console.log("\nInitializing project with template:", template, "\n");
   const templatePath = path.join(__dirname, template, mode);
   const copySource = ["**"];
-  if (!eslint) copySource.push("!eslintrc.json");
+  if (!eslint) copySource.push("!eslint.config.mjs");
   if (!tailwind)
     copySource.push(
       mode == "ts" ? "tailwind.config.ts" : "!tailwind.config.mjs",
@@ -65,8 +65,7 @@ export const installTemplate = async ({
     cwd: templatePath,
     rename(name) {
       switch (name) {
-        case "gitignore":
-        case "eslintrc.json": {
+        case "gitignore": {
           return `.${name}`;
         }
         // README.md is ignored by webpack-asset-relocator-loader used by ncc:
@@ -232,6 +231,8 @@ export const installTemplate = async ({
       ...packageJson.devDependencies,
       eslint: "^9",
       "eslint-config-next": version,
+      // TODO: Remove @eslint/eslintrc once eslint-config-next is pure Flat config
+      "@eslint/eslintrc": "^3",
     };
   }
 

--- a/test/integration/create-next-app/lib/specification.ts
+++ b/test/integration/create-next-app/lib/specification.ts
@@ -26,12 +26,13 @@ export const projectSpecification: ProjectSpecification = {
   global: {
     files: [
       'package.json',
-      '.eslintrc.json',
+      'eslint.config.mjs',
       'node_modules/next',
       '.gitignore',
     ],
     deps: ['next', 'react', 'react-dom'],
-    devDeps: ['eslint', 'eslint-config-next'],
+    // TODO: Remove @eslint/eslintrc once eslint-config-next is pure Flat config
+    devDeps: ['eslint', 'eslint-config-next', '@eslint/eslintrc'],
   },
   default: {
     js: {

--- a/test/integration/create-next-app/prompts.test.ts
+++ b/test/integration/create-next-app/prompts.test.ts
@@ -194,7 +194,7 @@ describe('create-next-app prompts', () => {
             projectName,
             files: [
               'app',
-              '.eslintrc.json',
+              'eslint.config.mjs',
               'package.json',
               'tailwind.config.ts',
               'tsconfig.json',


### PR DESCRIPTION
### Why?

As we upgraded create-next-app ESLint to v9, use flat config (with compatible function) for the templates.

`eslint.config.mjs`:

```mjs
import { dirname } from "path";
import { fileURLToPath } from "url";
import { FlatCompat } from "@eslint/eslintrc";

const __filename = fileURLToPath(import.meta.url);
const __dirname = dirname(__filename);

const compat = new FlatCompat({
  baseDirectory: __dirname,
});

const eslintConfig = [...compat.extends("next/core-web-vitals")];

export default eslintConfig;
```

As `import.meta.dirname` was introduced in Node.js version v20.11.0, we can simplify to when on minimum version:

```mjs
import { FlatCompat } from "@eslint/eslintrc";

const compat = new FlatCompat({
  baseDirectory: import.meta.dirname,
});

const eslintConfig = [...compat.extends("next/core-web-vitals")];

export default eslintConfig;
```

But best is that other dependency plugins support flat config so we can upgrade to pure Flat Config as well.

Closes NDX-374