### PR TITLE
docs: eslint flat config

### DIFF
--- a/docs/01-app/03-api-reference/05-config/03-eslint.mdx
+++ b/docs/01-app/03-api-reference/05-config/03-eslint.mdx
@@ -159,10 +159,10 @@ export default eslintConfig
 In addition to the Next.js ESLint rules, `create-next-app --typescript` will also add TypeScript-specific lint rules with `next/typescript` to your config:
 
 ```mjs filename="eslint.config.mjs"
-  // import.meta.dirname is available after Node.js v20.11.0
 import { FlatCompat } from '@eslint/eslintrc'
 
 const compat = new FlatCompat({
+  // import.meta.dirname is available after Node.js v20.11.0
   baseDirectory: import.meta.dirname,
 })
 

--- a/docs/01-app/03-api-reference/05-config/03-eslint.mdx
+++ b/docs/01-app/03-api-reference/05-config/03-eslint.mdx
@@ -76,6 +76,7 @@ If you're using `eslint-plugin-next` in a project where Next.js isn't installed 
 import { FlatCompat } from '@eslint/eslintrc'
 
 const compat = new FlatCompat({
+  // import.meta.dirname is available after Node.js v20.11.0
   baseDirectory: import.meta.dirname,
 })
 
@@ -111,6 +112,7 @@ If you would like to modify or disable any rules provided by the supported plugi
 import { FlatCompat } from '@eslint/eslintrc'
 
 const compat = new FlatCompat({
+  // import.meta.dirname is available after Node.js v20.11.0
   baseDirectory: import.meta.dirname,
 })
 
@@ -135,6 +137,7 @@ The `next/core-web-vitals` rule set is enabled when `next lint` is run for the f
 import { FlatCompat } from '@eslint/eslintrc'
 
 const compat = new FlatCompat({
+  // import.meta.dirname is available after Node.js v20.11.0
   baseDirectory: import.meta.dirname,
 })
 
@@ -156,6 +159,7 @@ export default eslintConfig
 In addition to the Next.js ESLint rules, `create-next-app --typescript` will also add TypeScript-specific lint rules with `next/typescript` to your config:
 
 ```mjs filename="eslint.config.mjs"
+  // import.meta.dirname is available after Node.js v20.11.0
 import { FlatCompat } from '@eslint/eslintrc'
 
 const compat = new FlatCompat({
@@ -196,6 +200,7 @@ Then, add `prettier` to your existing ESLint config:
 import { FlatCompat } from '@eslint/eslintrc'
 
 const compat = new FlatCompat({
+  // import.meta.dirname is available after Node.js v20.11.0
   baseDirectory: import.meta.dirname,
 })
 
@@ -305,6 +310,7 @@ import js from '@eslint/js'
 import { FlatCompat } from '@eslint/eslintrc'
 
 const compat = new FlatCompat({
+  // import.meta.dirname is available after Node.js v20.11.0
   baseDirectory: import.meta.dirname,
   recommendedConfig: js.configs.recommended,
 })

--- a/docs/01-app/03-api-reference/05-config/03-eslint.mdx
+++ b/docs/01-app/03-api-reference/05-config/03-eslint.mdx
@@ -97,24 +97,44 @@ next lint --no-cache
 
 If you would like to modify or disable any rules provided by the supported plugins (`react`, `react-hooks`, `next`), you can directly change them using the `rules` property in your `.eslintrc`:
 
-```json filename=".eslintrc.json"
-{
-  "extends": "next",
-  "rules": {
-    "react/no-unescaped-entities": "off",
-    "@next/next/no-page-custom-font": "off"
-  }
-}
+```mjs filename="eslint.config.mjs"
+import { FlatCompat } from '@eslint/eslintrc'
+
+const compat = new FlatCompat({
+  baseDirectory: import.meta.dirname,
+})
+
+const eslintConfig = [
+  ...compat.config({
+    extends: ['next'],
+    rules: {
+      'react/no-unescaped-entities': 'off',
+      '@next/next/no-page-custom-font': 'off',
+    },
+  }),
+]
+
+export default eslintConfig
 ```
 
 ### With Core Web Vitals
 
 The `next/core-web-vitals` rule set is enabled when `next lint` is run for the first time and the **strict** option is selected.
 
-```json filename=".eslintrc.json"
-{
-  "extends": "next/core-web-vitals"
-}
+```mjs filename="eslint.config.mjs"
+import { FlatCompat } from '@eslint/eslintrc'
+
+const compat = new FlatCompat({
+  baseDirectory: import.meta.dirname,
+})
+
+const eslintConfig = [
+  ...compat.config({
+    extends: ['next/core-web-vitals'],
+  }),
+]
+
+export default eslintConfig
 ```
 
 `next/core-web-vitals` updates `eslint-plugin-next` to error on a number of rules that are warnings by default if they affect [Core Web Vitals](https://web.dev/vitals/).
@@ -125,10 +145,20 @@ The `next/core-web-vitals` rule set is enabled when `next lint` is run for the f
 
 In addition to the Next.js ESLint rules, `create-next-app --typescript` will also add TypeScript-specific lint rules with `next/typescript` to your config:
 
-```json filename=".eslintrc.json"
-{
-  "extends": ["next/core-web-vitals", "next/typescript"]
-}
+```mjs filename="eslint.config.mjs"
+import { FlatCompat } from '@eslint/eslintrc'
+
+const compat = new FlatCompat({
+  baseDirectory: import.meta.dirname,
+})
+
+const eslintConfig = [
+  ...compat.config({
+    extends: ['next/core-web-vitals', 'next/typescript'],
+  }),
+]
+
+export default eslintConfig
 ```
 
 Those rules are based on [`plugin:@typescript-eslint/recommended`](https://typescript-eslint.io/linting/configs#recommended).
@@ -152,10 +182,20 @@ bun add --dev eslint-config-prettier
 
 Then, add `prettier` to your existing ESLint config:
 
-```json filename=".eslintrc.json"
-{
-  "extends": ["next", "prettier"]
-}
+```mjs filename="eslint.config.mjs"
+import { FlatCompat } from '@eslint/eslintrc'
+
+const compat = new FlatCompat({
+  baseDirectory: import.meta.dirname,
+})
+
+const eslintConfig = [
+  ...compat.config({
+    extends: ['next', 'prettier'],
+  }),
+]
+
+export default eslintConfig
 ```
 
 ### Running lint on staged files
@@ -250,10 +290,22 @@ This eliminates the risk of collisions or errors that can occur due to importing
 
 If you already use a separate ESLint configuration and want to include `eslint-config-next`, ensure that it is extended last after other configurations. For example:
 
-```json filename=".eslintrc.json"
-{
-  "extends": ["eslint:recommended", "next"]
-}
+```mjs filename="eslint.config.mjs"
+import js from '@eslint/js'
+import { FlatCompat } from '@eslint/eslintrc'
+
+const compat = new FlatCompat({
+  baseDirectory: import.meta.dirname,
+  recommendedConfig: js.configs.recommended,
+})
+
+const eslintConfig = [
+  ...compat.config({
+    extends: ['eslint:recommended', 'next'],
+  }),
+]
+
+export default eslintConfig
 ```
 
 The `next` configuration already handles setting default values for the `parser`, `plugins` and `settings` properties. There is no need to manually re-declare any of these properties unless you need a different configuration for your use case.

--- a/docs/01-app/03-api-reference/05-config/03-eslint.mdx
+++ b/docs/01-app/03-api-reference/05-config/03-eslint.mdx
@@ -72,15 +72,25 @@ next lint --dir pages --dir utils --file bar.js
 
 If you're using `eslint-plugin-next` in a project where Next.js isn't installed in your root directory (such as a monorepo), you can tell `eslint-plugin-next` where to find your Next.js application using the `settings` property in your `.eslintrc`:
 
-```json filename=".eslintrc.json"
-{
-  "extends": "next",
-  "settings": {
-    "next": {
-      "rootDir": "packages/my-app/"
-    }
-  }
-}
+```mjs filename="eslint.config.mjs"
+import { FlatCompat } from '@eslint/eslintrc'
+
+const compat = new FlatCompat({
+  baseDirectory: import.meta.dirname,
+})
+
+const eslintConfig = [
+  ...compat.config({
+    extends: ['next'],
+    settings: {
+      next: {
+        rootDir: 'packages/my-app/',
+      },
+    },
+  }),
+]
+
+export default eslintConfig
 ```
 
 `rootDir` can be a path (relative or absolute), a glob (i.e. `"packages/*/"`), or an array of paths and/or globs.


### PR DESCRIPTION
This PR replaced eslint-related docs code examples from `.eslintrc.json` with `eslint.config.mjs`.

Closes NDX-373