### PR TITLE
Bump Rust version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4151,9 +4151,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "2.15.0"
+version = "2.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbf98e1bcb85cc441bbf7cdfb11070d2537a100e2697d75397b2584c32492d1"
+checksum = "214f07a80874bb96a8433b3cdfc84980d56c7b02e1a0d7ba4ba0db5cef785e2b"
 dependencies = [
  "anyhow",
  "bitflags 2.5.0",
@@ -4168,15 +4168,15 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "2.1.0"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b4532cf86bfef556348ac65e561e3123879f0e7566cca6d43a6ff5326f13df"
+checksum = "e1c0f5d67ee408a4685b61f5ab7e58605c8ae3f2b4189f0127d804ff13d5560a"
 
 [[package]]
 name = "napi-derive"
-version = "2.15.0"
+version = "2.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7622f0dbe0968af2dacdd64870eee6dee94f93c989c841f1ad8f300cf1abd514"
+checksum = "7cbe2585d8ac223f7d34f13701434b9d5f4eb9c332cccce8dee57ea18ab8ab0c"
 dependencies = [
  "cfg-if",
  "convert_case",
@@ -4188,9 +4188,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "1.0.60"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cf2d74ac66fd1cccb646be75fdd1c1dce8acfe20a68f61566a31da0d3eb9786"
+checksum = "1639aaa9eeb76e91c6ae66da8ce3e89e921cd3885e99ec85f4abacae72fc91bf"
 dependencies = [
  "convert_case",
  "once_cell",
@@ -4203,9 +4203,9 @@ dependencies = [
 
 [[package]]
 name = "napi-sys"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2503fa6af34dc83fb74888df8b22afe933b58d37daf7d80424b1c60c68196b8b"
+checksum = "427802e8ec3a734331fec1035594a210ce1ff4dc5bc1950530920ab717964ea3"
 dependencies = [
  "libloading",
 ]

--- a/crates/napi/build.rs
+++ b/crates/napi/build.rs
@@ -20,9 +20,6 @@ fn main() {
         println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
     }
 
-    // Workaround for "unexpected `cfg` condition value: `noop`" from napi-rs
-    println!("cargo::rustc-check-cfg=cfg(noop)");
-
     // Resolve a potential linker issue for unit tests on linux
     // https://github.com/napi-rs/napi-rs/issues/1782
     #[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]

--- a/crates/napi/build.rs
+++ b/crates/napi/build.rs
@@ -20,6 +20,9 @@ fn main() {
         println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
     }
 
+    // Workaround for "unexpected `cfg` condition value: `noop`" from napi-rs
+    println!("cargo::rustc-check-cfg=cfg(noop)");
+
     // Resolve a potential linker issue for unit tests on linux
     // https://github.com/napi-rs/napi-rs/issues/1782
     #[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-10-04"
+channel = "nightly-2024-11-23"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-11-23"
+channel = "nightly-2024-12-01"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-12-01"
+channel = "nightly-2024-12-10"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1272,7 +1272,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                             CachedDataItemValue::InProgressCell { value },
                         ) if cell_counters
                             .get(&cell.type_id)
-                            .map_or(true, |start_index| cell.index >= *start_index) =>
+                            .is_none_or(|start_index| cell.index >= *start_index) =>
                         {
                             value.event.notify(usize::MAX);
                             true
@@ -1283,8 +1283,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             ));
             removed_data.extend(task.extract_if(CachedDataItemIndex::CellData, |key, _| {
                 matches!(key, &CachedDataItemKey::CellData { cell } if cell_counters
-                        .get(&cell.type_id)
-                        .map_or(true, |start_index| cell.index >= *start_index))
+                        .get(&cell.type_id).is_none_or(|start_index| cell.index >= *start_index))
             }));
             if self.should_track_children() {
                 old_edges.extend(task.iter(CachedDataItemIndex::Children).filter_map(
@@ -1323,7 +1322,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                             CachedDataItemKey::CellDependent { cell, task }
                                 if cell_counters
                                     .get(&cell.type_id)
-                                    .map_or(true, |start_index| cell.index >= *start_index) =>
+                                    .is_none_or(|start_index| cell.index >= *start_index) =>
                             {
                                 Some(OutdatedEdge::RemovedCellDependent(task, cell.type_id))
                             }
@@ -1340,7 +1339,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                         CachedDataItemValue::InProgressCell { value },
                     ) if cell_counters
                         .get(&cell.type_id)
-                        .map_or(true, |start_index| cell.index >= *start_index) =>
+                        .is_none_or(|start_index| cell.index >= *start_index) =>
                     {
                         value.event.notify(usize::MAX);
                         return true;
@@ -1348,7 +1347,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                     (&CachedDataItemKey::CellData { cell }, _)
                         if cell_counters
                             .get(&cell.type_id)
-                            .map_or(true, |start_index| cell.index >= *start_index) =>
+                            .is_none_or(|start_index| cell.index >= *start_index) =>
                     {
                         return true;
                     }
@@ -1371,7 +1370,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                     (&CachedDataItemKey::CellDependent { cell, task }, _)
                         if cell_counters
                             .get(&cell.type_id)
-                            .map_or(true, |start_index| cell.index >= *start_index) =>
+                            .is_none_or(|start_index| cell.index >= *start_index) =>
                     {
                         old_edges.push(OutdatedEdge::RemovedCellDependent(task, cell.type_id));
                     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -576,7 +576,7 @@ impl AggregationUpdateQueue {
                                     if update.base_aggregation_number < base_aggregation_number {
                                         true
                                     } else if let Some(distance) = distance {
-                                        update.distance.map_or(true, |d| d < distance)
+                                        update.distance.is_none_or(|d| d < distance)
                                     } else {
                                         false
                                     };

--- a/turbopack/crates/turbo-tasks-backend/src/database/fresh_db_optimization.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/fresh_db_optimization.rs
@@ -13,7 +13,7 @@ use crate::database::{
 };
 
 pub fn is_fresh(path: &Path) -> bool {
-    fs::exists(path).map_or(false, |exists| !exists)
+    fs::exists(path).is_ok_and(|exists| !exists)
 }
 
 pub struct FreshDbOptimization<T: KeyValueDatabase> {

--- a/turbopack/crates/turbo-tasks-backend/src/utils/chunked_vec.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/utils/chunked_vec.rs
@@ -49,7 +49,7 @@ impl<T> ChunkedVec<T> {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.chunks.first().map_or(true, |chunk| chunk.is_empty())
+        self.chunks.first().is_none_or(|chunk| chunk.is_empty())
     }
 }
 

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/derive_non_local_value/fail_contains_vc_inside_generic.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/derive_non_local_value/fail_contains_vc_inside_generic.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Vc<i32>: NonLocalValue` is not satisfied
  --> tests/derive_non_local_value/fail_contains_vc_inside_generic.rs:7:8
   |
 7 |     a: Option<Box<[Vc<i32>; 4]>>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NonLocalValue` is not implemented for `Vc<i32>`, which is required by `std::option::Option<Box<[Vc<i32>; 4]>>: NonLocalValue`
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NonLocalValue` is not implemented for `Vc<i32>`
   |
   = help: the following other types implement trait `NonLocalValue`:
             &T

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/derive_non_local_value/fail_underconstrained_generic.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/derive_non_local_value/fail_underconstrained_generic.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `DeriveNonLocalValueAssertion::<T>::assert_impl_Non
 5 | #[derive(NonLocalValue)]
   |          ^^^^^^^^^^^^^ required by this bound in `DeriveNonLocalValueAssertion::<T>::assert_impl_NonLocalValue`
   = note: this error originates in the derive macro `NonLocalValue` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `NonLocalValue`
   |
 6 | struct ContainsUnderconstrainedGeneric<T: turbo_tasks::NonLocalValue> {
   |                                         ++++++++++++++++++++++++++++

--- a/turbopack/crates/turbo-tasks-memory/src/task/aggregation.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/task/aggregation.rs
@@ -482,7 +482,7 @@ impl DerefMut for TaskGuard<'_> {
     }
 }
 
-impl<'l> AggregationNodeGuard for TaskGuard<'l> {
+impl AggregationNodeGuard for TaskGuard<'_> {
     type Data = Aggregated;
     type NodeRef = TaskId;
     type DataChange = TaskChange;

--- a/turbopack/crates/turbo-tasks/src/debug/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/debug/mod.rs
@@ -379,7 +379,7 @@ pub enum ValueDebugFormatString<'a> {
     ),
 }
 
-impl<'a> ValueDebugFormatString<'a> {
+impl ValueDebugFormatString<'_> {
     /// Convert the `ValueDebugFormatString` into a `String`.
     ///
     /// This can fail when resolving `Vc` types.

--- a/turbopack/crates/turbopack-bench/src/lib.rs
+++ b/turbopack/crates/turbopack-bench/src/lib.rs
@@ -387,10 +387,10 @@ fn insert_code(
 
 static CHANGE_TIMEOUT_MESSAGE: &str = "update was not registered by bundler";
 
-async fn make_change<'a>(
+async fn make_change(
     module: &Path,
     bundler: &dyn Bundler,
-    guard: &mut PageGuard<'a>,
+    guard: &mut PageGuard<'_>,
     location: CodeLocation,
     timeout_duration: Duration,
     measurement: &WallTime,

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -1949,7 +1949,7 @@ impl JsValue {
                             if var_graph
                                 .free_var_ids
                                 .get(&first_str.into())
-                                .map_or(false, |id| var_graph.values.contains_key(id))
+                                .is_some_and(|id| var_graph.values.contains_key(id))
                             {
                                 // `typeof foo...` but `foo` was reassigned
                                 return None;

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -3248,7 +3248,7 @@ fn detect_dynamic_export(p: &Program) -> DetectedDynamicExportType {
         // Check for imports/exports
         if m.body.iter().any(|item| {
             item.as_module_decl().is_some_and(|module_decl| {
-                module_decl.as_import().map_or(true, |import| {
+                module_decl.as_import().is_none_or(|import| {
                     !is_turbopack_helper_import(import) && !is_swc_helper_import(import)
                 })
             })

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -3247,7 +3247,7 @@ fn detect_dynamic_export(p: &Program) -> DetectedDynamicExportType {
     if let Program::Module(m) = p {
         // Check for imports/exports
         if m.body.iter().any(|item| {
-            item.as_module_decl().map_or(false, |module_decl| {
+            item.as_module_decl().is_some_and(|module_decl| {
                 module_decl.as_import().map_or(true, |import| {
                     !is_turbopack_helper_import(import) && !is_swc_helper_import(import)
                 })

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -355,7 +355,7 @@ struct AnalysisState<'a> {
     url_rewrite_behavior: Option<UrlRewriteBehavior>,
 }
 
-impl<'a> AnalysisState<'a> {
+impl AnalysisState<'_> {
     /// Links a value to the graph, returning the linked value.
     async fn link_value(&self, value: JsValue, attributes: &ImportAttributes) -> Result<JsValue> {
         let fun_args_values = self.fun_args_values.lock().clone();

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -810,7 +810,7 @@ impl DepGraph {
                             for decl in &v.decls {
                                 let disable_export_merging = comments
                                     .has_flag(decl.name.span().lo, FLAG_DISABLE_EXPORT_MERGING)
-                                    || decl.init.as_deref().map_or(false, |e| {
+                                    || decl.init.as_deref().is_some_and(|e| {
                                         comments.has_flag(e.span().lo, FLAG_DISABLE_EXPORT_MERGING)
                                     });
 
@@ -1245,7 +1245,7 @@ impl DepGraph {
 
                         let side_effects = !has_explicit_pure
                             && (vars.found_unresolved
-                                || decl.init.as_deref().map_or(false, |e| {
+                                || decl.init.as_deref().is_some_and(|e| {
                                     e.may_have_side_effects(&ExprCtx {
                                         unresolved_ctxt,
                                         is_unresolved_ref_safe: false,

--- a/turbopack/crates/turbopack-swc-utils/src/emitter.rs
+++ b/turbopack/crates/turbopack-swc-utils/src/emitter.rs
@@ -102,7 +102,7 @@ impl Emitter for IssueEmitter {
         let is_lint = db
             .code
             .as_ref()
-            .map_or(false, |d| matches!(d, DiagnosticId::Lint(_)));
+            .is_some_and(|d| matches!(d, DiagnosticId::Lint(_)));
 
         let severity = (if is_lint {
             IssueSeverity::Suggestion

--- a/turbopack/crates/turbopack-trace-server/src/store.rs
+++ b/turbopack/crates/turbopack-trace-server/src/store.rs
@@ -73,7 +73,7 @@ impl Store {
     pub fn has_time_info(&self) -> bool {
         self.self_time_tree
             .as_ref()
-            .map_or(true, |tree| tree.len() > 0)
+            .is_none_or(|tree| tree.len() > 0)
     }
 
     pub fn add_span(


### PR DESCRIPTION
~~We should try to wait for https://github.com/napi-rs/napi-rs/issues/2370 to fix a lot of these warnings:~~
```
warning: unexpected `cfg` condition value: `noop`
  --> crates/napi/src/mdx.rs:25:1
   |
25 | #[napi]
   | ^^^^^^^
   |
   = note: expected values for `feature` are: `__internal_dhat-ad-hoc`, `__internal_dhat-heap`, `dhat`, `image-avif`, `image-extended`, `image-webp`, `plugin`, and `turbopack-ecmascript-plugins`
   = help: consider adding `noop` as a feature in `Cargo.toml`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
   = note: `#[warn(unexpected_cfgs)]` on by default
   = note: this warning originates in the attribute macro `napi` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Closes PACK-3645