### PR TITLE
perf(turbopack): Use `ResolvedVc` for `turbopack-css`

### DIFF
--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -126,7 +126,7 @@ impl Module for CssModuleAsset {
         // TODO: include CSS source map
 
         match &*result {
-            ParseCssResult::Ok { references, .. } => Ok(*references),
+            ParseCssResult::Ok { references, .. } => Ok(**references),
             ParseCssResult::Unparseable => Ok(ModuleReferences::empty()),
             ParseCssResult::NotFound => Ok(ModuleReferences::empty()),
         }
@@ -296,7 +296,7 @@ impl CssChunkItem for CssModuleChunkItem {
             Ok(CssChunkItemContent {
                 inner_code: output_code.to_owned().into(),
                 imports,
-                import_context: self.module.await?.import_context.map(|v| *v),
+                import_context: self.module.await?.import_context,
                 source_map: Some(*source_map),
             }
             .into())

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -234,7 +234,7 @@ impl CssChunkItem for CssModuleChunkItem {
                         {
                             imports.push(CssImport::Internal(
                                 import_ref.to_resolved().await?,
-                                css_item,
+                                css_item.to_resolved().await?,
                             ));
                         }
                     }

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -33,9 +33,9 @@ fn modifier() -> Vc<RcStr> {
 #[turbo_tasks::value]
 #[derive(Clone)]
 pub struct CssModuleAsset {
-    source: Vc<Box<dyn Source>>,
-    asset_context: Vc<Box<dyn AssetContext>>,
-    import_context: Option<Vc<ImportContext>>,
+    source: ResolvedVc<Box<dyn Source>>,
+    asset_context: ResolvedVc<Box<dyn AssetContext>>,
+    import_context: Option<ResolvedVc<ImportContext>>,
     ty: CssModuleAssetType,
     minify_type: MinifyType,
 }
@@ -172,8 +172,8 @@ impl ResolveOrigin for CssModuleAsset {
 
 #[turbo_tasks::value]
 struct CssModuleChunkItem {
-    module: Vc<CssModuleAsset>,
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
+    module: ResolvedVc<CssModuleAsset>,
+    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -45,11 +45,11 @@ impl CssModuleAsset {
     /// Creates a new CSS asset.
     #[turbo_tasks::function]
     pub fn new(
-        source: Vc<Box<dyn Source>>,
-        asset_context: Vc<Box<dyn AssetContext>>,
+        source: ResolvedVc<Box<dyn Source>>,
+        asset_context: ResolvedVc<Box<dyn AssetContext>>,
         ty: CssModuleAssetType,
         minify_type: MinifyType,
-        import_context: Option<Vc<ImportContext>>,
+        import_context: Option<ResolvedVc<ImportContext>>,
     ) -> Vc<Self> {
         Self::cell(CssModuleAsset {
             source,
@@ -74,9 +74,10 @@ impl ParseCss for CssModuleAsset {
         let this = self.await?;
 
         Ok(parse_css(
-            this.source,
+            *this.source,
             Vc::upcast(self),
             this.import_context
+                .map(|v| *v)
                 .unwrap_or_else(|| ImportContext::new(vec![], vec![], vec![])),
             this.ty,
         ))
@@ -144,8 +145,8 @@ impl Asset for CssModuleAsset {
 impl ChunkableModule for CssModuleAsset {
     #[turbo_tasks::function]
     fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
+        self: ResolvedVc<Self>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
         Vc::upcast(CssModuleChunkItem::cell(CssModuleChunkItem {
             module: self,
@@ -166,7 +167,7 @@ impl ResolveOrigin for CssModuleAsset {
 
     #[turbo_tasks::function]
     fn asset_context(&self) -> Vc<Box<dyn AssetContext>> {
-        self.asset_context
+        *self.asset_context
     }
 }
 
@@ -190,7 +191,7 @@ impl ChunkItem for CssModuleChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        Vc::upcast(self.chunking_context)
+        Vc::upcast(*self.chunking_context)
     }
 
     #[turbo_tasks::function]
@@ -200,7 +201,7 @@ impl ChunkItem for CssModuleChunkItem {
 
     #[turbo_tasks::function]
     fn module(&self) -> Vc<Box<dyn Module>> {
-        Vc::upcast(self.module)
+        Vc::upcast(*self.module)
     }
 }
 
@@ -227,7 +228,7 @@ impl CssChunkItem for CssModuleChunkItem {
                     if let Some(placeable) =
                         ResolvedVc::try_downcast::<Box<dyn CssChunkPlaceable>>(module).await?
                     {
-                        let item = placeable.as_chunk_item(chunking_context);
+                        let item = placeable.as_chunk_item(*chunking_context);
                         if let Some(css_item) =
                             Vc::try_resolve_downcast::<Box<dyn CssChunkItem>>(item).await?
                         {
@@ -252,7 +253,7 @@ impl CssChunkItem for CssModuleChunkItem {
                     if let Some(placeable) =
                         ResolvedVc::try_downcast::<Box<dyn CssChunkPlaceable>>(module).await?
                     {
-                        let item = placeable.as_chunk_item(chunking_context);
+                        let item = placeable.as_chunk_item(*chunking_context);
                         if let Some(css_item) =
                             Vc::try_resolve_downcast::<Box<dyn CssChunkItem>>(item).await?
                         {
@@ -268,7 +269,7 @@ impl CssChunkItem for CssModuleChunkItem {
             if let Some(code_gen) =
                 Vc::try_resolve_sidecast::<Box<dyn CodeGenerateable>>(*r).await?
             {
-                code_gens.push(code_gen.code_generation(chunking_context));
+                code_gens.push(code_gen.code_generation(*chunking_context));
             }
         }
         // need to keep that around to allow references into that
@@ -283,7 +284,7 @@ impl CssChunkItem for CssModuleChunkItem {
 
         let result = self
             .module
-            .finalize_css(chunking_context, self.module.await?.minify_type)
+            .finalize_css(*chunking_context, self.module.await?.minify_type)
             .await?;
 
         if let FinalCssResult::Ok {
@@ -295,7 +296,7 @@ impl CssChunkItem for CssModuleChunkItem {
             Ok(CssChunkItemContent {
                 inner_code: output_code.to_owned().into(),
                 imports,
-                import_context: self.module.await?.import_context,
+                import_context: self.module.await?.import_context.map(|v| *v),
                 source_map: Some(*source_map),
             }
             .into())
@@ -316,6 +317,6 @@ impl CssChunkItem for CssModuleChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        self.chunking_context
+        *self.chunking_context
     }
 }

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -204,7 +204,7 @@ impl OutputChunk for CssChunk {
                 else {
                     return Ok(vec![]);
                 };
-                Ok(css_item
+                css_item
                     .content()
                     .await?
                     .imports
@@ -218,7 +218,7 @@ impl OutputChunk for CssChunk {
                     })
                     .map(|v| async move { v.to_resolved().await })
                     .try_join()
-                    .await?)
+                    .await
             })
             .try_join()
             .await?

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -377,18 +377,21 @@ pub trait CssChunkPlaceable: ChunkableModule + Module + Asset {}
 #[derive(Clone, Debug)]
 #[turbo_tasks::value(shared)]
 pub enum CssImport {
-    External(Vc<RcStr>),
-    Internal(ResolvedVc<ImportAssetReference>, Vc<Box<dyn CssChunkItem>>),
+    External(ResolvedVc<RcStr>),
+    Internal(
+        ResolvedVc<ImportAssetReference>,
+        ResolvedVc<Box<dyn CssChunkItem>>,
+    ),
     Composes(ResolvedVc<Box<dyn CssChunkItem>>),
 }
 
 #[derive(Debug)]
 #[turbo_tasks::value(shared)]
 pub struct CssChunkItemContent {
-    pub import_context: Option<Vc<ImportContext>>,
+    pub import_context: Option<ResolvedVc<ImportContext>>,
     pub imports: Vec<CssImport>,
     pub inner_code: Rope,
-    pub source_map: Option<Vc<ParseCssResultSourceMap>>,
+    pub source_map: Option<ResolvedVc<ParseCssResultSourceMap>>,
 }
 
 #[turbo_tasks::value_trait]

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -91,7 +91,7 @@ impl CssChunk {
                     None => None,
                 }
             } else {
-                content.source_map.map(Vc::upcast)
+                content.source_map.map(ResolvedVc::upcast)
             };
 
             body.push_source(&content.inner_code, source_map);

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -91,7 +91,7 @@ impl CssChunk {
                     None => None,
                 }
             } else {
-                content.source_map.map(ResolvedVc::upcast)
+                content.source_map.map(ResolvedVc::upcast).map(|v| *v)
             };
 
             body.push_source(&content.inner_code, source_map);
@@ -136,7 +136,7 @@ impl CssChunk {
 
 pub async fn write_import_context(
     body: &mut impl std::io::Write,
-    import_context: Option<Vc<ImportContext>>,
+    import_context: Option<ResolvedVc<ImportContext>>,
 ) -> Result<String> {
     let mut close = String::new();
     if let Some(import_context) = import_context {

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -32,8 +32,8 @@ use crate::{process::ParseCssResultSourceMap, util::stringify_js, ImportAssetRef
 
 #[turbo_tasks::value]
 pub struct CssChunk {
-    pub chunking_context: Vc<Box<dyn ChunkingContext>>,
-    pub content: Vc<CssChunkContent>,
+    pub chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    pub content: ResolvedVc<CssChunkContent>,
 }
 
 #[turbo_tasks::value_impl]
@@ -163,8 +163,8 @@ pub async fn write_import_context(
 
 #[turbo_tasks::value]
 pub struct CssChunkContent {
-    pub chunk_items: Vec<Vc<Box<dyn CssChunkItem>>>,
-    pub referenced_output_assets: Vc<OutputAssets>,
+    pub chunk_items: Vec<ResolvedVc<Box<dyn CssChunkItem>>>,
+    pub referenced_output_assets: ResolvedVc<OutputAssets>,
 }
 
 #[turbo_tasks::value_impl]
@@ -349,7 +349,7 @@ impl GenerateSourceMap for CssChunk {
 
 #[turbo_tasks::value]
 pub struct CssChunkContext {
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
+    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -55,7 +55,7 @@ impl SingleItemCssChunk {
 
         writeln!(code, "/* {} */", id)?;
         let content = this.item.content().await?;
-        let close = write_import_context(&mut code, content.import_context.map(|v| *v)).await?;
+        let close = write_import_context(&mut code, content.import_context).await?;
 
         code.push_source(
             &content.inner_code,

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -55,9 +55,12 @@ impl SingleItemCssChunk {
 
         writeln!(code, "/* {} */", id)?;
         let content = this.item.content().await?;
-        let close = write_import_context(&mut code, content.import_context).await?;
+        let close = write_import_context(&mut code, content.import_context.map(|v| *v)).await?;
 
-        code.push_source(&content.inner_code, content.source_map.map(Vc::upcast));
+        code.push_source(
+            &content.inner_code,
+            content.source_map.map(ResolvedVc::upcast).map(|v| *v),
+        );
         write!(code, "{close}")?;
 
         if *this

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -31,8 +31,8 @@ impl SingleItemCssChunk {
     /// Creates a new [`Vc<SingleItemCssChunk>`].
     #[turbo_tasks::function]
     pub fn new(
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-        item: Vc<Box<dyn CssChunkItem>>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+        item: ResolvedVc<Box<dyn CssChunkItem>>,
     ) -> Vc<Self> {
         SingleItemCssChunk {
             chunking_context,
@@ -89,7 +89,7 @@ impl Chunk for SingleItemCssChunk {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        self.chunking_context
+        *self.chunking_context
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -22,8 +22,8 @@ use crate::chunk::{write_import_context, CssChunkItem};
 /// avoiding rule duplication.
 #[turbo_tasks::value]
 pub struct SingleItemCssChunk {
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
-    item: Vc<Box<dyn CssChunkItem>>,
+    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    item: ResolvedVc<Box<dyn CssChunkItem>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::File;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -14,7 +14,7 @@ use super::chunk::SingleItemCssChunk;
 /// Represents the source map of a single item CSS chunk.
 #[turbo_tasks::value]
 pub struct SingleItemCssChunkSourceMapAsset {
-    chunk: Vc<SingleItemCssChunk>,
+    chunk: ResolvedVc<SingleItemCssChunk>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
@@ -20,7 +20,7 @@ pub struct SingleItemCssChunkSourceMapAsset {
 #[turbo_tasks::value_impl]
 impl SingleItemCssChunkSourceMapAsset {
     #[turbo_tasks::function]
-    pub fn new(chunk: Vc<SingleItemCssChunk>) -> Vc<Self> {
+    pub fn new(chunk: ResolvedVc<SingleItemCssChunk>) -> Vc<Self> {
         SingleItemCssChunkSourceMapAsset { chunk }.cell()
     }
 }

--- a/turbopack/crates/turbopack-css/src/chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/source_map.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::File;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -14,7 +14,7 @@ use super::CssChunk;
 /// Represents the source map of an css chunk.
 #[turbo_tasks::value]
 pub struct CssChunkSourceMapAsset {
-    chunk: Vc<CssChunk>,
+    chunk: ResolvedVc<CssChunk>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-css/src/chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/source_map.rs
@@ -20,7 +20,7 @@ pub struct CssChunkSourceMapAsset {
 #[turbo_tasks::value_impl]
 impl CssChunkSourceMapAsset {
     #[turbo_tasks::function]
-    pub fn new(chunk: Vc<CssChunk>) -> Vc<Self> {
+    pub fn new(chunk: ResolvedVc<CssChunk>) -> Vc<Self> {
         CssChunkSourceMapAsset { chunk }.cell()
     }
 }

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -332,8 +332,8 @@ impl EcmascriptChunkItem for ModuleChunkItem {
 
                         let Some(resolved_module) = &*resolved_module else {
                             CssModuleComposesIssue {
-                                severity: IssueSeverity::Error.cell(),
-                                source: self.module.ident(),
+                                severity: IssueSeverity::Error.resolved_cell(),
+                                source: self.module.ident().to_resolved().await?,
                                 message: formatdoc! {
                                     r#"
                                         Module {from} referenced in `composes: ... from {from};` can't be resolved.
@@ -349,8 +349,8 @@ impl EcmascriptChunkItem for ModuleChunkItem {
                                 .await?
                         else {
                             CssModuleComposesIssue {
-                                severity: IssueSeverity::Error.cell(),
-                                source: self.module.ident(),
+                                severity: IssueSeverity::Error.resolved_cell(),
+                                    source: self.module.ident().to_resolved().await?,
                                 message: formatdoc! {
                                     r#"
                                         Module {from} referenced in `composes: ... from {from};` is not a CSS module.
@@ -428,8 +428,8 @@ fn generate_minimal_source_map(filename: String, source: String) -> Vc<ParseResu
 
 #[turbo_tasks::value(shared)]
 struct CssModuleComposesIssue {
-    severity: Vc<IssueSeverity>,
-    source: Vc<AssetIdent>,
+    severity: ResolvedVc<IssueSeverity>,
+    source: ResolvedVc<AssetIdent>,
     message: RcStr,
 }
 
@@ -437,7 +437,7 @@ struct CssModuleComposesIssue {
 impl Issue for CssModuleComposesIssue {
     #[turbo_tasks::function]
     fn severity(&self) -> Vc<IssueSeverity> {
-        self.severity
+        *self.severity
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -39,11 +39,11 @@ fn modifier() -> Vc<RcStr> {
     Vc::cell("css module".into())
 }
 
-#[turbo_tasks::value]
+#[turbo_tasks::value(resolved)]
 #[derive(Clone)]
 pub struct ModuleCssAsset {
-    pub source: Vc<Box<dyn Source>>,
-    pub asset_context: Vc<Box<dyn AssetContext>>,
+    pub source: ResolvedVc<Box<dyn Source>>,
+    pub asset_context: ResolvedVc<Box<dyn AssetContext>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -116,7 +116,7 @@ enum ModuleCssClass {
     },
     Import {
         original: String,
-        from: Vc<CssModuleComposeReference>,
+        from: ResolvedVc<CssModuleComposeReference>,
     },
 }
 
@@ -268,8 +268,8 @@ impl ResolveOrigin for ModuleCssAsset {
 
 #[turbo_tasks::value]
 struct ModuleChunkItem {
-    module: Vc<ModuleCssAsset>,
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
+    module: ResolvedVc<ModuleCssAsset>,
+    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -39,7 +39,7 @@ fn modifier() -> Vc<RcStr> {
     Vc::cell("css module".into())
 }
 
-#[turbo_tasks::value(resolved)]
+#[turbo_tasks::value]
 #[derive(Clone)]
 pub struct ModuleCssAsset {
     pub source: ResolvedVc<Box<dyn Source>>,

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -267,7 +267,7 @@ impl ResolveOrigin for ModuleCssAsset {
 
     #[turbo_tasks::function]
     fn asset_context(&self) -> Vc<Box<dyn AssetContext>> {
-        self.asset_context
+        *self.asset_context
     }
 }
 
@@ -291,7 +291,7 @@ impl ChunkItem for ModuleChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        Vc::upcast(self.chunking_context)
+        Vc::upcast(*self.chunking_context)
     }
 
     #[turbo_tasks::function]
@@ -303,7 +303,7 @@ impl ChunkItem for ModuleChunkItem {
 
     #[turbo_tasks::function]
     fn module(&self) -> Vc<Box<dyn Module>> {
-        Vc::upcast(self.module)
+        Vc::upcast(*self.module)
     }
 }
 
@@ -311,7 +311,7 @@ impl ChunkItem for ModuleChunkItem {
 impl EcmascriptChunkItem for ModuleChunkItem {
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        self.chunking_context
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]
@@ -368,7 +368,7 @@ impl EcmascriptChunkItem for ModuleChunkItem {
                             ResolvedVc::upcast(css_module);
 
                         let module_id = placeable
-                            .as_chunk_item(Vc::upcast(self.chunking_context))
+                            .as_chunk_item(Vc::upcast(*self.chunking_context))
                             .id()
                             .await?;
                         let module_id = StringifyJs(&*module_id);

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -19,7 +19,7 @@ use swc_core::{
 };
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, ValueToString, Vc};
+use turbo_tasks::{FxIndexMap, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -646,9 +646,9 @@ impl GenerateSourceMap for ParseCssResultSourceMap {
 
 #[turbo_tasks::value]
 struct ParsingIssue {
-    msg: Vc<RcStr>,
-    file: Vc<FileSystemPath>,
-    source: Option<Vc<IssueSource>>,
+    msg: ResolvedVc<RcStr>,
+    file: ResolvedVc<FileSystemPath>,
+    source: Option<ResolvedVc<IssueSource>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-css/src/references/compose.rs
+++ b/turbopack/crates/turbopack-css/src/references/compose.rs
@@ -35,8 +35,8 @@ impl ModuleReference for CssModuleComposeReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         css_resolve(
-            self.origin,
-            self.request,
+            *self.origin,
+            *self.request,
             Value::new(CssReferenceSubType::Compose),
             // TODO: add real issue source, currently impossible because `CssClassName` doesn't
             // contain the source span

--- a/turbopack/crates/turbopack-css/src/references/compose.rs
+++ b/turbopack/crates/turbopack-css/src/references/compose.rs
@@ -22,7 +22,10 @@ pub struct CssModuleComposeReference {
 impl CssModuleComposeReference {
     /// Creates a new [`CssModuleComposeReference`].
     #[turbo_tasks::function]
-    pub fn new(origin: Vc<Box<dyn ResolveOrigin>>, request: Vc<Request>) -> Vc<Self> {
+    pub fn new(
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        request: ResolvedVc<Request>,
+    ) -> Vc<Self> {
         Self::cell(CssModuleComposeReference { origin, request })
     }
 }

--- a/turbopack/crates/turbopack-css/src/references/compose.rs
+++ b/turbopack/crates/turbopack-css/src/references/compose.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Value, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
 use turbopack_core::{
     chunk::ChunkableModuleReference,
     reference::ModuleReference,
@@ -14,8 +14,8 @@ use crate::references::css_resolve;
 #[turbo_tasks::value]
 #[derive(Hash, Debug)]
 pub struct CssModuleComposeReference {
-    pub origin: Vc<Box<dyn ResolveOrigin>>,
-    pub request: Vc<Request>,
+    pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+    pub request: ResolvedVc<Request>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-css/src/references/import.rs
+++ b/turbopack/crates/turbopack-css/src/references/import.rs
@@ -154,7 +154,7 @@ impl CodeGenerateable for ImportAssetReference {
             ..
         } = &*this.request.await?
         {
-            imports.push(CssImport::External(Vc::cell(
+            imports.push(CssImport::External(ResolvedVc::cell(
                 format!("{}{}", protocol, remainder).into(),
             )))
         }

--- a/turbopack/crates/turbopack-css/src/references/import.rs
+++ b/turbopack/crates/turbopack-css/src/references/import.rs
@@ -5,7 +5,7 @@ use lightningcss::{
     traits::ToCss,
 };
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Value, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
 use turbopack_core::{
     chunk::{ChunkableModuleReference, ChunkingContext},
     issue::IssueSource,
@@ -83,11 +83,11 @@ impl ImportAttributes {
 #[turbo_tasks::value]
 #[derive(Hash, Debug)]
 pub struct ImportAssetReference {
-    pub origin: Vc<Box<dyn ResolveOrigin>>,
-    pub request: Vc<Request>,
-    pub attributes: Vc<ImportAttributes>,
-    pub import_context: Vc<ImportContext>,
-    pub issue_source: Vc<IssueSource>,
+    pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+    pub request: ResolvedVc<Request>,
+    pub attributes: ResolvedVc<ImportAttributes>,
+    pub import_context: ResolvedVc<ImportContext>,
+    pub issue_source: ResolvedVc<IssueSource>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-css/src/references/import.rs
+++ b/turbopack/crates/turbopack-css/src/references/import.rs
@@ -94,11 +94,11 @@ pub struct ImportAssetReference {
 impl ImportAssetReference {
     #[turbo_tasks::function]
     pub fn new(
-        origin: Vc<Box<dyn ResolveOrigin>>,
-        request: Vc<Request>,
-        attributes: Vc<ImportAttributes>,
-        import_context: Vc<ImportContext>,
-        issue_source: Vc<IssueSource>,
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        request: ResolvedVc<Request>,
+        attributes: ResolvedVc<ImportAttributes>,
+        import_context: ResolvedVc<ImportContext>,
+        issue_source: ResolvedVc<IssueSource>,
     ) -> Vc<Self> {
         Self::cell(ImportAssetReference {
             origin,
@@ -121,10 +121,10 @@ impl ModuleReference for ImportAssetReference {
         };
 
         Ok(css_resolve(
-            self.origin,
-            self.request,
+            *self.origin,
+            *self.request,
             Value::new(CssReferenceSubType::AtImport(Some(import_context))),
-            Some(self.issue_source),
+            Some(*self.issue_source),
         ))
     }
 }

--- a/turbopack/crates/turbopack-css/src/references/mod.rs
+++ b/turbopack/crates/turbopack-css/src/references/mod.rs
@@ -8,7 +8,7 @@ use lightningcss::{
     visitor::{Visit, Visitor},
 };
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Value, Vc};
+use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbopack_core::{
     issue::IssueSource,
     reference::ModuleReference,
@@ -33,7 +33,7 @@ pub(crate) mod url;
 
 pub type AnalyzedRefs = (
     Vec<Vc<Box<dyn ModuleReference>>>,
-    Vec<(String, Vc<UrlAssetReference>)>,
+    Vec<(String, ResolvedVc<UrlAssetReference>)>,
 );
 
 /// Returns `(all_references, urls)`.

--- a/turbopack/crates/turbopack-css/src/references/mod.rs
+++ b/turbopack/crates/turbopack-css/src/references/mod.rs
@@ -8,7 +8,7 @@ use lightningcss::{
     visitor::{Visit, Visitor},
 };
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{Value, Vc};
 use turbopack_core::{
     issue::IssueSource,
     reference::ModuleReference,
@@ -33,7 +33,7 @@ pub(crate) mod url;
 
 pub type AnalyzedRefs = (
     Vec<Vc<Box<dyn ModuleReference>>>,
-    Vec<(String, ResolvedVc<UrlAssetReference>)>,
+    Vec<(String, Vc<UrlAssetReference>)>,
 );
 
 /// Returns `(all_references, urls)`.

--- a/turbopack/crates/turbopack-css/src/references/url.rs
+++ b/turbopack/crates/turbopack-css/src/references/url.rs
@@ -32,9 +32,9 @@ pub enum ReferencedAsset {
 #[turbo_tasks::value]
 #[derive(Hash, Debug)]
 pub struct UrlAssetReference {
-    pub origin: Vc<Box<dyn ResolveOrigin>>,
-    pub request: Vc<Request>,
-    pub issue_source: Vc<IssueSource>,
+    pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+    pub request: ResolvedVc<Request>,
+    pub issue_source: ResolvedVc<IssueSource>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-css/src/references/url.rs
+++ b/turbopack/crates/turbopack-css/src/references/url.rs
@@ -41,9 +41,9 @@ pub struct UrlAssetReference {
 impl UrlAssetReference {
     #[turbo_tasks::function]
     pub fn new(
-        origin: Vc<Box<dyn ResolveOrigin>>,
-        request: Vc<Request>,
-        issue_source: Vc<IssueSource>,
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        request: ResolvedVc<Request>,
+        issue_source: ResolvedVc<IssueSource>,
     ) -> Vc<Self> {
         Self::cell(UrlAssetReference {
             origin,
@@ -86,10 +86,10 @@ impl ModuleReference for UrlAssetReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         url_resolve(
-            self.origin,
-            self.request,
+            *self.origin,
+            *self.request,
             Value::new(ReferenceType::Url(UrlReferenceSubType::CssUrl)),
-            Some(self.issue_source),
+            Some(*self.issue_source),
             false,
         )
     }


### PR DESCRIPTION
### What?

Use `ResolvedVc<T>` instead of `Vc<T>` for struct fields in `turbopack-css`

### Why?

### How?


Closes PACK-3542