### PR TITLE
perf(turbopack): Use `ResolvedVc` for `next-core`

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -137,8 +137,12 @@ impl AppProject {
         let this = self.await?;
         Ok(ServerContextType::AppRSC {
             app_dir: this.app_dir,
-            client_transition: Some(Vc::upcast(self.client_transition())),
-            ecmascript_client_reference_transition_name: Some(self.client_transition_name()),
+            client_transition: Some(ResolvedVc::upcast(
+                self.client_transition().to_resolved().await?,
+            )),
+            ecmascript_client_reference_transition_name: Some(
+                self.client_transition_name().to_resolved().await?,
+            ),
         }
         .cell())
     }
@@ -148,7 +152,9 @@ impl AppProject {
         let this = self.await?;
         Ok(ServerContextType::AppRoute {
             app_dir: this.app_dir,
-            ecmascript_client_reference_transition_name: Some(self.client_transition_name()),
+            ecmascript_client_reference_transition_name: Some(
+                self.client_transition_name().to_resolved().await?,
+            ),
         }
         .cell())
     }

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -940,7 +940,7 @@ impl AppEndpoint {
                     } = &*find_server_entries(*rsc_entry).await?;
 
                     let mut client_references = client_reference_graph(
-                        server_utils.clone(),
+                        server_utils.iter().map(|&v| *v).collect(),
                         VisitedClientReferenceGraphNodes::empty(),
                     )
                     .await?
@@ -948,11 +948,11 @@ impl AppEndpoint {
 
                     for module in server_component_entries
                         .iter()
-                        .map(|m| Vc::upcast::<Box<dyn Module>>(*m))
-                        .chain(std::iter::once(*rsc_entry))
+                        .map(|m| ResolvedVc::upcast::<Box<dyn Module>>(*m))
+                        .chain(std::iter::once(rsc_entry))
                     {
                         let current_client_references =
-                            client_reference_graph(vec![module], client_references.visited_nodes)
+                            client_reference_graph(vec![*module], *client_references.visited_nodes)
                                 .await?;
 
                         client_references.extend(&current_client_references);
@@ -1536,7 +1536,7 @@ impl AppEndpoint {
                                 let chunk_group = chunking_context
                                     .chunk_group(
                                         server_component.ident(),
-                                        Vc::upcast(server_component),
+                                        *ResolvedVc::upcast(server_component),
                                         Value::new(current_availability_info),
                                     )
                                     .await?;

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -970,7 +970,7 @@ impl AppEndpoint {
                         .values()
                     {
                         let result = collect_next_dynamic_imports(
-                            refs.clone(),
+                            refs.iter().map(|v| **v).collect(),
                             Vc::upcast(this.app_project.client_module_context()),
                             visited_modules,
                         )
@@ -1496,7 +1496,7 @@ impl AppEndpoint {
                             let utils_module = IncludeModulesModule::new(
                                 AssetIdent::from_path(this.app_project.project().project_path())
                                     .with_modifier(server_utils_modifier()),
-                                client_references.server_utils.clone(),
+                                client_references.server_utils.iter().map(|v| **v).collect(),
                             );
 
                             let chunk_group = chunking_context

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -113,8 +113,7 @@ impl InstrumentationEndpoint {
             Value::new(ServerContextType::Instrumentation {
                 app_dir: this.app_dir,
                 ecmascript_client_reference_transition_name: this
-                    .ecmascript_client_reference_transition_name
-                    .map(|v| *v),
+                    .ecmascript_client_reference_transition_name,
             }),
             this.project.next_mode(),
         )
@@ -166,8 +165,7 @@ impl InstrumentationEndpoint {
                     Value::new(ServerContextType::Instrumentation {
                         app_dir: this.app_dir,
                         ecmascript_client_reference_transition_name: this
-                            .ecmascript_client_reference_transition_name
-                            .map(|v| *v),
+                            .ecmascript_client_reference_transition_name,
                     }),
                     this.project.next_mode(),
                 )

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -90,9 +90,7 @@ impl MiddlewareEndpoint {
             Value::new(ServerContextType::Middleware {
                 app_dir: self.app_dir,
                 ecmascript_client_reference_transition_name: self
-                    .ecmascript_client_reference_transition_name
-                    .as_deref()
-                    .copied(),
+                    .ecmascript_client_reference_transition_name,
             }),
             self.project.next_mode(),
         )

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -134,10 +134,10 @@ impl PagesProject {
                     project_path: _,
                 } = *dir.await?;
                 for &item in items.iter() {
-                    add_page_to_routes(routes, item, &make_route).await?;
+                    add_page_to_routes(routes, *item, &make_route).await?;
                 }
                 for &child in children.iter() {
-                    queue.push(child);
+                    queue.push(*child);
                 }
             }
             Ok(())
@@ -217,19 +217,19 @@ impl PagesProject {
     #[turbo_tasks::function]
     pub async fn document_endpoint(self: Vc<Self>) -> Result<Vc<Box<dyn Endpoint>>> {
         Ok(self.to_endpoint(
-            self.pages_structure().await?.document,
+            *self.pages_structure().await?.document,
             PageEndpointType::SsrOnly,
         ))
     }
 
     #[turbo_tasks::function]
     pub async fn app_endpoint(self: Vc<Self>) -> Result<Vc<Box<dyn Endpoint>>> {
-        Ok(self.to_endpoint(self.pages_structure().await?.app, PageEndpointType::Html))
+        Ok(self.to_endpoint(*self.pages_structure().await?.app, PageEndpointType::Html))
     }
 
     #[turbo_tasks::function]
     pub async fn error_endpoint(self: Vc<Self>) -> Result<Vc<Box<dyn Endpoint>>> {
-        Ok(self.to_endpoint(self.pages_structure().await?.error, PageEndpointType::Html))
+        Ok(self.to_endpoint(*self.pages_structure().await?.error, PageEndpointType::Html))
     }
 
     #[turbo_tasks::function]
@@ -665,7 +665,7 @@ impl PageEndpoint {
         ) {
             if let Some(chunkable) = Vc::try_resolve_downcast(page_loader).await? {
                 return Ok(Vc::upcast(HmrEntryModule::new(
-                    AssetIdent::from_path(this.page.await?.base_path),
+                    AssetIdent::from_path(*this.page.await?.base_path),
                     chunkable,
                 )));
             }
@@ -696,7 +696,7 @@ impl PageEndpoint {
             let client_chunking_context = this.pages_project.project().client_chunking_context();
 
             let client_chunks = client_chunking_context.evaluated_chunk_group_assets(
-                AssetIdent::from_path(this.page.await?.base_path),
+                AssetIdent::from_path(*this.page.await?.base_path),
                 this.pages_project
                     .client_runtime_entries()
                     .with_entry(client_main_module)

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -944,9 +944,10 @@ impl Project {
         let app_dir = *find_app_dir(self.project_path()).await?;
         let app_project = *self.app_project().await?;
 
-        let ecmascript_client_reference_transition_name = app_project
-            .as_ref()
-            .map(|app_project| app_project.client_transition_name());
+        let ecmascript_client_reference_transition_name = match app_project {
+            Some(app_project) => Some(app_project.client_transition_name().to_resolved().await?),
+            None => None,
+        };
 
         if let Some(app_project) = app_project {
             transitions.push((
@@ -1028,9 +1029,10 @@ impl Project {
         let app_dir = *find_app_dir(self.project_path()).await?;
         let app_project = &*self.app_project().await?;
 
-        let ecmascript_client_reference_transition_name = app_project
-            .as_ref()
-            .map(|app_project| app_project.client_transition_name());
+        let ecmascript_client_reference_transition_name = match app_project {
+            Some(app_project) => Some(app_project.client_transition_name().to_resolved().await?),
+            None => None,
+        };
 
         if let Some(app_project) = app_project {
             transitions.push((
@@ -1081,9 +1083,10 @@ impl Project {
         let app_dir = *find_app_dir(self.project_path()).await?;
         let app_project = &*self.app_project().await?;
 
-        let ecmascript_client_reference_transition_name = app_project
-            .as_ref()
-            .map(|app_project| app_project.client_transition_name());
+        let ecmascript_client_reference_transition_name = match app_project {
+            Some(app_project) => Some(app_project.client_transition_name().to_resolved().await?),
+            None => None,
+        };
 
         if let Some(app_project) = app_project {
             transitions.push((

--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -353,7 +353,7 @@ impl AppPageLoaderTreeBuilder {
             .await?;
         self.write_modules_entry(AppDirModuleType::DefaultPage, *default)
             .await?;
-        self.write_modules_entry(AppDirModuleType::GlobalError, global_error.map(|err| *err))
+        self.write_modules_entry(AppDirModuleType::GlobalError, *global_error)
             .await?;
 
         let modules_code = replace(&mut self.loader_tree_code, temp_loader_tree_code);

--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -402,7 +402,7 @@ pub struct AppPageLoaderTreeModule {
     pub imports: Vec<RcStr>,
     pub loader_tree_code: RcStr,
     pub inner_assets: FxIndexMap<RcStr, ResolvedVc<Box<dyn Module>>>,
-    pub pages: Vec<Vc<FileSystemPath>>,
+    pub pages: Vec<ResolvedVc<FileSystemPath>>,
 }
 
 impl AppPageLoaderTreeModule {

--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -27,7 +27,7 @@ use crate::{
 pub struct AppPageLoaderTreeBuilder {
     base: BaseLoaderTreeBuilder,
     loader_tree_code: String,
-    pages: Vec<Vc<FileSystemPath>>,
+    pages: Vec<ResolvedVc<FileSystemPath>>,
     /// next.config.js' basePath option to construct og metadata.
     base_path: Option<RcStr>,
 }

--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -49,7 +49,7 @@ impl AppPageLoaderTreeBuilder {
     async fn write_modules_entry(
         &mut self,
         module_type: AppDirModuleType,
-        path: Option<Vc<FileSystemPath>>,
+        path: Option<ResolvedVc<FileSystemPath>>,
     ) -> Result<()> {
         if let Some(path) = path {
             if matches!(module_type, AppDirModuleType::Page) {

--- a/crates/next-core/src/app_segment_config.rs
+++ b/crates/next-core/src/app_segment_config.rs
@@ -342,12 +342,14 @@ fn parse_config_value(
             let value = eval_context.eval(init);
             let Some(val) = value.as_str() else {
                 invalid_config("`dynamic` needs to be a static string", &value);
+                return;
             };
 
             config.dynamic = match serde_json::from_value(Value::String(val.to_string())) {
                 Ok(dynamic) => Some(dynamic),
                 Err(err) => {
                     invalid_config(&format!("`dynamic` has an invalid value: {}", err), &value);
+                    return;
                 }
             };
         }
@@ -355,6 +357,7 @@ fn parse_config_value(
             let value = eval_context.eval(init);
             let Some(val) = value.as_bool() else {
                 invalid_config("`dynamicParams` needs to be a static boolean", &value);
+                return;
             };
 
             config.dynamic_params = Some(val);
@@ -383,6 +386,7 @@ fn parse_config_value(
             let value = eval_context.eval(init);
             let Some(val) = value.as_str() else {
                 invalid_config("`fetchCache` needs to be a static string", &value);
+                return;
             };
 
             config.fetch_cache = match serde_json::from_value(Value::String(val.to_string())) {
@@ -392,6 +396,7 @@ fn parse_config_value(
                         &format!("`fetchCache` has an invalid value: {}", err),
                         &value,
                     );
+                    return;
                 }
             };
         }
@@ -399,12 +404,14 @@ fn parse_config_value(
             let value = eval_context.eval(init);
             let Some(val) = value.as_str() else {
                 invalid_config("`runtime` needs to be a static string", &value);
+                return;
             };
 
             config.runtime = match serde_json::from_value(Value::String(val.to_string())) {
                 Ok(runtime) => Some(runtime),
                 Err(err) => {
                     invalid_config(&format!("`runtime` has an invalid value: {}", err), &value);
+                    return;
                 }
             };
         }
@@ -435,6 +442,7 @@ fn parse_config_value(
                         "`preferredRegion` needs to be a static string or array of static strings",
                         &value,
                     );
+                    return;
                 }
             };
 
@@ -452,6 +460,7 @@ fn parse_config_value(
             let value = eval_context.eval(init);
             let Some(val) = value.as_bool() else {
                 invalid_config("`experimental_ppr` needs to be a static boolean", &value);
+                return;
             };
 
             config.experimental_ppr = Some(val);

--- a/crates/next-core/src/app_segment_config.rs
+++ b/crates/next-core/src/app_segment_config.rs
@@ -501,7 +501,7 @@ pub async fn parse_segment_config_from_loader_tree_internal(
         .into_iter()
         .flatten()
     {
-        let source = Vc::upcast(FileSource::new(path));
+        let source = Vc::upcast(FileSource::new(*path));
         config.apply_parent_config(&*parse_segment_config_from_source(source).await?);
     }
 

--- a/crates/next-core/src/app_segment_config.rs
+++ b/crates/next-core/src/app_segment_config.rs
@@ -315,7 +315,7 @@ fn issue_source(source: Vc<Box<dyn Source>>, span: Span) -> Vc<IssueSource> {
     IssueSource::from_swc_offsets(source, span.lo.to_usize(), span.hi.to_usize())
 }
 
-async fn parse_config_value(
+fn parse_config_value(
     source: Vc<Box<dyn Source>>,
     config: &mut NextSegmentConfig,
     ident: &Ident,

--- a/crates/next-core/src/app_segment_config.rs
+++ b/crates/next-core/src/app_segment_config.rs
@@ -166,9 +166,9 @@ impl NextSegmentConfig {
 /// An issue that occurred while parsing the app segment config.
 #[turbo_tasks::value(shared)]
 pub struct NextSegmentConfigParsingIssue {
-    ident: Vc<AssetIdent>,
-    detail: Vc<StyledString>,
-    source: Vc<IssueSource>,
+    ident: ResolvedVc<AssetIdent>,
+    detail: ResolvedVc<StyledString>,
+    source: ResolvedVc<IssueSource>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-core/src/app_segment_config.rs
+++ b/crates/next-core/src/app_segment_config.rs
@@ -8,7 +8,7 @@ use swc_core::{
     ecma::ast::{Decl, Expr, FnExpr, Ident, Program},
 };
 use turbo_rcstr::RcStr;
-use turbo_tasks::{trace::TraceRawVcs, TryJoinIterExt, ValueDefault, Vc};
+use turbo_tasks::{trace::TraceRawVcs, ResolvedVc, TryJoinIterExt, ValueDefault, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     file_source::FileSource,
@@ -207,7 +207,7 @@ impl Issue for NextSegmentConfigParsingIssue {
 
     #[turbo_tasks::function]
     fn detail(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(self.detail))
+        Vc::cell(Some(*self.detail))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/app_segment_config.rs
+++ b/crates/next-core/src/app_segment_config.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use anyhow::{bail, Ok, Result};
+use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use swc_core::{
@@ -334,7 +334,7 @@ async fn parse_config_value(
         .cell()
         .emit();
 
-        Ok(())
+        anyhow::Ok(())
     };
 
     match &*ident.sym {

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1418,9 +1418,9 @@ pub async fn get_global_metadata(
 
 #[turbo_tasks::value(shared)]
 struct DirectoryTreeIssue {
-    pub severity: Vc<IssueSeverity>,
-    pub app_dir: Vc<FileSystemPath>,
-    pub message: Vc<StyledString>,
+    pub severity: ResolvedVc<IssueSeverity>,
+    pub app_dir: ResolvedVc<FileSystemPath>,
+    pub message: ResolvedVc<StyledString>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1419,7 +1419,7 @@ pub async fn get_global_metadata(
 #[turbo_tasks::value(shared)]
 struct DirectoryTreeIssue {
     pub severity: ResolvedVc<IssueSeverity>,
-    pub app_dir: ResolvedVc<FileSystemPath>,
+    pub app_dir: Vc<FileSystemPath>,
     pub message: ResolvedVc<StyledString>,
 }
 
@@ -1442,7 +1442,7 @@ impl Issue for DirectoryTreeIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.app_dir
+        self.app_dir
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -538,14 +538,14 @@ fn match_parallel_route(name: &str) -> Option<&str> {
     name.strip_prefix('@')
 }
 
-async fn conflict_issue(
-    app_dir: Vc<FileSystemPath>,
+fn conflict_issue(
+    app_dir: ResolvedVc<FileSystemPath>,
     e: &OccupiedEntry<AppPath, Entrypoint>,
     a: &str,
     b: &str,
     value_a: &AppPage,
     value_b: &AppPage,
-) -> Result<()> {
+) {
     let item_names = if a == b {
         format!("{}s", a)
     } else {
@@ -553,7 +553,7 @@ async fn conflict_issue(
     };
 
     DirectoryTreeIssue {
-        app_dir: app_dir.to_resolved().await?,
+        app_dir,
         message: StyledString::Text(
             format!(
                 "Conflicting {} at {}: {a} at {value_a} and {b} at {value_b}",
@@ -567,8 +567,6 @@ async fn conflict_issue(
     }
     .cell()
     .emit();
-
-    Ok(())
 }
 
 fn add_app_page(
@@ -589,7 +587,14 @@ fn add_app_page(
     };
 
     let conflict = |existing_name: &str, existing_page: &AppPage| {
-        conflict_issue(app_dir, &e, "page", existing_name, &page, existing_page);
+        conflict_issue(
+            app_dir.to_resolved().await?,
+            &e,
+            "page",
+            existing_name,
+            &page,
+            existing_page,
+        );
     };
 
     let value = e.get();

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -306,17 +306,17 @@ async fn get_directory_tree_internal(
                 if let Some((stem, ext)) = basename.split_once('.') {
                     if page_extensions_value.iter().any(|e| e == ext) {
                         match stem {
-                            "page" => modules.page = Some(*file),
-                            "layout" => modules.layout = Some(*file),
-                            "error" => modules.error = Some(*file),
-                            "global-error" => modules.global_error = Some(file),
-                            "loading" => modules.loading = Some(*file),
-                            "template" => modules.template = Some(*file),
-                            "forbidden" => modules.forbidden = Some(*file),
-                            "unauthorized" => modules.unauthorized = Some(*file),
-                            "not-found" => modules.not_found = Some(*file),
-                            "default" => modules.default = Some(*file),
-                            "route" => modules.route = Some(file),
+                            "page" => modules.page = Some(**file),
+                            "layout" => modules.layout = Some(**file),
+                            "error" => modules.error = Some(**file),
+                            "global-error" => modules.global_error = Some(**file),
+                            "loading" => modules.loading = Some(**file),
+                            "template" => modules.template = Some(**file),
+                            "forbidden" => modules.forbidden = Some(**file),
+                            "unauthorized" => modules.unauthorized = Some(**file),
+                            "not-found" => modules.not_found = Some(**file),
+                            "default" => modules.default = Some(**file),
+                            "route" => modules.route = Some(**file),
                             _ => {}
                         }
                     }

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -587,14 +587,7 @@ fn add_app_page(
     };
 
     let conflict = |existing_name: &str, existing_page: &AppPage| {
-        conflict_issue(
-            app_dir.to_resolved().await?,
-            &e,
-            "page",
-            existing_name,
-            &page,
-            existing_page,
-        );
+        conflict_issue(app_dir, &e, "page", existing_name, &page, existing_page);
     };
 
     let value = e.get();
@@ -1434,7 +1427,7 @@ struct DirectoryTreeIssue {
 impl Issue for DirectoryTreeIssue {
     #[turbo_tasks::function]
     fn severity(&self) -> Vc<IssueSeverity> {
-        self.severity
+        *self.severity
     }
 
     #[turbo_tasks::function]
@@ -1449,11 +1442,11 @@ impl Issue for DirectoryTreeIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        self.app_dir
+        *self.app_dir
     }
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(self.message))
+        Vc::cell(Some(*self.message))
     }
 }

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -948,14 +948,14 @@ async fn directory_tree_to_loader_tree_internal(
             illegal_path_error = Some(e);
         }
 
-        let subtree = directory_tree_to_loader_tree_internal(
+        let subtree = Box::pin(directory_tree_to_loader_tree_internal(
             app_dir,
             global_metadata,
             subdir_name.clone(),
             subdirectory,
             child_app_page.clone(),
             for_app_path.clone(),
-        )
+        ))
         .await?;
 
         if let Some(illegal_path) = subtree.as_ref().and(illegal_path_error) {

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -539,7 +539,7 @@ fn match_parallel_route(name: &str) -> Option<&str> {
 }
 
 fn conflict_issue(
-    app_dir: ResolvedVc<FileSystemPath>,
+    app_dir: Vc<FileSystemPath>,
     e: &OccupiedEntry<AppPath, Entrypoint>,
     a: &str,
     b: &str,

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -538,14 +538,14 @@ fn match_parallel_route(name: &str) -> Option<&str> {
     name.strip_prefix('@')
 }
 
-fn conflict_issue(
+async fn conflict_issue(
     app_dir: Vc<FileSystemPath>,
     e: &OccupiedEntry<AppPath, Entrypoint>,
     a: &str,
     b: &str,
     value_a: &AppPage,
     value_b: &AppPage,
-) {
+) -> Result<()> {
     let item_names = if a == b {
         format!("{}s", a)
     } else {
@@ -553,7 +553,7 @@ fn conflict_issue(
     };
 
     DirectoryTreeIssue {
-        app_dir,
+        app_dir: app_dir.to_resolved().await?,
         message: StyledString::Text(
             format!(
                 "Conflicting {} at {}: {a} at {value_a} and {b} at {value_b}",
@@ -562,11 +562,13 @@ fn conflict_issue(
             )
             .into(),
         )
-        .cell(),
-        severity: IssueSeverity::Error.cell(),
+        .resolved_cell(),
+        severity: IssueSeverity::Error.resolved_cell(),
     }
     .cell()
     .emit();
+
+    Ok(())
 }
 
 fn add_app_page(

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -31,25 +31,25 @@ use crate::{
 #[derive(Default, Debug, Clone)]
 pub struct AppDirModules {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub page: Option<Vc<FileSystemPath>>,
+    pub page: Option<ResolvedVc<FileSystemPath>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub layout: Option<Vc<FileSystemPath>>,
+    pub layout: Option<ResolvedVc<FileSystemPath>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<Vc<FileSystemPath>>,
+    pub error: Option<ResolvedVc<FileSystemPath>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub global_error: Option<ResolvedVc<FileSystemPath>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub loading: Option<Vc<FileSystemPath>>,
+    pub loading: Option<ResolvedVc<FileSystemPath>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub template: Option<Vc<FileSystemPath>>,
+    pub template: Option<ResolvedVc<FileSystemPath>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub forbidden: Option<Vc<FileSystemPath>>,
+    pub forbidden: Option<ResolvedVc<FileSystemPath>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unauthorized: Option<Vc<FileSystemPath>>,
+    pub unauthorized: Option<ResolvedVc<FileSystemPath>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub not_found: Option<Vc<FileSystemPath>>,
+    pub not_found: Option<ResolvedVc<FileSystemPath>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default: Option<Vc<FileSystemPath>>,
+    pub default: Option<ResolvedVc<FileSystemPath>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub route: Option<ResolvedVc<FileSystemPath>>,
     #[serde(skip_serializing_if = "Metadata::is_empty", default)]
@@ -407,7 +407,7 @@ pub struct AppPageLoaderTree {
     pub segment: RcStr,
     pub parallel_routes: FxIndexMap<RcStr, AppPageLoaderTree>,
     pub modules: AppDirModules,
-    pub global_metadata: Vc<GlobalMetadata>,
+    pub global_metadata: ResolvedVc<GlobalMetadata>,
 }
 
 impl AppPageLoaderTree {
@@ -741,7 +741,7 @@ fn directory_tree_to_entrypoints(
 
 #[turbo_tasks::value]
 struct DuplicateParallelRouteIssue {
-    app_dir: Vc<FileSystemPath>,
+    app_dir: ResolvedVc<FileSystemPath>,
     page: AppPage,
 }
 

--- a/crates/next-core/src/base_loader_tree.rs
+++ b/crates/next-core/src/base_loader_tree.rs
@@ -89,7 +89,7 @@ impl BaseLoaderTreeBuilder {
     pub async fn create_module_tuple_code(
         &mut self,
         module_type: AppDirModuleType,
-        path: Vc<FileSystemPath>,
+        path: ResolvedVc<FileSystemPath>,
     ) -> Result<String> {
         let name = module_type.name();
         let i = self.unique_number();

--- a/crates/next-core/src/base_loader_tree.rs
+++ b/crates/next-core/src/base_loader_tree.rs
@@ -107,7 +107,7 @@ impl BaseLoaderTreeBuilder {
         );
 
         let module = self
-            .process_source(Vc::upcast(FileSource::new(path)))
+            .process_source(Vc::upcast(FileSource::new(*path)))
             .to_resolved()
             .await?;
 

--- a/crates/next-core/src/hmr_entry.rs
+++ b/crates/next-core/src/hmr_entry.rs
@@ -61,8 +61,8 @@ impl Module for HmrEntryModule {
 impl ChunkableModule for HmrEntryModule {
     #[turbo_tasks::function]
     fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
+        self: ResolvedVc<Self>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn ChunkItem>> {
         Vc::upcast(
             HmrEntryChunkItem {
@@ -133,8 +133,8 @@ impl ChunkableModuleReference for HmrEntryModuleReference {}
 /// The chunk item for [`HmrEntryModule`].
 #[turbo_tasks::value]
 struct HmrEntryChunkItem {
-    module: Vc<HmrEntryModule>,
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
+    module: ResolvedVc<HmrEntryModule>,
+    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -161,7 +161,7 @@ impl ChunkItem for HmrEntryChunkItem {
 
     #[turbo_tasks::function]
     fn module(&self) -> Vc<Box<dyn Module>> {
-        Vc::upcast(self.module)
+        Vc::upcast(*self.module)
     }
 }
 

--- a/crates/next-core/src/hmr_entry.rs
+++ b/crates/next-core/src/hmr_entry.rs
@@ -30,8 +30,8 @@ fn modifier() -> Vc<RcStr> {
 
 #[turbo_tasks::value(shared)]
 pub struct HmrEntryModule {
-    pub ident: Vc<AssetIdent>,
-    pub module: Vc<Box<dyn ChunkableModule>>,
+    pub ident: ResolvedVc<AssetIdent>,
+    pub module: ResolvedVc<Box<dyn ChunkableModule>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-core/src/hmr_entry.rs
+++ b/crates/next-core/src/hmr_entry.rs
@@ -141,7 +141,7 @@ struct HmrEntryChunkItem {
 impl ChunkItem for HmrEntryChunkItem {
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        Vc::upcast(self.chunking_context)
+        Vc::upcast(*self.chunking_context)
     }
 
     #[turbo_tasks::function]
@@ -169,14 +169,14 @@ impl ChunkItem for HmrEntryChunkItem {
 impl EcmascriptChunkItem for HmrEntryChunkItem {
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        self.chunking_context
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<EcmascriptChunkItemContent>> {
         let this = self.module.await?;
         let module = this.module;
-        let chunk_item = module.as_chunk_item(self.chunking_context);
+        let chunk_item = module.as_chunk_item(*self.chunking_context);
         let id = self.chunking_context.chunk_item_id(chunk_item).await?;
 
         let mut code = RopeBuilder::default();

--- a/crates/next-core/src/hmr_entry.rs
+++ b/crates/next-core/src/hmr_entry.rs
@@ -37,7 +37,10 @@ pub struct HmrEntryModule {
 #[turbo_tasks::value_impl]
 impl HmrEntryModule {
     #[turbo_tasks::function]
-    pub fn new(ident: Vc<AssetIdent>, module: Vc<Box<dyn ChunkableModule>>) -> Vc<Self> {
+    pub fn new(
+        ident: ResolvedVc<AssetIdent>,
+        module: ResolvedVc<Box<dyn ChunkableModule>>,
+    ) -> Vc<Self> {
         Self { ident, module }.cell()
     }
 }
@@ -52,7 +55,7 @@ impl Module for HmrEntryModule {
     #[turbo_tasks::function]
     fn references(&self) -> Vc<ModuleReferences> {
         Vc::cell(vec![Vc::upcast(HmrEntryModuleReference::new(Vc::upcast(
-            self.module,
+            *self.module,
         )))])
     }
 }

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -150,6 +150,7 @@ pub async fn get_app_client_references_chunks(
             }
             for client_reference in app_client_references.client_references.iter() {
                 if let Some(server_component) = client_reference.server_component() {
+                    let server_component = server_component.to_resolved().await?;
                     client_references_by_server_component
                         .entry(server_component)
                         .or_default()

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -34,7 +34,8 @@ pub struct ClientReferencesChunks {
         FxIndexMap<ClientReferenceType, (ResolvedVc<OutputAssets>, AvailabilityInfo)>,
     pub client_component_ssr_chunks:
         FxIndexMap<ClientReferenceType, (ResolvedVc<OutputAssets>, AvailabilityInfo)>,
-    pub layout_segment_client_chunks: FxIndexMap<Vc<NextServerComponentModule>, Vc<OutputAssets>>,
+    pub layout_segment_client_chunks:
+        FxIndexMap<ResolvedVc<NextServerComponentModule>, ResolvedVc<OutputAssets>>,
 }
 
 /// Computes all client references chunks.

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -235,7 +235,7 @@ pub async fn get_app_client_references_chunks(
                             } => {
                                 let ecmascript_client_reference_ref =
                                     ecmascript_client_reference.await?;
-                                *ResolvedVc::upcast(ecmascript_client_reference_ref.client_module)
+                                ResolvedVc::upcast(ecmascript_client_reference_ref.client_module)
                             }
                             ClientReferenceType::CssClientReference(css_module) => {
                                 ResolvedVc::upcast(*css_module)

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -121,12 +121,20 @@ pub async fn get_app_client_references_chunks(
                     .map(|&(client_reference_ty, (client_chunks, _))| {
                         (client_reference_ty, client_chunks)
                     })
+                    .map(|v| async move { Ok((v.0, (v.1 .0.to_resolved().await?, v.1 .1))) })
+                    .try_join()
+                    .await?
+                    .into_iter()
                     .collect(),
                 client_component_ssr_chunks: app_client_references_chunks
                     .iter()
                     .flat_map(|&(client_reference_ty, (_, ssr_chunks))| {
                         ssr_chunks.map(|ssr_chunks| (client_reference_ty, ssr_chunks))
                     })
+                    .map(|v| async move { Ok((v.0, (v.1 .0.to_resolved().await?, v.1 .1))) })
+                    .try_join()
+                    .await?
+                    .into_iter()
                     .collect(),
                 layout_segment_client_chunks: FxIndexMap::default(),
             }

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -155,9 +155,9 @@ pub async fn get_app_client_references_chunks(
             }
 
             let mut current_client_availability_info = client_availability_info.into_value();
-            let mut current_client_chunks = OutputAssets::empty();
+            let mut current_client_chunks = OutputAssets::empty().to_resolved().await?;
             let mut current_ssr_availability_info = AvailabilityInfo::Root;
-            let mut current_ssr_chunks = OutputAssets::empty();
+            let mut current_ssr_chunks = OutputAssets::empty().to_resolved().await?;
 
             let mut layout_segment_client_chunks = FxIndexMap::default();
             let mut client_component_ssr_chunks = FxIndexMap::default();
@@ -259,7 +259,7 @@ pub async fn get_app_client_references_chunks(
 
                     let client_chunks =
                         current_client_chunks.concatenate(client_chunk_group.assets);
-                    let client_chunks = client_chunks.resolve().await?;
+                    let client_chunks = client_chunks.to_resolved().await?;
 
                     if is_layout {
                         current_client_availability_info = client_chunk_group.availability_info;
@@ -284,7 +284,7 @@ pub async fn get_app_client_references_chunks(
                     let ssr_chunk_group = ssr_chunk_group.await?;
 
                     let ssr_chunks = current_ssr_chunks.concatenate(ssr_chunk_group.assets);
-                    let ssr_chunks = ssr_chunks.resolve().await?;
+                    let ssr_chunks = ssr_chunks.to_resolved().await?;
 
                     if is_layout {
                         current_ssr_availability_info = ssr_chunk_group.availability_info;

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -235,10 +235,10 @@ pub async fn get_app_client_references_chunks(
                             } => {
                                 let ecmascript_client_reference_ref =
                                     ecmascript_client_reference.await?;
-                                ResolvedVc::upcast(ecmascript_client_reference_ref.client_module)
+                                *ResolvedVc::upcast(ecmascript_client_reference_ref.client_module)
                             }
                             ClientReferenceType::CssClientReference(css_module) => {
-                                ResolvedVc::upcast(*css_module)
+                                *ResolvedVc::upcast(*css_module)
                             }
                         })
                     })

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -31,9 +31,9 @@ pub fn client_modules_ssr_modifier() -> Vc<RcStr> {
 #[turbo_tasks::value]
 pub struct ClientReferencesChunks {
     pub client_component_client_chunks:
-        FxIndexMap<ClientReferenceType, (Vc<OutputAssets>, AvailabilityInfo)>,
+        FxIndexMap<ClientReferenceType, (ResolvedVc<OutputAssets>, AvailabilityInfo)>,
     pub client_component_ssr_chunks:
-        FxIndexMap<ClientReferenceType, (Vc<OutputAssets>, AvailabilityInfo)>,
+        FxIndexMap<ClientReferenceType, (ResolvedVc<OutputAssets>, AvailabilityInfo)>,
     pub layout_segment_client_chunks: FxIndexMap<Vc<NextServerComponentModule>, Vc<OutputAssets>>,
 }
 

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -77,7 +77,7 @@ pub async fn get_app_client_references_chunks(
 
                                 (
                                     (
-                                        client_chunk_group.assets,
+                                        client_chunk_group.assets.to_resolved().await?,
                                         client_chunk_group.availability_info,
                                     ),
                                     if let Some(ssr_chunking_context) = ssr_chunking_context {
@@ -88,7 +88,7 @@ pub async fn get_app_client_references_chunks(
                                             .await?;
 
                                         Some((
-                                            ssr_chunk_group.assets,
+                                            ssr_chunk_group.assets.to_resolved().await?,
                                             ssr_chunk_group.availability_info,
                                         ))
                                     } else {
@@ -103,7 +103,7 @@ pub async fn get_app_client_references_chunks(
 
                                 (
                                     (
-                                        client_chunk_group.assets,
+                                        client_chunk_group.assets.to_resolved().await?,
                                         client_chunk_group.availability_info,
                                     ),
                                     None,
@@ -121,20 +121,12 @@ pub async fn get_app_client_references_chunks(
                     .map(|&(client_reference_ty, (client_chunks, _))| {
                         (client_reference_ty, client_chunks)
                     })
-                    .map(|v| async move { Ok((v.0, (v.1 .0.to_resolved().await?, v.1 .1))) })
-                    .try_join()
-                    .await?
-                    .into_iter()
                     .collect(),
                 client_component_ssr_chunks: app_client_references_chunks
                     .iter()
                     .flat_map(|&(client_reference_ty, (_, ssr_chunks))| {
                         ssr_chunks.map(|ssr_chunks| (client_reference_ty, ssr_chunks))
                     })
-                    .map(|v| async move { Ok((v.0, (v.1 .0.to_resolved().await?, v.1 .1))) })
-                    .try_join()
-                    .await?
-                    .into_iter()
                     .collect(),
                 layout_segment_client_chunks: FxIndexMap::default(),
             }

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -267,7 +267,8 @@ pub async fn get_app_client_references_chunks(
                         current_client_chunks = client_chunks;
                     }
 
-                    layout_segment_client_chunks.insert(server_component, client_chunks);
+                    layout_segment_client_chunks
+                        .insert(server_component.to_resolved().await?, client_chunks);
 
                     for &client_reference_ty in client_reference_types.iter() {
                         if let ClientReferenceType::EcmascriptClientReference { .. } =

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -238,7 +238,7 @@ pub async fn get_app_client_references_chunks(
                                 *ResolvedVc::upcast(ecmascript_client_reference_ref.client_module)
                             }
                             ClientReferenceType::CssClientReference(css_module) => {
-                                Vc::upcast(*css_module)
+                                ResolvedVc::upcast(*css_module)
                             }
                         })
                     })

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -98,7 +98,7 @@ pub async fn get_app_client_references_chunks(
                             }
                             ClientReferenceType::CssClientReference(css_module) => {
                                 let client_chunk_group = client_chunking_context
-                                    .root_chunk_group(Vc::upcast(css_module))
+                                    .root_chunk_group(*ResolvedVc::upcast(css_module))
                                     .await?;
 
                                 (

--- a/crates/next-core/src/next_app/app_entry.rs
+++ b/crates/next-core/src/next_app/app_entry.rs
@@ -1,5 +1,5 @@
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::ResolvedVc;
 use turbopack_core::module::Module;
 
 use crate::app_segment_config::NextSegmentConfig;

--- a/crates/next-core/src/next_app/app_entry.rs
+++ b/crates/next-core/src/next_app/app_entry.rs
@@ -15,5 +15,5 @@ pub struct AppEntry {
     /// The RSC module asset for the route or page.
     pub rsc_entry: ResolvedVc<Box<dyn Module>>,
     /// The source code config for this entry.
-    pub config: Vc<NextSegmentConfig>,
+    pub config: ResolvedVc<NextSegmentConfig>,
 }

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -132,7 +132,7 @@ pub async fn get_app_page_entry(
         pathname,
         original_name,
         rsc_entry: rsc_entry.to_resolved().await?,
-        config,
+        config: config.to_resolved().await?,
     }
     .cell())
 }

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -124,7 +124,7 @@ pub async fn get_app_route_entry(
         pathname,
         original_name,
         rsc_entry: rsc_entry.to_resolved().await?,
-        config,
+        config: config.to_resolved().await?,
     }
     .cell())
 }

--- a/crates/next-core/src/next_app/include_modules_module.rs
+++ b/crates/next-core/src/next_app/include_modules_module.rs
@@ -19,7 +19,7 @@ use turbopack_ecmascript::chunk::{
 /// runtime. It can be used to include modules into a chunk.
 #[turbo_tasks::value]
 pub struct IncludeModulesModule {
-    ident: Vc<AssetIdent>,
+    ident: ResolvedVc<AssetIdent>,
     modules: Vec<ResolvedVc<Box<dyn Module>>>,
 }
 
@@ -93,8 +93,8 @@ impl ChunkableModule for IncludeModulesModule {
 /// The chunk item for [`IncludeModulesModule`].
 #[turbo_tasks::value]
 struct IncludeModulesChunkItem {
-    module: Vc<IncludeModulesModule>,
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
+    module: ResolvedVc<IncludeModulesModule>,
+    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-core/src/next_app/include_modules_module.rs
+++ b/crates/next-core/src/next_app/include_modules_module.rs
@@ -26,7 +26,10 @@ pub struct IncludeModulesModule {
 #[turbo_tasks::value_impl]
 impl IncludeModulesModule {
     #[turbo_tasks::function]
-    pub fn new(ident: Vc<AssetIdent>, modules: Vec<ResolvedVc<Box<dyn Module>>>) -> Vc<Self> {
+    pub fn new(
+        ident: ResolvedVc<AssetIdent>,
+        modules: Vec<ResolvedVc<Box<dyn Module>>>,
+    ) -> Vc<Self> {
         Self { ident, modules }.cell()
     }
 }
@@ -41,7 +44,7 @@ impl Asset for IncludeModulesModule {
 impl Module for IncludeModulesModule {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        self.ident
+        *self.ident
     }
 
     #[turbo_tasks::function]
@@ -101,7 +104,7 @@ struct IncludeModulesChunkItem {
 impl ChunkItem for IncludeModulesChunkItem {
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        Vc::upcast(self.chunking_context)
+        Vc::upcast(*self.chunking_context)
     }
     #[turbo_tasks::function]
     fn asset_ident(&self) -> Vc<AssetIdent> {

--- a/crates/next-core/src/next_app/include_modules_module.rs
+++ b/crates/next-core/src/next_app/include_modules_module.rs
@@ -80,8 +80,8 @@ impl EcmascriptChunkPlaceable for IncludeModulesModule {
 impl ChunkableModule for IncludeModulesModule {
     #[turbo_tasks::function]
     fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
+        self: ResolvedVc<Self>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn ChunkItem>> {
         Vc::upcast(
             IncludeModulesChunkItem {

--- a/crates/next-core/src/next_app/include_modules_module.rs
+++ b/crates/next-core/src/next_app/include_modules_module.rs
@@ -120,7 +120,7 @@ impl ChunkItem for IncludeModulesChunkItem {
 
     #[turbo_tasks::function]
     fn module(&self) -> Vc<Box<dyn Module>> {
-        Vc::upcast(self.module)
+        Vc::upcast(*self.module)
     }
 }
 
@@ -128,7 +128,7 @@ impl ChunkItem for IncludeModulesChunkItem {
 impl EcmascriptChunkItem for IncludeModulesChunkItem {
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        self.chunking_context
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -460,8 +460,11 @@ pub async fn get_client_runtime_entries(
         // functions to be available.
         if let Some(request) = enable_react_refresh {
             runtime_entries.push(
-                RuntimeEntry::Request(request.to_resolved().await?, project_root.join("_".into()))
-                    .cell(),
+                RuntimeEntry::Request(
+                    request.to_resolved().await?,
+                    project_root.join("_".into()).to_resolved().await?,
+                )
+                .resolved_cell(),
             )
         };
     }
@@ -474,9 +477,9 @@ pub async fn get_client_runtime_entries(
                 )))
                 .to_resolved()
                 .await?,
-                project_root.join("_".into()),
+                project_root.join("_".into()).to_resolved().await?,
             )
-            .cell(),
+            .resolved_cell(),
         );
     }
 

--- a/crates/next-core/src/next_client/runtime_entry.rs
+++ b/crates/next-core/src/next_client/runtime_entry.rs
@@ -12,7 +12,7 @@ use turbopack_ecmascript::resolve::cjs_resolve;
 
 #[turbo_tasks::value(shared)]
 pub enum RuntimeEntry {
-    Request(ResolvedVc<Request>, Vc<FileSystemPath>),
+    Request(ResolvedVc<Request>, ResolvedVc<FileSystemPath>),
     Evaluatable(ResolvedVc<Box<dyn EvaluatableAsset>>),
     Source(ResolvedVc<Box<dyn Source>>),
 }
@@ -62,7 +62,7 @@ impl RuntimeEntry {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct RuntimeEntries(Vec<Vc<RuntimeEntry>>);
+pub struct RuntimeEntries(Vec<ResolvedVc<RuntimeEntry>>);
 
 #[turbo_tasks::value_impl]
 impl RuntimeEntries {

--- a/crates/next-core/src/next_client/runtime_entry.rs
+++ b/crates/next-core/src/next_client/runtime_entry.rs
@@ -33,7 +33,7 @@ impl RuntimeEntry {
         };
 
         let modules = cjs_resolve(
-            Vc::upcast(PlainResolveOrigin::new(asset_context, path)),
+            Vc::upcast(PlainResolveOrigin::new(asset_context, *path)),
             *request,
             None,
             false,

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -32,7 +32,7 @@ impl EcmascriptClientReferenceModule {
     /// * `ssr_module` - The SSR module.
     #[turbo_tasks::function]
     pub fn new(
-        server_ident: Vc<AssetIdent>,
+        server_ident: ResolvedVc<AssetIdent>,
         client_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
         ssr_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
     ) -> Vc<EcmascriptClientReferenceModule> {

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -15,7 +15,7 @@ use turbopack_ecmascript::chunk::EcmascriptChunkPlaceable;
 /// indicate which client reference should appear in the client reference manifest.
 #[turbo_tasks::value]
 pub struct EcmascriptClientReferenceModule {
-    pub server_ident: Vc<AssetIdent>,
+    pub server_ident: ResolvedVc<AssetIdent>,
     pub client_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
     pub ssr_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
 }

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
@@ -48,10 +48,10 @@ impl EcmascriptClientReferenceProxyModule {
     /// * `ssr_module` - The SSR module.
     #[turbo_tasks::function]
     pub fn new(
-        server_module_ident: Vc<AssetIdent>,
-        server_asset_context: Vc<Box<dyn AssetContext>>,
-        client_module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
-        ssr_module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
+        server_module_ident: ResolvedVc<AssetIdent>,
+        server_asset_context: ResolvedVc<Box<dyn AssetContext>>,
+        client_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
+        ssr_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
     ) -> Vc<EcmascriptClientReferenceProxyModule> {
         EcmascriptClientReferenceProxyModule {
             server_module_ident,

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
@@ -212,8 +212,8 @@ impl Asset for EcmascriptClientReferenceProxyModule {
 impl ChunkableModule for EcmascriptClientReferenceProxyModule {
     #[turbo_tasks::function]
     async fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
+        self: ResolvedVc<Self>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn ChunkItem>>> {
         let item = self.proxy_module().as_chunk_item(chunking_context);
         let ecmascript_item = Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkItem>>(item)
@@ -306,6 +306,6 @@ impl EcmascriptChunkItem for ProxyModuleChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        EcmascriptChunkItem::chunking_context(self.inner_proxy_module_chunk_item)
+        EcmascriptChunkItem::chunking_context(*self.inner_proxy_module_chunk_item)
     }
 }

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
@@ -3,7 +3,7 @@ use std::{io::Write, iter::once};
 use anyhow::{bail, Context, Result};
 use indoc::writedoc;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Value, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
 use turbo_tasks_fs::File;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -188,9 +188,9 @@ impl Module for EcmascriptClientReferenceProxyModule {
             .copied()
             .chain(once(Vc::upcast(SingleModuleReference::new(
                 Vc::upcast(EcmascriptClientReferenceModule::new(
-                    *server_module_ident,
-                    *client_module,
-                    *ssr_module,
+                    **server_module_ident,
+                    **client_module,
+                    **ssr_module,
                 )),
                 client_reference_description(),
             ))))

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
@@ -30,10 +30,10 @@ use super::ecmascript_client_reference_module::EcmascriptClientReferenceModule;
 /// a client or SSR asset.
 #[turbo_tasks::value]
 pub struct EcmascriptClientReferenceProxyModule {
-    server_module_ident: Vc<AssetIdent>,
-    server_asset_context: Vc<Box<dyn AssetContext>>,
-    client_module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
-    ssr_module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
+    server_module_ident: ResolvedVc<AssetIdent>,
+    server_asset_context: ResolvedVc<Box<dyn AssetContext>>,
+    client_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
+    ssr_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -245,9 +245,9 @@ impl EcmascriptChunkPlaceable for EcmascriptClientReferenceProxyModule {
 /// [`Vc<EcmascriptClientReferenceProxyModule>`].
 #[turbo_tasks::value]
 struct ProxyModuleChunkItem {
-    client_proxy_asset: Vc<EcmascriptClientReferenceProxyModule>,
-    inner_proxy_module_chunk_item: Vc<Box<dyn EcmascriptChunkItem>>,
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
+    client_proxy_asset: ResolvedVc<EcmascriptClientReferenceProxyModule>,
+    inner_proxy_module_chunk_item: ResolvedVc<Box<dyn EcmascriptChunkItem>>,
+    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
 }
 
 #[turbo_tasks::function]

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
@@ -274,7 +274,7 @@ impl ChunkItem for ProxyModuleChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        Vc::upcast(self.chunking_context)
+        Vc::upcast(*self.chunking_context)
     }
 
     #[turbo_tasks::function]
@@ -284,7 +284,7 @@ impl ChunkItem for ProxyModuleChunkItem {
 
     #[turbo_tasks::function]
     fn module(&self) -> Vc<Box<dyn Module>> {
-        Vc::upcast(self.client_proxy_asset)
+        Vc::upcast(*self.client_proxy_asset)
     }
 }
 

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
@@ -215,10 +215,12 @@ impl ChunkableModule for EcmascriptClientReferenceProxyModule {
         self: ResolvedVc<Self>,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn ChunkItem>>> {
-        let item = self.proxy_module().as_chunk_item(chunking_context);
+        let item = self.proxy_module().as_chunk_item(*chunking_context);
         let ecmascript_item = Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkItem>>(item)
             .await?
-            .context("EcmascriptModuleAsset must implement EcmascriptChunkItem")?;
+            .context("EcmascriptModuleAsset must implement EcmascriptChunkItem")?
+            .to_resolved()
+            .await?;
 
         Ok(Vc::upcast(
             ProxyModuleChunkItem {

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
@@ -17,8 +17,8 @@ use super::ecmascript_client_reference_proxy_module::EcmascriptClientReferencePr
 
 #[turbo_tasks::value(shared)]
 pub struct NextEcmascriptClientReferenceTransition {
-    client_transition: Vc<Box<dyn Transition>>,
-    ssr_transition: Vc<ContextTransition>,
+    client_transition: ResolvedVc<Box<dyn Transition>>,
+    ssr_transition: ResolvedVc<ContextTransition>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
@@ -25,8 +25,8 @@ pub struct NextEcmascriptClientReferenceTransition {
 impl NextEcmascriptClientReferenceTransition {
     #[turbo_tasks::function]
     pub fn new(
-        client_transition: Vc<Box<dyn Transition>>,
-        ssr_transition: Vc<ContextTransition>,
+        client_transition: ResolvedVc<Box<dyn Transition>>,
+        ssr_transition: ResolvedVc<ContextTransition>,
     ) -> Vc<Self> {
         NextEcmascriptClientReferenceTransition {
             client_transition,

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -247,10 +247,10 @@ pub async fn find_server_entries(entry: ResolvedVc<Box<dyn Module>>) -> Result<V
     for node in graph.reverse_topological() {
         match &node.ty {
             VisitClientReferenceNodeType::ServerUtilEntry(server_util, _) => {
-                server_utils.push(**server_util);
+                server_utils.push(*server_util);
             }
             VisitClientReferenceNodeType::ServerComponentEntry(server_component, _) => {
-                server_component_entries.push(**server_component);
+                server_component_entries.push(*server_component);
             }
             VisitClientReferenceNodeType::Internal(_, _)
             | VisitClientReferenceNodeType::ClientReference(_, _) => {}

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -362,7 +362,11 @@ impl Visit<VisitClientReferenceNode> for VisitClientReference {
                         state: node.state,
                         ty: VisitClientReferenceNodeType::ClientReference(
                             ClientReference {
-                                server_component: node.state.server_component(),
+                                server_component: node
+                                    .state
+                                    .server_component()
+                                    .to_resolved()
+                                    .await?,
                                 ty: ClientReferenceType::EcmascriptClientReference {
                                     parent_module: ResolvedVc::try_downcast_type::<
                                         EcmascriptClientReferenceProxyModule,
@@ -388,7 +392,7 @@ impl Visit<VisitClientReferenceNode> for VisitClientReference {
                             ClientReference {
                                 server_component: node.state.server_component(),
                                 ty: ClientReferenceType::CssClientReference(
-                                    *css_client_reference_asset,
+                                    css_client_reference_asset,
                                 ),
                             },
                             css_client_reference_asset.ident().to_string().await?,

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -69,7 +69,7 @@ impl Default for ClientReferenceGraphResult {
             client_references_by_server_component: Default::default(),
             server_component_entries: Default::default(),
             server_utils: Default::default(),
-            visited_nodes: ResolvedVc::cell(VisitedClientReferenceGraphNodes(Default::default())),
+            visited_nodes: VisitedClientReferenceGraphNodes(Default::default()).resolved_cell(),
         }
     }
 }

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -69,7 +69,7 @@ impl Default for ClientReferenceGraphResult {
             client_references_by_server_component: Default::default(),
             server_component_entries: Default::default(),
             server_utils: Default::default(),
-            visited_nodes: VisitedClientReferenceGraphNodes::empty(),
+            visited_nodes: ResolvedVc::cell(VisitedClientReferenceGraphNodes(Default::default())),
         }
     }
 }
@@ -206,7 +206,7 @@ pub async fn client_reference_graph(
             client_references_by_server_component,
             server_component_entries,
             server_utils,
-            visited_nodes: VisitedClientReferenceGraphNodes(visited_nodes.0).cell(),
+            visited_nodes: VisitedClientReferenceGraphNodes(visited_nodes.0).resolved_cell(),
         }
         .cell())
     }

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -364,14 +364,14 @@ impl Visit<VisitClientReferenceNode> for VisitClientReference {
                             ClientReference {
                                 server_component: node.state.server_component(),
                                 ty: ClientReferenceType::EcmascriptClientReference {
-                                    parent_module: *ResolvedVc::try_downcast_type::<
+                                    parent_module: ResolvedVc::try_downcast_type::<
                                         EcmascriptClientReferenceProxyModule,
                                     >(
                                         parent_module
                                     )
                                     .await?
                                     .unwrap(),
-                                    module: *client_reference_module,
+                                    module: client_reference_module,
                                 },
                             },
                             client_reference_module.ident().to_string().await?,

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -391,7 +391,12 @@ impl Visit<VisitClientReferenceNode> for VisitClientReference {
                         state: node.state,
                         ty: VisitClientReferenceNodeType::ClientReference(
                             ClientReference {
-                                server_component: node.state.server_component(),
+                                server_component: match node.state.server_component() {
+                                    Some(server_component) => {
+                                        Some(server_component.to_resolved().await?)
+                                    }
+                                    None => None,
+                                },
                                 ty: ClientReferenceType::CssClientReference(
                                     css_client_reference_asset,
                                 ),

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -193,10 +193,10 @@ pub async fn client_reference_graph(
                     }
                 }
                 VisitClientReferenceNodeType::ServerUtilEntry(server_util, _) => {
-                    server_utils.push(**server_util);
+                    server_utils.push(*server_util);
                 }
                 VisitClientReferenceNodeType::ServerComponentEntry(server_component, _) => {
-                    server_component_entries.push(**server_component);
+                    server_component_entries.push(*server_component);
                 }
             }
         }
@@ -362,11 +362,12 @@ impl Visit<VisitClientReferenceNode> for VisitClientReference {
                         state: node.state,
                         ty: VisitClientReferenceNodeType::ClientReference(
                             ClientReference {
-                                server_component: node
-                                    .state
-                                    .server_component()
-                                    .to_resolved()
-                                    .await?,
+                                server_component: match node.state.server_component() {
+                                    Some(server_component) => {
+                                        Some(server_component.to_resolved().await?)
+                                    }
+                                    None => None,
+                                },
                                 ty: ClientReferenceType::EcmascriptClientReference {
                                     parent_module: ResolvedVc::try_downcast_type::<
                                         EcmascriptClientReferenceProxyModule,

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -24,12 +24,12 @@ use crate::{
     Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Debug, ValueDebugFormat, TraceRawVcs,
 )]
 pub struct ClientReference {
-    server_component: Option<Vc<NextServerComponentModule>>,
+    server_component: Option<ResolvedVc<NextServerComponentModule>>,
     ty: ClientReferenceType,
 }
 
 impl ClientReference {
-    pub fn server_component(&self) -> Option<Vc<NextServerComponentModule>> {
+    pub fn server_component(&self) -> Option<ResolvedVc<NextServerComponentModule>> {
         self.server_component
     }
 
@@ -43,10 +43,10 @@ impl ClientReference {
 )]
 pub enum ClientReferenceType {
     EcmascriptClientReference {
-        parent_module: Vc<EcmascriptClientReferenceProxyModule>,
-        module: Vc<EcmascriptClientReferenceModule>,
+        parent_module: ResolvedVc<EcmascriptClientReferenceProxyModule>,
+        module: ResolvedVc<EcmascriptClientReferenceModule>,
     },
-    CssClientReference(Vc<CssModuleAsset>),
+    CssClientReference(ResolvedVc<CssModuleAsset>),
 }
 
 #[turbo_tasks::value(shared)]
@@ -187,7 +187,7 @@ pub async fn client_reference_graph(
                         client_references_by_server_component
                             .entry(client_reference.server_component)
                             .or_insert_with(Vec::new)
-                            .push(*ResolvedVc::upcast::<Box<dyn Module>>(
+                            .push(ResolvedVc::upcast::<Box<dyn Module>>(
                                 entry.await?.ssr_module,
                             ));
                     }

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -56,10 +56,10 @@ pub struct ClientReferenceGraphResult {
     /// Only the [`ClientReferenceType::EcmascriptClientReference`]s are listed in this map.
     #[allow(clippy::type_complexity)]
     pub client_references_by_server_component:
-        FxIndexMap<Option<Vc<NextServerComponentModule>>, Vec<Vc<Box<dyn Module>>>>,
-    pub server_component_entries: Vec<Vc<NextServerComponentModule>>,
-    pub server_utils: Vec<Vc<Box<dyn Module>>>,
-    pub visited_nodes: Vc<VisitedClientReferenceGraphNodes>,
+        FxIndexMap<Option<Vc<NextServerComponentModule>>, Vec<ResolvedVc<Box<dyn Module>>>>,
+    pub server_component_entries: Vec<ResolvedVc<NextServerComponentModule>>,
+    pub server_utils: Vec<ResolvedVc<Box<dyn Module>>>,
+    pub visited_nodes: ResolvedVc<VisitedClientReferenceGraphNodes>,
 }
 
 impl Default for ClientReferenceGraphResult {
@@ -217,8 +217,8 @@ pub async fn client_reference_graph(
 #[turbo_tasks::value(shared)]
 #[derive(Clone, Debug)]
 pub struct ServerEntries {
-    pub server_component_entries: Vec<Vc<NextServerComponentModule>>,
-    pub server_utils: Vec<Vc<Box<dyn Module>>>,
+    pub server_component_entries: Vec<ResolvedVc<NextServerComponentModule>>,
+    pub server_utils: Vec<ResolvedVc<Box<dyn Module>>>,
 }
 
 #[turbo_tasks::function]

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -56,7 +56,7 @@ pub struct ClientReferenceGraphResult {
     /// Only the [`ClientReferenceType::EcmascriptClientReference`]s are listed in this map.
     #[allow(clippy::type_complexity)]
     pub client_references_by_server_component:
-        FxIndexMap<Option<Vc<NextServerComponentModule>>, Vec<ResolvedVc<Box<dyn Module>>>>,
+        FxIndexMap<Option<ResolvedVc<NextServerComponentModule>>, Vec<ResolvedVc<Box<dyn Module>>>>,
     pub server_component_entries: Vec<ResolvedVc<NextServerComponentModule>>,
     pub server_utils: Vec<ResolvedVc<Box<dyn Module>>>,
     pub visited_nodes: ResolvedVc<VisitedClientReferenceGraphNodes>,

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1361,7 +1361,7 @@ impl Issue for OutdatedConfigIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        self.path
+        *self.path
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -31,13 +31,13 @@ use crate::{
 
 #[turbo_tasks::value]
 struct NextConfigAndCustomRoutes {
-    config: Vc<NextConfig>,
-    custom_routes: Vc<CustomRoutes>,
+    config: ResolvedVc<NextConfig>,
+    custom_routes: ResolvedVc<CustomRoutes>,
 }
 
 #[turbo_tasks::value]
 struct CustomRoutes {
-    rewrites: Vc<Rewrites>,
+    rewrites: ResolvedVc<Rewrites>,
 }
 
 #[turbo_tasks::value(transparent)]
@@ -1341,7 +1341,7 @@ impl JsConfig {
 
 #[turbo_tasks::value]
 struct OutdatedConfigIssue {
-    path: Vc<FileSystemPath>,
+    path: ResolvedVc<FileSystemPath>,
     old_name: RcStr,
     new_name: RcStr,
     description: RcStr,

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -14,7 +14,7 @@ use turbopack_core::{
 /// dynamic assets should appear in the dynamic manifest.
 #[turbo_tasks::value]
 pub struct NextDynamicEntryModule {
-    pub client_entry_module: Vc<Box<dyn Module>>,
+    pub client_entry_module: ResolvedVc<Box<dyn Module>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -35,12 +35,12 @@ impl NextDynamicEntryModule {
         client_chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<OutputAssets>> {
         let Some(client_entry_module) =
-            Vc::try_resolve_sidecast::<Box<dyn ChunkableModule>>(self.client_entry_module).await?
+            ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(self.client_entry_module).await?
         else {
             bail!("dynamic client asset must be chunkable");
         };
 
-        Ok(client_chunking_context.root_chunk_group_assets(client_entry_module))
+        Ok(client_chunking_context.root_chunk_group_assets(*client_entry_module))
     }
 }
 

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use turbo_rcstr::RcStr;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkableModule, ChunkingContext, ChunkingContextExt},

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -22,7 +22,7 @@ impl NextDynamicEntryModule {
     /// Create a new [`NextDynamicEntryModule`] from the given source CSS
     /// asset.
     #[turbo_tasks::function]
-    pub fn new(client_entry_module: Vc<Box<dyn Module>>) -> Vc<NextDynamicEntryModule> {
+    pub fn new(client_entry_module: ResolvedVc<Box<dyn Module>>) -> Vc<NextDynamicEntryModule> {
         NextDynamicEntryModule {
             client_entry_module,
         }

--- a/crates/next-core/src/next_dynamic/dynamic_transition.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_transition.rs
@@ -13,7 +13,7 @@ use super::NextDynamicEntryModule;
 /// create the dynamic entry, and the dynamic manifest entry.
 #[turbo_tasks::value]
 pub struct NextDynamicTransition {
-    client_transition: Vc<Box<dyn Transition>>,
+    client_transition: ResolvedVc<Box<dyn Transition>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-core/src/next_dynamic/dynamic_transition.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_transition.rs
@@ -19,7 +19,7 @@ pub struct NextDynamicTransition {
 #[turbo_tasks::value_impl]
 impl NextDynamicTransition {
     #[turbo_tasks::function]
-    pub fn new(client_transition: Vc<Box<dyn Transition>>) -> Vc<Self> {
+    pub fn new(client_transition: ResolvedVc<Box<dyn Transition>>) -> Vc<Self> {
         NextDynamicTransition { client_transition }.cell()
     }
 }

--- a/crates/next-core/src/next_dynamic/visit_dynamic.rs
+++ b/crates/next-core/src/next_dynamic/visit_dynamic.rs
@@ -15,7 +15,7 @@ use turbopack_core::{
 use super::NextDynamicEntryModule;
 
 #[turbo_tasks::value(transparent)]
-pub struct NextDynamicEntries(Vec<Vc<NextDynamicEntryModule>>);
+pub struct NextDynamicEntries(Vec<ResolvedVc<NextDynamicEntryModule>>);
 
 #[turbo_tasks::value_impl]
 impl NextDynamicEntries {

--- a/crates/next-core/src/next_dynamic/visit_dynamic.rs
+++ b/crates/next-core/src/next_dynamic/visit_dynamic.rs
@@ -54,7 +54,7 @@ impl NextDynamicEntries {
                         // traversal.
                     }
                     VisitDynamicNode::Dynamic(dynamic_asset, _) => {
-                        next_dynamics.push(*dynamic_asset);
+                        next_dynamics.push(dynamic_asset);
                     }
                 }
             }

--- a/crates/next-core/src/next_edge/unsupported.rs
+++ b/crates/next-core/src/next_edge/unsupported.rs
@@ -29,8 +29,8 @@ pub struct NextEdgeUnsupportedModuleReplacer {
 impl NextEdgeUnsupportedModuleReplacer {
     #[turbo_tasks::function]
     pub fn new(
-        project_path: Vc<FileSystemPath>,
-        execution_context: Vc<ExecutionContext>,
+        project_path: ResolvedVc<FileSystemPath>,
+        execution_context: ResolvedVc<ExecutionContext>,
     ) -> Vc<Self> {
         Self::cell(NextEdgeUnsupportedModuleReplacer {
             project_path,

--- a/crates/next-core/src/next_edge/unsupported.rs
+++ b/crates/next-core/src/next_edge/unsupported.rs
@@ -21,8 +21,8 @@ use turbopack_node::execution_context::ExecutionContext;
 /// This can be used by import map alias, refer `next_import_map` for the setup.
 #[turbo_tasks::value(shared)]
 pub struct NextEdgeUnsupportedModuleReplacer {
-    project_path: Vc<FileSystemPath>,
-    execution_context: Vc<ExecutionContext>,
+    project_path: ResolvedVc<FileSystemPath>,
+    execution_context: ResolvedVc<ExecutionContext>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-core/src/next_font/font_fallback.rs
+++ b/crates/next-core/src/next_font/font_fallback.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{trace::TraceRawVcs, Vc};
+use turbo_tasks::{trace::TraceRawVcs, ResolvedVc, Vc};
 
 pub(crate) struct DefaultFallbackFont {
     pub name: RcStr,
@@ -32,9 +32,9 @@ pub(crate) static DEFAULT_SERIF_FONT: Lazy<DefaultFallbackFont> =
 #[turbo_tasks::value(shared)]
 pub(crate) struct AutomaticFontFallback {
     /// e.g. `__Roboto_Fallback_c123b8`
-    pub scoped_font_family: Vc<RcStr>,
+    pub scoped_font_family: ResolvedVc<RcStr>,
     /// The name of font locally, used in `src: local("{}")`
-    pub local_font_family: Vc<RcStr>,
+    pub local_font_family: ResolvedVc<RcStr>,
     pub adjustment: Option<FontAdjustment>,
 }
 
@@ -60,7 +60,7 @@ impl FontFallback {
 }
 
 #[turbo_tasks::value(transparent)]
-pub(crate) struct FontFallbacks(Vec<Vc<FontFallback>>);
+pub(crate) struct FontFallbacks(Vec<ResolvedVc<FontFallback>>);
 
 #[turbo_tasks::value_impl]
 impl FontFallbacks {

--- a/crates/next-core/src/next_font/google/font_fallback.rs
+++ b/crates/next-core/src/next_font/google/font_fallback.rs
@@ -68,14 +68,16 @@ pub(super) async fn get_font_fallback(
                     scoped_font_family: get_scoped_font_family(
                         FontFamilyType::Fallback.cell(),
                         options_vc.font_family(),
-                    ),
-                    local_font_family: Vc::cell(fallback.font_family),
+                    )
+                    .to_resolved()
+                    .await?,
+                    local_font_family: ResolvedVc::cell(fallback.font_family),
                     adjustment: fallback.adjustment,
                 })
                 .cell(),
                 Err(_) => {
                     NextFontIssue {
-                        path: *lookup_path,
+                        path: lookup_path,
                         title: StyledString::Text(
                             format!(
                                 "Failed to find font override values for font `{}`",
@@ -83,12 +85,12 @@ pub(super) async fn get_font_fallback(
                             )
                             .into(),
                         )
-                        .cell(),
+                        .resolved_cell(),
                         description: StyledString::Text(
                             "Skipping generating a fallback font.".into(),
                         )
-                        .cell(),
-                        severity: IssueSeverity::Warning.cell(),
+                        .resolved_cell(),
+                        severity: IssueSeverity::Warning.resolved_cell(),
                     }
                     .cell()
                     .emit();

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -72,7 +72,7 @@ struct FontData(FxIndexMap<RcStr, FontDataEntry>);
 
 #[turbo_tasks::value(shared)]
 pub(crate) struct NextFontGoogleReplacer {
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
 }
 
 #[turbo_tasks::value_impl]
@@ -180,8 +180,8 @@ impl ImportMappingReplacement for NextFontGoogleReplacer {
 
 #[turbo_tasks::value(shared)]
 pub struct NextFontGoogleCssModuleReplacer {
-    project_path: Vc<FileSystemPath>,
-    execution_context: Vc<ExecutionContext>,
+    project_path: ResolvedVc<FileSystemPath>,
+    execution_context: ResolvedVc<ExecutionContext>,
 }
 
 #[turbo_tasks::value_impl]
@@ -315,7 +315,7 @@ struct NextFontGoogleFontFileOptions {
 
 #[turbo_tasks::value(shared)]
 pub struct NextFontGoogleFontFileReplacer {
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -78,7 +78,7 @@ pub(crate) struct NextFontGoogleReplacer {
 #[turbo_tasks::value_impl]
 impl NextFontGoogleReplacer {
     #[turbo_tasks::function]
-    pub fn new(project_path: Vc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(project_path: ResolvedVc<FileSystemPath>) -> Vc<Self> {
         Self::cell(NextFontGoogleReplacer { project_path })
     }
 
@@ -89,10 +89,10 @@ impl NextFontGoogleReplacer {
 
         let query_vc = Vc::cell(query);
 
-        let font_data = load_font_data(self.project_path);
+        let font_data = load_font_data(*self.project_path);
         let options = font_options_from_query_map(query_vc, font_data);
 
-        let fallback = get_font_fallback(self.project_path, options);
+        let fallback = get_font_fallback(*self.project_path, options);
         let properties = get_font_css_properties(options, fallback).await?;
         let js_asset = VirtualSource::new(
             next_js_file_path("internal/font/google".into())
@@ -170,7 +170,7 @@ impl ImportMappingReplacement for NextFontGoogleReplacer {
         };
 
         let this = &*self.await?;
-        if can_use_next_font(this.project_path, **query).await? {
+        if can_use_next_font(*this.project_path, **query).await? {
             Ok(self.import_map_result(query.await?.as_str().into()))
         } else {
             Ok(ImportMapResult::NoEntry.into())

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -201,7 +201,7 @@ impl NextFontGoogleCssModuleReplacer {
     async fn import_map_result(&self, query: RcStr) -> Result<Vc<ImportMapResult>> {
         let request_hash = get_request_hash(&query).await?;
         let query_vc = Vc::cell(query);
-        let font_data = load_font_data(self.project_path);
+        let font_data = load_font_data(*self.project_path);
         let options = font_options_from_query_map(query_vc, font_data);
         let stylesheet_url = get_stylesheet_url_from_options(options, font_data);
         let scoped_font_family =
@@ -223,11 +223,11 @@ impl NextFontGoogleCssModuleReplacer {
             .as_ref()
             .map_or_else(
                 || fetch_real_stylesheet(stylesheet_url, css_virtual_path).boxed(),
-                |p| get_mock_stylesheet(stylesheet_url, p, self.execution_context).boxed(),
+                |p| get_mock_stylesheet(stylesheet_url, p, *self.execution_context).boxed(),
             )
             .await?;
 
-        let font_fallback = get_font_fallback(self.project_path, options);
+        let font_fallback = get_font_fallback(*self.project_path, options);
 
         let stylesheet = match stylesheet_str {
             Some(s) => Some(
@@ -548,8 +548,8 @@ async fn get_font_css_properties(
     }
 
     Ok(FontCssProperties::cell(FontCssProperties {
-        font_family: Vc::cell(font_families.join(", ").into()),
-        weight: Vc::cell(match &options.weights {
+        font_family: ResolvedVc::cell(font_families.join(", ").into()),
+        weight: ResolvedVc::cell(match &options.weights {
             FontWeights::Variable => None,
             FontWeights::Fixed(weights) => {
                 if weights.len() > 1 {
@@ -560,13 +560,13 @@ async fn get_font_css_properties(
                 }
             }
         }),
-        style: Vc::cell(if options.styles.len() > 1 {
+        style: ResolvedVc::cell(if options.styles.len() > 1 {
             // Don't set a rule for style if multiple are requested
             None
         } else {
             options.styles.first().cloned()
         }),
-        variable: Vc::cell(options.variable.clone()),
+        variable: ResolvedVc::cell(options.variable.clone()),
     }))
 }
 

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -188,8 +188,8 @@ pub struct NextFontGoogleCssModuleReplacer {
 impl NextFontGoogleCssModuleReplacer {
     #[turbo_tasks::function]
     pub fn new(
-        project_path: Vc<FileSystemPath>,
-        execution_context: Vc<ExecutionContext>,
+        project_path: ResolvedVc<FileSystemPath>,
+        execution_context: ResolvedVc<ExecutionContext>,
     ) -> Vc<Self> {
         Self::cell(NextFontGoogleCssModuleReplacer {
             project_path,

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -321,7 +321,7 @@ pub struct NextFontGoogleFontFileReplacer {
 #[turbo_tasks::value_impl]
 impl NextFontGoogleFontFileReplacer {
     #[turbo_tasks::function]
-    pub fn new(project_path: Vc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(project_path: ResolvedVc<FileSystemPath>) -> Vc<Self> {
         Self::cell(NextFontGoogleFontFileReplacer { project_path })
     }
 }

--- a/crates/next-core/src/next_font/google/stylesheet.rs
+++ b/crates/next-core/src/next_font/google/stylesheet.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 
 use super::FontCssProperties;
 use crate::next_font::{
@@ -12,7 +12,7 @@ use crate::next_font::{
 pub(super) async fn build_stylesheet(
     base_stylesheet: Vc<Option<RcStr>>,
     font_css_properties: Vc<FontCssProperties>,
-    font_fallback: Vc<FontFallback>,
+    font_fallback: ResolvedVc<FontFallback>,
 ) -> Result<Vc<RcStr>> {
     let base_stylesheet = &*base_stylesheet.await?;
     let mut stylesheet = base_stylesheet

--- a/crates/next-core/src/next_font/issue.rs
+++ b/crates/next-core/src/next_font/issue.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString};
 

--- a/crates/next-core/src/next_font/issue.rs
+++ b/crates/next-core/src/next_font/issue.rs
@@ -19,21 +19,21 @@ impl Issue for NextFontIssue {
 
     #[turbo_tasks::function]
     fn severity(&self) -> Vc<IssueSeverity> {
-        self.severity
+        *self.severity
     }
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        self.path
+        *self.path
     }
 
     #[turbo_tasks::function]
     fn title(&self) -> Vc<StyledString> {
-        self.title
+        *self.title
     }
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(self.description))
+        Vc::cell(Some(*self.description))
     }
 }

--- a/crates/next-core/src/next_font/issue.rs
+++ b/crates/next-core/src/next_font/issue.rs
@@ -4,10 +4,10 @@ use turbopack_core::issue::{Issue, IssueSeverity, IssueStage, OptionStyledString
 
 #[turbo_tasks::value(shared)]
 pub(crate) struct NextFontIssue {
-    pub(crate) path: Vc<FileSystemPath>,
-    pub(crate) title: Vc<StyledString>,
-    pub(crate) description: Vc<StyledString>,
-    pub(crate) severity: Vc<IssueSeverity>,
+    pub(crate) path: ResolvedVc<FileSystemPath>,
+    pub(crate) title: ResolvedVc<StyledString>,
+    pub(crate) description: ResolvedVc<StyledString>,
+    pub(crate) severity: ResolvedVc<IssueSeverity>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-core/src/next_font/local/font_fallback.rs
+++ b/crates/next-core/src/next_font/local/font_fallback.rs
@@ -3,7 +3,7 @@ use allsorts::{
     Font,
 };
 use anyhow::{bail, Context, Result};
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 
 use super::{
@@ -38,23 +38,23 @@ pub(super) async fn get_font_fallbacks(
     match options.adjust_font_fallback {
         AdjustFontFallback::Arial => font_fallbacks.push(
             FontFallback::Automatic(AutomaticFontFallback {
-                scoped_font_family,
-                local_font_family: Vc::cell("Arial".into()),
+                scoped_font_family: scoped_font_family.to_resolved().await?,
+                local_font_family: ResolvedVc::cell("Arial".into()),
                 adjustment: Some(
                     get_font_adjustment(lookup_path, options_vc, &DEFAULT_SANS_SERIF_FONT).await?,
                 ),
             })
-            .into(),
+            .resolved_cell(),
         ),
         AdjustFontFallback::TimesNewRoman => font_fallbacks.push(
             FontFallback::Automatic(AutomaticFontFallback {
-                scoped_font_family,
-                local_font_family: Vc::cell("Times New Roman".into()),
+                scoped_font_family: scoped_font_family.to_resolved().await?,
+                local_font_family: ResolvedVc::cell("Times New Roman".into()),
                 adjustment: Some(
                     get_font_adjustment(lookup_path, options_vc, &DEFAULT_SERIF_FONT).await?,
                 ),
             })
-            .into(),
+            .resolved_cell(),
         ),
         AdjustFontFallback::None => (),
     };

--- a/crates/next-core/src/next_font/local/font_fallback.rs
+++ b/crates/next-core/src/next_font/local/font_fallback.rs
@@ -60,7 +60,7 @@ pub(super) async fn get_font_fallbacks(
     };
 
     if let Some(fallback) = &options.fallback {
-        font_fallbacks.push(FontFallback::Manual(fallback.clone()).into());
+        font_fallbacks.push(FontFallback::Manual(fallback.clone()).resolved_cell());
     }
 
     Ok(Vc::cell(font_fallbacks))

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -52,7 +52,7 @@ struct NextFontLocalFontFileOptions {
 
 #[turbo_tasks::value]
 pub(crate) struct NextFontLocalResolvePlugin {
-    root: Vc<FileSystemPath>,
+    root: ResolvedVc<FileSystemPath>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -329,7 +329,7 @@ impl Issue for FontResolvingIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        self.origin_path
+        *self.origin_path
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -58,7 +58,7 @@ pub(crate) struct NextFontLocalResolvePlugin {
 #[turbo_tasks::value_impl]
 impl NextFontLocalResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(root: Vc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(root: ResolvedVc<FileSystemPath>) -> Vc<Self> {
         NextFontLocalResolvePlugin { root }.cell()
     }
 }
@@ -98,7 +98,7 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
 
         match request_key.as_str() {
             "next/font/local/target.css" => {
-                if !can_use_next_font(this.root, **query_vc).await? {
+                if !can_use_next_font(*this.root, **query_vc).await? {
                     return Ok(ResolveResultOption::none());
                 }
 

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -115,8 +115,8 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                             source_error.downcast_ref::<FontError>()
                         {
                             FontResolvingIssue {
-                                origin_path: lookup_path,
-                                font_path: Vc::cell(font_path.clone()),
+                                origin_path: lookup_path.to_resolved().await?,
+                                font_path: ResolvedVc::cell(font_path.clone()),
                             }
                             .cell()
                             .emit();

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -316,8 +316,8 @@ async fn font_file_options_from_query_map(
 
 #[turbo_tasks::value(shared)]
 struct FontResolvingIssue {
-    font_path: Vc<RcStr>,
-    origin_path: Vc<FileSystemPath>,
+    font_path: ResolvedVc<RcStr>,
+    origin_path: ResolvedVc<FileSystemPath>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -260,7 +260,7 @@ async fn get_font_css_properties(
 
     Ok(FontCssProperties::cell(FontCssProperties {
         font_family: build_font_family_string(options_vc, font_fallbacks),
-        weight: Vc::cell(match &options.fonts {
+        weight: ResolvedVc::cell(match &options.fonts {
             FontDescriptors::Many(_) => None,
             // When the user only provided a top-level font file, include the font weight in the
             // className selector rules
@@ -272,13 +272,13 @@ async fn get_font_css_properties(
                 .filter(|w| !matches!(w, FontWeight::Variable(_, _)))
                 .map(|w| w.to_string().into()),
         }),
-        style: Vc::cell(match &options.fonts {
+        style: ResolvedVc::cell(match &options.fonts {
             FontDescriptors::Many(_) => None,
             // When the user only provided a top-level font file, include the font style in the
             // className selector rules
             FontDescriptors::One(descriptor) => descriptor.style.clone(),
         }),
-        variable: Vc::cell(options.variable.clone()),
+        variable: ResolvedVc::cell(options.variable.clone()),
     }))
 }
 

--- a/crates/next-core/src/next_font/util.rs
+++ b/crates/next-core/src/next_font/util.rs
@@ -13,10 +13,10 @@ use super::issue::NextFontIssue;
 /// module.
 #[turbo_tasks::value(shared)]
 pub(crate) struct FontCssProperties {
-    pub font_family: Vc<RcStr>,
-    pub weight: Vc<Option<RcStr>>,
-    pub style: Vc<Option<RcStr>>,
-    pub variable: Vc<Option<RcStr>>,
+    pub font_family: ResolvedVc<RcStr>,
+    pub weight: ResolvedVc<Option<RcStr>>,
+    pub style: ResolvedVc<Option<RcStr>>,
+    pub variable: ResolvedVc<Option<RcStr>>,
 }
 
 /// A hash of the requested querymap derived from how the user invoked

--- a/crates/next-core/src/next_font/util.rs
+++ b/crates/next-core/src/next_font/util.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use turbo_rcstr::RcStr;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{json::parse_json_with_source_context, FileSystemPath};
 use turbo_tasks_hash::hash_xxh3_hash64;
 use turbopack_core::issue::{IssueExt, IssueSeverity, StyledString};

--- a/crates/next-core/src/next_font/util.rs
+++ b/crates/next-core/src/next_font/util.rs
@@ -98,20 +98,20 @@ pub(crate) async fn can_use_next_font(
     let can_use = !document_re.is_match(&request.path);
     if !can_use {
         NextFontIssue {
-            path,
+            path: path.to_resolved().await?,
             title: StyledString::Line(vec![
                 StyledString::Code("next/font:".into()),
                 StyledString::Text(" error:".into()),
             ])
-            .cell(),
+            .resolved_cell(),
             description: StyledString::Line(vec![
                 StyledString::Text("Cannot be used within ".into()),
                 StyledString::Code(request.path),
             ])
-            .cell(),
-            severity: IssueSeverity::Error.into(),
+            .resolved_cell(),
+            severity: IssueSeverity::Error.resolved_cell(),
         }
-        .cell()
+        .resolved_cell()
         .emit();
     }
     Ok(can_use)

--- a/crates/next-core/src/next_image/module.rs
+++ b/crates/next-core/src/next_image/module.rs
@@ -36,11 +36,11 @@ pub struct StructuredImageModuleType {
 impl StructuredImageModuleType {
     #[turbo_tasks::function]
     pub(crate) async fn create_module(
-        source: Vc<Box<dyn Source>>,
+        source: ResolvedVc<Box<dyn Source>>,
         blur_placeholder_mode: BlurPlaceholderMode,
-        module_asset_context: Vc<ModuleAssetContext>,
+        module_asset_context: ResolvedVc<ModuleAssetContext>,
     ) -> Result<Vc<Box<dyn Module>>> {
-        let static_asset = StaticModuleAsset::new(source, Vc::upcast(module_asset_context))
+        let static_asset = StaticModuleAsset::new(*source, Vc::upcast(*module_asset_context))
             .to_resolved()
             .await?;
         Ok(module_asset_context

--- a/crates/next-core/src/next_image/source_asset.rs
+++ b/crates/next-core/src/next_image/source_asset.rs
@@ -31,7 +31,7 @@ fn blur_options() -> Vc<BlurPlaceholderOptions> {
 /// an object with meta information like width, height and a blur placeholder.
 #[turbo_tasks::value(shared)]
 pub struct StructuredImageFileSource {
-    pub image: Vc<Box<dyn Source>>,
+    pub image: ResolvedVc<Box<dyn Source>>,
     pub blur_placeholder_mode: BlurPlaceholderMode,
 }
 

--- a/crates/next-core/src/next_image/source_asset.rs
+++ b/crates/next-core/src/next_image/source_asset.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use anyhow::{bail, Result};
 use turbo_rcstr::RcStr;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{rope::RopeBuilder, FileContent};
 use turbopack_core::{
     asset::{Asset, AssetContent},

--- a/crates/next-core/src/next_route_matcher/mod.rs
+++ b/crates/next-core/src/next_route_matcher/mod.rs
@@ -16,7 +16,7 @@ mod prefix_suffix;
 /// A route matcher that matches a path against an exact route.
 #[turbo_tasks::value]
 pub(crate) struct NextExactMatcher {
-    path: Vc<RcStr>,
+    path: ResolvedVc<RcStr>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-core/src/next_route_matcher/mod.rs
+++ b/crates/next-core/src/next_route_matcher/mod.rs
@@ -22,7 +22,7 @@ pub(crate) struct NextExactMatcher {
 #[turbo_tasks::value_impl]
 impl NextExactMatcher {
     #[turbo_tasks::function]
-    pub fn new(path: Vc<RcStr>) -> Vc<Self> {
+    pub fn new(path: ResolvedVc<RcStr>) -> Vc<Self> {
         Self::cell(NextExactMatcher { path })
     }
 }
@@ -54,7 +54,7 @@ pub(crate) struct NextParamsMatcher {
 #[turbo_tasks::value_impl]
 impl NextParamsMatcher {
     #[turbo_tasks::function]
-    pub async fn new(path: Vc<RcStr>) -> Result<Vc<Self>> {
+    pub async fn new(path: ResolvedVc<RcStr>) -> Result<Vc<Self>> {
         Ok(Self::cell(NextParamsMatcher {
             matcher: build_path_regex(path.await?.as_str())?,
         }))
@@ -87,7 +87,7 @@ impl NextPrefixSuffixParamsMatcher {
     /// Converts a filename within the server root into a regular expression
     /// with named capture groups for every dynamic segment.
     #[turbo_tasks::function]
-    pub async fn new(path: Vc<RcStr>, prefix: RcStr, suffix: RcStr) -> Result<Vc<Self>> {
+    pub async fn new(path: ResolvedVc<RcStr>, prefix: RcStr, suffix: RcStr) -> Result<Vc<Self>> {
         Ok(Self::cell(NextPrefixSuffixParamsMatcher {
             matcher: PrefixSuffixMatcher::new(
                 prefix.to_string(),

--- a/crates/next-core/src/next_route_matcher/mod.rs
+++ b/crates/next-core/src/next_route_matcher/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use turbo_rcstr::RcStr;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_node::route_matcher::{Params, RouteMatcher, RouteMatcherRef};
 
 use self::{

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -724,7 +724,7 @@ pub async fn get_server_module_options_context(
             {
                 custom_source_transform_rules.push(get_ecma_transform_rule(
                     Box::new(ClientDirectiveTransformer::new(
-                        ecmascript_client_reference_transition_name,
+                        *ecmascript_client_reference_transition_name,
                     )),
                     enable_mdx_rs.is_some(),
                     true,

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -800,7 +800,7 @@ pub async fn get_server_module_options_context(
             {
                 common_next_server_rules.push(get_ecma_transform_rule(
                     Box::new(ClientDirectiveTransformer::new(
-                        ecmascript_client_reference_transition_name,
+                        *ecmascript_client_reference_transition_name,
                     )),
                     enable_mdx_rs.is_some(),
                     true,
@@ -878,7 +878,7 @@ pub async fn get_server_module_options_context(
             {
                 custom_source_transform_rules.push(get_ecma_transform_rule(
                     Box::new(ClientDirectiveTransformer::new(
-                        ecmascript_client_reference_transition_name,
+                        *ecmascript_client_reference_transition_name,
                     )),
                     enable_mdx_rs.is_some(),
                     true,

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -93,20 +93,20 @@ pub enum ServerContextType {
     },
     AppRSC {
         app_dir: ResolvedVc<FileSystemPath>,
-        ecmascript_client_reference_transition_name: Option<Vc<RcStr>>,
-        client_transition: Option<Vc<Box<dyn Transition>>>,
+        ecmascript_client_reference_transition_name: Option<ResolvedVc<RcStr>>,
+        client_transition: Option<ResolvedVc<Box<dyn Transition>>>,
     },
     AppRoute {
         app_dir: ResolvedVc<FileSystemPath>,
-        ecmascript_client_reference_transition_name: Option<Vc<RcStr>>,
+        ecmascript_client_reference_transition_name: Option<ResolvedVc<RcStr>>,
     },
     Middleware {
         app_dir: Option<ResolvedVc<FileSystemPath>>,
-        ecmascript_client_reference_transition_name: Option<Vc<RcStr>>,
+        ecmascript_client_reference_transition_name: Option<ResolvedVc<RcStr>>,
     },
     Instrumentation {
         app_dir: Option<ResolvedVc<FileSystemPath>>,
-        ecmascript_client_reference_transition_name: Option<Vc<RcStr>>,
+        ecmascript_client_reference_transition_name: Option<ResolvedVc<RcStr>>,
     },
 }
 

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -108,7 +108,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
         let predicate = self.predicate.await?;
         let must_be_external = match &*predicate {
             ExternalPredicate::AllExcept(exceptions) => {
-                if *condition(*self.root).matches(lookup_path).await? {
+                if *condition(*self.root).matches(*lookup_path).await? {
                     return Ok(ResolveResultOption::none());
                 }
 
@@ -221,7 +221,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
         };
         let result_from_original_location = loop {
             let node_resolved_from_original_location = resolve(
-                lookup_path,
+                *lookup_path,
                 reference_type.clone(),
                 request,
                 node_resolve_options,
@@ -485,7 +485,7 @@ impl Issue for ExternalizeIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        self.file_path
+        *self.file_path
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -38,8 +38,8 @@ pub enum ExternalPredicate {
 #[turbo_tasks::value]
 pub(crate) struct ExternalCjsModulesResolvePlugin {
     project_path: ResolvedVc<FileSystemPath>,
-    root: Vc<FileSystemPath>,
-    predicate: Vc<ExternalPredicate>,
+    root: ResolvedVc<FileSystemPath>,
+    predicate: ResolvedVc<ExternalPredicate>,
     import_externals: bool,
 }
 
@@ -455,7 +455,7 @@ async fn packages_glob(packages: Vc<Vec<RcStr>>) -> Result<Vc<OptionPackagesGlob
 
 #[turbo_tasks::value]
 struct ExternalizeIssue {
-    file_path: Vc<FileSystemPath>,
+    file_path: ResolvedVc<FileSystemPath>,
     package: RcStr,
     request_str: RcStr,
     reason: Vec<StyledString>,

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -42,7 +42,7 @@ pub struct NextServerComponentModule {
 #[turbo_tasks::value_impl]
 impl NextServerComponentModule {
     #[turbo_tasks::function]
-    pub fn new(module: Vc<Box<dyn EcmascriptChunkPlaceable>>) -> Vc<Self> {
+    pub fn new(module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>) -> Vc<Self> {
         NextServerComponentModule { module }.cell()
     }
 
@@ -62,7 +62,7 @@ impl Module for NextServerComponentModule {
     #[turbo_tasks::function]
     fn references(&self) -> Vc<ModuleReferences> {
         Vc::cell(vec![Vc::upcast(NextServerComponentModuleReference::new(
-            Vc::upcast(self.module),
+            Vc::upcast(*self.module),
         ))])
     }
 
@@ -113,7 +113,7 @@ impl EcmascriptChunkPlaceable for NextServerComponentModule {
     #[turbo_tasks::function]
     fn get_exports(&self) -> Vc<EcmascriptExports> {
         let module_reference = Vc::upcast(NextServerComponentModuleReference::new(Vc::upcast(
-            self.module,
+            *self.module,
         )));
 
         let mut exports = BTreeMap::new();

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -95,8 +95,8 @@ impl Asset for NextServerComponentModule {
 impl ChunkableModule for NextServerComponentModule {
     #[turbo_tasks::function]
     fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
+        self: ResolvedVc<Self>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
         Vc::upcast(
             NextServerComponentChunkItem {
@@ -152,7 +152,7 @@ impl EcmascriptChunkItem for NextServerComponentChunkItem {
 
         let module_id = inner
             .module
-            .as_chunk_item(Vc::upcast(self.chunking_context))
+            .as_chunk_item(Vc::upcast(*self.chunking_context))
             .id()
             .await?;
         Ok(EcmascriptChunkItemContent {
@@ -183,7 +183,7 @@ impl ChunkItem for NextServerComponentChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        self.chunking_context
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]
@@ -193,6 +193,6 @@ impl ChunkItem for NextServerComponentChunkItem {
 
     #[turbo_tasks::function]
     fn module(&self) -> Vc<Box<dyn Module>> {
-        Vc::upcast(self.inner)
+        Vc::upcast(*self.inner)
     }
 }

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -135,15 +135,15 @@ impl EcmascriptChunkPlaceable for NextServerComponentModule {
 
 #[turbo_tasks::value]
 struct NextServerComponentChunkItem {
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
-    inner: Vc<NextServerComponentModule>,
+    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    inner: ResolvedVc<NextServerComponentModule>,
 }
 
 #[turbo_tasks::value_impl]
 impl EcmascriptChunkItem for NextServerComponentChunkItem {
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        self.chunking_context
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -36,7 +36,7 @@ fn modifier() -> Vc<RcStr> {
 
 #[turbo_tasks::value(shared)]
 pub struct NextServerComponentModule {
-    module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
+    module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -344,7 +344,7 @@ pub(crate) struct ModuleFeatureReportResolvePlugin {
 #[turbo_tasks::value_impl]
 impl ModuleFeatureReportResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(root: Vc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(root: ResolvedVc<FileSystemPath>) -> Vc<Self> {
         ModuleFeatureReportResolvePlugin { root }.cell()
     }
 }

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -100,7 +100,7 @@ impl Issue for InvalidImportModuleIssue {
 /// configured when each context sets up its resolve options.
 #[turbo_tasks::value]
 pub(crate) struct InvalidImportResolvePlugin {
-    root: Vc<FileSystemPath>,
+    root: ResolvedVc<FileSystemPath>,
     invalid_import: RcStr,
     message: Vec<RcStr>,
 }
@@ -255,7 +255,7 @@ impl AfterResolvePlugin for NextExternalResolvePlugin {
 
 #[turbo_tasks::value]
 pub(crate) struct NextNodeSharedRuntimeResolvePlugin {
-    root: Vc<FileSystemPath>,
+    root: ResolvedVc<FileSystemPath>,
     server_context_type: ServerContextType,
 }
 
@@ -334,7 +334,7 @@ impl AfterResolvePlugin for NextNodeSharedRuntimeResolvePlugin {
 /// telemetry events if there is a match.
 #[turbo_tasks::value]
 pub(crate) struct ModuleFeatureReportResolvePlugin {
-    root: Vc<FileSystemPath>,
+    root: ResolvedVc<FileSystemPath>,
 }
 
 #[turbo_tasks::value_impl]
@@ -391,13 +391,13 @@ impl BeforeResolvePlugin for ModuleFeatureReportResolvePlugin {
 
 #[turbo_tasks::value]
 pub(crate) struct NextSharedRuntimeResolvePlugin {
-    root: Vc<FileSystemPath>,
+    root: ResolvedVc<FileSystemPath>,
 }
 
 #[turbo_tasks::value_impl]
 impl NextSharedRuntimeResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(root: Vc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(root: ResolvedVc<FileSystemPath>) -> Vc<Self> {
         NextSharedRuntimeResolvePlugin { root }.cell()
     }
 }

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -67,7 +67,7 @@ impl Issue for InvalidImportModuleIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        self.file_path
+        *self.file_path
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -132,7 +132,7 @@ impl BeforeResolvePlugin for InvalidImportResolvePlugin {
     #[turbo_tasks::function]
     fn before_resolve(
         &self,
-        lookup_path: Vc<FileSystemPath>,
+        lookup_path: ResolvedVc<FileSystemPath>,
         _reference_type: Value<ReferenceType>,
         _request: Vc<Request>,
     ) -> Vc<ResolveResultOption> {

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -108,7 +108,11 @@ pub(crate) struct InvalidImportResolvePlugin {
 #[turbo_tasks::value_impl]
 impl InvalidImportResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(root: Vc<FileSystemPath>, invalid_import: RcStr, message: Vec<RcStr>) -> Vc<Self> {
+    pub fn new(
+        root: ResolvedVc<FileSystemPath>,
+        invalid_import: RcStr,
+        message: Vec<RcStr>,
+    ) -> Vc<Self> {
         InvalidImportResolvePlugin {
             root,
             invalid_import,
@@ -263,7 +267,7 @@ pub(crate) struct NextNodeSharedRuntimeResolvePlugin {
 impl NextNodeSharedRuntimeResolvePlugin {
     #[turbo_tasks::function]
     pub fn new(
-        root: Vc<FileSystemPath>,
+        root: ResolvedVc<FileSystemPath>,
         server_context_type: Value<ServerContextType>,
     ) -> Vc<Self> {
         let server_context_type = server_context_type.into_value();

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -43,7 +43,7 @@ lazy_static! {
 
 #[turbo_tasks::value(shared)]
 pub struct InvalidImportModuleIssue {
-    pub file_path: Vc<FileSystemPath>,
+    pub file_path: ResolvedVc<FileSystemPath>,
     pub messages: Vec<RcStr>,
     pub skip_context_message: bool,
 }

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -65,16 +65,16 @@ pub async fn maybe_add_babel_loader(
                     && !*is_babel_loader_available(project_root).await?
                 {
                     BabelIssue {
-                        path: project_root,
+                        path: project_root.to_resolved().await?,
                         title: StyledString::Text(
                             "Unable to resolve babel-loader, but a babel config is present".into(),
                         )
-                        .cell(),
+                        .resolved_cell(),
                         description: StyledString::Text(
                             "Make sure babel-loader is installed via your package manager.".into(),
                         )
-                        .cell(),
-                        severity: IssueSeverity::Fatal.cell(),
+                        .resolved_cell(),
+                        severity: IssueSeverity::Fatal.resolved_cell(),
                     }
                     .cell()
                     .emit();
@@ -141,21 +141,21 @@ impl Issue for BabelIssue {
 
     #[turbo_tasks::function]
     fn severity(&self) -> Vc<IssueSeverity> {
-        self.severity
+        *self.severity
     }
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        self.path
+        *self.path
     }
 
     #[turbo_tasks::function]
     fn title(&self) -> Vc<StyledString> {
-        self.title
+        *self.title
     }
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(self.description))
+        Vc::cell(Some(*self.description))
     }
 }

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -126,10 +126,10 @@ pub async fn is_babel_loader_available(project_path: Vc<FileSystemPath>) -> Resu
 
 #[turbo_tasks::value]
 struct BabelIssue {
-    path: Vc<FileSystemPath>,
-    title: Vc<StyledString>,
-    description: Vc<StyledString>,
-    severity: Vc<IssueSeverity>,
+    path: ResolvedVc<FileSystemPath>,
+    title: ResolvedVc<StyledString>,
+    description: ResolvedVc<StyledString>,
+    severity: ResolvedVc<IssueSeverity>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -82,10 +82,10 @@ pub struct PageLoaderAsset {
 impl PageLoaderAsset {
     #[turbo_tasks::function]
     pub fn new(
-        server_root: Vc<FileSystemPath>,
-        pathname: Vc<RcStr>,
-        rebase_prefix_path: Vc<FileSystemPathOption>,
-        page_chunks: Vc<OutputAssets>,
+        server_root: ResolvedVc<FileSystemPath>,
+        pathname: ResolvedVc<RcStr>,
+        rebase_prefix_path: ResolvedVc<FileSystemPathOption>,
+        page_chunks: ResolvedVc<OutputAssets>,
     ) -> Vc<Self> {
         Self {
             server_root,

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -119,10 +119,10 @@ impl PageLoaderAsset {
                 })
                 .try_join()
                 .await?;
-            chunks = Vc::cell(rebased);
+            chunks = ResolvedVc::cell(rebased);
         };
 
-        Ok(ChunkData::from_assets(self.server_root, chunks))
+        Ok(ChunkData::from_assets(*self.server_root, *chunks))
     }
 }
 

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -72,10 +72,10 @@ pub async fn create_page_loader_entry_module(
 
 #[turbo_tasks::value(shared)]
 pub struct PageLoaderAsset {
-    pub server_root: Vc<FileSystemPath>,
-    pub pathname: Vc<RcStr>,
-    pub rebase_prefix_path: Vc<FileSystemPathOption>,
-    pub page_chunks: Vc<OutputAssets>,
+    pub server_root: ResolvedVc<FileSystemPath>,
+    pub pathname: ResolvedVc<RcStr>,
+    pub rebase_prefix_path: ResolvedVc<FileSystemPathOption>,
+    pub page_chunks: ResolvedVc<OutputAssets>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -138,7 +138,7 @@ impl OutputAsset for PageLoaderAsset {
         let root = self
             .rebase_prefix_path
             .await?
-            .map_or(self.server_root, |path| *path);
+            .map_or(*self.server_root, |path| *path);
         Ok(AssetIdent::from_path(
             root.join(
                 format!(
@@ -175,7 +175,7 @@ impl Asset for PageLoaderAsset {
     async fn content(self: Vc<Self>) -> Result<Vc<AssetContent>> {
         let this = &*self.await?;
 
-        let chunks_data = self.chunks_data(this.rebase_prefix_path).await?;
+        let chunks_data = self.chunks_data(*this.rebase_prefix_path).await?;
         let chunks_data = chunks_data.iter().try_join().await?;
         let chunks_data: Vec<_> = chunks_data
             .iter()

--- a/crates/next-core/src/pages_structure.rs
+++ b/crates/next-core/src/pages_structure.rs
@@ -11,17 +11,17 @@ use crate::next_import_map::get_next_package;
 /// A final route in the pages directory.
 #[turbo_tasks::value]
 pub struct PagesStructureItem {
-    pub base_path: Vc<FileSystemPath>,
-    pub extensions: Vc<Vec<RcStr>>,
+    pub base_path: ResolvedVc<FileSystemPath>,
+    pub extensions: ResolvedVc<Vec<RcStr>>,
     pub fallback_path: Option<ResolvedVc<FileSystemPath>>,
 
     /// Pathname of this item in the Next.js router.
-    pub next_router_path: Vc<FileSystemPath>,
+    pub next_router_path: ResolvedVc<FileSystemPath>,
     /// Unique path corresponding to this item. This differs from
     /// `next_router_path` in that it will include the trailing /index for index
     /// routes, which allows for differentiating with potential /index
     /// directories.
-    pub original_path: Vc<FileSystemPath>,
+    pub original_path: ResolvedVc<FileSystemPath>,
 }
 
 #[turbo_tasks::value_impl]
@@ -65,9 +65,9 @@ impl PagesStructureItem {
 /// folders.
 #[turbo_tasks::value]
 pub struct PagesStructure {
-    pub app: Vc<PagesStructureItem>,
-    pub document: Vc<PagesStructureItem>,
-    pub error: Vc<PagesStructureItem>,
+    pub app: ResolvedVc<PagesStructureItem>,
+    pub document: ResolvedVc<PagesStructureItem>,
+    pub error: ResolvedVc<PagesStructureItem>,
     pub api: Option<ResolvedVc<PagesDirectoryStructure>>,
     pub pages: Option<ResolvedVc<PagesDirectoryStructure>>,
 }
@@ -92,10 +92,10 @@ impl PagesStructure {
 
 #[turbo_tasks::value]
 pub struct PagesDirectoryStructure {
-    pub project_path: Vc<FileSystemPath>,
-    pub next_router_path: Vc<FileSystemPath>,
-    pub items: Vec<Vc<PagesStructureItem>>,
-    pub children: Vec<Vc<PagesDirectoryStructure>>,
+    pub project_path: ResolvedVc<FileSystemPath>,
+    pub next_router_path: ResolvedVc<FileSystemPath>,
+    pub items: Vec<ResolvedVc<PagesStructureItem>>,
+    pub children: Vec<ResolvedVc<PagesDirectoryStructure>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-core/src/pages_structure.rs
+++ b/crates/next-core/src/pages_structure.rs
@@ -232,8 +232,8 @@ async fn get_pages_structure_for_root_directory(
 
         Some(
             PagesDirectoryStructure {
-                project_path: **project_path,
-                next_router_path,
+                project_path: *project_path,
+                next_router_path: next_router_path.to_resolved().await?,
                 items: items.into_iter().map(|(_, v)| v).collect(),
                 children: children.into_iter().map(|(_, v)| v).collect(),
             }
@@ -358,8 +358,8 @@ async fn get_pages_structure_for_directory(
         children.sort_by_key(|(k, _)| *k);
 
         Ok(PagesDirectoryStructure {
-            project_path,
-            next_router_path,
+            project_path: *project_path,
+            next_router_path: next_router_path.to_resolved().await?,
             items: items.into_iter().map(|(_, v)| v).collect(),
             children: children.into_iter().map(|(_, v)| v).collect(),
         }

--- a/crates/next-core/src/pages_structure.rs
+++ b/crates/next-core/src/pages_structure.rs
@@ -28,11 +28,11 @@ pub struct PagesStructureItem {
 impl PagesStructureItem {
     #[turbo_tasks::function]
     fn new(
-        base_path: Vc<FileSystemPath>,
-        extensions: Vc<Vec<RcStr>>,
+        base_path: ResolvedVc<FileSystemPath>,
+        extensions: ResolvedVc<Vec<RcStr>>,
         fallback_path: Option<ResolvedVc<FileSystemPath>>,
-        next_router_path: Vc<FileSystemPath>,
-        original_path: Vc<FileSystemPath>,
+        next_router_path: ResolvedVc<FileSystemPath>,
+        original_path: ResolvedVc<FileSystemPath>,
     ) -> Vc<Self> {
         PagesStructureItem {
             base_path,
@@ -56,7 +56,7 @@ impl PagesStructureItem {
         if let Some(fallback_path) = self.fallback_path {
             Ok(*fallback_path)
         } else {
-            Ok(self.base_path)
+            Ok(*self.base_path)
         }
     }
 }
@@ -76,17 +76,17 @@ pub struct PagesStructure {
 impl PagesStructure {
     #[turbo_tasks::function]
     pub fn app(&self) -> Vc<PagesStructureItem> {
-        self.app
+        *self.app
     }
 
     #[turbo_tasks::function]
     pub fn document(&self) -> Vc<PagesStructureItem> {
-        self.document
+        *self.document
     }
 
     #[turbo_tasks::function]
     pub fn error(&self) -> Vc<PagesStructureItem> {
-        self.error
+        *self.error
     }
 }
 
@@ -104,7 +104,7 @@ impl PagesDirectoryStructure {
     /// system.
     #[turbo_tasks::function]
     pub fn project_path(&self) -> Vc<FileSystemPath> {
-        self.project_path
+        *self.project_path
     }
 }
 

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -456,7 +456,7 @@ pub async fn parse_config_from_source(
                                         }
                                     }
 
-                                    return config.cell();
+                                    return Ok(config.cell());
                                 } else {
                                     runtime_value_issue.emit();
                                 }
@@ -585,7 +585,7 @@ fn parse_config_from_js_value(module: Vc<Box<dyn Module>>, value: &JsValue) -> N
         );
     }
 
-    Ok(config)
+    config
 }
 
 /// Loads a next.js template, replaces `replacements` and `injections` and makes

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -317,7 +317,7 @@ async fn parse_route_matcher_from_js_value(
                 matchers.push(MiddlewareMatcherKind::Str(matcher.to_string()));
             } else {
                 emit_invalid_config_warning(
-                    ident.to_resolved().await?,
+                    ident,
                     "The matcher property must be a string or array of strings",
                     value,
                 );
@@ -353,7 +353,7 @@ async fn parse_route_matcher_from_js_value(
                     matchers.push(MiddlewareMatcherKind::Matcher(matcher));
                 } else {
                     emit_invalid_config_warning(
-                        ident.to_resolved().await?,
+                        ident,
                         "The matcher property must be a string or array of strings",
                         value,
                     );
@@ -361,7 +361,7 @@ async fn parse_route_matcher_from_js_value(
             }
         }
         _ => emit_invalid_config_warning(
-            ident.to_resolved().await?,
+            ident,
             "The matcher property must be a string or array of strings",
             value,
         ),
@@ -521,7 +521,7 @@ fn parse_config_from_js_value(
                                     }
                                 } else {
                                     emit_invalid_config_warning(
-                                        module.ident().to_resolved().await?,
+                                        module.ident(),
                                         "The runtime property must be a constant string.",
                                         value,
                                     );
@@ -549,7 +549,7 @@ fn parse_config_from_js_value(
                                                 regions.push(str.to_string().into());
                                             } else {
                                                 emit_invalid_config_warning(
-                                                    module.ident().to_resolved().await?,
+                                                    module.ident(),
                                                     "Values of the `config.regions` array need to \
                                                      static strings",
                                                     item,
@@ -560,7 +560,7 @@ fn parse_config_from_js_value(
                                     }
                                     _ => {
                                         emit_invalid_config_warning(
-                                            module.ident().to_resolved().await?,
+                                            module.ident(),
                                             "`config.regions` needs to be a static string or \
                                              array of static strings",
                                             value,
@@ -573,7 +573,7 @@ fn parse_config_from_js_value(
                         }
                     } else {
                         emit_invalid_config_warning(
-                            module.ident().to_resolved().await?,
+                            module.ident(),
                             "The exported config object must not contain non-constant strings.",
                             key,
                         );
@@ -583,7 +583,7 @@ fn parse_config_from_js_value(
         }
     } else {
         emit_invalid_config_warning(
-            module.ident().to_resolved().await?,
+            module.ident(),
             "The exported config object must be a valid object literal.",
             value,
         );

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -459,15 +459,15 @@ pub async fn parse_config_from_source(module: Vc<Box<dyn Module>>) -> Result<Vc<
                                 }
                             } else {
                                 NextSourceConfigParsingIssue {
-                                    ident: module.ident(),
+                                    ident: module.ident().to_resolved().await?,
                                     detail: StyledString::Text(
                                         "The exported segment runtime option must contain an \
                                          variable initializer."
                                             .into(),
                                     )
-                                    .cell(),
+                                    .resolved_cell(),
                                 }
-                                .cell()
+                                .resolved_cell()
                                 .emit()
                             }
                         }

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -196,8 +196,8 @@ impl ValueDefault for NextSourceConfig {
 /// An issue that occurred while parsing the page config.
 #[turbo_tasks::value(shared)]
 pub struct NextSourceConfigParsingIssue {
-    ident: Vc<AssetIdent>,
-    detail: Vc<StyledString>,
+    ident: ResolvedVc<AssetIdent>,
+    detail: ResolvedVc<StyledString>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -375,7 +375,9 @@ fn parse_route_matcher_from_js_value(
 }
 
 #[turbo_tasks::function]
-pub async fn parse_config_from_source(module: ResolvedVc<Box<dyn Module>>) -> Vc<NextSourceConfig> {
+pub async fn parse_config_from_source(
+    module: ResolvedVc<Box<dyn Module>>,
+) -> Result<Vc<NextSourceConfig>> {
     if let Some(ecmascript_asset) =
         ResolvedVc::try_sidecast::<Box<dyn EcmascriptParsable>>(module).await?
     {
@@ -404,7 +406,7 @@ pub async fn parse_config_from_source(module: ResolvedVc<Box<dyn Module>>) -> Vc
                             if let Some(init) = decl.init.as_ref() {
                                 return GLOBALS.set(globals, || {
                                     let value = eval_context.eval(init);
-                                    parse_config_from_js_value(*module, &value).cell()
+                                    Ok(parse_config_from_js_value(*module, &value).cell())
                                 });
                             } else {
                                 NextSourceConfigParsingIssue {
@@ -454,7 +456,7 @@ pub async fn parse_config_from_source(module: ResolvedVc<Box<dyn Module>>) -> Vc
                                         }
                                     }
 
-                                    return Ok(config.cell());
+                                    return config.cell();
                                 } else {
                                     runtime_value_issue.emit();
                                 }

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -196,7 +196,7 @@ impl ValueDefault for NextSourceConfig {
 /// An issue that occurred while parsing the page config.
 #[turbo_tasks::value(shared)]
 pub struct NextSourceConfigParsingIssue {
-    ident: ResolvedVc<AssetIdent>,
+    ident: Vc<AssetIdent>,
     detail: ResolvedVc<StyledString>,
 }
 
@@ -240,7 +240,7 @@ impl Issue for NextSourceConfigParsingIssue {
     }
 }
 
-fn emit_invalid_config_warning(ident: ResolvedVc<AssetIdent>, detail: &str, value: &JsValue) {
+fn emit_invalid_config_warning(ident: Vc<AssetIdent>, detail: &str, value: &JsValue) {
     let (explainer, hints) = value.explain(2, 0);
     NextSourceConfigParsingIssue {
         ident,
@@ -482,8 +482,8 @@ pub async fn parse_config_from_source(
     Ok(Default::default())
 }
 
-async fn parse_config_from_js_value(
-    module: ResolvedVc<Box<dyn Module>>,
+fn parse_config_from_js_value(
+    module: Vc<Box<dyn Module>>,
     value: &JsValue,
 ) -> Result<NextSourceConfig> {
     let mut config = NextSourceConfig::default();
@@ -492,7 +492,7 @@ async fn parse_config_from_js_value(
         for part in parts {
             match part {
                 ObjectPart::Spread(_) => emit_invalid_config_warning(
-                    module.ident().to_resolved().await?,
+                    module.ident(),
                     "Spread properties are not supported in the config export.",
                     value,
                 ),
@@ -511,7 +511,7 @@ async fn parse_config_from_js_value(
                                             }
                                             _ => {
                                                 emit_invalid_config_warning(
-                                                    module.ident().to_resolved().await?,
+                                                    module.ident(),
                                                     "The runtime property must be either \
                                                      \"nodejs\" or \"edge\".",
                                                     value,

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -367,11 +367,11 @@ async fn parse_route_matcher_from_js_value(
         ),
     }
 
-    if matchers.is_empty() {
+    Ok(if matchers.is_empty() {
         None
     } else {
         Some(matchers)
-    }
+    })
 }
 
 #[turbo_tasks::function]
@@ -379,7 +379,7 @@ pub async fn parse_config_from_source(
     module: ResolvedVc<Box<dyn Module>>,
 ) -> Result<Vc<NextSourceConfig>> {
     if let Some(ecmascript_asset) =
-        Vc::try_resolve_sidecast::<Box<dyn EcmascriptParsable>>(module).await?
+        ResolvedVc::try_sidecast::<Box<dyn EcmascriptParsable>>(module).await?
     {
         if let ParseResult::Ok {
             program: Program::Module(module_ast),

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -406,7 +406,7 @@ pub async fn parse_config_from_source(
                             if let Some(init) = decl.init.as_ref() {
                                 return GLOBALS.set(globals, || {
                                     let value = eval_context.eval(init);
-                                    Ok(parse_config_from_js_value(module, &value).cell())
+                                    parse_config_from_js_value(module, &value).cell()
                                 });
                             } else {
                                 NextSourceConfigParsingIssue {


### PR DESCRIPTION
### What?

Use `ResolvedVc<T>` instead of `Vc<T>` for struct fields in `next-core`

### Why?

### How?


Closes PACK-3568