### PR TITLE
Report tests to Datadog from Job that executed them

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -615,47 +615,6 @@ jobs:
       stepName: 'test-ppr-prod-${{ matrix.group }}'
     secrets: inherit
 
-  report-test-results-to-datadog:
-    needs:
-      [
-        'changes',
-        'test-unit',
-        'test-dev',
-        'test-prod',
-        'test-integration',
-        'test-ppr-dev',
-        'test-ppr-prod',
-        'test-ppr-integration',
-        'test-turbopack-dev',
-        'test-turbopack-integration',
-        'test-turbopack-production',
-        'test-turbopack-production-integration',
-      ]
-    if: ${{ always() && needs.changes.outputs.docs-only == 'false' && !github.event.pull_request.head.repo.fork }}
-
-    runs-on: ubuntu-latest
-    name: report test results to datadog
-    steps:
-      - name: Download test report artifacts
-        id: download-test-reports
-        uses: actions/download-artifact@v4
-        with:
-          pattern: test-reports-*
-          path: test
-          merge-multiple: true
-
-      - name: Upload test report to datadog
-        run: |
-          if [ -d ./test/test-junit-report ]; then
-            # Add a `test.type` tag to distinguish between turbopack and next.js runs
-            DD_ENV=ci npx @datadog/datadog-ci@2.23.1 junit upload --tags test.type:nextjs --service nextjs ./test/test-junit-report
-          fi
-
-          if [ -d ./test/turbopack-test-junit-report ]; then
-            # Add a `test.type` tag to distinguish between turbopack and next.js runs
-            DD_ENV=ci npx @datadog/datadog-ci@2.23.1 junit upload --tags test.type:turbopack --service nextjs ./test/turbopack-test-junit-report
-          fi
-
   tests-pass:
     needs:
       [

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -243,19 +243,27 @@ jobs:
           name: webpack bundle analysis stats-${{ steps.var.outputs.input_step_key }}
           path: packages/next/dist/compiled/next-server/report.*.html
 
-      - name: Upload test report artifacts
-        uses: actions/upload-artifact@v4
+      - name: Upload test report to datadog
         if: ${{ inputs.afterBuild && always() }}
-        with:
-          name: test-reports-${{ steps.var.outputs.input_step_key }}
-          path: |
-            test/test-junit-report
-            test/turbopack-test-junit-report
-            test/rspack-test-junit-report
-          if-no-files-found: ignore
+        env:
+          # Only available information in test execution that helps identify the job this was ran in.
+          DD_TEST_SESSION_NAME: ${{ inputs.stepName }}
+        run: |
+          # Add a `test.type` tag to distinguish between turbopack and next.js runs
+          if [ -d ./test/test-junit-report ]; then
+            npx @datadog/datadog-ci@2.45.1 junit upload \
+              --service nextjs \
+              --tags test.type:nextjs \
+              ./test/test-junit-report
+          fi
+          if [ -d ./test/turbopack-test-junit-report ]; then
+            npx @datadog/datadog-ci@2.45.1 junit upload \
+              --service nextjs \
+              --tags test.type:turbopack \
+              ./test/turbopack-test-junit-report
+          fi
 
-      # upload playwright snapshots from failed tests
-      - name: Upload test report artifacts
+      - name: Upload Playwright Snapshots
         uses: actions/upload-artifact@v4
         if: ${{ inputs.afterBuild && always() }}
         with:

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -252,14 +252,14 @@ jobs:
             npx @datadog/datadog-ci@2.45.1 junit upload \
               --service nextjs \
               --tags test.type:nextjs \
-              --tags nextjs.test_session.name:"${{ inputs.stepName }}" \
+              --tags test_session.name:"${{ inputs.stepName }}" \
               ./test/test-junit-report
           fi
           if [ -d ./test/turbopack-test-junit-report ]; then
             npx @datadog/datadog-ci@2.45.1 junit upload \
               --service nextjs \
               --tags test.type:turbopack \
-              --tags nextsj.test_session.name:"${{ inputs.stepName }}" \
+              --tags test_session.name:"${{ inputs.stepName }}" \
               ./test/turbopack-test-junit-report
           fi
 

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -249,17 +249,20 @@ jobs:
           # Only available information in test execution that helps identify the job this was ran in.
           DD_TEST_SESSION_NAME: ${{ inputs.stepName }}
         run: |
+          echo "DD_TEST_SESSION_NAME= '$DD_TEST_SESSION_NAME'"
           # Add a `test.type` tag to distinguish between turbopack and next.js runs
           if [ -d ./test/test-junit-report ]; then
             npx @datadog/datadog-ci@2.45.1 junit upload \
               --service nextjs \
               --tags test.type:nextjs \
+              --tags nexts.test_session_name:"$DD_TEST_SESSION_NAME" \
               ./test/test-junit-report
           fi
           if [ -d ./test/turbopack-test-junit-report ]; then
             npx @datadog/datadog-ci@2.45.1 junit upload \
               --service nextjs \
               --tags test.type:turbopack \
+              --tags nexts.test_session_name:"$DD_TEST_SESSION_NAME" \
               ./test/turbopack-test-junit-report
           fi
 

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -245,24 +245,21 @@ jobs:
 
       - name: Upload test report to datadog
         if: ${{ inputs.afterBuild && always() }}
-        env:
-          # Only available information in test execution that helps identify the job this was ran in.
-          DD_TEST_SESSION_NAME: ${{ inputs.stepName }}
         run: |
-          echo "DD_TEST_SESSION_NAME= '$DD_TEST_SESSION_NAME'"
           # Add a `test.type` tag to distinguish between turbopack and next.js runs
+          # Add a `nextjs.test_session.name` tag to help identify the job
           if [ -d ./test/test-junit-report ]; then
             npx @datadog/datadog-ci@2.45.1 junit upload \
               --service nextjs \
               --tags test.type:nextjs \
-              --tags nexts.test_session_name:"$DD_TEST_SESSION_NAME" \
+              --tags nextjs.test_session.name:"${{ inputs.stepName }}" \
               ./test/test-junit-report
           fi
           if [ -d ./test/turbopack-test-junit-report ]; then
             npx @datadog/datadog-ci@2.45.1 junit upload \
               --service nextjs \
               --tags test.type:turbopack \
-              --tags nexts.test_session_name:"$DD_TEST_SESSION_NAME" \
+              --tags nextsj.test_session.name:"${{ inputs.stepName }}" \
               ./test/turbopack-test-junit-report
           fi
 


### PR DESCRIPTION
TL;DR
```diff
-@test_session.name:report-test-results-to-datadog-datadog-ci junit upload
+@test_session.name:test-prod-react--4/7
```

Previously, each test run was associated with a separate Job that is responsible for uploading all reports.
This makes it harder to understand under which configuration a specific test failed.
Now we immediately upload test results from the respective job meaning a test run in Datadog can be associated with the actual CI job that ran it and therefore it's config (Turbopack vs Webpack, PPR vs no PPR, React 18 vs 19)

This increases feedback time slightly by up to 1 minute (the slowest single upload time).
I'd say this is an acceptable tradeoff given our current CI times.

This reduces the time until a "Retry failed jobs" is avaiable since we no longer need to pass the test results between jobs.
 
Tried setting `DD_GITHUB_JOB_NAME` and `DD_TEST_SESSION_NAME` without success: https://github.com/DataDog/datadog-ci/issues/1497

Before:
![CleanShot 2025-02-18 at 21 21 31](https://github.com/user-attachments/assets/90a01e56-7878-4530-a6b1-09e00497bc7d)


-- https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.branch%3A%22mischnic%2Fasync-info-module-graph%22&agg_m=count&agg_m_source=base&agg_t=count&cols=%40test.status%2C%40test_session.name%2C%40test.name%2C%40test.source.file%2C%40test.service%2C%40test.type%2C%40ci.pipeline.name%2C%40duration&currentTab=overview&eventStack=&fromUser=true&graphType=flamegraph&index=citest&start=1739305301799&end=1739910101799&paused=true

After:
![CleanShot 2025-02-18 at 23 13 01](https://github.com/user-attachments/assets/9b899c69-26d0-4d79-8db5-7ac2a1dfd1a5)


-- https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40ci.job.url%3A%22https%3A%2F%2Fgithub.com%2Fvercel%2Fnext.js%2Fcommit%2Fe785d486b106c745a89caa72188ef0446f87c1f1%2Fchecks%22&agg_m=count&agg_m_source=base&agg_t=count&cols=%40test_session.name%2C%40test.status%2C%40test.name%2C%40test.source.file%2C%40test.service%2C%40test.type%2C%40ci.pipeline.name%2C%40duration&currentTab=overview&eventStack=&fromUser=true&graphType=flamegraph&index=citest&start=1739311985833&end=1739916785833&paused=true