### PR TITLE
perf(turbopack): Use `ResolvedVc` for `next-api`

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -527,14 +527,14 @@ impl NapiRoute {
             } => NapiRoute {
                 pathname,
                 r#type: "page",
-                html_endpoint: convert_endpoint(html_endpoint),
-                data_endpoint: convert_endpoint(data_endpoint),
+                html_endpoint: convert_endpoint(*html_endpoint),
+                data_endpoint: convert_endpoint(*data_endpoint),
                 ..Default::default()
             },
             Route::PageApi { endpoint } => NapiRoute {
                 pathname,
                 r#type: "page-api",
-                endpoint: convert_endpoint(endpoint),
+                endpoint: convert_endpoint(*endpoint),
                 ..Default::default()
             },
             Route::AppPage(pages) => NapiRoute {
@@ -545,8 +545,8 @@ impl NapiRoute {
                         .into_iter()
                         .map(|page_route| AppPageNapiRoute {
                             original_name: Some(page_route.original_name),
-                            html_endpoint: convert_endpoint(page_route.html_endpoint),
-                            rsc_endpoint: convert_endpoint(page_route.rsc_endpoint),
+                            html_endpoint: convert_endpoint(*page_route.html_endpoint),
+                            rsc_endpoint: convert_endpoint(*page_route.rsc_endpoint),
                         })
                         .collect(),
                 ),
@@ -559,7 +559,7 @@ impl NapiRoute {
                 pathname,
                 original_name: Some(original_name),
                 r#type: "app-route",
-                endpoint: convert_endpoint(endpoint),
+                endpoint: convert_endpoint(*endpoint),
                 ..Default::default()
             },
             Route::Conflict => NapiRoute {
@@ -696,15 +696,15 @@ pub fn project_entrypoints_subscribe(
                         .transpose()?,
                     pages_document_endpoint: External::new(ExternalEndpoint(VcArc::new(
                         turbo_tasks.clone(),
-                        entrypoints.pages_document_endpoint,
+                        *entrypoints.pages_document_endpoint,
                     ))),
                     pages_app_endpoint: External::new(ExternalEndpoint(VcArc::new(
                         turbo_tasks.clone(),
-                        entrypoints.pages_app_endpoint,
+                        *entrypoints.pages_app_endpoint,
                     ))),
                     pages_error_endpoint: External::new(ExternalEndpoint(VcArc::new(
                         turbo_tasks.clone(),
-                        entrypoints.pages_error_endpoint,
+                        *entrypoints.pages_error_endpoint,
                     ))),
                 },
                 issues: issues

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1336,8 +1336,10 @@ impl AppEndpoint {
 
                 AppEndpointOutput::Edge {
                     files: *app_entry_chunks,
-                    server_assets: Vc::cell(server_assets.iter().cloned().collect::<Vec<_>>()),
-                    client_assets,
+                    server_assets: ResolvedVc::cell(
+                        server_assets.iter().cloned().collect::<Vec<_>>(),
+                    ),
+                    client_assets: client_assets.to_resolved().await?,
                 }
             }
             NextRuntime::NodeJs => {

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -978,7 +978,7 @@ impl AppEndpoint {
                                 .iter()
                                 .map(|(k, v)| (*k, v.clone())),
                         );
-                        visited_modules = result.visited_modules;
+                        visited_modules = *result.visited_modules;
                     }
 
                     client_dynamic_imports

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1461,11 +1461,14 @@ impl AppEndpoint {
                 {
                     let _span = tracing::info_span!("Server Components");
                     Vc::cell((
-                        chunking_context.evaluated_chunk_group_assets(
-                            app_entry.rsc_entry.ident(),
-                            Vc::cell(evaluatable_assets.clone()),
-                            Value::new(AvailabilityInfo::Root),
-                        ),
+                        chunking_context
+                            .evaluated_chunk_group_assets(
+                                app_entry.rsc_entry.ident(),
+                                Vc::cell(evaluatable_assets.clone()),
+                                Value::new(AvailabilityInfo::Root),
+                            )
+                            .to_resolved()
+                            .await?,
                         AvailabilityInfo::Untracked,
                     ))
                 }

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1648,7 +1648,6 @@ impl Endpoint for AppEndpoint {
             {
                 let node_root = this.app_project.project().node_root();
                 let server_paths = all_server_paths(*output_assets, node_root)
-                    .to_resolved()
                     .await?
                     .clone_value();
 

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -694,7 +694,7 @@ pub async fn app_entry_point_to_route(
                             app_project,
                             page,
                         }
-                        .cell(),
+                        .resolved_cell(),
                     ),
                 })
                 .collect(),

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -93,7 +93,7 @@ pub struct AppProject {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct OptionAppProject(Option<Vc<AppProject>>);
+pub struct OptionAppProject(Option<ResolvedVc<AppProject>>);
 
 impl AppProject {}
 
@@ -743,7 +743,7 @@ fn server_utils_modifier() -> Vc<RcStr> {
 }
 
 #[turbo_tasks::value(transparent)]
-struct OutputAssetsWithAvailability((Vc<OutputAssets>, AvailabilityInfo));
+struct OutputAssetsWithAvailability((ResolvedVc<OutputAssets>, AvailabilityInfo));
 
 #[derive(Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Debug, TraceRawVcs)]
 enum AppPageEndpointType {
@@ -769,7 +769,7 @@ enum AppEndpointType {
 #[turbo_tasks::value]
 struct AppEndpoint {
     ty: AppEndpointType,
-    app_project: Vc<AppProject>,
+    app_project: ResolvedVc<AppProject>,
     page: AppPage,
 }
 
@@ -1708,13 +1708,13 @@ impl Endpoint for AppEndpoint {
 enum AppEndpointOutput {
     NodeJs {
         rsc_chunk: ResolvedVc<Box<dyn OutputAsset>>,
-        server_assets: Vc<OutputAssets>,
-        client_assets: Vc<OutputAssets>,
+        server_assets: ResolvedVc<OutputAssets>,
+        client_assets: ResolvedVc<OutputAssets>,
     },
     Edge {
-        files: Vc<OutputAssets>,
-        server_assets: Vc<OutputAssets>,
-        client_assets: Vc<OutputAssets>,
+        files: ResolvedVc<OutputAssets>,
+        server_assets: ResolvedVc<OutputAssets>,
+        client_assets: ResolvedVc<OutputAssets>,
     },
 }
 

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1628,7 +1628,7 @@ impl Endpoint for AppEndpoint {
             let output = self.output().await?;
             // Must use self.output_assets() instead of output.output_assets() to make it a
             // single operation
-            let output_assets = self.output_assets();
+            let output_assets = self.output_assets().to_resolved().await?;
 
             let node_root = this.app_project.project().node_root();
 
@@ -1647,12 +1647,13 @@ impl Endpoint for AppEndpoint {
                 .is_development()
             {
                 let node_root = this.app_project.project().node_root();
-                let server_paths = all_server_paths(output_assets, node_root)
+                let server_paths = all_server_paths(*output_assets, node_root)
+                    .to_resolved()
                     .await?
                     .clone_value();
 
                 let client_relative_root = this.app_project.project().client_relative_path();
-                let client_paths = all_paths_in_root(output_assets, client_relative_root)
+                let client_paths = all_paths_in_root(*output_assets, client_relative_root)
                     .into_future()
                     .instrument(tracing::info_span!("client_paths"))
                     .await?

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -674,24 +674,24 @@ pub async fn app_entry_point_to_route(
                 .into_iter()
                 .map(|page| AppPageRoute {
                     original_name: page.to_string(),
-                    html_endpoint: Vc::upcast(
+                    html_endpoint: ResolvedVc::upcast(
                         AppEndpoint {
                             ty: AppEndpointType::Page {
                                 ty: AppPageEndpointType::Html,
                                 loader_tree: *loader_tree,
                             },
-                            app_project: app_project.to_resolved().await?,
+                            app_project,
                             page: page.clone(),
                         }
-                        .cell(),
+                        .resolved_cell(),
                     ),
-                    rsc_endpoint: Vc::upcast(
+                    rsc_endpoint: ResolvedVc::upcast(
                         AppEndpoint {
                             ty: AppEndpointType::Page {
                                 ty: AppPageEndpointType::Rsc,
                                 loader_tree: *loader_tree,
                             },
-                            app_project: app_project.to_resolved().await?,
+                            app_project,
                             page,
                         }
                         .cell(),
@@ -705,27 +705,27 @@ pub async fn app_entry_point_to_route(
             root_layouts,
         } => Route::AppRoute {
             original_name: page.to_string(),
-            endpoint: Vc::upcast(
+            endpoint: ResolvedVc::upcast(
                 AppEndpoint {
                     ty: AppEndpointType::Route {
                         path: *path,
                         root_layouts: *root_layouts,
                     },
-                    app_project: app_project.to_resolved().await?,
+                    app_project,
                     page,
                 }
-                .cell(),
+                .resolved_cell(),
             ),
         },
         AppEntrypoint::AppMetadata { page, metadata } => Route::AppRoute {
             original_name: page.to_string(),
-            endpoint: Vc::upcast(
+            endpoint: ResolvedVc::upcast(
                 AppEndpoint {
                     ty: AppEndpointType::Metadata { metadata },
-                    app_project: app_project.to_resolved().await?,
+                    app_project,
                     page,
                 }
-                .cell(),
+                .resolved_cell(),
             ),
         },
     }
@@ -769,7 +769,7 @@ enum AppEndpointType {
 #[turbo_tasks::value]
 struct AppEndpoint {
     ty: AppEndpointType,
-    app_project: ResolvedVc<AppProject>,
+    app_project: Vc<AppProject>,
     page: AppPage,
 }
 
@@ -1566,7 +1566,7 @@ impl AppEndpoint {
                 }
                 .instrument(tracing::trace_span!("server node entrypoint"))
                 .await?);
-                Vc::cell((Vc::cell(vec![rsc_chunk]), availability_info))
+                Vc::cell((ResolvedVc::cell(vec![rsc_chunk]), availability_info))
             }
         })
     }

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -664,11 +664,11 @@ impl AppProject {
 }
 
 #[turbo_tasks::function]
-pub fn app_entry_point_to_route(
+pub async fn app_entry_point_to_route(
     app_project: Vc<AppProject>,
     entrypoint: AppEntrypoint,
-) -> Vc<Route> {
-    match entrypoint {
+) -> Result<Vc<Route>> {
+    Ok(match entrypoint {
         AppEntrypoint::AppPage { pages, loader_tree } => Route::AppPage(
             pages
                 .into_iter()
@@ -680,7 +680,7 @@ pub fn app_entry_point_to_route(
                                 ty: AppPageEndpointType::Html,
                                 loader_tree: *loader_tree,
                             },
-                            app_project,
+                            app_project: app_project.to_resolved().await?,
                             page: page.clone(),
                         }
                         .cell(),
@@ -691,7 +691,7 @@ pub fn app_entry_point_to_route(
                                 ty: AppPageEndpointType::Rsc,
                                 loader_tree: *loader_tree,
                             },
-                            app_project,
+                            app_project: app_project.to_resolved().await?,
                             page,
                         }
                         .cell(),
@@ -711,7 +711,7 @@ pub fn app_entry_point_to_route(
                         path: *path,
                         root_layouts: *root_layouts,
                     },
-                    app_project,
+                    app_project: app_project.to_resolved().await?,
                     page,
                 }
                 .cell(),
@@ -722,14 +722,14 @@ pub fn app_entry_point_to_route(
             endpoint: Vc::upcast(
                 AppEndpoint {
                     ty: AppEndpointType::Metadata { metadata },
-                    app_project,
+                    app_project: app_project.to_resolved().await?,
                     page,
                 }
                 .cell(),
             ),
         },
     }
-    .cell()
+    .cell())
 }
 
 #[turbo_tasks::function]
@@ -1737,7 +1737,7 @@ impl AppEndpointOutput {
     pub fn server_assets(&self) -> Vc<OutputAssets> {
         match *self {
             AppEndpointOutput::NodeJs { server_assets, .. }
-            | AppEndpointOutput::Edge { server_assets, .. } => server_assets,
+            | AppEndpointOutput::Edge { server_assets, .. } => *server_assets,
         }
     }
 
@@ -1745,7 +1745,7 @@ impl AppEndpointOutput {
     pub fn client_assets(&self) -> Vc<OutputAssets> {
         match *self {
             AppEndpointOutput::NodeJs { client_assets, .. }
-            | AppEndpointOutput::Edge { client_assets, .. } => client_assets,
+            | AppEndpointOutput::Edge { client_assets, .. } => *client_assets,
         }
     }
 }

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1160,7 +1160,7 @@ impl AppEndpoint {
         let (app_entry_chunks, app_entry_chunks_availability) = &*self
             .app_entry_chunks(
                 client_references,
-                server_action_manifest_loader,
+                server_action_manifest_loader.map(|v| *v),
                 server_path,
                 process_client_assets,
             )

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1183,7 +1183,7 @@ impl AppEndpoint {
                     app_entry.original_name.clone(),
                     client_references,
                     client_references_chunks,
-                    *app_entry_chunks,
+                    **app_entry_chunks,
                     Value::new(*app_entry_chunks_availability),
                     client_chunking_context,
                     ssr_chunking_context,

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1413,8 +1413,10 @@ impl AppEndpoint {
 
                 AppEndpointOutput::NodeJs {
                     rsc_chunk,
-                    server_assets: Vc::cell(server_assets.iter().cloned().collect::<Vec<_>>()),
-                    client_assets,
+                    server_assets: ResolvedVc::cell(
+                        server_assets.iter().cloned().collect::<Vec<_>>(),
+                    ),
+                    client_assets: client_assets.to_resolved().await?,
                 }
             }
         }

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1236,7 +1236,7 @@ impl AppEndpoint {
                 file_paths_from_root
                     .extend(get_js_paths_from_root(&node_root_value, &app_entry_chunks_ref).await?);
 
-                let all_output_assets = all_assets_from_entries(*app_entry_chunks).await?;
+                let all_output_assets = all_assets_from_entries(**app_entry_chunks).await?;
 
                 wasm_paths_from_root
                     .extend(get_wasm_paths_from_root(&node_root_value, &middleware_assets).await?);

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -106,7 +106,7 @@ pub(crate) async fn collect_evaluated_chunk_group(
 #[turbo_tasks::value(shared)]
 pub struct NextDynamicImportsResult {
     pub client_dynamic_imports: FxIndexMap<ResolvedVc<Box<dyn Module>>, DynamicImportedModules>,
-    pub visited_modules: Vc<VisitedDynamicImportModules>,
+    pub visited_modules: ResolvedVc<VisitedDynamicImportModules>,
 }
 
 #[turbo_tasks::value(shared)]
@@ -430,7 +430,7 @@ pub struct DynamicImportsMap(pub (ResolvedVc<Box<dyn Module>>, DynamicImportedMo
 
 /// An Option wrapper around [DynamicImportsMap].
 #[turbo_tasks::value(transparent)]
-pub struct OptionDynamicImportsMap(Option<Vc<DynamicImportsMap>>);
+pub struct OptionDynamicImportsMap(Option<ResolvedVc<DynamicImportsMap>>);
 
 #[turbo_tasks::value(transparent)]
 pub struct DynamicImportedChunks(

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -421,7 +421,7 @@ impl Visit for CollectImportSourceVisitor {
 }
 
 pub type DynamicImportedModules = Vec<(RcStr, ResolvedVc<Box<dyn Module>>)>;
-pub type DynamicImportedOutputAssets = Vec<(RcStr, Vc<OutputAssets>)>;
+pub type DynamicImportedOutputAssets = Vec<(RcStr, ResolvedVc<OutputAssets>)>;
 
 /// A struct contains mapping for the dynamic imports to construct chunk per
 /// each individual module (Origin Module, Vec<(ImportSourceString, Module)>)

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -338,7 +338,10 @@ async fn build_dynamic_imports_map_for_module(
         }
     }
 
-    Ok(Vc::cell(Some(Vc::cell((server_module, import_sources)))))
+    Ok(Vc::cell(Some(ResolvedVc::cell((
+        server_module,
+        import_sources,
+    )))))
 }
 
 /// A visitor to check if there's import to `next/dynamic`, then collecting the

--- a/crates/next-api/src/entrypoints.rs
+++ b/crates/next-api/src/entrypoints.rs
@@ -1,5 +1,5 @@
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, Vc};
+use turbo_tasks::{FxIndexMap, ResolvedVc};
 
 use crate::{
     project::{Instrumentation, Middleware},

--- a/crates/next-api/src/entrypoints.rs
+++ b/crates/next-api/src/entrypoints.rs
@@ -11,7 +11,7 @@ pub struct Entrypoints {
     pub routes: FxIndexMap<RcStr, Route>,
     pub middleware: Option<Middleware>,
     pub instrumentation: Option<Instrumentation>,
-    pub pages_document_endpoint: Vc<Box<dyn Endpoint>>,
-    pub pages_app_endpoint: Vc<Box<dyn Endpoint>>,
-    pub pages_error_endpoint: Vc<Box<dyn Endpoint>>,
+    pub pages_document_endpoint: ResolvedVc<Box<dyn Endpoint>>,
+    pub pages_app_endpoint: ResolvedVc<Box<dyn Endpoint>>,
+    pub pages_error_endpoint: ResolvedVc<Box<dyn Endpoint>>,
 }

--- a/crates/next-api/src/global_module_id_strategy.rs
+++ b/crates/next-api/src/global_module_id_strategy.rs
@@ -26,9 +26,9 @@ impl GlobalModuleIdStrategyBuilder {
 
         let entrypoints = project.entrypoints().await?;
 
-        preprocessed_module_ids.push(preprocess_module_ids(entrypoints.pages_error_endpoint));
-        preprocessed_module_ids.push(preprocess_module_ids(entrypoints.pages_app_endpoint));
-        preprocessed_module_ids.push(preprocess_module_ids(entrypoints.pages_document_endpoint));
+        preprocessed_module_ids.push(preprocess_module_ids(*entrypoints.pages_error_endpoint));
+        preprocessed_module_ids.push(preprocess_module_ids(*entrypoints.pages_app_endpoint));
+        preprocessed_module_ids.push(preprocess_module_ids(*entrypoints.pages_document_endpoint));
 
         if let Some(middleware) = &entrypoints.middleware {
             preprocessed_module_ids.push(preprocess_module_ids(middleware.endpoint));

--- a/crates/next-api/src/global_module_id_strategy.rs
+++ b/crates/next-api/src/global_module_id_strategy.rs
@@ -47,18 +47,18 @@ impl GlobalModuleIdStrategyBuilder {
                     html_endpoint,
                     data_endpoint,
                 } => {
-                    preprocessed_module_ids.push(preprocess_module_ids(*html_endpoint));
-                    preprocessed_module_ids.push(preprocess_module_ids(*data_endpoint));
+                    preprocessed_module_ids.push(preprocess_module_ids(**html_endpoint));
+                    preprocessed_module_ids.push(preprocess_module_ids(**data_endpoint));
                 }
                 Route::PageApi { endpoint } => {
-                    preprocessed_module_ids.push(preprocess_module_ids(*endpoint));
+                    preprocessed_module_ids.push(preprocess_module_ids(**endpoint));
                 }
                 Route::AppPage(page_routes) => {
                     for page_route in page_routes {
                         preprocessed_module_ids
-                            .push(preprocess_module_ids(page_route.html_endpoint));
+                            .push(preprocess_module_ids(*page_route.html_endpoint));
                         preprocessed_module_ids
-                            .push(preprocess_module_ids(page_route.rsc_endpoint));
+                            .push(preprocess_module_ids(*page_route.rsc_endpoint));
                     }
                 }
                 Route::AppRoute {

--- a/crates/next-api/src/global_module_id_strategy.rs
+++ b/crates/next-api/src/global_module_id_strategy.rs
@@ -65,7 +65,7 @@ impl GlobalModuleIdStrategyBuilder {
                     original_name: _,
                     endpoint,
                 } => {
-                    preprocessed_module_ids.push(preprocess_module_ids(*endpoint));
+                    preprocessed_module_ids.push(preprocess_module_ids(**endpoint));
                 }
                 Route::Conflict => {
                     tracing::info!("WARN: conflict");

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -248,15 +248,13 @@ impl Endpoint for InstrumentationEndpoint {
         let span = tracing::info_span!("instrumentation endpoint");
         async move {
             let this = self.await?;
-            let output_assets = self.output_assets();
+            let output_assets = self.output_assets().to_resolved().await?;
             let _ = output_assets.resolve().await?;
-            let _ = this
-                .project
-                .emit_all_output_assets(ResolvedVc::cell(output_assets));
+            let _ = this.project.emit_all_output_assets(Vc::cell(output_assets));
 
             let server_paths = if this.project.next_mode().await?.is_development() {
                 let node_root = this.project.node_root();
-                all_server_paths(output_assets, node_root)
+                all_server_paths(*output_assets, node_root)
                     .await?
                     .clone_value()
             } else {

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -79,7 +79,7 @@ impl InstrumentationEndpoint {
             .await?;
 
         let edge_entry_module = wrap_edge_entry(
-            self.asset_context,
+            *self.asset_context,
             self.project.project_path(),
             *userland_module,
             "instrumentation".into(),
@@ -117,7 +117,7 @@ impl InstrumentationEndpoint {
             }),
             this.project.next_mode(),
         )
-        .resolve_entries(this.asset_context)
+        .resolve_entries(*this.asset_context)
         .await?
         .clone_value();
 
@@ -169,7 +169,7 @@ impl InstrumentationEndpoint {
                     }),
                     this.project.next_mode(),
                 )
-                .resolve_entries(this.asset_context),
+                .resolve_entries(*this.asset_context),
                 OutputAssets::empty(),
                 Value::new(AvailabilityInfo::Root),
             )
@@ -225,7 +225,7 @@ impl InstrumentationEndpoint {
             let mut output_assets = vec![chunk];
             if this.project.next_mode().await?.is_production() {
                 output_assets.push(ResolvedVc::upcast(
-                    NftJsonAsset::new(this.project, *chunk, vec![])
+                    NftJsonAsset::new(*this.project, *chunk, vec![])
                         .to_resolved()
                         .await?,
                 ));
@@ -250,7 +250,9 @@ impl Endpoint for InstrumentationEndpoint {
             let this = self.await?;
             let output_assets = self.output_assets();
             let _ = output_assets.resolve().await?;
-            let _ = this.project.emit_all_output_assets(Vc::cell(output_assets));
+            let _ = this
+                .project
+                .emit_all_output_assets(ResolvedVc::cell(output_assets));
 
             let server_paths = if this.project.next_mode().await?.is_development() {
                 let node_root = this.project.node_root();

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -35,9 +35,9 @@ use crate::{
 
 #[turbo_tasks::value]
 pub struct InstrumentationEndpoint {
-    project: Vc<Project>,
-    asset_context: Vc<Box<dyn AssetContext>>,
-    source: Vc<Box<dyn Source>>,
+    project: ResolvedVc<Project>,
+    asset_context: ResolvedVc<Box<dyn AssetContext>>,
+    source: ResolvedVc<Box<dyn Source>>,
     is_edge: bool,
 
     app_dir: Option<ResolvedVc<FileSystemPath>>,

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -48,9 +48,9 @@ pub struct InstrumentationEndpoint {
 impl InstrumentationEndpoint {
     #[turbo_tasks::function]
     pub fn new(
-        project: Vc<Project>,
-        asset_context: Vc<Box<dyn AssetContext>>,
-        source: Vc<Box<dyn Source>>,
+        project: ResolvedVc<Project>,
+        asset_context: ResolvedVc<Box<dyn AssetContext>>,
+        source: ResolvedVc<Box<dyn Source>>,
         is_edge: bool,
         app_dir: Option<ResolvedVc<FileSystemPath>>,
         ecmascript_client_reference_transition_name: Option<Vc<RcStr>>,
@@ -71,7 +71,7 @@ impl InstrumentationEndpoint {
         let userland_module = self
             .asset_context
             .process(
-                self.source,
+                *self.source,
                 Value::new(ReferenceType::Entry(EntryReferenceSubType::Instrumentation)),
             )
             .module()

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -36,9 +36,9 @@ use crate::{
 
 #[turbo_tasks::value]
 pub struct MiddlewareEndpoint {
-    project: Vc<Project>,
-    asset_context: Vc<Box<dyn AssetContext>>,
-    source: Vc<Box<dyn Source>>,
+    project: ResolvedVc<Project>,
+    asset_context: ResolvedVc<Box<dyn AssetContext>>,
+    source: ResolvedVc<Box<dyn Source>>,
     app_dir: Option<ResolvedVc<FileSystemPath>>,
     ecmascript_client_reference_transition_name: Option<ResolvedVc<RcStr>>,
 }

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -275,7 +275,7 @@ impl Endpoint for MiddlewareEndpoint {
         let span = tracing::info_span!("middleware endpoint");
         async move {
             let this = self.await?;
-            let output_assets = self.output_assets();
+            let output_assets = self.output_assets().to_resolved().await?;
             let _ = output_assets.resolve().await?;
             let _ = this.project.emit_all_output_assets(Vc::cell(output_assets));
 

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -68,19 +68,19 @@ impl MiddlewareEndpoint {
         let userland_module = self
             .asset_context
             .process(
-                self.source,
+                *self.source,
                 Value::new(ReferenceType::Entry(EntryReferenceSubType::Middleware)),
             )
             .module();
 
         let module = get_middleware_module(
-            self.asset_context,
+            *self.asset_context,
             self.project.project_path(),
             userland_module,
         );
 
         let module = wrap_edge_entry(
-            self.asset_context,
+            *self.asset_context,
             self.project.project_path(),
             module,
             "middleware".into(),
@@ -96,7 +96,7 @@ impl MiddlewareEndpoint {
             }),
             self.project.next_mode(),
         )
-        .resolve_entries(self.asset_context)
+        .resolve_entries(*self.asset_context)
         .await?
         .clone_value();
 

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -47,9 +47,9 @@ pub struct MiddlewareEndpoint {
 impl MiddlewareEndpoint {
     #[turbo_tasks::function]
     pub fn new(
-        project: Vc<Project>,
-        asset_context: Vc<Box<dyn AssetContext>>,
-        source: Vc<Box<dyn Source>>,
+        project: ResolvedVc<Project>,
+        asset_context: ResolvedVc<Box<dyn AssetContext>>,
+        source: ResolvedVc<Box<dyn Source>>,
         app_dir: Option<ResolvedVc<FileSystemPath>>,
         ecmascript_client_reference_transition_name: Option<ResolvedVc<RcStr>>,
     ) -> Vc<Self> {

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -261,7 +261,7 @@ impl MiddlewareEndpoint {
     fn userland_module(&self) -> Vc<Box<dyn Module>> {
         self.asset_context
             .process(
-                self.source,
+                *self.source,
                 Value::new(ReferenceType::Entry(EntryReferenceSubType::Middleware)),
             )
             .module()
@@ -281,13 +281,13 @@ impl Endpoint for MiddlewareEndpoint {
 
             let (server_paths, client_paths) = if this.project.next_mode().await?.is_development() {
                 let node_root = this.project.node_root();
-                let server_paths = all_server_paths(output_assets, node_root)
+                let server_paths = all_server_paths(*output_assets, node_root)
                     .await?
                     .clone_value();
 
                 // Middleware could in theory have a client path (e.g. `new URL`).
                 let client_relative_root = this.project.client_relative_path();
-                let client_paths = all_paths_in_root(output_assets, client_relative_root)
+                let client_paths = all_paths_in_root(*output_assets, client_relative_root)
                     .into_future()
                     .instrument(tracing::info_span!("client_paths"))
                     .await?

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -902,7 +902,7 @@ impl PageEndpoint {
 
                 Ok(SsrChunk::NodeJs {
                     entry: ssr_entry_chunk,
-                    dynamic_import_entries,
+                    dynamic_import_entries: dynamic_import_entries.to_resolved().await?,
                     server_asset_trace_file,
                 }
                 .cell())
@@ -1117,14 +1117,14 @@ impl PageEndpoint {
                     server_assets.push(pages_manifest);
 
                     let loadable_manifest_output =
-                        self.react_loadable_manifest(dynamic_import_entries);
+                        self.react_loadable_manifest(*dynamic_import_entries);
                     server_assets.extend(loadable_manifest_output.await?.iter().copied());
                 }
 
                 PageEndpointOutput::NodeJs {
                     entry_chunk: entry,
-                    server_assets: Vc::cell(server_assets),
-                    client_assets,
+                    server_assets: ResolvedVc::cell(server_assets),
+                    client_assets: client_assets.to_resolved().await?,
                 }
             }
             SsrChunk::Edge {

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -80,7 +80,7 @@ use crate::{
 
 #[turbo_tasks::value]
 pub struct PagesProject {
-    project: Vc<Project>,
+    project: ResolvedVc<Project>,
 }
 
 #[turbo_tasks::value_impl]
@@ -598,11 +598,11 @@ impl PagesProject {
 #[turbo_tasks::value]
 struct PageEndpoint {
     ty: PageEndpointType,
-    pages_project: Vc<PagesProject>,
-    pathname: Vc<RcStr>,
-    original_name: Vc<RcStr>,
-    page: Vc<PagesStructureItem>,
-    pages_structure: Vc<PagesStructure>,
+    pages_project: ResolvedVc<PagesProject>,
+    pathname: ResolvedVc<RcStr>,
+    original_name: ResolvedVc<RcStr>,
+    page: ResolvedVc<PagesStructureItem>,
+    pages_structure: ResolvedVc<PagesStructure>,
 }
 
 #[derive(
@@ -1359,13 +1359,13 @@ impl Endpoint for PageEndpoint {
 enum PageEndpointOutput {
     NodeJs {
         entry_chunk: ResolvedVc<Box<dyn OutputAsset>>,
-        server_assets: Vc<OutputAssets>,
-        client_assets: Vc<OutputAssets>,
+        server_assets: ResolvedVc<OutputAssets>,
+        client_assets: ResolvedVc<OutputAssets>,
     },
     Edge {
-        files: Vc<OutputAssets>,
-        server_assets: Vc<OutputAssets>,
-        client_assets: Vc<OutputAssets>,
+        files: ResolvedVc<OutputAssets>,
+        server_assets: ResolvedVc<OutputAssets>,
+        client_assets: ResolvedVc<OutputAssets>,
     },
 }
 
@@ -1405,11 +1405,11 @@ impl PageEndpointOutput {
 pub enum SsrChunk {
     NodeJs {
         entry: ResolvedVc<Box<dyn OutputAsset>>,
-        dynamic_import_entries: Vc<DynamicImportedChunks>,
+        dynamic_import_entries: ResolvedVc<DynamicImportedChunks>,
         server_asset_trace_file: ResolvedVc<OptionOutputAsset>,
     },
     Edge {
-        files: Vc<OutputAssets>,
-        dynamic_import_entries: Vc<DynamicImportedChunks>,
+        files: ResolvedVc<OutputAssets>,
+        dynamic_import_entries: ResolvedVc<DynamicImportedChunks>,
     },
 }

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -657,7 +657,7 @@ impl PageEndpoint {
         let page_loader = create_page_loader_entry_module(
             this.pages_project.client_module_context(),
             self.source(),
-            this.pathname,
+            *this.pathname,
         );
         if matches!(
             *this.pages_project.project().next_mode().await?,
@@ -762,12 +762,12 @@ impl PageEndpoint {
 
         let ssr_module = if is_edge {
             create_page_ssr_entry_module(
-                this.pathname,
+                *this.pathname,
                 reference_type,
                 project_root,
                 Vc::upcast(edge_module_context),
                 self.source(),
-                this.original_name,
+                *this.original_name,
                 this.pages_structure,
                 config.runtime,
                 this.pages_project.project().next_config(),
@@ -1268,7 +1268,7 @@ impl Endpoint for PageEndpoint {
             let output = self.output().await?;
             // Must use self.output_assets() instead of output.output_assets() to make it a
             // single operation
-            let output_assets = self.output_assets();
+            let output_assets = self.output_assets().to_resolved().await?;
 
             let _ = this
                 .pages_project

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -781,13 +781,13 @@ impl PageEndpoint {
                 ssr_module
             } else {
                 create_page_ssr_entry_module(
-                    this.pathname,
+                    *this.pathname,
                     reference_type,
                     project_root,
                     Vc::upcast(module_context),
                     self.source(),
-                    this.original_name,
-                    this.pages_structure,
+                    *this.original_name,
+                    *this.pages_structure,
                     config.runtime,
                     this.pages_project.project().next_config(),
                 )

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -146,7 +146,7 @@ impl PagesProject {
         if let Some(api) = *api {
             add_dir_to_routes(&mut routes, *api, |pathname, original_name, page| {
                 Route::PageApi {
-                    endpoint: Vc::upcast(PageEndpoint::new(
+                    endpoint: ResolvedVc::upcast(PageEndpoint::new(
                         PageEndpointType::Api,
                         self,
                         pathname,
@@ -160,7 +160,7 @@ impl PagesProject {
         }
 
         let make_page_route = |pathname, original_name, page| Route::Page {
-            html_endpoint: Vc::upcast(PageEndpoint::new(
+            html_endpoint: ResolvedVc::upcast(PageEndpoint::new(
                 PageEndpointType::Html,
                 self,
                 pathname,
@@ -168,7 +168,7 @@ impl PagesProject {
                 page,
                 pages_structure,
             )),
-            data_endpoint: Vc::upcast(PageEndpoint::new(
+            data_endpoint: ResolvedVc::upcast(PageEndpoint::new(
                 PageEndpointType::Data,
                 self,
                 pathname,

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1,6 +1,7 @@
 use std::future::IntoFuture;
 
 use anyhow::{bail, Context, Result};
+use futures::future::BoxFuture;
 use next_core::{
     all_assets_from_entries, create_page_loader_entry_module, get_asset_path_from_pathname,
     get_edge_resolve_options_context,
@@ -105,7 +106,11 @@ impl PagesProject {
         async fn add_page_to_routes(
             routes: &mut FxIndexMap<RcStr, Route>,
             page: Vc<PagesStructureItem>,
-            make_route: impl Fn(Vc<RcStr>, Vc<RcStr>, Vc<PagesStructureItem>) -> Route,
+            make_route: impl Fn(
+                Vc<RcStr>,
+                Vc<RcStr>,
+                Vc<PagesStructureItem>,
+            ) -> BoxFuture<'static, Result<Route>>,
         ) -> Result<()> {
             let PagesStructureItem {
                 next_router_path,
@@ -115,7 +120,7 @@ impl PagesProject {
             let pathname: RcStr = format!("/{}", next_router_path.await?.path).into();
             let pathname_vc = Vc::cell(pathname.clone());
             let original_name = Vc::cell(format!("/{}", original_path.await?.path).into());
-            let route = make_route(pathname_vc, original_name, page);
+            let route = make_route(pathname_vc, original_name, page).await?;
             routes.insert(pathname, route);
             Ok(())
         }
@@ -123,7 +128,11 @@ impl PagesProject {
         async fn add_dir_to_routes(
             routes: &mut FxIndexMap<RcStr, Route>,
             dir: Vc<PagesDirectoryStructure>,
-            make_route: impl Fn(Vc<RcStr>, Vc<RcStr>, Vc<PagesStructureItem>) -> Route,
+            make_route: impl Fn(
+                Vc<RcStr>,
+                Vc<RcStr>,
+                Vc<PagesStructureItem>,
+            ) -> BoxFuture<'static, Result<Route>>,
         ) -> Result<()> {
             let mut queue = vec![dir];
             while let Some(dir) = queue.pop() {
@@ -145,37 +154,55 @@ impl PagesProject {
 
         if let Some(api) = *api {
             add_dir_to_routes(&mut routes, *api, |pathname, original_name, page| {
-                Route::PageApi {
-                    endpoint: ResolvedVc::upcast(PageEndpoint::new(
-                        PageEndpointType::Api,
-                        self,
-                        pathname,
-                        original_name,
-                        page,
-                        pages_structure,
-                    )),
-                }
+                Box::pin(async move {
+                    Ok(Route::PageApi {
+                        endpoint: ResolvedVc::upcast(
+                            PageEndpoint::new(
+                                PageEndpointType::Api,
+                                self,
+                                pathname,
+                                original_name,
+                                page,
+                                pages_structure,
+                            )
+                            .to_resolved()
+                            .await?,
+                        ),
+                    })
+                })
             })
             .await?;
         }
 
-        let make_page_route = |pathname, original_name, page| Route::Page {
-            html_endpoint: ResolvedVc::upcast(PageEndpoint::new(
-                PageEndpointType::Html,
-                self,
-                pathname,
-                original_name,
-                page,
-                pages_structure,
-            )),
-            data_endpoint: ResolvedVc::upcast(PageEndpoint::new(
-                PageEndpointType::Data,
-                self,
-                pathname,
-                original_name,
-                page,
-                pages_structure,
-            )),
+        let make_page_route = |pathname, original_name, page| -> BoxFuture<'_, _> {
+            Box::pin(async move {
+                Ok(Route::Page {
+                    html_endpoint: ResolvedVc::upcast(
+                        PageEndpoint::new(
+                            PageEndpointType::Html,
+                            self,
+                            pathname,
+                            original_name,
+                            page,
+                            pages_structure,
+                        )
+                        .to_resolved()
+                        .await?,
+                    ),
+                    data_endpoint: ResolvedVc::upcast(
+                        PageEndpoint::new(
+                            PageEndpointType::Data,
+                            self,
+                            pathname,
+                            original_name,
+                            page,
+                            pages_structure,
+                        )
+                        .to_resolved()
+                        .await?,
+                    ),
+                })
+            })
         };
 
         if let Some(pages) = *pages {

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -629,11 +629,11 @@ impl PageEndpoint {
     #[turbo_tasks::function]
     fn new(
         ty: PageEndpointType,
-        pages_project: Vc<PagesProject>,
-        pathname: Vc<RcStr>,
-        original_name: Vc<RcStr>,
-        page: Vc<PagesStructureItem>,
-        pages_structure: Vc<PagesStructure>,
+        pages_project: ResolvedVc<PagesProject>,
+        pathname: ResolvedVc<RcStr>,
+        original_name: ResolvedVc<RcStr>,
+        page: ResolvedVc<PagesStructureItem>,
+        pages_structure: ResolvedVc<PagesStructure>,
     ) -> Vc<Self> {
         PageEndpoint {
             ty,

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -86,7 +86,7 @@ pub struct PagesProject {
 #[turbo_tasks::value_impl]
 impl PagesProject {
     #[turbo_tasks::function]
-    pub fn new(project: Vc<Project>) -> Vc<Self> {
+    pub fn new(project: ResolvedVc<Project>) -> Vc<Self> {
         PagesProject { project }.cell()
     }
 
@@ -234,7 +234,7 @@ impl PagesProject {
 
     #[turbo_tasks::function]
     fn project(&self) -> Vc<Project> {
-        self.project
+        *self.project
     }
 
     #[turbo_tasks::function]
@@ -1209,13 +1209,14 @@ impl PageEndpoint {
                     server_assets.push(ResolvedVc::upcast(middleware_manifest_v2));
                 }
 
-                let loadable_manifest_output = self.react_loadable_manifest(dynamic_import_entries);
+                let loadable_manifest_output =
+                    self.react_loadable_manifest(*dynamic_import_entries);
                 server_assets.extend(loadable_manifest_output.await?.iter().copied());
 
                 PageEndpointOutput::Edge {
                     files,
-                    server_assets: Vc::cell(server_assets),
-                    client_assets,
+                    server_assets: ResolvedVc::cell(server_assets),
+                    client_assets: client_assets.to_resolved().await?,
                 }
             }
         };

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1157,7 +1157,7 @@ impl PageEndpoint {
                     file_paths_from_root
                         .extend(get_js_paths_from_root(&node_root_value, &files_value).await?);
 
-                    let all_output_assets = all_assets_from_entries(files).await?;
+                    let all_output_assets = all_assets_from_entries(*files).await?;
 
                     wasm_paths_from_root.extend(
                         get_wasm_paths_from_root(&node_root_value, &all_output_assets).await?,

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -721,7 +721,7 @@ impl PageEndpoint {
         let client_relative_path = self.client_relative_path();
         let page_loader = PageLoaderAsset::new(
             node_root,
-            this.pathname,
+            *this.pathname,
             client_relative_path,
             client_chunks,
         );

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -930,9 +930,9 @@ impl Project {
             routes,
             middleware,
             instrumentation,
-            pages_document_endpoint,
-            pages_app_endpoint,
-            pages_error_endpoint,
+            pages_document_endpoint: pages_document_endpoint.to_resolved().await?,
+            pages_app_endpoint: pages_app_endpoint.to_resolved().await?,
+            pages_error_endpoint: pages_error_endpoint.to_resolved().await?,
         }
         .cell())
     }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1360,8 +1360,8 @@ async fn all_assets_from_entries_operation_inner(
     operation: Vc<OutputAssetsOperation>,
 ) -> Result<Vc<OutputAssets>> {
     let assets = *operation.await?;
-    Vc::connect(assets);
-    Ok(all_assets_from_entries(assets))
+    Vc::connect(*assets);
+    Ok(all_assets_from_entries(*assets))
 }
 
 fn all_assets_from_entries_operation(

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -197,7 +197,7 @@ pub struct Instrumentation {
 pub struct ProjectContainer {
     name: RcStr,
     options_state: State<Option<ProjectOptions>>,
-    versioned_content_map: Option<Vc<VersionedContentMap>>,
+    versioned_content_map: Option<ResolvedVc<VersionedContentMap>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -436,24 +436,24 @@ pub struct Project {
     watch: WatchOptions,
 
     /// Next config.
-    next_config: Vc<NextConfig>,
+    next_config: ResolvedVc<NextConfig>,
 
     /// Js/Tsconfig read by load-jsconfig
-    js_config: Vc<JsConfig>,
+    js_config: ResolvedVc<JsConfig>,
 
     /// A map of environment variables to use when compiling code.
-    env: Vc<Box<dyn ProcessEnv>>,
+    env: ResolvedVc<Box<dyn ProcessEnv>>,
 
     /// A map of environment variables which should get injected at compile
     /// time.
-    define_env: Vc<ProjectDefineEnv>,
+    define_env: ResolvedVc<ProjectDefineEnv>,
 
     /// The browserslist query to use for targeting browsers.
     browserslist_query: RcStr,
 
-    mode: Vc<NextMode>,
+    mode: ResolvedVc<NextMode>,
 
-    versioned_content_map: Option<Vc<VersionedContentMap>>,
+    versioned_content_map: Option<ResolvedVc<VersionedContentMap>>,
 
     build_id: RcStr,
 
@@ -464,9 +464,9 @@ pub struct Project {
 
 #[turbo_tasks::value]
 pub struct ProjectDefineEnv {
-    client: Vc<EnvMap>,
-    edge: Vc<EnvMap>,
-    nodejs: Vc<EnvMap>,
+    client: ResolvedVc<EnvMap>,
+    edge: ResolvedVc<EnvMap>,
+    nodejs: ResolvedVc<EnvMap>,
 }
 
 #[turbo_tasks::value_impl]
@@ -489,10 +489,10 @@ impl ProjectDefineEnv {
 
 #[turbo_tasks::value(shared)]
 struct ConflictIssue {
-    path: Vc<FileSystemPath>,
-    title: Vc<StyledString>,
-    description: Vc<StyledString>,
-    severity: Vc<IssueSeverity>,
+    path: ResolvedVc<FileSystemPath>,
+    title: ResolvedVc<StyledString>,
+    description: ResolvedVc<StyledString>,
+    severity: ResolvedVc<IssueSeverity>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -483,7 +483,7 @@ impl ProjectDefineEnv {
 
     #[turbo_tasks::function]
     pub fn nodejs(&self) -> Vc<EnvMap> {
-        *self.nodejs
+        self.nodejs
     }
 }
 
@@ -519,7 +519,7 @@ impl Issue for ConflictIssue {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(self.description))
+        Vc::cell(Some(*self.description))
     }
 }
 
@@ -529,9 +529,10 @@ impl Project {
     pub async fn app_project(self: Vc<Self>) -> Result<Vc<OptionAppProject>> {
         let app_dir = find_app_dir(self.project_path()).await?;
 
-        Ok(Vc::cell(
-            app_dir.map(|app_dir| AppProject::new(self, *app_dir)),
-        ))
+        Ok(Vc::cell(match *app_dir {
+            Some(app_dir) => Some(AppProject::new(self, *app_dir).to_resolved().await?),
+            None => None,
+        }))
     }
 
     #[turbo_tasks::function]
@@ -611,17 +612,17 @@ impl Project {
 
     #[turbo_tasks::function]
     pub(super) fn next_config(&self) -> Vc<NextConfig> {
-        self.next_config
+        *self.next_config
     }
 
     #[turbo_tasks::function]
     pub(super) fn next_mode(&self) -> Vc<NextMode> {
-        self.mode
+        *self.mode
     }
 
     #[turbo_tasks::function]
     pub(super) fn js_config(&self) -> Vc<JsConfig> {
-        self.js_config
+        *self.js_config
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -880,15 +880,15 @@ impl Project {
                             format!("App Router and Pages Router both match path: {}", pathname)
                                 .into(),
                         )
-                        .cell(),
+                        .resolved_cell(),
                         description: StyledString::Text(
                             "Next.js does not support having both App Router and Pages Router \
                              routes matching the same path. Please remove one of the conflicting \
                              routes."
                                 .into(),
                         )
-                        .cell(),
-                        severity: IssueSeverity::Error.cell(),
+                        .resolved_cell(),
+                        severity: IssueSeverity::Error.resolved_cell(),
                     }
                     .cell()
                     .emit();

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -483,7 +483,7 @@ impl ProjectDefineEnv {
 
     #[turbo_tasks::function]
     pub fn nodejs(&self) -> Vc<EnvMap> {
-        self.nodejs
+        *self.nodejs
     }
 }
 
@@ -504,7 +504,7 @@ impl Issue for ConflictIssue {
 
     #[turbo_tasks::function]
     fn severity(&self) -> Vc<IssueSeverity> {
-        self.severity
+        *self.severity
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -346,9 +346,9 @@ impl ProjectContainer {
                 .context("ProjectContainer need to be initialized with initialize()")?;
             env_map = Vc::cell(options.env.iter().cloned().collect());
             define_env = ProjectDefineEnv {
-                client: Vc::cell(options.define_env.client.iter().cloned().collect()),
-                edge: Vc::cell(options.define_env.edge.iter().cloned().collect()),
-                nodejs: Vc::cell(options.define_env.nodejs.iter().cloned().collect()),
+                client: ResolvedVc::cell(options.define_env.client.iter().cloned().collect()),
+                edge: ResolvedVc::cell(options.define_env.edge.iter().cloned().collect()),
+                nodejs: ResolvedVc::cell(options.define_env.nodejs.iter().cloned().collect()),
             }
             .cell();
             next_config = NextConfig::from_string(Vc::cell(options.next_config.clone()));
@@ -473,17 +473,17 @@ pub struct ProjectDefineEnv {
 impl ProjectDefineEnv {
     #[turbo_tasks::function]
     pub fn client(&self) -> Vc<EnvMap> {
-        self.client
+        *self.client
     }
 
     #[turbo_tasks::function]
     pub fn edge(&self) -> Vc<EnvMap> {
-        self.edge
+        *self.edge
     }
 
     #[turbo_tasks::function]
     pub fn nodejs(&self) -> Vc<EnvMap> {
-        self.nodejs
+        *self.nodejs
     }
 }
 

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1364,7 +1364,7 @@ async fn all_assets_from_entries_operation_inner(
 ) -> Result<Vc<OutputAssets>> {
     let assets = *operation.await?;
     Vc::connect(*assets);
-    all_assets_from_entries(*assets).to_resolved().await
+    Ok(all_assets_from_entries(*assets))
 }
 
 async fn all_assets_from_entries_operation(

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1364,7 +1364,7 @@ async fn all_assets_from_entries_operation_inner(
 ) -> Result<Vc<OutputAssets>> {
     let assets = *operation.await?;
     Vc::connect(*assets);
-    Ok(all_assets_from_entries(*assets).to_resolved().await?)
+    all_assets_from_entries(*assets).to_resolved().await
 }
 
 async fn all_assets_from_entries_operation(

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -30,16 +30,16 @@ impl AppPageRoute {
 #[derive(Clone, Debug)]
 pub enum Route {
     Page {
-        html_endpoint: Vc<Box<dyn Endpoint>>,
-        data_endpoint: Vc<Box<dyn Endpoint>>,
+        html_endpoint: ResolvedVc<Box<dyn Endpoint>>,
+        data_endpoint: ResolvedVc<Box<dyn Endpoint>>,
     },
     PageApi {
-        endpoint: Vc<Box<dyn Endpoint>>,
+        endpoint: ResolvedVc<Box<dyn Endpoint>>,
     },
     AppPage(Vec<AppPageRoute>),
     AppRoute {
         original_name: String,
-        endpoint: Vc<Box<dyn Endpoint>>,
+        endpoint: ResolvedVc<Box<dyn Endpoint>>,
     },
     Conflict,
 }

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -22,8 +22,8 @@ impl AppPageRoute {
             rsc_endpoint,
             ..
         } = self;
-        *html_endpoint = html_endpoint.resolve().await?;
-        *rsc_endpoint = rsc_endpoint.resolve().await?;
+        *html_endpoint = html_endpoint.to_resolved().await?;
+        *rsc_endpoint = rsc_endpoint.to_resolved().await?;
         Ok(())
     }
 }

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -53,11 +53,11 @@ impl Route {
                 html_endpoint,
                 data_endpoint,
             } => {
-                *html_endpoint = html_endpoint.resolve().await?;
-                *data_endpoint = data_endpoint.resolve().await?;
+                *html_endpoint = html_endpoint.to_resolved().await?;
+                *data_endpoint = data_endpoint.to_resolved().await?;
             }
             Route::PageApi { endpoint } => {
-                *endpoint = endpoint.resolve().await?;
+                *endpoint = endpoint.to_resolved().await?;
             }
             Route::AppPage(routes) => {
                 for route in routes {
@@ -65,7 +65,7 @@ impl Route {
                 }
             }
             Route::AppRoute { endpoint, .. } => {
-                *endpoint = endpoint.resolve().await?;
+                *endpoint = endpoint.to_resolved().await?;
             }
             Route::Conflict => {}
         }

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{debug::ValueDebugFormat, trace::TraceRawVcs, Completion, FxIndexMap, Vc};
+use turbo_tasks::{
+    debug::ValueDebugFormat, trace::TraceRawVcs, Completion, FxIndexMap, ResolvedVc, Vc,
+};
 use turbopack_core::module::Modules;
 
 use crate::paths::ServerPath;
@@ -9,8 +11,8 @@ use crate::paths::ServerPath;
 #[derive(TraceRawVcs, Serialize, Deserialize, PartialEq, Eq, ValueDebugFormat, Clone, Debug)]
 pub struct AppPageRoute {
     pub original_name: String,
-    pub html_endpoint: Vc<Box<dyn Endpoint>>,
-    pub rsc_endpoint: Vc<Box<dyn Endpoint>>,
+    pub html_endpoint: ResolvedVc<Box<dyn Endpoint>>,
+    pub rsc_endpoint: ResolvedVc<Box<dyn Endpoint>>,
 }
 
 impl AppPageRoute {

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -47,7 +47,7 @@ use turbopack_ecmascript::{
 
 #[turbo_tasks::value]
 pub(crate) struct ServerActionsManifest {
-    pub loader: Vc<Box<dyn EvaluatableAsset>>,
+    pub loader: ResolvedVc<Box<dyn EvaluatableAsset>>,
     pub manifest: ResolvedVc<Box<dyn OutputAsset>>,
 }
 
@@ -512,7 +512,7 @@ struct ActionMap(FxIndexMap<String, String>);
 
 /// An Option wrapper around [ActionMap].
 #[turbo_tasks::value(transparent)]
-struct OptionActionMap(Option<Vc<ActionMap>>);
+struct OptionActionMap(Option<ResolvedVc<ActionMap>>);
 
 #[turbo_tasks::value_impl]
 impl OptionActionMap {

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -79,7 +79,7 @@ pub(crate) async fn create_server_actions_manifest(
     let chunk_item = loader.as_chunk_item(Vc::upcast(chunking_context));
     let manifest = build_manifest(node_root, page_name, runtime, actions, chunk_item).await?;
     Ok(ServerActionsManifest {
-        loader: evaluable,
+        loader: evaluable.to_resolved().await?,
         manifest,
     }
     .cell())
@@ -394,7 +394,7 @@ async fn parse_actions(module: Vc<Box<dyn Module>>) -> Result<Vc<OptionActionMap
 
     let mut actions = FxIndexMap::from_iter(actions.into_iter());
     actions.sort_keys();
-    Ok(Vc::cell(Some(Vc::cell(actions))))
+    Ok(Vc::cell(Some(ResolvedVc::cell(actions))))
 }
 
 fn all_export_names(program: &Program) -> Vec<Atom> {
@@ -483,7 +483,7 @@ fn is_turbopack_internal_var(with: &Option<Box<ObjectLit>>) -> bool {
 /// collecting into a flat-mapped [FxIndexMap].
 async fn parse_actions_filter_map(
     (layer, module, name): FindActionsNode,
-) -> Result<Option<(FindActionsNode, Vc<ActionMap>)>> {
+) -> Result<Option<(FindActionsNode, ResolvedVc<ActionMap>)>> {
     parse_actions(*module).await.map(|option_action_map| {
         option_action_map
             .clone_value()

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -20,22 +20,23 @@ use turbopack_core::{
 /// it's stored for later usage and we want to reconnect this operation when
 /// it's received from the map again.
 #[turbo_tasks::value(transparent)]
-pub struct OutputAssetsOperation(Vc<OutputAssets>);
+pub struct OutputAssetsOperation(ResolvedVc<OutputAssets>);
 
 #[derive(Clone, TraceRawVcs, PartialEq, Eq, ValueDebugFormat, Serialize, Deserialize, Debug)]
 struct MapEntry {
     // must not be resolved
     assets_operation: Vc<OutputAssets>,
     /// Precomputed map for quick access to output asset by filepath
-    path_to_asset: HashMap<ResolvedVc<FileSystemPath>, Vc<Box<dyn OutputAsset>>>,
+    path_to_asset: HashMap<ResolvedVc<FileSystemPath>, ResolvedVc<Box<dyn OutputAsset>>>,
 }
 
 #[turbo_tasks::value(transparent)]
 struct OptionMapEntry(Option<MapEntry>);
 
-type PathToOutputOperation = HashMap<ResolvedVc<FileSystemPath>, FxIndexSet<Vc<OutputAssets>>>;
+type PathToOutputOperation =
+    HashMap<ResolvedVc<FileSystemPath>, FxIndexSet<ResolvedVc<OutputAssets>>>;
 // A precomputed map for quick access to output asset by filepath
-type OutputOperationToComputeEntry = HashMap<Vc<OutputAssets>, Vc<OptionMapEntry>>;
+type OutputOperationToComputeEntry = HashMap<ResolvedVc<OutputAssets>, ResolvedVc<OptionMapEntry>>;
 
 #[turbo_tasks::value]
 pub struct VersionedContentMap {

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -84,8 +84,9 @@ impl VersionedContentMap {
             client_output_path,
         );
         let assets = *assets_operation.await?;
-        this.map_op_to_compute_entry
-            .update_conditionally(|map| map.insert(assets, compute_entry) != Some(compute_entry));
+        this.map_op_to_compute_entry.update_conditionally(|map| {
+            map.insert(assets, compute_entry.to_resolved().await?) != Some(compute_entry)
+        });
         Ok(())
     }
 
@@ -244,7 +245,7 @@ impl VersionedContentMap {
             return Vc::cell(None);
         };
         // Need to reconnect the operation to the map
-        Vc::connect(compute_entry);
+        Vc::connect(*compute_entry);
 
         compute_entry
     }

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -237,7 +237,7 @@ impl VersionedContentMap {
             return Vc::cell(None);
         };
         // Need to reconnect the operation to the map
-        Vc::connect(assets);
+        Vc::connect(*assets);
 
         let compute_entry = {
             let map = self.map_op_to_compute_entry.get();
@@ -249,6 +249,6 @@ impl VersionedContentMap {
         // Need to reconnect the operation to the map
         Vc::connect(*compute_entry);
 
-        compute_entry
+        *compute_entry
     }
 }

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -77,16 +77,18 @@ impl VersionedContentMap {
         client_output_path: Vc<FileSystemPath>,
     ) -> Result<()> {
         let this = self.await?;
-        let compute_entry = self.compute_entry(
-            assets_operation,
-            node_root,
-            client_relative_path,
-            client_output_path,
-        );
+        let compute_entry = self
+            .compute_entry(
+                assets_operation,
+                node_root,
+                client_relative_path,
+                client_output_path,
+            )
+            .to_resolved()
+            .await?;
         let assets = *assets_operation.await?;
-        this.map_op_to_compute_entry.update_conditionally(|map| {
-            map.insert(assets, compute_entry.to_resolved().await?) != Some(compute_entry)
-        });
+        this.map_op_to_compute_entry
+            .update_conditionally(|map| map.insert(assets, compute_entry) != Some(compute_entry));
         Ok(())
     }
 


### PR DESCRIPTION
### What?

Use `ResolvedVc<T>` instead of `Vc<T>` for struct fields in `next-api`

### Why?

### How?


Closes PACK-3549