### PR TITLE
chore(CI): Remove sysroot override for macos arm64

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -146,10 +146,6 @@ jobs:
             # --env-mode loose is a breaking change required with turbo 2.x since Strict mode is now the default
             # TODO: we should add the relevant envs later to to switch to strict mode
             build: |
-              export CC=$(xcrun -f clang);
-              export CXX=$(xcrun -f clang++);
-              SYSROOT=$(xcrun --sdk macosx --show-sdk-path);
-              export CFLAGS="-isysroot $SYSROOT -isystem $SYSROOT";
               npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}" "turbo@${TURBO_VERSION}" && corepack enable
               turbo run build-native-release -vvv --env-mode loose --remote-cache-timeout 90 --summarize -- --target aarch64-apple-darwin
               strip -x packages/next-swc/native/next-swc.*.node


### PR DESCRIPTION
This is extracted from #72513. This override appears to break the build for rocksdb. It doesn't seem like there's any good reason for us to do this.

It looks like we used to do a cross-build for macos arm64 (#28138), which would explain the need to override the sysroot, but we don't do that anymore. We don't do this override for x86-64 builds (even though that one _is_ a cross-build? The napi cli probably does the right thing for us...).

Manually triggered `build-and-deploy` CI job: https://github.com/vercel/next.js/actions/runs/12018322261

Closes PACK-3543