### PR TITLE
feat(after): unflag unstable_after internals

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -100,6 +100,7 @@ import type { AppSegmentConfig } from './segment-config/app/app-segment-config'
 import type { AppSegment } from './segment-config/app/app-segments'
 import { collectSegments } from './segment-config/app/app-segments'
 import { createIncrementalCache } from '../export/helpers/create-incremental-cache'
+import { InvariantError } from '../shared/lib/invariant-error'
 
 export type ROUTER_TYPE = 'pages' | 'app'
 
@@ -1316,6 +1317,13 @@ export async function buildAppStaticPaths({
         dynamicIO,
         authInterrupts,
       },
+      waitUntil: undefined,
+      onClose: () => {
+        throw new InvariantError(
+          'unexpected onClose call in buildAppStaticPaths'
+        )
+      },
+      onAfterTaskError: undefined,
       buildId,
     },
   })

--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
@@ -154,11 +154,7 @@ export function getRender({
     event?: NextFetchEvent
   ) {
     const extendedReq = new WebNextRequest(request)
-    const extendedRes = new WebNextResponse(
-      undefined,
-      // tracking onClose adds overhead, so only do it if `experimental.after` is on.
-      !!process.env.__NEXT_AFTER
-    )
+    const extendedRes = new WebNextResponse(undefined)
 
     handler(extendedReq, extendedRes)
     const result = await extendedRes.toResponse()

--- a/packages/next/src/server/after/after-context.test.ts
+++ b/packages/next/src/server/after/after-context.test.ts
@@ -53,6 +53,7 @@ describe('AfterContext', () => {
     })
 
     const afterContext = new AfterContext({
+      isEnabled: true,
       waitUntil,
       onClose,
       onTaskError: undefined,
@@ -120,6 +121,7 @@ describe('AfterContext', () => {
     })
 
     const afterContext = new AfterContext({
+      isEnabled: true,
       waitUntil,
       onClose,
       onTaskError: undefined,
@@ -168,6 +170,7 @@ describe('AfterContext', () => {
     })
 
     const afterContext = new AfterContext({
+      isEnabled: true,
       waitUntil,
       onClose,
       onTaskError: undefined,
@@ -259,6 +262,7 @@ describe('AfterContext', () => {
     })
 
     const afterContext = new AfterContext({
+      isEnabled: true,
       waitUntil,
       onClose,
       onTaskError: undefined,
@@ -319,6 +323,7 @@ describe('AfterContext', () => {
     })
 
     const afterContext = new AfterContext({
+      isEnabled: true,
       waitUntil,
       onClose,
       onTaskError: undefined,
@@ -359,6 +364,7 @@ describe('AfterContext', () => {
     const onTaskError = jest.fn()
 
     const afterContext = new AfterContext({
+      isEnabled: true,
       waitUntil,
       onClose,
       onTaskError,
@@ -422,6 +428,7 @@ describe('AfterContext', () => {
     const onClose = jest.fn()
 
     const afterContext = new AfterContext({
+      isEnabled: true,
       waitUntil,
       onClose,
       onTaskError: undefined,
@@ -445,36 +452,6 @@ describe('AfterContext', () => {
     expect(afterCallback1).not.toHaveBeenCalled()
   })
 
-  it('throws from after() if onClose is not provided', async () => {
-    const waitUntilPromises: Promise<unknown>[] = []
-    const waitUntil = jest.fn((promise) => waitUntilPromises.push(promise))
-
-    const onClose = undefined
-
-    const afterContext = new AfterContext({
-      waitUntil,
-      onClose,
-      onTaskError: undefined,
-    })
-
-    const workStore = createMockWorkStore(afterContext)
-
-    const run = createRun(afterContext, workStore)
-
-    // ==================================
-
-    const afterCallback1 = jest.fn()
-
-    expect(() =>
-      run(() => {
-        after(afterCallback1)
-      })
-    ).toThrow(/Missing `onClose` implementation/)
-
-    expect(waitUntil).not.toHaveBeenCalled()
-    expect(afterCallback1).not.toHaveBeenCalled()
-  })
-
   it('does NOT shadow workAsyncStorage within after callbacks', async () => {
     const waitUntil = jest.fn()
 
@@ -484,6 +461,7 @@ describe('AfterContext', () => {
     })
 
     const afterContext = new AfterContext({
+      isEnabled: true,
       waitUntil,
       onClose,
       onTaskError: undefined,
@@ -529,6 +507,7 @@ describe('AfterContext', () => {
     })
 
     const afterContext = new AfterContext({
+      isEnabled: true,
       waitUntil,
       onClose,
       onTaskError: undefined,

--- a/packages/next/src/server/after/after-context.ts
+++ b/packages/next/src/server/after/after-context.ts
@@ -12,24 +12,32 @@ import {
 } from '../app-render/work-unit-async-storage.external'
 
 export type AfterContextOpts = {
+  isEnabled: boolean
   waitUntil: RequestLifecycleOpts['waitUntil'] | undefined
-  onClose: RequestLifecycleOpts['onClose'] | undefined
+  onClose: RequestLifecycleOpts['onClose']
   onTaskError: RequestLifecycleOpts['onAfterTaskError'] | undefined
 }
 
 export class AfterContext {
   private waitUntil: RequestLifecycleOpts['waitUntil'] | undefined
-  private onClose: RequestLifecycleOpts['onClose'] | undefined
+  private onClose: RequestLifecycleOpts['onClose']
   private onTaskError: RequestLifecycleOpts['onAfterTaskError'] | undefined
+  public readonly isEnabled: boolean
 
   private runCallbacksOnClosePromise: Promise<void> | undefined
   private callbackQueue: PromiseQueue
   private workUnitStores = new Set<WorkUnitStore>()
 
-  constructor({ waitUntil, onClose, onTaskError }: AfterContextOpts) {
+  constructor({
+    waitUntil,
+    onClose,
+    onTaskError,
+    isEnabled,
+  }: AfterContextOpts) {
     this.waitUntil = waitUntil
     this.onClose = onClose
     this.onTaskError = onTaskError
+    this.isEnabled = isEnabled
 
     this.callbackQueue = new PromiseQueue()
     this.callbackQueue.pause()
@@ -55,11 +63,6 @@ export class AfterContext {
     // if something is wrong, throw synchronously, bubbling up to the `unstable_after` callsite.
     if (!this.waitUntil) {
       errorWaitUntilNotAvailable()
-    }
-    if (!this.onClose) {
-      throw new InvariantError(
-        'unstable_after: Missing `onClose` implementation'
-      )
     }
 
     const workUnitStore = workUnitAsyncStorage.getStore()

--- a/packages/next/src/server/after/after.ts
+++ b/packages/next/src/server/after/after.ts
@@ -17,7 +17,7 @@ export function unstable_after<T>(task: AfterTask<T>): void {
   }
 
   const { afterContext } = workStore
-  if (!afterContext) {
+  if (!afterContext.isEnabled) {
     throw new Error(
       '`unstable_after` must be explicitly enabled by setting `experimental.after: true` in your next.config.js.'
     )

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -45,7 +45,7 @@ export interface WorkStore {
   dynamicShouldError?: boolean
   pendingRevalidates?: Record<string, Promise<any>>
   pendingRevalidateWrites?: Array<Promise<void>> // This is like pendingRevalidates but isn't used for deduping.
-  readonly afterContext: AfterContext | undefined
+  readonly afterContext: AfterContext
 
   dynamicUsageDescription?: string
   dynamicUsageStack?: string

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -62,7 +62,7 @@ export type WorkStoreContext = {
     | 'isDebugDynamicAccesses'
     | 'buildId'
   > &
-    Partial<RequestLifecycleOpts> &
+    RequestLifecycleOpts &
     Partial<Pick<RenderOpts, 'reactLoadableManifest'>>
 }
 
@@ -128,14 +128,16 @@ export function createWorkStore({
 }
 
 function createAfterContext(
-  renderOpts: Partial<RequestLifecycleOpts> & {
+  renderOpts: RequestLifecycleOpts & {
     experimental: Pick<RenderOpts['experimental'], 'after'>
   }
-): AfterContext | undefined {
-  const isAfterEnabled = renderOpts?.experimental?.after ?? false
-  if (!isAfterEnabled) {
-    return undefined
-  }
+): AfterContext {
+  const isEnabled = renderOpts?.experimental?.after ?? false
   const { waitUntil, onClose, onAfterTaskError } = renderOpts
-  return new AfterContext({ waitUntil, onClose, onTaskError: onAfterTaskError })
+  return new AfterContext({
+    waitUntil,
+    isEnabled,
+    onClose,
+    onTaskError: onAfterTaskError,
+  })
 }

--- a/packages/next/src/server/base-http/web.test.ts
+++ b/packages/next/src/server/base-http/web.test.ts
@@ -1,10 +1,6 @@
 import { WebNextResponse } from './web'
 
 describe('WebNextResponse onClose', () => {
-  it("doesn't track onClose unless enabled", () => {
-    const webNextResponse = new WebNextResponse(undefined, false).body('abcdef')
-    expect(() => webNextResponse.onClose(() => {})).toThrow()
-  })
   it('stream body', async () => {
     const cb = jest.fn()
     const ts = new TransformStream({
@@ -13,7 +9,7 @@ describe('WebNextResponse onClose', () => {
       },
     })
 
-    const webNextResponse = new WebNextResponse(ts, true)
+    const webNextResponse = new WebNextResponse(ts)
     webNextResponse.onClose(cb)
     webNextResponse.send()
     expect(cb).toHaveBeenCalledTimes(0)
@@ -34,7 +30,7 @@ describe('WebNextResponse onClose', () => {
 
   it('string body', async () => {
     const cb = jest.fn()
-    const webNextResponse = new WebNextResponse(undefined, true).body('abcdef')
+    const webNextResponse = new WebNextResponse(undefined).body('abcdef')
     webNextResponse.onClose(cb)
     webNextResponse.send()
     expect(cb).toHaveBeenCalledTimes(0)

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -265,7 +265,7 @@ export type LoadedRenderOpts = RenderOpts &
 
 export type RequestLifecycleOpts = {
   waitUntil: ((promise: Promise<any>) => void) | undefined
-  onClose: ((callback: () => void) => void) | undefined
+  onClose: (callback: () => void) => void
   onAfterTaskError: ((error: unknown) => void) | undefined
 }
 

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -16,10 +16,7 @@ import { FLIGHT_HEADERS } from '../../client/components/app-router-headers'
 import { ensureInstrumentationRegistered } from './globals'
 import { createRequestStoreForAPI } from '../async-storage/request-store'
 import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
-import {
-  createWorkStore,
-  type WorkStoreContext,
-} from '../async-storage/work-store'
+import { createWorkStore } from '../async-storage/work-store'
 import { workAsyncStorage } from '../app-render/work-async-storage.external'
 import { NEXT_ROUTER_PREFETCH_HEADER } from '../../client/components/app-router-headers'
 import { getTracer } from '../lib/trace/tracer'
@@ -229,13 +226,8 @@ export async function adapter(
         params.request.nextConfig?.experimental?.after ??
         !!process.env.__NEXT_AFTER
 
-      let waitUntil: WorkStoreContext['renderOpts']['waitUntil'] = undefined
-      let closeController: CloseController | undefined = undefined
-
-      if (isAfterEnabled) {
-        waitUntil = event.waitUntil.bind(event)
-        closeController = new CloseController()
-      }
+      const waitUntil = event.waitUntil.bind(event)
+      const closeController = new CloseController()
 
       return getTracer().trace(
         MiddlewareSpan.execute,
@@ -277,9 +269,8 @@ export async function adapter(
                 buildId: buildId ?? '',
                 supportsDynamicResponse: true,
                 waitUntil,
-                onClose: closeController
-                  ? closeController.onClose.bind(closeController)
-                  : undefined,
+                onClose: closeController.onClose.bind(closeController),
+                onAfterTaskError: undefined,
               },
               requestEndedState: { ended: false },
               isPrefetchRequest: request.headers.has(

--- a/packages/next/src/server/web/edge-route-module-wrapper.ts
+++ b/packages/next/src/server/web/edge-route-module-wrapper.ts
@@ -13,7 +13,6 @@ import type { NextFetchEvent } from './spec-extension/fetch-event'
 import { internal_getCurrentFunctionWaitUntil } from './internal-edge-wait-until'
 import { getUtils } from '../server-utils'
 import { searchParamsToUrlQuery } from '../../shared/lib/router/utils/querystring'
-import type { RequestLifecycleOpts } from '../base-server'
 import { CloseController, trackStreamConsumed } from './web-on-close'
 import { getEdgePreviewProps } from './get-edge-preview-props'
 import type { NextConfigComplete } from '../config-shared'
@@ -88,13 +87,8 @@ export class EdgeRouteModuleWrapper {
 
     const isAfterEnabled = !!process.env.__NEXT_AFTER
 
-    let waitUntil: RequestLifecycleOpts['waitUntil'] = undefined
-    let closeController: CloseController | undefined
-
-    if (isAfterEnabled) {
-      waitUntil = evt.waitUntil.bind(evt)
-      closeController = new CloseController()
-    }
+    const waitUntil = evt.waitUntil.bind(evt)
+    const closeController = new CloseController()
 
     const previewProps = getEdgePreviewProps()
 
@@ -112,9 +106,8 @@ export class EdgeRouteModuleWrapper {
       renderOpts: {
         supportsDynamicResponse: true,
         waitUntil,
-        onClose: closeController
-          ? closeController.onClose.bind(closeController)
-          : undefined,
+        onClose: closeController.onClose.bind(closeController),
+        onAfterTaskError: undefined,
         experimental: {
           after: isAfterEnabled,
           dynamicIO: !!process.env.__NEXT_DYNAMIC_IO,


### PR DESCRIPTION
this PR changes `after`-related code to unconditionally set everything up even if `experimental.after` is disabled, because we want to be able to re-use some of the `after` machinery for instrumentation-related things.