### PR TITLE
perf(turbopack): Use `ResolvedVc` for `turbopack-dev-server`

### DIFF
--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -157,7 +157,7 @@ pub async fn create_web_entry_source(
         .await?;
 
     let entry_asset = Vc::upcast(DevHtmlAsset::new(
-        server_root.join("index.html".into()),
+        server_root.join("index.html".into()).to_resolved().await?,
         entries,
     ));
 

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -44,7 +44,7 @@ fn dev_html_chunk_reference_description() -> Vc<RcStr> {
 impl OutputAsset for DevHtmlAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(self.path)
+        AssetIdent::from_path(*self.path)
     }
 
     #[turbo_tasks::function]
@@ -68,7 +68,7 @@ impl Asset for DevHtmlAsset {
 
 impl DevHtmlAsset {
     /// Create a new dev HTML asset.
-    pub fn new(path: Vc<FileSystemPath>, entries: Vec<DevHtmlEntry>) -> Vc<Self> {
+    pub fn new(path: ResolvedVc<FileSystemPath>, entries: Vec<DevHtmlEntry>) -> Vc<Self> {
         DevHtmlAsset {
             path,
             entries,
@@ -79,7 +79,7 @@ impl DevHtmlAsset {
 
     /// Create a new dev HTML asset.
     pub fn new_with_body(
-        path: Vc<FileSystemPath>,
+        path: ResolvedVc<FileSystemPath>,
         entries: Vec<DevHtmlEntry>,
         body: RcStr,
     ) -> Vc<Self> {
@@ -95,7 +95,7 @@ impl DevHtmlAsset {
 #[turbo_tasks::value_impl]
 impl DevHtmlAsset {
     #[turbo_tasks::function]
-    pub async fn with_path(self: Vc<Self>, path: Vc<FileSystemPath>) -> Result<Vc<Self>> {
+    pub async fn with_path(self: Vc<Self>, path: ResolvedVc<FileSystemPath>) -> Result<Vc<Self>> {
         let mut html: DevHtmlAsset = self.await?.clone_value();
         html.path = path;
         Ok(html.cell())

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -30,7 +30,7 @@ type DevHtmlEntry = (
 #[turbo_tasks::value(shared)]
 #[derive(Clone)]
 pub struct DevHtmlAsset {
-    path: Vc<FileSystemPath>,
+    path: ResolvedVc<FileSystemPath>,
     entries: Vec<DevHtmlEntry>,
     body: Option<RcStr>,
 }

--- a/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, collections::HashSet, fmt::Display};
 
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ReadRef, TryJoinIterExt, Vc};
+use turbo_tasks::{ReadRef, ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::{json::parse_json_with_source_context, File};
 use turbopack_core::{
     asset::AssetContent,
@@ -18,7 +18,7 @@ use crate::source::{
 
 #[turbo_tasks::value(shared)]
 pub struct IntrospectionSource {
-    pub roots: HashSet<Vc<Box<dyn Introspectable>>>,
+    pub roots: HashSet<ResolvedVc<Box<dyn Introspectable>>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
@@ -36,7 +36,7 @@ impl Introspectable for IntrospectionSource {
     #[turbo_tasks::function]
     fn children(&self) -> Vc<IntrospectableChildren> {
         let name = Vc::cell("root".into());
-        Vc::cell(self.roots.iter().map(|root| (name, *root)).collect())
+        Vc::cell(self.roots.iter().map(|root| (name, **root)).collect())
     }
 }
 

--- a/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
@@ -76,12 +76,16 @@ impl<T: Display> Display for HtmlStringEscaped<T> {
 #[turbo_tasks::value_impl]
 impl ContentSource for IntrospectionSource {
     #[turbo_tasks::function]
-    fn get_routes(self: Vc<Self>) -> Vc<RouteTree> {
-        Vc::<RouteTrees>::cell(vec![
-            RouteTree::new_route(Vec::new(), RouteType::Exact, Vc::upcast(self)),
-            RouteTree::new_route(Vec::new(), RouteType::CatchAll, Vc::upcast(self)),
+    async fn get_routes(self: Vc<Self>) -> Result<Vc<RouteTree>> {
+        Ok(Vc::<RouteTrees>::cell(vec![
+            RouteTree::new_route(Vec::new(), RouteType::Exact, Vc::upcast(self))
+                .to_resolved()
+                .await?,
+            RouteTree::new_route(Vec::new(), RouteType::CatchAll, Vc::upcast(self))
+                .to_resolved()
+                .await?,
         ])
-        .merge()
+        .merge())
     }
 }
 

--- a/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
@@ -89,7 +89,7 @@ impl ContentSource for IntrospectionSource {
 impl GetContentSourceContent for IntrospectionSource {
     #[turbo_tasks::function]
     async fn get(
-        self: Vc<Self>,
+        self: ResolvedVc<Self>,
         path: RcStr,
         _data: turbo_tasks::Value<ContentSourceData>,
     ) -> Result<Vc<ContentSourceContent>> {
@@ -100,12 +100,12 @@ impl GetContentSourceContent for IntrospectionSource {
             if roots.len() == 1 {
                 *roots.iter().next().unwrap()
             } else {
-                Vc::upcast(self)
+                ResolvedVc::upcast(self)
             }
         } else {
             parse_json_with_source_context(path)?
         };
-        let internal_ty = Vc::debug_identifier(introspectable).await?;
+        let internal_ty = Vc::debug_identifier(*introspectable).await?;
         fn str_or_err(s: &Result<ReadRef<RcStr>>) -> Cow<'_, str> {
             s.as_ref().map_or_else(
                 |e| Cow::<'_, str>::Owned(format!("ERROR: {:?}", e)),

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -29,8 +29,8 @@ type ExpandedState = State<HashSet<RcStr>>;
 
 #[turbo_tasks::value(serialization = "none", eq = "manual", cell = "new")]
 pub struct AssetGraphContentSource {
-    root_path: Vc<FileSystemPath>,
-    root_assets: Vc<OutputAssetsSet>,
+    root_path: ResolvedVc<FileSystemPath>,
+    root_assets: ResolvedVc<OutputAssetsSet>,
     expanded: Option<ExpandedState>,
 }
 
@@ -237,9 +237,9 @@ impl ContentSource for AssetGraphContentSource {
 
 #[turbo_tasks::value]
 struct AssetGraphGetContentSourceContent {
-    source: Vc<AssetGraphContentSource>,
+    source: ResolvedVc<AssetGraphContentSource>,
     path: RcStr,
-    asset: Vc<Box<dyn OutputAsset>>,
+    asset: ResolvedVc<Box<dyn OutputAsset>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -39,7 +39,7 @@ impl AssetGraphContentSource {
     /// Serves all assets references by root_asset.
     #[turbo_tasks::function]
     pub fn new_eager(
-        root_path: Vc<FileSystemPath>,
+        root_path: ResolvedVc<FileSystemPath>,
         root_asset: ResolvedVc<Box<dyn OutputAsset>>,
     ) -> Vc<Self> {
         Self::cell(AssetGraphContentSource {
@@ -53,7 +53,7 @@ impl AssetGraphContentSource {
     /// asset when it has served its content before.
     #[turbo_tasks::function]
     pub fn new_lazy(
-        root_path: Vc<FileSystemPath>,
+        root_path: ResolvedVc<FileSystemPath>,
         root_asset: ResolvedVc<Box<dyn OutputAsset>>,
     ) -> Vc<Self> {
         Self::cell(AssetGraphContentSource {
@@ -66,8 +66,8 @@ impl AssetGraphContentSource {
     /// Serves all assets references by all root_assets.
     #[turbo_tasks::function]
     pub fn new_eager_multiple(
-        root_path: Vc<FileSystemPath>,
-        root_assets: Vc<OutputAssetsSet>,
+        root_path: ResolvedVc<FileSystemPath>,
+        root_assets: ResolvedVc<OutputAssetsSet>,
     ) -> Vc<Self> {
         Self::cell(AssetGraphContentSource {
             root_path,
@@ -80,8 +80,8 @@ impl AssetGraphContentSource {
     /// of an asset when it has served its content before.
     #[turbo_tasks::function]
     pub fn new_lazy_multiple(
-        root_path: Vc<FileSystemPath>,
-        root_assets: Vc<OutputAssetsSet>,
+        root_path: ResolvedVc<FileSystemPath>,
+        root_assets: ResolvedVc<OutputAssetsSet>,
     ) -> Vc<Self> {
         Self::cell(AssetGraphContentSource {
             root_path,

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -230,7 +230,7 @@ impl ContentSource for AssetGraphContentSource {
                     )),
                 )
             })
-            .map(|v| async move { v.await })
+            .map(|v| async move { v.to_resolved().await })
             .try_join()
             .await?;
         Ok(Vc::<RouteTrees>::cell(routes).merge())

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -230,7 +230,9 @@ impl ContentSource for AssetGraphContentSource {
                     )),
                 )
             })
-            .collect();
+            .map(|v| async move { v.await })
+            .try_join()
+            .await?;
         Ok(Vc::<RouteTrees>::cell(routes).merge())
     }
 }

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -246,9 +246,9 @@ struct AssetGraphGetContentSourceContent {
 impl AssetGraphGetContentSourceContent {
     #[turbo_tasks::function]
     pub fn new(
-        source: Vc<AssetGraphContentSource>,
+        source: ResolvedVc<AssetGraphContentSource>,
         path: RcStr,
-        asset: Vc<Box<dyn OutputAsset>>,
+        asset: ResolvedVc<Box<dyn OutputAsset>>,
     ) -> Vc<Self> {
         Self::cell(AssetGraphGetContentSourceContent {
             source,

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -44,7 +44,7 @@ impl AssetGraphContentSource {
     ) -> Vc<Self> {
         Self::cell(AssetGraphContentSource {
             root_path,
-            root_assets: Vc::cell(fxindexset! { root_asset }),
+            root_assets: ResolvedVc::cell(fxindexset! { root_asset }),
             expanded: None,
         })
     }
@@ -58,7 +58,7 @@ impl AssetGraphContentSource {
     ) -> Vc<Self> {
         Self::cell(AssetGraphContentSource {
             root_path,
-            root_assets: Vc::cell(fxindexset! { root_asset }),
+            root_assets: ResolvedVc::cell(fxindexset! { root_asset }),
             expanded: Some(State::new(HashSet::new())),
         })
     }

--- a/turbopack/crates/turbopack-dev-server/src/source/combined.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/combined.rs
@@ -19,7 +19,7 @@ pub struct CombinedContentSource {
 }
 
 impl CombinedContentSource {
-    pub fn new(sources: Vec<Vc<Box<dyn ContentSource>>>) -> Vc<Self> {
+    pub fn new(sources: Vec<ResolvedVc<Box<dyn ContentSource>>>) -> Vc<Self> {
         CombinedContentSource { sources }.cell()
     }
 }

--- a/turbopack/crates/turbopack-dev-server/src/source/combined.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/combined.rs
@@ -58,7 +58,7 @@ impl Introspectable for CombinedContentSource {
             .map(|&source| async move {
                 Ok(
                     if let Some(source) =
-                        Vc::try_resolve_sidecast::<Box<dyn Introspectable>>(source).await?
+                        ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(source).await?
                     {
                         Some(source.title().await?)
                     } else {

--- a/turbopack/crates/turbopack-dev-server/src/source/combined.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/combined.rs
@@ -86,13 +86,13 @@ impl Introspectable for CombinedContentSource {
                 .iter()
                 .copied()
                 .map(|s| async move {
-                    Ok(Vc::try_resolve_sidecast::<Box<dyn Introspectable>>(s).await?)
+                    Ok(ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(s).await?)
                 })
                 .try_join()
                 .await?
                 .into_iter()
                 .flatten()
-                .map(|i| (source, i))
+                .map(|i| (source, *i))
                 .collect(),
         ))
     }

--- a/turbopack/crates/turbopack-dev-server/src/source/combined.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/combined.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{TryJoinIterExt, Vc};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbopack_core::introspect::{Introspectable, IntrospectableChildren};
 
 use super::{
@@ -15,7 +15,7 @@ use crate::source::ContentSources;
 /// not a [ContentSourceContent::NotFound]) will be returned.
 #[turbo_tasks::value(shared)]
 pub struct CombinedContentSource {
-    pub sources: Vec<Vc<Box<dyn ContentSource>>>,
+    pub sources: Vec<ResolvedVc<Box<dyn ContentSource>>>,
 }
 
 impl CombinedContentSource {

--- a/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Completion, State, Value, Vc};
+use turbo_tasks::{Completion, ResolvedVc, State, Value, Vc};
 use turbopack_core::introspect::{Introspectable, IntrospectableChildren};
 
 use super::{
@@ -67,7 +67,7 @@ impl ContentSource for ConditionalContentSource {
 
 #[turbo_tasks::value]
 struct ConditionalContentSourceMapper {
-    source: Vc<ConditionalContentSource>,
+    source: ResolvedVc<ConditionalContentSource>,
 }
 
 #[turbo_tasks::value_impl]
@@ -152,8 +152,8 @@ impl Introspectable for ConditionalContentSource {
 
 #[turbo_tasks::value(serialization = "none", eq = "manual", cell = "new")]
 struct ActivateOnGetContentSource {
-    source: Vc<ConditionalContentSource>,
-    get_content: Vc<Box<dyn GetContentSourceContent>>,
+    source: ResolvedVc<ConditionalContentSource>,
+    get_content: ResolvedVc<Box<dyn GetContentSourceContent>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
@@ -23,8 +23,8 @@ use crate::source::{ContentSourceContent, ContentSources};
 /// served once.
 #[turbo_tasks::value(serialization = "none", eq = "manual", cell = "new")]
 pub struct ConditionalContentSource {
-    activator: Vc<Box<dyn ContentSource>>,
-    action: Vc<Box<dyn ContentSource>>,
+    activator: ResolvedVc<Box<dyn ContentSource>>,
+    action: ResolvedVc<Box<dyn ContentSource>>,
     activated: State<bool>,
 }
 
@@ -32,8 +32,8 @@ pub struct ConditionalContentSource {
 impl ConditionalContentSource {
     #[turbo_tasks::function]
     pub fn new(
-        activator: Vc<Box<dyn ContentSource>>,
-        action: Vc<Box<dyn ContentSource>>,
+        activator: ResolvedVc<Box<dyn ContentSource>>,
+        action: ResolvedVc<Box<dyn ContentSource>>,
     ) -> Vc<Self> {
         ConditionalContentSource {
             activator,

--- a/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
@@ -141,10 +141,10 @@ impl Introspectable for ConditionalContentSource {
             [
                 ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.activator)
                     .await?
-                    .map(|i| (activator_key(), i)),
+                    .map(|i| (activator_key(), *i)),
                 ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.action)
                     .await?
-                    .map(|i| (action_key(), i)),
+                    .map(|i| (action_key(), *i)),
             ]
             .into_iter()
             .flatten()

--- a/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
@@ -127,7 +127,7 @@ impl Introspectable for ConditionalContentSource {
     #[turbo_tasks::function]
     async fn title(&self) -> Result<Vc<RcStr>> {
         if let Some(activator) =
-            Vc::try_resolve_sidecast::<Box<dyn Introspectable>>(self.activator).await?
+            ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.activator).await?
         {
             Ok(activator.title())
         } else {

--- a/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
@@ -139,10 +139,10 @@ impl Introspectable for ConditionalContentSource {
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         Ok(Vc::cell(
             [
-                Vc::try_resolve_sidecast::<Box<dyn Introspectable>>(self.activator)
+                ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.activator)
                     .await?
                     .map(|i| (activator_key(), i)),
-                Vc::try_resolve_sidecast::<Box<dyn Introspectable>>(self.action)
+                ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.action)
                     .await?
                     .map(|i| (action_key(), i)),
             ]

--- a/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
@@ -107,7 +107,7 @@ impl GetContentSourceContent for IssueContextGetContentSourceContent {
         let result = self
             .get_content
             .vary()
-            .issue_file_path(source.file_path, &*source.description)
+            .issue_file_path(*source.file_path, &*source.description)
             .await?;
         Ok(result)
     }

--- a/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
@@ -58,7 +58,7 @@ impl ContentSource for IssueFilePathContentSource {
         let routes = this
             .source
             .get_routes()
-            .issue_file_path(*this.file_path, &*this.description)
+            .issue_file_path(this.file_path.map(|v| *v), &*this.description)
             .await?;
         Ok(routes.map_routes(Vc::upcast(
             IssueContextContentSourceMapper { source: self }.cell(),
@@ -107,7 +107,7 @@ impl GetContentSourceContent for IssueContextGetContentSourceContent {
         let result = self
             .get_content
             .vary()
-            .issue_file_path(*source.file_path, &*source.description)
+            .issue_file_path(source.file_path.map(|v| *v), &*source.description)
             .await?;
         Ok(result)
     }
@@ -122,7 +122,7 @@ impl GetContentSourceContent for IssueContextGetContentSourceContent {
         let result = self
             .get_content
             .get(path, data)
-            .issue_file_path(*source.file_path, &*source.description)
+            .issue_file_path(source.file_path.map(|v| *v), &*source.description)
             .await?;
         Ok(result)
     }

--- a/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Value, Vc};
+use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     introspect::{Introspectable, IntrospectableChildren},
@@ -15,9 +15,9 @@ use super::{
 
 #[turbo_tasks::value]
 pub struct IssueFilePathContentSource {
-    file_path: Option<Vc<FileSystemPath>>,
+    file_path: Option<ResolvedVc<FileSystemPath>>,
     description: RcStr,
-    source: Vc<Box<dyn ContentSource>>,
+    source: ResolvedVc<Box<dyn ContentSource>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -70,7 +70,7 @@ impl ContentSource for IssueFilePathContentSource {
 
 #[turbo_tasks::value]
 struct IssueContextContentSourceMapper {
-    source: Vc<IssueFilePathContentSource>,
+    source: ResolvedVc<IssueFilePathContentSource>,
 }
 
 #[turbo_tasks::value_impl]
@@ -92,8 +92,8 @@ impl MapGetContentSourceContent for IssueContextContentSourceMapper {
 
 #[turbo_tasks::value]
 struct IssueContextGetContentSourceContent {
-    get_content: Vc<Box<dyn GetContentSourceContent>>,
-    source: Vc<IssueFilePathContentSource>,
+    get_content: ResolvedVc<Box<dyn GetContentSourceContent>>,
+    source: ResolvedVc<IssueFilePathContentSource>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
@@ -119,7 +119,7 @@ impl GetContentSourceContent for IssueContextGetContentSourceContent {
         let result = self
             .get_content
             .get(path, data)
-            .issue_file_path(source.file_path, &*source.description)
+            .issue_file_path(*source.file_path, &*source.description)
             .await?;
         Ok(result)
     }
@@ -131,7 +131,7 @@ impl Introspectable for IssueFilePathContentSource {
     async fn ty(&self) -> Result<Vc<RcStr>> {
         Ok(
             if let Some(source) =
-                Vc::try_resolve_sidecast::<Box<dyn Introspectable>>(self.source).await?
+                ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.source).await?
             {
                 source.ty()
             } else {
@@ -144,7 +144,7 @@ impl Introspectable for IssueFilePathContentSource {
     async fn title(&self) -> Result<Vc<RcStr>> {
         Ok(
             if let Some(source) =
-                Vc::try_resolve_sidecast::<Box<dyn Introspectable>>(self.source).await?
+                ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.source).await?
             {
                 let title = source.title().await?;
                 Vc::cell(format!("{}: {}", self.description, title).into())
@@ -158,7 +158,7 @@ impl Introspectable for IssueFilePathContentSource {
     async fn details(&self) -> Result<Vc<RcStr>> {
         Ok(
             if let Some(source) =
-                Vc::try_resolve_sidecast::<Box<dyn Introspectable>>(self.source).await?
+                ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.source).await?
             {
                 source.details()
             } else {
@@ -171,7 +171,7 @@ impl Introspectable for IssueFilePathContentSource {
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         Ok(
             if let Some(source) =
-                Vc::try_resolve_sidecast::<Box<dyn Introspectable>>(self.source).await?
+                ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.source).await?
             {
                 source.children()
             } else {

--- a/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
@@ -50,12 +50,12 @@ impl IssueFilePathContentSource {
 #[turbo_tasks::value_impl]
 impl ContentSource for IssueFilePathContentSource {
     #[turbo_tasks::function]
-    async fn get_routes(self: Vc<Self>) -> Result<Vc<RouteTree>> {
+    async fn get_routes(self: ResolvedVc<Self>) -> Result<Vc<RouteTree>> {
         let this = self.await?;
         let routes = this
             .source
             .get_routes()
-            .issue_file_path(this.file_path, &*this.description)
+            .issue_file_path(*this.file_path, &*this.description)
             .await?;
         Ok(routes.map_routes(Vc::upcast(
             IssueContextContentSourceMapper { source: self }.cell(),

--- a/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
@@ -24,9 +24,9 @@ pub struct IssueFilePathContentSource {
 impl IssueFilePathContentSource {
     #[turbo_tasks::function]
     pub fn new_file_path(
-        file_path: Vc<FileSystemPath>,
+        file_path: ResolvedVc<FileSystemPath>,
         description: RcStr,
-        source: Vc<Box<dyn ContentSource>>,
+        source: ResolvedVc<Box<dyn ContentSource>>,
     ) -> Vc<Self> {
         IssueFilePathContentSource {
             file_path: Some(file_path),
@@ -37,7 +37,10 @@ impl IssueFilePathContentSource {
     }
 
     #[turbo_tasks::function]
-    pub fn new_description(description: RcStr, source: Vc<Box<dyn ContentSource>>) -> Vc<Self> {
+    pub fn new_description(
+        description: RcStr,
+        source: ResolvedVc<Box<dyn ContentSource>>,
+    ) -> Vc<Self> {
         IssueFilePathContentSource {
             file_path: None,
             description,
@@ -78,7 +81,7 @@ impl MapGetContentSourceContent for IssueContextContentSourceMapper {
     #[turbo_tasks::function]
     fn map_get_content(
         &self,
-        get_content: Vc<Box<dyn GetContentSourceContent>>,
+        get_content: ResolvedVc<Box<dyn GetContentSourceContent>>,
     ) -> Vc<Box<dyn GetContentSourceContent>> {
         Vc::upcast(
             IssueContextGetContentSourceContent {

--- a/turbopack/crates/turbopack-dev-server/src/source/lazy_instantiated.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/lazy_instantiated.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::introspect::{Introspectable, IntrospectableChildren};
 
 use super::{route_tree::RouteTree, ContentSource};
@@ -17,7 +17,7 @@ pub trait GetContentSource {
 /// actually used.
 #[turbo_tasks::value(shared)]
 pub struct LazyInstantiatedContentSource {
-    pub get_source: Vc<Box<dyn GetContentSource>>,
+    pub get_source: ResolvedVc<Box<dyn GetContentSource>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-dev-server/src/source/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/mod.rs
@@ -119,18 +119,18 @@ impl GetContentSourceContent for ContentSourceContent {
 #[turbo_tasks::value_impl]
 impl ContentSourceContent {
     #[turbo_tasks::function]
-    pub fn static_content(
+    pub async fn static_content(
         content: ResolvedVc<Box<dyn VersionedContent>>,
-    ) -> Vc<ContentSourceContent> {
-        ContentSourceContent::Static(
+    ) -> Result<Vc<ContentSourceContent>> {
+        Ok(ContentSourceContent::Static(
             StaticContent {
                 content,
                 status_code: 200,
-                headers: HeaderList::empty(),
+                headers: HeaderList::empty().to_resolved().await?,
             }
             .resolved_cell(),
         )
-        .cell()
+        .cell())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-dev-server/src/source/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/mod.rs
@@ -75,13 +75,13 @@ pub trait GetContentSourceContent {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct GetContentSourceContents(Vec<Vc<Box<dyn GetContentSourceContent>>>);
+pub struct GetContentSourceContents(Vec<ResolvedVc<Box<dyn GetContentSourceContent>>>);
 
 #[turbo_tasks::value]
 pub struct StaticContent {
-    pub content: Vc<Box<dyn VersionedContent>>,
+    pub content: ResolvedVc<Box<dyn VersionedContent>>,
     pub status_code: u16,
-    pub headers: Vc<HeaderList>,
+    pub headers: ResolvedVc<HeaderList>,
 }
 
 #[turbo_tasks::value(shared)]
@@ -200,7 +200,7 @@ pub struct ContentSourceData {
     /// requested.
     pub raw_headers: Option<Vec<(RcStr, RcStr)>>,
     /// Request body, if requested.
-    pub body: Option<Vc<Body>>,
+    pub body: Option<ResolvedVc<Body>>,
     /// See [ContentSourceDataVary::cache_buster].
     pub cache_buster: u64,
 }
@@ -443,7 +443,7 @@ where
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct ContentSources(Vec<Vc<Box<dyn ContentSource>>>);
+pub struct ContentSources(Vec<ResolvedVc<Box<dyn ContentSource>>>);
 
 #[turbo_tasks::value_impl]
 impl ContentSources {

--- a/turbopack/crates/turbopack-dev-server/src/source/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/mod.rs
@@ -124,7 +124,7 @@ impl ContentSourceContent {
     ) -> Vc<ContentSourceContent> {
         ContentSourceContent::Static(
             StaticContent {
-                content: *content,
+                content,
                 status_code: 200,
                 headers: HeaderList::empty(),
             }

--- a/turbopack/crates/turbopack-dev-server/src/source/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/mod.rs
@@ -141,9 +141,9 @@ impl ContentSourceContent {
     ) -> Vc<ContentSourceContent> {
         ContentSourceContent::Static(
             StaticContent {
-                content: *content,
+                content,
                 status_code,
-                headers: *headers,
+                headers,
             }
             .resolved_cell(),
         )

--- a/turbopack/crates/turbopack-dev-server/src/source/resolve.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/resolve.rs
@@ -146,7 +146,7 @@ async fn request_to_data(
         data.original_url = Some(original_request.uri.to_string().into());
     }
     if vary.body {
-        data.body = Some(request.body.clone().into());
+        data.body = Some(request.body.clone().resolved_cell());
     }
     if vary.raw_query {
         data.raw_query = Some(request.uri.query().unwrap_or("").into());

--- a/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
@@ -370,19 +370,19 @@ impl RouteTree {
         } = &mut this;
 
         for s in sources.iter_mut() {
-            *s = mapper.map_get_content(*s);
+            *s = mapper.map_get_content(**s).to_resolved().await?;
         }
         for s in catch_all_sources.iter_mut() {
-            *s = mapper.map_get_content(*s);
+            *s = mapper.map_get_content(**s).to_resolved().await?;
         }
         for s in fallback_sources.iter_mut() {
-            *s = mapper.map_get_content(*s);
+            *s = mapper.map_get_content(**s).to_resolved().await?;
         }
         for s in not_found_sources.iter_mut() {
-            *s = mapper.map_get_content(*s);
+            *s = mapper.map_get_content(**s).to_resolved().await?;
         }
         for r in static_segments.values_mut() {
-            *r = r.map_routes(mapper);
+            *r = r.map_routes(mapper).to_resolved().await?;
         }
         for r in dynamic_segments.iter_mut() {
             *r = r.map_routes(mapper).to_resolved().await?;

--- a/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
@@ -41,7 +41,7 @@ impl BaseSegment {
 /// lead to creating new tasks over and over. A celled list leads to task reuse
 /// and faster operation.
 #[turbo_tasks::value(transparent)]
-pub struct RouteTrees(Vec<Vc<RouteTree>>);
+pub struct RouteTrees(Vec<ResolvedVc<RouteTree>>);
 
 #[turbo_tasks::value_impl]
 impl RouteTrees {
@@ -101,12 +101,12 @@ impl RouteTrees {
 #[derive(Default, Clone, Debug)]
 pub struct RouteTree {
     base: Vec<BaseSegment>,
-    sources: Vec<Vc<Box<dyn GetContentSourceContent>>>,
-    static_segments: FxIndexMap<RcStr, Vc<RouteTree>>,
+    sources: Vec<ResolvedVc<Box<dyn GetContentSourceContent>>>,
+    static_segments: FxIndexMap<RcStr, ResolvedVc<RouteTree>>,
     dynamic_segments: Vec<ResolvedVc<RouteTree>>,
-    catch_all_sources: Vec<Vc<Box<dyn GetContentSourceContent>>>,
-    fallback_sources: Vec<Vc<Box<dyn GetContentSourceContent>>>,
-    not_found_sources: Vec<Vc<Box<dyn GetContentSourceContent>>>,
+    catch_all_sources: Vec<ResolvedVc<Box<dyn GetContentSourceContent>>>,
+    fallback_sources: Vec<ResolvedVc<Box<dyn GetContentSourceContent>>>,
+    not_found_sources: Vec<ResolvedVc<Box<dyn GetContentSourceContent>>>,
 }
 
 impl RouteTree {

--- a/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
@@ -53,7 +53,7 @@ impl RouteTrees {
             return Ok(RouteTree::default().cell());
         }
         if trees.len() == 1 {
-            return Ok(*trees.iter().next().unwrap());
+            return Ok(**trees.iter().next().unwrap());
         }
 
         // Find common base
@@ -81,7 +81,7 @@ impl RouteTrees {
                 if tree_values[i].base.len() > common_base {
                     tree.with_base_len(common_base)
                 } else {
-                    *tree
+                    **tree
                 }
             })
             .collect::<Vec<_>>();

--- a/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
@@ -335,7 +335,7 @@ impl RouteTree {
             match selector_segment {
                 BaseSegment::Static(value) => Ok(RouteTree {
                     base,
-                    static_segments: fxindexmap! { value => inner.cell() },
+                    static_segments: fxindexmap! { value => inner.resolved_cell() },
                     ..Default::default()
                 }
                 .cell()),

--- a/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
@@ -172,7 +172,7 @@ impl RouteTree {
                         if value.len() == 1 {
                             value.into_iter().next().unwrap()
                         } else {
-                            Vc::<RouteTrees>::cell(value).merge().resolve().await?
+                            Vc::<RouteTrees>::cell(value).merge().to_resolved().await?
                         },
                     ))
                 })

--- a/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
@@ -114,7 +114,7 @@ impl RouteTree {
     pub fn new_route_ref(
         base_segments: Vec<BaseSegment>,
         route_type: RouteType,
-        source: Vc<Box<dyn GetContentSourceContent>>,
+        source: ResolvedVc<Box<dyn GetContentSourceContent>>,
     ) -> Self {
         match route_type {
             RouteType::Exact => Self {
@@ -250,7 +250,7 @@ impl RouteTree {
     pub fn new_route(
         base_segments: Vec<BaseSegment>,
         route_type: RouteType,
-        source: Vc<Box<dyn GetContentSourceContent>>,
+        source: ResolvedVc<Box<dyn GetContentSourceContent>>,
     ) -> Vc<Self> {
         RouteTree::new_route_ref(base_segments, route_type, source).cell()
     }

--- a/turbopack/crates/turbopack-dev-server/src/source/router.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/router.rs
@@ -2,7 +2,7 @@ use std::iter::once;
 
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{TryJoinIterExt, Value, Vc};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, Vc};
 use turbopack_core::introspect::{Introspectable, IntrospectableChildren};
 
 use super::{
@@ -19,9 +19,9 @@ use crate::source::{route_tree::MapGetContentSourceContent, ContentSources};
 /// other subpaths, including if the request path does not include the prefix.
 #[turbo_tasks::value(shared)]
 pub struct PrefixedRouterContentSource {
-    pub prefix: Vc<RcStr>,
-    pub routes: Vec<(RcStr, Vc<Box<dyn ContentSource>>)>,
-    pub fallback: Vc<Box<dyn ContentSource>>,
+    pub prefix: ResolvedVc<RcStr>,
+    pub routes: Vec<(RcStr, ResolvedVc<Box<dyn ContentSource>>)>,
+    pub fallback: ResolvedVc<Box<dyn ContentSource>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -121,7 +121,7 @@ impl ContentSource for PrefixedRouterContentSource {
 
 #[turbo_tasks::value]
 struct PrefixedRouterContentSourceMapper {
-    prefix: Vc<RcStr>,
+    prefix: ResolvedVc<RcStr>,
     path: RcStr,
 }
 
@@ -144,8 +144,8 @@ impl MapGetContentSourceContent for PrefixedRouterContentSourceMapper {
 
 #[turbo_tasks::value]
 struct PrefixedRouterGetContentSourceContent {
-    mapper: Vc<PrefixedRouterContentSourceMapper>,
-    get_content: Vc<Box<dyn GetContentSourceContent>>,
+    mapper: ResolvedVc<PrefixedRouterContentSourceMapper>,
+    get_content: ResolvedVc<Box<dyn GetContentSourceContent>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-dev-server/src/source/router.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/router.rs
@@ -42,8 +42,8 @@ impl PrefixedRouterContentSource {
 }
 
 fn get_children(
-    routes: &[(RcStr, Vc<Box<dyn ContentSource>>)],
-    fallback: &Vc<Box<dyn ContentSource>>,
+    routes: &[(RcStr, ResolvedVc<Box<dyn ContentSource>>)],
+    fallback: &ResolvedVc<Box<dyn ContentSource>>,
 ) -> Vc<ContentSources> {
     Vc::cell(
         routes
@@ -55,8 +55,8 @@ fn get_children(
 }
 
 async fn get_introspection_children(
-    routes: &[(RcStr, Vc<Box<dyn ContentSource>>)],
-    fallback: &Vc<Box<dyn ContentSource>>,
+    routes: &[(RcStr, ResolvedVc<Box<dyn ContentSource>>)],
+    fallback: &ResolvedVc<Box<dyn ContentSource>>,
 ) -> Result<Vc<IntrospectableChildren>> {
     Ok(Vc::cell(
         routes

--- a/turbopack/crates/turbopack-dev-server/src/source/router.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/router.rs
@@ -129,8 +129,8 @@ struct PrefixedRouterContentSourceMapper {
 impl MapGetContentSourceContent for PrefixedRouterContentSourceMapper {
     #[turbo_tasks::function]
     fn map_get_content(
-        self: Vc<Self>,
-        get_content: Vc<Box<dyn GetContentSourceContent>>,
+        self: ResolvedVc<Self>,
+        get_content: ResolvedVc<Box<dyn GetContentSourceContent>>,
     ) -> Vc<Box<dyn GetContentSourceContent>> {
         Vc::upcast(
             PrefixedRouterGetContentSourceContent {

--- a/turbopack/crates/turbopack-dev-server/src/source/router.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/router.rs
@@ -28,9 +28,9 @@ pub struct PrefixedRouterContentSource {
 impl PrefixedRouterContentSource {
     #[turbo_tasks::function]
     pub fn new(
-        prefix: Vc<RcStr>,
-        routes: Vec<(RcStr, Vc<Box<dyn ContentSource>>)>,
-        fallback: Vc<Box<dyn ContentSource>>,
+        prefix: ResolvedVc<RcStr>,
+        routes: Vec<(RcStr, ResolvedVc<Box<dyn ContentSource>>)>,
+        fallback: ResolvedVc<Box<dyn ContentSource>>,
     ) -> Vc<Self> {
         PrefixedRouterContentSource {
             prefix,

--- a/turbopack/crates/turbopack-dev-server/src/source/router.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/router.rs
@@ -64,7 +64,7 @@ async fn get_introspection_children(
             .cloned()
             .chain(std::iter::once((RcStr::default(), *fallback)))
             .map(|(path, source)| async move {
-                Ok(Vc::try_resolve_sidecast::<Box<dyn Introspectable>>(source)
+                Ok(ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(source)
                     .await?
                     .map(|i| (Vc::cell(path), i)))
             })

--- a/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Value, Vc};
+use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbo_tasks_fs::{DirectoryContent, DirectoryEntry, FileSystemPath};
 use turbopack_core::{
     asset::Asset,
@@ -16,8 +16,8 @@ use super::{
 
 #[turbo_tasks::value(shared)]
 pub struct StaticAssetsContentSource {
-    pub prefix: Vc<RcStr>,
-    pub dir: Vc<FileSystemPath>,
+    pub prefix: ResolvedVc<RcStr>,
+    pub dir: ResolvedVc<FileSystemPath>,
 }
 
 #[turbo_tasks::value_impl]
@@ -82,7 +82,7 @@ impl ContentSource for StaticAssetsContentSource {
 
 #[turbo_tasks::value]
 struct StaticAssetsContentSourceItem {
-    path: Vc<FileSystemPath>,
+    path: ResolvedVc<FileSystemPath>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
@@ -30,8 +30,8 @@ impl StaticAssetsContentSource {
 
     #[turbo_tasks::function]
     pub async fn with_prefix(
-        prefix: Vc<RcStr>,
-        dir: Vc<FileSystemPath>,
+        prefix: ResolvedVc<RcStr>,
+        dir: ResolvedVc<FileSystemPath>,
     ) -> Result<Vc<StaticAssetsContentSource>> {
         if cfg!(debug_assertions) {
             let prefix_string = prefix.await?;

--- a/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
@@ -76,7 +76,7 @@ impl ContentSource for StaticAssetsContentSource {
     async fn get_routes(&self) -> Result<Vc<RouteTree>> {
         let prefix = self.prefix.await?;
         let prefix = BaseSegment::from_static_pathname(prefix.as_str()).collect::<Vec<_>>();
-        Ok(get_routes_from_directory(self.dir).with_prepended_base(prefix))
+        Ok(get_routes_from_directory(*self.dir).with_prepended_base(prefix))
     }
 }
 
@@ -88,7 +88,7 @@ struct StaticAssetsContentSourceItem {
 #[turbo_tasks::value_impl]
 impl StaticAssetsContentSourceItem {
     #[turbo_tasks::function]
-    pub fn new(path: Vc<FileSystemPath>) -> Vc<StaticAssetsContentSourceItem> {
+    pub fn new(path: ResolvedVc<FileSystemPath>) -> Vc<StaticAssetsContentSourceItem> {
         StaticAssetsContentSourceItem { path }.cell()
     }
 }

--- a/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, Vc};
 use turbo_tasks_fs::{DirectoryContent, DirectoryEntry, FileSystemPath};
 use turbopack_core::{
     asset::Asset,
@@ -66,7 +66,9 @@ async fn get_routes_from_directory(dir: Vc<FileSystemPath>) -> Result<Vc<RouteTr
             ),
             _ => None,
         })
-        .collect();
+        .map(|v| async move { v.to_resolved().await })
+        .try_join()
+        .await?;
     Ok(Vc::<RouteTrees>::cell(routes).merge())
 }
 

--- a/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
@@ -97,7 +97,7 @@ impl StaticAssetsContentSourceItem {
 impl GetContentSourceContent for StaticAssetsContentSourceItem {
     #[turbo_tasks::function]
     fn get(&self, _path: RcStr, _data: Value<ContentSourceData>) -> Vc<ContentSourceContent> {
-        let content = Vc::upcast::<Box<dyn Asset>>(FileSource::new(self.path)).content();
+        let content = Vc::upcast::<Box<dyn Asset>>(FileSource::new(*self.path)).content();
         ContentSourceContent::static_content(content.versioned())
     }
 }

--- a/turbopack/crates/turbopack-dev-server/src/source/wrapping_source.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/wrapping_source.rs
@@ -33,8 +33,8 @@ pub struct WrappedGetContentSourceContent {
 impl WrappedGetContentSourceContent {
     #[turbo_tasks::function]
     pub fn new(
-        inner: Vc<Box<dyn GetContentSourceContent>>,
-        processor: Vc<Box<dyn ContentSourceProcessor>>,
+        inner: ResolvedVc<Box<dyn GetContentSourceContent>>,
+        processor: ResolvedVc<Box<dyn ContentSourceProcessor>>,
     ) -> Vc<Self> {
         WrappedGetContentSourceContent { inner, processor }.cell()
     }

--- a/turbopack/crates/turbopack-dev-server/src/source/wrapping_source.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/wrapping_source.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Value, Vc};
+use turbo_tasks::{ResolvedVc, Value, Vc};
 
 use super::{
     ContentSourceContent, ContentSourceData, ContentSourceDataVary, GetContentSourceContent,
@@ -25,8 +25,8 @@ pub trait ContentSourceProcessor {
 
 #[turbo_tasks::value]
 pub struct WrappedGetContentSourceContent {
-    inner: Vc<Box<dyn GetContentSourceContent>>,
-    processor: Vc<Box<dyn ContentSourceProcessor>>,
+    inner: ResolvedVc<Box<dyn GetContentSourceContent>>,
+    processor: ResolvedVc<Box<dyn ContentSourceProcessor>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-dev-server/src/update/stream.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/stream.rs
@@ -6,7 +6,7 @@ use tokio::sync::mpsc::Sender;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{IntoTraitRef, ReadRef, TransientInstance, Vc};
+use turbo_tasks::{IntoTraitRef, ReadRef, ResolvedVc, TransientInstance, Vc};
 use turbo_tasks_fs::{FileSystem, FileSystemPath};
 use turbopack_core::{
     error::PrettyPrintError,
@@ -282,7 +282,7 @@ pub enum UpdateStreamItem {
 
 #[turbo_tasks::value(serialization = "none")]
 struct FatalStreamIssue {
-    description: Vc<StyledString>,
+    description: ResolvedVc<StyledString>,
     resource: RcStr,
 }
 

--- a/turbopack/crates/turbopack-dev-server/src/update/stream.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/stream.rs
@@ -310,6 +310,6 @@ impl Issue for FatalStreamIssue {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(self.description))
+        Vc::cell(Some(*self.description))
     }
 }

--- a/turbopack/crates/turbopack-dev-server/src/update/stream.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/stream.rs
@@ -58,7 +58,7 @@ async fn get_update_stream_item(
                 FatalStreamIssue {
                     resource,
                     description: StyledString::Text(format!("{}", PrettyPrintError(&e)).into())
-                        .cell(),
+                        .resolved_cell(),
                 }
                 .cell()
                 .into_plain(OptionIssueProcessingPathItems::none())

--- a/turbopack/crates/turbopack-node/src/render/node_api_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/node_api_source.rs
@@ -150,7 +150,7 @@ impl GetContentSourceContent for NodeApiContentSource {
                     data: Some(self.render_data.await?),
                 }
                 .cell(),
-                *body,
+                **body,
                 self.debug,
             )
             .to_resolved()

--- a/turbopack/crates/turbopack-node/src/render/rendered_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/rendered_source.rs
@@ -68,12 +68,12 @@ pub fn create_node_rendered_source(
         render_data,
         debug,
     }
-    .cell();
+    .resolved_cell();
     Vc::upcast(ConditionalContentSource::new(
-        Vc::upcast(source),
+        Vc::upcast(*source),
         Vc::upcast(
             LazyInstantiatedContentSource {
-                get_source: Vc::upcast(source),
+                get_source: ResolvedVc::upcast(source),
             }
             .cell(),
         ),


### PR DESCRIPTION
### What?

Use `ResolvedVc<T>` instead of `Vc<T>` for struct fields in `turbopack-dev-server`

### Why?

### How?


Closes PACK-3550