### PR TITLE
perf(turbopack): Use `ResolvedVc` for `turbopack`, `turbopack-tests`, `turbopack-wasm`

### DIFF
--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -52,8 +52,8 @@ use crate::util::REPO_ROOT;
 
 #[turbo_tasks::value]
 struct RunTestResult {
-    js_result: Vc<JsResult>,
-    path: Vc<FileSystemPath>,
+    js_result: ResolvedVc<JsResult>,
+    path: ResolvedVc<FileSystemPath>,
 }
 
 #[turbo_tasks::value]
@@ -201,9 +201,9 @@ struct TestOptions {
 
 #[turbo_tasks::value]
 struct PreparedTest {
-    path: Vc<FileSystemPath>,
-    project_path: Vc<FileSystemPath>,
-    tests_path: Vc<FileSystemPath>,
+    path: ResolvedVc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
+    tests_path: ResolvedVc<FileSystemPath>,
     project_root: ResolvedVc<FileSystemPath>,
     options: TestOptions,
 }

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -392,11 +392,11 @@ async fn run_test(prepared_test: Vc<PreparedTest>) -> Result<Vc<RunTestResult>> 
 
     let res = evaluate(
         jest_entry_asset,
-        path.to_resolved().await?,
+        *path,
         Vc::upcast(CommandLineProcessEnv::new()),
         test_source.ident(),
         asset_context,
-        Vc::upcast(*chunking_context),
+        Vc::upcast(chunking_context),
         None,
         vec![],
         Completion::immutable(),

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -392,11 +392,11 @@ async fn run_test(prepared_test: Vc<PreparedTest>) -> Result<Vc<RunTestResult>> 
 
     let res = evaluate(
         jest_entry_asset,
-        path,
+        path.to_resolved().await?,
         Vc::upcast(CommandLineProcessEnv::new()),
         test_source.ident(),
         asset_context,
-        Vc::upcast(chunking_context),
+        Vc::upcast(*chunking_context),
         None,
         vec![],
         Completion::immutable(),
@@ -418,14 +418,14 @@ async fn run_test(prepared_test: Vc<PreparedTest>) -> Result<Vc<RunTestResult>> 
                     test_results: vec![],
                 },
             }
-            .cell(),
+            .resolved_cell(),
             path,
         }
         .cell());
     };
 
     Ok(RunTestResult {
-        js_result: JsResult::cell(parse_json_with_source_context(bytes.to_str()?)?),
+        js_result: JsResult::resolved_cell(parse_json_with_source_context(bytes.to_str()?)?),
         path,
     }
     .cell())

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -190,7 +190,7 @@ async fn run_inner(
         snapshot_issues(prepared_test, run_result).await?;
     }
 
-    Ok(run_result.await?.js_result)
+    Ok(*run_result.await?.js_result)
 }
 
 #[derive(PartialEq, Eq, Debug, Default, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat)]
@@ -245,10 +245,10 @@ async fn prepare_test(resource: RcStr) -> Result<Vc<PreparedTest>> {
     }
 
     Ok(PreparedTest {
-        path,
-        project_path,
-        tests_path,
-        project_root,
+        path: path.to_resolved().await?,
+        project_path: project_path.to_resolved().await?,
+        tests_path: tests_path.to_resolved().await?,
+        project_root: project_root.to_resolved().await?,
         options,
     }
     .cell())

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -46,8 +46,8 @@ pub struct WebAssemblyModuleAsset {
 impl WebAssemblyModuleAsset {
     #[turbo_tasks::function]
     pub fn new(
-        source: Vc<WebAssemblySource>,
-        asset_context: Vc<Box<dyn AssetContext>>,
+        source: ResolvedVc<WebAssemblySource>,
+        asset_context: ResolvedVc<Box<dyn AssetContext>>,
     ) -> Vc<Self> {
         Self::cell(WebAssemblyModuleAsset {
             source,
@@ -57,7 +57,7 @@ impl WebAssemblyModuleAsset {
 
     #[turbo_tasks::function]
     fn wasm_asset(&self, chunking_context: Vc<Box<dyn ChunkingContext>>) -> Vc<WebAssemblyAsset> {
-        WebAssemblyAsset::new(self.source, chunking_context)
+        WebAssemblyAsset::new(*self.source, chunking_context)
     }
 
     #[turbo_tasks::function]
@@ -134,8 +134,8 @@ impl Asset for WebAssemblyModuleAsset {
 impl ChunkableModule for WebAssemblyModuleAsset {
     #[turbo_tasks::function]
     fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
+        self: ResolvedVc<Self>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
         Vc::upcast(
             ModuleChunkItem {
@@ -169,7 +169,7 @@ impl ResolveOrigin for WebAssemblyModuleAsset {
 
     #[turbo_tasks::function]
     fn asset_context(&self) -> Vc<Box<dyn AssetContext>> {
-        self.asset_context
+        *self.asset_context
     }
 
     #[turbo_tasks::function]
@@ -196,14 +196,14 @@ impl ChunkItem for ModuleChunkItem {
         let loader = self
             .module
             .loader()
-            .as_chunk_item(Vc::upcast(self.chunking_context));
+            .as_chunk_item(Vc::upcast(*self.chunking_context));
 
         loader.references()
     }
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        Vc::upcast(self.chunking_context)
+        Vc::upcast(*self.chunking_context)
     }
 
     #[turbo_tasks::function]
@@ -215,7 +215,7 @@ impl ChunkItem for ModuleChunkItem {
 
     #[turbo_tasks::function]
     fn module(&self) -> Vc<Box<dyn Module>> {
-        Vc::upcast(self.module)
+        Vc::upcast(*self.module)
     }
 
     #[turbo_tasks::function]
@@ -228,7 +228,7 @@ impl ChunkItem for ModuleChunkItem {
 impl EcmascriptChunkItem for ModuleChunkItem {
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        self.chunking_context
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]
@@ -242,7 +242,7 @@ impl EcmascriptChunkItem for ModuleChunkItem {
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<EcmascriptChunkItemContent>> {
         let loader_asset = self.module.loader();
-        let item = loader_asset.as_chunk_item(Vc::upcast(self.chunking_context));
+        let item = loader_asset.as_chunk_item(Vc::upcast(*self.chunking_context));
 
         let ecmascript_item = Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkItem>>(item)
             .await?

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -66,9 +66,9 @@ impl WebAssemblyModuleAsset {
         let query = &*this.source.ident().query().await?;
 
         let loader_source = if query == "?module" {
-            compiling_loader_source(this.source)
+            compiling_loader_source(*this.source)
         } else {
-            instantiating_loader_source(this.source)
+            instantiating_loader_source(*this.source)
         };
 
         let module = this.asset_context.process(

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -74,7 +74,7 @@ impl WebAssemblyModuleAsset {
         let module = this.asset_context.process(
             loader_source,
             Value::new(ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
-                "WASM_PATH".into() => ResolvedVc::upcast(RawWebAssemblyModuleAsset::new(this.source, this.asset_context).to_resolved().await?),
+                "WASM_PATH".into() => ResolvedVc::upcast(RawWebAssemblyModuleAsset::new(*this.source, *this.asset_context).to_resolved().await?),
             }))),
         ).module();
 

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -38,8 +38,8 @@ fn modifier() -> Vc<RcStr> {
 #[turbo_tasks::value]
 #[derive(Clone)]
 pub struct WebAssemblyModuleAsset {
-    source: Vc<WebAssemblySource>,
-    asset_context: Vc<Box<dyn AssetContext>>,
+    source: ResolvedVc<WebAssemblySource>,
+    asset_context: ResolvedVc<Box<dyn AssetContext>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -180,8 +180,8 @@ impl ResolveOrigin for WebAssemblyModuleAsset {
 
 #[turbo_tasks::value]
 struct ModuleChunkItem {
-    module: Vc<WebAssemblyModuleAsset>,
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
+    module: ResolvedVc<WebAssemblyModuleAsset>,
+    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-wasm/src/output_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/output_asset.rs
@@ -1,5 +1,5 @@
 use turbo_rcstr::RcStr;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::ChunkingContext,
@@ -19,8 +19,8 @@ fn modifier() -> Vc<RcStr> {
 /// [ChunkingContext].
 #[turbo_tasks::value]
 pub(crate) struct WebAssemblyAsset {
-    source: Vc<WebAssemblySource>,
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
+    source: ResolvedVc<WebAssemblySource>,
+    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-wasm/src/output_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/output_asset.rs
@@ -27,8 +27,8 @@ pub(crate) struct WebAssemblyAsset {
 impl WebAssemblyAsset {
     #[turbo_tasks::function]
     pub(crate) fn new(
-        source: Vc<WebAssemblySource>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
+        source: ResolvedVc<WebAssemblySource>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Self> {
         Self::cell(WebAssemblyAsset {
             source,

--- a/turbopack/crates/turbopack-wasm/src/raw.rs
+++ b/turbopack/crates/turbopack-wasm/src/raw.rs
@@ -137,7 +137,7 @@ impl ChunkItem for RawModuleChunkItem {
 
     #[turbo_tasks::function]
     fn module(&self) -> Vc<Box<dyn Module>> {
-        Vc::upcast(self.module)
+        Vc::upcast(*self.module)
     }
 }
 
@@ -145,7 +145,7 @@ impl ChunkItem for RawModuleChunkItem {
 impl EcmascriptChunkItem for RawModuleChunkItem {
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        self.chunking_context
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-wasm/src/raw.rs
+++ b/turbopack/crates/turbopack-wasm/src/raw.rs
@@ -38,8 +38,8 @@ pub struct RawWebAssemblyModuleAsset {
 impl RawWebAssemblyModuleAsset {
     #[turbo_tasks::function]
     pub fn new(
-        source: Vc<WebAssemblySource>,
-        asset_context: Vc<Box<dyn AssetContext>>,
+        source: ResolvedVc<WebAssemblySource>,
+        asset_context: ResolvedVc<Box<dyn AssetContext>>,
     ) -> Vc<Self> {
         Self::cell(RawWebAssemblyModuleAsset {
             source,
@@ -48,8 +48,11 @@ impl RawWebAssemblyModuleAsset {
     }
 
     #[turbo_tasks::function]
-    fn wasm_asset(&self, chunking_context: Vc<Box<dyn ChunkingContext>>) -> Vc<WebAssemblyAsset> {
-        WebAssemblyAsset::new(self.source, chunking_context)
+    fn wasm_asset(
+        &self,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    ) -> Vc<WebAssemblyAsset> {
+        WebAssemblyAsset::new(*self.source, chunking_context)
     }
 }
 

--- a/turbopack/crates/turbopack-wasm/src/raw.rs
+++ b/turbopack/crates/turbopack-wasm/src/raw.rs
@@ -104,7 +104,7 @@ impl EcmascriptChunkPlaceable for RawWebAssemblyModuleAsset {
 #[turbo_tasks::value]
 struct RawModuleChunkItem {
     module: ResolvedVc<RawWebAssemblyModuleAsset>,
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
+    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     wasm_asset: ResolvedVc<WebAssemblyAsset>,
 }
 
@@ -118,7 +118,7 @@ impl ChunkItem for RawModuleChunkItem {
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<ModuleReferences>> {
         Ok(Vc::cell(vec![Vc::upcast(SingleOutputAssetReference::new(
-            Vc::upcast(self.wasm_asset),
+            Vc::upcast(*self.wasm_asset),
             Vc::cell(format!("wasm(url) {}", self.wasm_asset.ident().to_string().await?).into()),
         ))]))
     }

--- a/turbopack/crates/turbopack-wasm/src/raw.rs
+++ b/turbopack/crates/turbopack-wasm/src/raw.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
@@ -30,8 +30,8 @@ fn modifier() -> Vc<RcStr> {
 #[turbo_tasks::value]
 #[derive(Clone)]
 pub struct RawWebAssemblyModuleAsset {
-    source: Vc<WebAssemblySource>,
-    asset_context: Vc<Box<dyn AssetContext>>,
+    source: ResolvedVc<WebAssemblySource>,
+    asset_context: ResolvedVc<Box<dyn AssetContext>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -100,9 +100,9 @@ impl EcmascriptChunkPlaceable for RawWebAssemblyModuleAsset {
 
 #[turbo_tasks::value]
 struct RawModuleChunkItem {
-    module: Vc<RawWebAssemblyModuleAsset>,
+    module: ResolvedVc<RawWebAssemblyModuleAsset>,
     chunking_context: Vc<Box<dyn ChunkingContext>>,
-    wasm_asset: Vc<WebAssemblyAsset>,
+    wasm_asset: ResolvedVc<WebAssemblyAsset>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-wasm/src/raw.rs
+++ b/turbopack/crates/turbopack-wasm/src/raw.rs
@@ -84,7 +84,7 @@ impl ChunkableModule for RawWebAssemblyModuleAsset {
                 module: self,
                 chunking_context,
                 wasm_asset: self
-                    .wasm_asset(Vc::upcast(chunking_context))
+                    .wasm_asset(Vc::upcast(*chunking_context))
                     .to_resolved()
                     .await?,
             }
@@ -125,7 +125,7 @@ impl ChunkItem for RawModuleChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        Vc::upcast(self.chunking_context)
+        Vc::upcast(*self.chunking_context)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-wasm/src/source.rs
+++ b/turbopack/crates/turbopack-wasm/src/source.rs
@@ -41,7 +41,7 @@ pub struct WebAssemblySource {
 #[turbo_tasks::value_impl]
 impl WebAssemblySource {
     #[turbo_tasks::function]
-    pub fn new(source: Vc<Box<dyn Source>>, source_ty: WebAssemblySourceType) -> Vc<Self> {
+    pub fn new(source: ResolvedVc<Box<dyn Source>>, source_ty: WebAssemblySourceType) -> Vc<Self> {
         Self::cell(WebAssemblySource { source, source_ty })
     }
 }

--- a/turbopack/crates/turbopack-wasm/src/source.rs
+++ b/turbopack/crates/turbopack-wasm/src/source.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{trace::TraceRawVcs, TaskInput, Vc};
+use turbo_tasks::{trace::TraceRawVcs, ResolvedVc, TaskInput, Vc};
 use turbo_tasks_fs::{File, FileContent};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -34,7 +34,7 @@ pub enum WebAssemblySourceType {
 #[turbo_tasks::value]
 #[derive(Clone)]
 pub struct WebAssemblySource {
-    source: Vc<Box<dyn Source>>,
+    source: ResolvedVc<Box<dyn Source>>,
     source_ty: WebAssemblySourceType,
 }
 

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -107,7 +107,7 @@ async fn apply_module_type(
             let mut builder = EcmascriptModuleAsset::builder(
                 source,
                 Vc::upcast(context_for_module),
-                *transforms,
+                **transforms,
                 **options,
                 module_asset_context.compile_time_info(),
             );
@@ -570,7 +570,11 @@ async fn process_default_internal(
                                 transforms,
                                 options,
                             }) => Some(ModuleType::Ecmascript {
-                                transforms: prepend.extend(transforms).extend(**append),
+                                transforms: prepend
+                                    .extend(transforms)
+                                    .extend(**append)
+                                    .to_resolved()
+                                    .await?,
                                 options,
                             }),
                             Some(ModuleType::Typescript {
@@ -579,7 +583,11 @@ async fn process_default_internal(
                                 analyze_types,
                                 options,
                             }) => Some(ModuleType::Typescript {
-                                transforms: prepend.extend(transforms).extend(**append),
+                                transforms: prepend
+                                    .extend(transforms)
+                                    .extend(**append)
+                                    .to_resolved()
+                                    .await?,
                                 tsx,
                                 analyze_types,
                                 options,

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -571,7 +571,7 @@ async fn process_default_internal(
                                 options,
                             }) => Some(ModuleType::Ecmascript {
                                 transforms: prepend
-                                    .extend(transforms)
+                                    .extend(*transforms)
                                     .extend(**append)
                                     .to_resolved()
                                     .await?,
@@ -584,7 +584,7 @@ async fn process_default_internal(
                                 options,
                             }) => Some(ModuleType::Typescript {
                                 transforms: prepend
-                                    .extend(transforms)
+                                    .extend(*transforms)
                                     .extend(**append)
                                     .to_resolved()
                                     .await?,

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -370,7 +370,7 @@ impl ModuleOptions {
             ModuleRule::new(
                 RuleCondition::ResourcePathHasNoExtension,
                 vec![ModuleRuleEffect::ModuleType(ModuleType::Ecmascript {
-                    transforms: vendor_transforms,
+                    transforms: vendor_transforms.to_resolved().await?,
                     options: ecmascript_options_vc,
                 })],
             ),

--- a/turbopack/crates/turbopack/src/module_options/module_rule.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_rule.rs
@@ -79,12 +79,12 @@ pub enum ModuleRuleEffect {
 #[derive(Hash, Debug, Copy, Clone)]
 pub enum ModuleType {
     Ecmascript {
-        transforms: Vc<EcmascriptInputTransforms>,
+        transforms: ResolvedVc<EcmascriptInputTransforms>,
         #[turbo_tasks(trace_ignore)]
         options: ResolvedVc<EcmascriptOptions>,
     },
     Typescript {
-        transforms: Vc<EcmascriptInputTransforms>,
+        transforms: ResolvedVc<EcmascriptInputTransforms>,
         // parse JSX syntax.
         tsx: bool,
         // follow references to imported types.
@@ -93,7 +93,7 @@ pub enum ModuleType {
         options: ResolvedVc<EcmascriptOptions>,
     },
     TypescriptDeclaration {
-        transforms: Vc<EcmascriptInputTransforms>,
+        transforms: ResolvedVc<EcmascriptInputTransforms>,
         #[turbo_tasks(trace_ignore)]
         options: ResolvedVc<EcmascriptOptions>,
     },


### PR DESCRIPTION
### What?

Use `ResolvedVc<T>` instead of `Vc<T>` for struct fields in `turbopack`, `turbopack-tests`, `turbopack-wasm`.

### Why?

### How?


Closes PACK-3546