### PR TITLE
perf(turbopack): Use `ResolvedVc` for `turbopack-browser`

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -398,12 +398,12 @@ pub async fn get_client_module_options_context(
 
 #[turbo_tasks::function]
 pub async fn get_client_chunking_context(
-    project_path: Vc<FileSystemPath>,
-    client_root: Vc<FileSystemPath>,
-    asset_prefix: Vc<Option<RcStr>>,
-    environment: Vc<Environment>,
+    project_path: ResolvedVc<FileSystemPath>,
+    client_root: ResolvedVc<FileSystemPath>,
+    asset_prefix: ResolvedVc<Option<RcStr>>,
+    environment: ResolvedVc<Environment>,
     mode: Vc<NextMode>,
-    module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>,
+    module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     turbo_minify: Vc<bool>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
     let next_mode = mode.await?;
@@ -411,8 +411,11 @@ pub async fn get_client_chunking_context(
         project_path,
         client_root,
         client_root,
-        client_root.join("static/chunks".into()),
-        get_client_assets_path(client_root),
+        client_root
+            .join("static/chunks".into())
+            .to_resolved()
+            .await?,
+        get_client_assets_path(*client_root).to_resolved().await?,
         environment,
         next_mode.runtime_type(),
     )

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -200,12 +200,12 @@ pub async fn get_edge_resolve_options_context(
 #[turbo_tasks::function]
 pub async fn get_edge_chunking_context_with_client_assets(
     mode: Vc<NextMode>,
-    project_path: Vc<FileSystemPath>,
-    node_root: Vc<FileSystemPath>,
-    client_root: Vc<FileSystemPath>,
-    asset_prefix: Vc<Option<RcStr>>,
-    environment: Vc<Environment>,
-    module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>,
+    project_path: ResolvedVc<FileSystemPath>,
+    node_root: ResolvedVc<FileSystemPath>,
+    client_root: ResolvedVc<FileSystemPath>,
+    asset_prefix: ResolvedVc<Option<RcStr>>,
+    environment: ResolvedVc<Environment>,
+    module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     turbo_minify: Vc<bool>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
     let output_root = node_root.join("server/edge".into());

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -259,7 +259,7 @@ pub async fn get_edge_chunking_context(
         // instead. This special blob url is handled by the custom fetch
         // implementation in the edge sandbox. It will respond with the
         // asset from the output directory.
-        .asset_base_path(Vc::cell(Some("blob:server/edge/".into())))
+        .asset_base_path(ResolvedVc::cell(Some("blob:server/edge/".into())))
         .minify_type(if *turbo_minify.await? {
             MinifyType::Minify
         } else {

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -208,15 +208,18 @@ pub async fn get_edge_chunking_context_with_client_assets(
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     turbo_minify: Vc<bool>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
-    let output_root = node_root.join("server/edge".into());
+    let output_root = node_root.join("server/edge".into()).to_resolved().await?;
     let next_mode = mode.await?;
     Ok(Vc::upcast(
         BrowserChunkingContext::builder(
             project_path,
             output_root,
             client_root,
-            output_root.join("chunks/ssr".into()),
-            client_root.join("static/media".into()),
+            output_root.join("chunks/ssr".into()).to_resolved().await?,
+            client_root
+                .join("static/media".into())
+                .to_resolved()
+                .await?,
             environment,
             next_mode.runtime_type(),
         )
@@ -234,21 +237,21 @@ pub async fn get_edge_chunking_context_with_client_assets(
 #[turbo_tasks::function]
 pub async fn get_edge_chunking_context(
     mode: Vc<NextMode>,
-    project_path: Vc<FileSystemPath>,
-    node_root: Vc<FileSystemPath>,
-    environment: Vc<Environment>,
-    module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>,
+    project_path: ResolvedVc<FileSystemPath>,
+    node_root: ResolvedVc<FileSystemPath>,
+    environment: ResolvedVc<Environment>,
+    module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     turbo_minify: Vc<bool>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
-    let output_root = node_root.join("server/edge".into());
+    let output_root = node_root.join("server/edge".into()).to_resolved().await?;
     let next_mode = mode.await?;
     Ok(Vc::upcast(
         BrowserChunkingContext::builder(
             project_path,
             output_root,
             output_root,
-            output_root.join("chunks".into()),
-            output_root.join("assets".into()),
+            output_root.join("chunks".into()).to_resolved().await?,
+            output_root.join("assets".into()).to_resolved().await?,
             environment,
             next_mode.runtime_type(),
         )

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -111,33 +111,33 @@ pub struct BrowserChunkingContext {
     name: Option<RcStr>,
     /// This path get stripped off of chunk paths before generating output asset
     /// paths.
-    context_path: Vc<FileSystemPath>,
+    context_path: ResolvedVc<FileSystemPath>,
     /// Whether to write file sources as file:// paths in source maps
     should_use_file_source_map_uris: bool,
     /// This path is used to compute the url to request chunks from
-    output_root: Vc<FileSystemPath>,
+    output_root: ResolvedVc<FileSystemPath>,
     /// This path is used to compute the url to request assets from
-    client_root: Vc<FileSystemPath>,
+    client_root: ResolvedVc<FileSystemPath>,
     /// Chunks are placed at this path
-    chunk_root_path: Vc<FileSystemPath>,
+    chunk_root_path: ResolvedVc<FileSystemPath>,
     /// Chunks reference source maps assets
     reference_chunk_source_maps: bool,
     /// Css chunks reference source maps assets
     reference_css_chunk_source_maps: bool,
     /// Static assets are placed at this path
-    asset_root_path: Vc<FileSystemPath>,
+    asset_root_path: ResolvedVc<FileSystemPath>,
     /// Base path that will be prepended to all chunk URLs when loading them.
     /// This path will not appear in chunk paths or chunk data.
-    chunk_base_path: Vc<Option<RcStr>>,
+    chunk_base_path: ResolvedVc<Option<RcStr>>,
     /// URL prefix that will be prepended to all static asset URLs when loading
     /// them.
-    asset_base_path: Vc<Option<RcStr>>,
+    asset_base_path: ResolvedVc<Option<RcStr>>,
     /// Enable HMR for this chunking
     enable_hot_module_replacement: bool,
     /// Enable tracing for this chunking
     enable_tracing: bool,
     /// The environment chunks will be evaluated in.
-    environment: Vc<Environment>,
+    environment: ResolvedVc<Environment>,
     /// The kind of runtime to include in the output.
     runtime_type: RuntimeType,
     /// Whether to minify resulting chunks
@@ -145,7 +145,7 @@ pub struct BrowserChunkingContext {
     /// Whether to use manifest chunks for lazy compilation
     manifest_chunks: bool,
     /// The module id strategy to use
-    module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>,
+    module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
 }
 
 impl BrowserChunkingContext {

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -89,7 +89,10 @@ impl BrowserChunkingContextBuilder {
         self
     }
 
-    pub fn module_id_strategy(mut self, module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>) -> Self {
+    pub fn module_id_strategy(
+        mut self,
+        module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
+    ) -> Self {
         self.chunking_context.module_id_strategy = module_id_strategy;
         self
     }
@@ -194,7 +197,7 @@ impl BrowserChunkingContext {
 
     /// Returns the asset base path.
     pub fn chunk_base_path(&self) -> Vc<Option<RcStr>> {
-        self.chunk_base_path
+        *self.chunk_base_path
     }
 
     /// Returns the minify type.
@@ -276,17 +279,17 @@ impl ChunkingContext for BrowserChunkingContext {
 
     #[turbo_tasks::function]
     fn context_path(&self) -> Vc<FileSystemPath> {
-        self.context_path
+        *self.context_path
     }
 
     #[turbo_tasks::function]
     fn output_root(&self) -> Vc<FileSystemPath> {
-        self.output_root
+        *self.output_root
     }
 
     #[turbo_tasks::function]
     fn environment(&self) -> Vc<Environment> {
-        self.environment
+        *self.environment
     }
 
     #[turbo_tasks::function]
@@ -296,7 +299,7 @@ impl ChunkingContext for BrowserChunkingContext {
         extension: RcStr,
     ) -> Result<Vc<FileSystemPath>> {
         let root_path = self.chunk_root_path;
-        let name = ident.output_name(self.context_path, extension).await?;
+        let name = ident.output_name(*self.context_path, extension).await?;
         Ok(root_path.join(name.clone_value()))
     }
 

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -54,12 +54,12 @@ impl BrowserChunkingContextBuilder {
         self
     }
 
-    pub fn asset_base_path(mut self, asset_base_path: Vc<Option<RcStr>>) -> Self {
+    pub fn asset_base_path(mut self, asset_base_path: ResolvedVc<Option<RcStr>>) -> Self {
         self.chunking_context.asset_base_path = asset_base_path;
         self
     }
 
-    pub fn chunk_base_path(mut self, chunk_base_path: Vc<Option<RcStr>>) -> Self {
+    pub fn chunk_base_path(mut self, chunk_base_path: ResolvedVc<Option<RcStr>>) -> Self {
         self.chunking_context.chunk_base_path = chunk_base_path;
         self
     }
@@ -150,12 +150,12 @@ pub struct BrowserChunkingContext {
 
 impl BrowserChunkingContext {
     pub fn builder(
-        context_path: Vc<FileSystemPath>,
-        output_root: Vc<FileSystemPath>,
-        client_root: Vc<FileSystemPath>,
-        chunk_root_path: Vc<FileSystemPath>,
-        asset_root_path: Vc<FileSystemPath>,
-        environment: Vc<Environment>,
+        context_path: ResolvedVc<FileSystemPath>,
+        output_root: ResolvedVc<FileSystemPath>,
+        client_root: ResolvedVc<FileSystemPath>,
+        chunk_root_path: ResolvedVc<FileSystemPath>,
+        asset_root_path: ResolvedVc<FileSystemPath>,
+        environment: ResolvedVc<Environment>,
         runtime_type: RuntimeType,
     ) -> BrowserChunkingContextBuilder {
         BrowserChunkingContextBuilder {
@@ -169,15 +169,15 @@ impl BrowserChunkingContext {
                 reference_chunk_source_maps: true,
                 reference_css_chunk_source_maps: true,
                 asset_root_path,
-                chunk_base_path: Default::default(),
-                asset_base_path: Default::default(),
+                chunk_base_path: ResolvedVc::cell(None),
+                asset_base_path: ResolvedVc::cell(None),
                 enable_hot_module_replacement: false,
                 enable_tracing: false,
                 environment,
                 runtime_type,
                 minify_type: MinifyType::NoMinify,
                 manifest_chunks: false,
-                module_id_strategy: Vc::upcast(DevModuleIdStrategy::new()),
+                module_id_strategy: ResolvedVc::upcast(DevModuleIdStrategy::new_resolved()),
             },
         }
     }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
@@ -75,7 +75,7 @@ impl EcmascriptDevChunkListContent {
 
         for (chunk_path, chunk_content) in &self.chunks_contents {
             if let Some(mergeable) =
-                Vc::try_resolve_sidecast::<Box<dyn MergeableVersionedContent>>(*chunk_content)
+                ResolvedVc::try_sidecast::<Box<dyn MergeableVersionedContent>>(*chunk_content)
                     .await?
             {
                 let merger = mergeable.get_merger().resolve().await?;

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
@@ -92,7 +92,7 @@ impl EcmascriptDevChunkListContent {
             .into_iter()
             .map(|(merger, contents)| async move {
                 Ok((
-                    merger,
+                    merger.to_resolved().await?,
                     merger
                         .merge(Vc::cell(contents))
                         .version()

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use anyhow::{Context, Result};
 use indoc::writedoc;
 use serde::Serialize;
-use turbo_tasks::{FxIndexMap, IntoTraitRef, TryJoinIterExt, Vc};
+use turbo_tasks::{FxIndexMap, IntoTraitRef, ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::File;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -26,7 +26,7 @@ use super::{
 #[turbo_tasks::value]
 pub(super) struct EcmascriptDevChunkListContent {
     chunk_list_path: String,
-    pub(super) chunks_contents: FxIndexMap<String, Vc<Box<dyn VersionedContent>>>,
+    pub(super) chunks_contents: FxIndexMap<String, ResolvedVc<Box<dyn VersionedContent>>>,
     source: EcmascriptDevChunkListSource,
 }
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
@@ -53,7 +53,7 @@ impl EcmascriptDevChunkListContent {
                             output_root
                                 .get_path_to(&*chunk.ident().path().await?)
                                 .map(|path| path.to_string()),
-                            chunk.versioned_content(),
+                            chunk.versioned_content().to_resolved().await?,
                         ))
                     }
                 })

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/update.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/update.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use serde::Serialize;
-use turbo_tasks::{FxIndexMap, IntoTraitRef, TraitRef, Vc};
+use turbo_tasks::{FxIndexMap, IntoTraitRef, ResolvedVc, TraitRef, Vc};
 use turbopack_core::version::{
     MergeableVersionedContent, PartialUpdate, TotalUpdate, Update, Version, VersionedContent,
     VersionedContentMerger,
@@ -92,7 +92,7 @@ pub(super) async fn update_chunk_list(
 
     for (chunk_path, chunk_content) in &content.chunks_contents {
         if let Some(mergeable) =
-            Vc::try_resolve_sidecast::<Box<dyn MergeableVersionedContent>>(*chunk_content).await?
+            ResolvedVc::try_sidecast::<Box<dyn MergeableVersionedContent>>(*chunk_content).await?
         {
             let merger = mergeable.get_merger().resolve().await?;
             by_merger.entry(merger).or_default().push(*chunk_content);

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/update.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/update.rs
@@ -94,7 +94,7 @@ pub(super) async fn update_chunk_list(
         if let Some(mergeable) =
             ResolvedVc::try_sidecast::<Box<dyn MergeableVersionedContent>>(*chunk_content).await?
         {
-            let merger = mergeable.get_merger().resolve().await?;
+            let merger = mergeable.get_merger().to_resolved().await?;
             by_merger.entry(merger).or_default().push(*chunk_content);
         } else {
             by_path.insert(chunk_path, chunk_content);

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/version.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/version.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, TraitRef, TryJoinIterExt, Vc};
+use turbo_tasks::{FxIndexMap, ResolvedVc, TraitRef, TryJoinIterExt, Vc};
 use turbo_tasks_hash::{encode_hex, Xxh3Hash64Hasher};
 use turbopack_core::version::{Version, VersionedContentMerger};
 
@@ -16,7 +16,7 @@ pub(super) struct EcmascriptDevChunkListVersion {
     pub by_path: FxIndexMap<String, VersionTraitRef>,
     /// A map from chunk merger to the version of the merged contents of chunks.
     #[turbo_tasks(trace_ignore)]
-    pub by_merger: FxIndexMap<Vc<Box<dyn VersionedContentMerger>>, VersionTraitRef>,
+    pub by_merger: FxIndexMap<ResolvedVc<Box<dyn VersionedContentMerger>>, VersionTraitRef>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/merged/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/merged/content.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use turbo_tasks::{TryJoinIterExt, Vc};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbopack_core::{
     asset::AssetContent,
     version::{Update, Version, VersionedContent},
@@ -17,7 +17,7 @@ use super::{
 /// [`EcmascriptChunkContentMerger`]: super::merger::EcmascriptChunkContentMerger
 #[turbo_tasks::value(serialization = "none", shared)]
 pub(super) struct EcmascriptDevMergedChunkContent {
-    pub contents: Vec<Vc<EcmascriptDevChunkContent>>,
+    pub contents: Vec<ResolvedVc<EcmascriptDevChunkContent>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/merged/merger.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/merged/merger.rs
@@ -33,7 +33,7 @@ impl VersionedContentMerger for EcmascriptDevChunkContentMerger {
                 if let Some(content) =
                     Vc::try_resolve_downcast_type::<EcmascriptDevChunkContent>(*content).await?
                 {
-                    Ok(content)
+                    Ok(content.to_resolved().await?)
                 } else {
                     bail!("expected Vc<EcmascriptDevChunkContent>")
                 }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/merged/merger.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/merged/merger.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use turbo_tasks::{TryJoinIterExt, Vc};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbopack_core::version::{VersionedContent, VersionedContentMerger, VersionedContents};
 
 use super::{super::content::EcmascriptDevChunkContent, content::EcmascriptDevMergedChunkContent};
@@ -31,9 +31,9 @@ impl VersionedContentMerger for EcmascriptDevChunkContentMerger {
             .iter()
             .map(|content| async move {
                 if let Some(content) =
-                    Vc::try_resolve_downcast_type::<EcmascriptDevChunkContent>(*content).await?
+                    ResolvedVc::try_downcast_type::<EcmascriptDevChunkContent>(*content).await?
                 {
-                    Ok(content.to_resolved().await?)
+                    Ok(content)
                 } else {
                     bail!("expected Vc<EcmascriptDevChunkContent>")
                 }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/merged/update.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/merged/update.rs
@@ -198,7 +198,7 @@ pub(super) async fn update_ecmascript_merged_chunk(
             from_versions_by_chunk_path.swap_remove(chunk_path)
         {
             // The chunk was present in the previous version, so we must update it.
-            let update = update_ecmascript_chunk(*content, from_version).await?;
+            let update = update_ecmascript_chunk(**content, from_version).await?;
 
             match update {
                 EcmascriptChunkUpdate::None => {

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -31,25 +31,25 @@ use crate::{
 };
 
 #[turbo_tasks::function]
-pub fn get_client_chunking_context(
-    project_path: Vc<FileSystemPath>,
-    server_root: Vc<FileSystemPath>,
-    environment: Vc<Environment>,
-) -> Vc<Box<dyn ChunkingContext>> {
-    Vc::upcast(
+pub async fn get_client_chunking_context(
+    project_path: ResolvedVc<FileSystemPath>,
+    server_root: ResolvedVc<FileSystemPath>,
+    environment: ResolvedVc<Environment>,
+) -> Result<Vc<Box<dyn ChunkingContext>>> {
+    Ok(Vc::upcast(
         BrowserChunkingContext::builder(
             project_path,
             server_root,
             server_root,
-            server_root.join("/_chunks".into()),
-            server_root.join("/_assets".into()),
+            server_root.join("/_chunks".into()).to_resolved().await?,
+            server_root.join("/_assets".into()).to_resolved().await?,
             environment,
             RuntimeType::Development,
         )
         .hot_module_replacement()
         .use_file_source_map_uris()
         .build(),
-    )
+    ))
 }
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/version.rs
+++ b/turbopack/crates/turbopack-core/src/version.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use anyhow::{anyhow, Result};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    debug::ValueDebugFormat, trace::TraceRawVcs, IntoTraitRef, ReadRef, State, TraitRef, Vc,
+    debug::ValueDebugFormat, trace::TraceRawVcs, IntoTraitRef, ReadRef, ResolvedVc, State,
+    TraitRef, Vc,
 };
 use turbo_tasks_fs::{FileContent, LinkType};
 use turbo_tasks_hash::{encode_hex, hash_xxh3_hash64};
@@ -146,7 +147,7 @@ pub trait VersionedContentMerger {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct VersionedContents(Vec<Vc<Box<dyn VersionedContent>>>);
+pub struct VersionedContents(Vec<ResolvedVc<Box<dyn VersionedContent>>>);
 
 #[turbo_tasks::value]
 pub struct NotFoundVersion;

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -331,12 +331,12 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
     let chunking_context: Vc<Box<dyn ChunkingContext>> = match options.runtime {
         Runtime::Browser => Vc::upcast(
             BrowserChunkingContext::builder(
-                *project_root,
-                *path,
-                *path,
-                *chunk_root_path,
-                *static_root_path,
-                *env,
+                project_root,
+                path,
+                path,
+                chunk_root_path,
+                static_root_path,
+                env,
                 options.runtime_type,
             )
             .build(),


### PR DESCRIPTION
### What?

Use `ResolvedVc<T>` instead of `Vc<T>` for struct fields in `turbopack-browser`

### Why?

### How?


Closes PACK-3567