### PR TITLE
perf(turbopack): Use `ResolvedVc` for `turbopack-nodejs`

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -633,7 +633,7 @@ impl Project {
 
     #[turbo_tasks::function]
     pub(super) async fn execution_context(self: Vc<Self>) -> Result<Vc<ExecutionContext>> {
-        let node_root = self.node_root();
+        let node_root = self.node_root().to_resolved().await?;
         let next_mode = self.next_mode().await?;
 
         let node_execution_chunking_context = Vc::upcast(
@@ -641,8 +641,8 @@ impl Project {
                 self.project_path(),
                 node_root,
                 node_root,
-                node_root.join("build/chunks".into()),
-                node_root.join("build/assets".into()),
+                node_root.join("build/chunks".into()).to_resolved().await?,
+                node_root.join("build/assets".into()).to_resolved().await?,
                 node_build_environment(),
                 next_mode.runtime_type(),
             )

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -638,12 +638,12 @@ impl Project {
 
         let node_execution_chunking_context = Vc::upcast(
             NodeJsChunkingContext::builder(
-                self.project_path(),
+                self.project_path().to_resolved().await?,
                 node_root,
                 node_root,
                 node_root.join("build/chunks".into()).to_resolved().await?,
                 node_root.join("build/assets".into()).to_resolved().await?,
-                node_build_environment(),
+                node_build_environment().to_resolved().await?,
                 next_mode.runtime_type(),
             )
             .build(),

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -974,12 +974,12 @@ pub fn get_server_runtime_entries(
 #[turbo_tasks::function]
 pub async fn get_server_chunking_context_with_client_assets(
     mode: Vc<NextMode>,
-    project_path: Vc<FileSystemPath>,
-    node_root: Vc<FileSystemPath>,
-    client_root: Vc<FileSystemPath>,
-    asset_prefix: Vc<Option<RcStr>>,
-    environment: Vc<Environment>,
-    module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>,
+    project_path: ResolvedVc<FileSystemPath>,
+    node_root: ResolvedVc<FileSystemPath>,
+    client_root: ResolvedVc<FileSystemPath>,
+    asset_prefix: ResolvedVc<Option<RcStr>>,
+    environment: ResolvedVc<Environment>,
+    module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     turbo_minify: Vc<bool>,
 ) -> Result<Vc<NodeJsChunkingContext>> {
     let next_mode = mode.await?;

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -1043,7 +1043,7 @@ pub async fn get_server_chunking_context(
     } else {
         MinifyType::NoMinify
     })
-    .module_id_strategy(*module_id_strategy)
+    .module_id_strategy(module_id_strategy)
     .file_tracing(next_mode.is_production());
 
     if next_mode.is_development() {

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -1019,10 +1019,10 @@ pub async fn get_server_chunking_context_with_client_assets(
 #[turbo_tasks::function]
 pub async fn get_server_chunking_context(
     mode: Vc<NextMode>,
-    project_path: Vc<FileSystemPath>,
-    node_root: Vc<FileSystemPath>,
-    environment: Vc<Environment>,
-    module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>,
+    project_path: ResolvedVc<FileSystemPath>,
+    node_root: ResolvedVc<FileSystemPath>,
+    environment: ResolvedVc<Environment>,
+    module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     turbo_minify: Vc<bool>,
 ) -> Result<Vc<NodeJsChunkingContext>> {
     let next_mode = mode.await?;
@@ -1033,8 +1033,8 @@ pub async fn get_server_chunking_context(
         project_path,
         node_root,
         node_root,
-        node_root.join("server/chunks".into()),
-        node_root.join("server/assets".into()),
+        node_root.join("server/chunks".into()).to_resolved().await?,
+        node_root.join("server/assets".into()).to_resolved().await?,
         environment,
         next_mode.runtime_type(),
     )
@@ -1043,7 +1043,7 @@ pub async fn get_server_chunking_context(
     } else {
         MinifyType::NoMinify
     })
-    .module_id_strategy(module_id_strategy)
+    .module_id_strategy(*module_id_strategy)
     .file_tracing(next_mode.is_production());
 
     if next_mode.is_development() {

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -990,8 +990,14 @@ pub async fn get_server_chunking_context_with_client_assets(
         project_path,
         node_root,
         client_root,
-        node_root.join("server/chunks/ssr".into()),
-        client_root.join("static/media".into()),
+        node_root
+            .join("server/chunks/ssr".into())
+            .to_resolved()
+            .await?,
+        client_root
+            .join("static/media".into())
+            .to_resolved()
+            .await?,
         environment,
         next_mode.runtime_type(),
     )

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -178,7 +178,9 @@ async fn build_internal(
             browserslist_query: browserslist_query.clone(),
         }
         .resolved_cell(),
-    )));
+    )))
+    .to_resolved()
+    .await?;
     let output_fs = output_fs(project_dir.clone());
     let project_fs = project_fs(root_dir.clone());
     let project_relative = project_dir.strip_prefix(&*root_dir).unwrap();
@@ -187,8 +189,12 @@ async fn build_internal(
         .unwrap_or(project_relative)
         .replace(MAIN_SEPARATOR, "/")
         .into();
-    let project_path = project_fs.root().join(project_relative);
-    let build_output_root = output_fs.root().join("dist".into());
+    let project_path = project_fs
+        .root()
+        .join(project_relative)
+        .to_resolved()
+        .await?;
+    let build_output_root = output_fs.root().join("dist".into()).to_resolved().await?;
 
     let node_env = NodeEnv::Production.cell();
 
@@ -211,9 +217,13 @@ async fn build_internal(
 
     let compile_time_info = get_client_compile_time_info(browserslist_query, node_env);
     let execution_context =
-        ExecutionContext::new(project_path, chunking_context, load_env(project_path));
-    let asset_context =
-        get_client_asset_context(project_path, execution_context, compile_time_info, node_env);
+        ExecutionContext::new(*project_path, chunking_context, load_env(*project_path));
+    let asset_context = get_client_asset_context(
+        *project_path,
+        execution_context,
+        compile_time_info,
+        node_env,
+    );
 
     let entry_requests = (*entry_requests
         .await?

--- a/turbopack/crates/turbopack-cli/src/dev/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/mod.rs
@@ -304,7 +304,7 @@ async fn source(
     );
     let static_source = Vc::upcast(StaticAssetsContentSource::new(
         Default::default(),
-        project_path.join("public".into()).to_resolved().await?,
+        project_path.join("public".into()),
     ));
     let main_source = CombinedContentSource::new(vec![static_source, web_source]);
     let introspect = Vc::upcast(
@@ -314,11 +314,11 @@ async fn source(
         .cell(),
     );
     let main_source = Vc::upcast(main_source);
-    Vc::upcast(PrefixedRouterContentSource::new(
+    Ok(Vc::upcast(PrefixedRouterContentSource::new(
         Default::default(),
         vec![("__turbopack__".into(), introspect)],
         main_source,
-    ))
+    )))
 }
 
 pub fn register() {

--- a/turbopack/crates/turbopack-core/src/chunk/module_id_strategies.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/module_id_strategies.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, ValueToString, Vc};
+use turbo_tasks::{FxIndexMap, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_hash::hash_xxh3_hash64;
 
 use super::ModuleId;
@@ -17,6 +17,10 @@ pub struct DevModuleIdStrategy;
 impl DevModuleIdStrategy {
     pub fn new() -> Vc<Self> {
         DevModuleIdStrategy {}.cell()
+    }
+
+    pub fn new_resolved() -> ResolvedVc<Self> {
+        DevModuleIdStrategy {}.resolved_cell()
     }
 }
 

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -215,7 +215,7 @@ impl ChunkingContext for NodeJsChunkingContext {
 
     #[turbo_tasks::function]
     fn is_tracing_enabled(&self) -> Vc<bool> {
-        Vc::cell(*self.enable_file_tracing)
+        Vc::cell(self.enable_file_tracing)
     }
 
     #[turbo_tasks::function]
@@ -246,8 +246,8 @@ impl ChunkingContext for NodeJsChunkingContext {
         ident: Vc<AssetIdent>,
         extension: RcStr,
     ) -> Result<Vc<FileSystemPath>> {
-        let root_path = self.chunk_root_path;
-        let name = ident.output_name(self.context_path, extension).await?;
+        let root_path = *self.chunk_root_path;
+        let name = ident.output_name(*self.context_path, extension).await?;
         Ok(root_path.join(name.clone_value()))
     }
 

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -200,22 +200,22 @@ impl ChunkingContext for NodeJsChunkingContext {
 
     #[turbo_tasks::function]
     fn context_path(&self) -> Vc<FileSystemPath> {
-        self.context_path
+        *self.context_path
     }
 
     #[turbo_tasks::function]
     fn output_root(&self) -> Vc<FileSystemPath> {
-        self.output_root
+        *self.output_root
     }
 
     #[turbo_tasks::function]
     fn environment(&self) -> Vc<Environment> {
-        self.environment
+        *self.environment
     }
 
     #[turbo_tasks::function]
     fn is_tracing_enabled(&self) -> Vc<bool> {
-        Vc::cell(self.enable_file_tracing)
+        Vc::cell(*self.enable_file_tracing)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -82,19 +82,19 @@ impl NodeJsChunkingContextBuilder {
 pub struct NodeJsChunkingContext {
     /// This path get stripped off of chunk paths before generating output asset
     /// paths.
-    context_path: Vc<FileSystemPath>,
+    context_path: ResolvedVc<FileSystemPath>,
     /// This path is used to compute the url to request chunks or assets from
-    output_root: Vc<FileSystemPath>,
+    output_root: ResolvedVc<FileSystemPath>,
     /// This path is used to compute the url to request chunks or assets from
-    client_root: Vc<FileSystemPath>,
+    client_root: ResolvedVc<FileSystemPath>,
     /// Chunks are placed at this path
-    chunk_root_path: Vc<FileSystemPath>,
+    chunk_root_path: ResolvedVc<FileSystemPath>,
     /// Static assets are placed at this path
-    asset_root_path: Vc<FileSystemPath>,
+    asset_root_path: ResolvedVc<FileSystemPath>,
     /// Static assets requested from this url base
-    asset_prefix: Vc<Option<RcStr>>,
+    asset_prefix: ResolvedVc<Option<RcStr>>,
     /// The environment chunks will be evaluated in.
-    environment: Vc<Environment>,
+    environment: ResolvedVc<Environment>,
     /// The kind of runtime to include in the output.
     runtime_type: RuntimeType,
     /// Enable tracing for this chunking
@@ -104,7 +104,7 @@ pub struct NodeJsChunkingContext {
     /// Whether to use manifest chunks for lazy compilation
     manifest_chunks: bool,
     /// The strategy to use for generating module ids
-    module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>,
+    module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     /// Whether to use file:// uris for source map sources
     should_use_file_source_map_uris: bool,
 }

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -35,7 +35,7 @@ pub struct NodeJsChunkingContextBuilder {
 }
 
 impl NodeJsChunkingContextBuilder {
-    pub fn asset_prefix(mut self, asset_prefix: Vc<Option<RcStr>>) -> Self {
+    pub fn asset_prefix(mut self, asset_prefix: ResolvedVc<Option<RcStr>>) -> Self {
         self.chunking_context.asset_prefix = asset_prefix;
         self
     }
@@ -65,7 +65,10 @@ impl NodeJsChunkingContextBuilder {
         self
     }
 
-    pub fn module_id_strategy(mut self, module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>) -> Self {
+    pub fn module_id_strategy(
+        mut self,
+        module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
+    ) -> Self {
         self.chunking_context.module_id_strategy = module_id_strategy;
         self
     }
@@ -112,12 +115,12 @@ pub struct NodeJsChunkingContext {
 impl NodeJsChunkingContext {
     /// Creates a new chunking context builder.
     pub fn builder(
-        context_path: Vc<FileSystemPath>,
-        output_root: Vc<FileSystemPath>,
-        client_root: Vc<FileSystemPath>,
-        chunk_root_path: Vc<FileSystemPath>,
-        asset_root_path: Vc<FileSystemPath>,
-        environment: Vc<Environment>,
+        context_path: ResolvedVc<FileSystemPath>,
+        output_root: ResolvedVc<FileSystemPath>,
+        client_root: ResolvedVc<FileSystemPath>,
+        chunk_root_path: ResolvedVc<FileSystemPath>,
+        asset_root_path: ResolvedVc<FileSystemPath>,
+        environment: ResolvedVc<Environment>,
         runtime_type: RuntimeType,
     ) -> NodeJsChunkingContextBuilder {
         NodeJsChunkingContextBuilder {
@@ -127,14 +130,14 @@ impl NodeJsChunkingContext {
                 client_root,
                 chunk_root_path,
                 asset_root_path,
-                asset_prefix: Default::default(),
+                asset_prefix: ResolvedVc::cell(None),
                 enable_file_tracing: false,
                 environment,
                 runtime_type,
                 minify_type: MinifyType::NoMinify,
                 manifest_chunks: false,
                 should_use_file_source_map_uris: false,
-                module_id_strategy: Vc::upcast(DevModuleIdStrategy::new()),
+                module_id_strategy: ResolvedVc::upcast(DevModuleIdStrategy::new_resolved()),
             },
         }
     }
@@ -164,7 +167,7 @@ impl NodeJsChunkingContext {
 
     #[turbo_tasks::function]
     pub fn asset_prefix(&self) -> Vc<Option<RcStr>> {
-        self.asset_prefix
+        *self.asset_prefix
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
@@ -18,8 +18,8 @@ use crate::NodeJsChunkingContext;
 /// Production Ecmascript chunk targeting Node.js.
 #[turbo_tasks::value(shared)]
 pub(crate) struct EcmascriptBuildNodeChunk {
-    chunking_context: Vc<NodeJsChunkingContext>,
-    chunk: Vc<EcmascriptChunk>,
+    chunking_context: ResolvedVc<NodeJsChunkingContext>,
+    chunk: ResolvedVc<EcmascriptChunk>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
@@ -27,8 +27,8 @@ impl EcmascriptBuildNodeChunk {
     /// Creates a new [`Vc<EcmascriptBuildNodeChunk>`].
     #[turbo_tasks::function]
     pub fn new(
-        chunking_context: Vc<NodeJsChunkingContext>,
-        chunk: Vc<EcmascriptChunk>,
+        chunking_context: ResolvedVc<NodeJsChunkingContext>,
+        chunk: ResolvedVc<EcmascriptChunk>,
     ) -> Vc<Self> {
         EcmascriptBuildNodeChunk {
             chunking_context,
@@ -57,7 +57,7 @@ impl EcmascriptBuildNodeChunk {
     async fn own_content(self: Vc<Self>) -> Result<Vc<EcmascriptBuildNodeChunkContent>> {
         let this = self.await?;
         Ok(EcmascriptBuildNodeChunkContent::new(
-            this.chunking_context,
+            *this.chunking_context,
             self,
             this.chunk.chunk_content(),
         ))
@@ -148,7 +148,7 @@ impl Introspectable for EcmascriptBuildNodeChunk {
     #[turbo_tasks::function]
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         let mut children = FxIndexSet::default();
-        let introspectable_chunk = Vc::upcast::<Box<dyn Introspectable>>(self.chunk)
+        let introspectable_chunk = ResolvedVc::upcast::<Box<dyn Introspectable>>(self.chunk)
             .resolve()
             .await?;
         children.insert((Vc::cell("chunk".into()), introspectable_chunk));

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -32,9 +32,9 @@ pub(super) struct EcmascriptBuildNodeChunkContent {
 impl EcmascriptBuildNodeChunkContent {
     #[turbo_tasks::function]
     pub(crate) fn new(
-        chunking_context: Vc<NodeJsChunkingContext>,
-        chunk: Vc<EcmascriptBuildNodeChunk>,
-        content: Vc<EcmascriptChunkContent>,
+        chunking_context: ResolvedVc<NodeJsChunkingContext>,
+        chunk: ResolvedVc<EcmascriptBuildNodeChunk>,
+        content: ResolvedVc<EcmascriptChunkContent>,
     ) -> Vc<Self> {
         EcmascriptBuildNodeChunkContent {
             content,
@@ -80,7 +80,7 @@ impl EcmascriptBuildNodeChunkContent {
             "#,
         )?;
 
-        for (id, item_code) in chunk_items(this.content).await? {
+        for (id, item_code) in chunk_items(*this.content).await? {
             write!(code, "{}: ", StringifyJs(&id))?;
             code.push_code(&item_code);
             writeln!(code, ",")?;
@@ -113,7 +113,7 @@ impl EcmascriptBuildNodeChunkContent {
         Ok(EcmascriptBuildNodeChunkVersion::new(
             self.chunking_context.output_root(),
             self.chunk.ident().path(),
-            self.content,
+            *self.content,
             self.chunking_context.await?.minify_type(),
         ))
     }

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use anyhow::Result;
 use indoc::writedoc;
-use turbo_tasks::{ReadRef, TryJoinIterExt, Vc};
+use turbo_tasks::{ReadRef, ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::File;
 use turbopack_core::{
     asset::AssetContent,
@@ -23,9 +23,9 @@ use crate::NodeJsChunkingContext;
 
 #[turbo_tasks::value]
 pub(super) struct EcmascriptBuildNodeChunkContent {
-    pub(super) content: Vc<EcmascriptChunkContent>,
-    pub(super) chunking_context: Vc<NodeJsChunkingContext>,
-    pub(super) chunk: Vc<EcmascriptBuildNodeChunk>,
+    pub(super) content: ResolvedVc<EcmascriptChunkContent>,
+    pub(super) chunking_context: ResolvedVc<NodeJsChunkingContext>,
+    pub(super) chunk: ResolvedVc<EcmascriptBuildNodeChunk>,
 }
 
 #[turbo_tasks::value_impl]
@@ -76,7 +76,7 @@ impl EcmascriptBuildNodeChunkContent {
             code,
             r#"
                 module.exports = {{
-    
+
             "#,
         )?;
 

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -34,11 +34,11 @@ impl EcmascriptBuildNodeEntryChunk {
     /// Creates a new [`Vc<EcmascriptBuildNodeEntryChunk>`].
     #[turbo_tasks::function]
     pub fn new(
-        path: Vc<FileSystemPath>,
-        chunking_context: Vc<NodeJsChunkingContext>,
-        other_chunks: Vc<OutputAssets>,
-        evaluatable_assets: Vc<EvaluatableAssets>,
-        exported_module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
+        path: ResolvedVc<FileSystemPath>,
+        chunking_context: ResolvedVc<NodeJsChunkingContext>,
+        other_chunks: ResolvedVc<OutputAssets>,
+        evaluatable_assets: ResolvedVc<EvaluatableAssets>,
+        exported_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
     ) -> Vc<Self> {
         EcmascriptBuildNodeEntryChunk {
             path,
@@ -113,7 +113,7 @@ impl EcmascriptBuildNodeEntryChunk {
                     .await?
             {
                 let runtime_module_id = placeable
-                    .as_chunk_item(Vc::upcast(this.chunking_context))
+                    .as_chunk_item(Vc::upcast(*this.chunking_context))
                     .id()
                     .await?;
 
@@ -129,7 +129,7 @@ impl EcmascriptBuildNodeEntryChunk {
 
         let runtime_module_id = this
             .exported_module
-            .as_chunk_item(Vc::upcast(this.chunking_context))
+            .as_chunk_item(Vc::upcast(*this.chunking_context))
             .id()
             .await?;
 

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -22,11 +22,11 @@ use crate::NodeJsChunkingContext;
 /// runtime entries.
 #[turbo_tasks::value(shared)]
 pub(crate) struct EcmascriptBuildNodeEntryChunk {
-    path: Vc<FileSystemPath>,
-    chunking_context: Vc<NodeJsChunkingContext>,
-    other_chunks: Vc<OutputAssets>,
-    evaluatable_assets: Vc<EvaluatableAssets>,
-    exported_module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
+    path: ResolvedVc<FileSystemPath>,
+    chunking_context: ResolvedVc<NodeJsChunkingContext>,
+    other_chunks: ResolvedVc<OutputAssets>,
+    evaluatable_assets: ResolvedVc<EvaluatableAssets>,
+    exported_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -146,7 +146,7 @@ impl EcmascriptBuildNodeEntryChunk {
 
     #[turbo_tasks::function]
     fn runtime_chunk(&self) -> Vc<EcmascriptBuildNodeRuntimeChunk> {
-        EcmascriptBuildNodeRuntimeChunk::new(self.chunking_context)
+        EcmascriptBuildNodeRuntimeChunk::new(*self.chunking_context)
     }
 }
 
@@ -172,7 +172,7 @@ fn chunk_reference_description() -> Vc<RcStr> {
 impl OutputAsset for EcmascriptBuildNodeEntryChunk {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(self.path)
+        AssetIdent::from_path(*self.path)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -21,7 +21,7 @@ use crate::NodeJsChunkingContext;
 /// An Ecmascript chunk that contains the Node.js runtime code.
 #[turbo_tasks::value(shared)]
 pub(crate) struct EcmascriptBuildNodeRuntimeChunk {
-    chunking_context: Vc<NodeJsChunkingContext>,
+    chunking_context: ResolvedVc<NodeJsChunkingContext>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -28,7 +28,7 @@ pub(crate) struct EcmascriptBuildNodeRuntimeChunk {
 impl EcmascriptBuildNodeRuntimeChunk {
     /// Creates a new [`Vc<EcmascriptBuildNodeRuntimeChunk>`].
     #[turbo_tasks::function]
-    pub fn new(chunking_context: Vc<NodeJsChunkingContext>) -> Vc<Self> {
+    pub fn new(chunking_context: ResolvedVc<NodeJsChunkingContext>) -> Vc<Self> {
         EcmascriptBuildNodeRuntimeChunk { chunking_context }.cell()
     }
 

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -267,8 +267,8 @@ async fn run_test(prepared_test: Vc<PreparedTest>) -> Result<Vc<RunTestResult>> 
     let jest_entry_path = tests_path.join("js/jest-entry.ts".into());
     let test_path = project_path.join("input/index.js".into());
 
-    let chunk_root_path = path.join("output".into());
-    let static_root_path = path.join("static".into());
+    let chunk_root_path = path.join("output".into()).to_resolved().await?;
+    let static_root_path = path.join("static".into()).to_resolved().await?;
 
     let env = Environment::new(Value::new(ExecutionEnvironment::NodeJsBuildTime(
         NodeJsEnvironment::default().resolved_cell(),
@@ -357,12 +357,12 @@ async fn run_test(prepared_test: Vc<PreparedTest>) -> Result<Vc<RunTestResult>> 
     ));
 
     let chunking_context = NodeJsChunkingContext::builder(
-        *project_root,
+        project_root,
         chunk_root_path,
         static_root_path,
         chunk_root_path,
         static_root_path,
-        *env,
+        env,
         RuntimeType::Development,
     )
     .build();

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -354,12 +354,12 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         ),
         Runtime::NodeJs => Vc::upcast(
             NodeJsChunkingContext::builder(
-                *project_root,
+                project_root,
                 path,
                 path,
                 chunk_root_path.to_resolved().await?,
                 static_root_path.to_resolved().await?,
-                *env,
+                env,
                 options.runtime_type,
             )
             .minify_type(options.minify_type)
@@ -367,9 +367,9 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         ),
     };
 
-    let expected_paths = expected(chunk_root_path)
+    let expected_paths = expected(*chunk_root_path)
         .await?
-        .union(&expected(static_root_path).await?)
+        .union(&expected(*static_root_path).await?)
         .copied()
         .collect();
 
@@ -453,7 +453,7 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         .await
         .context("Actual assets doesn't match with expected assets")?;
 
-    Ok(path)
+    Ok(*path)
 }
 
 async fn walk_asset(

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -209,8 +209,15 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
 
     let relative_path = test_path.strip_prefix(&*REPO_ROOT)?;
     let relative_path: RcStr = sys_to_unix(relative_path.to_str().unwrap()).into();
-    let path = root_fs.root().join(relative_path.clone());
-    let project_path = project_root.join(relative_path.clone());
+    let path = root_fs
+        .root()
+        .join(relative_path.clone())
+        .to_resolved()
+        .await?;
+    let project_path = project_root
+        .join(relative_path.clone())
+        .to_resolved()
+        .await?;
 
     let entry_asset = project_path.join(options.entry.into());
 
@@ -329,8 +336,8 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         .await?
         .map(|asset| EvaluatableAssets::one(asset.to_evaluatable(asset_context)));
 
-    let chunk_root_path = path.join("output".into());
-    let static_root_path = path.join("static".into());
+    let chunk_root_path = path.join("output".into()).to_resolved().await?;
+    let static_root_path = path.join("static".into()).to_resolved().await?;
 
     let chunking_context: Vc<Box<dyn ChunkingContext>> = match options.runtime {
         Runtime::Browser => Vc::upcast(
@@ -350,8 +357,8 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                 *project_root,
                 path,
                 path,
-                chunk_root_path,
-                static_root_path,
+                chunk_root_path.to_resolved().await?,
+                static_root_path.to_resolved().await?,
                 *env,
                 options.runtime_type,
             )

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -332,7 +332,7 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         Vc::cell("test".into()),
     ));
 
-    let runtime_entries = maybe_load_env(asset_context, project_path)
+    let runtime_entries = maybe_load_env(asset_context, *project_path)
         .await?
         .map(|asset| EvaluatableAssets::one(asset.to_evaluatable(asset_context)));
 
@@ -343,10 +343,10 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         Runtime::Browser => Vc::upcast(
             BrowserChunkingContext::builder(
                 *project_root,
-                path,
-                path,
-                chunk_root_path,
-                static_root_path,
+                *path,
+                *path,
+                *chunk_root_path,
+                *static_root_path,
                 *env,
                 options.runtime_type,
             )


### PR DESCRIPTION
### What?

Use `ResolvedVc<T>` instead of `Vc<T>` for struct fields in `turbopack-nodejs`.

### Why?

### How?


Closes PACK-3547