### PR TITLE
perf(turbopack): Use `ResolvedVc` for `turbopack-env`

### DIFF
--- a/turbopack/crates/turbopack-env/src/asset.rs
+++ b/turbopack/crates/turbopack-env/src/asset.rs
@@ -25,8 +25,11 @@ pub struct ProcessEnvAsset {
 #[turbo_tasks::value_impl]
 impl ProcessEnvAsset {
     #[turbo_tasks::function]
-    pub fn new(root: Vc<FileSystemPath>, env: Vc<Box<dyn ProcessEnv>>) -> Vc<Self> {
-        ProcessEnvAsset { root, env }.cell()
+    pub async fn new(
+        root: ResolvedVc<FileSystemPath>,
+        env: ResolvedVc<Box<dyn ProcessEnv>>,
+    ) -> Result<Vc<Self>> {
+        Ok(ProcessEnvAsset { root, env }.cell())
     }
 }
 

--- a/turbopack/crates/turbopack-env/src/asset.rs
+++ b/turbopack/crates/turbopack-env/src/asset.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use anyhow::Result;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::{rope::RopeBuilder, File, FileSystemPath};
 use turbopack_core::{
@@ -16,10 +16,10 @@ use turbopack_ecmascript::utils::StringifyJs;
 #[turbo_tasks::value]
 pub struct ProcessEnvAsset {
     /// The root path which we can construct our env asset path.
-    root: Vc<FileSystemPath>,
+    root: ResolvedVc<FileSystemPath>,
 
     /// A HashMap filled with the env key/values.
-    env: Vc<Box<dyn ProcessEnv>>,
+    env: ResolvedVc<Box<dyn ProcessEnv>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-env/src/embeddable.rs
+++ b/turbopack/crates/turbopack-env/src/embeddable.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_env::{EnvMap, ProcessEnv};
 use turbopack_ecmascript::utils::StringifyJs;
 
@@ -8,7 +8,7 @@ use turbopack_ecmascript::utils::StringifyJs;
 /// output.
 #[turbo_tasks::value]
 pub struct EmbeddableProcessEnv {
-    prior: Vc<Box<dyn ProcessEnv>>,
+    prior: ResolvedVc<Box<dyn ProcessEnv>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-env/src/embeddable.rs
+++ b/turbopack/crates/turbopack-env/src/embeddable.rs
@@ -14,8 +14,8 @@ pub struct EmbeddableProcessEnv {
 #[turbo_tasks::value_impl]
 impl EmbeddableProcessEnv {
     #[turbo_tasks::function]
-    pub fn new(prior: Vc<Box<dyn ProcessEnv>>) -> Vc<Self> {
-        EmbeddableProcessEnv { prior }.cell()
+    pub fn new(prior: ResolvedVc<Box<dyn ProcessEnv>>) -> Result<Vc<Self>> {
+        Ok(EmbeddableProcessEnv { prior }.cell())
     }
 }
 

--- a/turbopack/crates/turbopack-env/src/issue.rs
+++ b/turbopack/crates/turbopack-env/src/issue.rs
@@ -1,12 +1,12 @@
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{Issue, IssueStage, OptionStyledString, StyledString};
 
 /// An issue that occurred while resolving the parsing or evaluating the .env.
 #[turbo_tasks::value(shared)]
 pub struct ProcessEnvIssue {
-    pub path: Vc<FileSystemPath>,
-    pub description: Vc<StyledString>,
+    pub path: ResolvedVc<FileSystemPath>,
+    pub description: ResolvedVc<StyledString>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-env/src/issue.rs
+++ b/turbopack/crates/turbopack-env/src/issue.rs
@@ -23,11 +23,11 @@ impl Issue for ProcessEnvIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        self.path
+        *self.path
     }
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(self.description))
+        Vc::cell(Some(*self.description))
     }
 }

--- a/turbopack/crates/turbopack-env/src/try_env.rs
+++ b/turbopack/crates/turbopack-env/src/try_env.rs
@@ -16,14 +16,19 @@ pub struct TryDotenvProcessEnv {
 #[turbo_tasks::value_impl]
 impl TryDotenvProcessEnv {
     #[turbo_tasks::function]
-    pub fn new(prior: Vc<Box<dyn ProcessEnv>>, path: Vc<FileSystemPath>) -> Vc<Self> {
-        let dotenv = DotenvProcessEnv::new(Some(prior), path);
-        TryDotenvProcessEnv {
+    pub async fn new(
+        prior: ResolvedVc<Box<dyn ProcessEnv>>,
+        path: ResolvedVc<FileSystemPath>,
+    ) -> Result<Vc<Self>> {
+        let dotenv = DotenvProcessEnv::new(Some(prior), path)
+            .to_resolved()
+            .await?;
+        Ok(TryDotenvProcessEnv {
             dotenv,
             prior,
             path,
         }
-        .cell()
+        .cell())
     }
 }
 

--- a/turbopack/crates/turbopack-env/src/try_env.rs
+++ b/turbopack/crates/turbopack-env/src/try_env.rs
@@ -20,7 +20,7 @@ impl TryDotenvProcessEnv {
         prior: ResolvedVc<Box<dyn ProcessEnv>>,
         path: ResolvedVc<FileSystemPath>,
     ) -> Result<Vc<Self>> {
-        let dotenv = DotenvProcessEnv::new(Some(prior), path)
+        let dotenv = DotenvProcessEnv::new(Some(*prior), *path)
             .to_resolved()
             .await?;
         Ok(TryDotenvProcessEnv {
@@ -55,7 +55,8 @@ impl ProcessEnv for TryDotenvProcessEnv {
                     // read_all_with_prior will wrap a current error with a context containing the
                     // failing file, which we don't really care about (we report the filepath as the
                     // Issue context, not the description). So extract the real error.
-                    description: StyledString::Text(e.root_cause().to_string().into()).cell(),
+                    description: StyledString::Text(e.root_cause().to_string().into())
+                        .resolved_cell(),
                 }
                 .cell()
                 .emit();

--- a/turbopack/crates/turbopack-env/src/try_env.rs
+++ b/turbopack/crates/turbopack-env/src/try_env.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_env::{DotenvProcessEnv, EnvMap, ProcessEnv};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{IssueExt, StyledString};
@@ -8,9 +8,9 @@ use crate::ProcessEnvIssue;
 
 #[turbo_tasks::value]
 pub struct TryDotenvProcessEnv {
-    dotenv: Vc<DotenvProcessEnv>,
-    prior: Vc<Box<dyn ProcessEnv>>,
-    path: Vc<FileSystemPath>,
+    dotenv: ResolvedVc<DotenvProcessEnv>,
+    prior: ResolvedVc<Box<dyn ProcessEnv>>,
+    path: ResolvedVc<FileSystemPath>,
 }
 
 #[turbo_tasks::value_impl]


### PR DESCRIPTION
### What?

Use `ResolvedVc<T>` instead of `Vc<T>` for struct fields in `turbopack-env`.

### Why?

### How?


Closes PACK-3548