### PR TITLE
Make `notFound()` work in `"use cache"` page

### DIFF
--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -22,7 +22,7 @@ type SSRErrorHandler = (
 export type DigestedError = Error & { digest: string }
 
 export function createFlightReactServerErrorHandler(
-  dev: boolean,
+  shouldFormatError: boolean,
   onReactServerRenderError: (err: DigestedError) => void
 ): RSCErrorHandler {
   return (thrownValue: unknown) => {
@@ -56,7 +56,7 @@ export function createFlightReactServerErrorHandler(
     }
 
     // Format server errors in development to add more helpful error messages
-    if (dev) {
+    if (shouldFormatError) {
       formatServerError(err)
     }
 
@@ -77,7 +77,7 @@ export function createFlightReactServerErrorHandler(
 }
 
 export function createHTMLReactServerErrorHandler(
-  dev: boolean,
+  shouldFormatError: boolean,
   isNextExport: boolean,
   reactServerErrors: Map<string, DigestedError>,
   silenceLogger: boolean,
@@ -120,7 +120,7 @@ export function createHTMLReactServerErrorHandler(
     }
 
     // Format server errors in development to add more helpful error messages
-    if (dev) {
+    if (shouldFormatError) {
       formatServerError(err)
     }
 
@@ -153,7 +153,7 @@ export function createHTMLReactServerErrorHandler(
 }
 
 export function createHTMLErrorHandler(
-  dev: boolean,
+  shouldFormatError: boolean,
   isNextExport: boolean,
   reactServerErrors: Map<string, DigestedError>,
   allCapturedErrors: Array<unknown>,
@@ -200,7 +200,7 @@ export function createHTMLErrorHandler(
     }
 
     // Format server errors in development to add more helpful error messages
-    if (dev) {
+    if (shouldFormatError) {
       formatServerError(err)
     }
 

--- a/test/e2e/app-dir/use-cache/app/not-found/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/not-found/page.tsx
@@ -1,0 +1,9 @@
+'use cache'
+
+import { notFound } from 'next/navigation'
+
+export default async function Page() {
+  notFound()
+
+  return <p>This will never render</p>
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -452,4 +452,10 @@ describe('use-cache', () => {
       expect(await browser.elementByCss('p').text()).toBe(value)
     })
   })
+
+  it('renders the not-found page when `notFound()` is used', async () => {
+    const browser = await next.browser('/not-found')
+    const text = await browser.elementByCss('h2').text()
+    expect(text).toBe('This page could not be found.')
+  })
 })


### PR DESCRIPTION
When `notFound()` is called in a `"use cache"` function, we need to make sure that the custom error digest is included in the serialized RSC payload. Otherwise the `HTTPAccessFallbackErrorBoundary` won't be able to detect the error as an `HTTPAccessFallbackError`. `createFlightReactServerErrorHandler` already handles forwarding the digest correctly for router errors (and other next-internal errors), so we can just reuse it.

fixes #73130