### PR TITLE
Docs: Update `turbopack` API Reference

### DIFF
--- a/docs/01-app/02-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/02-building-your-application/07-configuring/05-mdx.mdx
@@ -649,7 +649,7 @@ export default withMDX(nextConfig)
 
 ### Using Plugins with Turbopack
 
-To use plugins with [Turbopack](/docs/architecture/turbopack), upgrade to the latest `@next/mdx` and specify plugin names using a string:
+To use plugins with [Turbopack](/docs/api-reference/turbopack), upgrade to the latest `@next/mdx` and specify plugin names using a string:
 
 ```js filename="next.config.mjs"
 import createMDX from '@next/mdx'
@@ -671,7 +671,7 @@ export default withMDX(nextConfig)
 
 > **Good to know**:
 >
-> remark and rehype plugins without serializable options cannot be used yet with [Turbopack](/docs/architecture/turbopack), due to [inability to pass JavaScript functions to Rust](https://github.com/vercel/next.js/issues/71819#issuecomment-2461802968)
+> remark and rehype plugins without serializable options cannot be used yet with [Turbopack](/docs/api-reference/turbopack), due to [inability to pass JavaScript functions to Rust](https://github.com/vercel/next.js/issues/71819#issuecomment-2461802968)
 
 ## Remote MDX
 

--- a/docs/01-app/02-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/02-building-your-application/07-configuring/05-mdx.mdx
@@ -649,7 +649,7 @@ export default withMDX(nextConfig)
 
 ### Using Plugins with Turbopack
 
-To use plugins with [Turbopack](/docs/api-reference/turbopack), upgrade to the latest `@next/mdx` and specify plugin names using a string:
+To use plugins with [Turbopack](/docs/app/api-reference/turbopack), upgrade to the latest `@next/mdx` and specify plugin names using a string:
 
 ```js filename="next.config.mjs"
 import createMDX from '@next/mdx'
@@ -671,7 +671,7 @@ export default withMDX(nextConfig)
 
 > **Good to know**:
 >
-> remark and rehype plugins without serializable options cannot be used yet with [Turbopack](/docs/api-reference/turbopack), due to [inability to pass JavaScript functions to Rust](https://github.com/vercel/next.js/issues/71819#issuecomment-2461802968)
+> remark and rehype plugins without serializable options cannot be used yet with [Turbopack](/docs/app/api-reference/turbopack), due to [inability to pass JavaScript functions to Rust](https://github.com/vercel/next.js/issues/71819#issuecomment-2461802968)
 
 ## Remote MDX
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbo.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbo.mdx
@@ -6,7 +6,7 @@ version: experimental
 
 {/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
 
-The `turbo` option lets you customize [Turbopack](/docs/api-reference/turbopack) to transform different files and change how modules are resolved.
+The `turbo` option lets you customize [Turbopack](/docs/app/api-reference/turbopack) to transform different files and change how modules are resolved.
 
 ```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbo.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbo.mdx
@@ -6,7 +6,7 @@ version: experimental
 
 {/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
 
-The `turbo` option lets you customize [Turbopack](/docs/architecture/turbopack) to transform different files and change how modules are resolved.
+The `turbo` option lets you customize [Turbopack](/docs/api-reference/turbopack) to transform different files and change how modules are resolved.
 
 ```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'

--- a/docs/01-app/03-api-reference/06-cli/next.mdx
+++ b/docs/01-app/03-api-reference/06-cli/next.mdx
@@ -45,7 +45,7 @@ The following commands are available:
 | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `-h, --help`                             | Show all available options.                                                                                                                          |
 | `[directory]`                            | A directory in which to build the application. If not provided, current directory is used.                                                           |
-| `--turbopack`                            | Starts development mode using [Turbopack](https://nextjs.org/docs/architecture/turbopack).                                                           |
+| `--turbopack`                            | Starts development mode using [Turbopack](https://nextjs.org/docs/api-reference/turbopack).                                                          |
 | `-p` or `--port <port>`                  | Specify a port number on which to start the application. Default: 3000, env: PORT                                                                    |
 | `-H`or `--hostname <hostname>`           | Specify a hostname on which to start the application. Useful for making the application available for other devices on the network. Default: 0.0.0.0 |
 | `--experimental-https`                   | Starts the server with HTTPS and generates a self-signed certificate.                                                                                |

--- a/docs/01-app/03-api-reference/06-cli/next.mdx
+++ b/docs/01-app/03-api-reference/06-cli/next.mdx
@@ -45,7 +45,7 @@ The following commands are available:
 | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `-h, --help`                             | Show all available options.                                                                                                                          |
 | `[directory]`                            | A directory in which to build the application. If not provided, current directory is used.                                                           |
-| `--turbopack`                            | Starts development mode using [Turbopack](https://nextjs.org/docs/api-reference/turbopack).                                                          |
+| `--turbopack`                            | Starts development mode using [Turbopack](/docs/app/api-reference/turbopack).                                                                        |
 | `-p` or `--port <port>`                  | Specify a port number on which to start the application. Default: 3000, env: PORT                                                                    |
 | `-H`or `--hostname <hostname>`           | Specify a hostname on which to start the application. Useful for making the application available for other devices on the network. Default: 0.0.0.0 |
 | `--experimental-https`                   | Starts the server with HTTPS and generates a self-signed certificate.                                                                                |

--- a/docs/01-app/03-api-reference/08-turbopack.mdx
+++ b/docs/01-app/03-api-reference/08-turbopack.mdx
@@ -3,11 +3,9 @@ title: Turbopack
 description: Turbopack is an incremental bundler optimized for JavaScript and TypeScript, written in Rust, and built into Next.js.
 ---
 
-[Turbopack](https://turbo.build/pack) is an incremental bundler optimized for JavaScript and TypeScript, written in Rust, and built into Next.js.
+[Turbopack](https://turbo.build/pack) is an incremental bundler optimized for JavaScript and TypeScript, written in Rust, and built into Next.js. Turbopack can be used in Next.js in both the `pages` and `app` directories for faster local development.
 
-## Usage
-
-Turbopack can be used in Next.js in both the `pages` and `app` directories for faster local development. To enable Turbopack, use the `--turbopack` flag when running the Next.js development server.
+To enable Turbopack, use the `--turbopack` flag when running the Next.js development server.
 
 ```json filename="package.json" highlight={3}
 {

--- a/docs/01-app/03-api-reference/08-turbopack.mdx
+++ b/docs/01-app/03-api-reference/08-turbopack.mdx
@@ -3,6 +3,8 @@ title: Turbopack
 description: Turbopack is an incremental bundler optimized for JavaScript and TypeScript, written in Rust, and built into Next.js.
 ---
 
+{/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
+
 [Turbopack](https://turbo.build/pack) is an incremental bundler optimized for JavaScript and TypeScript, written in Rust, and built into Next.js. Turbopack can be used in Next.js in both the `pages` and `app` directories for faster local development.
 
 To enable Turbopack, use the `--turbopack` flag when running the Next.js development server.
@@ -18,11 +20,13 @@ To enable Turbopack, use the `--turbopack` flag when running the Next.js develop
 }
 ```
 
-## Supported features
+## Reference
+
+### Supported features
 
 Turbopack in Next.js requires zero-configuration for most users and can be extended for more advanced use cases. To learn more about the currently supported features for Turbopack, view the [API Reference](/docs/app/api-reference/config/next-config-js/turbo).
 
-## Unsupported features
+### Unsupported features
 
 Turbopack currently only supports `next dev` and does not support `next build`. We are currently working on support for builds as we move closer towards stability.
 
@@ -72,7 +76,9 @@ These features are currently not supported:
   - We are currently not planning to support `:import` and `:export` ICSS rules in Next.js with Turbopack as [Lightning CSS](https://lightningcss.dev/css-modules.html) the CSS parser Turbopack uses does not support these rules.
 - `unstable_allowDynamic` configuration in edge runtime
 
-## Generating Trace Files
+## Examples
+
+### Generating Trace Files
 
 Trace files allow the Next.js team to investigate and improve performance metrics and memory usage. To generate a trace file, append `NEXT_TURBOPACK_TRACING=1` to the `next dev --turbopack` command, this will generate a `.next/trace.log` file.
 

--- a/docs/02-pages/03-api-reference/08-turbopack.mdx
+++ b/docs/02-pages/03-api-reference/08-turbopack.mdx
@@ -1,0 +1,5 @@
+---
+title: Turbopack
+description: Turbopack is an incremental bundler optimized for JavaScript and TypeScript, written in Rust, and built into Next.js.
+source: app/api-reference/turbopack
+---

--- a/test/e2e/app-dir/loader-file-named-export-custom-loader-error/loader-file-named-export-custom-loader-error.test.ts
+++ b/test/e2e/app-dir/loader-file-named-export-custom-loader-error/loader-file-named-export-custom-loader-error.test.ts
@@ -37,7 +37,7 @@ describe('Error test if the loader file export a named function', () => {
     })
 
     // next build doesn't support turbopack yet
-    // see https://nextjs.org/docs/architecture/turbopack#unsupported-features
+    // see https://nextjs.org/docs/api-reference/turbopack#unsupported-features
     ;(isNextStart && !process.env.TURBOPACK ? describe : describe.skip)(
       'build and start only',
       () => {

--- a/test/e2e/app-dir/loader-file-named-export-custom-loader-error/loader-file-named-export-custom-loader-error.test.ts
+++ b/test/e2e/app-dir/loader-file-named-export-custom-loader-error/loader-file-named-export-custom-loader-error.test.ts
@@ -37,7 +37,7 @@ describe('Error test if the loader file export a named function', () => {
     })
 
     // next build doesn't support turbopack yet
-    // see https://nextjs.org/docs/api-reference/turbopack#unsupported-features
+    // see https://nextjs.org/docs/app/api-reference/turbopack#unsupported-features
     ;(isNextStart && !process.env.TURBOPACK ? describe : describe.skip)(
       'build and start only',
       () => {


### PR DESCRIPTION
Closes: https://linear.app/vercel/issue/DOC-3886/[page]-turbopack

- Moves `Turbopack` page under API Reference
- Shares page between `app` and `pages` docs
- Updates page to follow template

Redirects: https://github.com/vercel/front/pull/38704