### PR TITLE
feat(after): allow using unstable_after in generateStaticParams

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1270,6 +1270,7 @@ export default async function build(
       )
 
       const isAppDynamicIOEnabled = Boolean(config.experimental.dynamicIO)
+      const isAfterEnabled = Boolean(config.experimental.after)
       const isAuthInterruptsEnabled = Boolean(
         config.experimental.authInterrupts
       )
@@ -2002,6 +2003,7 @@ export default async function build(
               configFileName,
               runtimeEnvConfig,
               dynamicIO: isAppDynamicIOEnabled,
+              after: isAfterEnabled,
               authInterrupts: isAuthInterruptsEnabled,
               httpAgentOptions: config.httpAgentOptions,
               locales: config.i18n?.locales,
@@ -2226,6 +2228,7 @@ export default async function build(
                             edgeInfo,
                             pageType,
                             dynamicIO: isAppDynamicIOEnabled,
+                            after: isAfterEnabled,
                             authInterrupts: isAuthInterruptsEnabled,
                             cacheHandler: config.cacheHandler,
                             cacheHandlers: config.experimental.cacheHandlers,

--- a/packages/next/src/server/after/after-context.ts
+++ b/packages/next/src/server/after/after-context.ts
@@ -66,12 +66,9 @@ export class AfterContext {
     }
 
     const workUnitStore = workUnitAsyncStorage.getStore()
-    if (!workUnitStore) {
-      throw new InvariantError(
-        'Missing workUnitStore in AfterContext.addCallback'
-      )
+    if (workUnitStore) {
+      this.workUnitStores.add(workUnitStore)
     }
-    this.workUnitStores.add(workUnitStore)
 
     // this should only happen once.
     if (!this.runCallbacksOnClosePromise) {

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -765,6 +765,7 @@ export default class DevServer extends Server {
             publicRuntimeConfig,
             serverRuntimeConfig,
             dynamicIO: Boolean(this.nextConfig.experimental.dynamicIO),
+            after: Boolean(this.nextConfig.experimental.after),
           },
           httpAgentOptions,
           locales,

--- a/packages/next/src/server/dev/static-paths-worker.ts
+++ b/packages/next/src/server/dev/static-paths-worker.ts
@@ -26,6 +26,7 @@ type RuntimeConfig = {
   publicRuntimeConfig: { [key: string]: any }
   serverRuntimeConfig: { [key: string]: any }
   dynamicIO: boolean
+  after: boolean
 }
 
 // we call getStaticPaths in a separate process to ensure
@@ -96,6 +97,7 @@ export async function loadStaticPaths({
       dir,
       page: pathname,
       dynamicIO: config.dynamicIO,
+      after: config.after,
       segments,
       configFileName: config.configFileName,
       distDir,

--- a/test/e2e/app-dir/next-after-app-static/generate-static-params-error/app/callback/[myParam]/page.tsx
+++ b/test/e2e/app-dir/next-after-app-static/generate-static-params-error/app/callback/[myParam]/page.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+import { unstable_after as after } from 'next/server'
+import { setTimeout } from 'timers/promises'
+
+export function generateStaticParams() {
+  after(async () => {
+    await setTimeout(500)
+    throw new Error(
+      `My cool error thrown inside unstable_after on route "/callback/[myParam]"`
+    )
+  })
+  return [{ myParam: 'a' }, { myParam: 'b' }, { myParam: 'c' }]
+}
+
+export default async function Page(props) {
+  const params = await props.params
+  return <div>Param: {params.myParam}</div>
+}

--- a/test/e2e/app-dir/next-after-app-static/generate-static-params-error/app/layout.tsx
+++ b/test/e2e/app-dir/next-after-app-static/generate-static-params-error/app/layout.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react'
+
+export default function AppLayout({ children }) {
+  return (
+    <html>
+      <head></head>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/next-after-app-static/generate-static-params-error/index.test.ts
+++ b/test/e2e/app-dir/next-after-app-static/generate-static-params-error/index.test.ts
@@ -1,0 +1,30 @@
+/* eslint-env jest */
+import { isNextDev, nextTestSetup } from 'e2e-utils'
+
+// This test relies on next.build() so it can't work in dev mode.
+const _describe = isNextDev ? describe.skip : describe
+
+_describe('unstable_after() in generateStaticParams - thrown errors', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true, // can't access build errors in deploy tests
+  })
+
+  if (skipped) return
+
+  it('fails the build if an error is thrown inside unstable_after', async () => {
+    const buildResult = await next.build()
+    expect(buildResult?.exitCode).toBe(1)
+
+    {
+      const path = '/callback/[myParam]'
+      expect(next.cliOutput).toContain(
+        `Failed to collect page data for ${path}`
+      )
+      expect(next.cliOutput).toContain(
+        `My cool error thrown inside unstable_after on route "${path}"`
+      )
+    }
+  })
+})

--- a/test/e2e/app-dir/next-after-app-static/generate-static-params-error/next.config.js
+++ b/test/e2e/app-dir/next-after-app-static/generate-static-params-error/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  experimental: {
+    after: true,
+  },
+}

--- a/test/e2e/app-dir/next-after-app-static/generate-static-params-error/utils/log.js
+++ b/test/e2e/app-dir/next-after-app-static/generate-static-params-error/utils/log.js
@@ -1,0 +1,16 @@
+export function cliLog(/** @type {string | Record<string, any>} */ data) {
+  console.log('<test-log>' + JSON.stringify(data) + '</test-log>')
+}
+
+export function readCliLogs(/** @type {string} */ output) {
+  return output
+    .split('\n')
+    .map((line) => {
+      const match = line.match(/^<test-log>(?<value>.+?)<\/test-log>$/)
+      if (!match) {
+        return null
+      }
+      return JSON.parse(match.groups.value)
+    })
+    .filter(Boolean)
+}

--- a/test/e2e/app-dir/next-after-app-static/generate-static-params/app/layout.tsx
+++ b/test/e2e/app-dir/next-after-app-static/generate-static-params/app/layout.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react'
+
+export default function AppLayout({ children }) {
+  return (
+    <html>
+      <head></head>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/next-after-app-static/generate-static-params/app/one/[myParam]/page.tsx
+++ b/test/e2e/app-dir/next-after-app-static/generate-static-params/app/one/[myParam]/page.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react'
+import { unstable_after as after } from 'next/server'
+import { cliLog } from '../../../utils/log'
+
+export function generateStaticParams() {
+  after(() => {
+    cliLog({ source: '[generateStaticParams] /one/[myParam]' })
+  })
+  return [{ myParam: 'a' }, { myParam: 'b' }, { myParam: 'c' }]
+}
+
+export default async function Page(props) {
+  const params = await props.params
+  return <div>Param: {params.myParam}</div>
+}

--- a/test/e2e/app-dir/next-after-app-static/generate-static-params/app/two/[myParam]/page.tsx
+++ b/test/e2e/app-dir/next-after-app-static/generate-static-params/app/two/[myParam]/page.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react'
+import { unstable_after as after } from 'next/server'
+import { cliLog } from '../../../utils/log'
+
+export function generateStaticParams() {
+  after(() => {
+    cliLog({ source: '[generateStaticParams] /two/[myParam]' })
+  })
+  return [{ myParam: 'd' }, { myParam: 'e' }, { myParam: 'f' }]
+}
+
+export default async function Page(props) {
+  const params = await props.params
+  return <div>Param: {params.myParam}</div>
+}

--- a/test/e2e/app-dir/next-after-app-static/generate-static-params/index.test.ts
+++ b/test/e2e/app-dir/next-after-app-static/generate-static-params/index.test.ts
@@ -1,0 +1,45 @@
+/* eslint-env jest */
+import { isNextDev, nextTestSetup } from 'e2e-utils'
+import * as Log from './utils/log'
+
+// This test relies on next.build() so it can't work in dev mode.
+const _describe = isNextDev ? describe.skip : describe
+
+_describe('unstable_after() in generateStaticParams', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true, // reading CLI logs to observe after
+    skipStart: true,
+  })
+
+  if (skipped) return
+
+  let currentCliOutputIndex = 0
+  beforeEach(() => {
+    currentCliOutputIndex = next.cliOutput.length
+  })
+
+  const getLogs = () => {
+    if (next.cliOutput.length < currentCliOutputIndex) {
+      // cliOutput shrank since we started the test, so something (like a `sandbox`) reset the logs
+      currentCliOutputIndex = 0
+    }
+    return next.cliOutput.slice(currentCliOutputIndex)
+  }
+
+  it('runs unstable_after callbacks for each page during build', async () => {
+    const buildResult = await next.build()
+    expect(buildResult?.exitCode).toBe(0)
+
+    {
+      // after should run at build time
+      const logsFromAfter = Log.readCliLogs(getLogs())
+      expect(logsFromAfter).toContainEqual({
+        source: '[generateStaticParams] /one/[myParam]',
+      })
+      expect(logsFromAfter).toContainEqual({
+        source: '[generateStaticParams] /two/[myParam]',
+      })
+    }
+  })
+})

--- a/test/e2e/app-dir/next-after-app-static/generate-static-params/next.config.js
+++ b/test/e2e/app-dir/next-after-app-static/generate-static-params/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  experimental: {
+    after: true,
+  },
+}

--- a/test/e2e/app-dir/next-after-app-static/generate-static-params/utils/log.js
+++ b/test/e2e/app-dir/next-after-app-static/generate-static-params/utils/log.js
@@ -1,0 +1,16 @@
+export function cliLog(/** @type {string | Record<string, any>} */ data) {
+  console.log('<test-log>' + JSON.stringify(data) + '</test-log>')
+}
+
+export function readCliLogs(/** @type {string} */ output) {
+  return output
+    .split('\n')
+    .map((line) => {
+      const match = line.match(/^<test-log>(?<value>.+?)<\/test-log>$/)
+      if (!match) {
+        return null
+      }
+      return JSON.parse(match.groups.value)
+    })
+    .filter(Boolean)
+}


### PR DESCRIPTION
Allows using `unstable_after` in `generateStaticParams`. definitely niche, but since we're now allowing `after` to be used during build, i see no reason not to.

Also fixes an issue where we didn't pass `experimental.after` into the context used for `generateStaticParams`, so if `after` was called, it'd always say that you have to enable `experimental.after` even if you already did.