### PR TITLE
Turbopack: Single-graph-traversal and migrate next/dynamic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4634,6 +4634,8 @@ checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
  "indexmap 1.9.3",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3954,6 +3954,7 @@ dependencies = [
  "futures",
  "indexmap 2.5.0",
  "next-core",
+ "petgraph",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3951,6 +3951,7 @@ name = "next-api"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "auto-hash-map",
  "futures",
  "indexmap 2.5.0",
  "next-core",

--- a/crates/next-api/Cargo.toml
+++ b/crates/next-api/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = { workspace = true, features = ["backtrace"] }
 futures = { workspace = true }
 indexmap = { workspace = true }
 next-core = { workspace = true }
-petgraph = { workspace = true }
+petgraph = { workspace = true, features = ["serde-1"]}
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/next-api/Cargo.toml
+++ b/crates/next-api/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = { workspace = true, features = ["backtrace"] }
 futures = { workspace = true }
 indexmap = { workspace = true }
 next-core = { workspace = true }
+petgraph = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/next-api/Cargo.toml
+++ b/crates/next-api/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }
+auto-hash-map = { workspace = true }
 futures = { workspace = true }
 indexmap = { workspace = true }
 next-core = { workspace = true }

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -932,9 +932,9 @@ impl AppEndpoint {
                 let client_shared_availability_info = client_shared_chunk_group.availability_info;
 
                 let reduced_graphs = get_reduced_graphs_for_page(
+                    this.app_project.project(),
                     *rsc_entry,
                     Vc::upcast(this.app_project.client_module_context()),
-                    this.app_project.project(),
                 );
                 // "app/client.js [app-ssr] (ecmascript)" ->
                 //      [("./dynamic", "app/dynamic.js [app-client] (ecmascript)")])]

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -40,8 +40,8 @@ use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    fxindexmap, fxindexset, trace::TraceRawVcs, Completion, FxIndexMap, FxIndexSet, ResolvedVc,
-    TryJoinIterExt, Value, ValueToString, Vc,
+    fxindexmap, fxindexset, trace::TraceRawVcs, Completion, FxIndexSet, ResolvedVc, TryJoinIterExt,
+    Value, ValueToString, Vc,
 };
 use turbo_tasks_env::{CustomProcessEnv, ProcessEnv};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
@@ -936,13 +936,9 @@ impl AppEndpoint {
                     *rsc_entry,
                     Vc::upcast(this.app_project.client_module_context()),
                 );
-                let next_dynamic_imports: FxIndexMap<_, _> = reduced_graphs
+                let next_dynamic_imports = reduced_graphs
                     .get_next_dynamic_imports_for_page(*rsc_entry)
-                    .await?
-                    .clone_value()
-                    // TODO remove this duplicate collect
-                    .into_iter()
-                    .collect();
+                    .await?;
 
                 let client_references = {
                     let ServerEntries {
@@ -1297,7 +1293,9 @@ impl AppEndpoint {
 
                     let dynamic_import_entries = collect_evaluated_chunk_group(
                         Vc::upcast(client_chunking_context),
-                        next_dynamic_imports.unwrap_or_default(),
+                        next_dynamic_imports
+                            .as_deref()
+                            .unwrap_or(&Default::default()),
                     )
                     .await?;
                     let loadable_manifest_output = create_react_loadable_manifest(
@@ -1346,7 +1344,9 @@ impl AppEndpoint {
                     let availability_info = Value::new(AvailabilityInfo::Root);
                     let dynamic_import_entries = collect_chunk_group(
                         Vc::upcast(client_chunking_context),
-                        next_dynamic_imports.unwrap_or_default(),
+                        next_dynamic_imports
+                            .as_deref()
+                            .unwrap_or(&Default::default()),
                         availability_info,
                     )
                     .await?;

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    future::IntoFuture,
-};
+use std::future::IntoFuture;
 
 use anyhow::{Context, Result};
 use next_core::{
@@ -72,13 +69,10 @@ use turbopack_core::{
 use turbopack_ecmascript::resolve::cjs_resolve;
 
 use crate::{
-    dynamic_imports::{
-        collect_chunk_group, collect_evaluated_chunk_group, collect_next_dynamic_imports,
-        VisitedDynamicImportModules,
-    },
+    dynamic_imports::{collect_chunk_group, collect_evaluated_chunk_group},
     font::create_font_manifest,
     loadable_manifest::create_react_loadable_manifest,
-    module_graph::{get_module_graph_for_page, get_reduced_graphs_for_page, SingleModuleGraph},
+    module_graph::get_reduced_graphs_for_page,
     nft_json::NftJsonAsset,
     paths::{
         all_paths_in_root, all_server_paths, get_asset_paths_from_root, get_js_paths_from_root,

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -72,7 +72,7 @@ use crate::{
     dynamic_imports::{collect_chunk_group, collect_evaluated_chunk_group},
     font::create_font_manifest,
     loadable_manifest::create_react_loadable_manifest,
-    module_graph::get_reduced_graphs_for_page,
+    module_graph::get_reduced_graphs_for_endpoint,
     nft_json::NftJsonAsset,
     paths::{
         all_paths_in_root, all_server_paths, get_asset_paths_from_root, get_js_paths_from_root,
@@ -931,13 +931,13 @@ impl AppEndpoint {
                 }
                 let client_shared_availability_info = client_shared_chunk_group.availability_info;
 
-                let reduced_graphs = get_reduced_graphs_for_page(
+                let reduced_graphs = get_reduced_graphs_for_endpoint(
                     this.app_project.project(),
                     *rsc_entry,
                     Vc::upcast(this.app_project.client_module_context()),
                 );
                 let next_dynamic_imports = reduced_graphs
-                    .get_next_dynamic_imports_for_page(*rsc_entry)
+                    .get_next_dynamic_imports_for_endpoint(*rsc_entry)
                     .await?;
 
                 let client_references = {

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1121,27 +1121,6 @@ impl AppEndpoint {
                     }
                 }
 
-                println!(
-                    "client_dynamic_imports {:?}",
-                    next_dynamic_imports
-                        .iter()
-                        .map(|(k, v)| async move {
-                            Ok(
-                                (
-                                    k.ident().to_string().await?,
-                                    v.iter()
-                                        .map(|(k, v)| async move {
-                                            Ok((k, v.ident().to_string().await?))
-                                        })
-                                        .try_join()
-                                        .await?,
-                                ),
-                            )
-                        })
-                        .try_join()
-                        .await?
-                );
-
                 (
                     Some(next_dynamic_imports),
                     Some(client_references_cell),

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -936,8 +936,6 @@ impl AppEndpoint {
                     *rsc_entry,
                     Vc::upcast(this.app_project.client_module_context()),
                 );
-                // "app/client.js [app-ssr] (ecmascript)" ->
-                //      [("./dynamic", "app/dynamic.js [app-client] (ecmascript)")])]
                 let next_dynamic_imports: FxIndexMap<_, _> = reduced_graphs
                     .get_next_dynamic_imports_for_page(*rsc_entry)
                     .await?

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1,4 +1,7 @@
-use std::future::IntoFuture;
+use std::{
+    collections::{HashMap, HashSet},
+    future::IntoFuture,
+};
 
 use anyhow::{Context, Result};
 use next_core::{
@@ -75,6 +78,7 @@ use crate::{
     },
     font::create_font_manifest,
     loadable_manifest::create_react_loadable_manifest,
+    module_graph::{get_module_graph_for_page, get_reduced_graphs_for_page, SingleModuleGraph},
     nft_json::NftJsonAsset,
     paths::{
         all_paths_in_root, all_server_paths, get_asset_paths_from_root, get_js_paths_from_root,
@@ -912,7 +916,7 @@ impl AppEndpoint {
             None
         };
 
-        let (client_dynamic_imports, client_references, client_references_chunks) =
+        let (next_dynamic_imports, client_references, client_references_chunks) =
             if process_client_components {
                 let client_shared_chunk_group = get_app_client_shared_chunk_group(
                     AssetIdent::from_path(this.app_project.project().project_path())
@@ -932,6 +936,20 @@ impl AppEndpoint {
                     }
                 }
                 let client_shared_availability_info = client_shared_chunk_group.availability_info;
+
+                let reduced_graphs = get_reduced_graphs_for_page(
+                    *rsc_entry,
+                    Vc::upcast(this.app_project.client_module_context()),
+                );
+                // "app/client.js [app-ssr] (ecmascript)" ->
+                //      [("./dynamic", "app/dynamic.js [app-client] (ecmascript)")])]
+                let next_dynamic_imports: FxIndexMap<_, _> = reduced_graphs
+                    .get_next_dynamic_imports_for_page(*rsc_entry)
+                    .await?
+                    .clone_value()
+                    // TODO remove this duplicate collect
+                    .into_iter()
+                    .collect();
 
                 let client_references = {
                     let ServerEntries {
@@ -960,32 +978,6 @@ impl AppEndpoint {
                     client_references
                 };
                 let client_references_cell = client_references.clone().cell();
-
-                let client_dynamic_imports = {
-                    let mut client_dynamic_imports = FxIndexMap::default();
-                    let mut visited_modules = VisitedDynamicImportModules::empty();
-
-                    for refs in client_references
-                        .client_references_by_server_component
-                        .values()
-                    {
-                        let result = collect_next_dynamic_imports(
-                            refs.iter().map(|v| **v).collect(),
-                            Vc::upcast(this.app_project.client_module_context()),
-                            visited_modules,
-                        )
-                        .await?;
-                        client_dynamic_imports.extend(
-                            result
-                                .client_dynamic_imports
-                                .iter()
-                                .map(|(k, v)| (*k, v.clone())),
-                        );
-                        visited_modules = *result.visited_modules;
-                    }
-
-                    client_dynamic_imports
-                };
 
                 let client_references_chunks = get_app_client_references_chunks(
                     client_references_cell,
@@ -1129,8 +1121,29 @@ impl AppEndpoint {
                     }
                 }
 
+                println!(
+                    "client_dynamic_imports {:?}",
+                    next_dynamic_imports
+                        .iter()
+                        .map(|(k, v)| async move {
+                            Ok(
+                                (
+                                    k.ident().to_string().await?,
+                                    v.iter()
+                                        .map(|(k, v)| async move {
+                                            Ok((k, v.ident().to_string().await?))
+                                        })
+                                        .try_join()
+                                        .await?,
+                                ),
+                            )
+                        })
+                        .try_join()
+                        .await?
+                );
+
                 (
-                    Some(client_dynamic_imports),
+                    Some(next_dynamic_imports),
                     Some(client_references_cell),
                     Some(client_references_chunks),
                 )
@@ -1310,19 +1323,9 @@ impl AppEndpoint {
                             .await?;
                     server_assets.insert(app_paths_manifest_output);
 
-                    // create react-loadable-manifest for next/dynamic
-                    let mut dynamic_import_modules = collect_next_dynamic_imports(
-                        vec![*ResolvedVc::upcast(app_entry.rsc_entry)],
-                        Vc::upcast(this.app_project.client_module_context()),
-                        VisitedDynamicImportModules::empty(),
-                    )
-                    .await?
-                    .client_dynamic_imports
-                    .clone();
-                    dynamic_import_modules.extend(client_dynamic_imports.into_iter().flatten());
                     let dynamic_import_entries = collect_evaluated_chunk_group(
                         Vc::upcast(client_chunking_context),
-                        dynamic_import_modules,
+                        next_dynamic_imports.unwrap_or_default(),
                     )
                     .await?;
                     let loadable_manifest_output = create_react_loadable_manifest(
@@ -1369,18 +1372,9 @@ impl AppEndpoint {
 
                     // create react-loadable-manifest for next/dynamic
                     let availability_info = Value::new(AvailabilityInfo::Root);
-                    let mut dynamic_import_modules = collect_next_dynamic_imports(
-                        vec![*ResolvedVc::upcast(app_entry.rsc_entry)],
-                        Vc::upcast(this.app_project.client_module_context()),
-                        VisitedDynamicImportModules::empty(),
-                    )
-                    .await?
-                    .client_dynamic_imports
-                    .clone();
-                    dynamic_import_modules.extend(client_dynamic_imports.into_iter().flatten());
                     let dynamic_import_entries = collect_chunk_group(
                         Vc::upcast(client_chunking_context),
-                        dynamic_import_modules,
+                        next_dynamic_imports.unwrap_or_default(),
                         availability_info,
                     )
                     .await?;

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -934,6 +934,7 @@ impl AppEndpoint {
                 let reduced_graphs = get_reduced_graphs_for_page(
                     *rsc_entry,
                     Vc::upcast(this.app_project.client_module_context()),
+                    this.app_project.project(),
                 );
                 // "app/client.js [app-ssr] (ecmascript)" ->
                 //      [("./dynamic", "app/dynamic.js [app-client] (ecmascript)")])]

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -466,7 +466,8 @@ pub async fn map_next_dynamic(
                 };
                 if is_ssr {
                     if let Some(v) =
-                        &*build_dynamic_imports_map_for_module(client_asset_context, module).await?
+                        &*build_dynamic_imports_map_for_module(client_asset_context, *module)
+                            .await?
                     {
                         return Ok(Some(v.await?.clone_value()));
                     }

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -284,15 +284,16 @@ pub async fn map_next_dynamic(
         .enumerate_nodes()
         .map(|(_, module)| {
             async move {
-                let is_ssr = match module.ident().await?.layer {
+                let is_browser = match module.ident().await?.layer {
                     Some(layer) => {
                         // TODO: compare module contexts instead?
                         let layer = &*layer.await?;
-                        layer == "app-rsc" || layer == "app-ssr"
+                        layer == "app-client" || layer == "client"
                     }
                     None => false,
                 };
-                if is_ssr {
+                // Only collect in RSC and SSR
+                if !is_browser {
                     if let Some(v) =
                         &*build_dynamic_imports_map_for_module(client_asset_context, *module)
                             .await?

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -450,11 +450,10 @@ pub async fn map_next_dynamic(
     graph: Vc<SingleModuleGraph>,
     client_asset_context: Vc<Box<dyn AssetContext>>,
 ) -> Result<Vc<DynamicImportsHashMap>> {
-    let graph = &graph.await?.graph;
     let data = graph
-        .node_indices()
-        .map(|idx| {
-            let module = *graph.node_weight(idx).unwrap();
+        .await?
+        .enumerate_nodes()
+        .map(|(_, module)| {
             async move {
                 let is_ssr = match module.ident().await?.layer {
                     Some(layer) => {

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -288,7 +288,7 @@ pub async fn map_next_dynamic(
                 let is_browser = node
                     .layer
                     .as_ref()
-                    .is_some_and(|layer| layer == "app-client" || layer == "client");
+                    .is_some_and(|layer| &**layer == "app-client" || &**layer == "client");
                 if !is_browser {
                     // Only collect in RSC and SSR
                     if let Some(v) =

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -282,20 +282,17 @@ pub async fn map_next_dynamic(
     let data = graph
         .await?
         .enumerate_nodes()
-        .map(|(_, module)| {
+        .map(|(_, node)| {
             async move {
-                let is_browser = match module.ident().await?.layer {
-                    Some(layer) => {
-                        // TODO: compare module contexts instead?
-                        let layer = &*layer.await?;
-                        layer == "app-client" || layer == "client"
-                    }
-                    None => false,
-                };
-                // Only collect in RSC and SSR
+                // TODO: compare module contexts instead?
+                let is_browser = node
+                    .layer
+                    .as_ref()
+                    .is_some_and(|layer| layer == "app-client" || layer == "client");
                 if !is_browser {
+                    // Only collect in RSC and SSR
                     if let Some(v) =
-                        &*build_dynamic_imports_map_for_module(client_asset_context, *module)
+                        &*build_dynamic_imports_map_for_module(client_asset_context, *node.module)
                             .await?
                     {
                         return Ok(Some(v.await?.clone_value()));

--- a/crates/next-api/src/lib.rs
+++ b/crates/next-api/src/lib.rs
@@ -12,6 +12,7 @@ pub mod global_module_id_strategy;
 mod instrumentation;
 mod loadable_manifest;
 mod middleware;
+mod module_graph;
 mod nft_json;
 mod pages;
 pub mod paths;

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -1,43 +1,250 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::{Context, Result};
+use next_core::next_client_reference::{find_server_entries, ServerEntries};
 use petgraph::graph::{DiGraph, NodeIndex};
-use turbo_tasks::Vc;
-use turbopack_core::{module::Module, reference::primary_referenced_modules};
+use turbo_tasks::{ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Vc};
+use turbopack_core::{
+    context::AssetContext, module::Module, reference::primary_referenced_modules,
+};
 
-#[derive(Debug)]
+use crate::dynamic_imports::{map_next_dynamic, DynamicImportsHashMap};
+
+#[turbo_tasks::value(cell = "new", eq = "manual", into = "new")]
+#[derive(Clone, Debug, Default)]
 pub struct SingleModuleGraph {
-    graph: DiGraph<Vc<Box<dyn Module>>, ()>,
-    modules: HashMap<Vc<Box<dyn Module>>, NodeIndex<u32>>,
+    #[turbo_tasks(trace_ignore)]
+    pub graph: DiGraph<Vc<Box<dyn Module>>, ()>,
 }
 
-impl SingleModuleGraph {
-    pub fn new() -> Self {
-        Self {
-            graph: Default::default(),
-            modules: Default::default(),
-        }
-    }
+#[turbo_tasks::value(transparent)]
+#[derive(Clone, Debug)]
+pub struct SingleModuleGraphs(pub Vec<Vc<SingleModuleGraph>>);
 
-    pub async fn add_module_subgraph(&mut self, module: Vc<Box<dyn Module>>) -> Result<()> {
-        let mut stack = vec![(None, module)];
+#[turbo_tasks::value(transparent)]
+#[derive(Clone, Debug)]
+pub struct ModuleSet(pub HashSet<Vc<Box<dyn Module>>>);
+
+#[turbo_tasks::value_impl]
+impl SingleModuleGraph {
+    #[turbo_tasks::function]
+    pub async fn new_with_entries(entries: Vec<Vc<Box<dyn Module>>>) -> Result<Vc<Self>> {
+        let mut graph = DiGraph::new();
+
+        let mut modules: HashMap<Vc<Box<dyn Module>>, NodeIndex<u32>> = HashMap::new();
+        let mut stack: Vec<_> = entries.into_iter().map(|e| (None, e)).collect();
         while let Some((parent_idx, module)) = stack.pop() {
-            if let Some(idx) = self.modules.get(&module) {
+            if let Some(idx) = modules.get(&module) {
                 let parent_idx = parent_idx.context("Existing module without parent")?;
-                self.graph.add_edge(parent_idx, *idx, ());
+                graph.add_edge(parent_idx, *idx, ());
                 continue;
             }
 
-            let idx = self.graph.add_node(module);
-            self.modules.insert(module, idx);
+            let idx = graph.add_node(module);
+            modules.insert(module, idx);
             if let Some(parent_idx) = parent_idx {
-                self.graph.add_edge(parent_idx, idx, ());
+                graph.add_edge(parent_idx, idx, ());
             }
 
+            // TODO this includes
+            // [project]/packages/next/dist/shared/lib/lazy-dynamic/loadable.js.map
             for reference in primary_referenced_modules(module).await?.iter() {
                 stack.push((Some(idx), **reference));
             }
         }
-        Ok(())
+
+        Ok(SingleModuleGraph { graph }.cell())
     }
+
+    #[turbo_tasks::function]
+    pub async fn new_with_entries_visited(
+        entries: Vec<Vc<Box<dyn Module>>>,
+        visited_modules: Vc<ModuleSet>,
+    ) -> Result<Vc<Self>> {
+        let visited_modules = visited_modules.await?;
+
+        let mut graph = DiGraph::new();
+
+        let mut modules: HashMap<Vc<Box<dyn Module>>, NodeIndex<u32>> = HashMap::new();
+        let mut stack: Vec<_> = entries.into_iter().map(|e| (None, e)).collect();
+        while let Some((parent_idx, module)) = stack.pop() {
+            // println!(
+            //     "module: {:?} {:?}",
+            //     parent_idx,
+            //     module.ident().to_string().await?
+            // );
+            if visited_modules.contains(&module) {
+                continue;
+            }
+            if let Some(idx) = modules.get(&module) {
+                if let Some(parent_idx) = parent_idx {
+                    graph.add_edge(parent_idx, *idx, ());
+                }
+                continue;
+            }
+
+            let idx = graph.add_node(module);
+            modules.insert(module, idx);
+            if let Some(parent_idx) = parent_idx {
+                graph.add_edge(parent_idx, idx, ());
+            }
+
+            // TODO this includes
+            // [project]/packages/next/dist/shared/lib/lazy-dynamic/loadable.js.map
+            for reference in primary_referenced_modules(module).await?.iter() {
+                stack.push((Some(idx), **reference));
+            }
+        }
+
+        Ok(SingleModuleGraph { graph }.cell())
+    }
+}
+
+pub async fn get_module_graph_for_page(
+    rsc_entry: Vc<Box<dyn Module>>,
+) -> Result<SingleModuleGraphs> {
+    // TODO
+    // if is_production() {
+    //    return the one graph for the whole app
+    // }
+
+    let ServerEntries {
+        server_utils,
+        server_component_entries,
+    } = &*find_server_entries(rsc_entry).await?;
+
+    let graph = SingleModuleGraph::new_with_entries_visited(
+        server_utils.clone(),
+        Vc::cell(Default::default()),
+    );
+    let mut visited_modules: HashSet<_> = graph.await?.graph.node_weights().copied().collect();
+
+    let mut graphs = vec![graph];
+    for module in server_component_entries
+        .iter()
+        .map(|m| Vc::upcast::<Box<dyn Module>>(*m))
+        .chain(std::iter::once(rsc_entry))
+    {
+        let graph = SingleModuleGraph::new_with_entries_visited(
+            vec![module],
+            Vc::cell(visited_modules.clone()),
+        );
+        visited_modules.extend(graph.await?.graph.node_weights().copied());
+        graphs.push(graph);
+    }
+
+    Ok(SingleModuleGraphs(graphs))
+}
+
+#[turbo_tasks::value]
+pub struct NextDynamicGraph {
+    graph: ResolvedVc<SingleModuleGraph>,
+    /// RSC/SSR importer -> dynamic imports (specifier and client module)
+    data: ResolvedVc<DynamicImportsHashMap>,
+}
+#[turbo_tasks::value_impl]
+impl NextDynamicGraph {
+    #[turbo_tasks::function]
+    pub async fn new_with_entries(
+        graph: ResolvedVc<SingleModuleGraph>,
+        client_asset_context: Vc<Box<dyn AssetContext>>,
+    ) -> Result<Vc<Self>> {
+        let mapped = map_next_dynamic(*graph, client_asset_context);
+
+        // TODO shrink graph here, using the information from `mapped` (which lists the relevant
+        // nodes)
+
+        // This would clone the graph and allow changing the node weights. We can probably get away
+        // with keeping the sidecar information separate from the graph itself, though.
+        //
+        // let mut reduced_modules: HashMap<Vc<Box<dyn Module>>, NodeIndex<u32>> =
+        // HashMap::new(); let mut reduced_graph = DiGraph::new();
+        // for idx in graph.node_indices() {
+        //     let weight = *graph.node_weight(idx).unwrap();
+        //     let new_idx = reduced_graph.add_node(weight);
+        //     reduced_modules.insert(weight, new_idx);
+        //     for e in graph.edges_directed(idx, petgraph::Direction::Outgoing) {
+        //         let target_weight = *graph.node_weight(e.target()).context("Missing
+        // target")?;         if let Some(new_target_idx) =
+        // reduced_modules.get(&target_weight) {
+        // reduced_graph.add_edge(new_idx, *new_target_idx, ());         } else {
+        //             let new_idx = reduced_graph.add_node(target_weight);
+        //             reduced_modules.insert(target_weight, new_idx);
+        //         }
+        //     }
+        // }
+
+        Ok(NextDynamicGraph {
+            graph,
+            data: mapped.to_resolved().await?,
+        }
+        .cell())
+    }
+    #[turbo_tasks::function]
+    pub async fn get_next_dynamic_imports_for_page(
+        &self,
+        _rsc_entry: Vc<Box<dyn Module>>,
+    ) -> Result<Vc<DynamicImportsHashMap>> {
+        // TODO
+        // if production {
+        //    return walk graph and return relevant nodes to this page
+        // }
+        Ok(*self.data)
+    }
+}
+
+// In dev, a graph containing the modules of the current page
+// In prod, a graph contaning everything in the whole app
+#[turbo_tasks::value]
+pub struct ReducedGraphs {
+    pub next_dynamic: Vec<ResolvedVc<NextDynamicGraph>>,
+    // TODO add other graphs
+}
+
+#[turbo_tasks::value_impl]
+impl ReducedGraphs {
+    #[turbo_tasks::function]
+    pub async fn get_next_dynamic_imports_for_page(
+        &self,
+        rsc_entry: Vc<Box<dyn Module>>,
+    ) -> Result<Vc<DynamicImportsHashMap>> {
+        let result = self
+            .next_dynamic
+            .iter()
+            .map(|graph| async move {
+                Ok(graph
+                    .get_next_dynamic_imports_for_page(rsc_entry)
+                    .await?
+                    .iter()
+                    .map(|(k, v)| (*k, v.clone()))
+                    // TODO remove this collect and return an iterator instead
+                    .collect::<Vec<_>>())
+            })
+            .try_flat_join()
+            .await?;
+
+        Ok(DynamicImportsHashMap(result.into_iter().collect()).cell())
+    }
+}
+
+#[turbo_tasks::function]
+pub async fn get_reduced_graphs_for_page(
+    rsc_entry: Vc<Box<dyn Module>>,
+    // TODO instead do that later on per-page traversal
+    client_asset_context: Vc<Box<dyn AssetContext>>,
+) -> Result<Vc<ReducedGraphs>> {
+    // if production
+    //   // ignore rsc_entry
+    //   let graphs = create_module_graph_for_entries(project.get_all_entries())
+    // else
+    //
+    let graphs = get_module_graph_for_page(rsc_entry).await?.0;
+
+    let next_dynamic = graphs
+        .iter()
+        .map(|graph| NextDynamicGraph::new_with_entries(*graph, client_asset_context).to_resolved())
+        .try_join()
+        .await?;
+
+    Ok(ReducedGraphs { next_dynamic }.cell())
 }

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -68,11 +68,6 @@ impl SingleModuleGraph {
         let mut modules: HashMap<Vc<Box<dyn Module>>, NodeIndex<u32>> = HashMap::new();
         let mut stack: Vec<_> = entries.into_iter().map(|e| (None, e)).collect();
         while let Some((parent_idx, module)) = stack.pop() {
-            // println!(
-            //     "module: {:?} {:?}",
-            //     parent_idx,
-            //     module.ident().to_string().await?
-            // );
             if visited_modules.contains(&module) {
                 continue;
             }

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -1,0 +1,43 @@
+use std::collections::HashMap;
+
+use anyhow::{Context, Result};
+use petgraph::graph::{DiGraph, NodeIndex};
+use turbo_tasks::Vc;
+use turbopack_core::{module::Module, reference::primary_referenced_modules};
+
+#[derive(Debug)]
+pub struct SingleModuleGraph {
+    graph: DiGraph<Vc<Box<dyn Module>>, ()>,
+    modules: HashMap<Vc<Box<dyn Module>>, NodeIndex<u32>>,
+}
+
+impl SingleModuleGraph {
+    pub fn new() -> Self {
+        Self {
+            graph: Default::default(),
+            modules: Default::default(),
+        }
+    }
+
+    pub async fn add_module_subgraph(&mut self, module: Vc<Box<dyn Module>>) -> Result<()> {
+        let mut stack = vec![(None, module)];
+        while let Some((parent_idx, module)) = stack.pop() {
+            if let Some(idx) = self.modules.get(&module) {
+                let parent_idx = parent_idx.context("Existing module without parent")?;
+                self.graph.add_edge(parent_idx, *idx, ());
+                continue;
+            }
+
+            let idx = self.graph.add_node(module);
+            self.modules.insert(module, idx);
+            if let Some(parent_idx) = parent_idx {
+                self.graph.add_edge(parent_idx, idx, ());
+            }
+
+            for reference in primary_referenced_modules(module).await?.iter() {
+                stack.push((Some(idx), **reference));
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -72,9 +72,10 @@ impl SingleModuleGraph {
                 graph.add_edge(parent_idx, idx, ());
             }
 
-            // TODO this includes
-            // [project]/packages/next/dist/shared/lib/lazy-dynamic/loadable.js.map
             for reference in primary_referenced_modules(*module).await?.iter() {
+                if reference.ident().path().await?.extension_ref() == Some("map") {
+                    continue;
+                }
                 stack.push((Some(idx), *reference));
             }
         }

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -450,20 +450,6 @@ async fn get_module_graph_for_endpoint(
     Ok(Vc::cell(graphs))
 }
 
-#[turbo_tasks::function]
-async fn get_module_graph_for_app_without_issues(
-    entries: Vc<Modules>,
-) -> Result<Vc<SingleModuleGraph>> {
-    let vc = SingleModuleGraph::new_with_entries(entries);
-    let graph = vc.resolve_strongly_consistent().await?;
-    let _issues = vc.take_collectibles::<Box<dyn Issue>>();
-    // println!(
-    //     "taking {:?}",
-    //     _issues.iter().map(|i| i.dbg()).try_join().await?
-    // );
-    Ok(graph)
-}
-
 #[turbo_tasks::value]
 pub struct NextDynamicGraph {
     is_single_page: bool,
@@ -547,7 +533,7 @@ impl NextDynamicGraph {
     }
 }
 
-/// The consumers of this shoudln't need to care about the exact contents since it's abstracted away
+/// The consumers of this shouldn't need to care about the exact contents since it's abstracted away
 /// by the accessor functions, but
 /// - In dev, contains information about the modules of the current endpoint only
 /// - In prod, there is a single `ReducedGraphs` for the whole app, containing all pages
@@ -613,7 +599,7 @@ async fn get_reduced_graphs_for_endpoint_inner(
             false,
             vec![
                 async move {
-                    get_module_graph_for_app_without_issues(project.get_all_entries())
+                    SingleModuleGraph::new_with_entries(project.get_all_entries())
                         .to_resolved()
                         .await
                 }

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -243,7 +243,7 @@ impl SingleModuleGraph {
 
         let mut modules: HashMap<ResolvedVc<Box<dyn Module>>, NodeIndex<u32>> = HashMap::new();
         {
-            let _span = tracing::info_span!("build petgraph").entered();
+            let _span = tracing::info_span!("build module graph").entered();
             for (parent, current) in children_modules_iter.into_breadth_first_edges() {
                 let parent_idx =
                     parent.map(|parent| *modules.get(&parent.module().unwrap()).unwrap());

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -66,7 +66,7 @@ use crate::{
     dynamic_imports::{collect_chunk_group, collect_evaluated_chunk_group, DynamicImportedChunks},
     font::create_font_manifest,
     loadable_manifest::create_react_loadable_manifest,
-    module_graph::get_reduced_graphs_for_page,
+    module_graph::get_reduced_graphs_for_endpoint,
     nft_json::NftJsonAsset,
     paths::{
         all_paths_in_root, all_server_paths, get_asset_paths_from_root, get_js_paths_from_root,
@@ -844,13 +844,13 @@ impl PageEndpoint {
                 runtime,
             } = *self.internal_ssr_chunk_module().await?;
 
-            let reduced_graphs = get_reduced_graphs_for_page(
+            let reduced_graphs = get_reduced_graphs_for_endpoint(
                 this.pages_project.project(),
                 *ssr_module,
                 Vc::upcast(this.pages_project.client_module_context()),
             );
             let next_dynamic_imports = reduced_graphs
-                .get_next_dynamic_imports_for_page(*ssr_module)
+                .get_next_dynamic_imports_for_endpoint(*ssr_module)
                 .await?;
 
             let is_edge = matches!(runtime, NextRuntime::Edge);

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -849,13 +849,9 @@ impl PageEndpoint {
                 *ssr_module,
                 Vc::upcast(this.pages_project.client_module_context()),
             );
-            let next_dynamic_imports: FxIndexMap<_, _> = reduced_graphs
+            let next_dynamic_imports = reduced_graphs
                 .get_next_dynamic_imports_for_page(*ssr_module)
-                .await?
-                .clone_value()
-                // TODO remove this duplicate collect
-                .into_iter()
-                .collect();
+                .await?;
 
             let is_edge = matches!(runtime, NextRuntime::Edge);
             if is_edge {
@@ -878,7 +874,7 @@ impl PageEndpoint {
                     this.pages_project.project().client_chunking_context();
                 let dynamic_import_entries = collect_evaluated_chunk_group(
                     Vc::upcast(client_chunking_context),
-                    next_dynamic_imports,
+                    &next_dynamic_imports,
                 )
                 .await?
                 .to_resolved()
@@ -913,7 +909,7 @@ impl PageEndpoint {
                     this.pages_project.project().client_chunking_context();
                 let dynamic_import_entries = collect_chunk_group(
                     Vc::upcast(client_chunking_context),
-                    next_dynamic_imports,
+                    &next_dynamic_imports,
                     Value::new(AvailabilityInfo::Root),
                 )
                 .await?

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -684,9 +684,9 @@ impl Project {
         let entrypoints = self.entrypoints().await?;
 
         modules.extend(self.client_main_modules().await?.iter().copied());
-        add_endpoint(entrypoints.pages_error_endpoint, &mut modules).await?;
-        add_endpoint(entrypoints.pages_app_endpoint, &mut modules).await?;
-        add_endpoint(entrypoints.pages_document_endpoint, &mut modules).await?;
+        add_endpoint(*entrypoints.pages_error_endpoint, &mut modules).await?;
+        add_endpoint(*entrypoints.pages_app_endpoint, &mut modules).await?;
+        add_endpoint(*entrypoints.pages_document_endpoint, &mut modules).await?;
 
         if let Some(middleware) = &entrypoints.middleware {
             add_endpoint(middleware.endpoint, &mut modules).await?;

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -47,7 +47,7 @@ use turbopack_core::{
     diagnostics::DiagnosticExt,
     file_source::FileSource,
     issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
-    module::Modules,
+    module::{Module, Modules},
     output::{OutputAsset, OutputAssets},
     resolve::{find_context_file, FindContextFileResult},
     source_map::OptionSourceMap,
@@ -67,7 +67,6 @@ use crate::{
     global_module_id_strategy::GlobalModuleIdStrategyBuilder,
     instrumentation::InstrumentationEndpoint,
     middleware::MiddlewareEndpoint,
-    module_graph::SingleModuleGraph,
     pages::PagesProject,
     route::{Endpoint, Route},
     versioned_content_map::{OutputAssetsOperation, VersionedContentMap},
@@ -665,6 +664,72 @@ impl Project {
     #[turbo_tasks::function]
     pub(super) fn client_compile_time_info(&self) -> Vc<CompileTimeInfo> {
         get_client_compile_time_info(self.browserslist_query.clone(), self.define_env.client())
+    }
+
+    #[turbo_tasks::function]
+    pub async fn get_all_entries(self: Vc<Self>) -> Result<Vc<Modules>> {
+        let mut modules = Vec::new();
+
+        async fn add_endpoint(
+            endpoint: Vc<Box<dyn Endpoint>>,
+            modules: &mut Vec<ResolvedVc<Box<dyn Module>>>,
+        ) -> Result<()> {
+            let root_modules = endpoint.root_modules().await?;
+            modules.extend(root_modules.iter().copied());
+            Ok(())
+        }
+
+        modules.extend(self.client_main_modules().await?.iter().copied());
+
+        let entrypoints = self.entrypoints().await?;
+
+        modules.extend(self.client_main_modules().await?.iter().copied());
+        add_endpoint(entrypoints.pages_error_endpoint, &mut modules).await?;
+        add_endpoint(entrypoints.pages_app_endpoint, &mut modules).await?;
+        add_endpoint(entrypoints.pages_document_endpoint, &mut modules).await?;
+
+        if let Some(middleware) = &entrypoints.middleware {
+            add_endpoint(middleware.endpoint, &mut modules).await?;
+        }
+
+        if let Some(instrumentation) = &entrypoints.instrumentation {
+            let node_js = instrumentation.node_js;
+            let edge = instrumentation.edge;
+            add_endpoint(node_js, &mut modules).await?;
+            add_endpoint(edge, &mut modules).await?;
+        }
+
+        for (_, route) in entrypoints.routes.iter() {
+            match route {
+                Route::Page {
+                    html_endpoint,
+                    data_endpoint,
+                } => {
+                    add_endpoint(*html_endpoint, &mut modules).await?;
+                    add_endpoint(*data_endpoint, &mut modules).await?;
+                }
+                Route::PageApi { endpoint } => {
+                    add_endpoint(*endpoint, &mut modules).await?;
+                }
+                Route::AppPage(page_routes) => {
+                    for page_route in page_routes {
+                        add_endpoint(page_route.html_endpoint, &mut modules).await?;
+                        add_endpoint(page_route.rsc_endpoint, &mut modules).await?;
+                    }
+                }
+                Route::AppRoute {
+                    original_name: _,
+                    endpoint,
+                } => {
+                    add_endpoint(*endpoint, &mut modules).await?;
+                }
+                Route::Conflict => {
+                    tracing::info!("WARN: conflict");
+                }
+            }
+        }
+
+        Ok(Vc::cell(modules))
     }
 
     #[turbo_tasks::function]
@@ -1322,26 +1387,9 @@ impl Project {
         Ok(Vc::cell(modules))
     }
 
-    #[turbo_tasks::function]
-    pub async fn get_module_graph(self: Vc<Self>) -> Result<Vc<()>> {
-        let mut _single_module_graph = SingleModuleGraph::new_with_entries(
-            self.client_main_modules()
-                .await?
-                .iter()
-                .map(|m| **m)
-                .collect(),
-        )
-        .await?;
-
-        // dbg!(_single_module_graph);
-
-        Ok(Vc::cell(()))
-    }
-
     /// Gets the module id strategy for the project.
     #[turbo_tasks::function]
     pub async fn module_id_strategy(self: Vc<Self>) -> Result<Vc<Box<dyn ModuleIdStrategy>>> {
-        self.get_module_graph().await?;
         let module_id_strategy = self.next_config().module_id_strategy_config();
         match *module_id_strategy.await? {
             Some(ModuleIdStrategyConfig::Named) => Ok(Vc::upcast(DevModuleIdStrategy::new())),

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -705,11 +705,11 @@ impl Project {
                     html_endpoint,
                     data_endpoint,
                 } => {
-                    add_endpoint(*html_endpoint, &mut modules).await?;
-                    add_endpoint(*data_endpoint, &mut modules).await?;
+                    add_endpoint(**html_endpoint, &mut modules).await?;
+                    add_endpoint(**data_endpoint, &mut modules).await?;
                 }
                 Route::PageApi { endpoint } => {
-                    add_endpoint(*endpoint, &mut modules).await?;
+                    add_endpoint(**endpoint, &mut modules).await?;
                 }
                 Route::AppPage(page_routes) => {
                     for page_route in page_routes {
@@ -721,7 +721,7 @@ impl Project {
                     original_name: _,
                     endpoint,
                 } => {
-                    add_endpoint(*endpoint, &mut modules).await?;
+                    add_endpoint(**endpoint, &mut modules).await?;
                 }
                 Route::Conflict => {
                     tracing::info!("WARN: conflict");

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1324,14 +1324,16 @@ impl Project {
 
     #[turbo_tasks::function]
     pub async fn get_module_graph(self: Vc<Self>) -> Result<Vc<()>> {
-        let mut _single_module_graph = SingleModuleGraph::new();
-        for client_main_module in self.client_main_modules().await?.iter() {
-            _single_module_graph
-                .add_module_subgraph(**client_main_module)
-                .await?;
-        }
+        let mut _single_module_graph = SingleModuleGraph::new_with_entries(
+            self.client_main_modules()
+                .await?
+                .iter()
+                .map(|m| **m)
+                .collect(),
+        )
+        .await?;
 
-        dbg!(_single_module_graph);
+        // dbg!(_single_module_graph);
 
         Ok(Vc::cell(()))
     }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -68,7 +68,7 @@ use crate::{
     instrumentation::InstrumentationEndpoint,
     middleware::MiddlewareEndpoint,
     pages::PagesProject,
-    route::{Endpoint, Route},
+    route::{AppPageRoute, Endpoint, Route},
     versioned_content_map::{OutputAssetsOperation, VersionedContentMap},
 };
 
@@ -703,18 +703,21 @@ impl Project {
             match route {
                 Route::Page {
                     html_endpoint,
-                    data_endpoint,
+                    data_endpoint: _,
                 } => {
                     add_endpoint(**html_endpoint, &mut modules).await?;
-                    add_endpoint(**data_endpoint, &mut modules).await?;
                 }
                 Route::PageApi { endpoint } => {
                     add_endpoint(**endpoint, &mut modules).await?;
                 }
                 Route::AppPage(page_routes) => {
-                    for page_route in page_routes {
-                        add_endpoint(page_route.html_endpoint, &mut modules).await?;
-                        add_endpoint(page_route.rsc_endpoint, &mut modules).await?;
+                    for AppPageRoute {
+                        original_name: _,
+                        html_endpoint,
+                        rsc_endpoint: _,
+                    } in page_routes
+                    {
+                        add_endpoint(*html_endpoint, &mut modules).await?;
                     }
                 }
                 Route::AppRoute {

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -105,7 +105,7 @@ impl Asset for EcmascriptClientReferenceModule {
 }
 
 #[turbo_tasks::value]
-struct EcmascriptClientReference {
+pub(crate) struct EcmascriptClientReference {
     module: ResolvedVc<Box<dyn Module>>,
     ty: ChunkGroupType,
     description: ResolvedVc<RcStr>,

--- a/turbopack/crates/turbo-tasks/src/graph/adjacency_map.rs
+++ b/turbopack/crates/turbo-tasks/src/graph/adjacency_map.rs
@@ -88,7 +88,7 @@ where
         }
     }
 
-    /// Returns an owned iterator over the nodes in reverse topological order,
+    /// Returns an owned iterator over all edges (node pairs) in breadth first order,
     /// starting from the roots.
     pub fn into_breadth_first_edges(self) -> IntoBreadthFirstEdges<T> {
         IntoBreadthFirstEdges {
@@ -212,7 +212,7 @@ where
             return Some((parent, current));
         };
 
-        if !self.visited.contains(&current) {
+        if self.visited.insert(current.clone()) {
             self.stack.extend(
                 neighbors
                     .iter()
@@ -220,7 +220,6 @@ where
                     .map(|neighbor| (Some(current.clone()), neighbor.clone())),
             );
         }
-        self.visited.insert(current.clone());
 
         Some((parent, current))
     }

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -22,8 +22,6 @@ use crate::{
     Copy,
     PartialEq,
     Eq,
-    PartialOrd,
-    Ord,
     Hash,
     Serialize,
     Deserialize,
@@ -34,6 +32,24 @@ pub enum MinifyType {
     #[default]
     Minify,
     NoMinify,
+}
+
+#[derive(
+    Debug,
+    TaskInput,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    DeterministicHash,
+)]
+pub enum ChunkGroupType {
+    Entry,
+    Evaluated,
 }
 
 #[turbo_tasks::value(shared)]

--- a/turbopack/crates/turbopack-core/src/introspect/utils.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/utils.rs
@@ -39,6 +39,11 @@ fn passthrough_reference_ty() -> Vc<RcStr> {
 }
 
 #[turbo_tasks::function]
+fn isolated_reference_ty() -> Vc<RcStr> {
+    Vc::cell("isolated reference".into())
+}
+
+#[turbo_tasks::function]
 fn traced_reference_ty() -> Vc<RcStr> {
     Vc::cell("traced reference".into())
 }
@@ -81,6 +86,7 @@ pub async fn children_from_module_references(
                     key = parallel_inherit_async_reference_ty()
                 }
                 Some(ChunkingType::Async) => key = async_reference_ty(),
+                Some(ChunkingType::Isolated { .. }) => key = isolated_reference_ty(),
                 Some(ChunkingType::Passthrough) => key = passthrough_reference_ty(),
                 Some(ChunkingType::Traced) => key = traced_reference_ty(),
             }

--- a/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
@@ -83,7 +83,7 @@ async fn get_inherit_async_referenced_asset(
     let Some(r) = Vc::try_resolve_downcast::<Box<dyn ChunkableModuleReference>>(r).await? else {
         return Ok(None);
     };
-    let Some(ty) = *r.chunking_type().await? else {
+    let Some(ty) = &*r.chunking_type().await? else {
         return Ok(None);
     };
     if !matches!(ty, ChunkingType::ParallelInheritAsync) {


### PR DESCRIPTION
Closes PACK-3535

- Adds some infrastructure for the single-graph-traversal stuff, ~~focusing on dev with layout segment optimization for now~~
- Migrate next/dynamic collection to it
- This shouldn't make any observable change to the output