### PR TITLE
refactor: remove isStandaloneMode context from metadata resolver

### DIFF
--- a/packages/next/src/lib/metadata/metadata-context.tsx
+++ b/packages/next/src/lib/metadata/metadata-context.tsx
@@ -10,7 +10,6 @@ export function createMetadataContext(
   return {
     pathname,
     trailingSlash: renderOpts.trailingSlash,
-    isStandaloneMode: renderOpts.nextConfigOutput === 'standalone',
   }
 }
 

--- a/packages/next/src/lib/metadata/resolve-metadata.test.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.test.ts
@@ -17,7 +17,6 @@ function accumulateMetadata(metadataItems: MetadataItems) {
   return originAccumulateMetadata(fullMetadataItems, {
     pathname: '/test',
     trailingSlash: false,
-    isStandaloneMode: false,
   })
 }
 

--- a/packages/next/src/lib/metadata/resolvers/resolve-opengraph.test.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-opengraph.test.ts
@@ -7,7 +7,7 @@ describe('resolveImages', () => {
   it(`should resolve images`, () => {
     const images = [image1, { url: image2, alt: 'Image2' }]
 
-    expect(resolveImages(images, null, false)).toEqual([
+    expect(resolveImages(images, null)).toEqual([
       { url: new URL(image1) },
       { url: new URL(image2), alt: 'Image2' },
     ])
@@ -16,7 +16,7 @@ describe('resolveImages', () => {
   it('should not mutate passed images', () => {
     const images = [image1, { url: image2, alt: 'Image2' }]
 
-    resolveImages(images, null, false)
+    resolveImages(images, null)
 
     expect(images).toEqual([image1, { url: image2, alt: 'Image2' }])
   })
@@ -44,7 +44,7 @@ describe('resolveOpenGraph', () => {
         // pass authors as empty string
         { type: 'article', authors: '' },
         null,
-        { isStandaloneMode: false, trailingSlash: false, pathname: '' },
+        { trailingSlash: false, pathname: '' },
         ''
       )
     ).toEqual({
@@ -63,7 +63,7 @@ describe('resolveOpenGraph', () => {
       resolveOpenGraph(
         { type: 'article', authors: null },
         null,
-        { isStandaloneMode: false, trailingSlash: false, pathname: '' },
+        { trailingSlash: false, pathname: '' },
         ''
       )
     ).toEqual({

--- a/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
@@ -53,7 +53,6 @@ describe('resolveAbsoluteUrlWithPathname', () => {
     const opts = {
       trailingSlash: false,
       pathname: '/',
-      isStandaloneMode: false,
     }
     const resolver = (url: string | URL) =>
       resolveAbsoluteUrlWithPathname(url, metadataBase, opts)
@@ -69,7 +68,6 @@ describe('resolveAbsoluteUrlWithPathname', () => {
     const opts = {
       trailingSlash: true,
       pathname: '/',
-      isStandaloneMode: false,
     }
     const resolver = (url: string | URL) =>
       resolveAbsoluteUrlWithPathname(url, metadataBase, opts)

--- a/packages/next/src/lib/metadata/types/resolvers.ts
+++ b/packages/next/src/lib/metadata/types/resolvers.ts
@@ -16,5 +16,4 @@ export type FieldResolverExtraArgs<
 export type MetadataContext = {
   pathname: string
   trailingSlash: boolean
-  isStandaloneMode: boolean
 }

--- a/test/e2e/app-dir/metadata-warnings/index.test.ts
+++ b/test/e2e/app-dir/metadata-warnings/index.test.ts
@@ -4,28 +4,13 @@ const METADATA_BASE_WARN_STRING =
   'metadataBase property in metadata export is not set for resolving social open graph or twitter images,'
 
 describe('app dir - metadata missing metadataBase', () => {
-  const { next, isNextDev, isNextDeploy, skipped } = nextTestSetup({
+  const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
   })
 
   if (skipped) {
     return
-  }
-
-  if (process.env.TEST_STANDALONE === '1') {
-    beforeAll(async () => {
-      await next.stop()
-      await next.patchFile(
-        'next.config.js',
-        `
-        module.exports = {
-          output: 'standalone',
-        }
-      `
-      )
-      await next.start()
-    })
   }
 
   // If it's start mode, we get the whole logs since they're from build process.
@@ -43,33 +28,19 @@ describe('app dir - metadata missing metadataBase', () => {
     })
   }
 
-  if (process.env.TEST_STANDALONE === '1') {
-    // Standalone mode should always show the warning
-    it('should fallback to localhost if metadataBase is missing for absolute urls resolving', async () => {
-      const logStartPosition = next.cliOutput.length
-      await next.fetch('/og-image-convention')
-      const output = getCliOutput(logStartPosition)
+  it('should show warning in vercel deployment output in default build output mode', async () => {
+    const logStartPosition = next.cliOutput.length
+    await next.fetch('/og-image-convention')
+    const output = getCliOutput(logStartPosition)
 
+    // TODO: This is currently broken and will be addressed in a follow-up PR. We
+    // currently warn even for metadata that conforms to the `opengraph-image` convention.
+    if (false) {
+      expect(output).not.toInclude(METADATA_BASE_WARN_STRING)
+    } else {
       expect(output).toInclude(METADATA_BASE_WARN_STRING)
-      expect(output).toMatch(/using "http:\/\/localhost:\d+/)
-      expect(output).toInclude(
-        '. See https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadatabase'
-      )
-    })
-  } else {
-    // Default output mode
-    it('should show warning in vercel deployment output in default build output mode', async () => {
-      const logStartPosition = next.cliOutput.length
-      await next.fetch('/og-image-convention')
-      const output = getCliOutput(logStartPosition)
-
-      if (isNextDeploy || isNextDev) {
-        expect(output).not.toInclude(METADATA_BASE_WARN_STRING)
-      } else {
-        expect(output).toInclude(METADATA_BASE_WARN_STRING)
-      }
-    })
-  }
+    }
+  })
 
   it('should warn for unsupported metadata properties', async () => {
     const logStartPosition = next.cliOutput.length

--- a/test/e2e/app-dir/metadata-warnings/standalone.test.ts
+++ b/test/e2e/app-dir/metadata-warnings/standalone.test.ts
@@ -1,2 +1,0 @@
-process.env.TEST_STANDALONE = '1'
-require('./index.test')


### PR DESCRIPTION
This removes a check that appears to be redundant: we only want to warn about the fallback behavior when deployed in an environment where the env vars needed to detect proper fallback values (eg, not deployed to Vercel) aren't available. Since this check is already captured, we don't need both. 

The rationale for explicitly logging in standalone mode (even in dev) is that `standalone` mode won't ever be deployed to Vercel. But it's equally possible for you to build a Next.js app and not deploy it to Vercel. At best, this was reducing some additional console noise. But at worst, you're deploying an app that will serve a `localhost` URL in production. If you're using a relative URL without a metadataBase, it seems worth explicitly calling out as early as possible that we're going to fill in a fallback for you. 

Ultimately we should surface this information regardless of env in devtools. But since warning is the default, in #73066 I've updated it to only warn in dev when explicitly passing a relative og URL, rather than always making it warn when using the `opengraph-image` convention.