### PR TITLE
refactor: remove indirection in metadata image resolution

### DIFF
--- a/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
@@ -126,7 +126,7 @@ describe('getSocialImageFallbackMetadataBase', () => {
   describe('fallbackMetadataBase when metadataBase is not present', () => {
     let originalEnv: NodeJS.ProcessEnv
     function getSocialImageFallbackMetadataBaseHelper(): string {
-      return getSocialImageFallbackMetadataBase(null).fallbackMetadataBase.href
+      return getSocialImageFallbackMetadataBase(null).href
     }
 
     beforeEach(() => {

--- a/packages/next/src/lib/metadata/resolvers/resolve-url.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.ts
@@ -21,11 +21,9 @@ function getProductionDeploymentUrl(): URL | undefined {
 
 // For deployment url for metadata routes, prefer to use the deployment url if possible
 // as these routes are unique to the deployments url.
-export function getSocialImageFallbackMetadataBase(metadataBase: URL | null): {
-  fallbackMetadataBase: URL
-  isMetadataBaseMissing: boolean
-} {
-  const isMetadataBaseMissing = !metadataBase
+export function getSocialImageFallbackMetadataBase(
+  metadataBase: URL | null
+): URL {
   const defaultMetadataBase = createLocalMetadataBase()
   const previewDeploymentUrl = getPreviewDeploymentUrl()
   const productionDeploymentUrl = getProductionDeploymentUrl()
@@ -42,10 +40,7 @@ export function getSocialImageFallbackMetadataBase(metadataBase: URL | null): {
         : metadataBase || productionDeploymentUrl || defaultMetadataBase
   }
 
-  return {
-    fallbackMetadataBase,
-    isMetadataBaseMissing,
-  }
+  return fallbackMetadataBase
 }
 
 function resolveUrl(url: null | undefined, metadataBase: URL | null): null


### PR DESCRIPTION
This refactors some unnecessary indirection that made it trickier for me to understand the flow of ogImage resolution. Specifically:

- `getSocialImageFallbackMetadataBase` was taking in `metadataBase` and then inverting it and returning `isMetadataBaseMissing` which is circular. It was also being called higher up in the stack than it needed to be resulting in args being passed through intermediary functions that didn't need it
- `validateResolvedImageUrl` was removed in favor of grabbing the fallback and warning appropriately in `resolveAndValidateImage`. This makes it more obvious that when we're warning about using the fallback, we should actually use the fallback, which I've done in #73066