### PR TITLE
feat: added compression to resume data cache using deflate

### DIFF
--- a/packages/next/src/server/app-render/postponed-state.test.ts
+++ b/packages/next/src/server/app-render/postponed-state.test.ts
@@ -1,5 +1,8 @@
 import { createPrerenderResumeDataCache } from '../resume-data-cache/resume-data-cache'
-import { streamFromString } from '../stream-utils/node-web-streams-helper'
+import {
+  streamFromString,
+  streamToString,
+} from '../stream-utils/node-web-streams-helper'
 import {
   DynamicState,
   getDynamicDataPostponedState,
@@ -31,9 +34,30 @@ describe('getDynamicHTMLPostponedState', () => {
       prerenderResumeDataCache
     )
 
-    expect(state).toMatchInlineSnapshot(
-      `"169:39[["slug","%%drp:slug:e9615126684e5%%"]]{"%%drp:slug:e9615126684e5%%":"%%drp:slug:e9615126684e5%%","nested":{"%%drp:slug:e9615126684e5%%":"%%drp:slug:e9615126684e5%%"}}{"store":{"fetch":{},"cache":{"1":{"value":"aGVsbG8=","tags":[],"stale":0,"timestamp":0,"expire":0,"revalidate":0}}}}"`
-    )
+    const parsed = parsePostponedState(state, { slug: '123' })
+    expect(parsed).toMatchInlineSnapshot(`
+      {
+        "data": {
+          "123": "123",
+          "nested": {
+            "123": "123",
+          },
+        },
+        "renderResumeDataCache": {
+          "cache": Map {
+            "1" => Promise {},
+          },
+          "fetch": Map {},
+        },
+        "type": 2,
+      }
+    `)
+
+    const value = await parsed.renderResumeDataCache.cache.get('1')
+
+    expect(value).toBeDefined()
+
+    await expect(streamToString(value!.value)).resolves.toEqual('hello')
   })
 
   it('serializes a HTML postponed state without fallback params', async () => {

--- a/packages/next/src/server/resume-data-cache/resume-data-cache.test.ts
+++ b/packages/next/src/server/resume-data-cache/resume-data-cache.test.ts
@@ -4,6 +4,24 @@ import {
 } from './resume-data-cache'
 import { createPrerenderResumeDataCache } from './resume-data-cache'
 import { streamFromString } from '../stream-utils/node-web-streams-helper'
+import { inflateSync } from 'node:zlib'
+
+function createCacheWithSingleEntry() {
+  const cache = createPrerenderResumeDataCache()
+  cache.cache.set(
+    'key',
+    Promise.resolve({
+      value: streamFromString('value'),
+      tags: [],
+      stale: 0,
+      timestamp: 0,
+      expire: 0,
+      revalidate: 0,
+    })
+  )
+
+  return cache
+}
 
 describe('stringifyResumeDataCache', () => {
   it('serializes an empty cache', async () => {
@@ -12,20 +30,17 @@ describe('stringifyResumeDataCache', () => {
   })
 
   it('serializes a cache with a single entry', async () => {
-    const cache = createPrerenderResumeDataCache()
-    cache.cache.set(
-      'key',
-      Promise.resolve({
-        value: streamFromString('value'),
-        tags: [],
-        stale: 0,
-        timestamp: 0,
-        expire: 0,
-        revalidate: 0,
-      })
-    )
+    const cache = createCacheWithSingleEntry()
+    const compressed = await stringifyResumeDataCache(cache)
 
-    expect(await stringifyResumeDataCache(cache)).toMatchInlineSnapshot(
+    // We have to decompress the output because the compressed string is not
+    // deterministic. If it fails here it's because the compressed string is
+    // different.
+    const decompressed = inflateSync(
+      Buffer.from(compressed, 'base64')
+    ).toString('utf-8')
+
+    expect(decompressed).toMatchInlineSnapshot(
       `"{"store":{"fetch":{},"cache":{"key":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":0,"revalidate":0}}}}"`
     )
   })
@@ -36,5 +51,15 @@ describe('parseResumeDataCache', () => {
     expect(createRenderResumeDataCache('null')).toEqual(
       createPrerenderResumeDataCache()
     )
+  })
+
+  it('parses a cache with a single entry', async () => {
+    const cache = createCacheWithSingleEntry()
+    const serialized = await stringifyResumeDataCache(cache)
+
+    const parsed = createRenderResumeDataCache(serialized)
+
+    expect(parsed.cache.size).toBe(1)
+    expect(parsed.fetch.size).toBe(0)
   })
 })


### PR DESCRIPTION
Previously the resume data cache was simply a JSON encoded string. This adds deflate compression to it to help reduce the bandwidth between the edge and the file system.