### PR TITLE
Single graph traversal: collect app and page entries and construct a single graph

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -931,6 +931,7 @@ impl AppEndpoint {
                 let reduced_graphs = get_reduced_graphs_for_page(
                     *rsc_entry,
                     Vc::upcast(this.app_project.client_module_context()),
+                    this.app_project.project(),
                 );
                 // "app/client.js [app-ssr] (ecmascript)" ->
                 //      [("./dynamic", "app/dynamic.js [app-client] (ecmascript)")])]

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -463,7 +463,8 @@ pub async fn map_next_dynamic(
                 };
                 if is_ssr {
                     if let Some(v) =
-                        &*build_dynamic_imports_map_for_module(client_asset_context, module).await?
+                        &*build_dynamic_imports_map_for_module(client_asset_context, *module)
+                            .await?
                     {
                         return Ok(Some(v.await?.clone_value()));
                     }

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -43,8 +43,9 @@ impl SingleModuleGraph {
         let mut stack: Vec<_> = entries.await?.iter().map(|e| (None, *e)).collect();
         while let Some((parent_idx, module)) = stack.pop() {
             if let Some(idx) = modules.get(&module) {
-                let parent_idx = parent_idx.context("Existing module without parent")?;
-                graph.add_edge(parent_idx, *idx, ());
+                if let Some(parent_idx) = parent_idx {
+                    graph.add_edge(parent_idx, *idx, ());
+                }
                 continue;
             }
 

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use next_core::{
     mode::NextMode,
     next_client_reference::{find_server_entries, ServerEntries},

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -67,7 +67,6 @@ use crate::{
     global_module_id_strategy::GlobalModuleIdStrategyBuilder,
     instrumentation::InstrumentationEndpoint,
     middleware::MiddlewareEndpoint,
-    module_graph::SingleModuleGraph,
     pages::PagesProject,
     route::{Endpoint, Route},
     versioned_content_map::{OutputAssetsOperation, VersionedContentMap},
@@ -1367,20 +1366,9 @@ impl Project {
         Ok(Vc::cell(modules))
     }
 
-    #[turbo_tasks::function]
-    pub async fn get_module_graph(self: Vc<Self>) -> Result<Vc<()>> {
-        let mut _single_module_graph =
-            SingleModuleGraph::new_with_entries(self.client_main_modules()).await?;
-
-        // dbg!(_single_module_graph);
-
-        Ok(Vc::cell(()))
-    }
-
     /// Gets the module id strategy for the project.
     #[turbo_tasks::function]
     pub async fn module_id_strategy(self: Vc<Self>) -> Result<Vc<Box<dyn ModuleIdStrategy>>> {
-        self.get_module_graph().await?;
         let module_id_strategy = self.next_config().module_id_strategy_config();
         match *module_id_strategy.await? {
             Some(ModuleIdStrategyConfig::Named) => Ok(Vc::upcast(DevModuleIdStrategy::new())),


### PR DESCRIPTION
Entry collection is modeled after https://github.com/vercel/next.js/blob/6f679eef0addac257da440c38d3a5303a763d506/crates/next-api/src/global_module_id_strategy.rs#L19-L23


Closes PACK-3552