### PR TITLE
perf(turbopack): Use `ResolvedVc` for `next-api`, part 1

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1337,8 +1337,10 @@ impl AppEndpoint {
                 }
 
                 AppEndpointOutput::Edge {
-                    files: *app_entry_chunks,
-                    server_assets: Vc::cell(server_assets.iter().cloned().collect::<Vec<_>>()),
+                    files: app_entry_chunks,
+                    server_assets: ResolvedVc::cell(
+                        server_assets.iter().cloned().collect::<Vec<_>>(),
+                    ),
                     client_assets,
                 }
             }
@@ -1413,7 +1415,9 @@ impl AppEndpoint {
 
                 AppEndpointOutput::NodeJs {
                     rsc_chunk,
-                    server_assets: Vc::cell(server_assets.iter().cloned().collect::<Vec<_>>()),
+                    server_assets: ResolvedVc::cell(
+                        server_assets.iter().cloned().collect::<Vec<_>>(),
+                    ),
                     client_assets,
                 }
             }

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -769,7 +769,7 @@ enum AppEndpointType {
 #[turbo_tasks::value]
 struct AppEndpoint {
     ty: AppEndpointType,
-    app_project: Vc<AppProject>,
+    app_project: ResolvedVc<AppProject>,
     page: AppPage,
 }
 
@@ -1708,13 +1708,13 @@ impl Endpoint for AppEndpoint {
 enum AppEndpointOutput {
     NodeJs {
         rsc_chunk: ResolvedVc<Box<dyn OutputAsset>>,
-        server_assets: Vc<OutputAssets>,
-        client_assets: Vc<OutputAssets>,
+        server_assets: ResolvedVc<OutputAssets>,
+        client_assets: ResolvedVc<OutputAssets>,
     },
     Edge {
-        files: Vc<OutputAssets>,
-        server_assets: Vc<OutputAssets>,
-        client_assets: Vc<OutputAssets>,
+        files: ResolvedVc<OutputAssets>,
+        server_assets: ResolvedVc<OutputAssets>,
+        client_assets: ResolvedVc<OutputAssets>,
     },
 }
 

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1337,7 +1337,7 @@ impl AppEndpoint {
                 }
 
                 AppEndpointOutput::Edge {
-                    files: app_entry_chunks,
+                    files: app_entry_chunks.to_resolved().await?,
                     server_assets: ResolvedVc::cell(
                         server_assets.iter().cloned().collect::<Vec<_>>(),
                     ),
@@ -1743,7 +1743,7 @@ impl AppEndpointOutput {
     pub fn server_assets(&self) -> Vc<OutputAssets> {
         match *self {
             AppEndpointOutput::NodeJs { server_assets, .. }
-            | AppEndpointOutput::Edge { server_assets, .. } => server_assets,
+            | AppEndpointOutput::Edge { server_assets, .. } => *server_assets,
         }
     }
 
@@ -1751,7 +1751,7 @@ impl AppEndpointOutput {
     pub fn client_assets(&self) -> Vc<OutputAssets> {
         match *self {
             AppEndpointOutput::NodeJs { client_assets, .. }
-            | AppEndpointOutput::Edge { client_assets, .. } => client_assets,
+            | AppEndpointOutput::Edge { client_assets, .. } => *client_assets,
         }
     }
 }

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -665,7 +665,7 @@ impl AppProject {
 
 #[turbo_tasks::function]
 pub fn app_entry_point_to_route(
-    app_project: Vc<AppProject>,
+    app_project: ResolvedVc<AppProject>,
     entrypoint: AppEntrypoint,
 ) -> Vc<Route> {
     match entrypoint {
@@ -1168,7 +1168,9 @@ impl AppEndpoint {
         let app_entry_chunks_ref = app_entry_chunks.await?;
         server_assets.extend(app_entry_chunks_ref.iter().copied());
 
-        let client_assets = OutputAssets::new(client_assets.iter().map(|asset| **asset).collect());
+        let client_assets = OutputAssets::new(client_assets.iter().map(|asset| **asset).collect())
+            .to_resolved()
+            .await?;
 
         // these references are important for turbotrace
         let mut client_reference_manifest = None;
@@ -1207,7 +1209,7 @@ impl AppEndpoint {
                 &app_entry.original_name,
                 &app_entry.original_name,
                 &app_entry.original_name,
-                client_assets,
+                *client_assets,
                 true,
             )
             .await?;

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -35,9 +35,9 @@ use crate::{
 
 #[turbo_tasks::value]
 pub struct InstrumentationEndpoint {
-    project: Vc<Project>,
-    asset_context: Vc<Box<dyn AssetContext>>,
-    source: Vc<Box<dyn Source>>,
+    project: ResolvedVc<Project>,
+    asset_context: ResolvedVc<Box<dyn AssetContext>>,
+    source: ResolvedVc<Box<dyn Source>>,
     is_edge: bool,
 
     app_dir: Option<ResolvedVc<FileSystemPath>>,

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -48,9 +48,9 @@ pub struct InstrumentationEndpoint {
 impl InstrumentationEndpoint {
     #[turbo_tasks::function]
     pub fn new(
-        project: Vc<Project>,
-        asset_context: Vc<Box<dyn AssetContext>>,
-        source: Vc<Box<dyn Source>>,
+        project: ResolvedVc<Project>,
+        asset_context: ResolvedVc<Box<dyn AssetContext>>,
+        source: ResolvedVc<Box<dyn Source>>,
         is_edge: bool,
         app_dir: Option<ResolvedVc<FileSystemPath>>,
         ecmascript_client_reference_transition_name: Option<Vc<RcStr>>,
@@ -71,7 +71,7 @@ impl InstrumentationEndpoint {
         let userland_module = self
             .asset_context
             .process(
-                self.source,
+                *self.source,
                 Value::new(ReferenceType::Entry(EntryReferenceSubType::Instrumentation)),
             )
             .module()
@@ -79,7 +79,7 @@ impl InstrumentationEndpoint {
             .await?;
 
         let edge_entry_module = wrap_edge_entry(
-            self.asset_context,
+            *self.asset_context,
             self.project.project_path(),
             *userland_module,
             "instrumentation".into(),
@@ -117,7 +117,7 @@ impl InstrumentationEndpoint {
             }),
             this.project.next_mode(),
         )
-        .resolve_entries(this.asset_context)
+        .resolve_entries(*this.asset_context)
         .await?
         .clone_value();
 
@@ -169,7 +169,7 @@ impl InstrumentationEndpoint {
                     }),
                     this.project.next_mode(),
                 )
-                .resolve_entries(this.asset_context),
+                .resolve_entries(*this.asset_context),
                 OutputAssets::empty(),
                 Value::new(AvailabilityInfo::Root),
             )
@@ -225,7 +225,7 @@ impl InstrumentationEndpoint {
             let mut output_assets = vec![chunk];
             if this.project.next_mode().await?.is_production() {
                 output_assets.push(ResolvedVc::upcast(
-                    NftJsonAsset::new(this.project, *chunk, vec![])
+                    NftJsonAsset::new(*this.project, *chunk, vec![])
                         .to_resolved()
                         .await?,
                 ));

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -47,9 +47,9 @@ pub struct MiddlewareEndpoint {
 impl MiddlewareEndpoint {
     #[turbo_tasks::function]
     pub fn new(
-        project: Vc<Project>,
-        asset_context: Vc<Box<dyn AssetContext>>,
-        source: Vc<Box<dyn Source>>,
+        project: ResolvedVc<Project>,
+        asset_context: ResolvedVc<Box<dyn AssetContext>>,
+        source: ResolvedVc<Box<dyn Source>>,
         app_dir: Option<ResolvedVc<FileSystemPath>>,
         ecmascript_client_reference_transition_name: Option<ResolvedVc<RcStr>>,
     ) -> Vc<Self> {
@@ -68,19 +68,19 @@ impl MiddlewareEndpoint {
         let userland_module = self
             .asset_context
             .process(
-                self.source,
+                *self.source,
                 Value::new(ReferenceType::Entry(EntryReferenceSubType::Middleware)),
             )
             .module();
 
         let module = get_middleware_module(
-            self.asset_context,
+            *self.asset_context,
             self.project.project_path(),
             userland_module,
         );
 
         let module = wrap_edge_entry(
-            self.asset_context,
+            *self.asset_context,
             self.project.project_path(),
             module,
             "middleware".into(),

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -96,7 +96,7 @@ impl MiddlewareEndpoint {
             }),
             self.project.next_mode(),
         )
-        .resolve_entries(self.asset_context)
+        .resolve_entries(*self.asset_context)
         .await?
         .clone_value();
 
@@ -261,7 +261,7 @@ impl MiddlewareEndpoint {
     fn userland_module(&self) -> Vc<Box<dyn Module>> {
         self.asset_context
             .process(
-                self.source,
+                *self.source,
                 Value::new(ReferenceType::Entry(EntryReferenceSubType::Middleware)),
             )
             .module()

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -36,9 +36,9 @@ use crate::{
 
 #[turbo_tasks::value]
 pub struct MiddlewareEndpoint {
-    project: Vc<Project>,
-    asset_context: Vc<Box<dyn AssetContext>>,
-    source: Vc<Box<dyn Source>>,
+    project: ResolvedVc<Project>,
+    asset_context: ResolvedVc<Box<dyn AssetContext>>,
+    source: ResolvedVc<Box<dyn Source>>,
     app_dir: Option<ResolvedVc<FileSystemPath>>,
     ecmascript_client_reference_transition_name: Option<ResolvedVc<RcStr>>,
 }


### PR DESCRIPTION
### What?

Use `ResolvedVc<T>` instead of `Vc<T>` for struct fields in `next-api`, but split into multiple PRs.

### Why?

To reduce scope of changes of each PRs so I can debug HMR failures.

### How?


Closes PACK-3555