### PR TITLE
perf(turbopack): Use `ResolvedVc` for `next-api`, part 2

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -755,11 +755,11 @@ enum AppPageEndpointType {
 enum AppEndpointType {
     Page {
         ty: AppPageEndpointType,
-        loader_tree: Vc<AppPageLoaderTree>,
+        loader_tree: ResolvedVc<AppPageLoaderTree>,
     },
     Route {
-        path: Vc<FileSystemPath>,
-        root_layouts: Vc<FileSystemPathVec>,
+        path: ResolvedVc<FileSystemPath>,
+        root_layouts: ResolvedVc<FileSystemPathVec>,
     },
     Metadata {
         metadata: MetadataItem,

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -678,7 +678,7 @@ pub fn app_entry_point_to_route(
                         AppEndpoint {
                             ty: AppEndpointType::Page {
                                 ty: AppPageEndpointType::Html,
-                                loader_tree: *loader_tree,
+                                loader_tree,
                             },
                             app_project,
                             page: page.clone(),
@@ -689,7 +689,7 @@ pub fn app_entry_point_to_route(
                         AppEndpoint {
                             ty: AppEndpointType::Page {
                                 ty: AppPageEndpointType::Rsc,
-                                loader_tree: *loader_tree,
+                                loader_tree,
                             },
                             app_project,
                             page,
@@ -707,10 +707,7 @@ pub fn app_entry_point_to_route(
             original_name: page.to_string(),
             endpoint: Vc::upcast(
                 AppEndpoint {
-                    ty: AppEndpointType::Route {
-                        path: *path,
-                        root_layouts: *root_layouts,
-                    },
+                    ty: AppEndpointType::Route { path, root_layouts },
                     app_project,
                     page,
                 }
@@ -843,9 +840,9 @@ impl AppEndpoint {
 
         let next_config = self.await?.app_project.project().next_config();
         let app_entry = match this.ty {
-            AppEndpointType::Page { loader_tree, .. } => self.app_page_entry(loader_tree),
+            AppEndpointType::Page { loader_tree, .. } => self.app_page_entry(*loader_tree),
             AppEndpointType::Route { path, root_layouts } => {
-                self.app_route_entry(path, root_layouts, next_config)
+                self.app_route_entry(*path, *root_layouts, next_config)
             }
             AppEndpointType::Metadata { metadata } => {
                 self.app_metadata_entry(metadata, next_config)

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -41,7 +41,7 @@ pub struct InstrumentationEndpoint {
     is_edge: bool,
 
     app_dir: Option<ResolvedVc<FileSystemPath>>,
-    ecmascript_client_reference_transition_name: Option<Vc<RcStr>>,
+    ecmascript_client_reference_transition_name: Option<ResolvedVc<RcStr>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -53,7 +53,7 @@ impl InstrumentationEndpoint {
         source: ResolvedVc<Box<dyn Source>>,
         is_edge: bool,
         app_dir: Option<ResolvedVc<FileSystemPath>>,
-        ecmascript_client_reference_transition_name: Option<Vc<RcStr>>,
+        ecmascript_client_reference_transition_name: Option<ResolvedVc<RcStr>>,
     ) -> Vc<Self> {
         Self {
             project,

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -113,7 +113,8 @@ impl InstrumentationEndpoint {
             Value::new(ServerContextType::Instrumentation {
                 app_dir: this.app_dir,
                 ecmascript_client_reference_transition_name: this
-                    .ecmascript_client_reference_transition_name,
+                    .ecmascript_client_reference_transition_name
+                    .map(|v| *v),
             }),
             this.project.next_mode(),
         )
@@ -165,7 +166,8 @@ impl InstrumentationEndpoint {
                     Value::new(ServerContextType::Instrumentation {
                         app_dir: this.app_dir,
                         ecmascript_client_reference_transition_name: this
-                            .ecmascript_client_reference_transition_name,
+                            .ecmascript_client_reference_transition_name
+                            .map(|v| *v),
                     }),
                     this.project.next_mode(),
                 )


### PR DESCRIPTION
### What?

Use `ResolvedVc<T>` instead of `Vc<T>` for struct fields in `next-api`, but split into multiple PRs.

### Why?

To reduce scope of changes of each PRs so I can debug HMR failures.

### How?


Closes PACK-3559