### PR TITLE
perf(turbopack): Use `ResolvedVc` for `next-api`, part 3

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1149,7 +1149,7 @@ impl AppEndpoint {
             )
             .await?;
             server_assets.insert(server_action_manifest.manifest);
-            Some(server_action_manifest.loader)
+            Some(server_action_manifest.loader.to_resolved().await?)
         } else {
             None
         };
@@ -1157,7 +1157,7 @@ impl AppEndpoint {
         let (app_entry_chunks, app_entry_chunks_availability) = &*self
             .app_entry_chunks(
                 client_references,
-                server_action_manifest_loader,
+                server_action_manifest_loader.map(|v| *v),
                 server_path,
                 process_client_assets,
             )

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -80,7 +80,7 @@ use crate::{
 
 #[turbo_tasks::value]
 pub struct PagesProject {
-    project: Vc<Project>,
+    project: ResolvedVc<Project>,
 }
 
 #[turbo_tasks::value_impl]
@@ -598,11 +598,11 @@ impl PagesProject {
 #[turbo_tasks::value]
 struct PageEndpoint {
     ty: PageEndpointType,
-    pages_project: Vc<PagesProject>,
-    pathname: Vc<RcStr>,
-    original_name: Vc<RcStr>,
-    page: Vc<PagesStructureItem>,
-    pages_structure: Vc<PagesStructure>,
+    pages_project: ResolvedVc<PagesProject>,
+    pathname: ResolvedVc<RcStr>,
+    original_name: ResolvedVc<RcStr>,
+    page: ResolvedVc<PagesStructureItem>,
+    pages_structure: ResolvedVc<PagesStructure>,
 }
 
 #[derive(
@@ -1359,13 +1359,13 @@ impl Endpoint for PageEndpoint {
 enum PageEndpointOutput {
     NodeJs {
         entry_chunk: ResolvedVc<Box<dyn OutputAsset>>,
-        server_assets: Vc<OutputAssets>,
-        client_assets: Vc<OutputAssets>,
+        server_assets: ResolvedVc<OutputAssets>,
+        client_assets: ResolvedVc<OutputAssets>,
     },
     Edge {
-        files: Vc<OutputAssets>,
-        server_assets: Vc<OutputAssets>,
-        client_assets: Vc<OutputAssets>,
+        files: ResolvedVc<OutputAssets>,
+        server_assets: ResolvedVc<OutputAssets>,
+        client_assets: ResolvedVc<OutputAssets>,
     },
 }
 
@@ -1405,11 +1405,11 @@ impl PageEndpointOutput {
 pub enum SsrChunk {
     NodeJs {
         entry: ResolvedVc<Box<dyn OutputAsset>>,
-        dynamic_import_entries: Vc<DynamicImportedChunks>,
+        dynamic_import_entries: ResolvedVc<DynamicImportedChunks>,
         server_asset_trace_file: ResolvedVc<OptionOutputAsset>,
     },
     Edge {
-        files: Vc<OutputAssets>,
-        dynamic_import_entries: Vc<DynamicImportedChunks>,
+        files: ResolvedVc<OutputAssets>,
+        dynamic_import_entries: ResolvedVc<DynamicImportedChunks>,
     },
 }

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1216,12 +1216,13 @@ impl PageEndpoint {
                     server_assets.push(ResolvedVc::upcast(middleware_manifest_v2));
                 }
 
-                let loadable_manifest_output = self.react_loadable_manifest(dynamic_import_entries);
+                let loadable_manifest_output =
+                    self.react_loadable_manifest(*dynamic_import_entries);
                 server_assets.extend(loadable_manifest_output.await?.iter().copied());
 
                 PageEndpointOutput::Edge {
                     files,
-                    server_assets: Vc::cell(server_assets),
+                    server_assets: ResolvedVc::cell(server_assets),
                     client_assets,
                 }
             }
@@ -1395,7 +1396,7 @@ impl PageEndpointOutput {
     pub fn server_assets(&self) -> Vc<OutputAssets> {
         match *self {
             PageEndpointOutput::NodeJs { server_assets, .. }
-            | PageEndpointOutput::Edge { server_assets, .. } => server_assets,
+            | PageEndpointOutput::Edge { server_assets, .. } => *server_assets,
         }
     }
 
@@ -1403,7 +1404,7 @@ impl PageEndpointOutput {
     pub fn client_assets(&self) -> Vc<OutputAssets> {
         match *self {
             PageEndpointOutput::NodeJs { client_assets, .. }
-            | PageEndpointOutput::Edge { client_assets, .. } => client_assets,
+            | PageEndpointOutput::Edge { client_assets, .. } => *client_assets,
         }
     }
 }

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -86,7 +86,7 @@ pub struct PagesProject {
 #[turbo_tasks::value_impl]
 impl PagesProject {
     #[turbo_tasks::function]
-    pub fn new(project: Vc<Project>) -> Vc<Self> {
+    pub fn new(project: ResolvedVc<Project>) -> Vc<Self> {
         PagesProject { project }.cell()
     }
 
@@ -234,7 +234,7 @@ impl PagesProject {
 
     #[turbo_tasks::function]
     fn project(&self) -> Vc<Project> {
-        self.project
+        *self.project
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1082,7 +1082,7 @@ impl PageEndpoint {
             original_name,
             &manifest_path_prefix,
             &pathname,
-            client_assets,
+            *client_assets,
             false,
         )
         .await?;
@@ -1164,7 +1164,7 @@ impl PageEndpoint {
                     file_paths_from_root
                         .extend(get_js_paths_from_root(&node_root_value, &files_value).await?);
 
-                    let all_output_assets = all_assets_from_entries(files).await?;
+                    let all_output_assets = all_assets_from_entries(*files).await?;
 
                     wasm_paths_from_root.extend(
                         get_wasm_paths_from_root(&node_root_value, &all_output_assets).await?,

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -887,6 +887,8 @@ impl PageEndpoint {
                     dynamic_import_modules,
                     Value::new(AvailabilityInfo::Root),
                 )
+                .await?
+                .to_resolved()
                 .await?;
 
                 let server_asset_trace_file = if this
@@ -1069,7 +1071,7 @@ impl PageEndpoint {
         let pathname = this.pathname.await?;
         let original_name = &*this.original_name.await?;
 
-        let client_assets = OutputAssets::new(client_assets);
+        let client_assets = OutputAssets::new(client_assets).to_resolved().await?;
 
         let manifest_path_prefix = get_asset_prefix_from_pathname(&pathname);
         let node_root = this.pages_project.project().node_root();
@@ -1122,13 +1124,13 @@ impl PageEndpoint {
                     server_assets.push(pages_manifest);
 
                     let loadable_manifest_output =
-                        self.react_loadable_manifest(dynamic_import_entries);
+                        self.react_loadable_manifest(*dynamic_import_entries);
                     server_assets.extend(loadable_manifest_output.await?.iter().copied());
                 }
 
                 PageEndpointOutput::NodeJs {
                     entry_chunk: entry,
-                    server_assets: Vc::cell(server_assets),
+                    server_assets: ResolvedVc::cell(server_assets),
                     client_assets,
                 }
             }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -197,7 +197,7 @@ pub struct Instrumentation {
 pub struct ProjectContainer {
     name: RcStr,
     options_state: State<Option<ProjectOptions>>,
-    versioned_content_map: Option<Vc<VersionedContentMap>>,
+    versioned_content_map: Option<ResolvedVc<VersionedContentMap>>,
 }
 
 #[turbo_tasks::value_impl]


### PR DESCRIPTION
### What?

Use `ResolvedVc<T>` instead of `Vc<T>` for struct fields in `next-api`, but split into multiple PRs.

### Why?

To reduce scope of changes of each PRs so I can debug HMR failures.

### How?


Closes PACK-3563