### PR TITLE
perf(turbopack): Use `ResolvedVc` for `next-api`, part 5

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -692,15 +692,15 @@ pub fn project_entrypoints_subscribe(
                         .transpose()?,
                     pages_document_endpoint: External::new(ExternalEndpoint(VcArc::new(
                         turbo_tasks.clone(),
-                        entrypoints.pages_document_endpoint,
+                        *entrypoints.pages_document_endpoint,
                     ))),
                     pages_app_endpoint: External::new(ExternalEndpoint(VcArc::new(
                         turbo_tasks.clone(),
-                        entrypoints.pages_app_endpoint,
+                        *entrypoints.pages_app_endpoint,
                     ))),
                     pages_error_endpoint: External::new(ExternalEndpoint(VcArc::new(
                         turbo_tasks.clone(),
-                        entrypoints.pages_error_endpoint,
+                        *entrypoints.pages_error_endpoint,
                     ))),
                 },
                 issues: issues

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1235,7 +1235,7 @@ impl AppEndpoint {
                 file_paths_from_root
                     .extend(get_js_paths_from_root(&node_root_value, &app_entry_chunks_ref).await?);
 
-                let all_output_assets = all_assets_from_entries(*app_entry_chunks).await?;
+                let all_output_assets = all_assets_from_entries(**app_entry_chunks).await?;
 
                 wasm_paths_from_root
                     .extend(get_wasm_paths_from_root(&node_root_value, &middleware_assets).await?);

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -93,7 +93,7 @@ pub struct AppProject {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct OptionAppProject(Option<Vc<AppProject>>);
+pub struct OptionAppProject(Option<ResolvedVc<AppProject>>);
 
 impl AppProject {}
 
@@ -740,7 +740,7 @@ fn server_utils_modifier() -> Vc<RcStr> {
 }
 
 #[turbo_tasks::value(transparent)]
-struct OutputAssetsWithAvailability((Vc<OutputAssets>, AvailabilityInfo));
+struct OutputAssetsWithAvailability((ResolvedVc<OutputAssets>, AvailabilityInfo));
 
 #[derive(Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Debug, TraceRawVcs)]
 enum AppPageEndpointType {

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -975,7 +975,7 @@ impl AppEndpoint {
                                 .iter()
                                 .map(|(k, v)| (*k, v.clone())),
                         );
-                        visited_modules = result.visited_modules;
+                        visited_modules = *result.visited_modules;
                     }
 
                     client_dynamic_imports
@@ -1182,7 +1182,7 @@ impl AppEndpoint {
                     app_entry.original_name.clone(),
                     client_references,
                     client_references_chunks,
-                    *app_entry_chunks,
+                    **app_entry_chunks,
                     Value::new(*app_entry_chunks_availability),
                     client_chunking_context,
                     ssr_chunking_context,

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1460,11 +1460,14 @@ impl AppEndpoint {
                 {
                     let _span = tracing::info_span!("Server Components");
                     Vc::cell((
-                        chunking_context.evaluated_chunk_group_assets(
-                            app_entry.rsc_entry.ident(),
-                            Vc::cell(evaluatable_assets.clone()),
-                            Value::new(AvailabilityInfo::Root),
-                        ),
+                        chunking_context
+                            .evaluated_chunk_group_assets(
+                                app_entry.rsc_entry.ident(),
+                                Vc::cell(evaluatable_assets.clone()),
+                                Value::new(AvailabilityInfo::Root),
+                            )
+                            .to_resolved()
+                            .await?,
                         AvailabilityInfo::Untracked,
                     ))
                 }
@@ -1565,7 +1568,7 @@ impl AppEndpoint {
                 }
                 .instrument(tracing::trace_span!("server node entrypoint"))
                 .await?);
-                Vc::cell((Vc::cell(vec![rsc_chunk]), availability_info))
+                Vc::cell((ResolvedVc::cell(vec![rsc_chunk]), availability_info))
             }
         })
     }

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -106,7 +106,7 @@ pub(crate) async fn collect_evaluated_chunk_group(
 #[turbo_tasks::value(shared)]
 pub struct NextDynamicImportsResult {
     pub client_dynamic_imports: FxIndexMap<ResolvedVc<Box<dyn Module>>, DynamicImportedModules>,
-    pub visited_modules: Vc<VisitedDynamicImportModules>,
+    pub visited_modules: ResolvedVc<VisitedDynamicImportModules>,
 }
 
 #[turbo_tasks::value(shared)]
@@ -421,7 +421,7 @@ impl Visit for CollectImportSourceVisitor {
 }
 
 pub type DynamicImportedModules = Vec<(RcStr, ResolvedVc<Box<dyn Module>>)>;
-pub type DynamicImportedOutputAssets = Vec<(RcStr, Vc<OutputAssets>)>;
+pub type DynamicImportedOutputAssets = Vec<(RcStr, ResolvedVc<OutputAssets>)>;
 
 /// A struct contains mapping for the dynamic imports to construct chunk per
 /// each individual module (Origin Module, Vec<(ImportSourceString, Module)>)
@@ -430,7 +430,7 @@ pub struct DynamicImportsMap(pub (ResolvedVc<Box<dyn Module>>, DynamicImportedMo
 
 /// An Option wrapper around [DynamicImportsMap].
 #[turbo_tasks::value(transparent)]
-pub struct OptionDynamicImportsMap(Option<Vc<DynamicImportsMap>>);
+pub struct OptionDynamicImportsMap(Option<ResolvedVc<DynamicImportsMap>>);
 
 #[turbo_tasks::value(transparent)]
 pub struct DynamicImportedChunks(

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -45,7 +45,7 @@ where
     for (origin_module, dynamic_imports) in dynamic_import_entries {
         for (imported_raw_str, imported_module) in dynamic_imports {
             let chunk = if let Some(chunk) = chunks_hash.get(&imported_raw_str) {
-                chunk
+                *chunk
             } else {
                 let Some(module) =
                     ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(imported_module).await?
@@ -201,7 +201,7 @@ pub(crate) async fn collect_next_dynamic_imports(
 
         Ok(NextDynamicImportsResult {
             client_dynamic_imports: import_mappings,
-            visited_modules: VisitedDynamicImportModules(visited_modules.0).cell(),
+            visited_modules: VisitedDynamicImportModules(visited_modules.0).resolved_cell(),
         }
         .cell())
     }
@@ -338,7 +338,10 @@ async fn build_dynamic_imports_map_for_module(
         }
     }
 
-    Ok(Vc::cell(Some(Vc::cell((server_module, import_sources)))))
+    Ok(Vc::cell(Some(ResolvedVc::cell((
+        server_module,
+        import_sources,
+    )))))
 }
 
 /// A visitor to check if there's import to `next/dynamic`, then collecting the

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -37,7 +37,7 @@ where
     F: FnMut(Vc<Box<dyn ChunkableModule>>) -> Fu,
     Fu: Future<Output = Result<Vc<OutputAssets>>> + Send,
 {
-    let mut chunks_hash: HashMap<RcStr, Vc<OutputAssets>> = HashMap::new();
+    let mut chunks_hash: HashMap<RcStr, ResolvedVc<OutputAssets>> = HashMap::new();
     let mut dynamic_import_chunks = FxIndexMap::default();
 
     // Iterate over the collected import mappings, and create a chunk for each
@@ -45,7 +45,7 @@ where
     for (origin_module, dynamic_imports) in dynamic_import_entries {
         for (imported_raw_str, imported_module) in dynamic_imports {
             let chunk = if let Some(chunk) = chunks_hash.get(&imported_raw_str) {
-                *chunk
+                chunk
             } else {
                 let Some(module) =
                     ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(imported_module).await?
@@ -59,7 +59,7 @@ where
                 // naive hash to have additional
                 // chunks in case if there are same modules being imported in different
                 // origins.
-                let chunk_group = build_chunk(*module).await?;
+                let chunk_group = build_chunk(*module).await?.to_resolved().await?;
                 chunks_hash.insert(imported_raw_str.clone(), chunk_group);
                 chunk_group
             };

--- a/crates/next-api/src/entrypoints.rs
+++ b/crates/next-api/src/entrypoints.rs
@@ -1,5 +1,5 @@
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, Vc};
+use turbo_tasks::{FxIndexMap, ResolvedVc, Vc};
 
 use crate::{
     project::{Instrumentation, Middleware},
@@ -11,7 +11,7 @@ pub struct Entrypoints {
     pub routes: FxIndexMap<RcStr, Route>,
     pub middleware: Option<Middleware>,
     pub instrumentation: Option<Instrumentation>,
-    pub pages_document_endpoint: Vc<Box<dyn Endpoint>>,
-    pub pages_app_endpoint: Vc<Box<dyn Endpoint>>,
-    pub pages_error_endpoint: Vc<Box<dyn Endpoint>>,
+    pub pages_document_endpoint: ResolvedVc<Box<dyn Endpoint>>,
+    pub pages_app_endpoint: ResolvedVc<Box<dyn Endpoint>>,
+    pub pages_error_endpoint: ResolvedVc<Box<dyn Endpoint>>,
 }

--- a/crates/next-api/src/entrypoints.rs
+++ b/crates/next-api/src/entrypoints.rs
@@ -1,5 +1,5 @@
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, ResolvedVc, Vc};
+use turbo_tasks::{FxIndexMap, ResolvedVc};
 
 use crate::{
     project::{Instrumentation, Middleware},

--- a/crates/next-api/src/global_module_id_strategy.rs
+++ b/crates/next-api/src/global_module_id_strategy.rs
@@ -26,9 +26,9 @@ impl GlobalModuleIdStrategyBuilder {
 
         let entrypoints = project.entrypoints().await?;
 
-        preprocessed_module_ids.push(preprocess_module_ids(entrypoints.pages_error_endpoint));
-        preprocessed_module_ids.push(preprocess_module_ids(entrypoints.pages_app_endpoint));
-        preprocessed_module_ids.push(preprocess_module_ids(entrypoints.pages_document_endpoint));
+        preprocessed_module_ids.push(preprocess_module_ids(*entrypoints.pages_error_endpoint));
+        preprocessed_module_ids.push(preprocess_module_ids(*entrypoints.pages_app_endpoint));
+        preprocessed_module_ids.push(preprocess_module_ids(*entrypoints.pages_document_endpoint));
 
         if let Some(middleware) = &entrypoints.middleware {
             preprocessed_module_ids.push(preprocess_module_ids(middleware.endpoint));

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -533,9 +533,9 @@ impl Project {
     pub async fn app_project(self: Vc<Self>) -> Result<Vc<OptionAppProject>> {
         let app_dir = find_app_dir(self.project_path()).await?;
 
-        Ok(Vc::cell(
-            app_dir.map(|app_dir| AppProject::new(self, *app_dir)),
-        ))
+        Ok(Vc::cell(app_dir.map(
+            |app_dir: ResolvedVc<FileSystemPath>| AppProject::new(self, *app_dir),
+        )))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -533,9 +533,10 @@ impl Project {
     pub async fn app_project(self: Vc<Self>) -> Result<Vc<OptionAppProject>> {
         let app_dir = find_app_dir(self.project_path()).await?;
 
-        Ok(Vc::cell(app_dir.map(
-            |app_dir: ResolvedVc<FileSystemPath>| AppProject::new(self, *app_dir),
-        )))
+        Ok(match *app_dir {
+            Some(app_dir) => Vc::cell(Some(AppProject::new(self, *app_dir).to_resolved().await?)),
+            None => Vc::cell(None),
+        })
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -903,9 +903,13 @@ impl Project {
             }
         }
 
-        let pages_document_endpoint = self.pages_project().document_endpoint();
-        let pages_app_endpoint = self.pages_project().app_endpoint();
-        let pages_error_endpoint = self.pages_project().error_endpoint();
+        let pages_document_endpoint = self
+            .pages_project()
+            .document_endpoint()
+            .to_resolved()
+            .await?;
+        let pages_app_endpoint = self.pages_project().app_endpoint().to_resolved().await?;
+        let pages_error_endpoint = self.pages_project().error_endpoint().to_resolved().await?;
 
         let middleware = self.find_middleware();
         let middleware = if let FindContextFileResult::Found(..) = *middleware.await? {


### PR DESCRIPTION
### What?

Use `ResolvedVc<T>` instead of `Vc<T>` for struct fields in `next-api`, but split into multiple PRs.

### Why?

To reduce scope of changes of each PRs so I can debug HMR failures.

### How?


Closes PACK-3569