### PR TITLE
perf(turbopack): Use `ResolvedVc` for `next-api`, part 6

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -493,10 +493,10 @@ impl ProjectDefineEnv {
 
 #[turbo_tasks::value(shared)]
 struct ConflictIssue {
-    path: Vc<FileSystemPath>,
-    title: Vc<StyledString>,
-    description: Vc<StyledString>,
-    severity: Vc<IssueSeverity>,
+    path: ResolvedVc<FileSystemPath>,
+    title: ResolvedVc<StyledString>,
+    description: ResolvedVc<StyledString>,
+    severity: ResolvedVc<IssueSeverity>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -30,16 +30,16 @@ impl AppPageRoute {
 #[derive(Clone, Debug)]
 pub enum Route {
     Page {
-        html_endpoint: Vc<Box<dyn Endpoint>>,
-        data_endpoint: Vc<Box<dyn Endpoint>>,
+        html_endpoint: ResolvedVc<Box<dyn Endpoint>>,
+        data_endpoint: ResolvedVc<Box<dyn Endpoint>>,
     },
     PageApi {
-        endpoint: Vc<Box<dyn Endpoint>>,
+        endpoint: ResolvedVc<Box<dyn Endpoint>>,
     },
     AppPage(Vec<AppPageRoute>),
     AppRoute {
         original_name: String,
-        endpoint: Vc<Box<dyn Endpoint>>,
+        endpoint: ResolvedVc<Box<dyn Endpoint>>,
     },
     Conflict,
 }

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -514,7 +514,7 @@ struct ActionMap(FxIndexMap<String, String>);
 
 /// An Option wrapper around [ActionMap].
 #[turbo_tasks::value(transparent)]
-struct OptionActionMap(Option<Vc<ActionMap>>);
+struct OptionActionMap(Option<ResolvedVc<ActionMap>>);
 
 #[turbo_tasks::value_impl]
 impl OptionActionMap {


### PR DESCRIPTION
### What?

Use `ResolvedVc<T>` instead of `Vc<T>` for struct fields in `next-api`, but split into multiple PRs.

### Why?

To reduce scope of changes of each PRs so I can debug HMR failures.

### How?


Closes PACK-3581