### PR TITLE
15.1 docs: `unstablePersistentCaching`

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbo.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbo.mdx
@@ -45,14 +45,18 @@ module.exports = nextConfig
 
 The following options are available for the `turbo` configuration:
 
-| Option              | Description                                                               |
-| ------------------- | ------------------------------------------------------------------------- |
-| `rules`             | List of unsupported webpack loaders to apply when running with Turbopack. |
-| `resolveAlias`      | Map aliased imports to modules to load in their place.                    |
-| `resolveExtensions` | List of extensions to resolve when importing files.                       |
-| `moduleIdStrategy`  | Assign module IDs                                                         |
-| `treeShaking`       | Enable tree shaking for the turbopack dev server and build.               |
-| `memoryLimit`       | A target memory limit for turbo, in bytes.                                |
+| Option                    | Description                                                                |
+| ------------------------- | -------------------------------------------------------------------------- |
+| `loaders`                 | List of webpack loaders to apply when running with Turbopack.              |
+| `memoryLimit`             | A target memory limit for turbo, in bytes.                                 |
+| `moduleIdStrategy`        | Assign module IDs                                                          |
+| `minify`                  | Enable minification. Defaults to true in build mode and false in dev mode. |
+| `resolveAlias`            | Map aliased imports to modules to load in their place.                     |
+| `resolveExtensions`       | List of extensions to resolve when importing files.                        |
+| `rules`                   | List of unsupported webpack loaders to apply when running with Turbopack.  |
+| `root`                    | The repo root directory.                                                   |
+| `treeShaking`             | Enable tree shaking for the turbopack dev server and build.                |
+| `unstablePersistentCache` | Enable the persistent cache for turbopack dev and build servers.           |
 
 ### Supported loaders
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbo.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbo.mdx
@@ -56,7 +56,7 @@ The following options are available for the `turbo` configuration:
 | `rules`                   | `Record<string, TurboRuleConfigItemOrShortcut>` | List of unsupported webpack loaders to apply when running with Turbopack.  |
 | `root`                    | `string`                                        | The repo root directory.                                                   |
 | `treeShaking`             | `boolean`                                       | Enable tree shaking for the turbopack dev server and build.                |
-| `unstablePersistentCache` | `boolean`                                       | Enable the persistent cache for turbopack dev and build servers.           |
+| `unstablePersistentCaching` | `boolean`                                       | Enable the persistent cache for Turbopack dev server and build.           |
 
 ### Supported loaders
 
@@ -76,7 +76,7 @@ The following loaders have been tested to work with Turbopack's webpack loader i
 
 Turbopack's Persistent Caching allows compilation work to persist across restarts of the development server or builds, reducing cold start times for all applications by caching previously compiled work, and only recompiling what has changed.
 
-To enable persistent caching, set the `unstablePersistentCache` option to `true` in `next.config.js`:
+To enable persistent caching, set the `unstablePersistentCaching` option to `true` in `next.config.js`:
 
 ```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'
@@ -84,7 +84,7 @@ import type { NextConfig } from 'next'
 const nextConfig: NextConfig = {
   experimental: {
     turbo: {
-      unstablePersistentCache: true,
+      unstablePersistentCaching: true,
     },
   },
 }
@@ -96,7 +96,7 @@ export default nextConfig
 module.exports = {
   experimental: {
     turbo: {
-      unstablePersistentCache: true,
+      unstablePersistentCaching: true,
     },
   },
 }

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbo.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbo.mdx
@@ -72,6 +72,36 @@ The following loaders have been tested to work with Turbopack's webpack loader i
 
 ## Examples
 
+### EnablingPersistent Caching
+
+Persistent caching allows compilation work to persist across restarts of the development server or builds, reducing cold start times for large applications by caching previously compiled work, and only re-compiling what has changed.
+
+To enable persistent caching, set the `unstablePersistentCache` option to `true` in `next.config.js`:
+
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    turbo: {
+      unstablePersistentCache: true,
+    },
+  },
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" switcher
+module.exports = {
+  experimental: {
+    turbo: {
+      unstablePersistentCache: true,
+    },
+  },
+}
+```
+
 ### Configuring webpack loaders
 
 If you need loader support beyond what's built in, many webpack loaders already work with Turbopack. There are currently some limitations:

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbo.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbo.mdx
@@ -45,18 +45,16 @@ module.exports = nextConfig
 
 The following options are available for the `turbo` configuration:
 
-| Option                    | Type                                            | Description                                                                |
-| ------------------------- | ----------------------------------------------- | -------------------------------------------------------------------------- |
-| `loaders`                 | `Record<string, TurboLoaderItem[]>`             | List of webpack loaders to apply when running with Turbopack.              |
-| `memoryLimit`             | `number`                                        | A target memory limit for turbo, in bytes.                                 |
-| `moduleIdStrategy`        | `'named'` or `'deterministic'`                  | Assign module IDs                                                          |
-| `minify`                  | `boolean`                                       | Enable minification. Defaults to true in build mode and false in dev mode. |
-| `resolveAlias`            | `Record<string>`                                | Map aliased imports to modules to load in their place.                     |
-| `resolveExtensions`       | `string[]`                                      | List of extensions to resolve when importing files.                        |
-| `rules`                   | `Record<string, TurboRuleConfigItemOrShortcut>` | List of unsupported webpack loaders to apply when running with Turbopack.  |
-| `root`                    | `string`                                        | The repo root directory.                                                   |
-| `treeShaking`             | `boolean`                                       | Enable tree shaking for the turbopack dev server and build.                |
-| `unstablePersistentCaching` | `boolean`                                       | Enable the persistent cache for Turbopack dev server and build.           |
+| Option                      | Type                                            | Description                                                                |
+| --------------------------- | ----------------------------------------------- | -------------------------------------------------------------------------- |
+| `moduleIdStrategy`          | `'named'` or `'deterministic'`                  | The module ID strategy to use.                                             |
+| `minify`                    | `boolean`                                       | Enable minification. Defaults to true in build mode and false in dev mode. |
+| `resolveAlias`              | `Record<string>`                                | Map aliased imports to modules to load in their place.                     |
+| `resolveExtensions`         | `string[]`                                      | List of extensions to resolve when importing files.                        |
+| `rules`                     | `Record<string, TurboRuleConfigItemOrShortcut>` | List of unsupported webpack loaders to apply when running with Turbopack.  |
+| `root`                      | `string`                                        | The repo root directory.                                                   |
+| `treeShaking`               | `boolean`                                       | Enable tree shaking for the turbopack dev server and build.                |
+| `unstablePersistentCaching` | `boolean`                                       | Enable the persistent cache for Turbopack dev server and build.            |
 
 ### Supported loaders
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbo.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbo.mdx
@@ -72,7 +72,7 @@ The following loaders have been tested to work with Turbopack's webpack loader i
 
 ## Examples
 
-### EnablingPersistent Caching
+### Enabling Persistent Caching
 
 Persistent caching allows compilation work to persist across restarts of the development server or builds, reducing cold start times for large applications by caching previously compiled work, and only re-compiling what has changed.
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbo.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbo.mdx
@@ -45,18 +45,18 @@ module.exports = nextConfig
 
 The following options are available for the `turbo` configuration:
 
-| Option                    | Description                                                                |
-| ------------------------- | -------------------------------------------------------------------------- |
-| `loaders`                 | List of webpack loaders to apply when running with Turbopack.              |
-| `memoryLimit`             | A target memory limit for turbo, in bytes.                                 |
-| `moduleIdStrategy`        | Assign module IDs                                                          |
-| `minify`                  | Enable minification. Defaults to true in build mode and false in dev mode. |
-| `resolveAlias`            | Map aliased imports to modules to load in their place.                     |
-| `resolveExtensions`       | List of extensions to resolve when importing files.                        |
-| `rules`                   | List of unsupported webpack loaders to apply when running with Turbopack.  |
-| `root`                    | The repo root directory.                                                   |
-| `treeShaking`             | Enable tree shaking for the turbopack dev server and build.                |
-| `unstablePersistentCache` | Enable the persistent cache for turbopack dev and build servers.           |
+| Option                    | Type                                            | Description                                                                |
+| ------------------------- | ----------------------------------------------- | -------------------------------------------------------------------------- |
+| `loaders`                 | `Record<string, TurboLoaderItem[]>`             | List of webpack loaders to apply when running with Turbopack.              |
+| `memoryLimit`             | `number`                                        | A target memory limit for turbo, in bytes.                                 |
+| `moduleIdStrategy`        | `'named'` or `'deterministic'`                  | Assign module IDs                                                          |
+| `minify`                  | `boolean`                                       | Enable minification. Defaults to true in build mode and false in dev mode. |
+| `resolveAlias`            | `Record<string>`                                | Map aliased imports to modules to load in their place.                     |
+| `resolveExtensions`       | `string[]`                                      | List of extensions to resolve when importing files.                        |
+| `rules`                   | `Record<string, TurboRuleConfigItemOrShortcut>` | List of unsupported webpack loaders to apply when running with Turbopack.  |
+| `root`                    | `string`                                        | The repo root directory.                                                   |
+| `treeShaking`             | `boolean`                                       | Enable tree shaking for the turbopack dev server and build.                |
+| `unstablePersistentCache` | `boolean`                                       | Enable the persistent cache for turbopack dev and build servers.           |
 
 ### Supported loaders
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbo.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbo.mdx
@@ -74,7 +74,7 @@ The following loaders have been tested to work with Turbopack's webpack loader i
 
 ### Enabling Persistent Caching
 
-Persistent caching allows compilation work to persist across restarts of the development server or builds, reducing cold start times for large applications by caching previously compiled work, and only re-compiling what has changed.
+Turbopack's Persistent Caching allows compilation work to persist across restarts of the development server or builds, reducing cold start times for all applications by caching previously compiled work, and only recompiling what has changed.
 
 To enable persistent caching, set the `unstablePersistentCache` option to `true` in `next.config.js`:
 

--- a/docs/01-app/03-api-reference/08-turbopack.mdx
+++ b/docs/01-app/03-api-reference/08-turbopack.mdx
@@ -24,7 +24,7 @@ To enable Turbopack, use the `--turbopack` flag when running the Next.js develop
 
 ### Supported features
 
-Turbopack in Next.js requires zero-configuration for most users and can be extended for more advanced use cases. To learn more about the currently supported features for Turbopack, view the [API Reference](/docs/app/api-reference/config/next-config-js/turbo).
+Turbopack in Next.js requires zero-configuration for most users and can be extended for more advanced use cases. To learn more about the currently supported features for Turbopack, view the `turbo` config option [API Reference](/docs/app/api-reference/config/next-config-js/turbo).
 
 ### Unsupported features
 


### PR DESCRIPTION
**DO NOT MERGE.**

Closes: https://linear.app/vercel/issue/DOC-3817/[experimental]-turbopack-incremental-caching

Also: 
- Adds missing `turbo` options
- Adds missing types

Related PRs: 
- https://github.com/vercel/next.js/pull/70904
- https://github.com/vercel/next.js/pull/71090
