### PR TITLE
docs(server-actions): add missing formData type

### DIFF
--- a/docs/01-app/02-building-your-application/02-data-fetching/03-server-actions-and-mutations.mdx
+++ b/docs/01-app/02-building-your-application/02-data-fetching/03-server-actions-and-mutations.mdx
@@ -510,7 +510,7 @@ export function Thread({ messages }: { messages: Message[] }) {
     string
   >(messages, (state, newMessage) => [...state, { message: newMessage }])
 
-  const formAction = async (formData) => {
+  const formAction = async (formData: FormData) => {
     const message = formData.get('message') as string
     addOptimisticMessage(message)
     await send(message)


### PR DESCRIPTION
This PR adds the missing `FormData` type annotation to the formData parameter in the server actions example.