### PR TITLE
Pin undici in tests

### DIFF
--- a/test/e2e/app-dir/app-external/app-external.test.ts
+++ b/test/e2e/app-dir/app-external/app-external.test.ts
@@ -24,8 +24,8 @@ describe('app dir - external dependency', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     dependencies: {
-      swr: 'latest',
-      undici: 'latest',
+      swr: '2.2.5',
+      undici: '6.21.0',
     },
     packageJson: {
       scripts: {


### PR DESCRIPTION
undici 7 was released 30 minutes ago and broke the tests because Turbopack now has troubles with its `node:sqlite` import.

You can see the test failure in https://github.com/vercel/next.js/pull/73261#issuecomment-2504054040

```
Error: Cannot find module 'node:sqlite': Unsupported external type Url for commonjs reference
    at <unknown> (.next/server/chunks/ssr/c1118_undici_e1ac85._.js:35:29147)
    at [project]/node_modules/.pnpm/undici@7.0.0/node_modules/undici/lib/cache/sqlite-cache-store.js [app-rsc] (ecmascript) (.next/server/chunks/ssr/c1118_undici_e1ac85._.js:35:29278)
    at instantiateModule (.next/server/chunks/ssr/[turbopack]_runtime.js:590:23)
    at getOrInstantiateModuleFromParent (.next/server/chunks/ssr/[turbopack]_runtime.js:645:12)
    at commonJsRequire (.next/server/chunks/ssr/[turbopack]_runtime.js:147:20)
    at [project]/node_modules/.pnpm/undici@7.0.0/node_modules/undici/index.js [app-rsc] (ecmascript) (.next/server/chunks/ssr/c1118_undici_e1ac85._.js:116:5860)
    at instantiateModule (.next/server/chunks/ssr/[turbopack]_runtime.js:590:23)
    at getOrInstantiateModuleFromParent (.next/server/chunks/ssr/[turbopack]_runtime.js:645:12)
    at esmImport (.next/server/chunks/ssr/[turbopack]_runtime.js:132:20)
    at [project]/app/undici/page.js [app-rsc] (ecmascript) <internal part 2> (.next/server/chunks/ssr/[root of the server]__83c897._.js:1:5666) {
```

https://github.com/nodejs/undici/blob/1cfe0949053aac6267f11b919cee9315a27f1fd6/index.js#L52-L59

https://github.com/nodejs/undici/blob/1cfe0949053aac6267f11b919cee9315a27f1fd6/lib/cache/sqlite-cache-store.js#L3

Closes PACK-3556