### PR TITLE
[Turbopack] Performance improvements for Persistent Caching

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1,5 +1,6 @@
 pub mod indexed;
 mod operation;
+mod persisted_storage_log;
 mod storage;
 
 use std::{
@@ -43,6 +44,7 @@ use crate::{
             AggregationUpdateQueue, CleanupOldEdgesOperation, ConnectChildOperation,
             ExecuteContext, ExecuteContextImpl, Operation, OutdatedEdge, TaskDirtyCause, TaskGuard,
         },
+        persisted_storage_log::PersistedStorageLog,
         storage::{get, get_many, get_mut, iter_many, remove, Storage},
     },
     backing_storage::BackingStorage,
@@ -133,7 +135,6 @@ impl Default for BackendOptions {
 pub struct TurboTasksBackend<B: BackingStorage>(Arc<TurboTasksBackendInner<B>>);
 
 type TaskCacheLog = Sharded<ChunkedVec<(Arc<CachedTaskType>, TaskId)>>;
-type StorageLog = Sharded<ChunkedVec<CachedDataUpdate>>;
 
 struct TurboTasksBackendInner<B: BackingStorage> {
     options: BackendOptions,
@@ -148,8 +149,8 @@ struct TurboTasksBackendInner<B: BackingStorage> {
     task_cache: BiMap<Arc<CachedTaskType>, TaskId>,
     transient_tasks: DashMap<TaskId, Arc<TransientTask>, BuildHasherDefault<FxHasher>>,
 
-    persisted_storage_data_log: Option<StorageLog>,
-    persisted_storage_meta_log: Option<StorageLog>,
+    persisted_storage_data_log: Option<PersistedStorageLog>,
+    persisted_storage_meta_log: Option<PersistedStorageLog>,
     storage: Storage<TaskId, CachedDataItem>,
 
     /// Number of executing operations + Highest bit is set when snapshot is
@@ -207,8 +208,8 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             persisted_task_cache_log: need_log.then(|| Sharded::new(shard_amount)),
             task_cache: BiMap::new(),
             transient_tasks: DashMap::default(),
-            persisted_storage_data_log: need_log.then(|| Sharded::new(shard_amount)),
-            persisted_storage_meta_log: need_log.then(|| Sharded::new(shard_amount)),
+            persisted_storage_data_log: need_log.then(|| PersistedStorageLog::new(shard_amount)),
+            persisted_storage_meta_log: need_log.then(|| PersistedStorageLog::new(shard_amount)),
             storage: Storage::new(),
             in_progress_operations: AtomicUsize::new(0),
             snapshot_request: Mutex::new(SnapshotRequest::new()),
@@ -312,10 +313,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         }
     }
 
-    fn persisted_storage_log(
-        &self,
-        category: TaskDataCategory,
-    ) -> Option<&Sharded<ChunkedVec<CachedDataUpdate>>> {
+    fn persisted_storage_log(&self, category: TaskDataCategory) -> Option<&PersistedStorageLog> {
         match category {
             TaskDataCategory::Data => &self.persisted_storage_data_log,
             TaskDataCategory::Meta => &self.persisted_storage_meta_log,
@@ -696,12 +694,16 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             .map(|op| op.arc().clone())
             .collect::<Vec<_>>();
         drop(snapshot_request);
-        fn take_from_log<T: Default>(log: &Option<Sharded<T>>) -> Vec<T> {
+        fn take_from_log(log: &Option<PersistedStorageLog>) -> Vec<ChunkedVec<CachedDataUpdate>> {
             log.as_ref().map(|l| l.take()).unwrap_or_default()
         }
         let persisted_storage_meta_log = take_from_log(&self.persisted_storage_meta_log);
         let persisted_storage_data_log = take_from_log(&self.persisted_storage_data_log);
-        let persisted_task_cache_log = take_from_log(&self.persisted_task_cache_log);
+        let persisted_task_cache_log = self
+            .persisted_task_cache_log
+            .as_ref()
+            .map(|l| l.take())
+            .unwrap_or_default();
         let mut snapshot_request = self.snapshot_request.lock();
         snapshot_request.snapshot_requested = false;
         self.in_progress_operations

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -702,7 +702,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         let persisted_task_cache_log = self
             .persisted_task_cache_log
             .as_ref()
-            .map(|l| l.take())
+            .map(|l| l.take(|i| i))
             .unwrap_or_default();
         let mut snapshot_request = self.snapshot_request.lock();
         snapshot_request.snapshot_requested = false;

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -741,7 +741,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 persisted_storage_meta_log,
                 persisted_storage_data_log,
             ) {
-                println!("Persisting failed: {}", err);
+                println!("Persisting failed: {:?}", err);
                 return None;
             }
         }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -623,13 +623,10 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
             .filter_map(|(key, value)| match (key, value) {
                 (CachedDataItemKey::CellData { cell }, CachedDataItemValue::CellData { value }) => {
                     count += 1;
-                    Some((
-                        CachedDataItemKey::CellData { cell: *cell },
-                        None,
-                        Some(CachedDataItemValue::CellData {
-                            value: value.clone(),
-                        }),
-                    ))
+                    Some(CachedDataItem::CellData {
+                        cell: *cell,
+                        value: value.clone(),
+                    })
                 }
                 _ => None,
             });
@@ -637,7 +634,7 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
             self.backend
                 .persisted_storage_log(TaskDataCategory::Data)
                 .unwrap()
-                .push_batch(self.task_id, cell_data);
+                .push_batch_insert(self.task_id, cell_data);
             self.task
                 .persistance_state_mut()
                 .add_persisting_items(count);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -21,10 +21,7 @@ use crate::{
         TurboTasksBackend, TurboTasksBackendInner,
     },
     backing_storage::BackingStorage,
-    data::{
-        CachedDataItem, CachedDataItemIndex, CachedDataItemKey, CachedDataItemValue,
-        CachedDataUpdate,
-    },
+    data::{CachedDataItem, CachedDataItemIndex, CachedDataItemKey, CachedDataItemValue},
 };
 
 pub trait Operation:
@@ -419,13 +416,7 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
             self.backend
                 .persisted_storage_log(key.category())
                 .unwrap()
-                .lock(self.task_id)
-                .push(CachedDataUpdate {
-                    key,
-                    task: self.task_id,
-                    value: Some(value),
-                    old_value: None,
-                });
+                .push(self.task_id, key, None, Some(value));
             true
         } else {
             false
@@ -451,15 +442,13 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
             self.backend
                 .persisted_storage_log(key.category())
                 .unwrap()
-                .lock(self.task_id)
-                .push(CachedDataUpdate {
+                .push(
+                    self.task_id,
                     key,
-                    task: self.task_id,
-                    value: Some(value),
-                    old_value: old
-                        .as_ref()
+                    old.as_ref()
                         .and_then(|old| old.is_persistent().then(|| old.clone())),
-                });
+                    Some(value),
+                );
             old
         } else {
             let item = CachedDataItem::from_key_and_value(key.clone(), value);
@@ -469,13 +458,7 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
                     self.backend
                         .persisted_storage_log(key.category())
                         .unwrap()
-                        .lock(self.task_id)
-                        .push(CachedDataUpdate {
-                            key,
-                            task: self.task_id,
-                            value: None,
-                            old_value: Some(old.clone()),
-                        });
+                        .push(self.task_id, key, Some(old.clone()), None);
                 }
                 Some(old)
             } else {
@@ -510,29 +493,21 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
                 (None, false) => {}
                 (Some(old_value), false) => {
                     add_persisting_item = true;
-                    backend
-                        .persisted_storage_log(key.category())
-                        .unwrap()
-                        .lock(*task_id)
-                        .push(CachedDataUpdate {
-                            key: key.clone(),
-                            task: *task_id,
-                            value: None,
-                            old_value: Some(old_value),
-                        });
+                    backend.persisted_storage_log(key.category()).unwrap().push(
+                        *task_id,
+                        key.clone(),
+                        Some(old_value),
+                        None,
+                    );
                 }
                 (old_value, true) => {
                     add_persisting_item = true;
-                    backend
-                        .persisted_storage_log(key.category())
-                        .unwrap()
-                        .lock(*task_id)
-                        .push(CachedDataUpdate {
-                            key: key.clone(),
-                            task: *task_id,
-                            value: new.clone(),
-                            old_value,
-                        });
+                    backend.persisted_storage_log(key.category()).unwrap().push(
+                        *task_id,
+                        key.clone(),
+                        old_value,
+                        new.clone(),
+                    );
                 }
             }
 
@@ -556,13 +531,12 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
                 self.backend
                     .persisted_storage_log(key.category())
                     .unwrap()
-                    .lock(self.task_id)
-                    .push(CachedDataUpdate {
+                    .push(
+                        self.task_id,
                         key,
-                        task: self.task_id,
-                        value: None,
-                        old_value: value.is_persistent().then(|| value.clone()),
-                    });
+                        value.is_persistent().then(|| value.clone()),
+                        None,
+                    );
             }
             Some(value)
         } else {
@@ -615,13 +589,7 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
                 self.backend
                     .persisted_storage_log(key.category())
                     .unwrap()
-                    .lock(self.task_id)
-                    .push(CachedDataUpdate {
-                        key,
-                        task: self.task_id,
-                        value: None,
-                        old_value: Some(value),
-                    });
+                    .push(self.task_id, key, Some(value), None);
             }
         }))
     }
@@ -640,13 +608,7 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
                 self.backend
                     .persisted_storage_log(key.category())
                     .unwrap()
-                    .lock(self.task_id)
-                    .push(CachedDataUpdate {
-                        key,
-                        task: self.task_id,
-                        value: None,
-                        old_value: Some(value),
-                    });
+                    .push(self.task_id, key, Some(value), None);
             }
         }))
     }
@@ -661,24 +623,21 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
             .filter_map(|(key, value)| match (key, value) {
                 (CachedDataItemKey::CellData { cell }, CachedDataItemValue::CellData { value }) => {
                     count += 1;
-                    Some(CachedDataUpdate {
-                        task: self.task_id,
-                        key: CachedDataItemKey::CellData { cell: *cell },
-                        value: Some(CachedDataItemValue::CellData {
+                    Some((
+                        CachedDataItemKey::CellData { cell: *cell },
+                        None,
+                        Some(CachedDataItemValue::CellData {
                             value: value.clone(),
                         }),
-                        old_value: None,
-                    })
+                    ))
                 }
                 _ => None,
             });
         {
-            let mut guard = self
-                .backend
+            self.backend
                 .persisted_storage_log(TaskDataCategory::Data)
                 .unwrap()
-                .lock(self.task_id);
-            guard.extend(cell_data);
+                .push_batch(self.task_id, cell_data);
             self.task
                 .persistance_state_mut()
                 .add_persisting_items(count);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/persisted_storage_log.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/persisted_storage_log.rs
@@ -1,12 +1,27 @@
-use turbo_tasks::TaskId;
+use turbo_tasks::{KeyValuePair, TaskId};
 
 use crate::{
-    data::{CachedDataItemKey, CachedDataItemValue, CachedDataUpdate},
+    data::{CachedDataItem, CachedDataItemKey, CachedDataItemValue, CachedDataUpdate},
     utils::{chunked_vec::ChunkedVec, sharded::Sharded},
 };
 
+#[derive(Default)]
+struct ShardData {
+    last_task: Option<TaskId>,
+    data: ChunkedVec<CachedDataUpdate>,
+}
+
+impl ShardData {
+    fn set_task(&mut self, task: TaskId) {
+        if self.last_task != Some(task) {
+            self.data.push(CachedDataUpdate::Task { task });
+            self.last_task = Some(task);
+        }
+    }
+}
+
 pub struct PersistedStorageLog {
-    data: Sharded<ChunkedVec<CachedDataUpdate>>,
+    data: Sharded<ShardData>,
 }
 
 impl PersistedStorageLog {
@@ -23,38 +38,41 @@ impl PersistedStorageLog {
         old_value: Option<CachedDataItemValue>,
         new_value: Option<CachedDataItemValue>,
     ) {
-        let update = CachedDataUpdate {
-            task,
-            key,
-            old_value,
-            value: new_value,
-        };
-        self.data.lock(&task).push(update);
+        let mut guard = self.data.lock(&task);
+        guard.set_task(task);
+        match (old_value, new_value) {
+            (None, None) => {}
+            (None, Some(new_value)) => guard.data.push(CachedDataUpdate::New {
+                item: CachedDataItem::from_key_and_value(key, new_value),
+            }),
+            (Some(old_value), None) => guard.data.push(CachedDataUpdate::Removed {
+                old_item: CachedDataItem::from_key_and_value(key, old_value),
+            }),
+            (Some(old_value), Some(new_value)) => {
+                guard.data.push(CachedDataUpdate::Replace1 {
+                    old_item: CachedDataItem::from_key_and_value(key, old_value),
+                });
+                guard
+                    .data
+                    .push(CachedDataUpdate::Replace2 { value: new_value });
+            }
+        }
     }
 
-    pub fn push_batch(
+    pub fn push_batch_insert(
         &self,
         task: TaskId,
-        updates: impl IntoIterator<
-            Item = (
-                CachedDataItemKey,
-                Option<CachedDataItemValue>,
-                Option<CachedDataItemValue>,
-            ),
-        >,
+        updates: impl IntoIterator<Item = CachedDataItem>,
     ) {
         let updates = updates
             .into_iter()
-            .map(|(key, old_value, value)| CachedDataUpdate {
-                task,
-                key,
-                old_value,
-                value,
-            });
-        self.data.lock(&task).extend(updates);
+            .map(|item| CachedDataUpdate::New { item });
+        let mut guard = self.data.lock(&task);
+        guard.set_task(task);
+        guard.data.extend(updates);
     }
 
     pub fn take(&self) -> Vec<ChunkedVec<CachedDataUpdate>> {
-        self.data.take()
+        self.data.take(|shard| shard.data)
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/persisted_storage_log.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/persisted_storage_log.rs
@@ -1,0 +1,60 @@
+use turbo_tasks::TaskId;
+
+use crate::{
+    data::{CachedDataItemKey, CachedDataItemValue, CachedDataUpdate},
+    utils::{chunked_vec::ChunkedVec, sharded::Sharded},
+};
+
+pub struct PersistedStorageLog {
+    data: Sharded<ChunkedVec<CachedDataUpdate>>,
+}
+
+impl PersistedStorageLog {
+    pub fn new(shard_amount: usize) -> Self {
+        Self {
+            data: Sharded::new(shard_amount),
+        }
+    }
+
+    pub fn push(
+        &self,
+        task: TaskId,
+        key: CachedDataItemKey,
+        old_value: Option<CachedDataItemValue>,
+        new_value: Option<CachedDataItemValue>,
+    ) {
+        let update = CachedDataUpdate {
+            task,
+            key,
+            old_value,
+            value: new_value,
+        };
+        self.data.lock(&task).push(update);
+    }
+
+    pub fn push_batch(
+        &self,
+        task: TaskId,
+        updates: impl IntoIterator<
+            Item = (
+                CachedDataItemKey,
+                Option<CachedDataItemValue>,
+                Option<CachedDataItemValue>,
+            ),
+        >,
+    ) {
+        let updates = updates
+            .into_iter()
+            .map(|(key, old_value, value)| CachedDataUpdate {
+                task,
+                key,
+                old_value,
+                value,
+            });
+        self.data.lock(&task).extend(updates);
+    }
+
+    pub fn take(&self) -> Vec<ChunkedVec<CachedDataUpdate>> {
+        self.data.take()
+    }
+}

--- a/turbopack/crates/turbo-tasks-backend/src/backend/persisted_storage_log.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/persisted_storage_log.rs
@@ -38,7 +38,7 @@ impl PersistedStorageLog {
         old_value: Option<CachedDataItemValue>,
         new_value: Option<CachedDataItemValue>,
     ) {
-        let mut guard = self.data.lock(&task);
+        let mut guard = self.data.lock(task);
         guard.set_task(task);
         match (old_value, new_value) {
             (None, None) => {}
@@ -67,7 +67,7 @@ impl PersistedStorageLog {
         let updates = updates
             .into_iter()
             .map(|item| CachedDataUpdate::New { item });
-        let mut guard = self.data.lock(&task);
+        let mut guard = self.data.lock(task);
         guard.set_task(task);
         guard.data.extend(updates);
     }

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -475,10 +475,6 @@ impl CachedDataItem {
         }
     }
 
-    pub fn is_optional(&self) -> bool {
-        matches!(self, CachedDataItem::CellData { .. })
-    }
-
     pub fn new_scheduled(description: impl Fn() -> String + Sync + Send + 'static) -> Self {
         CachedDataItem::InProgress {
             value: InProgressState::Scheduled {
@@ -539,6 +535,10 @@ impl CachedDataItemKey {
             CachedDataItemKey::OutdatedChild { .. } => false,
             CachedDataItemKey::Error { .. } => false,
         }
+    }
+
+    pub fn is_optional(&self) -> bool {
+        matches!(self, CachedDataItemKey::CellData { .. })
     }
 
     pub fn category(&self) -> TaskDataCategory {

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -693,10 +693,15 @@ impl CachedDataItemValue {
 }
 
 #[derive(Debug)]
-pub struct CachedDataUpdate {
-    pub task: TaskId,
-    // TODO generate CachedDataItemUpdate to avoid repeating the variant field 3 times
-    pub key: CachedDataItemKey,
-    pub value: Option<CachedDataItemValue>,
-    pub old_value: Option<CachedDataItemValue>,
+pub enum CachedDataUpdate {
+    /// Sets the current task id.
+    Task { task: TaskId },
+    /// An item was added. There was no old value.
+    New { item: CachedDataItem },
+    /// An item was removed.
+    Removed { old_item: CachedDataItem },
+    /// An item was replaced. This is step 1 and tells about the key and the old value
+    Replace1 { old_item: CachedDataItem },
+    /// An item was replaced. This is step 2 and tells about the new value.
+    Replace2 { value: CachedDataItemValue },
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/fresh_db_optimization.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/fresh_db_optimization.rs
@@ -42,6 +42,10 @@ impl<T: KeyValueDatabase> KeyValueDatabase for FreshDbOptimization<T> {
         T::lower_read_transaction(tx)
     }
 
+    fn is_empty(&self) -> bool {
+        self.fresh_db.load(Ordering::Acquire) || self.database.is_empty()
+    }
+
     fn begin_read_transaction(&self) -> Result<Self::ReadTransaction<'_>> {
         self.database.begin_read_transaction()
     }

--- a/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
@@ -24,6 +24,10 @@ pub trait KeyValueDatabase {
 
     fn begin_read_transaction(&self) -> Result<Self::ReadTransaction<'_>>;
 
+    fn is_empty(&self) -> bool {
+        false
+    }
+
     type ValueBuffer<'l>: std::borrow::Borrow<[u8]>
     where
         Self: 'l;

--- a/turbopack/crates/turbo-tasks-backend/src/database/read_transaction_cache.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/read_transaction_cache.rs
@@ -59,6 +59,10 @@ impl<T: KeyValueDatabase + 'static> KeyValueDatabase for ReadTransactionCache<T>
         unsafe { transmute::<&'r Self::ReadTransaction<'l>, &'r Self::ReadTransaction<'i>>(tx) }
     }
 
+    fn is_empty(&self) -> bool {
+        self.database.is_empty()
+    }
+
     fn begin_read_transaction(&self) -> Result<Self::ReadTransaction<'_>> {
         let guard = self.read_transactions_cache.load();
         let container = guard

--- a/turbopack/crates/turbo-tasks-backend/src/database/startup_cache.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/startup_cache.rs
@@ -110,6 +110,10 @@ impl<T: KeyValueDatabase> KeyValueDatabase for StartupCacheLayer<T> {
         T::lower_read_transaction(tx)
     }
 
+    fn is_empty(&self) -> bool {
+        self.database.is_empty()
+    }
+
     fn begin_read_transaction(&self) -> Result<Self::ReadTransaction<'_>> {
         self.database.begin_read_transaction()
     }

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -365,6 +365,11 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorage
             let id = TaskId::from(u32::from_le_bytes(bytes));
             Ok(Some(id))
         }
+        if self.database.is_empty() {
+            // Checking if the database is empty is a performance optimization
+            // to avoid serializing the task type.
+            return None;
+        }
         let id = self
             .with_tx(tx, |tx| lookup(&self.database, tx, task_type))
             .inspect_err(|err| println!("Looking up task id for {task_type:?} failed: {err:?}"))

--- a/turbopack/crates/turbo-tasks-backend/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(anonymous_lifetime_in_impl_trait)]
 #![feature(associated_type_defaults)]
+#![feature(iter_collect_into)]
 
 mod backend;
 mod backing_storage;

--- a/turbopack/crates/turbo-tasks-backend/src/utils/sharded.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/utils/sharded.rs
@@ -38,14 +38,14 @@ impl<T, H> Sharded<T, H> {
         self.data[shard as usize].lock()
     }
 
-    pub fn take(&self) -> Vec<T>
+    pub fn take<R>(&self, map: impl Fn(T) -> R) -> Vec<R>
     where
         T: Default,
     {
         let locked = self.data.iter().map(|m| m.lock()).collect::<Vec<_>>();
         locked
             .into_iter()
-            .map(|mut m| std::mem::take(&mut *m))
+            .map(|mut m| map(std::mem::take(&mut *m)))
             .collect()
     }
 }


### PR DESCRIPTION
### What?

* improve persisting error
* skip hash map when there is no old data, reuse data vec
* avoid allocations during prepare
* refactor persistented storage log
* Use instructions log for less memory and faster lookup
* skip task_type serialization for an empty database


Closes PACK-3579