### PR TITLE
Devlow: exit with non-zero code on failure

### DIFF
--- a/scripts/devlow-bench.mjs
+++ b/scripts/devlow-bench.mjs
@@ -47,6 +47,11 @@ const nextBuildWorkflow =
         __NEXT_TEST_MODE: '1',
       }
 
+      const serverEnv = {
+        ...env,
+        PORT: '0',
+      }
+
       const benchmarkDir = resolve(REPO_ROOT, 'bench', benchDir)
 
       // cleanup .next directory to remove persistent cache
@@ -88,7 +93,7 @@ const nextBuildWorkflow =
       const startArgs = [turbopack ? 'start-turbopack' : 'start-webpack']
       let shell = command('pnpm', startArgs, {
         cwd: benchmarkDir,
-        env,
+        env: serverEnv,
       })
       const killShell = async () => {
         if (shell) {
@@ -200,7 +205,7 @@ const nextBuildWorkflow =
       // run command to start dev server
       shell = command('pnpm', startArgs, {
         cwd: benchmarkDir,
-        env,
+        env: serverEnv,
       })
 
       // wait for server to be ready
@@ -222,7 +227,6 @@ const nextBuildWorkflow =
       )
       await shell.reportMemUsage('mem usage after open page with cache')
     } catch (e) {
-      console.log('CAUGHT', e)
       throw e
     } finally {
       // This must run in order
@@ -278,11 +282,16 @@ const nextDevWorkflow =
         __NEXT_TEST_MODE: '1',
       }
 
+      const serverEnv = {
+        ...env,
+        PORT: '0',
+      }
+
       // run command to start dev server
       const args = [turbopack ? 'dev-turbopack' : 'dev-webpack']
       let shell = command('pnpm', args, {
         cwd: benchmarkDir,
-        env,
+        env: serverEnv,
       })
       const killShell = async () => {
         if (shell) {
@@ -516,7 +525,7 @@ const nextDevWorkflow =
       // run command to start dev server
       shell = command('pnpm', args, {
         cwd: benchmarkDir,
-        env,
+        env: serverEnv,
       })
 
       // wait for server to be ready
@@ -537,9 +546,6 @@ const nextDevWorkflow =
         'lines'
       )
       await shell.reportMemUsage('mem usage after open page with cache')
-    } catch (e) {
-      console.log('CAUGHT', e)
-      throw e
     } finally {
       // This must run in order
       // eslint-disable-next-line no-await-in-loop

--- a/turbopack/packages/devlow-bench/src/runner.ts
+++ b/turbopack/packages/devlow-bench/src/runner.ts
@@ -57,6 +57,7 @@ export async function runScenarios(
       );
     } catch (e) {
       await fullIface.error(variant.scenario.name, variant.props, e);
+      process.exitCode = 1
     }
   }
 


### PR DESCRIPTION
This allows remaining variants/scenarios to run while still ensuring that CI can recognize the failure.


Closes PACK-3565