### PR TITLE
test: reduce number of rendering loop causing flakiness

### DIFF
--- a/test/integration/custom-server/test/index.test.js
+++ b/test/integration/custom-server/test/index.test.js
@@ -101,7 +101,7 @@ describe.each([
     })
 
     it('should set the assetPrefix to a given request', async () => {
-      for (let lc = 0; lc < 1000; lc++) {
+      for (let lc = 0; lc < 10; lc++) {
         const [normalUsage, dynamicUsage] = await Promise.all([
           await renderViaHTTP(nextUrl, '/asset', undefined, { agent }),
           await renderViaHTTP(nextUrl, '/asset?setAssetPrefix=1', undefined, {


### PR DESCRIPTION
### Why?

This PR reduced the rendering loop from 1000 to 10 while testing the `assetPrefix` set correctly based on a given request.

- [Origin PR](https://github.com/vercel/next.js/pull/3661)
- [DataDog](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Anextjs%20%40test.status%3Afail%20%40test.name%3A%28%22Custom%20Server%20using%20HTTPS%20with%20dynamic%20assetPrefix%20should%20set%20the%20assetPrefix%20to%20a%20given%20request%22%20OR%20%22Custom%20Server%20using%20HTTP%20with%20dynamic%20assetPrefix%20should%20set%20the%20assetPrefix%20to%20a%20given%20request%22%29&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=citest&viz=stream&start=1732124858573&end=1732729658573&paused=false)
- [CI](https://github.com/vercel/next.js/actions/runs/12053767138/job/33615269019?pr=72959#step:29:948)