### PR TITLE
rename cssChunkPlugin experimental options

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/cssChunking.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/cssChunking.mdx
@@ -13,7 +13,7 @@ import type { NextConfig } from 'next'
 
 const nextConfig = {
   experimental: {
-    cssChunking: 'loose', // default
+    cssChunking: true, // default
   },
 } satisfies NextConfig
 
@@ -24,7 +24,7 @@ export default nextConfig
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {
-    cssChunking: 'loose', // default
+    cssChunking: true, // default
   },
 }
 
@@ -33,10 +33,10 @@ module.exports = nextConfig
 
 ## Options
 
-- **`'loose'` (default)**: Next.js will try to merge CSS files whenever possible, determining explicit and implicit dependencies between files from import order to reduce the number of chunks and therefore the number of requests.
+- **`true` (default)**: Next.js will try to merge CSS files whenever possible, determining explicit and implicit dependencies between files from import order to reduce the number of chunks and therefore the number of requests.
+- **`false`**: Next.js will not attempt to merge or re-order your CSS files.
 - **`'strict'`**: Next.js will load CSS files in the correct order they are imported into your files, which can lead to more chunks and requests.
-- **`'disabled'**: Next.js will not attempt to merge or re-order your CSS files.
 
-You may consider using `'strict'` if you run into unexpected CSS behavior. For example, if you import `a.css` and `b.css` in different files using a different `import` order (`a` before `b`, or `b` before `a`), `'loose'` will merge the files in any order and assume there are no dependencies between them. However, if `b.css` depends on `a.css`, you may want to use `'strict'` to prevent the files from being merged, and instead, load them in the order they are imported - which can result in more chunks and requests.
+You may consider using `'strict'` if you run into unexpected CSS behavior. For example, if you import `a.css` and `b.css` in different files using a different `import` order (`a` before `b`, or `b` before `a`), `true` will merge the files in any order and assume there are no dependencies between them. However, if `b.css` depends on `a.css`, you may want to use `'strict'` to prevent the files from being merged, and instead, load them in the order they are imported - which can result in more chunks and requests.
 
-For most applications, we recommend `'loose'` as it leads to fewer requests and better performance.
+For most applications, we recommend `true` as it leads to fewer requests and better performance.

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1927,7 +1927,7 @@ export default async function getBaseWebpackConfig(
         }),
       !dev &&
         isClient &&
-        config.experimental.cssChunking !== 'disabled' &&
+        config.experimental.cssChunking &&
         new CssChunkingPlugin(config.experimental.cssChunking === 'strict'),
       !dev &&
         isClient &&

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -328,7 +328,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         manualClientBasePath: z.boolean().optional(),
         middlewarePrefetch: z.enum(['strict', 'flexible']).optional(),
         multiZoneDraftMode: z.boolean().optional(),
-        cssChunking: z.enum(['strict', 'loose', 'disabled']).optional(),
+        cssChunking: z.union([z.boolean(), z.literal('strict')]).optional(),
         nextScriptWorkers: z.boolean().optional(),
         // The critter option is unknown, use z.any() here
         optimizeCss: z.union([z.boolean(), z.any()]).optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -297,12 +297,12 @@ export interface ExperimentalConfig {
   middlewarePrefetch?: 'strict' | 'flexible'
   manualClientBasePath?: boolean
   /**
-   * CSS Chunking strategy. Defaults to 'loose', which guesses dependencies
+   * CSS Chunking strategy. Defaults to `true` ("loose" mode), which guesses dependencies
    * between CSS files to keep ordering of them.
    * An alternative is 'strict', which will try to keep correct ordering as
    * much as possible, even when this leads to many requests.
    */
-  cssChunking?: 'strict' | 'loose' | 'disabled'
+  cssChunking?: boolean | 'strict'
   disablePostcssPresetEnv?: boolean
   cpus?: number
   memoryBasedWorkersCount?: boolean
@@ -1090,7 +1090,7 @@ export const defaultConfig: NextConfig = {
       remote: process.env.NEXT_REMOTE_CACHE_HANDLER_PATH,
       static: process.env.NEXT_STATIC_CACHE_HANDLER_PATH,
     },
-    cssChunking: 'loose',
+    cssChunking: true,
     multiZoneDraftMode: false,
     appNavFailHandling: Boolean(process.env.NEXT_PRIVATE_FLYING_SHUTTLE),
     flyingShuttle: Boolean(process.env.NEXT_PRIVATE_FLYING_SHUTTLE)

--- a/test/e2e/app-dir/css-chunking/next.config.js
+++ b/test/e2e/app-dir/css-chunking/next.config.js
@@ -3,7 +3,7 @@
  */
 const nextConfig = {
   experimental: {
-    cssChunking: 'disabled',
+    cssChunking: false,
   },
 }
 

--- a/test/e2e/app-dir/css-order/css-order.test.ts
+++ b/test/e2e/app-dir/css-order/css-order.test.ts
@@ -226,7 +226,7 @@ const options = (mode: string) => ({
   },
   skipDeployment: true,
 })
-describe.each(process.env.TURBOPACK ? ['turbo'] : ['strict', 'loose'])(
+describe.each(process.env.TURBOPACK ? ['turbo'] : ['strict', true])(
   'css-order %s',
   (mode: string) => {
     const { next, isNextDev, skipped } = nextTestSetup(options(mode))


### PR DESCRIPTION
This treats the default ("loose")/disabled as a boolean, with an optional "strict" literal, to make the API a bit more ergonomic. 