### PR TITLE
[Turbopack] reland refactor filesystem writes to an effect based system

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1642,10 +1642,10 @@ impl Endpoint for AppEndpoint {
 
             let node_root_ref = &node_root.await?;
 
-            this.app_project
+            let _ = this
+                .app_project
                 .project()
-                .emit_all_output_assets(Vc::cell(output_assets))
-                .await?;
+                .emit_all_output_assets(Vc::cell(output_assets));
 
             let (server_paths, client_paths) = if this
                 .app_project

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -250,7 +250,11 @@ impl Endpoint for InstrumentationEndpoint {
             let this = self.await?;
             let output_assets = self.output_assets();
             let _ = output_assets.resolve().await?;
-            let _ = this.project.emit_all_output_assets(Vc::cell(output_assets));
+            let _ = this
+                .project
+                .emit_all_output_assets(Vc::cell(output_assets))
+                .resolve()
+                .await?;
 
             let server_paths = if this.project.next_mode().await?.is_development() {
                 let node_root = this.project.node_root();

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -250,9 +250,7 @@ impl Endpoint for InstrumentationEndpoint {
             let this = self.await?;
             let output_assets = self.output_assets();
             let _ = output_assets.resolve().await?;
-            this.project
-                .emit_all_output_assets(Vc::cell(output_assets))
-                .await?;
+            let _ = this.project.emit_all_output_assets(Vc::cell(output_assets));
 
             let server_paths = if this.project.next_mode().await?.is_development() {
                 let node_root = this.project.node_root();

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -275,9 +275,7 @@ impl Endpoint for MiddlewareEndpoint {
             let this = self.await?;
             let output_assets = self.output_assets();
             let _ = output_assets.resolve().await?;
-            this.project
-                .emit_all_output_assets(Vc::cell(output_assets))
-                .await?;
+            let _ = this.project.emit_all_output_assets(Vc::cell(output_assets));
 
             let (server_paths, client_paths) = if this.project.next_mode().await?.is_development() {
                 let node_root = this.project.node_root();

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -275,7 +275,11 @@ impl Endpoint for MiddlewareEndpoint {
             let this = self.await?;
             let output_assets = self.output_assets();
             let _ = output_assets.resolve().await?;
-            let _ = this.project.emit_all_output_assets(Vc::cell(output_assets));
+            let _ = this
+                .project
+                .emit_all_output_assets(Vc::cell(output_assets))
+                .resolve()
+                .await?;
 
             let (server_paths, client_paths) = if this.project.next_mode().await?.is_development() {
                 let node_root = this.project.node_root();

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1280,7 +1280,9 @@ impl Endpoint for PageEndpoint {
             let _ = this
                 .pages_project
                 .project()
-                .emit_all_output_assets(Vc::cell(output_assets));
+                .emit_all_output_assets(Vc::cell(output_assets))
+                .resolve()
+                .await?;
 
             let node_root = this.pages_project.project().node_root();
 

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1277,10 +1277,10 @@ impl Endpoint for PageEndpoint {
             // single operation
             let output_assets = self.output_assets();
 
-            this.pages_project
+            let _ = this
+                .pages_project
                 .project()
-                .emit_all_output_assets(Vc::cell(output_assets))
-                .await?;
+                .emit_all_output_assets(Vc::cell(output_assets));
 
             let node_root = this.pages_project.project().node_root();
 

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1178,7 +1178,7 @@ impl Project {
     pub async fn emit_all_output_assets(
         self: Vc<Self>,
         output_assets: Vc<OutputAssetsOperation>,
-    ) -> Result<Vc<()>> {
+    ) -> Result<()> {
         let span = tracing::info_span!("emitting");
         async move {
             let all_output_assets = all_assets_from_entries_operation(output_assets);
@@ -1187,27 +1187,23 @@ impl Project {
             let node_root = self.node_root();
 
             if let Some(map) = self.await?.versioned_content_map {
-                let _ = map
-                    .insert_output_assets(
-                        all_output_assets,
-                        node_root,
-                        client_relative_path,
-                        node_root,
-                    )
-                    .resolve()
-                    .await?;
+                let _ = map.insert_output_assets(
+                    all_output_assets,
+                    node_root,
+                    client_relative_path,
+                    node_root,
+                );
 
-                Ok(Vc::cell(()))
+                Ok(())
             } else {
                 let _ = emit_assets(
                     *all_output_assets.await?,
                     node_root,
                     client_relative_path,
                     node_root,
-                )
-                .resolve()
-                .await?;
-                Ok(Vc::cell(()))
+                );
+
+                Ok(())
             }
         }
         .instrument(span)

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1187,12 +1187,15 @@ impl Project {
             let node_root = self.node_root();
 
             if let Some(map) = self.await?.versioned_content_map {
-                let _ = map.insert_output_assets(
-                    all_output_assets,
-                    node_root,
-                    client_relative_path,
-                    node_root,
-                );
+                let _ = map
+                    .insert_output_assets(
+                        all_output_assets,
+                        node_root,
+                        client_relative_path,
+                        node_root,
+                    )
+                    .resolve()
+                    .await?;
 
                 Ok(())
             } else {
@@ -1201,7 +1204,9 @@ impl Project {
                     node_root,
                     client_relative_path,
                     node_root,
-                );
+                )
+                .resolve()
+                .await?;
 
                 Ok(())
             }

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -140,7 +140,9 @@ impl VersionedContentMap {
         });
 
         // Make sure all written client assets are up-to-date
-        let _ = emit_assets(assets, node_root, client_relative_path, client_output_path);
+        let _ = emit_assets(assets, node_root, client_relative_path, client_output_path)
+            .resolve()
+            .await?;
         let map_entry = Vc::cell(Some(MapEntry {
             assets_operation: assets,
             path_to_asset: entries.into_iter().collect(),

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use tracing::Instrument;
 use turbo_tasks::{
     graph::{AdjacencyMap, GraphTraversal},
-    Completion, Completions, ResolvedVc, TryFlatJoinIterExt, ValueToString, Vc,
+    ResolvedVc, TryFlatJoinIterExt, ValueToString, Vc,
 };
 use turbo_tasks_fs::{rebase, FileSystemPath};
 use turbopack_core::{
@@ -21,13 +21,13 @@ pub fn emit_all_assets(
     node_root: Vc<FileSystemPath>,
     client_relative_path: Vc<FileSystemPath>,
     client_output_path: Vc<FileSystemPath>,
-) -> Vc<Completion> {
-    emit_assets(
+) {
+    let _ = emit_assets(
         all_assets_from_entries(assets),
         node_root,
         client_relative_path,
         client_output_path,
-    )
+    );
 }
 
 /// Emits all assets transitively reachable from the given chunks, that are
@@ -41,42 +41,39 @@ pub async fn emit_assets(
     node_root: Vc<FileSystemPath>,
     client_relative_path: Vc<FileSystemPath>,
     client_output_path: Vc<FileSystemPath>,
-) -> Result<Vc<Completion>> {
-    Ok(Vc::<Completions>::cell(
-        assets
-            .await?
-            .iter()
-            .copied()
-            .map(|asset| async move {
-                let asset = asset.resolve().await?;
-                let path = asset.ident().path();
-                let span =
-                    tracing::info_span!("emit asset", name = path.to_string().await?.as_str());
-                async move {
-                    let path = path.await?;
-                    Ok(if path.is_inside_ref(&*node_root.await?) {
-                        Some(emit(asset))
-                    } else if path.is_inside_ref(&*client_relative_path.await?) {
-                        // Client assets are emitted to the client output path, which is prefixed
-                        // with _next. We need to rebase them to remove that
-                        // prefix.
-                        Some(emit_rebase(asset, client_relative_path, client_output_path))
-                    } else {
-                        None
-                    })
-                }
-                .instrument(span)
-                .await
-            })
-            .try_flat_join()
-            .await?,
-    )
-    .completed())
+) -> Result<()> {
+    let _: Vec<Vc<()>> = assets
+        .await?
+        .iter()
+        .copied()
+        .map(|asset| async move {
+            let asset = asset.resolve().await?;
+            let path = asset.ident().path();
+            let span = tracing::info_span!("emit asset", name = %path.to_string().await?);
+            async move {
+                let path = path.await?;
+                Ok(if path.is_inside_ref(&*node_root.await?) {
+                    Some(emit(asset))
+                } else if path.is_inside_ref(&*client_relative_path.await?) {
+                    // Client assets are emitted to the client output path, which is prefixed
+                    // with _next. We need to rebase them to remove that
+                    // prefix.
+                    Some(emit_rebase(asset, client_relative_path, client_output_path))
+                } else {
+                    None
+                })
+            }
+            .instrument(span)
+            .await
+        })
+        .try_flat_join()
+        .await?;
+    Ok(())
 }
 
 #[turbo_tasks::function]
-fn emit(asset: Vc<Box<dyn OutputAsset>>) -> Vc<Completion> {
-    asset.content().write(asset.ident().path())
+fn emit(asset: Vc<Box<dyn OutputAsset>>) {
+    let _ = asset.content().write(asset.ident().path());
 }
 
 #[turbo_tasks::function]
@@ -84,10 +81,11 @@ async fn emit_rebase(
     asset: Vc<Box<dyn OutputAsset>>,
     from: Vc<FileSystemPath>,
     to: Vc<FileSystemPath>,
-) -> Result<Vc<Completion>> {
+) -> Result<()> {
     let path = rebase(asset.ident().path(), from, to);
     let content = asset.content();
-    Ok(content.resolve().await?.write(path.resolve().await?))
+    let _ = content.resolve().await?.write(path.resolve().await?);
+    Ok(())
 }
 
 /// Walks the asset graph from multiple assets and collect all referenced

--- a/turbopack/crates/turbo-tasks-fs/src/attach.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/attach.rs
@@ -164,16 +164,12 @@ impl FileSystem for AttachedFileSystem {
     }
 
     #[turbo_tasks::function(fs)]
-    fn write(self: Vc<Self>, path: Vc<FileSystemPath>, content: Vc<FileContent>) -> Vc<Completion> {
+    fn write(self: Vc<Self>, path: Vc<FileSystemPath>, content: Vc<FileContent>) -> Vc<()> {
         self.get_inner_fs_path(path).write(content)
     }
 
     #[turbo_tasks::function(fs)]
-    fn write_link(
-        self: Vc<Self>,
-        path: Vc<FileSystemPath>,
-        target: Vc<LinkContent>,
-    ) -> Vc<Completion> {
+    fn write_link(self: Vc<Self>, path: Vc<FileSystemPath>, target: Vc<LinkContent>) -> Vc<()> {
         self.get_inner_fs_path(path).write_link(target)
     }
 

--- a/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
@@ -76,20 +76,12 @@ impl FileSystem for EmbeddedFileSystem {
     }
 
     #[turbo_tasks::function]
-    fn write(
-        &self,
-        _path: Vc<FileSystemPath>,
-        _content: Vc<FileContent>,
-    ) -> Result<Vc<Completion>> {
+    fn write(&self, _path: Vc<FileSystemPath>, _content: Vc<FileContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible to the embedded filesystem")
     }
 
     #[turbo_tasks::function]
-    fn write_link(
-        &self,
-        _path: Vc<FileSystemPath>,
-        _target: Vc<LinkContent>,
-    ) -> Result<Vc<Completion>> {
+    fn write_link(&self, _path: Vc<FileSystemPath>, _target: Vc<LinkContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible to the embedded filesystem")
     }
 

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -53,7 +53,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::{
     fs,
-    io::{AsyncBufReadExt, AsyncReadExt, BufReader},
+    io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader},
     sync::{RwLock, RwLockReadGuard},
 };
 use tracing::Instrument;
@@ -744,6 +744,7 @@ impl FileSystem for DiskFileSystem {
                             tokio::io::copy(&mut file.read(), &mut f).await?;
                             #[cfg(target_family = "unix")]
                             f.set_permissions(file.meta.permissions.into()).await?;
+                            f.flush().await?;
                             #[cfg(feature = "write_version")]
                             {
                                 let mut full_path = full_path.into_owned();
@@ -759,6 +760,7 @@ impl FileSystem for DiskFileSystem {
                                 tokio::io::copy(&mut file.read(), &mut f).await?;
                                 #[cfg(target_family = "unix")]
                                 f.set_permissions(file.meta.permissions.into()).await?;
+                                f.flush().await?;
                             }
                             Ok::<(), io::Error>(())
                         }

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -59,8 +59,8 @@ use tokio::{
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    mark_session_dependent, mark_stateful, trace::TraceRawVcs, Completion, Invalidator, ReadRef,
-    ResolvedVc, ValueToString, Vc,
+    debug::ValueDebugFormat, effect, mark_session_dependent, mark_stateful, trace::TraceRawVcs,
+    Completion, Invalidator, ReadRef, ResolvedVc, ValueToString, Vc,
 };
 use turbo_tasks_hash::{
     hash_xxh3_hash128, hash_xxh3_hash64, DeterministicHash, DeterministicHasher,
@@ -183,21 +183,13 @@ pub trait FileSystem: ValueToString {
     fn read_link(self: Vc<Self>, fs_path: Vc<FileSystemPath>) -> Vc<LinkContent>;
     fn read_dir(self: Vc<Self>, fs_path: Vc<FileSystemPath>) -> Vc<DirectoryContent>;
     fn track(self: Vc<Self>, fs_path: Vc<FileSystemPath>) -> Vc<Completion>;
-    fn write(
-        self: Vc<Self>,
-        fs_path: Vc<FileSystemPath>,
-        content: Vc<FileContent>,
-    ) -> Vc<Completion>;
-    fn write_link(
-        self: Vc<Self>,
-        fs_path: Vc<FileSystemPath>,
-        target: Vc<LinkContent>,
-    ) -> Vc<Completion>;
+    fn write(self: Vc<Self>, fs_path: Vc<FileSystemPath>, content: Vc<FileContent>) -> Vc<()>;
+    fn write_link(self: Vc<Self>, fs_path: Vc<FileSystemPath>, target: Vc<LinkContent>) -> Vc<()>;
     fn metadata(self: Vc<Self>, fs_path: Vc<FileSystemPath>) -> Vc<FileMeta>;
 }
 
-#[turbo_tasks::value(cell = "new", eq = "manual")]
-pub struct DiskFileSystem {
+#[derive(Serialize, Deserialize, TraceRawVcs, ValueDebugFormat)]
+struct DiskFileSystemInner {
     pub name: RcStr,
     pub root: RcStr,
     #[turbo_tasks(debug_ignore, trace_ignore)]
@@ -205,20 +197,21 @@ pub struct DiskFileSystem {
     mutex_map: MutexMap<PathBuf>,
     #[turbo_tasks(debug_ignore, trace_ignore)]
     #[serde(skip)]
-    invalidator_map: Arc<InvalidatorMap>,
+    invalidator_map: InvalidatorMap,
     #[turbo_tasks(debug_ignore, trace_ignore)]
     #[serde(skip)]
-    dir_invalidator_map: Arc<InvalidatorMap>,
+    dir_invalidator_map: InvalidatorMap,
     /// Lock that makes invalidation atomic. It will keep a write lock during
     /// watcher invalidation and a read lock during other operations.
     #[turbo_tasks(debug_ignore, trace_ignore)]
     #[serde(skip)]
-    invalidation_lock: Arc<RwLock<()>>,
+    invalidation_lock: RwLock<()>,
+
     #[turbo_tasks(debug_ignore, trace_ignore)]
-    watcher: Arc<DiskWatcher>,
+    watcher: DiskWatcher,
 }
 
-impl DiskFileSystem {
+impl DiskFileSystemInner {
     /// Returns the root as Path
     fn root_path(&self) -> &Path {
         simplified(Path::new(&*self.root))
@@ -239,8 +232,11 @@ impl DiskFileSystem {
     /// registers the path as an invalidator for the current task,
     /// has to be called within a turbo-tasks function. It removes and returns
     /// the current list of invalidators.
-    fn register_sole_invalidator(&self, path: &Path) -> Result<HashSet<Invalidator>> {
-        let invalidator = turbo_tasks::get_invalidator();
+    fn register_sole_invalidator(
+        &self,
+        path: &Path,
+        invalidator: Invalidator,
+    ) -> Result<HashSet<Invalidator>> {
         let mut invalidator_map = self.invalidator_map.lock().unwrap();
         let old_invalidators = invalidator_map.insert(path_to_key(path), [invalidator].into());
         drop(invalidator_map);
@@ -268,7 +264,7 @@ impl DiskFileSystem {
         PathLockGuard(lock1, lock2)
     }
 
-    pub fn invalidate(&self) {
+    fn invalidate(&self) {
         let _span = tracing::info_span!("invalidate filesystem", path = &*self.root).entered();
         let span = tracing::Span::current();
         let handle = tokio::runtime::Handle::current();
@@ -285,7 +281,7 @@ impl DiskFileSystem {
         });
     }
 
-    pub fn invalidate_with_reason(&self) {
+    fn invalidate_with_reason(&self) {
         let _span = tracing::info_span!("invalidate filesystem", path = &*self.root).entered();
         let span = tracing::Span::current();
         let handle = tokio::runtime::Handle::current();
@@ -308,69 +304,6 @@ impl DiskFileSystem {
         });
     }
 
-    pub async fn start_watching(&self, poll_interval: Option<Duration>) -> Result<()> {
-        self.start_watching_internal(false, poll_interval).await
-    }
-
-    pub async fn start_watching_with_invalidation_reason(
-        &self,
-        poll_interval: Option<Duration>,
-    ) -> Result<()> {
-        self.start_watching_internal(true, poll_interval).await
-    }
-
-    #[tracing::instrument(level = "info", name = "start filesystem watching", skip_all, fields(path = %self.root))]
-    async fn start_watching_internal(
-        &self,
-        report_invalidation_reason: bool,
-        poll_interval: Option<Duration>,
-    ) -> Result<()> {
-        let invalidator_map = self.invalidator_map.clone();
-        let dir_invalidator_map = self.dir_invalidator_map.clone();
-        let root_path = self.root_path().to_path_buf();
-
-        // create the directory for the filesystem on disk, if it doesn't exist
-        retry_future(|| {
-            let path = root_path.as_path();
-            fs::create_dir_all(&root_path).instrument(tracing::info_span!(
-                "create root directory",
-                path = display(path.display())
-            ))
-        })
-        .await?;
-
-        let report_invalidation_reason =
-            report_invalidation_reason.then(|| (self.name.clone(), root_path.clone()));
-        let invalidation_lock = self.invalidation_lock.clone();
-
-        self.watcher.clone().start_watching(
-            self.name.clone(),
-            root_path,
-            report_invalidation_reason,
-            invalidation_lock,
-            invalidator_map,
-            dir_invalidator_map,
-            poll_interval,
-        )?;
-
-        Ok(())
-    }
-
-    pub fn stop_watching(&self) {
-        self.watcher.stop_watching();
-    }
-
-    pub async fn to_sys_path(&self, fs_path: Vc<FileSystemPath>) -> Result<PathBuf> {
-        // just in case there's a windows unc path prefix we remove it with `dunce`
-        let path = self.root_path();
-        let fs_path = fs_path.await?;
-        Ok(if fs_path.path.is_empty() {
-            path.to_path_buf()
-        } else {
-            path.join(&*unix_to_sys(&fs_path.path))
-        })
-    }
-
     fn invalidate_from_write(&self, full_path: &Path, invalidators: HashSet<Invalidator>) {
         if !invalidators.is_empty() {
             if let Some(path) = format_absolute_fs_path(full_path, &self.name, self.root_path()) {
@@ -388,6 +321,83 @@ impl DiskFileSystem {
                 });
             }
         }
+    }
+
+    #[tracing::instrument(level = "info", name = "start filesystem watching", skip_all, fields(path = %self.root))]
+    async fn start_watching_internal(
+        self: &Arc<Self>,
+        report_invalidation_reason: bool,
+        poll_interval: Option<Duration>,
+    ) -> Result<()> {
+        let root_path = self.root_path().to_path_buf();
+
+        // create the directory for the filesystem on disk, if it doesn't exist
+        retry_future(|| {
+            let path = root_path.as_path();
+            fs::create_dir_all(&root_path).instrument(tracing::info_span!(
+                "create root directory",
+                path = display(path.display())
+            ))
+        })
+        .await?;
+
+        self.watcher
+            .start_watching(self.clone(), report_invalidation_reason, poll_interval)?;
+
+        Ok(())
+    }
+}
+
+#[turbo_tasks::value(cell = "new", eq = "manual")]
+pub struct DiskFileSystem {
+    inner: Arc<DiskFileSystemInner>,
+}
+
+impl DiskFileSystem {
+    pub fn name(&self) -> &RcStr {
+        &self.inner.name
+    }
+
+    pub fn root(&self) -> &RcStr {
+        &self.inner.root
+    }
+
+    pub fn invalidate(&self) {
+        self.inner.invalidate();
+    }
+
+    pub fn invalidate_with_reason(&self) {
+        self.inner.invalidate_with_reason();
+    }
+
+    pub async fn start_watching(&self, poll_interval: Option<Duration>) -> Result<()> {
+        self.inner
+            .start_watching_internal(false, poll_interval)
+            .await
+    }
+
+    pub async fn start_watching_with_invalidation_reason(
+        &self,
+        poll_interval: Option<Duration>,
+    ) -> Result<()> {
+        self.inner
+            .start_watching_internal(true, poll_interval)
+            .await
+    }
+
+    pub fn stop_watching(&self) {
+        self.inner.watcher.stop_watching();
+    }
+
+    pub async fn to_sys_path(&self, fs_path: Vc<FileSystemPath>) -> Result<PathBuf> {
+        // just in case there's a windows unc path prefix we remove it with `dunce`
+        let path = self.inner.root_path();
+        let fs_path = fs_path.await?;
+        Ok(if fs_path.path.is_empty() {
+            path.to_path_buf()
+        } else {
+            path.join(&*unix_to_sys(&fs_path.path))
+        })
     }
 }
 
@@ -431,15 +441,17 @@ impl DiskFileSystem {
         mark_stateful();
 
         let instance = DiskFileSystem {
-            name,
-            root,
-            mutex_map: Default::default(),
-            invalidation_lock: Default::default(),
-            invalidator_map: Arc::new(InvalidatorMap::new()),
-            dir_invalidator_map: Arc::new(InvalidatorMap::new()),
-            watcher: Arc::new(DiskWatcher::new(
-                ignored_subpaths.into_iter().map(PathBuf::from).collect(),
-            )),
+            inner: Arc::new(DiskFileSystemInner {
+                name,
+                root,
+                mutex_map: Default::default(),
+                invalidation_lock: Default::default(),
+                invalidator_map: InvalidatorMap::new(),
+                dir_invalidator_map: InvalidatorMap::new(),
+                watcher: DiskWatcher::new(
+                    ignored_subpaths.into_iter().map(PathBuf::from).collect(),
+                ),
+            }),
         };
 
         Ok(Self::cell(instance))
@@ -452,7 +464,7 @@ impl DiskFileSystem {
     ) -> Result<Vc<InternalDirectoryContent>> {
         mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;
-        self.register_dir_invalidator(&full_path)?;
+        self.inner.register_dir_invalidator(&full_path)?;
 
         // we use the sync std function here as it's a lot faster (600%) in
         // node-file-trace
@@ -487,7 +499,7 @@ impl DiskFileSystem {
 
                 // we filter out any non unicode names and paths without the same root here
                 let file_name: RcStr = path.file_name()?.to_str()?.into();
-                let path_to_root = sys_to_unix(path.strip_prefix(&self.root).ok()?.to_str()?);
+                let path_to_root = sys_to_unix(path.strip_prefix(&self.inner.root).ok()?.to_str()?);
 
                 let path = path_to_root.into();
 
@@ -510,7 +522,7 @@ impl DiskFileSystem {
 
 impl Debug for DiskFileSystem {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "name: {}, root: {}", self.name, self.root)
+        write!(f, "name: {}, root: {}", self.inner.name, self.inner.root)
     }
 }
 
@@ -520,9 +532,9 @@ impl FileSystem for DiskFileSystem {
     async fn read(&self, fs_path: Vc<FileSystemPath>) -> Result<Vc<FileContent>> {
         mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;
-        self.register_invalidator(&full_path)?;
+        self.inner.register_invalidator(&full_path)?;
 
-        let _lock = self.lock_path(&full_path).await;
+        let _lock = self.inner.lock_path(&full_path).await;
         let content = match retry_future(|| File::from_path(full_path.clone()))
             .instrument(tracing::info_span!(
                 "read file",
@@ -577,9 +589,9 @@ impl FileSystem for DiskFileSystem {
     async fn read_link(&self, fs_path: Vc<FileSystemPath>) -> Result<Vc<LinkContent>> {
         mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;
-        self.register_invalidator(&full_path)?;
+        self.inner.register_invalidator(&full_path)?;
 
-        let _lock = self.lock_path(&full_path).await;
+        let _lock = self.inner.lock_path(&full_path).await;
         let link_path = match retry_future(|| fs::read_link(&full_path))
             .instrument(tracing::info_span!(
                 "read symlink",
@@ -618,7 +630,7 @@ impl FileSystem for DiskFileSystem {
         //
         // we use `dunce::simplify` to strip a potential UNC prefix on windows, on any
         // other OS this gets compiled away
-        let result = simplified(&file).strip_prefix(simplified(Path::new(&self.root)));
+        let result = simplified(&file).strip_prefix(simplified(Path::new(&self.inner.root)));
 
         let relative_to_root_path = match result {
             Ok(file) => PathBuf::from(sys_to_unix(&file.to_string_lossy()).as_ref()),
@@ -662,221 +674,254 @@ impl FileSystem for DiskFileSystem {
     async fn track(&self, fs_path: Vc<FileSystemPath>) -> Result<Vc<Completion>> {
         mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;
-        self.register_invalidator(&full_path)?;
+        self.inner.register_invalidator(&full_path)?;
         Ok(Completion::new())
     }
 
     #[turbo_tasks::function(fs)]
-    async fn write(
-        &self,
-        fs_path: Vc<FileSystemPath>,
-        content: Vc<FileContent>,
-    ) -> Result<Vc<Completion>> {
+    async fn write(&self, fs_path: Vc<FileSystemPath>, content: Vc<FileContent>) -> Result<()> {
         mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;
-        let full_path = validate_path_length(&full_path)?;
-
         let content = content.await?;
+        let inner = self.inner.clone();
+        let invalidator = turbo_tasks::get_invalidator();
 
-        let _lock = self.lock_path(&full_path).await;
+        effect(async move {
+            let full_path = validate_path_length(&full_path)?;
 
-        // Track the file, so that we will rewrite it if it ever changes.
-        let old_invalidators = self.register_sole_invalidator(&full_path)?;
+            let _lock = inner.lock_path(&full_path).await;
 
-        // We perform an untracked comparison here, so that this write is not dependent
-        // on a read's Vc<FileContent> (and the memory it holds). Our untracked read can
-        // be freed immediately. Given this is an output file, it's unlikely any Turbo
-        // code will need to read the file from disk into a Vc<FileContent>, so we're
-        // not wasting cycles.
-        let compare = content
-            .streaming_compare(&full_path)
-            .instrument(tracing::info_span!(
-                "read file before write",
-                path = display(full_path.display())
-            ))
-            .await?;
-        if compare == FileComparison::Equal {
-            if !old_invalidators.is_empty() {
-                let key = path_to_key(&full_path);
-                for i in old_invalidators {
-                    self.invalidator_map.insert(key.clone(), i);
-                }
-            }
-            return Ok(Completion::unchanged());
-        }
+            // Track the file, so that we will rewrite it if it ever changes.
+            let old_invalidators = inner.register_sole_invalidator(&full_path, invalidator)?;
 
-        let create_directory = compare == FileComparison::Create;
-
-        match &*content {
-            FileContent::Content(file) => {
-                if create_directory {
-                    if let Some(parent) = full_path.parent() {
-                        retry_future(move || fs::create_dir_all(parent))
-                            .instrument(tracing::info_span!(
-                                "create directory",
-                                path = display(parent.display())
-                            ))
-                            .await
-                            .with_context(|| {
-                                format!(
-                                    "failed to create directory {} for write to {}",
-                                    parent.display(),
-                                    full_path.display()
-                                )
-                            })?;
+            // We perform an untracked comparison here, so that this write is not dependent
+            // on a read's Vc<FileContent> (and the memory it holds). Our untracked read can
+            // be freed immediately. Given this is an output file, it's unlikely any Turbo
+            // code will need to read the file from disk into a Vc<FileContent>, so we're
+            // not wasting cycles.
+            let compare = content
+                .streaming_compare(&full_path)
+                .instrument(tracing::info_span!(
+                    "read file before write",
+                    path = display(full_path.display())
+                ))
+                .await?;
+            if compare == FileComparison::Equal {
+                if !old_invalidators.is_empty() {
+                    let key = path_to_key(&full_path);
+                    for i in old_invalidators {
+                        inner.invalidator_map.insert(key.clone(), i);
                     }
                 }
-                let full_path_to_write = full_path.clone();
-                retry_future(move || {
-                    let full_path = full_path_to_write.clone();
-                    async move {
-                        let mut f = fs::File::create(&full_path).await?;
-                        tokio::io::copy(&mut file.read(), &mut f).await?;
-                        #[cfg(target_family = "unix")]
-                        f.set_permissions(file.meta.permissions.into()).await?;
-                        #[cfg(feature = "write_version")]
-                        {
-                            let mut full_path = full_path.into_owned();
-                            let hash = hash_xxh3_hash64(file);
-                            let ext = full_path.extension();
-                            let ext = if let Some(ext) = ext {
-                                format!("{:016x}.{}", hash, ext.to_string_lossy())
-                            } else {
-                                format!("{:016x}", hash)
-                            };
-                            full_path.set_extension(ext);
+                return Ok(());
+            }
+
+            match &*content {
+                FileContent::Content(file) => {
+                    let create_directory = compare == FileComparison::Create;
+                    if create_directory {
+                        if let Some(parent) = full_path.parent() {
+                            retry_future(move || fs::create_dir_all(parent))
+                                .instrument(tracing::info_span!(
+                                    "create directory",
+                                    path = display(parent.display())
+                                ))
+                                .await
+                                .with_context(|| {
+                                    format!(
+                                        "failed to create directory {} for write to {}",
+                                        parent.display(),
+                                        full_path.display()
+                                    )
+                                })?;
+                        }
+                    }
+                    let full_path_to_write = full_path.clone();
+                    retry_future(move || {
+                        let full_path = full_path_to_write.clone();
+                        async move {
                             let mut f = fs::File::create(&full_path).await?;
                             tokio::io::copy(&mut file.read(), &mut f).await?;
                             #[cfg(target_family = "unix")]
                             f.set_permissions(file.meta.permissions.into()).await?;
+                            #[cfg(feature = "write_version")]
+                            {
+                                let mut full_path = full_path.into_owned();
+                                let hash = hash_xxh3_hash64(file);
+                                let ext = full_path.extension();
+                                let ext = if let Some(ext) = ext {
+                                    format!("{:016x}.{}", hash, ext.to_string_lossy())
+                                } else {
+                                    format!("{:016x}", hash)
+                                };
+                                full_path.set_extension(ext);
+                                let mut f = fs::File::create(&full_path).await?;
+                                tokio::io::copy(&mut file.read(), &mut f).await?;
+                                #[cfg(target_family = "unix")]
+                                f.set_permissions(file.meta.permissions.into()).await?;
+                            }
+                            Ok::<(), io::Error>(())
                         }
-                        Ok::<(), io::Error>(())
-                    }
-                })
-                .instrument(tracing::info_span!(
-                    "write file",
-                    path = display(full_path.display())
-                ))
-                .await
-                .with_context(|| format!("failed to write to {}", full_path.display()))?;
-            }
-            FileContent::NotFound => {
-                retry_future(|| fs::remove_file(full_path.clone()))
+                    })
                     .instrument(tracing::info_span!(
-                        "remove file",
+                        "write file",
                         path = display(full_path.display())
                     ))
                     .await
-                    .or_else(|err| {
-                        if err.kind() == ErrorKind::NotFound {
-                            Ok(())
-                        } else {
-                            Err(err)
-                        }
-                    })
-                    .with_context(|| anyhow!("removing {} failed", full_path.display()))?;
+                    .with_context(|| format!("failed to write to {}", full_path.display()))?;
+                }
+                FileContent::NotFound => {
+                    retry_future(|| fs::remove_file(full_path.clone()))
+                        .instrument(tracing::info_span!(
+                            "remove file",
+                            path = display(full_path.display())
+                        ))
+                        .await
+                        .or_else(|err| {
+                            if err.kind() == ErrorKind::NotFound {
+                                Ok(())
+                            } else {
+                                Err(err)
+                            }
+                        })
+                        .with_context(|| anyhow!("removing {} failed", full_path.display()))?;
+                }
             }
-        }
 
-        self.invalidate_from_write(&full_path, old_invalidators);
+            inner.invalidate_from_write(&full_path, old_invalidators);
 
-        Ok(Completion::new())
+            Ok(())
+        });
+
+        Ok(())
     }
 
     #[turbo_tasks::function(fs)]
-    async fn write_link(
-        &self,
-        fs_path: Vc<FileSystemPath>,
-        target: Vc<LinkContent>,
-    ) -> Result<Vc<Completion>> {
+    async fn write_link(&self, fs_path: Vc<FileSystemPath>, target: Vc<LinkContent>) -> Result<()> {
         mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;
-        // TODO(sokra) preform a untracked read here, register an invalidator and get
-        // all existing invalidators
-        let old_content = fs_path
-            .read_link()
-            .await
-            .with_context(|| format!("reading old symlink target of {}", full_path.display()))?;
-        let target_link = target.await?;
-        if target_link == old_content {
-            return Ok(Completion::unchanged());
-        }
-        let file_type = &*fs_path.get_type().await?;
-        let create_directory = file_type == &FileSystemEntryType::NotFound;
-        if create_directory {
-            if let Some(parent) = full_path.parent() {
-                retry_future(move || fs::create_dir_all(parent))
-                    .instrument(tracing::info_span!(
-                        "create directory",
-                        path = display(parent.display())
-                    ))
-                    .await
-                    .with_context(|| {
-                        format!(
-                            "failed to create directory {} for write to {}",
-                            parent.display(),
-                            full_path.display()
-                        )
-                    })?;
-            }
-        }
-        let _lock = self.lock_path(&full_path).await;
-        match &*target_link {
-            LinkContent::Link { target, link_type } => {
-                let link_type = *link_type;
-                let target_path = if link_type.contains(LinkType::ABSOLUTE) {
-                    Path::new(&self.root).join(unix_to_sys(target).as_ref())
-                } else {
-                    PathBuf::from(unix_to_sys(target).as_ref())
-                };
-                retry_blocking(&target_path, move |target_path| {
-                    let _span =
-                        tracing::info_span!("write symlink", path = display(target_path.display()))
-                            .entered();
-                    // we use the sync std method here because `symlink` is fast
-                    // if we put it into a task, it will be slower
-                    #[cfg(not(target_family = "windows"))]
-                    {
-                        std::os::unix::fs::symlink(target_path, &full_path)
+        let content = target.await?;
+        let inner = self.inner.clone();
+        let invalidator = turbo_tasks::get_invalidator();
+
+        effect(async move {
+            let full_path = validate_path_length(&full_path)?;
+
+            let _lock = inner.lock_path(&full_path).await;
+
+            let old_invalidators = inner.register_sole_invalidator(&full_path, invalidator)?;
+
+            // TODO(sokra) preform a untracked read here, register an invalidator and get
+            // all existing invalidators
+            let old_content = match retry_future(|| fs::read_link(&full_path))
+                .instrument(tracing::info_span!(
+                    "read symlink before write",
+                    path = display(full_path.display())
+                ))
+                .await
+            {
+                Ok(res) => Some((res.is_absolute(), res)),
+                Err(_) => None,
+            };
+            let is_equal = match (&*content, &old_content) {
+                (LinkContent::Link { target, link_type }, Some((old_is_absolute, old_target))) => {
+                    Path::new(&**target) == old_target
+                        && link_type.contains(LinkType::ABSOLUTE) == *old_is_absolute
+                }
+                (LinkContent::NotFound, None) => true,
+                _ => false,
+            };
+            if is_equal {
+                if !old_invalidators.is_empty() {
+                    let key = path_to_key(&full_path);
+                    for i in old_invalidators {
+                        inner.invalidator_map.insert(key.clone(), i);
                     }
-                    #[cfg(target_family = "windows")]
-                    {
-                        if link_type.contains(LinkType::DIRECTORY) {
-                            std::os::windows::fs::symlink_dir(target_path, &full_path)
-                        } else {
-                            std::os::windows::fs::symlink_file(target_path, &full_path)
+                }
+                return Ok(());
+            }
+
+            match &*content {
+                LinkContent::Link { target, link_type } => {
+                    let create_directory = old_content.is_none();
+                    if create_directory {
+                        if let Some(parent) = full_path.parent() {
+                            retry_future(move || fs::create_dir_all(parent))
+                                .instrument(tracing::info_span!(
+                                    "create directory",
+                                    path = display(parent.display())
+                                ))
+                                .await
+                                .with_context(|| {
+                                    format!(
+                                        "failed to create directory {} for write to {}",
+                                        parent.display(),
+                                        full_path.display()
+                                    )
+                                })?;
                         }
                     }
-                })
-                .await
-                .with_context(|| format!("create symlink to {}", target))?;
-            }
-            LinkContent::Invalid => {
-                anyhow::bail!("invalid symlink target: {}", full_path.display())
-            }
-            LinkContent::NotFound => {
-                retry_future(|| fs::remove_file(&full_path))
-                    .await
-                    .or_else(|err| {
-                        if err.kind() == ErrorKind::NotFound {
-                            Ok(())
-                        } else {
-                            Err(err)
+
+                    let link_type = *link_type;
+                    let target_path = if link_type.contains(LinkType::ABSOLUTE) {
+                        Path::new(&inner.root).join(unix_to_sys(target).as_ref())
+                    } else {
+                        PathBuf::from(unix_to_sys(target).as_ref())
+                    };
+                    let full_path = full_path.into_owned();
+                    retry_blocking(&target_path, move |target_path| {
+                        let _span = tracing::info_span!(
+                            "write symlink",
+                            path = display(target_path.display())
+                        )
+                        .entered();
+                        // we use the sync std method here because `symlink` is fast
+                        // if we put it into a task, it will be slower
+                        #[cfg(not(target_family = "windows"))]
+                        {
+                            std::os::unix::fs::symlink(target_path, &full_path)
+                        }
+                        #[cfg(target_family = "windows")]
+                        {
+                            if link_type.contains(LinkType::DIRECTORY) {
+                                std::os::windows::fs::symlink_dir(target_path, &full_path)
+                            } else {
+                                std::os::windows::fs::symlink_file(target_path, &full_path)
+                            }
                         }
                     })
-                    .with_context(|| anyhow!("removing {} failed", full_path.display()))?;
+                    .await
+                    .with_context(|| format!("create symlink to {}", target))?;
+                }
+                LinkContent::Invalid => {
+                    anyhow::bail!("invalid symlink target: {}", full_path.display())
+                }
+                LinkContent::NotFound => {
+                    retry_future(|| fs::remove_file(&full_path))
+                        .await
+                        .or_else(|err| {
+                            if err.kind() == ErrorKind::NotFound {
+                                Ok(())
+                            } else {
+                                Err(err)
+                            }
+                        })
+                        .with_context(|| anyhow!("removing {} failed", full_path.display()))?;
+                }
             }
-        }
-        Ok(Completion::new())
+
+            Ok(())
+        });
+        Ok(())
     }
 
     #[turbo_tasks::function(fs)]
     async fn metadata(&self, fs_path: Vc<FileSystemPath>) -> Result<Vc<FileMeta>> {
         mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;
-        self.register_invalidator(&full_path)?;
+        self.inner.register_invalidator(&full_path)?;
 
-        let _lock = self.lock_path(&full_path).await;
+        let _lock = self.inner.lock_path(&full_path).await;
         let meta = retry_future(|| fs::metadata(full_path.clone()))
             .instrument(tracing::info_span!(
                 "read metadata",
@@ -893,7 +938,7 @@ impl FileSystem for DiskFileSystem {
 impl ValueToString for DiskFileSystem {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(self.name.clone())
+        Vc::cell(self.inner.name.clone())
     }
 }
 
@@ -1377,11 +1422,11 @@ impl FileSystemPath {
         self.fs().track(self)
     }
 
-    pub fn write(self: Vc<Self>, content: Vc<FileContent>) -> Vc<Completion> {
+    pub fn write(self: Vc<Self>, content: Vc<FileContent>) -> Vc<()> {
         self.fs().write(self, content)
     }
 
-    pub fn write_link(self: Vc<Self>, target: Vc<LinkContent>) -> Vc<Completion> {
+    pub fn write_link(self: Vc<Self>, target: Vc<LinkContent>) -> Vc<()> {
         self.fs().write_link(self, target)
     }
 
@@ -2256,13 +2301,13 @@ impl FileSystem for NullFileSystem {
     }
 
     #[turbo_tasks::function]
-    fn write(&self, _fs_path: Vc<FileSystemPath>, _content: Vc<FileContent>) -> Vc<Completion> {
-        Completion::new()
+    fn write(&self, _fs_path: Vc<FileSystemPath>, _content: Vc<FileContent>) -> Vc<()> {
+        Vc::default()
     }
 
     #[turbo_tasks::function]
-    fn write_link(&self, _fs_path: Vc<FileSystemPath>, _target: Vc<LinkContent>) -> Vc<Completion> {
-        Completion::new()
+    fn write_link(&self, _fs_path: Vc<FileSystemPath>, _target: Vc<LinkContent>) -> Vc<()> {
+        Vc::default()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
@@ -66,20 +66,12 @@ impl FileSystem for VirtualFileSystem {
     }
 
     #[turbo_tasks::function]
-    fn write(
-        &self,
-        _fs_path: Vc<FileSystemPath>,
-        _content: Vc<FileContent>,
-    ) -> Result<Vc<Completion>> {
+    fn write(&self, _fs_path: Vc<FileSystemPath>, _content: Vc<FileContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible on the virtual file system")
     }
 
     #[turbo_tasks::function]
-    fn write_link(
-        &self,
-        _fs_path: Vc<FileSystemPath>,
-        _target: Vc<LinkContent>,
-    ) -> Result<Vc<Completion>> {
+    fn write_link(&self, _fs_path: Vc<FileSystemPath>, _target: Vc<LinkContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible on the virtual file system")
     }
 

--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -16,16 +16,13 @@ use notify::{
 };
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
-use tokio::sync::RwLock;
 use tracing::instrument;
-use turbo_rcstr::RcStr;
 use turbo_tasks::{spawn_thread, Invalidator};
 
 use crate::{
     format_absolute_fs_path,
     invalidation::{WatchChange, WatchStart},
-    invalidator_map::InvalidatorMap,
-    path_to_key,
+    path_to_key, DiskFileSystemInner,
 };
 
 enum DiskWatcherInternal {
@@ -137,13 +134,9 @@ impl DiskWatcher {
     /// - Doesn't emit duplicate create events
     /// - Doesn't emit Modify events after a Create event
     pub(crate) fn start_watching(
-        self: Arc<Self>,
-        name: RcStr,
-        root_path: PathBuf,
-        report_invalidation_reason: Option<(RcStr, PathBuf)>,
-        invalidation_lock: Arc<RwLock<()>>,
-        invalidator_map: Arc<InvalidatorMap>,
-        dir_invalidator_map: Arc<InvalidatorMap>,
+        &self,
+        inner: Arc<DiskFileSystemInner>,
+        report_invalidation_reason: bool,
         poll_interval: Option<Duration>,
     ) -> Result<()> {
         let mut watcher_guard = self.watcher.lock().unwrap();
@@ -169,7 +162,7 @@ impl DiskWatcher {
         // below will be monitored for changes.
         #[cfg(any(target_os = "macos", target_os = "windows"))]
         {
-            watcher.watch(&root_path, RecursiveMode::Recursive)?;
+            watcher.watch(inner.root_path(), RecursiveMode::Recursive)?;
         }
 
         #[cfg(not(any(target_os = "macos", target_os = "windows")))]
@@ -182,17 +175,17 @@ impl DiskWatcher {
         {
             let _span = tracing::info_span!("invalidate filesystem").entered();
             let span = tracing::Span::current();
-            let invalidator_map = take(&mut *invalidator_map.lock().unwrap());
-            let dir_invalidator_map = take(&mut *dir_invalidator_map.lock().unwrap());
+            let invalidator_map = take(&mut *inner.invalidator_map.lock().unwrap());
+            let dir_invalidator_map = take(&mut *inner.dir_invalidator_map.lock().unwrap());
             let iter = invalidator_map
                 .into_par_iter()
                 .chain(dir_invalidator_map.into_par_iter());
             let handle = tokio::runtime::Handle::current();
-            if report_invalidation_reason.is_some() {
+            if report_invalidation_reason {
                 iter.flat_map(|(path, invalidators)| {
                     let _span = span.clone().entered();
                     let reason = WatchStart {
-                        name: name.clone(),
+                        name: inner.name.clone(),
                         path: path.into(),
                     };
                     invalidators
@@ -221,14 +214,10 @@ impl DiskWatcher {
         drop(watcher_guard);
 
         spawn_thread(move || {
-            self.watch_thread(
-                rx,
-                root_path,
-                report_invalidation_reason,
-                invalidation_lock,
-                invalidator_map,
-                dir_invalidator_map,
-            )
+            inner
+                .clone()
+                .watcher
+                .watch_thread(rx, inner, report_invalidation_reason)
         });
 
         Ok(())
@@ -248,11 +237,8 @@ impl DiskWatcher {
     fn watch_thread(
         &self,
         rx: Receiver<notify::Result<notify::Event>>,
-        root_path: PathBuf,
-        report_invalidation_reason: Option<(RcStr, PathBuf)>,
-        invalidation_lock: Arc<RwLock<()>>,
-        invalidator_map: Arc<InvalidatorMap>,
-        dir_invalidator_map: Arc<InvalidatorMap>,
+        inner: Arc<DiskFileSystemInner>,
+        report_invalidation_reason: bool,
     ) {
         let mut batched_invalidate_path = HashSet::new();
         let mut batched_invalidate_path_dir = HashSet::new();
@@ -377,8 +363,10 @@ impl DiskWatcher {
                         println!("watch error ({:?}): {:?} ", paths, kind);
 
                         if paths.is_empty() {
-                            batched_invalidate_path_and_children.insert(root_path.clone());
-                            batched_invalidate_path_and_children_dir.insert(root_path.clone());
+                            batched_invalidate_path_and_children
+                                .insert(inner.root_path().to_path_buf());
+                            batched_invalidate_path_and_children_dir
+                                .insert(inner.root_path().to_path_buf());
                         } else {
                             batched_invalidate_path_and_children.extend(paths.clone());
                             batched_invalidate_path_and_children_dir.extend(paths.clone());
@@ -413,33 +401,37 @@ impl DiskWatcher {
             #[cfg(not(any(target_os = "macos", target_os = "windows")))]
             {
                 for path in batched_new_paths.drain() {
-                    let _ = self.restore_if_watching(&path, &root_path);
+                    let _ = self.restore_if_watching(&path, inner.root_path());
                 }
             }
 
-            let _lock = invalidation_lock.blocking_write();
+            let _lock = inner.invalidation_lock.blocking_write();
             {
-                let mut invalidator_map = invalidator_map.lock().unwrap();
+                let mut invalidator_map = inner.invalidator_map.lock().unwrap();
                 invalidate_path(
-                    &report_invalidation_reason,
+                    &inner,
+                    report_invalidation_reason,
                     &mut invalidator_map,
                     batched_invalidate_path.drain(),
                 );
                 invalidate_path_and_children_execute(
-                    &report_invalidation_reason,
+                    &inner,
+                    report_invalidation_reason,
                     &mut invalidator_map,
                     batched_invalidate_path_and_children.drain(),
                 );
             }
             {
-                let mut dir_invalidator_map = dir_invalidator_map.lock().unwrap();
+                let mut dir_invalidator_map = inner.dir_invalidator_map.lock().unwrap();
                 invalidate_path(
-                    &report_invalidation_reason,
+                    &inner,
+                    report_invalidation_reason,
                     &mut dir_invalidator_map,
                     batched_invalidate_path_dir.drain(),
                 );
                 invalidate_path_and_children_execute(
-                    &report_invalidation_reason,
+                    &inner,
+                    report_invalidation_reason,
                     &mut dir_invalidator_map,
                     batched_invalidate_path_and_children_dir.drain(),
                 );
@@ -450,12 +442,13 @@ impl DiskWatcher {
 
 #[instrument(parent = None, level = "info", name = "DiskFileSystem file change", skip_all, fields(name = display(path.display())))]
 fn invalidate(
-    report_invalidation_reason: &Option<(RcStr, PathBuf)>,
+    inner: &DiskFileSystemInner,
+    report_invalidation_reason: bool,
     path: &Path,
     invalidator: Invalidator,
 ) {
-    if let Some((name, root_path)) = report_invalidation_reason {
-        if let Some(path) = format_absolute_fs_path(path, name, root_path) {
+    if report_invalidation_reason {
+        if let Some(path) = format_absolute_fs_path(path, &inner.name, inner.root_path()) {
             invalidator.invalidate_with_reason(WatchChange { path });
             return;
         }
@@ -464,7 +457,8 @@ fn invalidate(
 }
 
 fn invalidate_path(
-    report_invalidation_reason: &Option<(RcStr, PathBuf)>,
+    inner: &DiskFileSystemInner,
+    report_invalidation_reason: bool,
     invalidator_map: &mut HashMap<String, HashSet<Invalidator>>,
     paths: impl Iterator<Item = PathBuf>,
 ) {
@@ -473,13 +467,14 @@ fn invalidate_path(
         if let Some(invalidators) = invalidator_map.remove(&key) {
             invalidators
                 .into_iter()
-                .for_each(|i| invalidate(report_invalidation_reason, &path, i));
+                .for_each(|i| invalidate(inner, report_invalidation_reason, &path, i));
         }
     }
 }
 
 fn invalidate_path_and_children_execute(
-    report_invalidation_reason: &Option<(RcStr, PathBuf)>,
+    inner: &DiskFileSystemInner,
+    report_invalidation_reason: bool,
     invalidator_map: &mut HashMap<String, HashSet<Invalidator>>,
     paths: impl Iterator<Item = PathBuf>,
 ) {
@@ -488,7 +483,7 @@ fn invalidate_path_and_children_execute(
         for (_, invalidators) in invalidator_map.extract_if(|key, _| key.starts_with(&path_key)) {
             invalidators
                 .into_iter()
-                .for_each(|i| invalidate(report_invalidation_reason, &path, i));
+                .for_each(|i| invalidate(inner, report_invalidation_reason, &path, i));
         }
     }
 }

--- a/turbopack/crates/turbo-tasks/src/effect.rs
+++ b/turbopack/crates/turbo-tasks/src/effect.rs
@@ -1,15 +1,19 @@
-use std::{borrow::Cow, collections::HashSet, future::Future, panic, pin::Pin};
+use std::{
+    borrow::Cow, collections::HashSet, future::Future, mem::replace, panic, pin::Pin, usize,
+};
 
 use anyhow::{anyhow, Result};
 use auto_hash_map::AutoSet;
 use parking_lot::Mutex;
-use tokio::task::JoinHandle;
 use tracing::{Instrument, Span};
 use turbo_tasks_macros::{TraceRawVcs, ValueDebugFormat};
 
 use crate::{
-    self as turbo_tasks, emit, manager::turbo_tasks_future_scope, CollectiblesSource, ReadRef,
-    TryJoinIterExt, Vc,
+    self as turbo_tasks, emit,
+    event::{Event, EventListener},
+    manager::turbo_tasks_future_scope,
+    util::SharedError,
+    CollectiblesSource, ReadRef, TryJoinIterExt, Vc,
 };
 
 /// A trait to emit a task effect as collectible. This trait only has one
@@ -29,30 +33,98 @@ struct EffectInner {
     span: Span,
 }
 
+enum EffectState {
+    NotStarted(EffectInner),
+    Started(Event),
+    Finished(Result<(), SharedError>),
+}
+
 /// The Effect instance collectible that is emitted for effects.
 #[turbo_tasks::value(serialization = "none", cell = "new", eq = "manual")]
 struct EffectInstance {
     #[turbo_tasks(trace_ignore, debug_ignore)]
-    inner: Mutex<Option<EffectInner>>,
+    inner: Mutex<EffectState>,
 }
 
 impl EffectInstance {
     fn new(future: impl Future<Output = Result<()>> + Send + Sync + 'static) -> Self {
         Self {
-            inner: Mutex::new(Some(EffectInner {
+            inner: Mutex::new(EffectState::NotStarted(EffectInner {
                 future: Box::pin(future),
                 span: Span::current(),
             })),
         }
     }
 
-    fn apply(&self) -> Option<JoinHandle<Result<()>>> {
-        let future = self.inner.lock().take();
-        future.map(|EffectInner { future, span }| {
-            tokio::spawn(
-                turbo_tasks_future_scope(turbo_tasks::turbo_tasks(), future).instrument(span),
-            )
-        })
+    async fn apply(&self) -> Result<()> {
+        loop {
+            enum State {
+                Started(EventListener),
+                NotStarted(EffectInner),
+            }
+            let state = {
+                let mut guard = self.inner.lock();
+                match &*guard {
+                    EffectState::Started(event) => {
+                        let listener = event.listen();
+                        State::Started(listener)
+                    }
+                    EffectState::Finished(result) => {
+                        return result.clone().map_err(Into::into);
+                    }
+                    EffectState::NotStarted(_) => {
+                        let EffectState::NotStarted(inner) = std::mem::replace(
+                            &mut *guard,
+                            EffectState::Started(Event::new(|| "Effect".to_string())),
+                        ) else {
+                            unreachable!();
+                        };
+                        State::NotStarted(inner)
+                    }
+                }
+            };
+            match state {
+                State::Started(listener) => {
+                    listener.await;
+                }
+                State::NotStarted(EffectInner { future, span }) => {
+                    let join_handle = tokio::spawn(
+                        turbo_tasks_future_scope(turbo_tasks::turbo_tasks(), future)
+                            .instrument(span),
+                    );
+                    let result = match join_handle.await {
+                        Ok(Err(err)) => Err(SharedError::new(err)),
+                        Err(err) => {
+                            let any = err.into_panic();
+                            let panic = match any.downcast::<String>() {
+                                Ok(owned) => Some(Cow::Owned(*owned)),
+                                Err(any) => match any.downcast::<&'static str>() {
+                                    Ok(str) => Some(Cow::Borrowed(*str)),
+                                    Err(_) => None,
+                                },
+                            };
+                            Err(SharedError::new(if let Some(panic) = panic {
+                                anyhow!("Task effect panicked: {panic}")
+                            } else {
+                                anyhow!("Task effect panicked")
+                            }))
+                        }
+                        Ok(Ok(())) => Ok(()),
+                    };
+                    let event = {
+                        let mut guard = self.inner.lock();
+                        let EffectState::Started(event) =
+                            replace(&mut *guard, EffectState::Finished(result.clone()))
+                        else {
+                            unreachable!();
+                        };
+                        event
+                    };
+                    event.notify(usize::MAX);
+                    return result.map_err(Into::into);
+                }
+            }
+        }
     }
 }
 
@@ -191,28 +263,11 @@ async fn apply_effect(
     effect: &ReadRef<EffectInstance>,
     first_error: &mut std::result::Result<(), anyhow::Error>,
 ) {
-    if let Some(join_handle) = effect.apply() {
-        match join_handle.await {
-            Ok(Err(err)) if first_error.is_ok() => {
-                *first_error = Err(err);
-            }
-            Err(err) if first_error.is_ok() => {
-                let any = err.into_panic();
-                let panic = match any.downcast::<String>() {
-                    Ok(owned) => Some(Cow::Owned(*owned)),
-                    Err(any) => match any.downcast::<&'static str>() {
-                        Ok(str) => Some(Cow::Borrowed(*str)),
-                        Err(_) => None,
-                    },
-                };
-                *first_error = Err(if let Some(panic) = panic {
-                    anyhow!("Task effect panicked: {panic}")
-                } else {
-                    anyhow!("Task effect panicked")
-                });
-            }
-            _ => {}
+    match effect.apply().await {
+        Err(err) if first_error.is_ok() => {
+            *first_error = Err(err);
         }
+        _ => {}
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/effect.rs
+++ b/turbopack/crates/turbo-tasks/src/effect.rs
@@ -1,6 +1,4 @@
-use std::{
-    borrow::Cow, collections::HashSet, future::Future, mem::replace, panic, pin::Pin, usize,
-};
+use std::{borrow::Cow, collections::HashSet, future::Future, mem::replace, panic, pin::Pin};
 
 use anyhow::{anyhow, Result};
 use auto_hash_map::AutoSet;

--- a/turbopack/crates/turbo-tasks/src/effect.rs
+++ b/turbopack/crates/turbo-tasks/src/effect.rs
@@ -1,0 +1,234 @@
+use std::{borrow::Cow, collections::HashSet, future::Future, panic, pin::Pin};
+
+use anyhow::{anyhow, Result};
+use auto_hash_map::AutoSet;
+use parking_lot::Mutex;
+use tokio::task::JoinHandle;
+use tracing::{Instrument, Span};
+use turbo_tasks_macros::{TraceRawVcs, ValueDebugFormat};
+
+use crate::{
+    self as turbo_tasks, emit, manager::turbo_tasks_future_scope, CollectiblesSource, ReadRef,
+    TryJoinIterExt, Vc,
+};
+
+/// A trait to emit a task effect as collectible. This trait only has one
+/// implementation, `EffectInstance` and no other implementation is allowed.
+/// The trait is private to this module so that no other implementation can be
+/// added.
+#[turbo_tasks::value_trait]
+trait Effect {}
+
+/// A future that represents the effect of a task. The future is executed when
+/// the effect is applied.
+type EffectFuture = Pin<Box<dyn Future<Output = Result<()>> + Send + Sync + 'static>>;
+
+/// The inner state of an effect instance if it has not been applied yet.
+struct EffectInner {
+    future: EffectFuture,
+    span: Span,
+}
+
+/// The Effect instance collectible that is emitted for effects.
+#[turbo_tasks::value(serialization = "none", cell = "new", eq = "manual")]
+struct EffectInstance {
+    #[turbo_tasks(trace_ignore, debug_ignore)]
+    inner: Mutex<Option<EffectInner>>,
+}
+
+impl EffectInstance {
+    fn new(future: impl Future<Output = Result<()>> + Send + Sync + 'static) -> Self {
+        Self {
+            inner: Mutex::new(Some(EffectInner {
+                future: Box::pin(future),
+                span: Span::current(),
+            })),
+        }
+    }
+
+    fn apply(&self) -> Option<JoinHandle<Result<()>>> {
+        let future = self.inner.lock().take();
+        future.map(|EffectInner { future, span }| {
+            tokio::spawn(
+                turbo_tasks_future_scope(turbo_tasks::turbo_tasks(), future).instrument(span),
+            )
+        })
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Effect for EffectInstance {}
+
+/// Schedules an effect to be applied. The passed future is executed once `apply_effects` is called.
+///
+/// The effect will only executed once. The passed future is executed outside of the current task
+/// and can't read any Vcs. These need to be read before. ReadRefs can be passed into the future.
+///
+/// Effects are executed in parallel, so they might need to use async locking to avoid problems.
+/// Order of execution of multiple effects is not defined. You must not use mutliple conflicting
+/// effects to avoid non-deterministic behavior.
+pub fn effect(future: impl Future<Output = Result<()>> + Send + Sync + 'static) {
+    emit::<Box<dyn Effect>>(Vc::upcast(EffectInstance::new(future).cell()));
+}
+
+/// Applies all effects that have been emitted by an operations.
+///
+/// Usually it's important that effects are strongly consistent, so one want to use `apply_effects`
+/// only on operations that have been strongly consistently read before.
+///
+/// The order of execution is not defined and effects are executed in parallel.
+///
+/// `apply_effects` must only be used in a "once" task. When used in a "root" task, a
+/// combination of `get_effects` and `Effects::apply` must be used.
+///
+/// # Example
+///
+/// ```rust
+/// let operation = some_turbo_tasks_function(args);
+/// let result = operation.strongly_consistent().await?;
+/// apply_effects(operation).await?;
+/// ```
+pub async fn apply_effects(source: impl CollectiblesSource) -> Result<()> {
+    let effects: AutoSet<Vc<Box<dyn Effect>>> = source.take_collectibles();
+    if effects.is_empty() {
+        return Ok(());
+    }
+    let span = tracing::info_span!("apply effects", count = effects.len());
+    async move {
+        let mut first_error = anyhow::Ok(());
+        for effect in effects {
+            let Some(effect) = Vc::try_resolve_downcast_type::<EffectInstance>(effect).await?
+            else {
+                panic!("Effect must only be implemented by EffectInstance");
+            };
+            apply_effect(&effect.await?, &mut first_error).await;
+        }
+        first_error
+    }
+    .instrument(span)
+    .await
+}
+
+/// Capture effects from an turbo-tasks operation. Since this captures collectibles it might
+/// invalidate the current task when effects are changing or even temporary change.
+///
+/// Therefore it's important to wrap this in a strongly consistent read before applying the effects
+/// with `Effects::apply`.
+///
+/// # Example
+///
+/// ```rust
+/// async fn some_turbo_tasks_function_with_effects(args: Args) -> Result<ResultWithEffects> {
+///     let operation = some_turbo_tasks_function(args);
+///     let result = operation.strongly_consistent().await?;
+///     let effects = get_effects(operation).await?;
+///     Ok(ResultWithEffects { result, effects })
+/// }
+///
+/// let result_with_effects = some_turbo_tasks_function_with_effects(args).strongly_consistent().await?;
+/// result_with_effects.effects.apply().await?;
+/// ```
+pub async fn get_effects(source: impl CollectiblesSource) -> Result<Effects> {
+    let effects: AutoSet<Vc<Box<dyn Effect>>> = source.take_collectibles();
+    let effects = effects
+        .into_iter()
+        .map(|effect| async move {
+            if let Some(effect) = Vc::try_resolve_downcast_type::<EffectInstance>(effect).await? {
+                Ok(effect.await?)
+            } else {
+                panic!("Effect must only be implemented by EffectInstance");
+            }
+        })
+        .try_join()
+        .await?;
+    Ok(Effects { effects })
+}
+
+/// Captured effects from an operation. This struct can be used to return Effects from a turbo-tasks
+/// function and apply them later.
+#[derive(TraceRawVcs, Default, ValueDebugFormat)]
+pub struct Effects {
+    #[turbo_tasks(trace_ignore, debug_ignore)]
+    effects: Vec<ReadRef<EffectInstance>>,
+}
+
+impl PartialEq for Effects {
+    fn eq(&self, other: &Self) -> bool {
+        if self.effects.len() != other.effects.len() {
+            return false;
+        }
+        let effect_ptrs = self
+            .effects
+            .iter()
+            .map(ReadRef::ptr)
+            .collect::<HashSet<_>>();
+        other
+            .effects
+            .iter()
+            .all(|e| effect_ptrs.contains(&ReadRef::ptr(e)))
+    }
+}
+
+impl Eq for Effects {}
+
+impl Effects {
+    /// Applies all effects that have been captured by this struct.
+    pub async fn apply(&self) -> Result<()> {
+        let span = tracing::info_span!("apply effects", count = self.effects.len());
+        async move {
+            let mut first_error = anyhow::Ok(());
+            for effect in self.effects.iter() {
+                apply_effect(effect, &mut first_error).await;
+            }
+            first_error
+        }
+        .instrument(span)
+        .await
+    }
+}
+
+async fn apply_effect(
+    effect: &ReadRef<EffectInstance>,
+    first_error: &mut std::result::Result<(), anyhow::Error>,
+) {
+    if let Some(join_handle) = effect.apply() {
+        match join_handle.await {
+            Ok(Err(err)) if first_error.is_ok() => {
+                *first_error = Err(err);
+            }
+            Err(err) if first_error.is_ok() => {
+                let any = err.into_panic();
+                let panic = match any.downcast::<String>() {
+                    Ok(owned) => Some(Cow::Owned(*owned)),
+                    Err(any) => match any.downcast::<&'static str>() {
+                        Ok(str) => Some(Cow::Borrowed(*str)),
+                        Err(_) => None,
+                    },
+                };
+                *first_error = Err(if let Some(panic) = panic {
+                    anyhow!("Task effect panicked: {panic}")
+                } else {
+                    anyhow!("Task effect panicked")
+                });
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{apply_effects, get_effects, CollectiblesSource};
+
+    #[test]
+    #[allow(dead_code)]
+    fn is_sync_and_send() {
+        fn assert_sync<T: Sync + Send>(_: T) {}
+        fn check_apply_effects<T: CollectiblesSource + Send + Sync>(t: T) {
+            assert_sync(apply_effects(t));
+        }
+        fn check_get_effects<T: CollectiblesSource + Send + Sync>(t: T) {
+            assert_sync(get_effects(t));
+        }
+    }
+}

--- a/turbopack/crates/turbo-tasks/src/invalidation.rs
+++ b/turbopack/crates/turbo-tasks/src/invalidation.rs
@@ -43,7 +43,7 @@ impl Invalidator {
             turbo_tasks,
             handle,
         } = self;
-        let _ = handle.enter();
+        let _guard = handle.enter();
         if let Some(turbo_tasks) = turbo_tasks.upgrade() {
             turbo_tasks.invalidate(task);
         }
@@ -55,7 +55,7 @@ impl Invalidator {
             turbo_tasks,
             handle,
         } = self;
-        let _ = handle.enter();
+        let _guard = handle.enter();
         if let Some(turbo_tasks) = turbo_tasks.upgrade() {
             turbo_tasks.invalidate_with_reason(
                 task,
@@ -70,7 +70,7 @@ impl Invalidator {
             turbo_tasks,
             handle,
         } = self;
-        let _ = handle.enter();
+        let _guard = handle.enter();
         if let Some(turbo_tasks) = turbo_tasks.upgrade() {
             turbo_tasks
                 .invalidate_with_reason(task, (reason as &'static dyn InvalidationReason).into());

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -43,6 +43,7 @@ mod completion;
 pub mod debug;
 mod display;
 pub mod duration_span;
+mod effect;
 pub mod event;
 pub mod graph;
 mod id;
@@ -85,6 +86,7 @@ use auto_hash_map::AutoSet;
 pub use collectibles::CollectiblesSource;
 pub use completion::{Completion, Completions};
 pub use display::ValueToString;
+pub use effect::{apply_effects, effect, get_effects, Effects};
 pub use id::{
     ExecutionId, FunctionId, LocalTaskId, SessionId, TaskId, TraitTypeId, ValueTypeId,
     TRANSIENT_TASK_BIT,

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1672,6 +1672,13 @@ pub fn turbo_tasks_scope<T>(tt: Arc<dyn TurboTasksApi>, f: impl FnOnce() -> T) -
     TURBO_TASKS.sync_scope(tt, f)
 }
 
+pub fn turbo_tasks_future_scope<T>(
+    tt: Arc<dyn TurboTasksApi>,
+    f: impl Future<Output = T>,
+) -> impl Future<Output = T> {
+    TURBO_TASKS.scope(tt, f)
+}
+
 pub fn with_turbo_tasks_for_testing<T>(
     tt: Arc<dyn TurboTasksApi>,
     current_task: TaskId,

--- a/turbopack/crates/turbo-tasks/src/read_ref.rs
+++ b/turbopack/crates/turbo-tasks/src/read_ref.rs
@@ -234,6 +234,10 @@ impl<T> ReadRef<T> {
     pub fn ptr_eq(&self, other: &ReadRef<T>) -> bool {
         triomphe::Arc::ptr_eq(&self.0, &other.0)
     }
+
+    pub fn ptr(&self) -> *const T {
+        &*self.0 as *const T
+    }
 }
 
 impl<T> ReadRef<T>

--- a/turbopack/crates/turbo-tasks/src/serialization_invalidation.rs
+++ b/turbopack/crates/turbo-tasks/src/serialization_invalidation.rs
@@ -36,7 +36,7 @@ impl SerializationInvalidator {
             turbo_tasks,
             handle,
         } = self;
-        let _ = handle.enter();
+        let _guard = handle.enter();
         if let Some(turbo_tasks) = turbo_tasks.upgrade() {
             turbo_tasks.invalidate_serialization(*task);
         }

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -8,7 +8,8 @@ use std::{
 use anyhow::{bail, Context, Result};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    ReadConsistency, ResolvedVc, TransientInstance, TryJoinIterExt, TurboTasks, Value, Vc,
+    apply_effects, ReadConsistency, ResolvedVc, TransientInstance, TryJoinIterExt, TurboTasks,
+    Value, Vc,
 };
 use turbo_tasks_fs::FileSystem;
 use turbo_tasks_memory::MemoryBackend;
@@ -128,7 +129,9 @@ impl TurbopackBuildBuilder {
             );
 
             // Await the result to propagate any errors.
-            build_result.await?;
+            build_result.strongly_consistent().await?;
+
+            apply_effects(build_result).await?;
 
             let issue_reporter: Vc<Box<dyn IssueReporter>> =
                 Vc::upcast(ConsoleUi::new(TransientInstance::new(LogOptions {

--- a/turbopack/crates/turbopack-core/src/asset.rs
+++ b/turbopack/crates/turbopack-core/src/asset.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Completion, ResolvedVc, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{
     FileContent, FileJsonContent, FileLinesContent, FileSystemPath, LinkContent, LinkType,
 };
@@ -86,17 +86,22 @@ impl AssetContent {
     }
 
     #[turbo_tasks::function]
-    pub async fn write(self: Vc<Self>, path: Vc<FileSystemPath>) -> Result<Vc<Completion>> {
+    pub async fn write(self: Vc<Self>, path: Vc<FileSystemPath>) -> Result<()> {
         let this = self.await?;
-        Ok(match &*this {
-            AssetContent::File(file) => path.write(**file),
-            AssetContent::Redirect { target, link_type } => path.write_link(
-                LinkContent::Link {
-                    target: target.clone(),
-                    link_type: *link_type,
-                }
-                .cell(),
-            ),
-        })
+        match &*this {
+            AssetContent::File(file) => {
+                let _ = path.write(**file);
+            }
+            AssetContent::Redirect { target, link_type } => {
+                let _ = path.write_link(
+                    LinkContent::Link {
+                        target: target.clone(),
+                        link_type: *link_type,
+                    }
+                    .cell(),
+                );
+            }
+        }
+        Ok(())
     }
 }

--- a/turbopack/crates/turbopack-core/src/code_builder.rs
+++ b/turbopack/crates/turbopack-core/src/code_builder.rs
@@ -251,7 +251,7 @@ pub async fn fileify_source_map(
         .await?
         .context("Expected the chunking context to have a DiskFileSystem")?
         .await?;
-    let prefix = format!("{}[{}]/", SOURCE_MAP_PREFIX, context_fs.name);
+    let prefix = format!("{}[{}]/", SOURCE_MAP_PREFIX, context_fs.name());
 
     let mut transformed = flattened.into_owned();
     let mut updates = IndexMap::new();

--- a/turbopack/crates/turbopack-core/src/server_fs.rs
+++ b/turbopack/crates/turbopack-core/src/server_fs.rs
@@ -39,20 +39,12 @@ impl FileSystem for ServerFileSystem {
     }
 
     #[turbo_tasks::function]
-    fn write(
-        &self,
-        _fs_path: Vc<FileSystemPath>,
-        _content: Vc<FileContent>,
-    ) -> Result<Vc<Completion>> {
+    fn write(&self, _fs_path: Vc<FileSystemPath>, _content: Vc<FileContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible to the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]
-    fn write_link(
-        &self,
-        _fs_path: Vc<FileSystemPath>,
-        _target: Vc<LinkContent>,
-    ) -> Result<Vc<Completion>> {
+    fn write_link(&self, _fs_path: Vc<FileSystemPath>, _target: Vc<LinkContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible to the marker filesystem for the server")
     }
 

--- a/turbopack/crates/turbopack-dev-server/src/http.rs
+++ b/turbopack/crates/turbopack-dev-server/src/http.rs
@@ -10,7 +10,9 @@ use hyper::{
 };
 use mime::Mime;
 use tokio_util::io::{ReaderStream, StreamReader};
-use turbo_tasks::{util::SharedError, CollectiblesSource, ReadRef, TransientInstance, Vc};
+use turbo_tasks::{
+    apply_effects, util::SharedError, CollectiblesSource, ReadRef, TransientInstance, Vc,
+};
 use turbo_tasks_bytes::Bytes;
 use turbo_tasks_fs::FileContent;
 use turbopack_core::{
@@ -80,6 +82,7 @@ pub async fn process_request_with_content_source(
     let request = http_request_to_source_request(request).await?;
     let result = get_from_source(source, TransientInstance::new(request));
     let resolved_result = result.resolve_strongly_consistent().await?;
+    apply_effects(result).await?;
     let side_effects: AutoSet<Vc<Box<dyn ContentSourceSideEffect>>> = result.peek_collectibles();
     handle_issues(
         result,

--- a/turbopack/crates/turbopack-dev-server/src/lib.rs
+++ b/turbopack/crates/turbopack-dev-server/src/lib.rs
@@ -33,7 +33,8 @@ use socket2::{Domain, Protocol, Socket, Type};
 use tokio::task::JoinHandle;
 use tracing::{event, info_span, Instrument, Level, Span};
 use turbo_tasks::{
-    run_once_with_reason, trace::TraceRawVcs, util::FormatDuration, TurboTasksApi, Vc,
+    apply_effects, run_once_with_reason, trace::TraceRawVcs, util::FormatDuration, TurboTasksApi,
+    Vc,
 };
 use turbopack_core::{
     error::PrettyPrintError,
@@ -211,6 +212,7 @@ impl DevServerBuilder {
                             let path = uri.path().to_string();
                             let source = source_provider.get_source();
                             let resolved_source = source.resolve_strongly_consistent().await?;
+                            apply_effects(source).await?;
                             handle_issues(
                                 source,
                                 issue_reporter,

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -161,8 +161,8 @@ async fn emit_evaluate_pool_assets(
     );
 
     let output_root = chunking_context.output_root().to_resolved().await?;
-    let _ = emit_package_json(*output_root);
-    let _ = emit(bootstrap, *output_root);
+    let _ = emit_package_json(*output_root).resolve().await?;
+    let _ = emit(bootstrap, *output_root).resolve().await?;
 
     Ok(EmittedEvaluatePoolAssets {
         bootstrap: bootstrap.to_resolved().await?,

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -44,7 +44,11 @@ async fn emit(
     intermediate_output_path: Vc<FileSystemPath>,
 ) -> Result<()> {
     for asset in internal_assets(intermediate_asset, intermediate_output_path).await? {
-        let _ = asset.content().write(asset.ident().path());
+        let _ = asset
+            .content()
+            .write(asset.ident().path())
+            .resolve()
+            .await?;
     }
     Ok(())
 }
@@ -215,7 +219,7 @@ pub async fn get_renderer_pool(
 ) -> Result<Vc<NodeJsPool>> {
     emit_package_json(intermediate_output_path).await?;
 
-    let _ = emit(intermediate_asset, *output_root);
+    let _ = emit(intermediate_asset, *output_root).resolve().await?;
     let assets_for_source_mapping =
         internal_assets_for_source_mapping(intermediate_asset, *output_root);
 

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -11,12 +11,13 @@ pub use node_entry::{NodeEntry, NodeRenderingEntries, NodeRenderingEntry};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     graph::{AdjacencyMap, GraphTraversal},
-    Completion, Completions, FxIndexSet, ResolvedVc, TryJoinIterExt, ValueToString, Vc,
+    FxIndexSet, ResolvedVc, TryJoinIterExt, ValueToString, Vc,
 };
 use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::{to_sys_path, File, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
+    changed::content_changed,
     chunk::{ChunkingContext, ChunkingContextExt, EvaluatableAssets},
     module::Module,
     output::{OutputAsset, OutputAssets, OutputAssetsSet},
@@ -41,16 +42,11 @@ pub mod transforms;
 async fn emit(
     intermediate_asset: Vc<Box<dyn OutputAsset>>,
     intermediate_output_path: Vc<FileSystemPath>,
-) -> Result<Vc<Completion>> {
-    Ok(Vc::<Completions>::cell(
-        internal_assets(intermediate_asset, intermediate_output_path)
-            .strongly_consistent()
-            .await?
-            .iter()
-            .map(|a| a.content().write(a.ident().path()))
-            .collect(),
-    )
-    .completed())
+) -> Result<()> {
+    for asset in internal_assets(intermediate_asset, intermediate_output_path).await? {
+        let _ = asset.content().write(asset.ident().path());
+    }
+    Ok(())
 }
 
 /// List of the all assets of the "internal" subgraph and a list of boundary
@@ -196,7 +192,7 @@ async fn separate_assets(
 /// Emit a basic package.json that sets the type of the package to commonjs.
 /// Currently code generated for Node is CommonJS, while authored code may be
 /// ESM, for example.
-fn emit_package_json(dir: Vc<FileSystemPath>) -> Vc<Completion> {
+fn emit_package_json(dir: Vc<FileSystemPath>) -> Vc<()> {
     emit(
         Vc::upcast(VirtualOutputAsset::new(
             dir.join("package.json".into()),
@@ -219,7 +215,7 @@ pub async fn get_renderer_pool(
 ) -> Result<Vc<NodeJsPool>> {
     emit_package_json(intermediate_output_path).await?;
 
-    let emit = emit(intermediate_asset, *output_root);
+    let _ = emit(intermediate_asset, *output_root);
     let assets_for_source_mapping =
         internal_assets_for_source_mapping(intermediate_asset, *output_root);
 
@@ -237,8 +233,9 @@ pub async fn get_renderer_pool(
             entrypoint.to_string().await?
         );
     };
+    // Invalidate pool when code content changes
+    content_changed(Vc::upcast(intermediate_asset)).await?;
 
-    emit.await?;
     Ok(NodeJsPool::new(
         cwd,
         entrypoint,

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -12,7 +12,7 @@ use dunce::canonicalize;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    debug::ValueDebugFormat, fxindexmap, trace::TraceRawVcs, Completion, ResolvedVc,
+    apply_effects, debug::ValueDebugFormat, fxindexmap, trace::TraceRawVcs, Completion, ResolvedVc,
     TryJoinIterExt, TurboTasks, Value, Vc,
 };
 use turbo_tasks_bytes::stream::SingleValue;
@@ -66,6 +66,8 @@ struct JsResult {
     jest_result: JestRunResult,
 }
 
+#[turbo_tasks::value]
+#[derive(Copy, Clone, Debug, Hash)]
 enum IssueSnapshotMode {
     Snapshots,
     NoSnapshots,
@@ -168,16 +170,27 @@ async fn run(resource: PathBuf, snapshot_mode: IssueSnapshotMode) -> Result<JsRe
 
     let tt = TurboTasks::new(MemoryBackend::default());
     tt.run_once(async move {
-        let resource_str = resource.to_str().unwrap();
-        let prepared_test = prepare_test(resource_str.into());
-        let run_result = run_test(prepared_test);
-        if matches!(snapshot_mode, IssueSnapshotMode::Snapshots) {
-            snapshot_issues(prepared_test, run_result).await?;
-        }
+        let emit = run_inner(resource.to_str().unwrap().into(), Value::new(snapshot_mode));
+        let result = emit.strongly_consistent().await?;
+        apply_effects(emit).await?;
 
-        Ok((*run_result.await.unwrap().js_result.await.unwrap()).clone())
+        Ok(result.clone_value())
     })
     .await
+}
+
+#[turbo_tasks::function]
+async fn run_inner(
+    resource: RcStr,
+    snapshot_mode: Value<IssueSnapshotMode>,
+) -> Result<Vc<JsResult>> {
+    let prepared_test = prepare_test(resource);
+    let run_result = run_test(prepared_test);
+    if *snapshot_mode == IssueSnapshotMode::Snapshots {
+        snapshot_issues(prepared_test, run_result).await?;
+    }
+
+    Ok(*run_result.await?.js_result)
 }
 
 #[derive(PartialEq, Eq, Debug, Default, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat)]

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -15,7 +15,8 @@ use serde::Deserialize;
 use serde_json::json;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    ReadConsistency, ReadRef, ResolvedVc, TryJoinIterExt, TurboTasks, Value, ValueToString, Vc,
+    apply_effects, ReadConsistency, ReadRef, ResolvedVc, TryJoinIterExt, TurboTasks, Value,
+    ValueToString, Vc,
 };
 use turbo_tasks_env::DotenvProcessEnv;
 use turbo_tasks_fs::{
@@ -156,23 +157,33 @@ async fn run(resource: PathBuf) -> Result<()> {
 
     let tt = TurboTasks::new(MemoryBackend::default());
     let task = tt.spawn_once_task(async move {
-        let out = run_test(resource.to_str().unwrap().into());
-        let _ = out.resolve_strongly_consistent().await?;
-        let captured_issues = out.peek_issues_with_path().await?;
+        let emit = run_inner(resource.to_str().unwrap().into());
+        emit.strongly_consistent().await?;
+        apply_effects(emit).await?;
 
-        let plain_issues = captured_issues
-            .iter_with_shortest_path()
-            .map(|(issue_vc, path)| async move { issue_vc.into_plain(path).await })
-            .try_join()
-            .await?;
-
-        snapshot_issues(plain_issues, out.join("issues".into()), &REPO_ROOT)
-            .await
-            .context("Unable to handle issues")?;
         Ok(Vc::<()>::default())
     });
     tt.wait_task_completion(task, ReadConsistency::Strong)
         .await?;
+
+    Ok(())
+}
+
+#[turbo_tasks::function]
+async fn run_inner(resource: RcStr) -> Result<()> {
+    let out = run_test(resource);
+    let _ = out.resolve_strongly_consistent().await?;
+    let captured_issues = out.peek_issues_with_path().await?;
+
+    let plain_issues = captured_issues
+        .iter_with_shortest_path()
+        .map(|(issue_vc, path)| async move { issue_vc.into_plain(path).await })
+        .try_join()
+        .await?;
+
+    snapshot_issues(plain_issues, out.join("issues".into()), &REPO_ROOT)
+        .await
+        .context("Unable to handle issues")?;
 
     Ok(())
 }

--- a/turbopack/crates/turbopack/benches/node_file_trace.rs
+++ b/turbopack/crates/turbopack/benches/node_file_trace.rs
@@ -3,7 +3,7 @@ use std::{fs, path::PathBuf};
 use criterion::{Bencher, BenchmarkId, Criterion};
 use regex::Regex;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ReadConsistency, TurboTasks, Value, Vc};
+use turbo_tasks::{apply_effects, ReadConsistency, TurboTasks, Value, Vc};
 use turbo_tasks_fs::{DiskFileSystem, FileSystem, NullFileSystem};
 use turbo_tasks_memory::MemoryBackend;
 use turbopack::{
@@ -117,7 +117,9 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
                     .module();
                 let rebased = RebasedAsset::new(Vc::upcast(module), input_dir, output_dir);
 
-                emit_with_completion(Vc::upcast(rebased), output_dir).await?;
+                let emit = emit_with_completion(Vc::upcast(rebased), output_dir);
+                emit.strongly_consistent().await?;
+                apply_effects(emit).await?;
 
                 Ok::<Vc<()>, _>(Default::default())
             });

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -30,7 +30,7 @@ use graph::{aggregate, AggregatedGraph, AggregatedGraphNodeContent};
 use module_options::{ModuleOptions, ModuleOptionsContext, ModuleRuleEffect, ModuleType};
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Completion, ResolvedVc, Value, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
 use turbo_tasks_fs::{glob::Glob, FileSystemPath};
 pub use turbopack_core::condition;
 use turbopack_core::{
@@ -904,54 +904,49 @@ impl AssetContext for ModuleAssetContext {
 }
 
 #[turbo_tasks::function]
-pub fn emit_with_completion(
-    asset: Vc<Box<dyn OutputAsset>>,
-    output_dir: Vc<FileSystemPath>,
-) -> Vc<Completion> {
-    emit_assets_aggregated(asset, output_dir)
+pub fn emit_with_completion(asset: Vc<Box<dyn OutputAsset>>, output_dir: Vc<FileSystemPath>) {
+    let _ = emit_assets_aggregated(asset, output_dir);
 }
 
 #[turbo_tasks::function]
-fn emit_assets_aggregated(
-    asset: Vc<Box<dyn OutputAsset>>,
-    output_dir: Vc<FileSystemPath>,
-) -> Vc<Completion> {
+fn emit_assets_aggregated(asset: Vc<Box<dyn OutputAsset>>, output_dir: Vc<FileSystemPath>) {
     let aggregated = aggregate(asset);
-    emit_aggregated_assets(aggregated, output_dir)
+    let _ = emit_aggregated_assets(aggregated, output_dir);
 }
 
 #[turbo_tasks::function]
 async fn emit_aggregated_assets(
     aggregated: Vc<AggregatedGraph>,
     output_dir: Vc<FileSystemPath>,
-) -> Result<Vc<Completion>> {
-    Ok(match &*aggregated.content().await? {
-        AggregatedGraphNodeContent::Asset(asset) => emit_asset_into_dir(**asset, output_dir),
+) -> Result<()> {
+    match &*aggregated.content().await? {
+        AggregatedGraphNodeContent::Asset(asset) => {
+            let _ = emit_asset_into_dir(**asset, output_dir);
+        }
         AggregatedGraphNodeContent::Children(children) => {
             for aggregated in children {
-                emit_aggregated_assets(**aggregated, output_dir).await?;
+                let _ = emit_aggregated_assets(**aggregated, output_dir);
             }
-            Completion::new()
         }
-    })
+    }
+    Ok(())
 }
 
 #[turbo_tasks::function]
-pub fn emit_asset(asset: Vc<Box<dyn OutputAsset>>) -> Vc<Completion> {
-    asset.content().write(asset.ident().path())
+pub fn emit_asset(asset: Vc<Box<dyn OutputAsset>>) {
+    let _ = asset.content().write(asset.ident().path());
 }
 
 #[turbo_tasks::function]
 pub async fn emit_asset_into_dir(
     asset: Vc<Box<dyn OutputAsset>>,
     output_dir: Vc<FileSystemPath>,
-) -> Result<Vc<Completion>> {
+) -> Result<()> {
     let dir = &*output_dir.await?;
-    Ok(if asset.ident().path().await?.is_inside_ref(dir) {
-        emit_asset(asset)
-    } else {
-        Completion::new()
-    })
+    if asset.ident().path().await?.is_inside_ref(dir) {
+        let _ = emit_asset(asset);
+    }
+    Ok(())
 }
 
 type OutputAssetSet = HashSet<Vc<Box<dyn OutputAsset>>>;

--- a/turbopack/crates/turbopack/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack/tests/node-file-trace.rs
@@ -30,7 +30,9 @@ use rstest_reuse::{
 use serde::{Deserialize, Serialize};
 use tokio::{process::Command, time::timeout};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{backend::Backend, ReadRef, ResolvedVc, TurboTasks, Value, ValueToString, Vc};
+use turbo_tasks::{
+    apply_effects, backend::Backend, ReadRef, ResolvedVc, TurboTasks, Value, ValueToString, Vc,
+};
 use turbo_tasks_fs::{DiskFileSystem, FileSystem, FileSystemPath};
 use turbo_tasks_memory::MemoryBackend;
 use turbopack::{
@@ -464,7 +466,9 @@ fn node_file_trace<B: Backend + 'static>(
 
                 print_graph(ResolvedVc::upcast(rebased)).await?;
 
-                emit_with_completion(*ResolvedVc::upcast(rebased), output_dir).await?;
+                let emit = emit_with_completion(*ResolvedVc::upcast(rebased), output_dir);
+                emit.strongly_consistent().await?;
+                apply_effects(emit).await?;
 
                 #[cfg(not(feature = "bench_against_node_nft"))]
                 {
@@ -659,10 +663,12 @@ fn clean_stderr(str: &str) -> String {
     lazy_static! {
         static ref EXPERIMENTAL_WARNING: Regex =
             Regex::new(r"\(node:\d+\) ExperimentalWarning:").unwrap();
+        static ref DEPRECATION_WARNING: Regex =
+            Regex::new(r"\(node:\d+\) \[DEP\d+] DeprecationWarning:").unwrap();
     }
-    EXPERIMENTAL_WARNING
-        .replace_all(str, "(node:XXXX) ExperimentalWarning:")
-        .to_string()
+    let str = EXPERIMENTAL_WARNING.replace_all(str, "(node:XXXX) ExperimentalWarning:");
+    let str = DEPRECATION_WARNING.replace_all(&str, "(node:XXXX) [DEPXXXX] DeprecationWarning:");
+    str.to_string()
 }
 
 fn diff(expected: &str, actual: &str) -> String {


### PR DESCRIPTION
Reverting the revert https://github.com/vercel/next.js/pull/73287 

see https://github.com/vercel/next.js/pull/72847

---

Quoting from the tokio::fs::File documentation:

> A file will not be closed immediately when it goes out of scope if there are any IO operations that have not yet completed. To ensure that a file is closed immediately when it is dropped, you should call flush before dropping it.

So that means we will return from write_to_disk before files are fully written. That was a bug before, but since with effects the write calls are executed much later. The manifest files are read directly after write_to_disk returns, so they are most likely to fail.

So adding `flush` to fix that.

---

Another bug with the effects implementation is that only the first `apply_effects` call waits for the effect execution to complete. If there are concurrent `apply_effects` on the same effects, the later one would return immediately.

Added some logic to handle that.

Closes PACK-3578