### PR TITLE
chore(turbo-tasks): Add a lint for `Vc<T>` in turbo-tasks types

### DIFF
--- a/.config/ast-grep/rules/resolved-vc.yml
+++ b/.config/ast-grep/rules/resolved-vc.yml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: no-vc-struct
+message: Don't use a Vc directly in a struct
+note: 'Prefer using ResolvedVc, or add a `// no-resolved-vc(<AUTHOR>): <REASON>` comment'
+severity: warning
+language: rust
+
+rule:
+  pattern:
+    context: 'let x: Vc<$A> = 1;'
+    selector: generic_type
+  inside:
+    stopBy: end
+    kind: field_declaration
+    not:
+      follows:
+        kind: line_comment
+        regex: \s*//\s*no-resolved-vc\((.+)\):.+
+    inside:
+      inside:
+        any:
+          - kind: struct_item
+            follows:
+              stopBy:
+                not:
+                  kind: attribute_item
+              kind: attribute_item
+              has:
+                kind: attribute
+                regex: '^turbo_tasks::value(\(.*\))?$'
+          - inside:
+              kind: enum_variant_list
+              inside:
+                follows:
+                  stopBy:
+                    not:
+                      kind: attribute_item
+                  kind: attribute_item
+                  has:
+                    kind: attribute
+                    regex: '^turbo_tasks::value(\(.*\))?$'
+fix: ResolvedVc<$A>

--- a/.config/ast-grep/rules/resolved-vc.yml
+++ b/.config/ast-grep/rules/resolved-vc.yml
@@ -12,7 +12,6 @@ rule:
     selector: generic_type
   inside:
     stopBy: end
-    kind: field_declaration
     not:
       follows:
         kind: line_comment

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -36,6 +36,7 @@ pub struct ResolvedVc<T>
 where
     T: ?Sized,
 {
+    // no-resolved-vc(kdy1): This is a resolved Vc, so we don't need to resolve it again
     pub(crate) node: Vc<T>,
 }
 


### PR DESCRIPTION
### What?

Add a lint for `Vc<T>` in structs or enums with `#[turbo_tasks::value]`.

### Why?

We need to change them to `ResolvedVc<T>` so I'm adding a lint to check make it easier.

### How?

I asked a question of `ast-grep` discord. 

- https://discord.com/channels/1107749847722889217/1113524796316200980/1311549077275676753

Closes PACK-3571