### PR TITLE
next-api: `ResolvedVc<T>`

### DIFF
--- a/.config/ast-grep/rules/resolved-vc.yml
+++ b/.config/ast-grep/rules/resolved-vc.yml
@@ -18,10 +18,26 @@ rule:
         kind: line_comment
         regex: \s*//\s*no-resolved-vc\((.+)\):.+
     inside:
-      stopBy: end
-      follows:
-        kind: attribute_item
-        has:
-          kind: attribute
-          regex: '^turbo_tasks::value(\(.*\))?$'
+      inside:
+        any:
+          - kind: struct_item
+            follows:
+              stopBy:
+                not:
+                  kind: attribute_item
+              kind: attribute_item
+              has:
+                kind: attribute
+                regex: '^turbo_tasks::value(\(.*\))?$'
+          - inside:
+              kind: enum_variant_list
+              inside:
+                follows:
+                  stopBy:
+                    not:
+                      kind: attribute_item
+                  kind: attribute_item
+                  has:
+                    kind: attribute
+                    regex: '^turbo_tasks::value(\(.*\))?$'
 fix: ResolvedVc<$A>

--- a/.config/ast-grep/rules/resolved-vc.yml
+++ b/.config/ast-grep/rules/resolved-vc.yml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: no-vc-struct
+message: Don't use a Vc directly in a struct
+note: 'Prefer using ResolvedVc, or add a `// no-resolved-vc(<AUTHOR>): <REASON>` comment'
+severity: warning
+language: rust
+
+rule:
+  pattern:
+    context: 'let x: Vc<$A> = 1;'
+    selector: generic_type
+  inside:
+    stopBy: end
+    follows:
+      kind: attribute_item
+      has:
+        kind: attribute
+        regex: '^turbo_tasks::value$'
+fix: ResolvedVc<$A>

--- a/.config/ast-grep/rules/resolved-vc.yml
+++ b/.config/ast-grep/rules/resolved-vc.yml
@@ -12,9 +12,16 @@ rule:
     selector: generic_type
   inside:
     stopBy: end
-    follows:
-      kind: attribute_item
-      has:
-        kind: attribute
-        regex: '^turbo_tasks::value$'
+    kind: field_declaration
+    not:
+      follows:
+        kind: line_comment
+        regex: \s*//\s*no-resolved-vc\((.+)\):.+
+    inside:
+      stopBy: end
+      follows:
+        kind: attribute_item
+        has:
+          kind: attribute
+          regex: '^turbo_tasks::value$'
 fix: ResolvedVc<$A>

--- a/.config/ast-grep/rules/resolved-vc.yml
+++ b/.config/ast-grep/rules/resolved-vc.yml
@@ -23,5 +23,5 @@ rule:
         kind: attribute_item
         has:
           kind: attribute
-          regex: '^turbo_tasks::value$'
+          regex: '^turbo_tasks::value(\(.*\))?$'
 fix: ResolvedVc<$A>

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -581,7 +581,7 @@ impl NapiMiddleware {
         Ok(NapiMiddleware {
             endpoint: External::new(ExternalEndpoint(VcArc::new(
                 turbo_tasks.clone(),
-                value.endpoint,
+                *value.endpoint,
             ))),
         })
     }
@@ -598,11 +598,11 @@ impl NapiInstrumentation {
         Ok(NapiInstrumentation {
             node_js: External::new(ExternalEndpoint(VcArc::new(
                 turbo_tasks.clone(),
-                value.node_js,
+                *value.node_js,
             ))),
             edge: External::new(ExternalEndpoint(VcArc::new(
                 turbo_tasks.clone(),
-                value.edge,
+                *value.edge,
             ))),
         })
     }

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -172,7 +172,7 @@ pub(crate) async fn collect_next_dynamic_imports(
                     .await?
                     .into_iter(),
                 NextDynamicVisit {
-                    client_asset_context: client_asset_context.resolve().await?,
+                    client_asset_context: client_asset_context.to_resolved().await?,
                 },
             )
             .await
@@ -275,7 +275,7 @@ impl turbo_tasks::graph::Visit<NextDynamicVisitEntry> for NextDynamicVisit {
         };
         let client_asset_context = self.client_asset_context;
         async move {
-            Ok(get_next_dynamic_edges(client_asset_context, *module)
+            Ok(get_next_dynamic_edges(*client_asset_context, *module)
                 .await?
                 .into_iter()
                 .cloned())

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -254,7 +254,7 @@ async fn get_next_dynamic_edges(
 }
 
 struct NextDynamicVisit {
-    client_asset_context: Vc<Box<dyn AssetContext>>,
+    client_asset_context: ResolvedVc<Box<dyn AssetContext>>,
 }
 
 impl turbo_tasks::graph::Visit<NextDynamicVisitEntry> for NextDynamicVisit {

--- a/crates/next-api/src/global_module_id_strategy.rs
+++ b/crates/next-api/src/global_module_id_strategy.rs
@@ -31,14 +31,14 @@ impl GlobalModuleIdStrategyBuilder {
         preprocessed_module_ids.push(preprocess_module_ids(*entrypoints.pages_document_endpoint));
 
         if let Some(middleware) = &entrypoints.middleware {
-            preprocessed_module_ids.push(preprocess_module_ids(middleware.endpoint));
+            preprocessed_module_ids.push(preprocess_module_ids(*middleware.endpoint));
         }
 
         if let Some(instrumentation) = &entrypoints.instrumentation {
             let node_js = instrumentation.node_js;
             let edge = instrumentation.edge;
-            preprocessed_module_ids.push(preprocess_module_ids(node_js));
-            preprocessed_module_ids.push(preprocess_module_ids(edge));
+            preprocessed_module_ids.push(preprocess_module_ids(*node_js));
+            preprocessed_module_ids.push(preprocess_module_ids(*edge));
         }
 
         for (_, route) in entrypoints.routes.iter() {

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -508,22 +508,22 @@ impl Issue for ConflictIssue {
 
     #[turbo_tasks::function]
     fn severity(&self) -> Vc<IssueSeverity> {
-        self.severity
+        *self.severity
     }
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        self.path
+        *self.path
     }
 
     #[turbo_tasks::function]
     fn title(&self) -> Vc<StyledString> {
-        self.title
+        *self.title
     }
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(self.description))
+        Vc::cell(Some(*self.description))
     }
 }
 
@@ -879,20 +879,20 @@ impl Project {
             match routes.entry(pathname.clone()) {
                 Entry::Occupied(mut entry) => {
                     ConflictIssue {
-                        path: self.project_path(),
+                        path: self.project_path().to_resolved().await?,
                         title: StyledString::Text(
                             format!("App Router and Pages Router both match path: {}", pathname)
                                 .into(),
                         )
-                        .cell(),
+                        .resolved_cell(),
                         description: StyledString::Text(
                             "Next.js does not support having both App Router and Pages Router \
                              routes matching the same path. Please remove one of the conflicting \
                              routes."
                                 .into(),
                         )
-                        .cell(),
-                        severity: IssueSeverity::Error.cell(),
+                        .resolved_cell(),
+                        severity: IssueSeverity::Error.resolved_cell(),
                     }
                     .cell()
                     .emit();

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -184,13 +184,13 @@ pub struct DefineEnv {
 
 #[derive(Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, ValueDebugFormat)]
 pub struct Middleware {
-    pub endpoint: Vc<Box<dyn Endpoint>>,
+    pub endpoint: ResolvedVc<Box<dyn Endpoint>>,
 }
 
 #[derive(Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, ValueDebugFormat)]
 pub struct Instrumentation {
-    pub node_js: Vc<Box<dyn Endpoint>>,
-    pub edge: Vc<Box<dyn Endpoint>>,
+    pub node_js: ResolvedVc<Box<dyn Endpoint>>,
+    pub edge: ResolvedVc<Box<dyn Endpoint>>,
 }
 
 #[turbo_tasks::value]
@@ -493,10 +493,10 @@ impl ProjectDefineEnv {
 
 #[turbo_tasks::value(shared)]
 struct ConflictIssue {
-    path: Vc<FileSystemPath>,
-    title: Vc<StyledString>,
-    description: Vc<StyledString>,
-    severity: Vc<IssueSeverity>,
+    path: ResolvedVc<FileSystemPath>,
+    title: ResolvedVc<StyledString>,
+    description: ResolvedVc<StyledString>,
+    severity: ResolvedVc<IssueSeverity>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -915,7 +915,7 @@ impl Project {
         let middleware = self.find_middleware();
         let middleware = if let FindContextFileResult::Found(..) = *middleware.await? {
             Some(Middleware {
-                endpoint: self.middleware_endpoint(),
+                endpoint: self.middleware_endpoint().to_resolved().await?,
             })
         } else {
             None
@@ -924,8 +924,8 @@ impl Project {
         let instrumentation = self.find_instrumentation();
         let instrumentation = if let FindContextFileResult::Found(..) = *instrumentation.await? {
             Some(Instrumentation {
-                node_js: self.instrumentation_endpoint(false),
-                edge: self.instrumentation_endpoint(true),
+                node_js: self.instrumentation_endpoint(false).to_resolved().await?,
+                edge: self.instrumentation_endpoint(true).to_resolved().await?,
             })
         } else {
             None

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -30,16 +30,16 @@ impl AppPageRoute {
 #[derive(Clone, Debug)]
 pub enum Route {
     Page {
-        html_endpoint: Vc<Box<dyn Endpoint>>,
-        data_endpoint: Vc<Box<dyn Endpoint>>,
+        html_endpoint: ResolvedVc<Box<dyn Endpoint>>,
+        data_endpoint: ResolvedVc<Box<dyn Endpoint>>,
     },
     PageApi {
-        endpoint: Vc<Box<dyn Endpoint>>,
+        endpoint: ResolvedVc<Box<dyn Endpoint>>,
     },
     AppPage(Vec<AppPageRoute>),
     AppRoute {
         original_name: String,
-        endpoint: Vc<Box<dyn Endpoint>>,
+        endpoint: ResolvedVc<Box<dyn Endpoint>>,
     },
     Conflict,
 }

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -36,6 +36,7 @@ pub struct ResolvedVc<T>
 where
     T: ?Sized,
 {
+    // no-resolved-vc(kdy1): This is a resolved Vc, so we don't need to resolve it again
     pub(crate) node: Vc<T>,
 }
 


### PR DESCRIPTION
### What?

Use `ResolvedVc<T>` for `Vc<T>` for remaining fields.

### Why?

### How?



Closes PACK-3570