### PR TITLE
refactor(turbopack): Use `ResolvedVc<T>` for struct fields in `turbopack-css`

### DIFF
--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -654,8 +654,8 @@ struct ParsingIssue {
 #[turbo_tasks::value_impl]
 impl Issue for ParsingIssue {
     #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.file
+    fn file_path(&self) -> ResolvedVc<FileSystemPath> {
+        *self.file
     }
 
     #[turbo_tasks::function]
@@ -670,7 +670,7 @@ impl Issue for ParsingIssue {
 
     #[turbo_tasks::function]
     fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(self.source.map(|s| s.resolve_source_map(self.file)))
+        Vc::cell(self.source.map(|s| s.resolve_source_map(*self.file)))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -399,7 +399,10 @@ async fn process_content(
                     }
                 }
 
-                for err in warnings.read().unwrap().iter() {
+                // We need to collect here because we need to avoid holding the lock while calling
+                // `.await` in the loop.
+                let warngins = warnings.read().unwrap().iter().cloned().collect::<Vec<_>>();
+                for err in warngins.iter() {
                     match err.kind {
                         lightningcss::error::ParserError::UnexpectedToken(_)
                         | lightningcss::error::ParserError::UnexpectedImportRule

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -335,7 +335,7 @@ pub async fn parse_css(
 async fn process_content(
     content_vc: Vc<FileContent>,
     code: String,
-    fs_path_vc: Vc<FileSystemPath>,
+    fs_path_vc: ResolvedVc<FileSystemPath>,
     filename: &str,
     source: Vc<Box<dyn Source>>,
     origin: Vc<Box<dyn ResolveOrigin>>,
@@ -485,12 +485,14 @@ enum CssError {
 }
 
 impl CssError {
-    fn report(self, file: Vc<FileSystemPath>) {
+    fn report(self, file: ResolvedVc<FileSystemPath>) {
         match self {
             CssError::LightningCssSelectorInModuleNotPure { selector } => {
                 ParsingIssue {
                     file,
-                    msg: Vc::cell(format!("{CSS_MODULE_ERROR}, (lightningcss, {selector})").into()),
+                    msg: ResolvedVc::cell(
+                        format!("{CSS_MODULE_ERROR}, (lightningcss, {selector})").into(),
+                    ),
                     source: None,
                 }
                 .cell()
@@ -654,7 +656,7 @@ struct ParsingIssue {
 #[turbo_tasks::value_impl]
 impl Issue for ParsingIssue {
     #[turbo_tasks::function]
-    fn file_path(&self) -> ResolvedVc<FileSystemPath> {
+    fn file_path(&self) -> Vc<FileSystemPath> {
         *self.file
     }
 

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -414,8 +414,8 @@ async fn process_content(
                             });
 
                             ParsingIssue {
-                                file: fs_path_vc,
-                                msg: Vc::cell(err.to_string().into()),
+                                file: fs_path_vc.to_resolved().await?,
+                                msg: ResolvedVc::cell(err.to_string().into()),
                                 source,
                             }
                             .cell()

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -421,7 +421,7 @@ async fn process_content(
                             };
 
                             ParsingIssue {
-                                file: fs_path_vc.to_resolved().await?,
+                                file: fs_path_vc,
                                 msg: ResolvedVc::cell(err.to_string().into()),
                                 source,
                             }
@@ -454,7 +454,7 @@ async fn process_content(
                     None => None,
                 };
                 ParsingIssue {
-                    file: fs_path_vc.to_resolved().await?,
+                    file: fs_path_vc,
                     msg: ResolvedVc::cell(e.to_string().into()),
                     source,
                 }

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -113,7 +113,7 @@ impl StyleSheetLike<'_, '_> {
 
 /// Multiple [ModuleReference]s
 #[turbo_tasks::value(transparent)]
-pub struct UnresolvedUrlReferences(pub Vec<(String, Vc<UrlAssetReference>)>);
+pub struct UnresolvedUrlReferences(pub Vec<(String, ResolvedVc<UrlAssetReference>)>);
 
 #[turbo_tasks::value(shared, serialization = "none", eq = "manual", cell = "new")]
 pub enum ParseCssResult {

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -405,7 +405,7 @@ async fn process_content(
                         | lightningcss::error::ParserError::UnexpectedImportRule
                         | lightningcss::error::ParserError::SelectorError(..)
                         | lightningcss::error::ParserError::EndOfInput => {
-                            let source = match err.loc {
+                            let source = match &err.loc {
                                 Some(loc) => {
                                     let pos = SourcePos {
                                         line: loc.line as _,

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -440,8 +440,8 @@ async fn process_content(
                     IssueSource::from_line_col(source, pos, pos)
                 });
                 ParsingIssue {
-                    file: fs_path_vc,
-                    msg: Vc::cell(e.to_string().into()),
+                    file: fs_path_vc.to_resolved().await?,
+                    msg: ResolvedVc::cell(e.to_string().into()),
                     source,
                 }
                 .cell()

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -646,9 +646,9 @@ impl GenerateSourceMap for ParseCssResultSourceMap {
 
 #[turbo_tasks::value]
 struct ParsingIssue {
-    msg: Vc<RcStr>,
-    file: Vc<FileSystemPath>,
-    source: Option<Vc<IssueSource>>,
+    msg: ResolvedVc<RcStr>,
+    file: ResolvedVc<FileSystemPath>,
+    source: Option<ResolvedVc<IssueSource>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-css/src/references/mod.rs
+++ b/turbopack/crates/turbopack-css/src/references/mod.rs
@@ -8,7 +8,7 @@ use lightningcss::{
     visitor::{Visit, Visitor},
 };
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{Value, Vc};
 use turbopack_core::{
     issue::IssueSource,
     reference::ModuleReference,

--- a/turbopack/crates/turbopack-css/src/references/mod.rs
+++ b/turbopack/crates/turbopack-css/src/references/mod.rs
@@ -8,7 +8,7 @@ use lightningcss::{
     visitor::{Visit, Visitor},
 };
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Value, Vc};
+use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbopack_core::{
     issue::IssueSource,
     reference::ModuleReference,
@@ -54,9 +54,9 @@ pub fn analyze_references(
 }
 
 struct ModuleReferencesVisitor<'a> {
-    source: Vc<Box<dyn Source>>,
-    origin: Vc<Box<dyn ResolveOrigin>>,
-    import_context: Vc<ImportContext>,
+    source: ResolvedVc<Box<dyn Source>>,
+    origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+    import_context: ResolvedVc<ImportContext>,
     references: &'a mut Vec<Vc<Box<dyn ModuleReference>>>,
     urls: &'a mut Vec<(String, Vc<UrlAssetReference>)>,
 }

--- a/turbopack/crates/turbopack-css/src/references/mod.rs
+++ b/turbopack/crates/turbopack-css/src/references/mod.rs
@@ -54,9 +54,9 @@ pub fn analyze_references(
 }
 
 struct ModuleReferencesVisitor<'a> {
-    source: ResolvedVc<Box<dyn Source>>,
-    origin: ResolvedVc<Box<dyn ResolveOrigin>>,
-    import_context: ResolvedVc<ImportContext>,
+    source: Vc<Box<dyn Source>>,
+    origin: Vc<Box<dyn ResolveOrigin>>,
+    import_context: Vc<ImportContext>,
     references: &'a mut Vec<Vc<Box<dyn ModuleReference>>>,
     urls: &'a mut Vec<(String, Vc<UrlAssetReference>)>,
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes PACK-3583