### PR TITLE
refactor(turbopack): Use `ResolvedVc<T>` for struct fields in `turbopack-core`

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -24,7 +24,9 @@ use tokio::{io::AsyncWriteExt, time::Instant};
 use tracing::Instrument;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{get_effects, Completion, Effects, ReadRef, TransientInstance, UpdateInfo, Vc};
+use turbo_tasks::{
+    get_effects, Completion, Effects, ReadRef, ResolvedVc, TransientInstance, UpdateInfo, Vc,
+};
 use turbo_tasks_fs::{
     util::uri_from_file, DiskFileSystem, FileContent, FileSystem, FileSystemPath,
 };
@@ -1023,7 +1025,7 @@ pub struct StackFrame {
 pub async fn get_source_map(
     container: Vc<ProjectContainer>,
     file_path: String,
-) -> Result<Option<Vc<SourceMap>>> {
+) -> Result<Option<ResolvedVc<SourceMap>>> {
     let (file, module) = match Url::parse(&file_path) {
         Ok(url) => match url.scheme() {
             "file" => {

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1457,10 +1457,10 @@ impl AppEndpoint {
                 let evaluatable = ResolvedVc::try_sidecast(app_entry.rsc_entry)
                     .await?
                     .context("Entry module must be evaluatable")?;
-                evaluatable_assets.push(*evaluatable);
+                evaluatable_assets.push(evaluatable);
 
                 if let Some(server_action_manifest_loader) = server_action_manifest_loader {
-                    evaluatable_assets.push(server_action_manifest_loader);
+                    evaluatable_assets.push(server_action_manifest_loader.to_resolved().await?);
                 }
 
                 {
@@ -1483,7 +1483,7 @@ impl AppEndpoint {
                     this.app_project.rsc_runtime_entries().await?.clone_value();
 
                 if let Some(server_action_manifest_loader) = server_action_manifest_loader {
-                    evaluatable_assets.push(server_action_manifest_loader);
+                    evaluatable_assets.push(server_action_manifest_loader.to_resolved().await?);
                 }
 
                 let EntryChunkGroupResult {
@@ -1511,7 +1511,7 @@ impl AppEndpoint {
                                 .await?;
 
                             current_chunks = current_chunks
-                                .concatenate(chunk_group.assets)
+                                .concatenate(*chunk_group.assets)
                                 .resolve()
                                 .await?;
                             current_availability_info = chunk_group.availability_info;
@@ -1545,7 +1545,7 @@ impl AppEndpoint {
                                     .await?;
 
                                 current_chunks = current_chunks
-                                    .concatenate(chunk_group.assets)
+                                    .concatenate(*chunk_group.assets)
                                     .resolve()
                                     .await?;
                                 current_availability_info = chunk_group.availability_info;

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -93,7 +93,7 @@ pub(crate) async fn collect_evaluated_chunk_group(
         if let Some(module) = Vc::try_resolve_downcast::<Box<dyn EvaluatableAsset>>(module).await? {
             Ok(chunking_context.evaluated_chunk_group_assets(
                 module.ident(),
-                Vc::cell(vec![Vc::upcast(module)]),
+                Vc::cell(vec![ResolvedVc::upcast(module.to_resolved().await?)]),
                 Value::new(AvailabilityInfo::Root),
             ))
         } else {

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -130,7 +130,7 @@ impl InstrumentationEndpoint {
         let Some(evaluatable) = ResolvedVc::try_sidecast(module).await? else {
             bail!("Entry module must be evaluatable");
         };
-        evaluatable_assets.push(*evaluatable);
+        evaluatable_assets.push(evaluatable);
 
         let edge_chunking_context = this.project.edge_chunking_context(false);
 

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -15,7 +15,7 @@ use turbo_tasks::{Completion, ResolvedVc, Value, Vc};
 use turbo_tasks_fs::{self, File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
-    chunk::{availability_info::AvailabilityInfo, ChunkingContextExt},
+    chunk::{availability_info::AvailabilityInfo, ChunkingContextExt, EvaluatableAsset},
     context::AssetContext,
     module::{Module, Modules},
     output::OutputAssets,
@@ -104,7 +104,7 @@ impl MiddlewareEndpoint {
             bail!("Entry module must be evaluatable");
         };
 
-        let evaluatable = Vc::try_resolve_sidecast(module)
+        let evaluatable = Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(module)
             .await?
             .context("Entry module must be evaluatable")?;
         evaluatable_assets.push(evaluatable.to_resolved().await?);

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -107,7 +107,7 @@ impl MiddlewareEndpoint {
         let evaluatable = Vc::try_resolve_sidecast(module)
             .await?
             .context("Entry module must be evaluatable")?;
-        evaluatable_assets.push(evaluatable);
+        evaluatable_assets.push(evaluatable.to_resolved().await?);
 
         let edge_chunking_context = self.project.edge_chunking_context(false);
 

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -831,7 +831,7 @@ impl PageEndpoint {
             let is_edge = matches!(runtime, NextRuntime::Edge);
             if is_edge {
                 let mut evaluatable_assets = edge_runtime_entries.await?.clone_value();
-                let evaluatable = *ResolvedVc::try_sidecast(ssr_module)
+                let evaluatable = ResolvedVc::try_sidecast(ssr_module)
                     .await?
                     .context("could not process page loader entry module")?;
                 evaluatable_assets.push(evaluatable);

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -523,7 +523,7 @@ impl Issue for ConflictIssue {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(*self.description))
+        Vc::cell(Some(self.description))
     }
 }
 

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -155,9 +155,10 @@ impl VersionedContentMap {
         self: Vc<Self>,
         path: Vc<FileSystemPath>,
     ) -> Result<Vc<OptionVersionedContent>> {
-        Ok(Vc::cell(
-            (*self.get_asset(path).await?).map(|a| a.versioned_content()),
-        ))
+        Ok(Vc::cell(match (*self.get_asset(path).await?) {
+            Some(asset) => Some(asset.versioned_content().to_resolved().await?),
+            None => None,
+        }))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -155,7 +155,7 @@ impl VersionedContentMap {
         self: Vc<Self>,
         path: Vc<FileSystemPath>,
     ) -> Result<Vc<OptionVersionedContent>> {
-        Ok(Vc::cell(match (*self.get_asset(path).await?) {
+        Ok(Vc::cell(match *self.get_asset(path).await? {
             Some(asset) => Some(asset.versioned_content().to_resolved().await?),
             None => None,
         }))

--- a/crates/next-api/src/webpack_stats.rs
+++ b/crates/next-api/src/webpack_stats.rs
@@ -39,7 +39,7 @@ where
             for item in chunk.chunk().chunk_items().await? {
                 // let name =
                 chunk_items
-                    .entry(*item)
+                    .entry(**item)
                     .or_default()
                     .insert(chunk_ident.clone().into());
             }

--- a/crates/next-core/src/app_segment_config.rs
+++ b/crates/next-core/src/app_segment_config.rs
@@ -203,13 +203,13 @@ impl Issue for NextSegmentConfigParsingIssue {
                  format from which some properties can be statically parsed at compiled-time."
                     .into(),
             )
-            .cell(),
+            .resolved_cell(),
         ))
     }
 
     #[turbo_tasks::function]
     fn detail(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(*self.detail))
+        Vc::cell(Some(self.detail))
     }
 
     #[turbo_tasks::function]
@@ -221,8 +221,13 @@ impl Issue for NextSegmentConfigParsingIssue {
     }
 
     #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(Some(self.source.resolve_source_map(self.ident.path())))
+    async fn source(&self) -> Result<Vc<OptionIssueSource>> {
+        Ok(Vc::cell(Some(
+            self.source
+                .resolve_source_map(self.ident.path())
+                .to_resolved()
+                .await?,
+        )))
     }
 }
 

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1443,6 +1443,6 @@ impl Issue for DirectoryTreeIssue {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(*self.message))
+        Vc::cell(Some(self.message))
     }
 }

--- a/crates/next-core/src/hmr_entry.rs
+++ b/crates/next-core/src/hmr_entry.rs
@@ -53,10 +53,12 @@ impl Module for HmrEntryModule {
     }
 
     #[turbo_tasks::function]
-    fn references(&self) -> Vc<ModuleReferences> {
-        Vc::cell(vec![Vc::upcast(HmrEntryModuleReference::new(Vc::upcast(
-            *self.module,
-        )))])
+    async fn references(&self) -> Result<Vc<ModuleReferences>> {
+        Ok(Vc::cell(vec![ResolvedVc::upcast(
+            HmrEntryModuleReference::new(Vc::upcast(*self.module))
+                .to_resolved()
+                .await?,
+        )]))
     }
 }
 

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -259,7 +259,7 @@ pub async fn get_app_client_references_chunks(
                     let client_chunk_group = client_chunk_group.await?;
 
                     let client_chunks =
-                        current_client_chunks.concatenate(client_chunk_group.assets);
+                        current_client_chunks.concatenate(*client_chunk_group.assets);
                     let client_chunks = client_chunks.to_resolved().await?;
 
                     if is_layout {
@@ -284,7 +284,7 @@ pub async fn get_app_client_references_chunks(
                 if let Some(ssr_chunk_group) = ssr_chunk_group {
                     let ssr_chunk_group = ssr_chunk_group.await?;
 
-                    let ssr_chunks = current_ssr_chunks.concatenate(ssr_chunk_group.assets);
+                    let ssr_chunks = current_ssr_chunks.concatenate(*ssr_chunk_group.assets);
                     let ssr_chunks = ssr_chunks.to_resolved().await?;
 
                     if is_layout {

--- a/crates/next-core/src/next_app/app_client_shared_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_shared_chunks.rs
@@ -16,7 +16,7 @@ pub async fn get_app_client_shared_chunk_group(
 ) -> Result<Vc<ChunkGroupResult>> {
     if app_client_runtime_entries.await?.is_empty() {
         return Ok(ChunkGroupResult {
-            assets: OutputAssets::empty(),
+            assets: OutputAssets::empty().to_resolved().await?,
             availability_info: AvailabilityInfo::Root,
         }
         .cell());

--- a/crates/next-core/src/next_app/include_modules_module.rs
+++ b/crates/next-core/src/next_app/include_modules_module.rs
@@ -53,8 +53,8 @@ impl Module for IncludeModulesModule {
             self.modules
                 .iter()
                 .map(|&module| async move {
-                    Ok(Vc::upcast(
-                        IncludedModuleReference::new(*module).resolve().await?,
+                    Ok(ResolvedVc::upcast(
+                        IncludedModuleReference::new(*module).to_resolved().await?,
                     ))
                 })
                 .try_join()

--- a/crates/next-core/src/next_client/runtime_entry.rs
+++ b/crates/next-core/src/next_client/runtime_entry.rs
@@ -48,7 +48,7 @@ impl RuntimeEntry {
             if let Some(entry) =
                 ResolvedVc::try_downcast::<Box<dyn EvaluatableAsset>>(module).await?
             {
-                runtime_entries.push(*entry);
+                runtime_entries.push(entry);
             } else {
                 bail!(
                     "runtime reference resolved to an asset ({}) that cannot be evaluated",

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -69,19 +69,27 @@ impl Module for EcmascriptClientReferenceModule {
     }
 
     #[turbo_tasks::function]
-    fn references(&self) -> Vc<ModuleReferences> {
+    async fn references(&self) -> Result<Vc<ModuleReferences>> {
         let client_module = ResolvedVc::upcast(self.client_module);
         let ssr_module = ResolvedVc::upcast(self.ssr_module);
-        Vc::cell(vec![
-            Vc::upcast(SingleModuleReference::new(
-                *client_module,
-                ecmascript_client_reference_client_ref_modifier(),
-            )),
-            Vc::upcast(SingleModuleReference::new(
-                *ssr_module,
-                ecmascript_client_reference_ssr_ref_modifier(),
-            )),
-        ])
+        Ok(Vc::cell(vec![
+            ResolvedVc::upcast(
+                SingleModuleReference::new(
+                    *client_module,
+                    ecmascript_client_reference_client_ref_modifier(),
+                )
+                .to_resolved()
+                .await?,
+            ),
+            ResolvedVc::upcast(
+                SingleModuleReference::new(
+                    *ssr_module,
+                    ecmascript_client_reference_ssr_ref_modifier(),
+                )
+                .to_resolved()
+                .await?,
+            ),
+        ]))
     }
 }
 

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
@@ -186,14 +186,18 @@ impl Module for EcmascriptClientReferenceProxyModule {
             .await?
             .iter()
             .copied()
-            .chain(once(Vc::upcast(SingleModuleReference::new(
-                Vc::upcast(EcmascriptClientReferenceModule::new(
-                    **server_module_ident,
-                    **client_module,
-                    **ssr_module,
-                )),
-                client_reference_description(),
-            ))))
+            .chain(once(ResolvedVc::upcast(
+                SingleModuleReference::new(
+                    Vc::upcast(EcmascriptClientReferenceModule::new(
+                        **server_module_ident,
+                        **client_module,
+                        **ssr_module,
+                    )),
+                    client_reference_description(),
+                )
+                .to_resolved()
+                .await?,
+            )))
             .collect();
 
         Ok(Vc::cell(references))

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
@@ -74,7 +74,7 @@ impl Transition for NextEcmascriptClientReferenceTransition {
                     .replace("next/dist/esm/", "next/dist/")
                     .into(),
             );
-            Vc::upcast(FileSource::new_with_query(path, ident_ref.query))
+            Vc::upcast(FileSource::new_with_query(path, *ident_ref.query))
         } else {
             source
         };

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1364,6 +1364,8 @@ impl Issue for OutdatedConfigIssue {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(StyledString::Text(self.description.clone()).cell()))
+        Vc::cell(Some(
+            StyledString::Text(self.description.clone()).resolved_cell(),
+        ))
     }
 }

--- a/crates/next-core/src/next_font/issue.rs
+++ b/crates/next-core/src/next_font/issue.rs
@@ -34,6 +34,6 @@ impl Issue for NextFontIssue {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(*self.description))
+        Vc::cell(Some(self.description))
     }
 }

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -501,7 +501,7 @@ impl Issue for ExternalizeIssue {
                 ]),
                 StyledString::Line(self.reason.clone()),
             ])
-            .cell(),
+            .resolved_cell(),
         )))
     }
 }

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -60,10 +60,12 @@ impl Module for NextServerComponentModule {
     }
 
     #[turbo_tasks::function]
-    fn references(&self) -> Vc<ModuleReferences> {
-        Vc::cell(vec![Vc::upcast(NextServerComponentModuleReference::new(
-            Vc::upcast(*self.module),
-        ))])
+    async fn references(&self) -> Result<Vc<ModuleReferences>> {
+        Ok(Vc::cell(vec![ResolvedVc::upcast(
+            NextServerComponentModuleReference::new(Vc::upcast(*self.module))
+                .to_resolved()
+                .await?,
+        )]))
     }
 
     #[turbo_tasks::function]
@@ -112,11 +114,9 @@ impl ChunkableModule for NextServerComponentModule {
 impl EcmascriptChunkPlaceable for NextServerComponentModule {
     #[turbo_tasks::function]
     async fn get_exports(&self) -> Result<Vc<EcmascriptExports>> {
-        let module_reference = ResolvedVc::upcast(
-            NextServerComponentModuleReference::new(Vc::upcast(*self.module))
-                .to_resolved()
-                .await?,
-        );
+        let module_reference = Vc::upcast(NextServerComponentModuleReference::new(Vc::upcast(
+            *self.module,
+        )));
 
         let mut exports = BTreeMap::new();
         exports.insert(

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -121,13 +121,13 @@ impl EcmascriptChunkPlaceable for NextServerComponentModule {
         let mut exports = BTreeMap::new();
         exports.insert(
             "default".into(),
-            EsmExport::ImportedBinding(*module_reference, "default".into(), false),
+            EsmExport::ImportedBinding(module_reference, "default".into(), false),
         );
 
         Ok(EcmascriptExports::EsmExports(
             EsmExports {
                 exports,
-                star_exports: vec![*module_reference],
+                star_exports: vec![module_reference],
             }
             .resolved_cell(),
         )

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -89,7 +89,7 @@ impl Issue for InvalidImportModuleIssue {
                     .map(|v| StyledString::Text(format!("{}\n", v).into()))
                     .collect::<Vec<StyledString>>(),
             )
-            .cell(),
+            .resolved_cell(),
         )))
     }
 }
@@ -252,7 +252,7 @@ impl AfterResolvePlugin for NextExternalResolvePlugin {
                 ty: ExternalType::CommonJs,
                 traced: ExternalTraced::Traced,
             })
-            .into(),
+            .resolved_cell(),
         )))
     }
 }
@@ -329,7 +329,7 @@ impl AfterResolvePlugin for NextNodeSharedRuntimeResolvePlugin {
             ResolveResult::source(ResolvedVc::upcast(
                 FileSource::new(new_path).to_resolved().await?,
             ))
-            .cell(),
+            .resolved_cell(),
         )))
     }
 }
@@ -431,7 +431,7 @@ impl AfterResolvePlugin for NextSharedRuntimeResolvePlugin {
             ResolveResult::source(ResolvedVc::upcast(
                 FileSource::new(new_path).to_resolved().await?,
             ))
-            .cell(),
+            .resolved_cell(),
         )))
     }
 }

--- a/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
+++ b/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
@@ -166,7 +166,7 @@ impl Issue for PageStaticInfoIssue {
                     .map(|v| StyledString::Text(format!("{}\n", v).into()))
                     .collect::<Vec<StyledString>>(),
             )
-            .cell(),
+            .resolved_cell(),
         ))
     }
 }

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -156,6 +156,6 @@ impl Issue for BabelIssue {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(*self.description))
+        Vc::cell(Some(self.description))
     }
 }

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -230,13 +230,13 @@ impl Issue for NextSourceConfigParsingIssue {
                  format from which some properties can be statically parsed at compiled-time."
                     .into(),
             )
-            .cell(),
+            .resolved_cell(),
         ))
     }
 
     #[turbo_tasks::function]
     fn detail(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(*self.detail))
+        Vc::cell(Some(self.detail))
     }
 }
 

--- a/turbopack/crates/turbo-tasks-fetch/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/lib.rs
@@ -202,12 +202,12 @@ impl Issue for FetchIssue {
                 }
                 FetchErrorKind::Other => format!("There was an issue requesting {}", url).into(),
             })
-            .cell(),
+            .resolved_cell(),
         )))
     }
 
     #[turbo_tasks::function]
     fn detail(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(*self.detail))
+        Vc::cell(Some(self.detail))
     }
 }

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -384,7 +384,7 @@ impl ChunkingContext for BrowserChunkingContext {
     async fn chunk_group(
         self: Vc<Self>,
         ident: Vc<AssetIdent>,
-        module: Vc<Box<dyn ChunkableModule>>,
+        module: ResolvedVc<Box<dyn ChunkableModule>>,
         availability_info: Value<AvailabilityInfo>,
     ) -> Result<Vc<ChunkGroupResult>> {
         let span = tracing::info_span!("chunking", ident = ident.to_string().await?.to_string());
@@ -396,7 +396,7 @@ impl ChunkingContext for BrowserChunkingContext {
                 availability_info,
             } = make_chunk_group(
                 Vc::upcast(self),
-                [Vc::upcast(module)],
+                [ResolvedVc::upcast(module)],
                 input_availability_info,
             )
             .await?;
@@ -435,7 +435,7 @@ impl ChunkingContext for BrowserChunkingContext {
             }
 
             Ok(ChunkGroupResult {
-                assets: Vc::cell(assets),
+                assets: ResolvedVc::cell(assets),
                 availability_info,
             }
             .cell())
@@ -463,7 +463,7 @@ impl ChunkingContext for BrowserChunkingContext {
 
             let entries = evaluatable_assets_ref
                 .iter()
-                .map(|&evaluatable| Vc::upcast(evaluatable));
+                .map(|&evaluatable| ResolvedVc::upcast(evaluatable));
 
             let MakeChunkGroupResult {
                 chunks,
@@ -498,7 +498,7 @@ impl ChunkingContext for BrowserChunkingContext {
             );
 
             Ok(ChunkGroupResult {
-                assets: Vc::cell(assets),
+                assets: ResolvedVc::cell(assets),
                 availability_info,
             }
             .cell())

--- a/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
@@ -173,7 +173,7 @@ impl Introspectable for EcmascriptDevChunk {
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         let mut children = FxIndexSet::default();
         let chunk = ResolvedVc::upcast::<Box<dyn Introspectable>>(self.chunk);
-        children.insert((Vc::cell("chunk".into()), *chunk));
+        children.insert((ResolvedVc::cell("chunk".into()), *chunk));
         Ok(Vc::cell(children))
     }
 }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content_entry.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content_entry.rs
@@ -100,11 +100,11 @@ async fn item_code(
                 let error_message = format!("{}", PrettyPrintError(&error));
                 let js_error_message = serde_json::to_string(&error_message)?;
                 CodeGenerationIssue {
-                    severity: IssueSeverity::Error.cell(),
-                    path: item.asset_ident().path(),
+                    severity: IssueSeverity::Error.resolved_cell(),
+                    path: item.asset_ident().path().to_resolved().await?,
                     title: StyledString::Text("Code generation for chunk item errored".into())
-                        .cell(),
-                    message: StyledString::Text(error_message.into()).cell(),
+                        .resolved_cell(),
+                    message: StyledString::Text(error_message.into()).resolved_cell(),
                 }
                 .cell()
                 .emit();

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -96,7 +96,7 @@ impl EcmascriptDevEvaluateChunk {
                 let chunking_context = this.chunking_context;
                 move |entry| async move {
                     if let Some(placeable) =
-                        Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(*entry)
+                        ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(*entry)
                             .await?
                     {
                         Ok(Some(
@@ -207,17 +207,19 @@ impl OutputAsset for EcmascriptDevEvaluateChunk {
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         let mut ident = self.ident.await?.clone_value();
 
-        ident.add_modifier(modifier());
+        ident.add_modifier(modifier().to_resolved().await?);
 
         let evaluatable_assets = self.evaluatable_assets.await?;
         ident.modifiers.extend(
             evaluatable_assets
                 .iter()
-                .map(|entry| entry.ident().to_string()),
+                .map(|entry| entry.ident().to_string().to_resolved())
+                .try_join()
+                .await?,
         );
 
         for chunk in &*self.other_chunks.await? {
-            ident.add_modifier(chunk.ident().to_string());
+            ident.add_modifier(chunk.ident().to_string().to_resolved().await?);
         }
 
         let ident = AssetIdent::new(Value::new(ident));

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
@@ -92,12 +92,12 @@ impl OutputAsset for EcmascriptDevChunkList {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         let mut ident = self.ident.await?.clone_value();
-        ident.add_modifier(modifier());
+        ident.add_modifier(modifier().to_resolved().await?);
 
         match self.source {
             EcmascriptDevChunkListSource::Entry => {}
             EcmascriptDevChunkListSource::Dynamic => {
-                ident.add_modifier(dynamic_modifier());
+                ident.add_modifier(dynamic_modifier().to_resolved().await?);
             }
         }
 

--- a/turbopack/crates/turbopack-browser/src/react_refresh.rs
+++ b/turbopack/crates/turbopack-browser/src/react_refresh.rs
@@ -109,7 +109,7 @@ impl Issue for ReactRefreshResolvingIssue {
                 StyledString::Code("@next/react-refresh-utils".into()),
                 StyledString::Text(" modules.".into()),
             ])
-            .cell(),
+            .resolved_cell(),
         ))
     }
 }

--- a/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
@@ -48,7 +48,7 @@ impl RuntimeEntry {
             if let Some(entry) =
                 ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(module).await?
             {
-                runtime_entries.push(*entry);
+                runtime_entries.push(entry);
             } else {
                 bail!(
                     "runtime reference resolved to an asset ({}) that cannot be evaluated",

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -23,7 +23,7 @@ pub struct MakeChunkGroupResult {
 /// Creates a chunk group from a set of entries.
 pub async fn make_chunk_group(
     chunking_context: Vc<Box<dyn ChunkingContext>>,
-    chunk_group_entries: impl IntoIterator<Item = Vc<Box<dyn Module>>>,
+    chunk_group_entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
     availability_info: AvailabilityInfo,
 ) -> Result<MakeChunkGroupResult> {
     let ChunkContentResult {
@@ -144,6 +144,7 @@ pub async fn make_chunk_group(
     let async_loader_external_module_references = async_loader_references
         .iter()
         .flat_map(|references| references.iter().copied())
+        .map(|v| *v)
         .collect();
 
     let mut referenced_output_assets = references_to_output_assets(external_module_references)

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -38,7 +38,7 @@ pub enum MinifyType {
 
 #[turbo_tasks::value(shared)]
 pub struct ChunkGroupResult {
-    pub assets: Vc<OutputAssets>,
+    pub assets: ResolvedVc<OutputAssets>,
     pub availability_info: AvailabilityInfo,
 }
 
@@ -291,7 +291,7 @@ async fn root_chunk_group_assets(
     chunking_context: Vc<Box<dyn ChunkingContext>>,
     module: Vc<Box<dyn ChunkableModule>>,
 ) -> Result<Vc<OutputAssets>> {
-    Ok(chunking_context.root_chunk_group(module).await?.assets)
+    Ok(*chunking_context.root_chunk_group(module).await?.assets)
 }
 
 #[turbo_tasks::function]
@@ -301,7 +301,7 @@ async fn evaluated_chunk_group_assets(
     evaluatable_assets: Vc<EvaluatableAssets>,
     availability_info: Value<AvailabilityInfo>,
 ) -> Result<Vc<OutputAssets>> {
-    Ok(chunking_context
+    Ok(*chunking_context
         .evaluated_chunk_group(ident, evaluatable_assets, availability_info)
         .await?
         .assets)
@@ -334,7 +334,7 @@ async fn chunk_group_assets(
     module: Vc<Box<dyn ChunkableModule>>,
     availability_info: Value<AvailabilityInfo>,
 ) -> Result<Vc<OutputAssets>> {
-    Ok(chunking_context
+    Ok(*chunking_context
         .chunk_group(module.ident(), module, availability_info)
         .await?
         .assets)

--- a/turbopack/crates/turbopack-core/src/chunk/data.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/data.rs
@@ -18,14 +18,14 @@ pub struct ChunkData {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct ChunkDataOption(Option<Vc<ChunkData>>);
+pub struct ChunkDataOption(Option<ResolvedVc<ChunkData>>);
 
 // NOTE(alexkirsz) Our convention for naming vector types is to add an "s" to
 // the end of the type name, but in this case it would be both gramatically
 // incorrect and clash with the variable names everywhere.
 // TODO(WEB-101) Should fix this.
 #[turbo_tasks::value(transparent)]
-pub struct ChunksData(Vec<Vc<ChunkData>>);
+pub struct ChunksData(Vec<ResolvedVc<ChunkData>>);
 
 #[turbo_tasks::function]
 fn module_chunk_reference_description() -> Vc<RcStr> {
@@ -59,7 +59,7 @@ impl ChunkData {
                     module_chunks: Vec::new(),
                     references: OutputAssets::empty().to_resolved().await?,
                 }
-                .cell(),
+                .resolved_cell(),
             )));
         };
 
@@ -114,7 +114,7 @@ impl ChunkData {
                 module_chunks,
                 references: ResolvedVc::cell(module_chunks_references),
             }
-            .cell(),
+            .resolved_cell(),
         )))
     }
 

--- a/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use turbo_tasks::{Upcast, Value, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, Upcast, Value, ValueToString, Vc};
 
 use super::ChunkableModule;
 use crate::{
@@ -57,7 +57,7 @@ async fn to_evaluatable(
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct EvaluatableAssets(Vec<Vc<Box<dyn EvaluatableAsset>>>);
+pub struct EvaluatableAssets(Vec<ResolvedVc<Box<dyn EvaluatableAsset>>>);
 
 #[turbo_tasks::value_impl]
 impl EvaluatableAssets {
@@ -67,19 +67,19 @@ impl EvaluatableAssets {
     }
 
     #[turbo_tasks::function]
-    pub fn one(entry: Vc<Box<dyn EvaluatableAsset>>) -> Vc<EvaluatableAssets> {
+    pub fn one(entry: ResolvedVc<Box<dyn EvaluatableAsset>>) -> Vc<EvaluatableAssets> {
         EvaluatableAssets(vec![entry]).cell()
     }
 
     #[turbo_tasks::function]
-    pub fn many(assets: Vec<Vc<Box<dyn EvaluatableAsset>>>) -> Vc<EvaluatableAssets> {
+    pub fn many(assets: Vec<ResolvedVc<Box<dyn EvaluatableAsset>>>) -> Vc<EvaluatableAssets> {
         EvaluatableAssets(assets).cell()
     }
 
     #[turbo_tasks::function]
     pub async fn with_entry(
         self: Vc<Self>,
-        entry: Vc<Box<dyn EvaluatableAsset>>,
+        entry: ResolvedVc<Box<dyn EvaluatableAsset>>,
     ) -> Result<Vc<EvaluatableAssets>> {
         let mut entries = self.await?.clone_value();
         entries.push(entry);

--- a/turbopack/crates/turbopack-core/src/code_builder.rs
+++ b/turbopack/crates/turbopack-core/src/code_builder.rs
@@ -210,10 +210,12 @@ impl GenerateSourceMap for Code {
                 },
             };
 
-            sections.push(SourceMapSection::new(pos, encoded))
+            sections.push(SourceMapSection::new(pos, encoded.to_resolved().await?))
         }
 
-        Ok(Vc::cell(Some(SourceMap::new_sectioned(sections).cell())))
+        Ok(Vc::cell(Some(
+            SourceMap::new_sectioned(sections).resolved_cell(),
+        )))
     }
 }
 
@@ -270,6 +272,6 @@ pub async fn fileify_source_map(
     }
 
     Ok(Vc::cell(Some(
-        SourceMap::new_decoded(sourcemap::DecodedMap::Regular(transformed)).cell(),
+        SourceMap::new_decoded(sourcemap::DecodedMap::Regular(transformed)).resolved_cell(),
     )))
 }

--- a/turbopack/crates/turbopack-core/src/introspect/mod.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/mod.rs
@@ -4,12 +4,12 @@ pub mod source;
 pub mod utils;
 
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexSet, Vc};
+use turbo_tasks::{FxIndexSet, ResolvedVc, Vc};
 
 type VcDynIntrospectable = Vc<Box<dyn Introspectable>>;
 
 #[turbo_tasks::value(transparent)]
-pub struct IntrospectableChildren(FxIndexSet<(Vc<RcStr>, VcDynIntrospectable)>);
+pub struct IntrospectableChildren(FxIndexSet<(ResolvedVc<RcStr>, VcDynIntrospectable)>);
 
 #[turbo_tasks::value_trait]
 pub trait Introspectable {

--- a/turbopack/crates/turbopack-core/src/introspect/utils.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/utils.rs
@@ -72,7 +72,7 @@ pub async fn children_from_module_references(
     for &reference in &*references {
         let mut key = key;
         if let Some(chunkable) =
-            Vc::try_resolve_downcast::<Box<dyn ChunkableModuleReference>>(reference).await?
+            ResolvedVc::try_downcast::<Box<dyn ChunkableModuleReference>>(reference).await?
         {
             match &*chunkable.chunking_type().await? {
                 None => {}
@@ -94,7 +94,7 @@ pub async fn children_from_module_references(
             .await?
             .iter()
         {
-            children.insert((key, IntrospectableModule::new(*module)));
+            children.insert((key.to_resolved().await?, IntrospectableModule::new(*module)));
         }
         for &output_asset in reference
             .resolve_reference()
@@ -102,7 +102,10 @@ pub async fn children_from_module_references(
             .await?
             .iter()
         {
-            children.insert((key, IntrospectableOutputAsset::new(*output_asset)));
+            children.insert((
+                key.to_resolved().await?,
+                IntrospectableOutputAsset::new(*output_asset),
+            ));
         }
     }
     Ok(Vc::cell(children))
@@ -117,7 +120,7 @@ pub async fn children_from_output_assets(
     let references = references.await?;
     for &reference in &*references {
         children.insert((
-            key,
+            key.to_resolved().await?,
             IntrospectableOutputAsset::new(*ResolvedVc::upcast(reference)),
         ));
     }

--- a/turbopack/crates/turbopack-core/src/issue/analyze.rs
+++ b/turbopack/crates/turbopack-core/src/issue/analyze.rs
@@ -53,14 +53,19 @@ impl Issue for AnalyzeIssue {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(*self.message))
+        Vc::cell(Some(self.message))
     }
 
     #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(
-            self.source
-                .map(|s| s.resolve_source_map(self.source_ident.path())),
-        )
+    async fn source(&self) -> Result<Vc<OptionIssueSource>> {
+        Ok(Vc::cell(match self.source {
+            Some(source) => Some(
+                source
+                    .resolve_source_map(self.source_ident.path())
+                    .to_resolved()
+                    .await?,
+            ),
+            None => None,
+        }))
     }
 }

--- a/turbopack/crates/turbopack-core/src/issue/code_gen.rs
+++ b/turbopack/crates/turbopack-core/src/issue/code_gen.rs
@@ -1,26 +1,26 @@
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use super::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString};
 
 #[turbo_tasks::value(shared)]
 pub struct CodeGenerationIssue {
-    pub severity: Vc<IssueSeverity>,
-    pub path: Vc<FileSystemPath>,
-    pub title: Vc<StyledString>,
-    pub message: Vc<StyledString>,
+    pub severity: ResolvedVc<IssueSeverity>,
+    pub path: ResolvedVc<FileSystemPath>,
+    pub title: ResolvedVc<StyledString>,
+    pub message: ResolvedVc<StyledString>,
 }
 
 #[turbo_tasks::value_impl]
 impl Issue for CodeGenerationIssue {
     #[turbo_tasks::function]
     fn severity(&self) -> Vc<IssueSeverity> {
-        self.severity
+        *self.severity
     }
 
     #[turbo_tasks::function]
     fn title(&self) -> Vc<StyledString> {
-        self.title
+        *self.title
     }
 
     #[turbo_tasks::function]
@@ -30,7 +30,7 @@ impl Issue for CodeGenerationIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        self.path
+        *self.path
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/output.rs
+++ b/turbopack/crates/turbopack-core/src/output.rs
@@ -47,6 +47,10 @@ impl OutputAssets {
     pub fn empty() -> Vc<Self> {
         Self::new(vec![])
     }
+
+    pub fn empty_resolved() -> ResolvedVc<Self> {
+        ResolvedVc::cell(vec![])
+    }
 }
 
 /// A set of [OutputAsset]s

--- a/turbopack/crates/turbopack-core/src/proxied_asset.rs
+++ b/turbopack/crates/turbopack-core/src/proxied_asset.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
@@ -15,15 +15,18 @@ use crate::{
 /// Next.js apps.
 #[turbo_tasks::value]
 pub struct ProxiedAsset {
-    asset: Vc<Box<dyn OutputAsset>>,
-    path: Vc<FileSystemPath>,
+    asset: ResolvedVc<Box<dyn OutputAsset>>,
+    path: ResolvedVc<FileSystemPath>,
 }
 
 #[turbo_tasks::value_impl]
 impl ProxiedAsset {
     /// Creates a new [`ProxiedAsset`] from an [`Asset`] and a path.
     #[turbo_tasks::function]
-    pub fn new(asset: Vc<Box<dyn OutputAsset>>, path: Vc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(
+        asset: ResolvedVc<Box<dyn OutputAsset>>,
+        path: ResolvedVc<FileSystemPath>,
+    ) -> Vc<Self> {
         ProxiedAsset { asset, path }.cell()
     }
 }
@@ -32,7 +35,7 @@ impl ProxiedAsset {
 impl OutputAsset for ProxiedAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(self.path)
+        AssetIdent::from_path(*self.path)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/raw_module.rs
+++ b/turbopack/crates/turbopack-core/src/raw_module.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 
 use crate::{
     asset::{Asset, AssetContent},
@@ -11,7 +11,7 @@ use crate::{
 /// This module has no references to other modules.
 #[turbo_tasks::value]
 pub struct RawModule {
-    source: Vc<Box<dyn Source>>,
+    source: ResolvedVc<Box<dyn Source>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -33,7 +33,7 @@ impl Asset for RawModule {
 #[turbo_tasks::value_impl]
 impl RawModule {
     #[turbo_tasks::function]
-    pub fn new(source: Vc<Box<dyn Source>>) -> Vc<RawModule> {
+    pub fn new(source: ResolvedVc<Box<dyn Source>>) -> Vc<RawModule> {
         RawModule { source }.cell()
     }
 }

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -34,7 +34,7 @@ pub trait ModuleReference: ValueToString {
 
 /// Multiple [ModuleReference]s
 #[turbo_tasks::value(transparent)]
-pub struct ModuleReferences(Vec<Vc<Box<dyn ModuleReference>>>);
+pub struct ModuleReferences(Vec<ResolvedVc<Box<dyn ModuleReference>>>);
 
 #[turbo_tasks::value_impl]
 impl ModuleReferences {
@@ -49,7 +49,7 @@ impl ModuleReferences {
 #[turbo_tasks::value]
 pub struct SingleModuleReference {
     asset: ResolvedVc<Box<dyn Module>>,
-    description: Vc<RcStr>,
+    description: ResolvedVc<RcStr>,
 }
 
 #[turbo_tasks::value_impl]
@@ -64,7 +64,7 @@ impl ModuleReference for SingleModuleReference {
 impl ValueToString for SingleModuleReference {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        self.description
+        *self.description
     }
 }
 
@@ -73,7 +73,7 @@ impl SingleModuleReference {
     /// Create a new [Vc<SingleModuleReference>] that resolves to the given
     /// asset.
     #[turbo_tasks::function]
-    pub fn new(asset: ResolvedVc<Box<dyn Module>>, description: Vc<RcStr>) -> Vc<Self> {
+    pub fn new(asset: ResolvedVc<Box<dyn Module>>, description: ResolvedVc<RcStr>) -> Vc<Self> {
         Self::cell(SingleModuleReference { asset, description })
     }
 
@@ -87,13 +87,13 @@ impl SingleModuleReference {
 #[turbo_tasks::value]
 pub struct SingleChunkableModuleReference {
     asset: ResolvedVc<Box<dyn Module>>,
-    description: Vc<RcStr>,
+    description: ResolvedVc<RcStr>,
 }
 
 #[turbo_tasks::value_impl]
 impl SingleChunkableModuleReference {
     #[turbo_tasks::function]
-    pub fn new(asset: ResolvedVc<Box<dyn Module>>, description: Vc<RcStr>) -> Vc<Self> {
+    pub fn new(asset: ResolvedVc<Box<dyn Module>>, description: ResolvedVc<RcStr>) -> Vc<Self> {
         Self::cell(SingleChunkableModuleReference { asset, description })
     }
 }
@@ -118,7 +118,7 @@ impl ModuleReference for SingleChunkableModuleReference {
 impl ValueToString for SingleChunkableModuleReference {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        self.description
+        *self.description
     }
 }
 
@@ -126,7 +126,7 @@ impl ValueToString for SingleChunkableModuleReference {
 #[turbo_tasks::value]
 pub struct SingleOutputAssetReference {
     asset: ResolvedVc<Box<dyn OutputAsset>>,
-    description: Vc<RcStr>,
+    description: ResolvedVc<RcStr>,
 }
 
 #[turbo_tasks::value_impl]
@@ -141,7 +141,7 @@ impl ModuleReference for SingleOutputAssetReference {
 impl ValueToString for SingleOutputAssetReference {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        self.description
+        *self.description
     }
 }
 
@@ -150,7 +150,10 @@ impl SingleOutputAssetReference {
     /// Create a new [Vc<SingleOutputAssetReference>] that resolves to the given
     /// asset.
     #[turbo_tasks::function]
-    pub fn new(asset: ResolvedVc<Box<dyn OutputAsset>>, description: Vc<RcStr>) -> Vc<Self> {
+    pub fn new(
+        asset: ResolvedVc<Box<dyn OutputAsset>>,
+        description: ResolvedVc<RcStr>,
+    ) -> Vc<Self> {
         Self::cell(SingleOutputAssetReference { asset, description })
     }
 

--- a/turbopack/crates/turbopack-core/src/reference/source_map.rs
+++ b/turbopack/crates/turbopack-core/src/reference/source_map.rs
@@ -61,7 +61,7 @@ impl GenerateSourceMap for SourceMapReference {
             return Ok(Vc::cell(None));
         };
         let source_map = SourceMap::new_from_file(file).await?;
-        Ok(Vc::cell(source_map.map(|m| m.cell())))
+        Ok(Vc::cell(source_map.map(|m| m.resolved_cell())))
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1024,12 +1024,12 @@ impl ResolveResult {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct ResolveResultOption(Option<Vc<ResolveResult>>);
+pub struct ResolveResultOption(Option<ResolvedVc<ResolveResult>>);
 
 #[turbo_tasks::value_impl]
 impl ResolveResultOption {
     #[turbo_tasks::function]
-    pub fn some(result: Vc<ResolveResult>) -> Vc<Self> {
+    pub fn some(result: ResolvedVc<ResolveResult>) -> Vc<Self> {
         ResolveResultOption(Some(result)).cell()
     }
 
@@ -1105,8 +1105,10 @@ enum ExportsFieldResult {
 /// Extracts the "exports" field out of the package.json, parsing it into an
 /// appropriate [AliasMap] for lookups.
 #[turbo_tasks::function]
-async fn exports_field(package_json_path: Vc<FileSystemPath>) -> Result<Vc<ExportsFieldResult>> {
-    let read = read_package_json(package_json_path).await?;
+async fn exports_field(
+    package_json_path: ResolvedVc<FileSystemPath>,
+) -> Result<Vc<ExportsFieldResult>> {
+    let read = read_package_json(*package_json_path).await?;
     let package_json = match &*read {
         Some(json) => json,
         None => return Ok(ExportsFieldResult::None.cell()),
@@ -1160,7 +1162,7 @@ async fn imports_field(lookup_path: Vc<FileSystemPath>) -> Result<Vc<ImportsFiel
         Ok(imports) => Ok(ImportsFieldResult::Some(imports, *package_json_path).cell()),
         Err(err) => {
             PackageJsonIssue {
-                path: **package_json_path,
+                path: *package_json_path,
                 error_message: err.to_string().into(),
             }
             .cell()
@@ -1572,7 +1574,7 @@ async fn handle_before_resolve_plugins(
             .before_resolve(lookup_path, reference_type.clone(), request)
             .await?
         {
-            return Ok(Some(result));
+            return Ok(Some(*result));
         }
     }
     Ok(None)
@@ -1599,7 +1601,7 @@ async fn handle_after_resolve_plugins(
                     .after_resolve(path, lookup_path, reference_type.clone(), request)
                     .await?
                 {
-                    return Ok(Some(result));
+                    return Ok(Some(*result));
                 }
             }
         }
@@ -2348,7 +2350,7 @@ async fn apply_in_package(
 enum FindSelfReferencePackageResult {
     Found {
         name: String,
-        package_path: Vc<FileSystemPath>,
+        package_path: ResolvedVc<FileSystemPath>,
     },
     NotFound,
 }
@@ -2367,7 +2369,7 @@ async fn find_self_reference(
                 if let Some(name) = json["name"].as_str() {
                     return Ok(FindSelfReferencePackageResult::Found {
                         name: name.to_string(),
-                        package_path: package_json_path.parent(),
+                        package_path: package_json_path.parent().to_resolved().await?,
                     }
                     .cell());
                 }
@@ -2414,7 +2416,7 @@ async fn resolve_module_request(
         if name == module {
             let result = resolve_into_package(
                 Value::new(path.clone()),
-                *package_path,
+                **package_path,
                 query,
                 fragment,
                 options,
@@ -3030,11 +3032,11 @@ pub enum ModulePart {
     Export(ResolvedVc<RcStr>),
     /// Represents a renamed export of a module.
     RenamedExport {
-        original_export: Vc<RcStr>,
-        export: Vc<RcStr>,
+        original_export: ResolvedVc<RcStr>,
+        export: ResolvedVc<RcStr>,
     },
     /// Represents a namespace object of a module exported as named export.
-    RenamedNamespace { export: Vc<RcStr> },
+    RenamedNamespace { export: ResolvedVc<RcStr> },
     /// A pointer to a specific part.
     Internal(u32),
     /// A pointer to a specific part, but with evaluation.
@@ -3061,15 +3063,15 @@ impl ModulePart {
     #[turbo_tasks::function]
     pub fn renamed_export(original_export: RcStr, export: RcStr) -> Vc<Self> {
         ModulePart::RenamedExport {
-            original_export: Vc::cell(original_export),
-            export: Vc::cell(export),
+            original_export: ResolvedVc::cell(original_export),
+            export: ResolvedVc::cell(export),
         }
         .cell()
     }
     #[turbo_tasks::function]
     pub fn renamed_namespace(export: RcStr) -> Vc<Self> {
         ModulePart::RenamedNamespace {
-            export: Vc::cell(export),
+            export: ResolvedVc::cell(export),
         }
         .cell()
     }

--- a/turbopack/crates/turbopack-core/src/resolve/origin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/origin.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Upcast, Value, Vc};
+use turbo_tasks::{ResolvedVc, Upcast, Value, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use super::{options::ResolveOptions, parse::Request, ModuleResolveResult};
@@ -45,7 +45,7 @@ pub trait ResolveOriginExt: Send {
     fn resolve_options(self: Vc<Self>, reference_type: Value<ReferenceType>) -> Vc<ResolveOptions>;
 
     /// Adds a transition that is used for resolved assets.
-    fn with_transition(self: Vc<Self>, transition: RcStr) -> Vc<Box<dyn ResolveOrigin>>;
+    fn with_transition(self: ResolvedVc<Self>, transition: RcStr) -> Vc<Box<dyn ResolveOrigin>>;
 }
 
 impl<T> ResolveOriginExt for T
@@ -66,10 +66,10 @@ where
             .resolve_options(self.origin_path(), reference_type)
     }
 
-    fn with_transition(self: Vc<Self>, transition: RcStr) -> Vc<Box<dyn ResolveOrigin>> {
+    fn with_transition(self: ResolvedVc<Self>, transition: RcStr) -> Vc<Box<dyn ResolveOrigin>> {
         Vc::upcast(
             ResolveOriginWithTransition {
-                previous: Vc::upcast(self),
+                previous: ResolvedVc::upcast(self),
                 transition,
             }
             .cell(),
@@ -102,16 +102,16 @@ async fn resolve_asset(
 /// A resolve origin for some path and context without additional modifications.
 #[turbo_tasks::value]
 pub struct PlainResolveOrigin {
-    asset_context: Vc<Box<dyn AssetContext>>,
-    origin_path: Vc<FileSystemPath>,
+    asset_context: ResolvedVc<Box<dyn AssetContext>>,
+    origin_path: ResolvedVc<FileSystemPath>,
 }
 
 #[turbo_tasks::value_impl]
 impl PlainResolveOrigin {
     #[turbo_tasks::function]
     pub fn new(
-        asset_context: Vc<Box<dyn AssetContext>>,
-        origin_path: Vc<FileSystemPath>,
+        asset_context: ResolvedVc<Box<dyn AssetContext>>,
+        origin_path: ResolvedVc<FileSystemPath>,
     ) -> Vc<Self> {
         PlainResolveOrigin {
             asset_context,
@@ -125,19 +125,19 @@ impl PlainResolveOrigin {
 impl ResolveOrigin for PlainResolveOrigin {
     #[turbo_tasks::function]
     fn origin_path(&self) -> Vc<FileSystemPath> {
-        self.origin_path
+        *self.origin_path
     }
 
     #[turbo_tasks::function]
     fn asset_context(&self) -> Vc<Box<dyn AssetContext>> {
-        self.asset_context
+        *self.asset_context
     }
 }
 
 /// Wraps a ResolveOrigin to add a transition.
 #[turbo_tasks::value]
 struct ResolveOriginWithTransition {
-    previous: Vc<Box<dyn ResolveOrigin>>,
+    previous: ResolvedVc<Box<dyn ResolveOrigin>>,
     transition: RcStr,
 }
 

--- a/turbopack/crates/turbopack-core/src/resolve/plugin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/plugin.rs
@@ -11,14 +11,14 @@ use crate::{
 /// A condition which determines if the hooks of a resolve plugin gets called.
 #[turbo_tasks::value]
 pub struct AfterResolvePluginCondition {
-    root: Vc<FileSystemPath>,
-    glob: Vc<Glob>,
+    root: ResolvedVc<FileSystemPath>,
+    glob: ResolvedVc<Glob>,
 }
 
 #[turbo_tasks::value_impl]
 impl AfterResolvePluginCondition {
     #[turbo_tasks::function]
-    pub fn new(root: Vc<FileSystemPath>, glob: Vc<Glob>) -> Vc<Self> {
+    pub fn new(root: ResolvedVc<FileSystemPath>, glob: ResolvedVc<Glob>) -> Vc<Self> {
         AfterResolvePluginCondition { root, glob }.cell()
     }
 

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -45,7 +45,7 @@ impl Asset for SourceMapAsset {
             bail!("asset does not support generating source maps")
         };
         let sm = if let Some(sm) = &*generate_source_map.generate_source_map().await? {
-            *sm
+            **sm
         } else {
             SourceMap::empty()
         };
@@ -86,7 +86,7 @@ impl Introspectable for SourceMapAsset {
         let mut children = FxIndexSet::default();
         if let Some(asset) = ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.asset).await?
         {
-            children.insert((Vc::cell("asset".into()), *asset));
+            children.insert((ResolvedVc::cell("asset".into()), *asset));
         }
         Ok(Vc::cell(children))
     }

--- a/turbopack/crates/turbopack-core/src/source_transform.rs
+++ b/turbopack/crates/turbopack-core/src/source_transform.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 
 use crate::source::Source;
 
@@ -8,7 +8,7 @@ pub trait SourceTransform {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct SourceTransforms(Vec<Vc<Box<dyn SourceTransform>>>);
+pub struct SourceTransforms(Vec<ResolvedVc<Box<dyn SourceTransform>>>);
 
 #[turbo_tasks::value_impl]
 impl SourceTransforms {

--- a/turbopack/crates/turbopack-core/src/version.rs
+++ b/turbopack/crates/turbopack-core/src/version.rs
@@ -12,7 +12,7 @@ use turbo_tasks_hash::{encode_hex, hash_xxh3_hash64};
 use crate::asset::AssetContent;
 
 #[turbo_tasks::value(transparent)]
-pub struct OptionVersionedContent(Option<Vc<Box<dyn VersionedContent>>>);
+pub struct OptionVersionedContent(Option<ResolvedVc<Box<dyn VersionedContent>>>);
 
 /// The content of an [Asset] alongside its version.
 #[turbo_tasks::value_trait]

--- a/turbopack/crates/turbopack-core/src/virtual_output.rs
+++ b/turbopack/crates/turbopack-core/src/virtual_output.rs
@@ -13,7 +13,7 @@ use crate::{
 pub struct VirtualOutputAsset {
     pub path: ResolvedVc<FileSystemPath>,
     pub content: ResolvedVc<AssetContent>,
-    pub references: Vc<OutputAssets>,
+    pub references: ResolvedVc<OutputAssets>,
 }
 
 #[turbo_tasks::value_impl]
@@ -23,7 +23,7 @@ impl VirtualOutputAsset {
         VirtualOutputAsset {
             path,
             content,
-            references: OutputAssets::empty(),
+            references: OutputAssets::empty_resolved(),
         }
         .cell()
     }
@@ -32,7 +32,7 @@ impl VirtualOutputAsset {
     pub fn new_with_references(
         path: ResolvedVc<FileSystemPath>,
         content: ResolvedVc<AssetContent>,
-        references: Vc<OutputAssets>,
+        references: ResolvedVc<OutputAssets>,
     ) -> Vc<Self> {
         VirtualOutputAsset {
             path,
@@ -52,7 +52,7 @@ impl OutputAsset for VirtualOutputAsset {
 
     #[turbo_tasks::function]
     fn references(&self) -> Vc<OutputAssets> {
-        self.references
+        *self.references
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -215,7 +215,7 @@ impl CssChunkItem for CssModuleChunkItem {
 
         for reference in references.iter() {
             if let Some(import_ref) =
-                Vc::try_resolve_downcast_type::<ImportAssetReference>(*reference).await?
+                ResolvedVc::try_downcast_type::<ImportAssetReference>(*reference).await?
             {
                 for &module in import_ref
                     .resolve_reference()
@@ -240,7 +240,7 @@ impl CssChunkItem for CssModuleChunkItem {
                     }
                 }
             } else if let Some(compose_ref) =
-                Vc::try_resolve_downcast_type::<CssModuleComposeReference>(*reference).await?
+                ResolvedVc::try_downcast_type::<CssModuleComposeReference>(*reference).await?
             {
                 for &module in compose_ref
                     .resolve_reference()
@@ -267,7 +267,7 @@ impl CssChunkItem for CssModuleChunkItem {
         let mut code_gens = Vec::new();
         for r in references.iter() {
             if let Some(code_gen) =
-                Vc::try_resolve_sidecast::<Box<dyn CodeGenerateable>>(*r).await?
+                ResolvedVc::try_sidecast::<Box<dyn CodeGenerateable>>(*r).await?
             {
                 code_gens.push(code_gen.code_generation(*chunking_context));
             }

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -86,15 +86,15 @@ impl CssChunk {
                 match source_map {
                     Some(map) => {
                         (*(fileify_source_map(map, self.chunking_context().context_path()).await?))
-                            .map(Vc::upcast)
+                            .map(ResolvedVc::upcast)
                     }
                     None => None,
                 }
             } else {
-                content.source_map.map(ResolvedVc::upcast).map(|v| *v)
+                content.source_map.map(ResolvedVc::upcast)
             };
 
-            body.push_source(&content.inner_code, source_map);
+            body.push_source(&content.inner_code, source_map.map(|v| *v));
 
             writeln!(body, "{close}")?;
             writeln!(body)?;
@@ -194,8 +194,9 @@ impl OutputChunk for CssChunk {
         let entries_chunk_items = &content.chunk_items;
         let included_ids = entries_chunk_items
             .iter()
-            .map(|chunk_item| CssChunkItem::id(**chunk_item))
-            .collect();
+            .map(|chunk_item| CssChunkItem::id(**chunk_item).to_resolved())
+            .try_join()
+            .await?;
         let imports_chunk_items: Vec<_> = entries_chunk_items
             .iter()
             .map(|&chunk_item| async move {
@@ -288,11 +289,11 @@ impl OutputAsset for CssChunk {
 
         let ident = AssetIdent {
             path: if let Some((common_path, _)) = common_path {
-                *common_path
+                common_path
             } else {
-                *ServerFileSystem::new().root().to_resolved().await?
+                ServerFileSystem::new().root().to_resolved().await?
             },
-            query: Vc::<RcStr>::default(),
+            query: ResolvedVc::cell(RcStr::default()),
             fragment: None,
             assets,
             modifiers: Vec::new(),
@@ -445,7 +446,7 @@ impl Introspectable for CssChunk {
             .clone_value();
         for &chunk_item in self.await?.content.await?.chunk_items.iter() {
             children.insert((
-                entry_module_key(),
+                entry_module_key().to_resolved().await?,
                 IntrospectableModule::new(chunk_item.module()),
             ));
         }

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
@@ -38,7 +38,7 @@ impl Asset for SingleItemCssChunkSourceMapAsset {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<AssetContent>> {
         let sm = if let Some(sm) = *self.chunk.generate_source_map().await? {
-            sm
+            *sm
         } else {
             SourceMap::empty()
         };

--- a/turbopack/crates/turbopack-css/src/chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/source_map.rs
@@ -38,7 +38,7 @@ impl Asset for CssChunkSourceMapAsset {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<AssetContent>> {
         let sm = if let Some(sm) = *self.chunk.generate_source_map().await? {
-            sm
+            *sm
         } else {
             SourceMap::empty()
         };

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -483,7 +483,13 @@ async fn process_content(
     Ok(ParseCssResult::Ok {
         code: content_vc.to_resolved().await?,
         stylesheet,
-        references: ResolvedVc::cell(references),
+        references: ResolvedVc::cell(
+            references
+                .into_iter()
+                .map(|v| v.to_resolved())
+                .try_join()
+                .await?,
+        ),
         url_references: ResolvedVc::cell(url_references),
         options: config,
     }
@@ -649,7 +655,7 @@ impl GenerateSourceMap for ParseCssResultSourceMap {
 
                 Vc::cell(Some(
                     turbopack_core::source_map::SourceMap::new_regular(builder.into_sourcemap())
-                        .cell(),
+                        .resolved_cell(),
                 ))
             }
             ParseCssResultSourceMap::Swc {
@@ -662,7 +668,7 @@ impl GenerateSourceMap for ParseCssResultSourceMap {
                     InlineSourcesContentConfig {},
                 );
                 Vc::cell(Some(
-                    turbopack_core::source_map::SourceMap::new_regular(map).cell(),
+                    turbopack_core::source_map::SourceMap::new_regular(map).resolved_cell(),
                 ))
             }
         }
@@ -694,14 +700,17 @@ impl Issue for ParsingIssue {
     }
 
     #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(self.source.map(|s| s.resolve_source_map(*self.file)))
+    async fn source(&self) -> Result<Vc<OptionIssueSource>> {
+        Ok(Vc::cell(match self.source {
+            Some(s) => Some(s.resolve_source_map(*self.file).to_resolved().await?),
+            None => None,
+        }))
     }
 
     #[turbo_tasks::function]
     async fn description(&self) -> Result<Vc<OptionStyledString>> {
         Ok(Vc::cell(Some(
-            StyledString::Text(self.msg.await?.as_str().into()).cell(),
+            StyledString::Text(self.msg.await?.as_str().into()).resolved_cell(),
         )))
     }
 }

--- a/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
@@ -35,7 +35,7 @@ impl Introspectable for IntrospectionSource {
 
     #[turbo_tasks::function]
     fn children(&self) -> Vc<IntrospectableChildren> {
-        let name = Vc::cell("root".into());
+        let name = ResolvedVc::cell("root".into());
         Vc::cell(self.roots.iter().map(|root| (name, **root)).collect())
     }
 }

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -317,9 +317,9 @@ impl Introspectable for AssetGraphContentSource {
     #[turbo_tasks::function]
     async fn children(self: Vc<Self>) -> Result<Vc<IntrospectableChildren>> {
         let this = self.await?;
-        let key = Vc::cell("root".into());
-        let inner_key = Vc::cell("inner".into());
-        let expanded_key = Vc::cell("expanded".into());
+        let key = ResolvedVc::cell("root".into());
+        let inner_key = ResolvedVc::cell("inner".into());
+        let expanded_key = ResolvedVc::cell("expanded".into());
 
         let root_assets = this.root_assets.await?;
         let root_asset_children = root_assets.iter().map(|&asset| {
@@ -375,7 +375,7 @@ impl Introspectable for FullyExpaned {
     #[turbo_tasks::function]
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         let source = self.0.await?;
-        let key = Vc::cell("asset".into());
+        let key = ResolvedVc::cell("asset".into());
 
         let expanded_assets =
             expand(&*source.root_assets.await?, &*source.root_path.await?, None).await?;

--- a/turbopack/crates/turbopack-dev-server/src/source/combined.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/combined.rs
@@ -85,7 +85,7 @@ impl Introspectable for CombinedContentSource {
 
     #[turbo_tasks::function]
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
-        let source = Vc::cell("source".into());
+        let source = ResolvedVc::cell("source".into());
         Ok(Vc::cell(
             self.sources
                 .iter()

--- a/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Completion, ResolvedVc, State, Value, Vc};
+use turbo_tasks::{Completion, ResolvedVc, State, TryJoinIterExt, Value, Vc};
 use turbopack_core::introspect::{Introspectable, IntrospectableChildren};
 
 use super::{
@@ -148,6 +148,10 @@ impl Introspectable for ConditionalContentSource {
             ]
             .into_iter()
             .flatten()
+            .map(|(k, v)| async move { Ok((k.to_resolved().await?, v)) })
+            .try_join()
+            .await?
+            .into_iter()
             .collect(),
         ))
     }

--- a/turbopack/crates/turbopack-dev-server/src/source/lazy_instantiated.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/lazy_instantiated.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbopack_core::introspect::{Introspectable, IntrospectableChildren};
 
 use super::{route_tree::RouteTree, ContentSource};
@@ -57,6 +57,10 @@ impl Introspectable for LazyInstantiatedContentSource {
             ]
             .into_iter()
             .flatten()
+            .map(|(k, v)| async move { Ok((k.to_resolved().await?, v)) })
+            .try_join()
+            .await?
+            .into_iter()
             .collect(),
         ))
     }

--- a/turbopack/crates/turbopack-dev-server/src/source/router.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/router.rs
@@ -66,7 +66,7 @@ async fn get_introspection_children(
             .map(|(path, source)| async move {
                 Ok(ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(source)
                     .await?
-                    .map(|i| (Vc::cell(path), *i)))
+                    .map(|i| (ResolvedVc::cell(path), *i)))
             })
             .try_join()
             .await?

--- a/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
@@ -135,7 +135,7 @@ impl Introspectable for StaticAssetsContentSource {
                     DirectoryEntry::Other(_) => todo!("what's DirectoryContent::Other?"),
                     DirectoryEntry::Error => todo!(),
                 };
-                (Vc::cell(name.clone()), child)
+                (ResolvedVc::cell(name.clone()), child)
             })
             .collect();
         Ok(Vc::cell(children))

--- a/turbopack/crates/turbopack-dev-server/src/update/stream.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/stream.rs
@@ -310,6 +310,6 @@ impl Issue for FatalStreamIssue {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(*self.description))
+        Vc::cell(Some(self.description))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -83,7 +83,7 @@ impl Issue for UnsupportedSwcEcmaTransformPluginsIssue {
                  platform."
                     .into(),
             )
-            .cell(),
+            .resolved_cell(),
         ))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
@@ -186,13 +186,15 @@ impl ChunkItem for AsyncLoaderChunkItem {
                 .await?
                 .iter()
                 .copied()
-                .map(|chunk| {
-                    Vc::upcast(SingleOutputAssetReference::new(
-                        *chunk,
-                        chunk_reference_description(),
+                .map(|chunk| async move {
+                    Ok(ResolvedVc::upcast(
+                        SingleOutputAssetReference::new(*chunk, chunk_reference_description())
+                            .to_resolved()
+                            .await?,
                     ))
                 })
-                .collect(),
+                .try_join()
+                .await?,
         ))
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
@@ -60,10 +60,14 @@ impl Module for AsyncLoaderModule {
 
     #[turbo_tasks::function]
     async fn references(self: Vc<Self>) -> Result<Vc<ModuleReferences>> {
-        Ok(Vc::cell(vec![Vc::upcast(SingleModuleReference::new(
-            *ResolvedVc::upcast(self.await?.inner),
-            inner_module_reference_description(),
-        ))]))
+        Ok(Vc::cell(vec![ResolvedVc::upcast(
+            SingleModuleReference::new(
+                *ResolvedVc::upcast(self.await?.inner),
+                inner_module_reference_description(),
+            )
+            .to_resolved()
+            .await?,
+        )]))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -155,6 +155,7 @@ impl EcmascriptChunkItemContent {
             match source_map {
                 Some(map) => fileify_source_map(map, *rewrite_source_path)
                     .await?
+                    .map(|v| *v)
                     .map(Vc::upcast),
                 None => None,
             }
@@ -265,11 +266,11 @@ async fn module_factory_with_code_generation_issue(
                 let error_message = format!("{}", PrettyPrintError(&error)).into();
                 let js_error_message = serde_json::to_string(&error_message)?;
                 CodeGenerationIssue {
-                    severity: IssueSeverity::Error.cell(),
-                    path: chunk_item.asset_ident().path(),
+                    severity: IssueSeverity::Error.resolved_cell(),
+                    path: chunk_item.asset_ident().path().to_resolved().await?,
                     title: StyledString::Text("Code generation for chunk item errored".into())
-                        .cell(),
-                    message: StyledString::Text(error_message).cell(),
+                        .resolved_cell(),
+                    message: StyledString::Text(error_message).resolved_cell(),
                 }
                 .cell()
                 .emit();

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -154,7 +154,7 @@ impl Issue for SideEffectsInPackageJsonIssue {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(self.description.map(|v| *v))
+        Vc::cell(self.description)
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
@@ -62,17 +62,30 @@ impl Module for ChunkGroupFilesAsset {
 
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<ModuleReferences>> {
-        let mut references: Vec<Vc<Box<dyn ModuleReference>>> = vec![Vc::upcast(
-            SingleModuleReference::new(*ResolvedVc::upcast(self.module), module_description()),
+        let mut references: Vec<ResolvedVc<Box<dyn ModuleReference>>> = vec![ResolvedVc::upcast(
+            SingleModuleReference::new(*ResolvedVc::upcast(self.module), module_description())
+                .to_resolved()
+                .await?,
         )];
 
         if let Some(runtime_entries) = self.runtime_entries {
-            references.extend(runtime_entries.await?.iter().map(|&entry| {
-                Vc::upcast(SingleModuleReference::new(
-                    Vc::upcast(entry),
-                    runtime_entry_description(),
-                ))
-            }));
+            references.extend(
+                runtime_entries
+                    .await?
+                    .iter()
+                    .map(|&entry| async move {
+                        Ok(ResolvedVc::upcast(
+                            SingleModuleReference::new(
+                                Vc::upcast(*entry),
+                                runtime_entry_description(),
+                            )
+                            .to_resolved()
+                            .await?,
+                        ))
+                    })
+                    .try_join()
+                    .await?,
+            );
         }
 
         Ok(Vc::cell(references))
@@ -204,14 +217,18 @@ impl ChunkItem for ChunkGroupFilesChunkItem {
                 .await?
                 .iter()
                 .copied()
-                .map(|chunk| {
-                    SingleOutputAssetReference::new(
-                        *chunk,
-                        chunk_group_chunk_reference_description(),
-                    )
+                .map(|chunk| async move {
+                    Ok(ResolvedVc::upcast(
+                        SingleOutputAssetReference::new(
+                            *chunk,
+                            chunk_group_chunk_reference_description(),
+                        )
+                        .to_resolved()
+                        .await?,
+                    ))
                 })
-                .map(Vc::upcast)
-                .collect(),
+                .try_join()
+                .await?,
         ))
     }
 
@@ -254,7 +271,7 @@ impl Introspectable for ChunkGroupFilesAsset {
     fn children(&self) -> Vc<IntrospectableChildren> {
         let mut children = FxIndexSet::default();
         children.insert((
-            Vc::cell("inner asset".into()),
+            ResolvedVc::cell("inner asset".into()),
             IntrospectableModule::new(*ResolvedVc::upcast(self.module)),
         ));
         Vc::cell(children)

--- a/turbopack/crates/turbopack-ecmascript/src/global_module_id_strategy.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/global_module_id_strategy.rs
@@ -54,7 +54,7 @@ async fn referenced_modules(module: Vc<Box<dyn Module>>) -> Result<Vc<Referenced
         .iter()
         .map(|reference| async move {
             let async_loader =
-                if Vc::try_resolve_downcast_type::<EsmAsyncAssetReference>(*reference)
+                if ResolvedVc::try_downcast_type::<EsmAsyncAssetReference>(*reference)
                     .await?
                     .is_some()
                 {

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -529,7 +529,7 @@ impl Module for EcmascriptModuleAsset {
                     asset.ident().to_resolved().await?,
                 );
             }
-            ident.add_modifier(modifier());
+            ident.add_modifier(modifier().to_resolved().await?);
             ident.layer = Some(self.asset_context.layer().to_resolved().await?);
             Ok(AssetIdent::new(Value::new(ident)))
         } else {
@@ -729,11 +729,11 @@ impl EcmascriptModuleContent {
         for r in references.await?.iter() {
             let r = r.resolve().await?;
             if let Some(code_gen) =
-                Vc::try_resolve_sidecast::<Box<dyn CodeGenerateableWithAsyncModuleInfo>>(r).await?
+                ResolvedVc::try_sidecast::<Box<dyn CodeGenerateableWithAsyncModuleInfo>>(r).await?
             {
                 code_gens.push(code_gen.code_generation(chunking_context, async_module_info));
             } else if let Some(code_gen) =
-                Vc::try_resolve_sidecast::<Box<dyn CodeGenerateable>>(r).await?
+                ResolvedVc::try_sidecast::<Box<dyn CodeGenerateable>>(r).await?
             {
                 code_gens.push(code_gen.code_generation(chunking_context));
             }

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -129,7 +129,7 @@ impl GenerateSourceMap for ParseResultSourceMap {
             input_map.as_deref(),
             InlineSourcesContentConfig {},
         );
-        Ok(Vc::cell(Some(SourceMap::new_regular(map).cell())))
+        Ok(Vc::cell(Some(SourceMap::new_regular(map).resolved_cell())))
     }
 }
 
@@ -494,7 +494,7 @@ impl Issue for ReadSourceIssue {
                 )
                 .into(),
             )
-            .cell(),
+            .resolved_cell(),
         ))
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
@@ -109,7 +109,7 @@ impl AsyncModule {
             .await?
             .iter()
             .map(|r| async {
-                let Some(referenced_asset) = get_inherit_async_referenced_asset(*r).await? else {
+                let Some(referenced_asset) = get_inherit_async_referenced_asset(**r).await? else {
                     return Ok(None);
                 };
                 Ok(match &*referenced_asset {
@@ -156,7 +156,8 @@ impl AsyncModule {
                     .await?
                     .iter()
                     .map(|r| async {
-                        let Some(referenced_asset) = get_inherit_async_referenced_asset(*r).await?
+                        let Some(referenced_asset) =
+                            get_inherit_async_referenced_asset(**r).await?
                         else {
                             return Ok(false);
                         };

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -116,7 +116,7 @@ impl EsmAssetReference {
     fn get_origin(&self) -> Vc<Box<dyn ResolveOrigin>> {
         let mut origin = *self.origin;
         if let Some(transition) = self.annotations.transition() {
-            origin = origin.with_transition(transition.into());
+            origin = self.origin.with_transition(transition.into());
         }
         origin
     }
@@ -460,7 +460,7 @@ impl Issue for InvalidExport {
                         .into(),
                 ),
             ])
-            .cell(),
+            .resolved_cell(),
         )))
     }
 
@@ -479,12 +479,12 @@ impl Issue for InvalidExport {
                         .into(),
                 ),
             ])
-            .cell(),
+            .resolved_cell(),
         )))
     }
 
     #[turbo_tasks::function]
     fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(Some(*self.source))
+        Vc::cell(Some(self.source))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -205,7 +205,7 @@ impl ChunkItem for CachedExternalModuleChunkItem {
         let additional_references = &self.module.await?.additional_references;
         if !additional_references.is_empty() {
             let mut module_references = self.module.references().await?.clone_value();
-            module_references.extend(additional_references.iter().map(|rvc| **rvc));
+            module_references.extend(additional_references.iter().copied());
             Ok(Vc::cell(module_references))
         } else {
             Ok(self.module.references())

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -285,12 +285,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
             self.add_code_gen(bindings);
         }
 
-        let references = self
-            .references
-            .iter()
-            .map(|v| async move { v.to_resolved().await })
-            .try_join()
-            .await?;
+        let references = self.references.into_iter().collect();
         let local_references: Vec<_> = track_reexport_references
             .then(|| self.local_references.into_iter())
             .into_iter()

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -285,26 +285,26 @@ impl AnalyzeEcmascriptModuleResultBuilder {
             self.add_code_gen(bindings);
         }
 
-        let references: Vec<_> = self.references.into_iter().collect();
-
+        let references = references
+            .iter()
+            .map(|v| async move { v.to_resolved().await })
+            .try_join()
+            .await?;
         let local_references: Vec<_> = track_reexport_references
             .then(|| self.local_references.into_iter())
             .into_iter()
             .flatten()
             .collect();
-
         let reexport_references: Vec<_> = track_reexport_references
             .then(|| self.reexport_references.into_iter())
             .into_iter()
             .flatten()
             .collect();
-
         let evaluation_references: Vec<_> = track_reexport_references
             .then(|| self.evaluation_references.into_iter())
             .into_iter()
             .flatten()
             .collect();
-
         for c in self.code_gens.iter_mut() {
             match c {
                 CodeGen::CodeGenerateable(c) => {
@@ -323,16 +323,10 @@ impl AnalyzeEcmascriptModuleResultBuilder {
             AnalyzeEcmascriptModuleResult {
                 // TODO(ResolvedVc): this is messy because I don't want to
                 //                   touch core while KDY is working on it
-                references: ResolvedVc::cell(references.into_iter().map(|rvc| *rvc).collect()),
-                local_references: ResolvedVc::cell(
-                    local_references.into_iter().map(|rvc| *rvc).collect(),
-                ),
-                reexport_references: ResolvedVc::cell(
-                    reexport_references.into_iter().map(|rvc| *rvc).collect(),
-                ),
-                evaluation_references: ResolvedVc::cell(
-                    evaluation_references.into_iter().map(|rvc| *rvc).collect(),
-                ),
+                references: ResolvedVc::cell(references),
+                local_references: ResolvedVc::cell(local_references),
+                reexport_references: ResolvedVc::cell(reexport_references),
+                evaluation_references: ResolvedVc::cell(evaluation_references),
                 code_generation: ResolvedVc::cell(self.code_gens),
                 exports: self.exports.resolved_cell(),
                 async_module: self.async_module,
@@ -3371,7 +3365,7 @@ fn is_invoking_node_process_eval(args: &[JsValue]) -> bool {
 #[turbo_tasks::function]
 fn maybe_decode_data_url(url: RcStr) -> Vc<OptionSourceMap> {
     if let Ok(map) = decode_data_url(&url) {
-        Vc::cell(Some(SourceMap::new_decoded(map).cell()))
+        Vc::cell(Some(SourceMap::new_decoded(map).resolved_cell()))
     } else {
         Vc::cell(None)
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -285,7 +285,8 @@ impl AnalyzeEcmascriptModuleResultBuilder {
             self.add_code_gen(bindings);
         }
 
-        let references = references
+        let references = self
+            .references
             .iter()
             .map(|v| async move { v.to_resolved().await })
             .try_join()

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -321,8 +321,6 @@ impl AnalyzeEcmascriptModuleResultBuilder {
         };
         Ok(AnalyzeEcmascriptModuleResult::cell(
             AnalyzeEcmascriptModuleResult {
-                // TODO(ResolvedVc): this is messy because I don't want to
-                //                   touch core while KDY is working on it
                 references: ResolvedVc::cell(references),
                 local_references: ResolvedVc::cell(local_references),
                 reexport_references: ResolvedVc::cell(reexport_references),

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -322,11 +322,11 @@ async fn to_single_pattern_mapping(
         | ModuleResolveResultItem::Custom(_) => {
             // TODO implement mapping
             CodeGenerationIssue {
-                severity: IssueSeverity::Bug.into(),
+                severity: IssueSeverity::Bug.resolved_cell(),
                 title: StyledString::Text(
                     "pattern mapping is not implemented for this result".into(),
                 )
-                .cell(),
+                .resolved_cell(),
                 message: StyledString::Text(
                     format!(
                         "the reference resolves to a non-trivial result, which is not supported \
@@ -335,8 +335,8 @@ async fn to_single_pattern_mapping(
                     )
                     .into(),
                 )
-                .cell(),
-                path: origin.origin_path(),
+                .resolved_cell(),
+                path: origin.origin_path().to_resolved().await?,
             }
             .cell()
             .emit();
@@ -360,13 +360,13 @@ async fn to_single_pattern_mapping(
         }
     }
     CodeGenerationIssue {
-        severity: IssueSeverity::Bug.into(),
-        title: StyledString::Text("non-ecmascript placeable asset".into()).cell(),
+        severity: IssueSeverity::Bug.resolved_cell(),
+        title: StyledString::Text("non-ecmascript placeable asset".into()).resolved_cell(),
         message: StyledString::Text(
             "asset is not placeable in ESM chunks, so it doesn't have a module id".into(),
         )
-        .cell(),
-        path: origin.origin_path(),
+        .resolved_cell(),
+        path: origin.origin_path().to_resolved().await?,
     }
     .cell()
     .emit();

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -371,7 +371,9 @@ impl Module for RequireContextAsset {
 
         Ok(Vc::cell(
             map.iter()
-                .map(|(_, entry)| Vc::upcast(Vc::<ResolvedModuleReference>::cell(entry.result)))
+                .map(|(_, entry)| {
+                    ResolvedVc::upcast(ResolvedVc::<ResolvedModuleReference>::cell(entry.result))
+                })
                 .collect(),
         ))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/type_issue.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/type_issue.rs
@@ -66,7 +66,7 @@ impl Issue for SpecifiedModuleTypeIssue {
                                                    format of the source code."
                     .into(),
             })
-            .cell(),
+            .resolved_cell(),
         ))
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -70,10 +70,11 @@ impl WorkerAssetReference {
         let Some(chunkable) = ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(module).await?
         else {
             CodeGenerationIssue {
-                severity: IssueSeverity::Bug.into(),
-                title: StyledString::Text("non-ecmascript placeable asset".into()).cell(),
-                message: StyledString::Text("asset is not placeable in ESM chunks".into()).cell(),
-                path: self.origin.origin_path(),
+                severity: IssueSeverity::Bug.resolved_cell(),
+                title: StyledString::Text("non-ecmascript placeable asset".into()).resolved_cell(),
+                message: StyledString::Text("asset is not placeable in ESM chunks".into())
+                    .resolved_cell(),
+                path: self.origin.origin_path().to_resolved().await?,
             }
             .cell()
             .emit();

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -85,10 +85,11 @@ impl Module for EcmascriptModuleFacadeModule {
                 let result = module.analyze().await?;
                 let references = result.evaluation_references;
                 let mut references = references.await?.clone_value();
-                references.push(Vc::upcast(EcmascriptModulePartReference::new_part(
-                    *self.module,
-                    ModulePart::locals(),
-                )));
+                references.push(ResolvedVc::upcast(
+                    EcmascriptModulePartReference::new_part(*self.module, ModulePart::locals())
+                        .to_resolved()
+                        .await?,
+                ));
                 references
             }
             ModulePart::Exports => {
@@ -103,29 +104,46 @@ impl Module for EcmascriptModuleFacadeModule {
                 let result = module.analyze().await?;
                 let references = result.reexport_references;
                 let mut references = references.await?.clone_value();
-                references.push(Vc::upcast(EcmascriptModulePartReference::new_part(
-                    *self.module,
-                    ModulePart::locals(),
-                )));
+                references.push(ResolvedVc::upcast(
+                    EcmascriptModulePartReference::new_part(*self.module, ModulePart::locals())
+                        .to_resolved()
+                        .await?,
+                ));
                 references
             }
             ModulePart::Facade => {
                 vec![
-                    Vc::upcast(EcmascriptModulePartReference::new_part(
-                        *self.module,
-                        ModulePart::evaluation(),
-                    )),
-                    Vc::upcast(EcmascriptModulePartReference::new_part(
-                        *self.module,
-                        ModulePart::exports(),
-                    )),
+                    ResolvedVc::upcast(
+                        EcmascriptModulePartReference::new_part(
+                            *self.module,
+                            ModulePart::evaluation(),
+                        )
+                        .to_resolved()
+                        .await?,
+                    ),
+                    ResolvedVc::upcast(
+                        EcmascriptModulePartReference::new_part(
+                            *self.module,
+                            ModulePart::exports(),
+                        )
+                        .to_resolved()
+                        .await?,
+                    ),
                 ]
             }
             ModulePart::RenamedNamespace { .. } => {
-                vec![Vc::upcast(EcmascriptModulePartReference::new(*self.module))]
+                vec![ResolvedVc::upcast(
+                    EcmascriptModulePartReference::new(*self.module)
+                        .to_resolved()
+                        .await?,
+                )]
             }
             ModulePart::RenamedExport { .. } => {
-                vec![Vc::upcast(EcmascriptModulePartReference::new(*self.module))]
+                vec![ResolvedVc::upcast(
+                    EcmascriptModulePartReference::new(*self.module)
+                        .to_resolved()
+                        .await?,
+                )]
             }
             _ => {
                 bail!("Unexpected ModulePart for EcmascriptModuleFacadeModule");

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effect_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effect_module.rs
@@ -60,7 +60,7 @@ impl Module for SideEffectsModule {
             self.resolved_as.ident().to_resolved().await?,
         );
 
-        ident.add_modifier(Vc::cell(RcStr::from("side effects")));
+        ident.add_modifier(ResolvedVc::cell(RcStr::from("side effects")));
 
         for (i, side_effect) in self.side_effects.iter().enumerate() {
             ident.add_asset(
@@ -77,16 +77,24 @@ impl Module for SideEffectsModule {
         let mut references = vec![];
 
         for &side_effect in self.side_effects.iter() {
-            references.push(Vc::upcast(SingleChunkableModuleReference::new(
-                Vc::upcast(side_effect),
-                Vc::cell(RcStr::from("side effect")),
-            )));
+            references.push(ResolvedVc::upcast(
+                SingleChunkableModuleReference::new(
+                    Vc::upcast(side_effect),
+                    Vc::cell(RcStr::from("side effect")),
+                )
+                .to_resolved()
+                .await?,
+            ));
         }
 
-        references.push(Vc::upcast(SingleChunkableModuleReference::new(
-            *ResolvedVc::upcast(self.resolved_as),
-            Vc::cell(RcStr::from("resolved as")),
-        )));
+        references.push(ResolvedVc::upcast(
+            SingleChunkableModuleReference::new(
+                *ResolvedVc::upcast(self.resolved_as),
+                Vc::cell(RcStr::from("resolved as")),
+            )
+            .to_resolved()
+            .await?,
+        ));
 
         Ok(Vc::cell(references))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/references.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/references.rs
@@ -63,7 +63,7 @@ pub async fn module_references(
 
 struct ModuleReferencesVisitor<'a> {
     runtime: ResolvedVc<WebpackRuntime>,
-    references: &'a mut Vec<Vc<Box<dyn ModuleReference>>>,
+    references: &'a mut Vec<ResolvedVc<Box<dyn ModuleReference>>>,
     transforms: ResolvedVc<EcmascriptInputTransforms>,
 }
 
@@ -74,13 +74,13 @@ impl Visit for ModuleReferencesVisitor<'_> {
                 if &*obj.sym == "__webpack_require__" && &*prop.sym == "e" {
                     if let [ExprOrSpread { spread: None, expr }] = &call.args[..] {
                         if let Expr::Lit(lit) = &**expr {
-                            self.references.push(Vc::upcast(
+                            self.references.push(ResolvedVc::upcast(
                                 WebpackChunkAssetReference {
                                     chunk_id: lit.clone(),
                                     runtime: self.runtime,
                                     transforms: self.transforms,
                                 }
-                                .cell(),
+                                .resolved_cell(),
                             ));
                         }
                     }

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -126,13 +126,15 @@ impl ChunkItem for WorkerLoaderChunkItem {
                 .await?
                 .iter()
                 .copied()
-                .map(|chunk| {
-                    Vc::upcast(SingleOutputAssetReference::new(
-                        *chunk,
-                        chunk_reference_description(),
+                .map(|chunk| async move {
+                    Ok(ResolvedVc::upcast(
+                        SingleOutputAssetReference::new(*chunk, chunk_reference_description())
+                            .to_resolved()
+                            .await?,
                     ))
                 })
-                .collect(),
+                .try_join()
+                .await?,
         ))
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -50,10 +50,14 @@ impl Module for WorkerLoaderModule {
 
     #[turbo_tasks::function]
     async fn references(self: Vc<Self>) -> Result<Vc<ModuleReferences>> {
-        Ok(Vc::cell(vec![Vc::upcast(SingleModuleReference::new(
-            *ResolvedVc::upcast(self.await?.inner),
-            inner_module_reference_description(),
-        ))]))
+        Ok(Vc::cell(vec![ResolvedVc::upcast(
+            SingleModuleReference::new(
+                *ResolvedVc::upcast(self.await?.inner),
+                inner_module_reference_description(),
+            )
+            .to_resolved()
+            .await?,
+        )]))
     }
 }
 

--- a/turbopack/crates/turbopack-env/src/issue.rs
+++ b/turbopack/crates/turbopack-env/src/issue.rs
@@ -28,6 +28,6 @@ impl Issue for ProcessEnvIssue {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(*self.description))
+        Vc::cell(Some(self.description))
     }
 }

--- a/turbopack/crates/turbopack-image/src/process/mod.rs
+++ b/turbopack/crates/turbopack-image/src/process/mod.rs
@@ -520,6 +520,6 @@ impl Issue for ImageProcessingIssue {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(*self.message))
+        Vc::cell(Some(self.message))
     }
 }

--- a/turbopack/crates/turbopack-mdx/src/lib.rs
+++ b/turbopack/crates/turbopack-mdx/src/lib.rs
@@ -269,8 +269,11 @@ impl Issue for MdxIssue {
     }
 
     #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(self.loc.map(|s| s.resolve_source_map(*self.path)))
+    async fn source(&self) -> Result<Vc<OptionIssueSource>> {
+        Ok(Vc::cell(match &self.loc {
+            Some(loc) => Some(loc.resolve_source_map(*self.path).to_resolved().await?),
+            None => None,
+        }))
     }
 
     #[turbo_tasks::function]
@@ -285,7 +288,9 @@ impl Issue for MdxIssue {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(StyledString::Text(self.reason.clone().into()).cell()))
+        Vc::cell(Some(
+            StyledString::Text(self.reason.clone().into()).resolved_cell(),
+        ))
     }
 }
 

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -143,7 +143,7 @@ async fn emit_evaluate_pool_assets(
             bail!("Internal module is not evaluatable");
         };
 
-        let mut entries = vec![globals_module];
+        let mut entries = vec![globals_module.to_resolved().await?];
         if let Some(runtime_entries) = runtime_entries {
             for &entry in &*runtime_entries.await? {
                 entries.push(entry)
@@ -702,7 +702,7 @@ impl Issue for EvaluationIssue {
                     .await?
                     .into(),
             )
-            .cell(),
+            .resolved_cell(),
         )))
     }
 }

--- a/turbopack/crates/turbopack-node/src/render/issue.rs
+++ b/turbopack/crates/turbopack-node/src/render/issue.rs
@@ -29,7 +29,7 @@ impl Issue for RenderingIssue {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(*self.message))
+        Vc::cell(Some(self.message))
     }
 
     #[turbo_tasks::function]
@@ -44,7 +44,7 @@ impl Issue for RenderingIssue {
             }
         }
 
-        Vc::cell(Some(StyledString::Stack(details).cell()))
+        Vc::cell(Some(StyledString::Stack(details).resolved_cell()))
     }
 
     // TODO parse stack trace into source location

--- a/turbopack/crates/turbopack-node/src/render/node_api_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/node_api_source.rs
@@ -194,11 +194,11 @@ impl Introspectable for NodeApiContentSource {
         for &entry in self.entry.entries().await?.iter() {
             let entry = entry.await?;
             set.insert((
-                Vc::cell("module".into()),
+                ResolvedVc::cell("module".into()),
                 IntrospectableModule::new(Vc::upcast(*entry.module)),
             ));
             set.insert((
-                Vc::cell("intermediate asset".into()),
+                ResolvedVc::cell("intermediate asset".into()),
                 IntrospectableOutputAsset::new(get_intermediate_asset(
                     *entry.chunking_context,
                     Vc::upcast(*entry.module),

--- a/turbopack/crates/turbopack-node/src/render/rendered_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/rendered_source.rs
@@ -277,11 +277,11 @@ impl Introspectable for NodeRenderContentSource {
         for &entry in self.entry.entries().await?.iter() {
             let entry = entry.await?;
             set.insert((
-                Vc::cell("module".into()),
+                ResolvedVc::cell("module".into()),
                 IntrospectableModule::new(Vc::upcast(*entry.module)),
             ));
             set.insert((
-                Vc::cell("intermediate asset".into()),
+                ResolvedVc::cell("intermediate asset".into()),
                 IntrospectableOutputAsset::new(get_intermediate_asset(
                     *entry.chunking_context,
                     *entry.module,

--- a/turbopack/crates/turbopack-node/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-node/src/source_map/mod.rs
@@ -225,7 +225,7 @@ async fn resolve_source_mapping(
     let Some(sm) = *generate_source_map.generate_source_map().await? else {
         return Ok(ResolvedSourceMapping::NoSourceMap);
     };
-    let trace = SourceMapTrace::new(sm, line, column, name.map(|s| s.clone().into()))
+    let trace = SourceMapTrace::new(*sm, line, column, name.map(|s| s.clone().into()))
         .trace()
         .await?;
     match &*trace {

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -561,7 +561,9 @@ impl Issue for PostCssTransformIssue {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(StyledString::Text(self.description.clone()).cell()))
+        Vc::cell(Some(
+            StyledString::Text(self.description.clone()).resolved_cell(),
+        ))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -164,7 +164,7 @@ impl Asset for WebpackLoadersProcessedAsset {
 impl GenerateSourceMap for WebpackLoadersProcessedAsset {
     #[turbo_tasks::function]
     async fn generate_source_map(self: Vc<Self>) -> Result<Vc<OptionSourceMap>> {
-        Ok(Vc::cell(self.process().await?.source_map.map(|v| *v)))
+        Ok(Vc::cell(self.process().await?.source_map))
     }
 }
 
@@ -728,7 +728,7 @@ impl Issue for BuildDependencyIssue {
                         .into(),
                 ),
             ])
-            .cell(),
+            .resolved_cell(),
         )))
     }
 }
@@ -818,7 +818,7 @@ impl Issue for EvaluateEmittedErrorIssue {
                     .await?
                     .into(),
             )
-            .cell(),
+            .resolved_cell(),
         )))
     }
 }
@@ -891,6 +891,6 @@ impl Issue for EvaluateErrorLoggingIssue {
                 }
             })
             .collect::<Vec<_>>();
-        Vc::cell(Some(StyledString::Stack(lines).cell()))
+        Vc::cell(Some(StyledString::Stack(lines).resolved_cell()))
     }
 }

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -287,7 +287,7 @@ impl ChunkingContext for NodeJsChunkingContext {
     async fn chunk_group(
         self: Vc<Self>,
         _ident: Vc<AssetIdent>,
-        module: Vc<Box<dyn ChunkableModule>>,
+        module: ResolvedVc<Box<dyn ChunkableModule>>,
         availability_info: Value<AvailabilityInfo>,
     ) -> Result<Vc<ChunkGroupResult>> {
         let span = tracing::info_span!(
@@ -300,7 +300,7 @@ impl ChunkingContext for NodeJsChunkingContext {
                 availability_info,
             } = make_chunk_group(
                 Vc::upcast(self),
-                [Vc::upcast(module)],
+                [ResolvedVc::upcast(module)],
                 availability_info.into_value(),
             )
             .await?;
@@ -312,7 +312,7 @@ impl ChunkingContext for NodeJsChunkingContext {
                 .await?;
 
             Ok(ChunkGroupResult {
-                assets: Vc::cell(assets),
+                assets: ResolvedVc::cell(assets),
                 availability_info,
             }
             .cell())
@@ -328,7 +328,7 @@ impl ChunkingContext for NodeJsChunkingContext {
     pub async fn entry_chunk_group(
         self: Vc<Self>,
         path: Vc<FileSystemPath>,
-        module: Vc<Box<dyn Module>>,
+        module: ResolvedVc<Box<dyn Module>>,
         evaluatable_assets: Vc<EvaluatableAssets>,
         extra_chunks: Vc<OutputAssets>,
         availability_info: Value<AvailabilityInfo>,
@@ -344,7 +344,7 @@ impl ChunkingContext for NodeJsChunkingContext {
                 evaluatable_assets
                     .await?
                     .iter()
-                    .map(|&asset| Vc::upcast(asset)),
+                    .map(|&asset| ResolvedVc::upcast(asset)),
             ),
             availability_info,
         )
@@ -363,7 +363,7 @@ impl ChunkingContext for NodeJsChunkingContext {
             )
             .collect();
 
-        let Some(module) = Vc::try_resolve_downcast(module).await? else {
+        let Some(module) = ResolvedVc::try_downcast(module).await? else {
             bail!("module must be placeable in an ecmascript chunk");
         };
 
@@ -373,7 +373,7 @@ impl ChunkingContext for NodeJsChunkingContext {
                 self,
                 Vc::cell(other_chunks),
                 evaluatable_assets,
-                module,
+                *module,
             )
             .to_resolved()
             .await?,

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
@@ -151,7 +151,7 @@ impl Introspectable for EcmascriptBuildNodeChunk {
         let introspectable_chunk = ResolvedVc::upcast::<Box<dyn Introspectable>>(self.chunk)
             .resolve()
             .await?;
-        children.insert((Vc::cell("chunk".into()), introspectable_chunk));
+        children.insert((ResolvedVc::cell("chunk".into()), introspectable_chunk));
         Ok(Vc::cell(children))
     }
 }

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -109,7 +109,7 @@ impl EcmascriptBuildNodeEntryChunk {
         let evaluatable_assets = this.evaluatable_assets.await?;
         for evaluatable_asset in &*evaluatable_assets {
             if let Some(placeable) =
-                Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(*evaluatable_asset)
+                ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(*evaluatable_asset)
                     .await?
             {
                 let runtime_module_id = placeable

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -531,7 +531,9 @@ impl Issue for TsConfigIssue {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(StyledString::Text(self.message.clone()).cell()))
+        Vc::cell(Some(
+            StyledString::Text(self.message.clone()).resolved_cell(),
+        ))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-static/src/lib.rs
+++ b/turbopack/crates/turbopack-static/src/lib.rs
@@ -134,16 +134,20 @@ impl ChunkItem for ModuleChunkItem {
 
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<ModuleReferences>> {
-        Ok(Vc::cell(vec![Vc::upcast(SingleOutputAssetReference::new(
-            *ResolvedVc::upcast(self.static_asset),
-            Vc::cell(
-                format!(
-                    "static(url) {}",
-                    self.static_asset.ident().to_string().await?
-                )
-                .into(),
-            ),
-        ))]))
+        Ok(Vc::cell(vec![ResolvedVc::upcast(
+            SingleOutputAssetReference::new(
+                *ResolvedVc::upcast(self.static_asset),
+                Vc::cell(
+                    format!(
+                        "static(url) {}",
+                        self.static_asset.ident().to_string().await?
+                    )
+                    .into(),
+                ),
+            )
+            .to_resolved()
+            .await?,
+        )]))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-wasm/src/raw.rs
+++ b/turbopack/crates/turbopack-wasm/src/raw.rs
@@ -117,10 +117,16 @@ impl ChunkItem for RawModuleChunkItem {
 
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<ModuleReferences>> {
-        Ok(Vc::cell(vec![Vc::upcast(SingleOutputAssetReference::new(
-            Vc::upcast(*self.wasm_asset),
-            Vc::cell(format!("wasm(url) {}", self.wasm_asset.ident().to_string().await?).into()),
-        ))]))
+        Ok(Vc::cell(vec![ResolvedVc::upcast(
+            SingleOutputAssetReference::new(
+                Vc::upcast(*self.wasm_asset),
+                Vc::cell(
+                    format!("wasm(url) {}", self.wasm_asset.ident().to_string().await?).into(),
+                ),
+            )
+            .to_resolved()
+            .await?,
+        )]))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -599,14 +599,15 @@ async fn process_default_internal(
                             }),
                             Some(module_type) => {
                                 ModuleIssue {
-                                    ident,
-                                    title: StyledString::Text("Invalid module type".into()).cell(),
+                                    ident: ident.to_resolved().await?,
+                                    title: StyledString::Text("Invalid module type".into())
+                                        .resolved_cell(),
                                     description: StyledString::Text(
                                         "The module type must be Ecmascript or Typescript to add \
                                          Ecmascript transforms"
                                             .into(),
                                     )
-                                    .cell(),
+                                    .resolved_cell(),
                                 }
                                 .cell()
                                 .emit();
@@ -614,14 +615,15 @@ async fn process_default_internal(
                             }
                             None => {
                                 ModuleIssue {
-                                    ident,
-                                    title: StyledString::Text("Missing module type".into()).cell(),
+                                    ident: ident.to_resolved().await?,
+                                    title: StyledString::Text("Missing module type".into())
+                                        .resolved_cell(),
                                     description: StyledString::Text(
                                         "The module type effect must be applied before adding \
                                          Ecmascript transforms"
                                             .into(),
                                     )
-                                    .cell(),
+                                    .resolved_cell(),
                                 }
                                 .cell()
                                 .emit();

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -412,17 +412,21 @@ impl ModuleOptions {
                 rules.push(ModuleRule::new(
                     RuleCondition::ResourcePathEndsWith(".css".to_string()),
                     vec![ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![
-                        Vc::upcast(PostCssTransform::new(
-                            node_evaluate_asset_context(
+                        ResolvedVc::upcast(
+                            PostCssTransform::new(
+                                node_evaluate_asset_context(
+                                    *execution_context,
+                                    Some(import_map),
+                                    None,
+                                    "postcss".into(),
+                                    true,
+                                ),
                                 *execution_context,
-                                Some(import_map),
-                                None,
-                                "postcss".into(),
-                                true,
-                            ),
-                            *execution_context,
-                            options.config_location,
-                        )),
+                                options.config_location,
+                            )
+                            .to_resolved()
+                            .await?,
+                        ),
                     ]))],
                 ));
             }
@@ -521,7 +525,11 @@ impl ModuleOptions {
                     RuleCondition::ResourcePathEndsWith(".mdx".to_string()),
                 ]),
                 vec![ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![
-                    Vc::upcast(MdxTransform::new(mdx_transform_options)),
+                    ResolvedVc::upcast(
+                        MdxTransform::new(mdx_transform_options)
+                            .to_resolved()
+                            .await?,
+                    ),
                 ]))],
             ));
         }
@@ -554,19 +562,23 @@ impl ModuleOptions {
                         RuleCondition::not(RuleCondition::ResourceIsVirtualSource),
                     ]),
                     vec![ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![
-                        Vc::upcast(WebpackLoaders::new(
-                            node_evaluate_asset_context(
+                        ResolvedVc::upcast(
+                            WebpackLoaders::new(
+                                node_evaluate_asset_context(
+                                    *execution_context,
+                                    Some(import_map),
+                                    None,
+                                    "webpack_loaders".into(),
+                                    false,
+                                ),
                                 *execution_context,
-                                Some(import_map),
-                                None,
-                                "webpack_loaders".into(),
-                                false,
-                            ),
-                            *execution_context,
-                            *rule.loaders,
-                            rule.rename_as.clone(),
-                            resolve_options_context,
-                        )),
+                                *rule.loaders,
+                                rule.rename_as.clone(),
+                                resolve_options_context,
+                            )
+                            .to_resolved()
+                            .await?,
+                        ),
                     ]))],
                 ));
             }

--- a/turbopack/crates/turbopack/src/unsupported_sass.rs
+++ b/turbopack/crates/turbopack/src/unsupported_sass.rs
@@ -90,7 +90,7 @@ impl Issue for UnsupportedSassModuleIssue {
     fn description(&self) -> Vc<OptionStyledString> {
         Vc::cell(Some(
             StyledString::Text("Turbopack does not yet support importing Sass modules.".into())
-                .cell(),
+                .resolved_cell(),
         ))
     }
 


### PR DESCRIPTION


Closes PACK-3611