### PR TITLE
docs: add await before headers() and cookies() calls

### DIFF
--- a/errors/next-dynamic-api-wrong-context.mdx
+++ b/errors/next-dynamic-api-wrong-context.mdx
@@ -17,9 +17,9 @@ Example:
 ```diff filename="app/page.js"
 import { cookies } from 'next/headers'
 
-- const cookieStore = cookies()
-export default function Page() {
-+ const cookieStore = cookies()
+- const cookieStore = await cookies()
+export default async function Page() {
++ const cookieStore = await cookies()
   return ...
 }
 ```
@@ -27,9 +27,9 @@ export default function Page() {
 ```diff filename="app/foo/route.js"
 import { headers } from 'next/headers'
 
-- const headersList = headers()
+- const headersList = await headers()
 export async function GET() {
-+ const headersList = headers()
++ const headersList = await headers()
   return ...
 }
 ```


### PR DESCRIPTION
### What?
Add missing await keywords to cookies() and headers() calls in the documentation.

### Why?
Next.js 15 changes previously synchronous Dynamic APIs (cookies(), headers()) to be asynchronous, requiring await.

### How?
```js
// Before
const cookieStore = cookies()

// After
const cookieStore = await cookies()
```