### PR TITLE
Format node_module package path for better readability

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/app/ReactDevOverlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/ReactDevOverlay.tsx
@@ -24,8 +24,8 @@ export default class ReactDevOverlay extends React.PureComponent<
 > {
   state = { isReactError: false }
 
-  static getDerivedStateFromError(error: Error): ReactDevOverlayState {
-    if (!error.stack) return { isReactError: false }
+  static getDerivedStateFromError(error: unknown): ReactDevOverlayState {
+    if (error && !(error as Error).stack) return { isReactError: false }
 
     RuntimeErrorHandler.hadRuntimeError = true
     return {

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/CallStackFrame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/CallStackFrame.tsx
@@ -48,7 +48,7 @@ export const CallStackFrame: React.FC<{
         onClick={open}
         title={hasSource ? 'Click to open in your editor' : undefined}
       >
-        <span>{fileSource}</span>
+        <span data-file-path>{fileSource}</span>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/normalize-node-modules-filepath.test.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/normalize-node-modules-filepath.test.ts
@@ -1,0 +1,58 @@
+import { normalizeNodeModuleFilePath } from './normalize-node-modules-filepath'
+
+describe('normalizeNodeModuleFilePath', () => {
+  it('should normalize basic node_modules filepath', () => {
+    expect(normalizeNodeModuleFilePath('node_modules/foo/bar')).toBe(
+      'node_modules/foo/bar'
+    )
+    expect(
+      normalizeNodeModuleFilePath('node_modules/.pnpm/foo/node_modules/bar')
+    ).toBe('node_modules/bar')
+    expect(
+      normalizeNodeModuleFilePath('node_modules/.yarn/foo/node_modules/bar')
+    ).toBe('node_modules/bar')
+    expect(normalizeNodeModuleFilePath('javascript/node_modules/foo/bar')).toBe(
+      'node_modules/foo/bar'
+    )
+  })
+
+  it('should normalize nested pnpm filepath', () => {
+    expect(
+      normalizeNodeModuleFilePath('node_modules/.pnpm/foo/node_modules/bar')
+    ).toBe('node_modules/bar')
+    expect(
+      normalizeNodeModuleFilePath(
+        'node_modules/.pnpm/react-dom@19.0.0/node_modules/react-dom/index.js'
+      )
+    ).toBe('node_modules/react-dom/index.js')
+    expect(
+      normalizeNodeModuleFilePath(
+        'node_modules/.pnpm/postcss@8.4.31/node_modules/source-map-js'
+      )
+    ).toBe('node_modules/source-map-js')
+  })
+
+  it('should normalize yarn PnP node_modules filepath', () => {
+    expect(
+      normalizeNodeModuleFilePath('node_modules/.yarn/foo/node_modules/bar')
+    ).toBe('node_modules/bar')
+    expect(
+      normalizeNodeModuleFilePath('node_modules/.yarn/foo/node_modules/bar')
+    ).toBe('node_modules/bar')
+    expect(
+      normalizeNodeModuleFilePath('.yarn/foo/node_modules/foo/node_modules/bar')
+    ).toBe('node_modules/bar')
+  })
+
+  it('should handle windows paths', () => {
+    expect(
+      normalizeNodeModuleFilePath('node_modules\\.yarn\\foo\\node_modules\\bar')
+    ).toBe('node_modules\\bar')
+    expect(
+      normalizeNodeModuleFilePath('node_modules\\.pnpm\\foo\\node_modules\\bar')
+    ).toBe('node_modules\\bar')
+    expect(
+      normalizeNodeModuleFilePath('javascript\\node_modules\\foo\\bar')
+    ).toBe('node_modules\\foo\\bar')
+  })
+})

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/normalize-node-modules-filepath.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/normalize-node-modules-filepath.ts
@@ -1,0 +1,35 @@
+export function normalizeNodeModuleFilePath(filePath: string): string {
+  const separatorRegex = /[\\/]/
+
+  const separator = filePath.match(separatorRegex)
+    ? filePath.match(separatorRegex)![0]
+    : '/'
+
+  // Webpack source frame could contain javascript/ prefix
+  if (/javascript[\\/]/.test(filePath)) {
+    filePath = filePath.replace(/javascript[\\/]/, '')
+  }
+
+  // Replace yarn's prefix, handling optional node_modules at the beginning
+  // e.g. node_modules/.yarn/foo/node_modules/bar -> node_modules/bar
+  filePath = filePath.replace(
+    /(?:node_modules[\\/])?(?:\.yarn\/[^/]+[\\/])+node_modules[\\/]([^/]+)/,
+    `node_modules${separator}$1`
+  )
+
+  // Replace pnpm's prefix, handling nested .pnpm directories
+  // e.g. node_modules/.pnpm/foo/node_modules/bar -> node_modules/bar
+  filePath = filePath.replace(
+    /node_modules[\\/](?:\.pnpm\/[^/]+\/node_modules\/)?(?:\.pnpm[\\/][^/]+\/)?([^/]+)/,
+    `node_modules${separator}$1`
+  )
+
+  // Handle multiple nested node_modules, selecting the last one
+  // e.g. node_modules/xxx/node_modules/yyy/node_modules/zzz -> node_modules/zzz
+  filePath = filePath.replace(
+    /^(.*)node_modules[\\/]([^/]+)/,
+    `node_modules${separator}$2`
+  )
+
+  return filePath
+}

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
@@ -17,6 +17,7 @@ import type { StackFrame } from 'next/dist/compiled/stacktrace-parser'
 import type { Project, TurbopackStackFrame } from '../../../../build/swc/types'
 import { getSourceMapFromFile } from '../internal/helpers/get-source-map-from-file'
 import { findSourceMap } from 'node:module'
+import { normalizeNodeModuleFilePath } from '../internal/helpers/normalize-node-modules-filepath'
 
 function shouldIgnorePath(modulePath: string): boolean {
   return (
@@ -40,7 +41,7 @@ export async function batchedTraceSource(
   if (!sourceFrame) {
     return {
       frame: {
-        file,
+        file: normalizeNodeModuleFilePath(file),
         lineNumber: frame.line ?? 0,
         column: frame.column ?? 0,
         methodName: frame.methodName ?? '<unknown>',
@@ -73,7 +74,7 @@ export async function batchedTraceSource(
 
   // TODO: get ignoredList from turbopack source map
   const ignorableFrame = {
-    file: sourceFrame.file,
+    file: normalizeNodeModuleFilePath(sourceFrame.file),
     lineNumber: sourceFrame.line ?? 0,
     column: sourceFrame.column ?? 0,
     methodName: sourceFrame.methodName ?? frame.methodName ?? '<unknown>',

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-webpack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-webpack.ts
@@ -25,6 +25,7 @@ import type {
 } from 'next/dist/compiled/source-map08'
 import { formatFrameSourceFile } from '../internal/helpers/webpack-module-path'
 import type { MappedPosition } from 'source-map'
+import { normalizeNodeModuleFilePath } from '../internal/helpers/normalize-node-modules-filepath'
 
 function shouldIgnorePath(modulePath: string): boolean {
   return (
@@ -226,9 +227,10 @@ export async function createOriginalStackFrame({
   const resolvedFilePath = sourceContent
     ? path.relative(rootDirectory, filePath)
     : sourcePosition.source
+  const normalizedFilePath = normalizeNodeModuleFilePath(resolvedFilePath)
 
   const traced: IgnorableStackFrame = {
-    file: resolvedFilePath,
+    file: normalizedFilePath,
     lineNumber: sourcePosition.line,
     column: (sourcePosition.column ?? 0) + 1,
     methodName:
@@ -413,7 +415,7 @@ export function getOverlayMiddleware(options: {
 
       // This stack frame is used for the one that couldn't locate the source or source mapped frame
       const defaultStackFrame: IgnorableStackFrame = {
-        file: frame.file,
+        file: normalizeNodeModuleFilePath(frame.file),
         lineNumber: frame.lineNumber,
         column: frame.column ?? 1,
         methodName: frame.methodName,

--- a/packages/next/src/client/react-client-callbacks/app-router.ts
+++ b/packages/next/src/client/react-client-callbacks/app-router.ts
@@ -44,7 +44,7 @@ export const onCaughtError: HydrationOptions['onCaughtError'] = (
     const stitchedError = getReactStitchedError(err)
     // TODO: change to passing down errorInfo later
     // In development mode, pass along the component stack to the error
-    if (errorInfo.componentStack) {
+    if (stitchedError && errorInfo.componentStack) {
       ;(stitchedError as any)._componentStack = errorInfo.componentStack
     }
 
@@ -80,7 +80,7 @@ export const onUncaughtError: HydrationOptions['onUncaughtError'] = (
     const stitchedError = getReactStitchedError(err)
     // TODO: change to passing down errorInfo later
     // In development mode, pass along the component stack to the error
-    if (errorInfo.componentStack) {
+    if (stitchedError && errorInfo.componentStack) {
       ;(stitchedError as any)._componentStack = errorInfo.componentStack
     }
 

--- a/test/development/app-dir/error-overlay/format-ignored-frame-filepath/app/client/page.tsx
+++ b/test/development/app-dir/error-overlay/format-ignored-frame-filepath/app/client/page.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+import useSWR from 'swr'
+
+export default function Page() {
+  const { error } = useSWR('/api/data', () => {
+    throw new Error('boom')
+  })
+  if (error) throw error
+}

--- a/test/development/app-dir/error-overlay/format-ignored-frame-filepath/app/layout.tsx
+++ b/test/development/app-dir/error-overlay/format-ignored-frame-filepath/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/error-overlay/format-ignored-frame-filepath/format-ignored-frame-filepath.test.ts
+++ b/test/development/app-dir/error-overlay/format-ignored-frame-filepath/format-ignored-frame-filepath.test.ts
@@ -18,6 +18,13 @@ async function getIgnoredFrameFilepaths(browser: BrowserInterface) {
 }
 
 describe('format-ignored-frame-filepath', () => {
+  // TODO: remove this when reactOwnerStack is enabled by default
+  if (process.env.__NEXT_EXPERIMENTAL_PPR === 'true') {
+    // Since PPR mode is just going to add owner stack, skip this test for now
+    it('skip ppr test', () => {})
+    return
+  }
+
   const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {

--- a/test/development/app-dir/error-overlay/format-ignored-frame-filepath/format-ignored-frame-filepath.test.ts
+++ b/test/development/app-dir/error-overlay/format-ignored-frame-filepath/format-ignored-frame-filepath.test.ts
@@ -1,0 +1,241 @@
+import { nextTestSetup } from 'e2e-utils'
+import { assertHasRedbox, toggleCollapseCallStackFrames } from 'next-test-utils'
+import { type BrowserInterface } from 'next-webdriver'
+
+async function getIgnoredFrameFilepaths(browser: BrowserInterface) {
+  await assertHasRedbox(browser)
+  await toggleCollapseCallStackFrames(browser)
+
+  const elements = await browser.elementsByCss('[data-file-path]')
+  const framesFilePaths = await Promise.all(
+    elements.map(async (el) => {
+      const line = await el.innerText()
+      // Remove the line number
+      return line.replace(/\(\d+:\d+\)?$/, '').trim()
+    })
+  )
+  return framesFilePaths.join('\n')
+}
+
+describe('format-ignored-frame-filepath', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    dependencies: {
+      swr: '2.2.5',
+    },
+  })
+
+  it('should normalize ignored node_modules filepath in app router', async () => {
+    const browser = await next.browser('/client')
+
+    const ignoredFrameFilepaths = await getIgnoredFrameFilepaths(browser)
+    if (process.env.TURBOPACK) {
+      expect(ignoredFrameFilepaths).toMatchInlineSnapshot(`
+        "node_modules/swr/dist/_internal/index.mjs
+        node_modules/swr/dist/core/index.mjs
+        node_modules/swr/dist/core/index.mjs
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js"
+      `)
+    } else {
+      expect(ignoredFrameFilepaths).toMatchInlineSnapshot(`
+        "node_modules/swr/dist/_internal/index.mjs
+        node_modules/swr/dist/core/index.mjs
+        node_modules/swr/dist/core/index.mjs
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js
+        node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js"
+      `)
+    }
+  })
+
+  it('should normalize ignored node_modules filepath in pages router', async () => {
+    const browser = await next.browser('/pages')
+
+    const ignoredFrameFilepaths = await getIgnoredFrameFilepaths(browser)
+    if (process.env.TURBOPACK) {
+      expect(ignoredFrameFilepaths).toMatchInlineSnapshot(`
+        "node_modules/swr/dist/_internal/index.mjs
+        node_modules/swr/dist/core/index.mjs
+        node_modules/swr/dist/core/index.mjs
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/scheduler/cjs/scheduler.development.js"
+      `)
+    } else {
+      expect(ignoredFrameFilepaths).toMatchInlineSnapshot(`
+        "node_modules/swr/dist/_internal/index.mjs
+        node_modules/swr/dist/core/index.mjs
+        node_modules/swr/dist/core/index.mjs
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/react-dom/cjs/react-dom-client.development.js
+        node_modules/scheduler/cjs/scheduler.development.js"
+      `)
+    }
+  })
+})

--- a/test/development/app-dir/error-overlay/format-ignored-frame-filepath/next.config.js
+++ b/test/development/app-dir/error-overlay/format-ignored-frame-filepath/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/development/app-dir/error-overlay/format-ignored-frame-filepath/pages/pages.tsx
+++ b/test/development/app-dir/error-overlay/format-ignored-frame-filepath/pages/pages.tsx
@@ -1,0 +1,8 @@
+import useSWR from 'swr'
+
+export default function Page() {
+  const { error } = useSWR('/api/data', () => {
+    throw new Error('boom')
+  })
+  if (error) throw error
+}


### PR DESCRIPTION
### What

Format the file source paths that from node_modules created by pnpm or yarn into a shorter and more readable path. Stripping out those `.pnpm/...<peer dep>` or `.yarn/...` prefix of the actual node_module package. Since we're having ignored list feature changes landed now, they're only existed in the ignored frames

#### Diff

![image](https://github.com/user-attachments/assets/3bb81627-c52e-4f03-9294-2f114b5afdf2)

Closes NDX-507