### PR TITLE
test: fix canary test with 18.3.1

### DIFF
--- a/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
+++ b/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
@@ -10,10 +10,14 @@ describe('error-ignored-frames', () => {
     files: __dirname,
   })
 
-  // TODO: remove this when reactOwnerStack is enabled by default
-  if (process.env.__NEXT_EXPERIMENTAL_PPR === 'true') {
+  if (
+    // TODO: remove this when reactOwnerStack is enabled by default
     // Since PPR mode is just going to add owner stack, skip this test for now
-    it('skip ppr test', () => {})
+    process.env.__NEXT_EXPERIMENTAL_PPR === 'true' ||
+    // Skip react 18 test as the call stacks are different
+    process.env.NEXT_TEST_REACT_VERSION === '18.3.1'
+  ) {
+    it('skip test', () => {})
     return
   }
 


### PR DESCRIPTION
Skip react 18 tests for few tests as they're using it got the different call stack. We don't need to ensure the call stack matching in all versions, only one is enough

x-ref: https://github.com/vercel/next.js/actions/runs/12071218438/attempts/3
