### PR TITLE
test: Skip jest link test on 18.3.1

### DIFF
--- a/test/production/jest/new-link-behavior.test.ts
+++ b/test/production/jest/new-link-behavior.test.ts
@@ -51,6 +51,15 @@ describe('next/jest newLinkBehavior', () => {
 
   afterAll(() => next.destroy())
 
+  if (
+    // TODO: remove this again
+    // Skip react 18 test as the call stacks are different
+    process.env.NEXT_TEST_REACT_VERSION === '18.3.1'
+  ) {
+    it('skip test', () => {})
+    return
+  }
+
   it(`should use new link behavior`, async () => {
     await next.start()
   })


### PR DESCRIPTION
This seems to fail consistently, e.g. on https://github.com/vercel/next.js/commit/f5e35b87b91ef43a46edef180a4389d245929e18

```
PASS test/mock.test.js
FAIL test/dynamic.test.js
  ● Console

    console.error
      An update to ForwardRef(LoadableComponent) inside a test was not wrapped in act(...).

      When testing, code that causes React state updates should be wrapped into act(...):

      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */

      This ensures that you're testing the behavior the user would see in the browser. Learn more at https://react.dev/link/wrap-tests-with-act

      at node_modules/.pnpm/react-dom@19.0.0-rc-b01722d5-20241114_react@19.0.0-rc-b01722d5-20241114/node_modules/react-dom/cjs/react-dom-client.development.js:15751:19
      at runWithFiberInDEV (node_modules/.pnpm/react-dom@19.0.0-rc-b01722d5-20241114_react@19.0.0-rc-b01722d5-20241114/node_modules/react-dom/cjs/react-dom-client.development.js:543:16)
      at warnIfUpdatesNotWrappedWithActDEV (node_modules/.pnpm/react-dom@19.0.0-rc-b01722d5-20241114_react@19.0.0-rc-b01722d5-20241114/node_modules/react-dom/cjs/react-dom-client.development.js:15750:9)
      at scheduleUpdateOnFiber (node_modules/.pnpm/react-dom@19.0.0-rc-b01722d5-20241114_react@19.0.0-rc-b01722d5-20241114/node_modules/react-dom/cjs/react-dom-client.development.js:14311:11)
      at forceStoreRerender (node_modules/.pnpm/react-dom@19.0.0-rc-b01722d5-20241114_react@19.0.0-rc-b01722d5-20241114/node_modules/react-dom/cjs/react-dom-client.development.js:6349:24)
      at node_modules/.pnpm/react-dom@19.0.0-rc-b01722d5-20241114_react@19.0.0-rc-b01722d5-20241114/node_modules/react-dom/cjs/react-dom-client.development.js:6334:41
      at callback (node_modules/.pnpm/next@file+..+next-repo-7b2581969f664a74c263fb3b7dcf7d3a9c11cf5a1a31f813a37fafdde376018f+packa_vardpirnjthth4v3pjzanjvigu/node_modules/next/src/shared/lib/loadable.shared-runtime.tsx:236:48)
          at Set.forEach (<anonymous>)
      at LoadableSubscription.forEach (node_modules/.pnpm/next@file+..+next-repo-7b2581969f664a74c263fb3b7dcf7d3a9c11cf5a1a31f813a37fafdde376018f+packa_vardpirnjthth4v3pjzanjvigu/node_modules/next/src/shared/lib/loadable.shared-runtime.tsx:236:21)
      at _update (node_modules/.pnpm/next@file+..+next-repo-7b2581969f664a74c263fb3b7dcf7d3a9c11cf5a1a31f813a37fafdde376018f+packa_vardpirnjthth4v3pjzanjvigu/node_modules/next/src/shared/lib/loadable.shared-runtime.tsx:218:14)

  ● Home › renders a heading

    The error below may be caused by using the wrong test environment, see https://jestjs.io/docs/configuration#testenvironment-string.
    Consider using the "jsdom" test environment.

    ReferenceError: document is not defined

       7 |               const { unmount } = render(<Home />);
       8 |
    >  9 |               const heading = screen.getByRole("heading", {
         |                                      ^
      10 |                 name: /Loading/i,
      11 |               });
      12 |

      at node_modules/.pnpm/nwsapi@2.2.15/node_modules/nwsapi/src/nwsapi.js:215:21
      at Factory (node_modules/.pnpm/nwsapi@2.2.15/node_modules/nwsapi/src/nwsapi.js:245:6)
      at initNwsapi (node_modules/.pnpm/jsdom@20.0.3/node_modules/jsdom/lib/jsdom/living/helpers/selectors.js:10:10)
      at exports.addNwsapi (node_modules/.pnpm/jsdom@20.0.3/node_modules/jsdom/lib/jsdom/living/helpers/selectors.js:38:24)
      at HTMLBodyElementImpl.querySelectorAll (node_modules/.pnpm/jsdom@20.0.3/node_modules/jsdom/lib/jsdom/living/nodes/ParentNode-impl.js:77:21)
      at HTMLBodyElement.querySelectorAll (node_modules/.pnpm/jsdom@20.0.3/node_modules/jsdom/lib/jsdom/living/generated/Element.js:1119:58)
      at queryAllByRole (node_modules/.pnpm/@testing-library+dom@10.4.0/node_modules/@testing-library/dom/dist/queries/role.js:111:31)
      at node_modules/.pnpm/@testing-library+dom@10.4.0/node_modules/@testing-library/dom/dist/query-helpers.js:74:17
      at node_modules/.pnpm/@testing-library+dom@10.4.0/node_modules/@testing-library/dom/dist/query-helpers.js:52:17
      at node_modules/.pnpm/@testing-library+dom@10.4.0/node_modules/@testing-library/dom/dist/query-helpers.js:95:19
      at Object.getByRole (test/dynamic.test.js:9:38)

Test Suites: 1 failed, 1 passed, 2 total
Tests:       1 failed, 1 passed, 2 total
Snapshots:   0 total
Time:        0.838 s
Ran all test suites matching /test\/mock.test.js|test\/dynamic.test.js/i.
 ELIFECYCLE  Command failed with exit code 1.
Failed to create next instance Error: next build failed with code/signal 1
    at ChildProcess.<anonymous> (/Users/niklas/code/next.js/test/lib/next-modes/next-start.ts:100:15)
    at ChildProcess.emit (node:events:517:28)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:292:12)
destroyed next instance: 2.065s
 FAIL  test/production/jest/index.test.ts (28.802 s)
  ● next/jest › should work

    next build failed with code/signal 1

       98 |           if (code || signal)
       99 |             reject(
    > 100 |               new Error(`next build failed with code/signal ${code || signal}`)
          |               ^
      101 |             )
      102 |           else resolve()
      103 |         })

      at ChildProcess.<anonymous> (lib/next-modes/next-start.ts:100:15)


  ● Test suite failed to run

    TypeError: Cannot read properties of undefined (reading 'destroy')

      149 |     })
      150 |   })
    > 151 |   afterAll(() => next.destroy())
          |                       ^
      152 |
      153 |   it('should work', async () => {
      154 |     const html = await renderViaHTTP(next.url, '/')

      at Object.destroy (production/jest/index.test.ts:151:23)

```

Closes PACK-3576