### PR TITLE
Pin version of `nwsapi` (revert later)

### DIFF
--- a/test/production/jest/index.test.ts
+++ b/test/production/jest/index.test.ts
@@ -137,6 +137,10 @@ describe('next/jest', () => {
         '@testing-library/jest-dom': '5.16.1',
         '@testing-library/react': '15.0.2',
         '@testing-library/user-event': '14.5.2',
+        // TODO: nwsapi is a transitive dependency of jest-environment-jsdom >
+        // jsdom. We're temporarily pinning the version here because later
+        // versions cause `ReferenceError: document is not defined`
+        nwsapi: '2.2.13',
       },
       packageJson: {
         scripts: {

--- a/test/production/jest/new-link-behavior.test.ts
+++ b/test/production/jest/new-link-behavior.test.ts
@@ -37,6 +37,10 @@ describe('next/jest newLinkBehavior', () => {
         jest: '29.7.0',
         'jest-environment-jsdom': '29.7.0',
         '@testing-library/react': '15.0.2',
+        // TODO: nwsapi is a transitive dependency of jest-environment-jsdom >
+        // jsdom. We're temporarily pinning the version here because later
+        // versions cause `ReferenceError: document is not defined`
+        nwsapi: '2.2.13',
       },
       packageJson: {
         scripts: {

--- a/test/production/jest/next-image-preload/next-image-preload.test.ts
+++ b/test/production/jest/next-image-preload/next-image-preload.test.ts
@@ -30,6 +30,10 @@ describe('next/jest', () => {
         'jest-environment-jsdom': '29.7.0',
         '@testing-library/react': '15.0.2',
         '@testing-library/jest-dom': '5.17.0',
+        // TODO: nwsapi is a transitive dependency of jest-environment-jsdom >
+        // jsdom. We're temporarily pinning the version here because later
+        // versions cause `ReferenceError: document is not defined`
+        nwsapi: '2.2.13',
       },
     })
   })

--- a/test/production/jest/remove-react-properties/remove-react-properties-jest.test.ts
+++ b/test/production/jest/remove-react-properties/remove-react-properties-jest.test.ts
@@ -37,6 +37,10 @@ describe('next/jest', () => {
         'jest-environment-jsdom': '29.7.0',
         '@testing-library/react': '15.0.2',
         '@testing-library/jest-dom': '5.16.4',
+        // TODO: nwsapi is a transitive dependency of jest-environment-jsdom >
+        // jsdom. We're temporarily pinning the version here because later
+        // versions cause `ReferenceError: document is not defined`
+        nwsapi: '2.2.13',
       },
       packageJson: {
         scripts: {


### PR DESCRIPTION
The latest version of `nwsapi` (which is a dependency of `jest-environment-jsdom > jsdom`) causes `ReferenceError: document is not defined` errors in some of our tests. We're pinning the old working version until https://github.com/dperini/nwsapi/issues/135 is resolved.