### PR TITLE
fix: empty generateStaticParams should still create an ISR route

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2278,10 +2278,7 @@ export default async function build(
                             })
                           }
 
-                          if (
-                            workerResult.prerenderedRoutes &&
-                            workerResult.prerenderedRoutes.length > 0
-                          ) {
+                          if (workerResult.prerenderedRoutes) {
                             staticPaths.set(
                               originalAppPath,
                               workerResult.prerenderedRoutes

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1382,6 +1382,7 @@ export async function buildAppStaticPaths({
     }
   )
 
+  let lastDynamicSegmentHadGenerateStaticParams = false
   for (const segment of segments) {
     // Check to see if there are any missing params for segments that have
     // dynamicParams set to false.
@@ -1401,6 +1402,15 @@ export async function buildAppStaticPaths({
           `Segment "${relative}" exports "dynamicParams: false" but the param "${segment.param}" is missing from the generated route params.`
         )
       }
+    }
+
+    if (
+      segment.isDynamicSegment &&
+      typeof segment.generateStaticParams !== 'function'
+    ) {
+      lastDynamicSegmentHadGenerateStaticParams = false
+    } else if (typeof segment.generateStaticParams === 'function') {
+      lastDynamicSegmentHadGenerateStaticParams = true
     }
   }
 
@@ -1437,7 +1447,9 @@ export async function buildAppStaticPaths({
 
   let result: PartialStaticPathsResult = {
     fallbackMode,
-    prerenderedRoutes: undefined,
+    prerenderedRoutes: lastDynamicSegmentHadGenerateStaticParams
+      ? []
+      : undefined,
   }
 
   if (hadAllParamsGenerated && fallbackMode) {

--- a/test/production/app-dir/empty-generate-static-params/app/[slug]/page.tsx
+++ b/test/production/app-dir/empty-generate-static-params/app/[slug]/page.tsx
@@ -1,0 +1,24 @@
+import { Suspense } from 'react'
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  return (
+    <div>
+      Hello World
+      <div>
+        <Params params={params} />
+      </div>
+    </div>
+  )
+}
+
+async function Params({ params }: { params: Promise<{ slug: string }> }) {
+  return <Suspense>{(await params).slug}</Suspense>
+}
+
+export async function generateStaticParams() {
+  return []
+}

--- a/test/production/app-dir/empty-generate-static-params/app/layout.tsx
+++ b/test/production/app-dir/empty-generate-static-params/app/layout.tsx
@@ -1,0 +1,10 @@
+import { ReactNode, Suspense } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <Suspense>{children}</Suspense>
+      </body>
+    </html>
+  )
+}

--- a/test/production/app-dir/empty-generate-static-params/app/page.tsx
+++ b/test/production/app-dir/empty-generate-static-params/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/empty-generate-static-params/empty-generate-static-params.test.ts
+++ b/test/production/app-dir/empty-generate-static-params/empty-generate-static-params.test.ts
@@ -1,0 +1,34 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('empty-generate-static-params', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) return
+
+  it('should mark the page with empty generateStaticParams as SSG in build output', async () => {
+    const isPPREnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+    expect(next.cliOutput).toContain(`${isPPREnabled ? '◐' : '●'} /[slug]`)
+  })
+
+  it('should be a cache miss on the initial render followed by a HIT after being generated', async () => {
+    const firstResponse = await next.fetch('/foo')
+    expect(firstResponse.status).toBe(200)
+
+    // With PPR enabled, the initial request doesn't send back a cache header
+    const isPPREnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+
+    expect(firstResponse.headers.get('x-nextjs-cache')).toBe(
+      isPPREnabled ? null : 'MISS'
+    )
+
+    retry(async () => {
+      const secondResponse = await next.fetch('/foo')
+      expect(secondResponse.status).toBe(200)
+      expect(secondResponse.headers.get('x-nextjs-cache')).toBe('HIT')
+    })
+  })
+})

--- a/test/production/app-dir/empty-generate-static-params/next.config.js
+++ b/test/production/app-dir/empty-generate-static-params/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
Returning an empty array from `generateStaticParams` should still be deployed as an ISR route to support the `dynamicParams = true` case, where a route can be generated & cached on demand. At the moment the only way to achieve this behavior is with `export const dynamic = 'force-static'`. As a result, these routes are being treated as dynamic and never return a cached response. 

This PR resolves the bug by fixing several distinct things:
- `prerenderedRoutes` does not need to be an array > 0 to mark a route as being a static path. This will ensure the build output shows the correct symbol and adds the path to the list of prerenders. 
- we initialize `prerenderedRoutes` to an empty array if we determine that the leaf-most segment (the thing rendering the current page) has a `generateStaticParams` function
- the function responsible for collecting segments associated with a page only considered the `children` branch, but for something like a parallel/interception route, those segments would be inside of a different parallel route key
- the regex for determining if a function was dynamic didn't consider that the dynamic route might also contain an interception marker (eg `(.)`)

This appears to have regressed in #68125

Closes NEXT-3905