### PR TITLE
feat: Conditionally intercept routes on link

### DIFF
--- a/docs/01-app/03-api-reference/02-components/link.mdx
+++ b/docs/01-app/03-api-reference/02-components/link.mdx
@@ -70,12 +70,13 @@ The following props can be passed to the `<Link>` component:
 
 <AppOnly>
 
-| Prop                     | Example             | Type             | Required |
-| ------------------------ | ------------------- | ---------------- | -------- |
-| [`href`](#href-required) | `href="/dashboard"` | String or Object | Yes      |
-| [`replace`](#replace)    | `replace={false}`   | Boolean          | -        |
-| [`scroll`](#scroll)      | `scroll={false}`    | Boolean          | -        |
-| [`prefetch`](#prefetch)  | `prefetch={false}`  | Boolean or null  | -        |
+| Prop                      | Example             | Type             | Required |
+| ------------------------- | ------------------- | ---------------- | -------- |
+| [`href`](#href-required)  | `href="/dashboard"` | String or Object | Yes      |
+| [`replace`](#replace)     | `replace={false}`   | Boolean          | -        |
+| [`scroll`](#scroll)       | `scroll={false}`    | Boolean          | -        |
+| [`prefetch`](#prefetch)   | `prefetch={false}`  | Boolean or null  | -        |
+| [`intercept`](#intercept) | `intercept={false}` | Boolean or null  | -        |
 
 </AppOnly>
 
@@ -320,6 +321,33 @@ export default function Page() {
   return (
     <Link href="/dashboard" prefetch={false}>
       Dashboard
+    </Link>
+  )
+}
+```
+
+</AppOnly>
+
+<AppOnly>
+
+### `intercept`
+
+Explicitly opt-out of intercepting for this specific link. Useful when you have a link that should only be intercepted in specific cases.
+
+An example use case would be if you have a user page which can be both intercepted and not intercepted:
+
+- The intercepted user page loads in a sheet / modal / ... for quick access
+- The non-intercepted user page is a full page.
+
+Here, if you are already on the full page you would want the 'edit' page to also open in the non intercepted variant. Since it would feel somewhat weird to have the user page in the background, and then a sheet / modal / ... where you can edit the user. It makes more sense to do it inline.
+
+```tsx
+import Link from 'next/link'
+
+export default function NonInterceptedUserPage() {
+  return (
+    <Link href="/edit intercept={false}>
+      Edit this user
     </Link>
   )
 }

--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -100,6 +100,12 @@ type InternalLinkProps = {
    * Optional event handler for when Link is clicked.
    */
   onClick?: React.MouseEventHandler<HTMLAnchorElement>
+  /**
+   * Optional boolean to control whether intercepted routes should be intercepted or not.
+   * @defaultValue `true`
+   * @see https://github.com/vercel/next.js/discussions/49146#discussioncomment-8266498
+   */
+  intercept?: boolean
 }
 
 // TODO-APP: Include the full set of Anchor props
@@ -159,7 +165,8 @@ function linkClicked(
   as: string,
   replace?: boolean,
   shallow?: boolean,
-  scroll?: boolean
+  scroll?: boolean,
+  intercept: boolean = true
 ): void {
   const { nodeName } = e.currentTarget
 
@@ -184,6 +191,7 @@ function linkClicked(
     } else {
       router[replace ? 'replace' : 'push'](as || href, {
         scroll: routerScroll,
+        intercept: intercept,
       })
     }
   }
@@ -229,6 +237,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
       onMouseEnter: onMouseEnterProp,
       onTouchStart: onTouchStartProp,
       legacyBehavior = false,
+      intercept = true,
       ...restProps
     } = props
 
@@ -305,6 +314,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
         onMouseEnter: true,
         onTouchStart: true,
         legacyBehavior: true,
+        intercept: true,
       } as const
       const optionalProps: LinkPropsOptional[] = Object.keys(
         optionalPropsGuard
@@ -522,7 +532,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
           return
         }
 
-        linkClicked(e, router, href, as, replace, shallow, scroll)
+        linkClicked(e, router, href, as, replace, shallow, scroll, intercept)
       },
       onMouseEnter(e) {
         if (!legacyBehavior && typeof onMouseEnterProp === 'function') {

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -174,7 +174,7 @@ function useChangeByServerResponse(
 
 function useNavigate(dispatch: React.Dispatch<ReducerActions>): RouterNavigate {
   return useCallback(
-    (href, navigateType, shouldScroll) => {
+    (href, navigateType, shouldScroll, shouldIntercept) => {
       const url = new URL(addBasePath(href), location.href)
 
       if (process.env.__NEXT_APP_NAV_FAIL_HANDLING) {
@@ -187,6 +187,7 @@ function useNavigate(dispatch: React.Dispatch<ReducerActions>): RouterNavigate {
         isExternalUrl: isExternalURL(url),
         locationSearch: location.search,
         shouldScroll: shouldScroll ?? true,
+        shouldIntercept: shouldIntercept ?? true,
         navigateType,
         allowAliasing: true,
       })
@@ -296,12 +297,22 @@ function Router({
             },
       replace: (href, options = {}) => {
         startTransition(() => {
-          navigate(href, 'replace', options.scroll ?? true)
+          navigate(
+            href,
+            'replace',
+            options.scroll ?? true,
+            options.intercept ?? true
+          )
         })
       },
       push: (href, options = {}) => {
         startTransition(() => {
-          navigate(href, 'push', options.scroll ?? true)
+          navigate(
+            href,
+            'push',
+            options.scroll ?? true,
+            options.intercept ?? true
+          )
         })
       },
       refresh: () => {

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -151,8 +151,14 @@ export function navigateReducer(
   state: ReadonlyReducerState,
   action: NavigateAction
 ): ReducerState {
-  const { url, isExternalUrl, navigateType, shouldScroll, allowAliasing } =
-    action
+  const {
+    url,
+    isExternalUrl,
+    navigateType,
+    shouldScroll,
+    shouldIntercept,
+    allowAliasing,
+  } = action
   const mutable: Mutable = {}
   const { hash } = url
   const href = createHrefFromUrl(url)
@@ -196,7 +202,7 @@ export function navigateReducer(
 
   const prefetchValues = getOrCreatePrefetchCacheEntry({
     url,
-    nextUrl: state.nextUrl,
+    nextUrl: shouldIntercept ? state.nextUrl : null,
     tree: state.tree,
     prefetchCache: state.prefetchCache,
     allowAliasing,

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -24,7 +24,8 @@ export type RouterChangeByServerResponse = ({
 export type RouterNavigate = (
   href: string,
   navigateType: 'push' | 'replace',
-  shouldScroll: boolean
+  shouldScroll: boolean,
+  shouldIntercept: boolean
 ) => void
 
 export interface Mutable {
@@ -112,6 +113,7 @@ export interface NavigateAction {
   locationSearch: Location['search']
   navigateType: 'push' | 'replace'
   shouldScroll: boolean
+  shouldIntercept: boolean
   allowAliasing: boolean
 }
 

--- a/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
@@ -102,6 +102,7 @@ export type ReadyCacheNode = {
 
 export interface NavigateOptions {
   scroll?: boolean
+  intercept?: boolean
 }
 
 export interface PrefetchOptions {

--- a/test/e2e/app-dir/conditionally-intercept-route/app/(.)route/page.tsx
+++ b/test/e2e/app-dir/conditionally-intercept-route/app/(.)route/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id={'intercepting-page'}>Intercepted</p>
+}

--- a/test/e2e/app-dir/conditionally-intercept-route/app/_components/button-with-router-action.tsx
+++ b/test/e2e/app-dir/conditionally-intercept-route/app/_components/button-with-router-action.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+export default function ButtonWithRouterAction({
+  action,
+  href,
+  intercept,
+  ...props
+}: {
+  action: 'push' | 'replace'
+  href: string
+  intercept?: boolean
+} & React.HTMLAttributes<HTMLButtonElement>) {
+  const router = useRouter()
+
+  return (
+    <button
+      onClick={() => {
+        router[action](href, {
+          intercept,
+        })
+      }}
+      {...props}
+    />
+  )
+}

--- a/test/e2e/app-dir/conditionally-intercept-route/app/layout.tsx
+++ b/test/e2e/app-dir/conditionally-intercept-route/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/conditionally-intercept-route/app/layout.tsx
+++ b/test/e2e/app-dir/conditionally-intercept-route/app/layout.tsx
@@ -1,8 +1,16 @@
 import { ReactNode } from 'react'
+import Link from 'next/link'
+
 export default function Root({ children }: { children: ReactNode }) {
   return (
     <html>
-      <body>{children}</body>
+      <body>
+        {children}
+        <hr />
+        <Link href={'/'} id={'back-to-index'}>
+          Back to index
+        </Link>
+      </body>
     </html>
   )
 }

--- a/test/e2e/app-dir/conditionally-intercept-route/app/page.tsx
+++ b/test/e2e/app-dir/conditionally-intercept-route/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import ButtonWithRouterAction from './_components/button-with-router-action'
 
 export default function Page() {
   return (
@@ -17,6 +18,64 @@ export default function Page() {
         <Link id="default-behavior" href="route">
           Open route (intercepted, default);
         </Link>
+      </div>
+      <div>
+        <ButtonWithRouterAction
+          id={'router-push-explicitly-not-intercepted'}
+          href="route"
+          intercept={false}
+          action={'push'}
+        >
+          Open route via router.push (non-intercepted, explicit opt-out)
+        </ButtonWithRouterAction>
+      </div>
+      <div>
+        <ButtonWithRouterAction
+          id={'router-push-default-behavior'}
+          href="route"
+          action={'push'}
+        >
+          Open route via router.push (intercepted, default)
+        </ButtonWithRouterAction>
+      </div>
+      <div>
+        <ButtonWithRouterAction
+          id={'router-push-explicitly-intercepted'}
+          href="route"
+          intercept={true}
+          action={'push'}
+        >
+          Open route via router.push (intercepted, explicit opt-in)
+        </ButtonWithRouterAction>
+      </div>
+      <div>
+        <ButtonWithRouterAction
+          id={'router-replace-explicitly-not-intercepted'}
+          href="route"
+          intercept={false}
+          action={'replace'}
+        >
+          Open route via router.replace (non-intercepted, explicit opt-out)
+        </ButtonWithRouterAction>
+      </div>
+      <div>
+        <ButtonWithRouterAction
+          id={'router-replace-default-behavior'}
+          href="route"
+          action={'replace'}
+        >
+          Open route via router.replace (intercepted, default)
+        </ButtonWithRouterAction>
+      </div>
+      <div>
+        <ButtonWithRouterAction
+          id={'router-replace-explicitly-intercepted'}
+          href="route"
+          intercept={true}
+          action={'replace'}
+        >
+          Open route via router.replace (intercepted, explicit opt-in)
+        </ButtonWithRouterAction>
       </div>
     </>
   )

--- a/test/e2e/app-dir/conditionally-intercept-route/app/page.tsx
+++ b/test/e2e/app-dir/conditionally-intercept-route/app/page.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <>
+      <div>
+        <Link id="explicitly-not-intercepted" intercept={false} href="route">
+          Open route (Non-intercepted);
+        </Link>
+      </div>
+      <div>
+        <Link id="explicitly-intercepted" intercept={true} href="route">
+          Open route (intercepted);
+        </Link>
+      </div>
+      <div>
+        <Link id="default-behavior" href="route">
+          Open route (intercepted, default);
+        </Link>
+      </div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/conditionally-intercept-route/app/route/page.tsx
+++ b/test/e2e/app-dir/conditionally-intercept-route/app/route/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id={'non-intercepting-page'}>Non-intercepted</p>
+}

--- a/test/e2e/app-dir/conditionally-intercept-route/conditionally-intercept-route.test.ts
+++ b/test/e2e/app-dir/conditionally-intercept-route/conditionally-intercept-route.test.ts
@@ -5,22 +5,64 @@ describe('link-attribute-to-conditionally-intercept-route', () => {
     files: __dirname,
   })
 
-  // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
-  it('should intercept by default', async () => {
+  // Test cases for the `Link` component
+  it('should intercept by default (Link)', async () => {
     const browser = await next.browser('/')
     await browser.elementByCss('#default-behavior').click()
     await browser.waitForElementByCss('#intercepting-page', 5000)
   })
 
-  it('should intercept if explicitly told to', async () => {
+  it('should intercept if explicitly told to (Link)', async () => {
     const browser = await next.browser('/')
     await browser.elementByCss('#explicitly-intercepted').click()
     await browser.waitForElementByCss('#intercepting-page', 5000)
   })
 
-  it('should not intercept if explicitly told not to', async () => {
+  it('should not intercept if explicitly told not to (Link)', async () => {
     const browser = await next.browser('/')
     await browser.elementByCss('#explicitly-not-intercepted').click()
+    await browser.waitForElementByCss('#non-intercepting-page', 5000)
+  })
+
+  // Test cases for `useRouter.push`
+  it('should intercept by default (useRouter.push)', async () => {
+    const browser = await next.browser('/')
+    await browser.elementByCss('#router-push-default-behavior').click()
+    await browser.waitForElementByCss('#intercepting-page', 5000)
+  })
+
+  it('should intercept if explicitly told to (useRouter.push)', async () => {
+    const browser = await next.browser('/')
+    await browser.elementByCss('#router-push-explicitly-intercepted').click()
+    await browser.waitForElementByCss('#intercepting-page', 5000)
+  })
+
+  it('should not intercept if explicitly told not to (useRouter.push)', async () => {
+    const browser = await next.browser('/')
+    await browser
+      .elementByCss('#router-push-explicitly-not-intercepted')
+      .click()
+    await browser.waitForElementByCss('#non-intercepting-page', 5000)
+  })
+
+  // Test cases for `useRouter.replace`
+  it('should intercept by default (useRouter.replace)', async () => {
+    const browser = await next.browser('/')
+    await browser.elementByCss('#router-replace-default-behavior').click()
+    await browser.waitForElementByCss('#intercepting-page', 5000)
+  })
+
+  it('should intercept if explicitly told to (useRouter.replace)', async () => {
+    const browser = await next.browser('/')
+    await browser.elementByCss('#router-replace-explicitly-intercepted').click()
+    await browser.waitForElementByCss('#intercepting-page', 5000)
+  })
+
+  it('should not intercept if explicitly told not to (useRouter.replace)', async () => {
+    const browser = await next.browser('/')
+    await browser
+      .elementByCss('#router-replace-explicitly-not-intercepted')
+      .click()
     await browser.waitForElementByCss('#non-intercepting-page', 5000)
   })
 })

--- a/test/e2e/app-dir/conditionally-intercept-route/conditionally-intercept-route.test.ts
+++ b/test/e2e/app-dir/conditionally-intercept-route/conditionally-intercept-route.test.ts
@@ -1,0 +1,26 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('link-attribute-to-conditionally-intercept-route', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
+  it('should intercept by default', async () => {
+    const browser = await next.browser('/')
+    await browser.elementByCss('#default-behavior').click()
+    await browser.waitForElementByCss('#intercepting-page', 5000)
+  })
+
+  it('should intercept if explicitly told to', async () => {
+    const browser = await next.browser('/')
+    await browser.elementByCss('#explicitly-intercepted').click()
+    await browser.waitForElementByCss('#intercepting-page', 5000)
+  })
+
+  it('should not intercept if explicitly told not to', async () => {
+    const browser = await next.browser('/')
+    await browser.elementByCss('#explicitly-not-intercepted').click()
+    await browser.waitForElementByCss('#non-intercepting-page', 5000)
+  })
+})

--- a/test/e2e/app-dir/conditionally-intercept-route/next.config.js
+++ b/test/e2e/app-dir/conditionally-intercept-route/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
## For Contributors

This PR adds an implementation of the feature discussed [here](https://github.com/vercel/next.js/discussions/49146) (#49146). It has not yet gone to an RFC, but it's a feature quite a few people want (including myself). So this PR aims to either get the feature landed, or revive the discussion and get some official input on why this may or may not be a good idea.

The implementation adds an (opt-in) attribute `intercept={boolean}`, for backwards compatibility. The tests added also test for the three cases:
1. explicitly setting `intercept` to true (=default)
2. explicitly setting `intercept` to false (do not intercept)
3. not specifying (=current behavior, so always intercept if there is an intercepted route)

[EDIT: This would also work for `useRouter.push` and `useRouter.replace`, which would solve issues such as #51648 without requiring workarounds like using `history.pushState`. Which could also be considered a bug, e.g. in #70886]

### Improving Documentation

- Added documentation for the `intercept` attribute to the app router docs for the `Link` component.

### Adding a feature

- Is there an RFC: No
- Is there a discussion: Yes, you can find the discussion here #49146 
- e2e tests are added
- documentation is added
- telemetry: I am not sure how to add this
- there are as far as I know no new errors associated with this change

## For Maintainers

Intercepted routes are only intercepted when the `Next-Url` header is set, which is why we have different behavior (i.e. intercepting) when navigating through a `Link` or `router.push` when compared to navigating directly or via an `a` tag.

In the simplest description, this PR adds a `intercept` option to `Link` such that we can toggle this header. Since the default behavior users probably want is to have the route intercepted, the default value is accordingly set to `true`.

### What?
Adds an `intercept` attribute to the `Link` component to opt-out of interception in some cases

### Why?
Imagine a dashboard where you want to have quick access to each resource, including some common actions. To create a separate view we use an intercepted route such that in 'quick access' the resource is opened in a panel, when the user refreshes the resource is opened through the regular route. Now if he clicks on edit it opens in the side panel again, which feels a bit weird. An opt-out of intercepting is needed on that specific link.

https://github.com/user-attachments/assets/0ccd0955-401b-4fd9-83cd-d4fd5fc910bc

### How?
By adding an `intercept` attribute/option to the `Link` component, we can toggle passing the `nextUrl` to the router, and thus preventing the interception.

Here is what the end result then might look like:

https://github.com/user-attachments/assets/a0c874e4-fd03-432a-8e99-62a724867041

# Request for input from maintainer
As far as I know, the `Next-Url` header is only used for intercepting, as suggested on:
- https://github.com/vercel/next.js/blob/b777614600bb927e82d795a065fb1dc1b0594d5e/packages/next/src/lib/generate-interception-routes-rewrites.ts#L53
- https://github.com/vercel/next.js/blob/b777614600bb927e82d795a065fb1dc1b0594d5e/packages/next/src/server/base-server.ts#L1902
- https://github.com/vercel/next.js/blob/b777614600bb927e82d795a065fb1dc1b0594d5e/packages/next/src/server/base-server.ts#L1912

Are there any other places which depends on this header, making this approach infeasible? If this is the case, would it be an option to still achieve the same result by altering the rewrite to also include a `missing` on a custom header?