### PR TITLE
[Turbopack] Persistent Caching fixups

### DIFF
--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 verify_sst_content = []
 strict_checks = []
 stats = ["quick_cache/stats"]
+print_stats = ["stats"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/turbopack/crates/turbo-persistence/src/constants.rs
+++ b/turbopack/crates/turbo-persistence/src/constants.rs
@@ -21,12 +21,8 @@ pub const DATA_THRESHOLD_PER_COMPACTED_FILE: usize = 256 * 1024 * 1024;
 pub const AQMF_CACHE_SIZE: u64 = 300 * 1024 * 1024;
 pub const AQMF_AVG_SIZE: usize = 37399;
 
-/// Maximum RAM bytes for index block cache
-pub const INDEX_BLOCK_CACHE_SIZE: u64 = 100 * 1024 * 1024;
-pub const INDEX_BLOCK_AVG_SIZE: usize = 152000;
-
 /// Maximum RAM bytes for key block cache
-pub const KEY_BLOCK_CACHE_SIZE: u64 = 300 * 1024 * 1024;
+pub const KEY_BLOCK_CACHE_SIZE: u64 = 400 * 1024 * 1024;
 pub const KEY_BLOCK_AVG_SIZE: usize = 16 * 1024;
 
 /// Maximum RAM bytes for value block cache

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -849,9 +849,9 @@ impl TurboPersistence {
         }
     }
 
-    /// Shuts down the database. This will print statistics if the `stats` feature is enabled.
+    /// Shuts down the database. This will print statistics if the `print_stats` feature is enabled.
     pub fn shutdown(&self) -> Result<()> {
-        #[cfg(feature = "stats")]
+        #[cfg(feature = "print_stats")]
         println!("{:#?}", self.statistics());
         Ok(())
     }

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -236,7 +236,6 @@ impl StaticSortedFile {
         key_hash: u64,
         key: &K,
         aqmf_cache: &AqmfCache,
-        index_block_cache: &BlockCache,
         key_block_cache: &BlockCache,
         value_block_cache: &BlockCache,
     ) -> Result<LookupResult> {
@@ -270,10 +269,8 @@ impl StaticSortedFile {
             }
         }
         let mut current_block = header.block_count - 1;
-        let mut cache = index_block_cache;
         loop {
-            let block = self.get_key_block(header, current_block, cache)?;
-            cache = key_block_cache;
+            let block = self.get_key_block(header, current_block, key_block_cache)?;
             let mut block = &block[..];
             let block_type = block.read_u8()?;
             match block_type {


### PR DESCRIPTION
### What?

* sync blob files on commit
  * This could cause a database corruption
* add print_stats feature to print stats on shutdown
* use memory map to read blob files
* shared index and key cache


Closes PACK-3593