### PR TITLE
[Segment Cache] Interception routes

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -280,7 +280,7 @@ function Router({
           ? // Unlike the old implementation, the Segment Cache doesn't store its
             // data in the router reducer state; it writes into a global mutable
             // cache. So we don't need to dispatch an action.
-            prefetchWithSegmentCache
+            (href) => prefetchWithSegmentCache(href, actionQueue.state.nextUrl)
           : (href, options) => {
               // Use the old prefetch implementation.
               const url = createPrefetchURL(href)
@@ -329,7 +329,7 @@ function Router({
     }
 
     return routerInstance
-  }, [dispatch, navigate])
+  }, [actionQueue, dispatch, navigate])
 
   useEffect(() => {
     // Exists for debugging purposes. Don't use in application code.

--- a/packages/next/src/client/components/segment-cache/cache-key.ts
+++ b/packages/next/src/client/components/segment-cache/cache-key.ts
@@ -2,14 +2,12 @@
 type Opaque<K, T> = T & { __brand: K }
 
 // Only functions in this module should be allowed to create CacheKeys.
-export type RouteCacheKeyId = Opaque<'RouteCacheKeyId', string>
 export type NormalizedHref = Opaque<'NormalizedHref', string>
-type NormalizedNextUrl = Opaque<'NormalizedNextUrl', string>
+export type NormalizedNextUrl = Opaque<'NormalizedNextUrl', string>
 
 export type RouteCacheKey = Opaque<
   'RouteCacheKey',
   {
-    id: RouteCacheKeyId
     href: NormalizedHref
     nextUrl: NormalizedNextUrl | null
   }
@@ -28,13 +26,9 @@ export function createCacheKey(
   originalUrl.search = ''
 
   const normalizedHref = originalUrl.href as NormalizedHref
-  const normalizedNextUrl = (
-    nextUrl !== null ? nextUrl : ''
-  ) as NormalizedNextUrl
-  const id = `|${normalizedHref}|${normalizedNextUrl}|` as RouteCacheKeyId
+  const normalizedNextUrl = nextUrl as NormalizedNextUrl | null
 
   const cacheKey = {
-    id,
     href: normalizedHref,
     nextUrl: normalizedNextUrl,
   } as RouteCacheKey

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -86,18 +86,9 @@ export function navigate(
 ): AsyncNavigationResult | SuccessfulNavigationResult | NoOpNavigationResult {
   const now = Date.now()
 
-  // TODO: Interception routes not yet implemented in Segment Cache. Pass a
-  // Next-URL to createCacheKey.
-  const cacheKey = createCacheKey(url.href, null)
+  const cacheKey = createCacheKey(url.href, nextUrl)
   const route = readRouteCacheEntry(now, cacheKey)
-  if (
-    route !== null &&
-    route.status === EntryStatus.Fulfilled &&
-    // TODO: Prefetching interception routes is not support yet by the Segment
-    // Cache. For now, treat this as a cache miss and fallthrough to a full
-    // dynamic navigation.
-    !route.couldBeIntercepted
-  ) {
+  if (route !== null && route.status === EntryStatus.Fulfilled) {
     // We have a matching prefetch.
     const snapshot = readRenderSnapshotFromCache(now, route.tree)
     const prefetchFlightRouterState = snapshot.flightRouterState

--- a/packages/next/src/client/components/segment-cache/prefetch.ts
+++ b/packages/next/src/client/components/segment-cache/prefetch.ts
@@ -7,15 +7,12 @@ import { schedulePrefetchTask } from './scheduler'
  * @param href - The URL to prefetch. Typically this will come from a <Link>,
  * or router.prefetch. It must be validated before we attempt to prefetch it.
  */
-export function prefetch(href: string) {
+export function prefetch(href: string, nextUrl: string | null) {
   const url = createPrefetchURL(href)
   if (url === null) {
     // This href should not be prefetched.
     return
   }
-
-  // TODO: Interception routes not yet implemented in Segment Cache. Pass a
-  // Next-URL to createCacheKey.
-  const cacheKey = createCacheKey(url.href, null)
+  const cacheKey = createCacheKey(url.href, nextUrl)
   schedulePrefetchTask(cacheKey)
 }

--- a/packages/next/src/client/components/segment-cache/tuple-map.ts
+++ b/packages/next/src/client/components/segment-cache/tuple-map.ts
@@ -1,0 +1,196 @@
+// Utility type. Prefix<[A, B, C, D]> matches [A], [A, B], [A, B, C] etc.
+export type Prefix<T extends any[]> = T extends [infer First, ...infer Rest]
+  ? [] | [First] | [First, ...Prefix<Rest>]
+  : []
+
+export type TupleMap<Keypath extends Array<any>, V> = {
+  set(keys: Prefix<Keypath>, value: V): void
+  get(keys: Prefix<Keypath>): V | null
+  delete(keys: Prefix<Keypath>): void
+}
+
+/**
+ * Creates a map whose keys are tuples. Tuples are compared per-element. This
+ * is useful when a key has multiple parts, but you don't want to concatenate
+ * them into a single string value.
+ *
+ * In the Segment Cache, we use this to store cache entries by both their href
+ * and their Next-URL.
+ *
+ * Example:
+ *   map.set(['https://localhost', 'foo/bar/baz'], 'yay');
+ *   map.get(['https://localhost', 'foo/bar/baz']); // returns 'yay'
+ */
+export function createTupleMap<Keypath extends Array<any>, V>(): TupleMap<
+  Keypath,
+  V
+> {
+  type MapEntryShared = {
+    parent: MapEntry | null
+    key: any
+    map: Map<any, MapEntry> | null
+  }
+
+  type EmptyMapEntry = MapEntryShared & {
+    value: null
+    hasValue: false
+  }
+
+  type FullMapEntry = MapEntryShared & {
+    value: V
+    hasValue: true
+  }
+
+  type MapEntry = EmptyMapEntry | FullMapEntry
+
+  let rootEntry: MapEntry = {
+    parent: null,
+    key: null,
+    hasValue: false,
+    value: null,
+    map: null,
+  }
+
+  // To optimize successive lookups, we cache the last accessed keypath.
+  // Although it's not encoded in the type, these are both null or
+  // both non-null. It uses object equality, so to take advantage of this
+  // optimization, you must pass the same array instance to each successive
+  // method call, and you must also not mutate the array between calls.
+  let lastAccessedEntry: MapEntry | null = null
+  let lastAccessedKeys: Prefix<Keypath> | null = null
+
+  function getOrCreateEntry(keys: Prefix<Keypath>): MapEntry {
+    if (lastAccessedKeys === keys) {
+      return lastAccessedEntry!
+    }
+
+    // Go through each level of keys until we find the entry that matches,
+    // or create a new one if it doesn't already exist.
+    let entry = rootEntry
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i]
+      let map = entry.map
+      if (map !== null) {
+        const existingEntry = map.get(key)
+        if (existingEntry !== undefined) {
+          // Found a match. Keep going.
+          entry = existingEntry
+          continue
+        }
+      } else {
+        map = new Map()
+        entry.map = map
+      }
+      // No entry exists yet at this level. Create a new one.
+      const newEntry: MapEntry = {
+        parent: entry,
+        key,
+        value: null,
+        hasValue: false,
+        map: null,
+      }
+      map.set(key, newEntry)
+      entry = newEntry
+    }
+
+    lastAccessedKeys = keys
+    lastAccessedEntry = entry
+
+    return entry
+  }
+
+  function getEntryIfExists(keys: Prefix<Keypath>): MapEntry | null {
+    if (lastAccessedKeys === keys) {
+      return lastAccessedEntry
+    }
+
+    // Go through each level of keys until we find the entry that matches, or
+    // return null if no match exists.
+    let entry = rootEntry
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i]
+      let map = entry.map
+      if (map !== null) {
+        const existingEntry = map.get(key)
+        if (existingEntry !== undefined) {
+          // Found a match. Keep going.
+          entry = existingEntry
+          continue
+        }
+      }
+      // No entry exists at this level.
+      return null
+    }
+
+    lastAccessedKeys = keys
+    lastAccessedEntry = entry
+
+    return entry
+  }
+
+  function set(keys: Prefix<Keypath>, value: V): void {
+    const entry = getOrCreateEntry(keys)
+    entry.hasValue = true
+    entry.value = value
+  }
+
+  function get(keys: Prefix<Keypath>): V | null {
+    const entry = getEntryIfExists(keys)
+    if (entry === null || !entry.hasValue) {
+      return null
+    }
+    return entry.value
+  }
+
+  function deleteEntry(keys: Prefix<Keypath>): void {
+    const entry = getEntryIfExists(keys)
+    if (entry === null || !entry.hasValue) {
+      return
+    }
+
+    // Found a match. Delete it from the cache.
+    const deletedEntry: EmptyMapEntry = entry as any
+    deletedEntry.hasValue = false
+    deletedEntry.value = null
+
+    // Check if we can garbage collect the entry.
+    if (deletedEntry.map === null) {
+      // Since this entry has no value, and also no child entries, we can
+      // garbage collect it. Remove it from its parent, and keep garbage
+      // collecting the parents until we reach a non-empty entry.
+
+      // Unlike a `set` operation, these are no longer valid because the entry
+      // itself is being modified, not just the value it contains.
+      lastAccessedEntry = null
+      lastAccessedKeys = null
+
+      let parent = deletedEntry.parent
+      let key = deletedEntry.key
+      while (parent !== null) {
+        const parentMap = parent.map
+        if (parentMap !== null) {
+          parentMap.delete(key)
+          if (parentMap.size === 0) {
+            // We just removed the last entry in the parent map.
+            parent.map = null
+            if (parent.value === null) {
+              // The parent node has no child entries, nor does it have a value
+              // on itself. It can be garbage collected. Keep going.
+              key = parent.key
+              parent = parent.parent
+              continue
+            }
+          }
+        }
+        // The parent is not empty. Stop garbage collecting.
+        break
+      }
+    }
+  }
+
+  return {
+    set,
+    get,
+    delete: deleteEntry,
+  }
+}

--- a/test/e2e/app-dir/segment-cache/basic/app/interception/feed/(..)photo/page.tsx
+++ b/test/e2e/app-dir/segment-cache/basic/app/interception/feed/(..)photo/page.tsx
@@ -1,0 +1,3 @@
+export default function InterceptedPhotoPage() {
+  return <div id="intercepted-photo-page">Intercepted photo page</div>
+}

--- a/test/e2e/app-dir/segment-cache/basic/app/interception/feed/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/basic/app/interception/feed/layout.tsx
@@ -1,0 +1,8 @@
+export default function FeedLayout({ children }) {
+  return (
+    <div>
+      Feed layout
+      <div>{children}</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/basic/app/interception/feed/page.tsx
+++ b/test/e2e/app-dir/segment-cache/basic/app/interception/feed/page.tsx
@@ -1,0 +1,5 @@
+import Link from 'next/link'
+
+export default function FeedPage() {
+  return <Link href="/interception/photo">Go to photo</Link>
+}

--- a/test/e2e/app-dir/segment-cache/basic/app/interception/photo/page.tsx
+++ b/test/e2e/app-dir/segment-cache/basic/app/interception/photo/page.tsx
@@ -1,0 +1,3 @@
+export default function PhotoPage() {
+  return 'Photo page (normal, not intercepted)'
+}


### PR DESCRIPTION
Implements prefetching support for interception routes using the Segment Cache.

The overall flow is the same as the previous prefetch cache implementation. If a page varies based on the Next-URL — in other words, if it might possibly be intercepted — we include the Next-URL as part of the cache key. However, since most pages do not vary on the Next-URL, and this is known at build time, for most pages we can omit the Next-URL from the cache key for all but the first request.

We do this by checking the Vary header of the first response, and if the Next-URL is not included, we re-key the cache entry to remove the Next-URL. All subsequent requests for the same page will match this entry regardless of the Next-URL.

---

One difference from the previous prefetch cache implementation: when an entry varies by Next-URL, rather than concatenating the Next-URL to the href to create a combined cache key, we store the entries in a tiered map structure whose keys are tuples of the href and Next-URL. Then we compare each key part separately. This might end up being overkill but it's nice because we don't have to worry about escaping the values, nor do we have to store an encoded cache key separately from its individual parts. We will likely use the same approach for storing segment cache entries, which vary on both the segment path and (in some cases; not yet implemented) the search params.