### PR TITLE
Sourcemap errors logged in Edge runtime

### DIFF
--- a/packages/next/src/server/node-environment-extensions/error-inspect.tsx
+++ b/packages/next/src/server/node-environment-extensions/error-inspect.tsx
@@ -1,3 +1,3 @@
-import { patchErrorInspect } from '../patch-error-inspect'
+import { patchErrorInspectNodeJS } from '../patch-error-inspect'
 
-patchErrorInspect()
+patchErrorInspectNodeJS(globalThis.Error)

--- a/packages/next/src/server/web/sandbox/context.ts
+++ b/packages/next/src/server/web/sandbox/context.ts
@@ -22,6 +22,7 @@ import UtilImplementation from 'node:util'
 import AsyncHooksImplementation from 'node:async_hooks'
 import { intervalsManager, timeoutsManager } from './resource-managers'
 import { createLocalRequestContext } from '../../after/builtin-request-context'
+import { patchErrorInspectEdgeLite } from '../../patch-error-inspect'
 
 interface ModuleContext {
   runtime: EdgeRuntime
@@ -477,6 +478,8 @@ Learn More: https://nextjs.org/docs/messages/edge-dynamic-code-evaluation`),
     'unhandledrejection',
     decorateUnhandledRejection
   )
+
+  patchErrorInspectEdgeLite(runtime.context.Error)
 
   return {
     runtime,

--- a/test/e2e/app-dir/server-source-maps/server-source-maps-edge.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps-edge.test.ts
@@ -30,10 +30,18 @@ describe('app-dir - server source maps edge runtime', () => {
         isTurbopack
           ? '\nError: Boom' +
               // TODO(veil): Should be sourcemapped
-              '\n    at logError (/'
+              '\n    at logError (.next'
           : '\nError: Boom' +
-              // TODO(veil): Should be sourcemapped
-              '\n    at logError (webpack'
+              '\n    at logError (app/rsc-error-log/page.js:2:16)' +
+              '\n    at logError (app/rsc-error-log/page.js:6:2)' +
+              '\n  1 | function logError() {' +
+              "\n> 2 |   console.error(new Error('Boom'))" +
+              '\n    |                ^' +
+              '\n  3 | }' +
+              '\n  4 |' +
+              '\n  5 | export default function Page() { {' +
+              '\n  ' +
+              '\n}'
       )
     } else {
       // TODO: Test `next build` with `--enable-source-maps`.


### PR DESCRIPTION
Edge Lite uses a different custom inspect symbol (`edge-runtime.inspect.custom`) and has a different signature for the custom inspect function. Most notably, it doesn't track the depth.

Turbopack isn't working for the simple case yet. 