### PR TITLE
chore: release turbopack npm packages

### DIFF
--- a/turbopack/packages/devlow-bench/package.json
+++ b/turbopack/packages/devlow-bench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/devlow-bench",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Benchmarking tool for the developer workflow",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- @vercel/devlow-bench@0.3.5

This has devlow properly set a non-zero exit code when an unhandled error occurs in a scenario.


Closes PACK-3597