### PR TITLE
chore(cna): add .pnpm-debug.log* to all cna gitignore

### DIFF
--- a/packages/create-next-app/templates/app-empty/js/gitignore
+++ b/packages/create-next-app/templates/app-empty/js/gitignore
@@ -28,6 +28,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
 .env*.local

--- a/packages/create-next-app/templates/app-empty/ts/gitignore
+++ b/packages/create-next-app/templates/app-empty/ts/gitignore
@@ -28,6 +28,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
 .env*.local

--- a/packages/create-next-app/templates/app-tw-empty/js/gitignore
+++ b/packages/create-next-app/templates/app-tw-empty/js/gitignore
@@ -28,6 +28,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
 .env*.local

--- a/packages/create-next-app/templates/app-tw-empty/ts/gitignore
+++ b/packages/create-next-app/templates/app-tw-empty/ts/gitignore
@@ -28,6 +28,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
 .env*.local

--- a/packages/create-next-app/templates/app-tw/js/gitignore
+++ b/packages/create-next-app/templates/app-tw/js/gitignore
@@ -28,6 +28,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
 .env*

--- a/packages/create-next-app/templates/app-tw/ts/gitignore
+++ b/packages/create-next-app/templates/app-tw/ts/gitignore
@@ -28,6 +28,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
 .env*

--- a/packages/create-next-app/templates/app/js/gitignore
+++ b/packages/create-next-app/templates/app/js/gitignore
@@ -28,6 +28,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
 .env*

--- a/packages/create-next-app/templates/app/ts/gitignore
+++ b/packages/create-next-app/templates/app/ts/gitignore
@@ -28,6 +28,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
 .env*

--- a/packages/create-next-app/templates/default-empty/js/gitignore
+++ b/packages/create-next-app/templates/default-empty/js/gitignore
@@ -28,6 +28,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
 .env*.local

--- a/packages/create-next-app/templates/default-empty/ts/gitignore
+++ b/packages/create-next-app/templates/default-empty/ts/gitignore
@@ -28,6 +28,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
 .env*.local

--- a/packages/create-next-app/templates/default-tw-empty/js/gitignore
+++ b/packages/create-next-app/templates/default-tw-empty/js/gitignore
@@ -28,6 +28,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
 .env*.local

--- a/packages/create-next-app/templates/default-tw-empty/ts/gitignore
+++ b/packages/create-next-app/templates/default-tw-empty/ts/gitignore
@@ -28,6 +28,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
 .env*.local

--- a/packages/create-next-app/templates/default-tw/js/gitignore
+++ b/packages/create-next-app/templates/default-tw/js/gitignore
@@ -28,6 +28,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
 .env*

--- a/packages/create-next-app/templates/default-tw/ts/gitignore
+++ b/packages/create-next-app/templates/default-tw/ts/gitignore
@@ -28,6 +28,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
 .env*

--- a/packages/create-next-app/templates/default/js/gitignore
+++ b/packages/create-next-app/templates/default/js/gitignore
@@ -28,6 +28,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
 .env*

--- a/packages/create-next-app/templates/default/ts/gitignore
+++ b/packages/create-next-app/templates/default/ts/gitignore
@@ -28,6 +28,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
 .env*


### PR DESCRIPTION
## Why?

We may as well include a `.pnpm-debug.log` since it's possible to create Create Next App with [pnpm](https://pnpm.io/).