### PR TITLE
refactor(after): remove unnecessary conditionals

### DIFF
--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -289,13 +289,11 @@ export async function adapter(
           } finally {
             // middleware cannot stream, so we can consider the response closed
             // as soon as the handler returns.
-            if (closeController) {
-              // we can delay running it until a bit later --
-              // if it's needed, we'll have a `waitUntil` lock anyway.
-              setTimeout(() => {
-                closeController!.dispatchClose()
-              }, 0)
-            }
+            // we can delay running it until a bit later --
+            // if it's needed, we'll have a `waitUntil` lock anyway.
+            setTimeout(() => {
+              closeController.dispatchClose()
+            }, 0)
           }
         }
       )

--- a/packages/next/src/server/web/edge-route-module-wrapper.ts
+++ b/packages/next/src/server/web/edge-route-module-wrapper.ts
@@ -127,25 +127,21 @@ export class EdgeRouteModuleWrapper {
     }
     evt.waitUntil(Promise.all(waitUntilPromises))
 
-    if (closeController) {
-      const _closeController = closeController // TS annoyance - "possibly undefined" in callbacks
-
-      if (!res.body) {
-        // we can delay running it until a bit later --
-        // if it's needed, we'll have a `waitUntil` lock anyway.
-        setTimeout(() => _closeController.dispatchClose(), 0)
-      } else {
-        // NOTE: if this is a streaming response, onClose may be called later,
-        // so we can't rely on `closeController.listeners` -- it might be 0 at this point.
-        const trackedBody = trackStreamConsumed(res.body, () =>
-          _closeController.dispatchClose()
-        )
-        res = new Response(trackedBody, {
-          status: res.status,
-          statusText: res.statusText,
-          headers: res.headers,
-        })
-      }
+    if (!res.body) {
+      // we can delay running it until a bit later --
+      // if it's needed, we'll have a `waitUntil` lock anyway.
+      setTimeout(() => closeController.dispatchClose(), 0)
+    } else {
+      // NOTE: if this is a streaming response, onClose may be called later,
+      // so we can't rely on `closeController.listeners` -- it might be 0 at this point.
+      const trackedBody = trackStreamConsumed(res.body, () =>
+        closeController.dispatchClose()
+      )
+      res = new Response(trackedBody, {
+        status: res.status,
+        statusText: res.statusText,
+        headers: res.headers,
+      })
     }
 
     return res


### PR DESCRIPTION
These should've been removed in #73190 because we're always creating a `closeController`.