### PR TITLE
examples: improve DX while copying command to create new project

### DIFF
--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -29,9 +29,13 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 
 ```bash
 npx create-next-app --example blog my-blog
-# or
+```
+
+```bash
 yarn create next-app --example blog my-blog
-# or
+```
+
+```bash
 pnpm create next-app --example blog my-blog
 ```
 

--- a/examples/cms-dotcms/README.md
+++ b/examples/cms-dotcms/README.md
@@ -60,9 +60,13 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 
 ```bash
 npx create-next-app --example cms-dotcms cms-dotcms-app
-# or
+```
+
+```bash
 yarn create next-app --example cms-dotcms cms-dotcms-app
-# or
+```
+
+```bash
 pnpm create next-app --example cms-dotcms cms-dotcms-app
 ```
 

--- a/examples/cms-enterspeed/README.md
+++ b/examples/cms-enterspeed/README.md
@@ -49,9 +49,13 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 
 ```bash
 npx create-next-app --example cms-enterspeed enterspeed-app
-# or
+```
+
+```bash
 yarn create next-app --example cms-enterspeed enterspeed-app
-# or
+```
+
+```bash
 pnpm create next-app -- --example cms-enterspeed enterspeed-app
 ```
 

--- a/examples/cms-makeswift/README.md
+++ b/examples/cms-makeswift/README.md
@@ -51,9 +51,13 @@ Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_mediu
 
    ```bash
    npx create-next-app --example cms-makeswift cms-makeswift-app
-   # or
+   ```
+
+   ```bash
    yarn create next-app --example cms-makeswift cms-makeswift-app
-   # or
+   ```
+
+   ```bash
    pnpm create next-app --example cms-makeswift cms-makeswift-app
    ```
 

--- a/examples/cms-umbraco/README.md
+++ b/examples/cms-umbraco/README.md
@@ -43,9 +43,13 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 
 ```bash
 npx create-next-app --example cms-umbraco umbraco-app
-# or
+```
+
+```bash
 yarn create next-app --example cms-umbraco umbraco-app
-# or
+```
+
+```bash
 pnpm create next-app --example cms-umbraco umbraco-app
 ```
 

--- a/examples/convex/README.md
+++ b/examples/convex/README.md
@@ -14,9 +14,13 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 
 ```bash
 npx create-next-app --example convex convex-app
-# or
+```
+
+```bash
 yarn create next-app --example convex convex-app
-# or
+```
+
+```bash
 pnpm create next-app --example convex convex-app
 ```
 

--- a/examples/custom-server/README.md
+++ b/examples/custom-server/README.md
@@ -17,8 +17,12 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 
 ```bash
 npx create-next-app --example custom-server custom-server-app
-# or
+```
+
+```bash
 yarn create next-app --example custom-server custom-server-app
-# or
+```
+
+```bash
 pnpm create next-app --example custom-server custom-server-app
 ```

--- a/examples/image-component/README.md
+++ b/examples/image-component/README.md
@@ -20,9 +20,13 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 
 ```bash
 npx create-next-app --example image-component image-app
-# or
+```
+
+```bash
 yarn create next-app --example image-component image-app
-# or
+```
+
+```bash
 pnpm create next-app --example image-component image-app
 ```
 

--- a/examples/image-legacy-component/README.md
+++ b/examples/image-legacy-component/README.md
@@ -20,9 +20,13 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 
 ```bash
 npx create-next-app --example image-legacy-component image-app
-# or
+```
+
+```bash
 yarn create next-app --example image-legacy-component image-app
-# or
+```
+
+```bash
 pnpm create next-app --example image-legacy-component image-app
 ```
 

--- a/examples/progressive-web-app/README.md
+++ b/examples/progressive-web-app/README.md
@@ -14,9 +14,13 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 
 ```bash
 npx create-next-app --example progressive-web-app progressive-web-app
-# or
+```
+
+```bash
 yarn create next-app --example progressive-web-app progressive-web-app
-# or
+```
+
+```bash
 pnpm create next-app --example progressive-web-app progressive-web-app
 ```
 

--- a/examples/with-axiom/README.md
+++ b/examples/with-axiom/README.md
@@ -16,9 +16,13 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 
 ```bash
 npx create-next-app --example with-axiom with-axiom-app
-# or
+```
+
+```bash
 yarn create next-app --example with-axiom with-axiom-app
-# or
+```
+
+```bash
 pnpm create next-app --example with-axiom with-axiom-app
 ```
 

--- a/examples/with-contentlayer/README.md
+++ b/examples/with-contentlayer/README.md
@@ -14,8 +14,14 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 
 ```bash
 npx create-next-app --example with-contentlayer with-contentlayer-app
-# or
+```
+
+```bash
 yarn create next-app --example with-contentlayer with-contentlayer-app
+```
+
+```bash
+pnpm create next-app --example with-contentlayer with-contentlayer-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-cookies-next/README.md
+++ b/examples/with-cookies-next/README.md
@@ -16,12 +16,18 @@ Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_mediu
 
 ## How to use
 
-Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
+Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init), [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/), or [pnpm](https://pnpm.io) to bootstrap the example:
 
 ```bash
 npx create-next-app --example with-cookies-next with-cookies-next-app
-# or
+```
+
+```bash
 yarn create next-app --example with-cookies-next with-cookies-next-app
+```
+
+```bash
+pnpm create next-app --example with-cookies-next with-cookies-next-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-docker-multi-env/README.md
+++ b/examples/with-docker-multi-env/README.md
@@ -8,9 +8,13 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 
 ```bash
 npx create-next-app --example with-docker-multi-env nextjs-docker-multi-env
-# or
+```
+
+```bash
 yarn create next-app --example with-docker-multi-env nextjs-docker-multi-env
-# or
+```
+
+```bash
 pnpm create next-app --example with-docker-multi-env nextjs-docker-multi-env
 ```
 

--- a/examples/with-docker/README.md
+++ b/examples/with-docker/README.md
@@ -8,9 +8,13 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 
 ```bash
 npx create-next-app --example with-docker nextjs-docker
-# or
+```
+
+```bash
 yarn create next-app --example with-docker nextjs-docker
-# or
+```
+
+```bash
 pnpm create next-app --example with-docker nextjs-docker
 ```
 

--- a/examples/with-mysql/README.md
+++ b/examples/with-mysql/README.md
@@ -32,9 +32,13 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 
 ```bash
 npx create-next-app --example with-mysql nextjs-mysql
-# or
+```
+
+```bash
 yarn create next-app --example with-mysql nextjs-mysql
-# or
+```
+
+```bash
 pnpm create next-app --example with-mysql nextjs-mysql
 ```
 

--- a/examples/with-next-seo/README.md
+++ b/examples/with-next-seo/README.md
@@ -14,9 +14,13 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 
 ```bash
 npx create-next-app --example with-next-seo next-seo-app
-# or
+```
+
+```bash
 yarn create next-app --example with-next-seo next-seo-app
-# or
+```
+
+```bash
 pnpm create next-app --example with-next-seo next-seo-app
 ```
 

--- a/examples/with-next-ui/README.md
+++ b/examples/with-next-ui/README.md
@@ -14,9 +14,13 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 
 ```bash
 npx create-next-app --example with-next-ui with-next-ui-app
-# or
+```
+
+```bash
 yarn create next-app --example with-next-ui with-next-ui-app
-# or
+```
+
+```bash
 pnpm create next-app --example with-next-ui with-next-ui-app
 ```
 

--- a/examples/with-nhost-auth-realtime-graphql/README.md
+++ b/examples/with-nhost-auth-realtime-graphql/README.md
@@ -18,9 +18,13 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 
 ```bash
 npx create-next-app --example with-nhost-auth-realtime-graphql nhost-app
-# or
+```
+
+```bash
 yarn create next-app --example with-nhost-auth-realtime-graphql nhost-app
-# or
+```
+
+```bash
 pnpm create next-app --example with-nhost-auth-realtime-graphql nhost-app
 ```
 

--- a/examples/with-particles/README.md
+++ b/examples/with-particles/README.md
@@ -16,9 +16,13 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 
 ```bash
 npx create-next-app --example with-particles with-particles-app
-# or
+```
+
+```bash
 yarn create next-app --example with-particles with-particles-app
-# or
+```
+
+```bash
 pnpm create next-app -- --example with-particles with-particles-app
 ```
 

--- a/examples/with-redis/README.md
+++ b/examples/with-redis/README.md
@@ -23,9 +23,13 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 
 ```bash
 npx create-next-app --example with-redis roadmap
-# or
+```
+
+```bash
 yarn create next-app --example with-redis roadmap
-# or
+```
+
+```bash
 pnpm create next-app --example with-redis roadmap
 ```
 

--- a/examples/with-sentry/README.md
+++ b/examples/with-sentry/README.md
@@ -34,9 +34,13 @@ To begin, execute [`create-next-app`](https://github.com/vercel/next.js/tree/can
 
 ```bash
 npx create-next-app --example with-sentry nextjs-sentry-example
-# or
+```
+
+```bash
 yarn create next-app --example with-sentry nextjs-sentry-example
-# or
+```
+
+```bash
 pnpm create next-app --example with-sentry nextjs-sentry-example
 ```
 

--- a/examples/with-sfcc/README.md
+++ b/examples/with-sfcc/README.md
@@ -15,7 +15,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/deploym
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init), [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/), or [pnpm](https://pnpm.io) to bootstrap the example:
 
 ```bash
- npx create-next-app --example with-sfcc nextjs-sfcc-app
+npx create-next-app --example with-sfcc nextjs-sfcc-app
 ```
 
 ```bash

--- a/examples/with-supabase/README.md
+++ b/examples/with-supabase/README.md
@@ -55,13 +55,21 @@ If you wish to just develop locally and not deploy to Vercel, [follow the steps 
 2. Create a Next.js app using the Supabase Starter template npx command
 
    ```bash
-   npx create-next-app -e with-supabase
+   npx create-next-app --example with-supabase with-supabase-app
+   ```
+
+   ```bash
+   yarn create next-app --example with-supabase with-supabase-app
+   ```
+
+   ```bash
+   pnpm create next-app --example with-supabase with-supabase-app
    ```
 
 3. Use `cd` to change into the app's directory
 
    ```bash
-   cd name-of-new-app
+   cd with-supabase-app
    ```
 
 4. Rename `.env.example` to `.env.local` and update the following:

--- a/examples/with-temporal/README.md
+++ b/examples/with-temporal/README.md
@@ -58,9 +58,13 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 
 ```bash
 npx create-next-app --example with-temporal next-temporal-app
-# or
+```
+
+```bash
 yarn create next-app --example with-temporal next-temporal-app
-# or
+```
+
+```bash
 pnpm create next-app --example with-temporal next-temporal-app
 ```
 

--- a/examples/with-userbase/README.md
+++ b/examples/with-userbase/README.md
@@ -16,9 +16,13 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 
 ```bash
 npx create-next-app --example with-userbase next-userbase-app
-# or
+```
+
+```bash
 yarn create next-app --example with-userbase next-userbase-app
-# or
+```
+
+```bash
 pnpm create next-app --example with-userbase next-userbase-app
 ```
 

--- a/examples/with-windicss/README.md
+++ b/examples/with-windicss/README.md
@@ -13,11 +13,15 @@ Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_mediu
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```bash
-npx create-next-app --example with-windicss
-# or
-yarn create next-app --example with-windicss
-# or
-pnpm create next-app --example with-windicss
+npx create-next-app --example with-windicss with-windicss-app
+```
+
+```bash
+yarn create next-app --example with-windicss with-windicss-app
+```
+
+```bash
+pnpm create next-app --example with-windicss with-windicss-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).


### PR DESCRIPTION
## Description

Follow up #38410.
Some examples remain the multiple commands in a single block, and we couldn't use copy button to select one line.
With this change users would be able to copy the command (using their choice package manager) with a single click using the github copy feature.

CC: @samcx 

### Adding or Updating Examples

- [x] The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- [x] Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md