### PR TITLE
docs(mdx): add a dynamic imports section for App Router

### DIFF
--- a/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
@@ -252,12 +252,9 @@ Navigating to the `/mdx-page` route should display your rendered MDX page.
 
 ### Using dynamic imports
 
-You can also dynamically import MDX in your pages. This is useful for:
+You can import dynamic MDX components instead of using filesystem routing for MDX files.
 
-- Programmatically rendering MDX.
-- Pairing it with dynamic route segments and [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params).
-
-Create a new dynamic page within the `/app` directory and add MDX files wherever you'd like:
+For example, you can have a dynamic route segment which loads MDX components from a separate directory:
 
 ```txt
   my-project

--- a/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
@@ -307,6 +307,8 @@ export const dynamicParams = false
 
 Navigating to `/blog/welcome` or `/blog/about` should display your prerendered MDX page.
 
+> **Good to know**: Make sure to include the relative path `@/content` and `.mdx` file extension in your `import()` so Webpack does not attempt to index every file.
+
 </AppOnly>
 
 ## Using custom styles and components

--- a/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
@@ -307,7 +307,7 @@ export const dynamicParams = false
 
 Navigating to `/blog/welcome` or `/blog/about` should display your prerendered MDX page.
 
-> **Good to know**: Make sure to include the relative path (e.g., `@/content`) and `.mdx` file extension in your `import()` so Webpack does not attempt to index every file.
+> **Good to know**: Make sure to include the relative path (e.g., `@/content`) and `.mdx` file extension in your `import()` so webpack does not attempt to index every file.
 
 </AppOnly>
 

--- a/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
@@ -269,7 +269,7 @@ For example, you can have a dynamic route segment which loads MDX components fro
   └── package.json
 ```
 
-Dynamically import the MDX file inside the page and add a `generateStaticParams` to statically prerender the pages with the MDX content:
+[`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) can be used to prerender the provided routes. By marking `dynamicParams` as `false`, accessing a route not defined in `generateStaticParams` will 404.
 
 ```tsx filename="app/blog/[slug]/page.tsx" switcher
 export default async function Page({

--- a/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
@@ -307,7 +307,7 @@ export const dynamicParams = false
 
 Navigating to `/blog/welcome` or `/blog/about` should display your prerendered MDX page.
 
-> **Good to know**: Make sure to include the relative path `@/content` and `.mdx` file extension in your `import()` so Webpack does not attempt to index every file.
+> **Good to know**: Make sure to include the relative path (e.g., `@/content`) and `.mdx` file extension in your `import()` so Webpack does not attempt to index every file.
 
 </AppOnly>
 

--- a/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
@@ -736,7 +736,7 @@ export default withMDX(nextConfig)
 
 ## Remote MDX
 
-If your MDX files or content lives _somewhere else_, you can fetch it dynamically on the server. This is useful for content stored in a separate local folder, CMS, database, or anywhere else. A popular community package for this use is [`next-mdx-remote`](https://github.com/hashicorp/next-mdx-remote#react-server-components-rsc--nextjs-app-directory-support).
+If your MDX files or content lives _somewhere else_, you can fetch it dynamically on the server. This is useful for content stored in a CMS, database, or anywhere else. A popular community package for this use is [`next-mdx-remote`](https://github.com/hashicorp/next-mdx-remote#react-server-components-rsc--nextjs-app-directory-support).
 
 > **Good to know**: Please proceed with caution. MDX compiles to JavaScript and is executed on the server. You should only fetch MDX content from a trusted source, otherwise this can lead to remote code execution (RCE).
 
@@ -748,7 +748,7 @@ The following example uses `next-mdx-remote`:
 import { MDXRemote } from 'next-mdx-remote/rsc'
 
 export default async function RemoteMdxPage() {
-  // MDX text - can be from a local file, database, CMS, fetch, anywhere...
+  // MDX text - can be from a database, CMS, fetch, anywhere...
   const res = await fetch('https://...')
   const markdown = await res.text()
   return <MDXRemote source={markdown} />
@@ -759,7 +759,7 @@ export default async function RemoteMdxPage() {
 import { MDXRemote } from 'next-mdx-remote/rsc'
 
 export default async function RemoteMdxPage() {
-  // MDX text - can be from a local file, database, CMS, fetch, anywhere...
+  // MDX text - can be from a database, CMS, fetch, anywhere...
   const res = await fetch('https://...')
   const markdown = await res.text()
   return <MDXRemote source={markdown} />
@@ -783,7 +783,7 @@ export default function RemoteMdxPage({ mdxSource }: Props) {
 }
 
 export async function getStaticProps() {
-  // MDX text - can be from a local file, database, CMS, fetch, anywhere...
+  // MDX text - can be from a database, CMS, fetch, anywhere...
   const res = await fetch('https:...')
   const mdxText = await res.text()
   const mdxSource = await serialize(mdxText)
@@ -800,7 +800,7 @@ export default function RemoteMdxPage({ mdxSource }) {
 }
 
 export async function getStaticProps() {
-  // MDX text - can be from a local file, database, CMS, fetch, anywhere...
+  // MDX text - can be from a database, CMS, fetch, anywhere...
   const res = await fetch('https:...')
   const mdxText = await res.text()
   const mdxSource = await serialize(mdxText)

--- a/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
@@ -248,6 +248,67 @@ export default function Page() {
 
 Navigating to the `/mdx-page` route should display your rendered MDX page.
 
+<AppOnly>
+
+### Using dynamic imports
+
+You can also dynamically import MDX in your pages.
+
+Create a new dynamic page within the `/app` directory and add MDX files wherever you'd like:
+
+```txt
+  my-project
+  ├── app
+  │   └── blog
+  │       └── [slug]
+  │           └── page.(tsx/js)
+  ├── content
+  │   ├── welcome.(mdx/md)
+      └── about.(mdx/md)
+  |── mdx-components.(tsx/js)
+  └── package.json
+```
+
+Dynamically import the MDX file inside the page and add a [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) to statically prerender the pages with the MDX content:
+
+```tsx filename="app/blog/[slug]/page.tsx" switcher
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const slug = (await params).slug
+  const { default: Post } = await import(`@/content/${slug}.mdx`)
+
+  return <Post />
+}
+
+export function generateStaticParams() {
+  return [{ slug: 'welcome' }, { slug: 'about' }]
+}
+
+export const dynamicParams = false
+```
+
+```jsx filename="app/blog/[slug]/page.js" switcher
+export default async function Page({ params }) {
+  const slug = params.slug
+  const { default: Post } = await import(`@/content/${slug}.mdx`)
+
+  return <Post />
+}
+
+export function generateStaticParams() {
+  return [{ slug: 'welcome' }, { slug: 'about' }]
+}
+
+export const dynamicParams = false
+```
+
+Navigating to `/blog/welcome` or `/blog/about` should display your prerendered MDX page.
+
+</AppOnly>
+
 ## Using custom styles and components
 
 Markdown, when rendered, maps to native HTML elements. For example, writing the following markdown:

--- a/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
@@ -305,9 +305,7 @@ export function generateStaticParams() {
 export const dynamicParams = false
 ```
 
-Navigating to `/blog/welcome` or `/blog/about` should display your prerendered MDX page.
-
-> **Good to know**: Make sure to include the relative path (e.g., `@/content`) and `.mdx` file extension in your `import()` so webpack does not attempt to index every file.
+> **Good to know**: Ensure you specify the `.mdx` file extension in your import. While it is not required to use [module path aliases](/docs/app/getting-started/installation#set-up-absolute-imports-and-module-path-aliases) (e.g., `@/content`), it does simplify your import path.
 
 </AppOnly>
 

--- a/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
@@ -252,7 +252,7 @@ Navigating to the `/mdx-page` route should display your rendered MDX page.
 
 ### Using dynamic imports
 
-You can also dynamically import MDX in your pages.
+You can also dynamically import MDX in your pages, which is useful when used in conjunction with a dynamic route.
 
 Create a new dynamic page within the `/app` directory and add MDX files wherever you'd like:
 

--- a/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
@@ -256,18 +256,13 @@ You can import dynamic MDX components instead of using filesystem routing for MD
 
 For example, you can have a dynamic route segment which loads MDX components from a separate directory:
 
-```txt
-  my-project
-  ├── app
-  │   └── blog
-  │       └── [slug]
-  │           └── page.(tsx/js)
-  ├── content
-  │   ├── welcome.(mdx/md)
-      └── about.(mdx/md)
-  |── mdx-components.(tsx/js)
-  └── package.json
-```
+<Image
+  alt="Route segments for dynamic MDX components"
+  srcLight="/docs/light/mdx-files.png"
+  srcDark="/docs/dark/mdx-files.png"
+  width="1600"
+  height="849"
+>
 
 [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) can be used to prerender the provided routes. By marking `dynamicParams` as `false`, accessing a route not defined in `generateStaticParams` will 404.
 

--- a/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
@@ -252,7 +252,10 @@ Navigating to the `/mdx-page` route should display your rendered MDX page.
 
 ### Using dynamic imports
 
-You can also dynamically import MDX in your pages, which is useful when used in conjunction with a dynamic route.
+You can also dynamically import MDX in your pages. This is useful for:
+
+- Programmatically rendering MDX.
+- Pairing it with dynamic route segments and [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params).
 
 Create a new dynamic page within the `/app` directory and add MDX files wherever you'd like:
 
@@ -269,7 +272,7 @@ Create a new dynamic page within the `/app` directory and add MDX files wherever
   └── package.json
 ```
 
-Dynamically import the MDX file inside the page and add a [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) to statically prerender the pages with the MDX content:
+Dynamically import the MDX file inside the page and add a `generateStaticParams` to statically prerender the pages with the MDX content:
 
 ```tsx filename="app/blog/[slug]/page.tsx" switcher
 export default async function Page({


### PR DESCRIPTION
## Why?

Adding a section dedicated to dynamically importing MDX files inside pages for App Router.

- x-ref: https://github.com/vercel/next.js/discussions/70417