### PR TITLE
fix: running cleanup before server is initialized

### DIFF
--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -134,7 +134,8 @@ export async function startServer(
     }
     throw new Error('Invariant upgrade handler was not setup')
   }
-  let nextServer: NextServer
+
+  let nextServer: NextServer | undefined
 
   // setup server listener as fast as possible
   if (selfSignedCertificate && !isDev) {
@@ -310,7 +311,7 @@ export async function startServer(
 
             // now that no new requests can come in, clean up the rest
             await Promise.all([
-              nextServer.close().catch(console.error),
+              nextServer?.close().catch(console.error),
               cleanupListeners?.runAll().catch(console.error),
             ])
 


### PR DESCRIPTION
Follow-up to #72590. `nextServer` is initialized asynchronously, so if the server is started and then quickly `ctrl+C`'d, it might be `undefined`.