### PR TITLE
refactor: rename ALS instances to prevent bad auto imports

### DIFF
--- a/packages/next/src/server/app-render/action-async-storage-instance.ts
+++ b/packages/next/src/server/app-render/action-async-storage-instance.ts
@@ -1,4 +1,5 @@
 import type { ActionAsyncStorage } from './action-async-storage.external'
 import { createAsyncLocalStorage } from './async-local-storage'
 
-export const actionAsyncStorage: ActionAsyncStorage = createAsyncLocalStorage()
+export const actionAsyncStorageInstance: ActionAsyncStorage =
+  createAsyncLocalStorage()

--- a/packages/next/src/server/app-render/action-async-storage.external.ts
+++ b/packages/next/src/server/app-render/action-async-storage.external.ts
@@ -1,7 +1,7 @@
 import type { AsyncLocalStorage } from 'async_hooks'
 
 // Share the instance module in the next-shared layer
-import { actionAsyncStorage } from './action-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
+import { actionAsyncStorageInstance } from './action-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
 export interface ActionStore {
   readonly isAction?: boolean
   readonly isAppRoute?: boolean
@@ -9,4 +9,4 @@ export interface ActionStore {
 
 export type ActionAsyncStorage = AsyncLocalStorage<ActionStore>
 
-export { actionAsyncStorage }
+export { actionAsyncStorageInstance as actionAsyncStorage }

--- a/packages/next/src/server/app-render/work-async-storage-instance.ts
+++ b/packages/next/src/server/app-render/work-async-storage-instance.ts
@@ -1,4 +1,5 @@
 import type { WorkAsyncStorage } from './work-async-storage.external'
 import { createAsyncLocalStorage } from './async-local-storage'
 
-export const workAsyncStorage: WorkAsyncStorage = createAsyncLocalStorage()
+export const workAsyncStorageInstance: WorkAsyncStorage =
+  createAsyncLocalStorage()

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -9,7 +9,7 @@ import type { AfterContext } from '../after/after-context'
 import type { CacheLife } from '../use-cache/cache-life'
 
 // Share the instance module in the next-shared layer
-import { workAsyncStorage } from './work-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
+import { workAsyncStorageInstance } from './work-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
 
 export interface WorkStore {
   readonly isStaticGeneration: boolean
@@ -73,4 +73,4 @@ export interface WorkStore {
 
 export type WorkAsyncStorage = AsyncLocalStorage<WorkStore>
 
-export { workAsyncStorage }
+export { workAsyncStorageInstance as workAsyncStorage }

--- a/packages/next/src/server/app-render/work-unit-async-storage-instance.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage-instance.ts
@@ -1,5 +1,5 @@
 import { createAsyncLocalStorage } from './async-local-storage'
 import type { WorkUnitAsyncStorage } from './work-unit-async-storage.external'
 
-export const workUnitAsyncStorage: WorkUnitAsyncStorage =
+export const workUnitAsyncStorageInstance: WorkUnitAsyncStorage =
   createAsyncLocalStorage()

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -7,7 +7,7 @@ import type { CacheSignal } from './cache-signal'
 import type { DynamicTrackingState } from './dynamic-rendering'
 
 // Share the instance module in the next-shared layer
-import { workUnitAsyncStorage } from './work-unit-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
+import { workUnitAsyncStorageInstance } from './work-unit-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
 import type { ServerComponentsHmrCache } from '../response-cache'
 import type {
   RenderResumeDataCache,
@@ -176,12 +176,12 @@ export type WorkUnitStore = RequestStore | CacheStore | PrerenderStore
 
 export type WorkUnitAsyncStorage = AsyncLocalStorage<WorkUnitStore>
 
-export { workUnitAsyncStorage }
+export { workUnitAsyncStorageInstance as workUnitAsyncStorage }
 
 export function getExpectedRequestStore(
   callingExpression: string
 ): RequestStore {
-  const workUnitStore = workUnitAsyncStorage.getStore()
+  const workUnitStore = workUnitAsyncStorageInstance.getStore()
   if (workUnitStore) {
     if (workUnitStore.type === 'request') {
       return workUnitStore

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -22,7 +22,7 @@ import {
 } from '../../../lib/constants'
 import { toRoute } from '../to-route'
 import { SharedRevalidateTimings } from './shared-revalidate-timings'
-import { workUnitAsyncStorage } from '../../app-render/work-unit-async-storage-instance'
+import { workUnitAsyncStorageInstance } from '../../app-render/work-unit-async-storage-instance'
 import {
   getPrerenderResumeDataCache,
   getRenderResumeDataCache,
@@ -405,7 +405,7 @@ export class IncrementalCache implements IncrementalCacheType {
     // unlike other caches if we have a cacheScope we use it even if
     // testmode would normally disable it or if requestHeaders say 'no-cache'.
     if (this.hasDynamicIO && ctx.kind === IncrementalCacheKind.FETCH) {
-      const workUnitStore = workUnitAsyncStorage.getStore()
+      const workUnitStore = workUnitAsyncStorageInstance.getStore()
       const resumeDataCache = workUnitStore
         ? getRenderResumeDataCache(workUnitStore)
         : null
@@ -550,7 +550,7 @@ export class IncrementalCache implements IncrementalCacheType {
     // is a transient in memory cache that populates caches ahead of a dynamic render in dev mode
     // to allow the RSC debug info to have the right environment associated to it.
     if (this.hasDynamicIO && data?.kind === CachedRouteKind.FETCH) {
-      const workUnitStore = workUnitAsyncStorage.getStore()
+      const workUnitStore = workUnitAsyncStorageInstance.getStore()
       const prerenderResumeDataCache = workUnitStore
         ? getPrerenderResumeDataCache(workUnitStore)
         : null


### PR DESCRIPTION
this is a little quality-of-life improvement, with no behavioral changes. it's slightly silly though.

for bundling reasons, our ALSes should only ever be imported from `some-async-storage.external`, not `some-async-storage-instance`. unfortunately editor autocomplete doesn't care about that, and always suggests `-instance` first.

we can solve this by renaming the undesireable one from `someAsyncStorage` to `someAsyncStorageInstace`, which makes it rank lower in the autocomplete suggestions, so the top suggestion becomes the correct one.

before the rename:
<img width="617" alt="Screenshot 2024-12-03 at 17 53 24" src="https://github.com/user-attachments/assets/750f653a-f108-4fbf-9da5-4825dac6389d">
after the rename:
<img width="587" alt="Screenshot 2024-12-03 at 17 52 45" src="https://github.com/user-attachments/assets/fa016050-9df3-44fb-b0c1-2821f84696dc">

### Alternatives considered
marking the instance with `/** @ignore */` doesn't work, because JSDoc comments propagate to reexports, so it hides *both* from autocomplete, which sucks.
