### PR TITLE
remove unnecessary internal middleware header from response

### DIFF
--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -164,6 +164,9 @@ export async function initialize(opts: {
     require('./render-server') as typeof import('./render-server')
 
   const requestHandlerImpl: WorkerRequestHandler = async (req, res) => {
+    // internal headers should not be honored by the request handler
+    delete req.headers['x-middleware-set-cookie']
+
     if (
       !opts.minimalMode &&
       config.i18n &&

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -166,7 +166,9 @@ export async function initialize(opts: {
 
   const requestHandlerImpl: WorkerRequestHandler = async (req, res) => {
     // internal headers should not be honored by the request handler
-    filterInternalHeaders(req.headers)
+    if (!process.env.NEXT_PRIVATE_TEST_HEADERS) {
+      filterInternalHeaders(req.headers)
+    }
 
     if (
       !opts.minimalMode &&

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -47,6 +47,7 @@ import {
 import { normalizedAssetPrefix } from '../../shared/lib/normalized-asset-prefix'
 import { NEXT_PATCH_SYMBOL } from './patch-fetch'
 import type { ServerInitResult } from './render-server'
+import { filterInternalHeaders } from './server-ipc/utils'
 
 const debug = setupDebug('next:router-server:main')
 const isNextFont = (pathname: string | null) =>
@@ -165,7 +166,7 @@ export async function initialize(opts: {
 
   const requestHandlerImpl: WorkerRequestHandler = async (req, res) => {
     // internal headers should not be honored by the request handler
-    delete req.headers['x-middleware-set-cookie']
+    filterInternalHeaders(req.headers)
 
     if (
       !opts.minimalMode &&

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -585,6 +585,14 @@ export function getResolveRoutes(
               ) {
                 continue
               }
+
+              // for set-cookie, the header shouldn't be added to the response
+              // as it's only needed for the request to the middleware function.
+              if (key === 'x-middleware-set-cookie') {
+                req.headers[key] = value
+                continue
+              }
+
               if (value) {
                 resHeaders[key] = value
                 req.headers[key] = value

--- a/packages/next/src/server/lib/server-ipc/utils.ts
+++ b/packages/next/src/server/lib/server-ipc/utils.ts
@@ -36,3 +36,26 @@ export const filterReqHeaders = (
   }
   return headers as Record<string, undefined | string | string[]>
 }
+
+// These are headers that are only used internally and should
+// not be honored from the external request
+const INTERNAL_HEADERS = [
+  'x-middleware-rewrite',
+  'x-middleware-redirect',
+  'x-middleware-set-cookie',
+  'x-middleware-skip',
+  'x-middleware-override-headers',
+  'x-middleware-next',
+  'x-now-route-matches',
+  'x-matched-path',
+]
+
+export const filterInternalHeaders = (
+  headers: Record<string, undefined | string | string[]>
+) => {
+  for (const header in headers) {
+    if (INTERNAL_HEADERS.includes(header)) {
+      delete headers[header]
+    }
+  }
+}

--- a/test/e2e/app-dir/app-middleware/app/cookies/page.js
+++ b/test/e2e/app-dir/app-middleware/app/cookies/page.js
@@ -1,0 +1,6 @@
+import { cookies } from 'next/headers'
+
+export default async function Page() {
+  const cookieLength = (await cookies()).size
+  return <div id="cookies">cookies: {cookieLength}</div>
+}

--- a/test/integration/required-server-files-ssr-404/test/index.test.js
+++ b/test/integration/required-server-files-ssr-404/test/index.test.js
@@ -44,6 +44,7 @@ describe('Required Server Files', () => {
         }
         await fs.rename(join(appDir, 'pages'), join(appDir, 'pages-bak'))
 
+        process.env.NEXT_PRIVATE_TEST_HEADERS = '1'
         nextApp = nextServer({
           conf: {},
           dir: appDir,
@@ -57,6 +58,7 @@ describe('Required Server Files', () => {
         console.log(`Listening at ::${appPort}`)
       })
       afterAll(async () => {
+        delete process.env.NEXT_PRIVATE_TEST_HEADERS
         if (server) server.close()
         await fs.rename(join(appDir, 'pages-bak'), join(appDir, 'pages'))
       })

--- a/test/production/standalone-mode/required-server-files/required-server-files-app.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-app.test.ts
@@ -26,6 +26,7 @@ describe('required server files app router', () => {
   }) => {
     // test build against environment with next support
     process.env.NOW_BUILDER = nextEnv ? '1' : ''
+    process.env.NEXT_PRIVATE_TEST_HEADERS = '1'
 
     next = await createNext({
       files: {
@@ -97,6 +98,7 @@ describe('required server files app router', () => {
     await setupNext({ nextEnv: true, minimalMode: true })
   })
   afterAll(async () => {
+    delete process.env.NEXT_PRIVATE_TEST_HEADERS
     await next.destroy()
     if (server) await killApp(server)
   })

--- a/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
@@ -25,6 +25,7 @@ describe('required server files i18n', () => {
 
   beforeAll(async () => {
     let wasmPkgIsAvailable = false
+    process.env.NEXT_PRIVATE_TEST_HEADERS = '1'
 
     const res = await nodeFetch(
       `https://registry.npmjs.com/@next/swc-wasm-nodejs/-/swc-wasm-nodejs-${
@@ -131,6 +132,7 @@ describe('required server files i18n', () => {
   })
 
   afterAll(async () => {
+    delete process.env.NEXT_PRIVATE_TEST_HEADERS
     await next.destroy()
     if (server) await killApp(server)
   })

--- a/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
@@ -28,6 +28,7 @@ describe('required server files app router', () => {
   }) => {
     // test build against environment with next support
     process.env.NOW_BUILDER = nextEnv ? '1' : ''
+    process.env.NEXT_PRIVATE_TEST_HEADERS = '1'
 
     next = await createNext({
       files: {
@@ -107,6 +108,7 @@ describe('required server files app router', () => {
     await setupNext({ nextEnv: true, minimalMode: true })
   })
   afterAll(async () => {
+    delete process.env.NEXT_PRIVATE_TEST_HEADERS
     await next.destroy()
     if (server) await killApp(server)
   })

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -29,6 +29,7 @@ describe('required server files', () => {
   const setupNext = async ({ nextEnv }: { nextEnv?: boolean }) => {
     // test build against environment with next support
     process.env.NOW_BUILDER = nextEnv ? '1' : ''
+    process.env.NEXT_PRIVATE_TEST_HEADERS = '1'
 
     next = await createNext({
       files: {
@@ -152,6 +153,7 @@ describe('required server files', () => {
   })
 
   afterAll(async () => {
+    delete process.env.NEXT_PRIVATE_TEST_HEADERS
     await next.destroy()
   })
 

--- a/test/production/standalone-mode/response-cache/index.test.ts
+++ b/test/production/standalone-mode/response-cache/index.test.ts
@@ -22,6 +22,7 @@ describe('minimal-mode-response-cache', () => {
   beforeAll(async () => {
     // test build against environment with next support
     process.env.NOW_BUILDER = '1'
+    process.env.NEXT_PRIVATE_TEST_HEADERS = '1'
 
     next = await createNext({
       files: new FileRef(join(__dirname, 'app')),
@@ -84,6 +85,7 @@ describe('minimal-mode-response-cache', () => {
     appPort = `http://127.0.0.1:${port}`
   })
   afterAll(async () => {
+    delete process.env.NEXT_PRIVATE_TEST_HEADERS
     await next.destroy()
     if (server) await killApp(server)
   })


### PR DESCRIPTION
x-middleware-set-cookie is an internal header used by the middleware handler and doesn't need to be forwarded onto the response.

this also adds handling to filter out internal request headers as they aren't intended to be used externally. 