### PR TITLE
fix: memory leak from `warnOnce()`

### DIFF
--- a/packages/next/src/build/output/log.ts
+++ b/packages/next/src/build/output/log.ts
@@ -1,4 +1,5 @@
 import { bold, green, magenta, red, yellow, white } from '../../lib/picocolors'
+import { LRUCache } from '../../server/lib/lru-cache'
 
 export const prefixes = {
   wait: white(bold('○')),
@@ -76,15 +77,12 @@ export function trace(...message: any[]) {
   prefixedLog('trace', ...message)
 }
 
-const warnOnceMessages = new Set()
-export function warnOnce(...message: any[]) {
-  if (!warnOnceMessages.has(message[0])) {
-    if (warnOnceMessages.size > 1000) {
-      // delete the oldest message (FIFO) to prevent memory leak
-      warnOnceMessages.delete(warnOnceMessages.values().next().value)
-    }
-    warnOnceMessages.add(message.join(' '))
+const warnOnceCache = new LRUCache<string>(10_000, (message) => message.length)
 
+export function warnOnce(...message: any[]) {
+  const key = message.join(' ')
+  if (!warnOnceCache.has(key)) {
+    warnOnceCache.set(key)
     warn(...message)
   }
 }

--- a/packages/next/src/build/output/log.ts
+++ b/packages/next/src/build/output/log.ts
@@ -79,6 +79,10 @@ export function trace(...message: any[]) {
 const warnOnceMessages = new Set()
 export function warnOnce(...message: any[]) {
   if (!warnOnceMessages.has(message[0])) {
+    if (warnOnceMessages.size > 1000) {
+      // delete the oldest message (FIFO) to prevent memory leak
+      warnOnceMessages.delete(warnOnceMessages.values().next().value)
+    }
     warnOnceMessages.add(message.join(' '))
 
     warn(...message)


### PR DESCRIPTION
The `warnOnce()` function is used to warn only one time, however this means we will be storing every possible message in memory forever (aka memory leak) since it can grow unbounded.

This PR changes the behavior to only store only 10KB in a Least Recently Used (LRU) cache.

The tradeoff here is that you might see the same warning twice if you have a lot of unique warnings.

- Related https://github.com/vercel/next.js/issues/54482
- Related https://github.com/vercel/next.js/issues/44685