### PR TITLE
Fix: Importing an ESM file from *next/dist/client/*.js fails

### DIFF
--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -8,11 +8,12 @@ import type {
 } from '../../server/config-shared'
 import type { ResolvedBaseUrl } from '../load-jsconfig'
 import { isWebpackServerOnlyLayer, isWebpackAppPagesLayer } from '../utils'
+import { escapeStringRegexp } from '../../shared/lib/escape-regexp'
 
 const nextDirname = path.dirname(require.resolve('next/package.json'))
 
 const nextDistPath = new RegExp(
-  `${nextDirname}[\\/]dist[\\/](shared[\\/]lib|client|pages)`
+  `${escapeStringRegexp(nextDirname)}[\\/]dist[\\/](shared[\\/]lib|client|pages)`
 )
 
 const nodeModulesPath = /[\\/]node_modules[\\/]/

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -9,7 +9,7 @@ import type { ResolvedBaseUrl } from '../load-jsconfig'
 import { isWebpackServerOnlyLayer, isWebpackAppPagesLayer } from '../utils'
 
 const nextDistPath =
-  /(next[\\/]dist[\\/]shared[\\/]lib)|(next[\\/]dist[\\/]client)|(next[\\/]dist[\\/]pages)/
+  /([\\/]next[\\/]dist[\\/]shared[\\/]lib)|([\\/]next[\\/]dist[\\/]client)|([\\/]next[\\/]dist[\\/]pages)/
 
 const nodeModulesPath = /[\\/]node_modules[\\/]/
 

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import { WEBPACK_LAYERS, type WebpackLayerName } from '../../lib/constants'
 import type {
   NextConfig,
@@ -8,8 +9,11 @@ import type {
 import type { ResolvedBaseUrl } from '../load-jsconfig'
 import { isWebpackServerOnlyLayer, isWebpackAppPagesLayer } from '../utils'
 
-const nextDistPath =
-  /([\\/]next[\\/]dist[\\/]shared[\\/]lib)|([\\/]next[\\/]dist[\\/]client)|([\\/]next[\\/]dist[\\/]pages)/
+const nextDirname = path.dirname(require.resolve('next/package.json'))
+
+const nextDistPath = new RegExp(
+  `${nextDirname}[\\/]dist[\\/](shared[\\/]lib|client|pages)`
+)
 
 const nodeModulesPath = /[\\/]node_modules[\\/]/
 

--- a/test/e2e/app-dir/next-dist-client-esm-import/adapter-next/dist/client/index.js
+++ b/test/e2e/app-dir/next-dist-client-esm-import/adapter-next/dist/client/index.js
@@ -1,0 +1,5 @@
+'use client'
+
+export function Hello() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/next-dist-client-esm-import/adapter-next/package.json
+++ b/test/e2e/app-dir/next-dist-client-esm-import/adapter-next/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@monorepo/adapter-next",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "default": "./dist/client/index.js"
+    }
+  }
+}

--- a/test/e2e/app-dir/next-dist-client-esm-import/app/layout.tsx
+++ b/test/e2e/app-dir/next-dist-client-esm-import/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/next-dist-client-esm-import/app/page.tsx
+++ b/test/e2e/app-dir/next-dist-client-esm-import/app/page.tsx
@@ -1,0 +1,6 @@
+// @ts-expect-error no types defined
+import { Hello } from '@monorepo/adapter-next'
+
+export default function Page() {
+  return <Hello />
+}

--- a/test/e2e/app-dir/next-dist-client-esm-import/next-dist-client-esm-import.test.ts
+++ b/test/e2e/app-dir/next-dist-client-esm-import/next-dist-client-esm-import.test.ts
@@ -1,9 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('next-dist-client-esm-import', () => {
+  const dependencies = require('./package.json').dependencies
+
+  if ((global as any).isNextDeploy) {
+    // The `link:` protocol is incompatible with the npm version that's used
+    // when this test is deployed, so we use `file:` instead.
+    dependencies['@monorepo/adapter-next'] = 'file:./adapter-next'
+  }
+
   const { next } = nextTestSetup({
     files: __dirname,
-    dependencies: require('./package.json').dependencies,
+    dependencies,
   })
 
   it('should resolve ESM modules that have "next/dist/client" in their filename', async () => {

--- a/test/e2e/app-dir/next-dist-client-esm-import/next-dist-client-esm-import.test.ts
+++ b/test/e2e/app-dir/next-dist-client-esm-import/next-dist-client-esm-import.test.ts
@@ -1,0 +1,15 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('next-dist-client-esm-import', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    dependencies: require('./package.json').dependencies,
+  })
+
+  it('should resolve ESM modules that have "next/dist/client" in their filename', async () => {
+    // The filename for the client component module that's imported in this
+    // fixture is: <node_modules>/@monorepo/adapter-next/dist/client/index.js
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('p').text()).toBe('hello world')
+  })
+})

--- a/test/e2e/app-dir/next-dist-client-esm-import/next.config.js
+++ b/test/e2e/app-dir/next-dist-client-esm-import/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/next-dist-client-esm-import/package.json
+++ b/test/e2e/app-dir/next-dist-client-esm-import/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@monorepo/adapter-next": "link:./adapter-next"
+  }
+}


### PR DESCRIPTION
The SWC options for ES modules of third-party dependencies that include `next/dist/client` in their filename, e.g.
`<snip>/adapter-next/dist/client/index.js`, incorrectly defined `commonjs` as module type because the regular expression that checks for internal Next.js CJS files did not include a leading slash. We're now using `require.resolve` to fully match the Next.js filenames, instead of relying on a partial regex match.

fixes #73413