### PR TITLE
[Segment Cache] Use LRU to manage cache data 

### DIFF
--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -278,7 +278,7 @@ export function createFromNextReadableStream(
   })
 }
 
-export function createUnclosingPrefetchStream(
+function createUnclosingPrefetchStream(
   originalFlightStream: ReadableStream<Uint8Array>
 ): ReadableStream<Uint8Array> {
   // When PPR is enabled, prefetch streams may contain references that never

--- a/packages/next/src/client/components/segment-cache/lru.ts
+++ b/packages/next/src/client/components/segment-cache/lru.ts
@@ -1,0 +1,138 @@
+export type LRU<T extends LRUNode> = {
+  put(node: T): void
+  delete(node: T): void
+  updateSize(node: T, size: number): void
+}
+
+// Doubly-linked list
+type LRUNode<T = any> = {
+  // Although it's not encoded in the type, these are both null if the node is
+  // not in the LRU; both non-null if it is.
+  prev: T | null
+  next: T | null
+  size: number
+}
+
+// Rather than create an internal LRU node, the passed-in type must conform
+// the LRUNode interface. This is just a memory optimization to avoid creating
+// another object; we only use this for Segment Cache entries so it doesn't need
+// to be general purpose.
+export function createLRU<T extends LRUNode>(
+  // From the LRU's perspective, the size unit is arbitrary, but for our
+  // purposes this is the byte size.
+  maxLruSize: number,
+  onEviction: (node: T) => void
+): LRU<T> {
+  let head: T | null = null
+  let didScheduleCleanup: boolean = false
+  let lruSize: number = 0
+
+  function put(node: T) {
+    if (head === node) {
+      // Already at the head
+      return
+    }
+    const prev = node.prev
+    const next = node.next
+    if (next === null || prev === null) {
+      // This is an insertion
+      lruSize += node.size
+      // Whenever we add an entry, we need to check if we've exceeded the
+      // max size. We don't evict entries immediately; they're evicted later in
+      // an asynchronous task.
+      ensureCleanupIsScheduled()
+    } else {
+      // This is a move. Remove from its current position.
+      prev.next = next
+      next.prev = prev
+    }
+
+    // Move to the front of the list
+    if (head === null) {
+      // This is the first entry
+      node.prev = node
+      node.next = node
+    } else {
+      // Add to the front of the list
+      const tail = head.prev
+      node.prev = tail
+      tail.next = node
+      node.next = head
+      head.prev = node
+    }
+    head = node
+  }
+
+  function updateSize(node: T, newNodeSize: number) {
+    // This is a separate function so that we can resize the entry after it's
+    // already been inserted.
+    if (node.next === null) {
+      // No longer part of LRU.
+      return
+    }
+    const prevNodeSize = node.size
+    node.size = newNodeSize
+    lruSize = lruSize - prevNodeSize + newNodeSize
+    ensureCleanupIsScheduled()
+  }
+
+  function deleteNode(deleted: T) {
+    const next = deleted.next
+    const prev = deleted.prev
+    if (next !== null && prev !== null) {
+      lruSize -= deleted.size
+
+      deleted.next = null
+      deleted.prev = null
+
+      // Remove from the list
+      if (head === deleted) {
+        // Update the head
+        if (next === head) {
+          // This was the last entry
+          head = null
+        } else {
+          head = next
+        }
+      } else {
+        prev.next = next
+        next.prev = prev
+      }
+    } else {
+      // Already deleted
+    }
+  }
+
+  function ensureCleanupIsScheduled() {
+    if (didScheduleCleanup || lruSize <= maxLruSize) {
+      return
+    }
+    didScheduleCleanup = true
+    requestCleanupCallback(cleanup)
+  }
+
+  function cleanup() {
+    didScheduleCleanup = false
+
+    // Evict entries until we're at 90% capacity. We can assume this won't
+    // infinite loop because even if `maxLruSize` were 0, eventually
+    // `deleteNode` sets `head` to `null` when we run out entries.
+    const ninetyPercentMax = maxLruSize * 0.9
+    while (lruSize > ninetyPercentMax && head !== null) {
+      const tail = head.prev
+      deleteNode(tail)
+      onEviction(tail)
+    }
+  }
+
+  return {
+    put,
+    delete: deleteNode,
+    updateSize,
+  }
+}
+
+const requestCleanupCallback =
+  typeof requestIdleCallback === 'function'
+    ? requestIdleCallback
+    : (cb: () => void) => setTimeout(cb, 0)

--- a/test/e2e/app-dir/segment-cache/memory-pressure/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/memory-pressure/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/memory-pressure/app/memory-pressure/[step]/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/memory-pressure/app/memory-pressure/[step]/layout.tsx
@@ -1,0 +1,9 @@
+import { Suspense } from 'react'
+
+export default async function Layout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return <Suspense fallback="Loading...">{children}</Suspense>
+}

--- a/test/e2e/app-dir/segment-cache/memory-pressure/app/memory-pressure/[step]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/memory-pressure/app/memory-pressure/[step]/page.tsx
@@ -1,0 +1,17 @@
+export default async function Page() {
+  // Render a large string such that a prefetch of this segment is roughly 1MB
+  // over the network
+  return <div id="memory-pressure-step-page">{'a'.repeat(1024 * 1024)}</div>
+}
+
+export async function generateStaticParams() {
+  // Generate some number of steps. This should be just enough to trigger the
+  // default LRU limit used by the client prefetch cache.
+  // TODO: Once we add a config option to set the prefetch limit, we can set a
+  // smaller number, to speed up testing iteration (and CI).
+  const result = []
+  for (let i = 0; i < 60; i++) {
+    result.push({ step: i.toString() })
+  }
+  return result
+}

--- a/test/e2e/app-dir/segment-cache/memory-pressure/app/memory-pressure/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/memory-pressure/app/memory-pressure/layout.tsx
@@ -1,0 +1,3 @@
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/test/e2e/app-dir/segment-cache/memory-pressure/app/memory-pressure/page.tsx
+++ b/test/e2e/app-dir/segment-cache/memory-pressure/app/memory-pressure/page.tsx
@@ -1,0 +1,85 @@
+'use client'
+import Link from 'next/link'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+function Tab1() {
+  return <Link href="/memory-pressure/0">Link 0</Link>
+}
+
+function Tab2() {
+  const links = []
+  for (let i = 1; i < 60; i++) {
+    links.push(<Link href={'/memory-pressure/' + i}>Link {i}</Link>)
+  }
+  return links
+}
+
+export default function MemoryPressure() {
+  const router = useRouter()
+  const [selectedTab, setSelectedTab] = useState('1')
+
+  const handlePageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSelectedTab(event.target.value)
+  }
+
+  return (
+    <form>
+      <h1>Memory pressure</h1>
+      <p>
+        Tests that prefetch data is evicted once the cache size grows too large,
+        using an LRU.
+      </p>
+      <p>
+        On page load, the first link is preloaded. When you switch to the second
+        tab, the first link is replaced by a large number of a new links.
+      </p>
+      <p>The payload for each link's prefetch is about 1MB.</p>
+      <p>
+        Switching tabs causes the cache size to exceed the limit{' '}
+        <em>
+          (currently hardcoded to 50MB, but we will make this configurable)
+        </em>
+        , and the prefetch for the first link will be evicted.
+      </p>
+      <div>
+        <button
+          id="navigate-to-link-0"
+          formAction={() => {
+            // Intentionally using the imperative API instead of a Link so that
+            // the presence of the button does not affect the
+            // prefetching behavior.
+            router.push('/memory-pressure/0')
+          }}
+        >
+          Navigate to link 0
+        </button>
+      </div>
+      <div>
+        <label>
+          <input
+            type="radio"
+            value="1"
+            checked={selectedTab === '1'}
+            onChange={handlePageChange}
+            name="tabSelection"
+          />
+          Page 1
+        </label>
+      </div>
+      <div>
+        <label>
+          <input
+            type="radio"
+            value="2"
+            checked={selectedTab === '2'}
+            onChange={handlePageChange}
+            name="tabSelection"
+          />
+          Page 2
+        </label>
+      </div>
+      <div>{selectedTab === '1' ? <Tab1 /> : <Tab2 />}</div>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/memory-pressure/next.config.js
+++ b/test/e2e/app-dir/segment-cache/memory-pressure/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    ppr: true,
+    dynamicIO: true,
+    clientSegmentCache: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/memory-pressure/segment-cache-memory-pressure.test.ts
+++ b/test/e2e/app-dir/segment-cache/memory-pressure/segment-cache-memory-pressure.test.ts
@@ -1,0 +1,180 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+
+describe('segment cache memory pressure', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+  if (isNextDev || skipped) {
+    test('disabled in development / deployment', () => {})
+    return
+  }
+
+  it('evicts least recently used prefetch data once cache size exceeds limit', async () => {
+    const interceptor = createRequestInterceptor()
+
+    // Loading the page triggers a prefetch of the first link.
+    const browser = await interceptor.waitForPrefetches(() =>
+      next.browser('/memory-pressure', {
+        beforePageLoad(page: Playwright.Page) {
+          page.route('**/*', async (route: Playwright.Route) => {
+            await interceptor.interceptRoute(page, route)
+          })
+        },
+      })
+    )
+
+    const switchToTab1 = await browser.elementByCss(
+      'input[type="radio"][value="1"]'
+    )
+    const switchToTab2 = await browser.elementByCss(
+      'input[type="radio"][value="2"]'
+    )
+
+    // Switching to tab 2 causes the cache to overflow, evicting the prefetch
+    // for the link on tab 1.
+    await interceptor.waitForPrefetches(async () => {
+      await switchToTab2.click()
+    })
+
+    // Switching back to tab 1 initiates a new prefetch for the first link.
+    // Otherwise, this will timeout.
+    await interceptor.waitForPrefetches(async () => {
+      await switchToTab1.click()
+    })
+  })
+})
+
+function createRequestInterceptor() {
+  // Test utility for intercepting internal RSC requests so we can control the
+  // timing of when they resolve. We want to avoid relying on internals and
+  // implementation details as much as possible, so the only thing this does
+  // for now is let you block and release requests from happening based on
+  // their type (prefetch requests, navigation requests).
+  let pendingPrefetches: Set<Playwright.Route> | null = null
+  let pendingNavigations: Set<Playwright.Route> | null = null
+
+  let prefetchesPromise: PromiseWithResolvers<void> = null
+  let lastPrefetchRequest: Playwright.Request | null = null
+
+  return {
+    lockNavigations() {
+      if (pendingNavigations !== null) {
+        throw new Error('Navigations are already locked')
+      }
+      pendingNavigations = new Set()
+      return {
+        async release() {
+          if (pendingNavigations === null) {
+            throw new Error('This lock was already released')
+          }
+          const routes = pendingNavigations
+          pendingNavigations = null
+          for (const route of routes) {
+            route.continue()
+          }
+        },
+      }
+    },
+
+    lockPrefetches() {
+      if (pendingPrefetches !== null) {
+        throw new Error('Prefetches are already locked')
+      }
+      pendingPrefetches = new Set()
+      return {
+        release() {
+          if (pendingPrefetches === null) {
+            throw new Error('This lock was already released')
+          }
+          const routes = pendingPrefetches
+          pendingPrefetches = null
+          for (const route of routes) {
+            route.continue()
+          }
+        },
+      }
+    },
+
+    /**
+     * Waits for the next for the next prefetch request, then keeps waiting
+     * until the prefetch queue is empty (to account for network throttling).
+     *
+     * If no prefetches are initiated, this will timeout.
+     */
+    async waitForPrefetches<T>(
+      scope: () => Promise<T> | T = (): undefined => {}
+    ): Promise<T> {
+      if (prefetchesPromise === null) {
+        let resolve
+        let reject
+        const promise: Promise<void> = new Promise((res, rej) => {
+          resolve = res
+          reject = rej
+        })
+        prefetchesPromise = {
+          resolve,
+          reject,
+          promise,
+        }
+      }
+      const result = await scope()
+      if (prefetchesPromise !== null) {
+        await prefetchesPromise.promise
+      }
+      return result
+    },
+
+    async interceptRoute(page: Playwright.Page, route: Playwright.Route) {
+      const request = route.request()
+      const requestHeaders = await request.allHeaders()
+
+      if (requestHeaders['RSC'.toLowerCase()]) {
+        // This is an RSC request. Check if it's a prefetch or a navigation.
+        if (requestHeaders['Next-Router-Prefetch'.toLowerCase()]) {
+          // This is a prefetch request.
+          if (prefetchesPromise !== null) {
+            // Wait for the prefetch response to finish, then wait an additional
+            // async task for additional prefetches to be initiated.
+            lastPrefetchRequest = request
+            const waitForMorePrefetches = async () => {
+              const response = await request.response()
+              await response.finished()
+              await page.evaluate(
+                () =>
+                  // If the prefetch queue is network throttled, the next
+                  // request should be issued within a microtask of the previous
+                  // one finishing.
+                  new Promise<void>((res) => requestIdleCallback(() => res()))
+              )
+              if (request === lastPrefetchRequest) {
+                // No further prefetches were initiated. Assume the prefetch
+                // queue is now empty.
+                prefetchesPromise.resolve()
+                prefetchesPromise = null
+                lastPrefetchRequest = null
+              }
+            }
+            waitForMorePrefetches().then(
+              () => {},
+              () => {}
+            )
+          }
+          if (pendingPrefetches !== null) {
+            pendingPrefetches.add(route)
+            return
+          }
+        } else {
+          // This is a navigation request.
+          if (pendingNavigations !== null) {
+            pendingNavigations.add(route)
+            return
+          }
+        }
+      }
+
+      await route.continue()
+    },
+  }
+}


### PR DESCRIPTION
Based on:

- #73434
---

This implements an LRU for data stored in the Segment Cache.

For now I've hardcoded in a cache size of 50mb, but as a follow up, we should look into creating a dynamic limit based on device memory constraints.

Segments and Route entries are managed by separate LRUs. We could combine them into a single LRU, but because they are separate types, we'd need to wrap each one in an extra LRU node (to maintain monomorphism, at the cost of additional memory).