### PR TITLE
turbopack-cli: Use correct fs and env for builds

### DIFF
--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -249,7 +249,7 @@ async fn build_internal(
         .await?)
         .to_vec();
 
-    let origin = PlainResolveOrigin::new(asset_context, output_fs.root().join("_".into()));
+    let origin = PlainResolveOrigin::new(asset_context, project_fs.root().join("_".into()));
     let project_dir = &project_dir;
     let entries = entry_requests
         .into_iter()

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -81,11 +81,12 @@ pub async fn get_client_import_map(
 #[turbo_tasks::function]
 pub async fn get_client_resolve_options_context(
     project_path: Vc<FileSystemPath>,
+    node_env: Vc<NodeEnv>,
 ) -> Result<Vc<ResolveOptionsContext>> {
     let next_client_import_map = get_client_import_map(project_path).to_resolved().await?;
     let module_options_context = ResolveOptionsContext {
         enable_node_modules: Some(project_path.root().to_resolved().await?),
-        custom_conditions: vec!["development".into()],
+        custom_conditions: vec![node_env.await?.to_string().into(), "browser".into()],
         import_map: Some(next_client_import_map),
         browser: true,
         module: true,
@@ -117,7 +118,7 @@ async fn get_client_module_options_context(
         ..Default::default()
     };
 
-    let resolve_options_context = get_client_resolve_options_context(project_path);
+    let resolve_options_context = get_client_resolve_options_context(project_path, node_env);
 
     let enable_react_refresh = matches!(*node_env.await?, NodeEnv::Development)
         && assert_can_resolve_react_refresh(project_path, resolve_options_context)
@@ -188,7 +189,7 @@ pub fn get_client_asset_context(
     compile_time_info: Vc<CompileTimeInfo>,
     node_env: Vc<NodeEnv>,
 ) -> Vc<Box<dyn AssetContext>> {
-    let resolve_options_context = get_client_resolve_options_context(project_path);
+    let resolve_options_context = get_client_resolve_options_context(project_path, node_env);
     let module_options_context = get_client_module_options_context(
         project_path,
         execution_context,

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -55,8 +55,9 @@ pub async fn get_client_chunking_context(
 #[turbo_tasks::function]
 pub async fn get_client_runtime_entries(
     project_path: ResolvedVc<FileSystemPath>,
+    node_env: Vc<NodeEnv>,
 ) -> Result<Vc<RuntimeEntries>> {
-    let resolve_options_context = get_client_resolve_options_context(*project_path);
+    let resolve_options_context = get_client_resolve_options_context(*project_path, node_env);
 
     let mut runtime_entries = Vec::new();
 
@@ -105,7 +106,7 @@ pub async fn create_web_entry_source(
         get_client_asset_context(project_path, execution_context, compile_time_info, node_env);
     let chunking_context =
         get_client_chunking_context(project_path, server_root, compile_time_info.environment());
-    let entries = get_client_runtime_entries(project_path);
+    let entries = get_client_runtime_entries(project_path, node_env);
 
     let runtime_entries = entries.resolve_entries(asset_context);
 


### PR DESCRIPTION
This fixes two issues with resolving for turbopack-cli in builds:

- Builds used the `output_fs` in the `ResolveOptionsContext` resolve origin, so node_modules were never found as the lookup path could never be in the same filesystem as the root path [0]. It now uses `project_fs`.
- Production used the `development` custom condition. It’s now `production` and `browser` is added by default.

[0] https://github.com/vercel/next.js/blob/8756f7a65bd9922b3bb90050ee225c8bcdf6a535/turbopack/crates/turbopack-core/src/resolve/mod.rs#L1302


Closes PACK-3609