### PR TITLE
docs: add the link of ESLint example to guideline

### DIFF
--- a/contributing/examples/adding-examples.md
+++ b/contributing/examples/adding-examples.md
@@ -3,7 +3,7 @@
 When you add an example to the [examples](https://github.com/vercel/next.js/tree/canary/examples) directory, please follow these guidelines to ensure high-quality examples:
 
 - TypeScript should be leveraged for new examples (no need for separate JavaScript and TypeScript examples, converting old JavaScript examples is preferred)
-- Examples should not add custom ESLint configuration (we have specific templates for ESLint)
+- Examples should not add custom ESLint configuration (we have [specific templates for ESLint](https://github.com/vercel/next.js/tree/canary/examples/with-eslint))
 - If API routes aren't used in an example, they should be omitted
 - If an example exists for a certain library and you would like to showcase a specific feature of that library, the existing example should be updated (instead of adding a new example)
 - Package manager specific config should not be added (e.g. `resolutions` in `package.json`)


### PR DESCRIPTION
## Summary

Add [`with-eslint`](https://github.com/vercel/next.js/tree/canary/examples/with-eslint) example link to [adding-examples.md](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md) for convenience.

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide