### PR TITLE
[Turbopack] small minor performance improvements for dirtyness tracking and scheduling

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 default = []
 verify_serialization = []
 trace_aggregation_update = []
+trace_find_and_schedule = []
 lmdb = ["dep:lmdb-rkv"]
 
 [dependencies]

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -446,6 +446,7 @@ impl PartialEq for OptimizeJob {
 
 impl Eq for OptimizeJob {}
 
+/// A job to find and schedule dirty tasks that is enqueued. See `find_and_schedule_dirty`.
 #[derive(Serialize, Deserialize, Clone)]
 struct FindAndScheduleJob {
     task_id: TaskId,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -361,8 +361,8 @@ impl AggregationUpdateJobItem {
         }
     }
 
-    fn entered(self) -> AggregationUpdatejobGuard {
-        AggregationUpdatejobGuard {
+    fn entered(self) -> AggregationUpdateJobGuard {
+        AggregationUpdateJobGuard {
             job: self.job,
             #[cfg(feature = "trace_aggregation_update")]
             _guard: self.span.map(|s| s.entered()),
@@ -370,7 +370,7 @@ impl AggregationUpdateJobItem {
     }
 }
 
-struct AggregationUpdatejobGuard {
+struct AggregationUpdateJobGuard {
     job: AggregationUpdateJob,
     #[cfg(feature = "trace_aggregation_update")]
     _guard: Option<tracing::span::EnteredSpan>,

--- a/turbopack/crates/turbo-tasks-backend/src/utils/deque_set.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/utils/deque_set.rs
@@ -24,7 +24,7 @@ impl<T, B: BuildHasher + Default> Default for DequeSet<T, B> {
     fn default() -> Self {
         Self {
             set: Default::default(),
-            queue: Default::default(),
+            queue: VecDeque::with_capacity(0),
         }
     }
 }


### PR DESCRIPTION
### What?

* avoid updating the count if the update is zero
* add tracing to find_and_schedule, avoid overvisiting
* only add CachedActiveUntilClean when the task is dirty or contains dirty containers



Closes PACK-3608