### PR TITLE
fix unnecessary to_resolved calls in test cases

### DIFF
--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -248,7 +248,7 @@ async fn prepare_test(resource: RcStr) -> Result<Vc<PreparedTest>> {
         path: path.to_resolved().await?,
         project_path: project_path.to_resolved().await?,
         tests_path: tests_path.to_resolved().await?,
-        project_root: project_root.to_resolved().await?,
+        project_root,
         options,
     }
     .cell())
@@ -320,7 +320,7 @@ async fn run_test(prepared_test: Vc<PreparedTest>) -> Result<Vc<RunTestResult>> 
                 import_externals: true,
                 ..Default::default()
             },
-            preset_env_versions: Some(env.to_resolved().await?),
+            preset_env_versions: Some(env),
             tree_shaking_mode: options.tree_shaking_mode,
             rules: vec![(
                 ContextCondition::InDirectory("node_modules".into()),

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -296,7 +296,7 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             css: CssOptionsContext {
                 ..Default::default()
             },
-            preset_env_versions: Some(env.to_resolved().await?),
+            preset_env_versions: Some(env),
             rules: vec![(
                 ContextCondition::InDirectory("node_modules".into()),
                 ModuleOptionsContext {
@@ -357,8 +357,8 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                 project_root,
                 path,
                 path,
-                chunk_root_path.to_resolved().await?,
-                static_root_path.to_resolved().await?,
+                chunk_root_path,
+                static_root_path,
                 env,
                 options.runtime_type,
             )


### PR DESCRIPTION
### What?

These cases cause warnings by the new check.


Closes PACK-3605