### PR TITLE
feat(cache): Add ability to ignore headers in cache key generation

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -354,9 +354,23 @@ export class IncrementalCache implements IncrementalCacheType {
     const headers =
       typeof (init.headers || {}).keys === 'function'
         ? Object.fromEntries(init.headers as Headers)
-        : Object.assign({}, init.headers)
+        : (Object.assign({}, init.headers) as Record<string, string>)
 
-    if ('traceparent' in headers) delete headers['traceparent']
+    const disableHeaders = (init as any)?.next?.disableHeaders
+    if (
+      disableHeaders ||
+      (Array.isArray(disableHeaders) && disableHeaders.length > 0)
+    ) {
+      if (Array.isArray(disableHeaders)) {
+        Object.keys(headers).forEach((key) => {
+          if (disableHeaders.includes(key)) delete headers[key]
+        })
+      } else {
+        Object.keys(headers).forEach((key) => {
+          delete headers[key]
+        })
+      }
+    }
 
     const cacheString = JSON.stringify([
       MAIN_KEY_PREFIX,

--- a/packages/next/types/global.d.ts
+++ b/packages/next/types/global.d.ts
@@ -53,6 +53,7 @@ interface Window {
 interface NextFetchRequestConfig {
   revalidate?: number | false
   tags?: string[]
+  disableHeaders?: true | string[]
 }
 
 interface RequestInit {


### PR DESCRIPTION
### What?
Adds the ability to ignore specific headers or all headers when generating cache keys in Next.js's incremental cache system.

### Why?
In certain scenarios, developers need to exclude specific headers (like user-agent or cookies) from affecting the cache key generation to achieve more consistent caching behavior across different requests.

Example usage:

```typescript
// Disable specific headers
const options = {
  next: {
    disableHeaders: ['user-agent', 'cookie']
  }
}
fetch(url,options)

// Disable all headers
const options = {
  next: {
    disableHeaders: true
  }
}
fetch(url,options)
```