### PR TITLE
15.1 docs: Add experimental tags to `forbidden` and `unauthorized` APIs

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/forbidden.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/forbidden.mdx
@@ -4,7 +4,7 @@ description: API reference for the forbidden.js special file.
 related:
   links:
     - app/api-reference/functions/forbidden
-version: canary
+version: experimental
 ---
 
 The **forbidden** file is used to render UI when the [`forbidden`](/docs/app/api-reference/functions/forbidden) function is invoked during authentication. Along with allowing you to customize the UI, Next.js will return a `403` status code.

--- a/docs/01-app/03-api-reference/03-file-conventions/unauthorized.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/unauthorized.mdx
@@ -4,7 +4,7 @@ description: API reference for the unauthorized.js special file.
 related:
   links:
     - app/api-reference/functions/unauthorized
-version: canary
+version: experimental
 ---
 
 The **unauthorized** file is used to render UI when the [`unauthorized`](/docs/app/api-reference/functions/unauthorized) function is invoked during authentication. Along with allowing you to customize the UI, Next.js will return a `401` status code.

--- a/docs/01-app/03-api-reference/04-functions/forbidden.mdx
+++ b/docs/01-app/03-api-reference/04-functions/forbidden.mdx
@@ -1,7 +1,7 @@
 ---
 title: forbidden
 description: API Reference for the forbidden function.
-version: canary
+version: experimental
 related:
   links:
     - app/api-reference/file-conventions/forbidden

--- a/docs/01-app/03-api-reference/04-functions/unauthorized.mdx
+++ b/docs/01-app/03-api-reference/04-functions/unauthorized.mdx
@@ -1,7 +1,7 @@
 ---
 title: unauthorized
 description: API Reference for the unauthorized function.
-version: canary
+version: experimental
 related:
   links:
     - app/api-reference/file-conventions/unauthorized


### PR DESCRIPTION
**Do not merge until 15.1 is released.** 

Currently these features are tagged as `canary`, but once 15.1 becomes stable, they'll be `experimental`. 

Closes: https://linear.app/vercel/issue/DOC-3928/update-forbidden-docs-to-add-experimental-tag
