### PR TITLE
feat(after): wrap tasks with console.createTask

### DIFF
--- a/packages/next/src/server/after/after-context.ts
+++ b/packages/next/src/server/after/after-context.ts
@@ -19,6 +19,8 @@ export type AfterContextOpts = {
   onTaskError: RequestLifecycleOpts['onAfterTaskError'] | undefined
 }
 
+export type AsyncStackTask = ReturnType<NonNullable<Console['createTask']>>
+
 export class AfterContext {
   private waitUntil: RequestLifecycleOpts['waitUntil'] | undefined
   private onClose: RequestLifecycleOpts['onClose']
@@ -44,7 +46,10 @@ export class AfterContext {
     this.callbackQueue.pause()
   }
 
-  public after(task: AfterTask): void {
+  public after(
+    task: AfterTask,
+    asyncStackTask?: AsyncStackTask | undefined
+  ): void {
     if (isThenable(task)) {
       if (!this.waitUntil) {
         errorWaitUntilNotAvailable()
@@ -52,7 +57,7 @@ export class AfterContext {
       this.waitUntil(task.catch((error) => this.reportTaskError(error)))
     } else if (typeof task === 'function') {
       // TODO(after): implement tracing
-      this.addCallback(task)
+      this.addCallback(task, asyncStackTask)
     } else {
       throw new Error(
         '`unstable_after()`: Argument must be a promise or a function'
@@ -60,7 +65,10 @@ export class AfterContext {
     }
   }
 
-  private addCallback(callback: AfterCallback) {
+  private addCallback(
+    callback: AfterCallback,
+    asyncStackTask?: AsyncStackTask | undefined
+  ) {
     // if something is wrong, throw synchronously, bubbling up to the `unstable_after` callsite.
     if (!this.waitUntil) {
       errorWaitUntilNotAvailable()
@@ -95,7 +103,7 @@ export class AfterContext {
     const wrappedCallback = bindSnapshot(async () => {
       try {
         await afterTaskAsyncStorage.run({ rootTaskSpawnPhase }, () =>
-          callback()
+          asyncStackTask ? asyncStackTask.run(callback) : callback()
         )
       } catch (error) {
         this.reportTaskError(error)

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -293,6 +293,13 @@ export type InferGetServerSidePropsType<T extends (args: any) => any> = Awaited<
   Extract<Awaited<ReturnType<T>>, { props: any }>['props']
 >
 
+/** A value returned by `console.createTask`
+ * https://developer.chrome.com/blog/devtools-modern-web-debugging#linked_stack_traces
+ */
+interface Task {
+  run<T>(f: () => T): T
+}
+
 declare global {
   interface Crypto {
     readonly subtle: SubtleCrypto
@@ -313,6 +320,13 @@ declare global {
       array: T
     ): T
     randomUUID(): string
+  }
+
+  interface Console {
+    /** https://developer.chrome.com/blog/devtools-modern-web-debugging#linked_stack_traces
+     * Available since node 19
+     * */
+    createTask?: (name: string) => Task
   }
 
   var __NEXT_HTTP_AGENT_OPTIONS: { keepAlive?: boolean } | undefined


### PR DESCRIPTION
This improves stack traces for `after` when using a debugger
See more: https://developer.chrome.com/blog/devtools-modern-web-debugging#linked_stack_traces