### PR TITLE
[Segment Cache] Add isPartial to segment prefetch 

### DIFF
--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
@@ -10,7 +10,7 @@ const getFlightData = (): NormalizedFlightData[] => {
       segmentPath: ['children', 'linking', 'children', 'about'],
       segment: 'about',
       tree: ['about', { children: ['', {}] }],
-      seedData: ['about', <h1>SubTreeData Injected!</h1>, {}, null],
+      seedData: ['about', <h1>SubTreeData Injected!</h1>, {}, null, false],
       head: '<title>Head Injected!</title>',
       isRootRender: false,
     },

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
@@ -11,7 +11,7 @@ const getFlightData = (): NormalizedFlightData[] => {
       segmentPath: ['children', 'linking', 'children', 'about'],
       segment: 'about',
       tree: ['about', { children: ['', {}] }],
-      seedData: ['about', <h1>About Page!</h1>, {}, null],
+      seedData: ['about', <h1>About Page!</h1>, {}, null, false],
       head: '<title>About page!</title>',
       isRootRender: false,
     },

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -181,6 +181,7 @@ function readRenderSnapshotFromCache(
 
   let rsc: React.ReactNode | null = null
   let loading: LoadingModuleData | Promise<LoadingModuleData> = null
+  let isPartial: boolean = true
 
   const segmentEntry = readSegmentCacheEntry(now, tree.path)
   if (segmentEntry !== null) {
@@ -189,6 +190,7 @@ function readRenderSnapshotFromCache(
         // Happy path: a cache hit
         rsc = segmentEntry.rsc
         loading = segmentEntry.loading
+        isPartial = segmentEntry.isPartial
         break
       }
       case EntryStatus.Pending: {
@@ -202,6 +204,10 @@ function readRenderSnapshotFromCache(
         loading = promiseForFulfilledEntry.then((entry) =>
           entry !== null ? entry.loading : null
         )
+        // Since we don't know yet whether the segment is partial or fully
+        // static, we must assume it's partial; we can't skip the
+        // dynamic request.
+        isPartial = true
         break
       }
       case EntryStatus.Rejected:
@@ -225,7 +231,13 @@ function readRenderSnapshotFromCache(
       null,
       isRootLayout,
     ],
-    seedData: [flightRouterStateSegment, rsc, childSeedDatas, loading],
+    seedData: [
+      flightRouterStateSegment,
+      rsc,
+      childSeedDatas,
+      loading,
+      isPartial,
+    ],
   }
 }
 

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -872,6 +872,7 @@ async function getErrorRSCPayload(
     </html>,
     {},
     null,
+    false,
   ]
 
   const globalErrorStyles = await getGlobalErrorStyles(tree, ctx)

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -97,6 +97,7 @@ export type CacheNodeSeedData = [
     [parallelRouterKey: string]: CacheNodeSeedData | null
   },
   loading: LoadingModuleData | Promise<LoadingModuleData>,
+  isPartial: boolean,
 ]
 
 export type FlightDataSegment = [


### PR DESCRIPTION
Based on

- #73434
- #73486 

---


During a navigation, we should be able to skip the dynamic request if the prefetched data does not contain any dynamic holes. In the previous cache implementation, we only tracked this per route; in the Segment Cache, we must track this per segment.

This updates the SegmentCacheEntry and CacheNodeSeedData types to include an `isPartial` field. The field is always false during a dynamic render, or when PPR is disabled.

This PR does not change any behavior; it only adds the new field.