### PR TITLE
Fix PostCSS dependency message handling

### DIFF
--- a/turbopack/crates/turbopack-node/js/src/transforms/postcss.ts
+++ b/turbopack/crates/turbopack-node/js/src/transforms/postcss.ts
@@ -1,5 +1,7 @@
 declare const __turbopack_external_require__: (id: string, thunk: () => any, esm?: boolean) => any;
 
+import type {Processor} from "postcss";
+
 // @ts-ignore
 import postcss from "@vercel/turbopack/postcss";
 // @ts-ignore
@@ -20,7 +22,7 @@ function toPath(file: string) {
   return sep !== "/" ? relPath.replaceAll(sep, "/") : relPath;
 }
 
-let processor: any;
+let processor: Processor | undefined;
 
 export const init = async (ipc: Ipc<IpcInfoMessage, IpcRequestMessage>) => {
   let config = importedConfig;
@@ -74,7 +76,7 @@ export default async function transform(
   cssContent: string,
   name: string
 ) {
-  const { css, map, messages } = await processor.process(cssContent, {
+  const { css, map, messages } = await processor!.process(cssContent, {
     from: name,
     to: name,
     map: {
@@ -97,7 +99,7 @@ export default async function transform(
           // There is also an info field, which we currently ignore
         });
         break;
-      case "file-dependency":
+      case "dependency":
       case "missing-dependency":
         ipc.sendInfo({
           type: "fileDependency",


### PR DESCRIPTION
Closes PACK-3606
Closes https://github.com/vercel/next.js/issues/73422

It's `"dependency"`, not `"file-dependency"`... (the Typescript types wouldn't have caught that either though)
https://github.com/webpack-contrib/postcss-loader/blob/8024e67c7b57c3656063f50465d924a24ec796ce/src/index.js#L191-L219

Apparently, we don't have a test for that...