### PR TITLE
docs: update the outdated generate sitemaps doc with versioned changes

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/generate-sitemaps.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-sitemaps.mdx
@@ -17,9 +17,7 @@ The `generateSitemaps` returns an array of objects with an `id` property.
 
 ## URLs
 
-In production, your generated sitemaps will be available at `/.../sitemap/[id].xml`. For example, `/product/sitemap/1.xml`.
-
-In development, you can view the generated sitemap on `/.../sitemap.xml/[id]`. For example, `/product/sitemap.xml/1`. This difference is temporary and will follow the production format.
+Your generated sitemaps will be available at `/.../sitemap/[id].xml`. For example, `/product/sitemap/1.xml`.
 
 ## Example
 
@@ -72,3 +70,10 @@ export default async function sitemap({ id }) {
   }))
 }
 ```
+
+## Version History
+
+| Version      | Changes                                                                                                                                              |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| `v15.0.0-RC` | `generateSitemaps` now generates consistent URLs between development and production                                                                  |
+| `v13.3.2`    | `generateSitemaps` introduced. In development, you can view the generated sitemap on `/.../sitemap.xml/[id]`. For example, `/product/sitemap.xml/1`. |     |

--- a/docs/01-app/03-api-reference/04-functions/generate-sitemaps.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-sitemaps.mdx
@@ -73,7 +73,7 @@ export default async function sitemap({ id }) {
 
 ## Version History
 
-| Version      | Changes                                                                                                                                              |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| Version   | Changes                                                                                                                                              |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
 | `v15.0.0` | `generateSitemaps` now generates consistent URLs between development and production                                                                  |
-| `v13.3.2`    | `generateSitemaps` introduced. In development, you can view the generated sitemap on `/.../sitemap.xml/[id]`. For example, `/product/sitemap.xml/1`. |     |
+| `v13.3.2` | `generateSitemaps` introduced. In development, you can view the generated sitemap on `/.../sitemap.xml/[id]`. For example, `/product/sitemap.xml/1`. |     |

--- a/docs/01-app/03-api-reference/04-functions/generate-sitemaps.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-sitemaps.mdx
@@ -75,5 +75,5 @@ export default async function sitemap({ id }) {
 
 | Version      | Changes                                                                                                                                              |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
-| `v15.0.0-RC` | `generateSitemaps` now generates consistent URLs between development and production                                                                  |
+| `v15.0.0` | `generateSitemaps` now generates consistent URLs between development and production                                                                  |
 | `v13.3.2`    | `generateSitemaps` introduced. In development, you can view the generated sitemap on `/.../sitemap.xml/[id]`. For example, `/product/sitemap.xml/1`. |     |


### PR DESCRIPTION
### What

The `generateSitempas`API page is outdated, we mentioned this change in the [v15 release blog](https://nextjs.org/blog/next-15) but not super highlighted with examples. 

> [Breaking] Remove .xml extension for dynamic sitemap routes and align sitemap URLs between development and production

Here we removed the legacy behavior from the description and added a new section of version history at the bottom for users to view and migrate

