### PR TITLE
[Turbopack] more debugging options for Persistent Cache

### DIFF
--- a/crates/napi/src/next_api/utils.rs
+++ b/crates/napi/src/next_api/utils.rs
@@ -129,7 +129,14 @@ pub fn create_turbo_tasks(
     Ok(if persistent_caching {
         NextTurboTasks::PersistentCaching(TurboTasks::new(
             turbo_tasks_backend::TurboTasksBackend::new(
-                turbo_tasks_backend::BackendOptions::default(),
+                turbo_tasks_backend::BackendOptions {
+                    storage_mode: Some(if std::env::var("TURBO_ENGINE_READ_ONLY").is_ok() {
+                        turbo_tasks_backend::StorageMode::ReadOnly
+                    } else {
+                        turbo_tasks_backend::StorageMode::ReadWrite
+                    }),
+                    ..Default::default()
+                },
                 default_backing_storage(&output_path.join("cache/turbopack"))?,
             ),
         ))

--- a/turbopack/crates/turbo-tasks-backend/src/database/db_versioning.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/db_versioning.rs
@@ -13,6 +13,9 @@ use anyhow::Result;
 const MAX_OTHER_DB_VERSIONS: usize = 2;
 
 pub fn handle_db_versioning(base_path: &Path) -> Result<PathBuf> {
+    if let Ok(version) = env::var("TURBO_ENGINE_VERSION") {
+        return Ok(base_path.join(version));
+    }
     // Database versioning. Pass `TURBO_ENGINE_IGNORE_DIRTY` at runtime to ignore a
     // dirty git repository. Pass `TURBO_ENGINE_DISABLE_VERSIONING` at runtime to disable
     // versioning and always use the same database.

--- a/turbopack/crates/turbo-tasks-backend/src/database/db_versioning.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/db_versioning.rs
@@ -87,7 +87,6 @@ pub fn handle_db_versioning(base_path: &Path) -> Result<PathBuf> {
             }
         }
     } else {
-        let _ = remove_dir_all(base_path);
         path = base_path.join("temp");
     }
 


### PR DESCRIPTION

### What?

* do no delete persistent cache when repo is dirty
* allow to specify a cache version with `TURBO_ENGINE_VERSION`
* add `TURBO_ENGINE_READ_ONLY` to switch to read only


Closes PACK-3617