### PR TITLE
[Turbopack] fix root and project path usages in a monorepo

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -1125,37 +1125,44 @@ pub async fn project_trace_source(
 
             let project_root_uri =
                 uri_from_file(project.container.project().project_root_path(), None).await? + "/";
-            let (file, original_file, is_internal) =
-                if let Some(source_file) = original_file.strip_prefix(&project_root_uri) {
-                    // Client code uses file://
-                    (
-                        get_relative_path_to(&current_directory_file_url, &original_file),
-                        Some(source_file.to_string()),
-                        false,
+            let (file, original_file, is_internal) = if let Some(source_file) =
+                original_file.strip_prefix(&project_root_uri)
+            {
+                // Client code uses file://
+                (
+                    get_relative_path_to(&current_directory_file_url, &original_file)
+                        // TODO(sokra) remove this to include a ./ here to make it a relative path
+                        .trim_start_matches("./")
+                        .to_string(),
+                    Some(source_file.to_string()),
+                    false,
+                )
+            } else if let Some(source_file) =
+                original_file.strip_prefix(&*SOURCE_MAP_PREFIX_PROJECT)
+            {
+                // Server code uses turbopack://[project]
+                // TODO should this also be file://?
+                (
+                    get_relative_path_to(
+                        &current_directory_file_url,
+                        &format!("{}/{}", project_root_uri, source_file),
                     )
-                } else if let Some(source_file) =
-                    original_file.strip_prefix(&*SOURCE_MAP_PREFIX_PROJECT)
-                {
-                    // Server code uses turbopack://[project]
-                    // TODO should this also be file://?
-                    (
-                        get_relative_path_to(
-                            &current_directory_file_url,
-                            &format!("{}/{}", project_root_uri, source_file),
-                        ),
-                        Some(source_file.to_string()),
-                        false,
-                    )
-                } else if let Some(source_file) = original_file.strip_prefix(SOURCE_MAP_PREFIX) {
-                    // All other code like turbopack://[turbopack] is internal code
-                    (source_file.to_string(), None, true)
-                } else {
-                    bail!(
-                        "Original file ({}) outside project ({})",
-                        original_file,
-                        project_root_uri
-                    )
-                };
+                    // TODO(sokra) remove this to include a ./ here to make it a relative path
+                    .trim_start_matches("./")
+                    .to_string(),
+                    Some(source_file.to_string()),
+                    false,
+                )
+            } else if let Some(source_file) = original_file.strip_prefix(SOURCE_MAP_PREFIX) {
+                // All other code like turbopack://[turbopack] is internal code
+                (source_file.to_string(), None, true)
+            } else {
+                bail!(
+                    "Original file ({}) outside project ({})",
+                    original_file,
+                    project_root_uri
+                )
+            };
 
             Ok(Some(StackFrame {
                 file,

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -1016,6 +1016,7 @@ pub fn project_update_info_subscribe(
 pub struct StackFrame {
     pub is_server: bool,
     pub is_internal: Option<bool>,
+    pub original_file: Option<String>,
     pub file: String,
     // 1-indexed, unlike source map tokens
     pub line: Option<u32>,
@@ -1124,37 +1125,41 @@ pub async fn project_trace_source(
 
             let project_root_uri =
                 uri_from_file(project.container.project().project_root_path(), None).await? + "/";
-            let (source_file, is_internal) = if original_file.starts_with(&project_root_uri) {
-                // Client code uses file://
-                (
-                    get_relative_path_to(&current_directory_file_url, &original_file),
-                    false,
-                )
-            } else if let Some(source_file) =
-                original_file.strip_prefix(&*SOURCE_MAP_PREFIX_PROJECT)
-            {
-                // Server code uses turbopack://[project]
-                // TODO should this also be file://?
-                (
-                    get_relative_path_to(
-                        &current_directory_file_url,
-                        &format!("{}/{}", project_root_uri, source_file),
-                    ),
-                    false,
-                )
-            } else if let Some(source_file) = original_file.strip_prefix(SOURCE_MAP_PREFIX) {
-                // All other code like turbopack://[turbopack] is internal code
-                (source_file.to_string(), true)
-            } else {
-                bail!(
-                    "Original file ({}) outside project ({})",
-                    original_file,
-                    project_root_uri
-                )
-            };
+            let (file, original_file, is_internal) =
+                if let Some(source_file) = original_file.strip_prefix(&project_root_uri) {
+                    // Client code uses file://
+                    (
+                        get_relative_path_to(&current_directory_file_url, &original_file),
+                        Some(source_file.to_string()),
+                        false,
+                    )
+                } else if let Some(source_file) =
+                    original_file.strip_prefix(&*SOURCE_MAP_PREFIX_PROJECT)
+                {
+                    // Server code uses turbopack://[project]
+                    // TODO should this also be file://?
+                    (
+                        get_relative_path_to(
+                            &current_directory_file_url,
+                            &format!("{}/{}", project_root_uri, source_file),
+                        ),
+                        Some(source_file.to_string()),
+                        false,
+                    )
+                } else if let Some(source_file) = original_file.strip_prefix(SOURCE_MAP_PREFIX) {
+                    // All other code like turbopack://[turbopack] is internal code
+                    (source_file.to_string(), None, true)
+                } else {
+                    bail!(
+                        "Original file ({}) outside project ({})",
+                        original_file,
+                        project_root_uri
+                    )
+                };
 
             Ok(Some(StackFrame {
-                file: source_file,
+                file,
+                original_file,
                 method_name: name.as_ref().map(ToString::to_string),
                 line,
                 column,

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -1145,7 +1145,7 @@ pub async fn project_trace_source(
                 (
                     get_relative_path_to(
                         &current_directory_file_url,
-                        &format!("{}/{}", project_root_uri, source_file),
+                        &format!("{}{}", project_root_uri, source_file),
                     )
                     // TODO(sokra) remove this to include a ./ here to make it a relative path
                     .trim_start_matches("./")

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -631,7 +631,7 @@ impl Project {
     }
 
     #[turbo_tasks::function]
-    fn project_root_path(self: Vc<Self>) -> Vc<FileSystemPath> {
+    pub fn project_root_path(self: Vc<Self>) -> Vc<FileSystemPath> {
         self.project_fs().root()
     }
 

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -693,7 +693,7 @@ impl Project {
 
         let node_execution_chunking_context = Vc::upcast(
             NodeJsChunkingContext::builder(
-                self.project_path().to_resolved().await?,
+                self.project_root_path().to_resolved().await?,
                 node_root,
                 node_root,
                 node_root.join("build/chunks".into()).to_resolved().await?,
@@ -820,7 +820,7 @@ impl Project {
     #[turbo_tasks::function]
     pub(super) fn client_chunking_context(self: Vc<Self>) -> Vc<Box<dyn ChunkingContext>> {
         get_client_chunking_context(
-            self.project_path(),
+            self.project_root_path(),
             self.client_relative_path(),
             self.next_config().computed_asset_prefix(),
             self.client_compile_time_info().environment(),
@@ -838,7 +838,7 @@ impl Project {
         if client_assets {
             get_server_chunking_context_with_client_assets(
                 self.next_mode(),
-                self.project_path(),
+                self.project_root_path(),
                 self.node_root(),
                 self.client_relative_path(),
                 self.next_config().computed_asset_prefix(),
@@ -849,7 +849,7 @@ impl Project {
         } else {
             get_server_chunking_context(
                 self.next_mode(),
-                self.project_path(),
+                self.project_root_path(),
                 self.node_root(),
                 self.server_compile_time_info().environment(),
                 self.module_id_strategy(),
@@ -866,7 +866,7 @@ impl Project {
         if client_assets {
             get_edge_chunking_context_with_client_assets(
                 self.next_mode(),
-                self.project_path(),
+                self.project_root_path(),
                 self.node_root(),
                 self.client_relative_path(),
                 self.next_config().computed_asset_prefix(),
@@ -877,7 +877,7 @@ impl Project {
         } else {
             get_edge_chunking_context(
                 self.next_mode(),
-                self.project_path(),
+                self.project_root_path(),
                 self.node_root(),
                 self.edge_compile_time_info().environment(),
                 self.module_id_strategy(),

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -974,7 +974,7 @@ pub fn get_server_runtime_entries(
 #[turbo_tasks::function]
 pub async fn get_server_chunking_context_with_client_assets(
     mode: Vc<NextMode>,
-    project_path: ResolvedVc<FileSystemPath>,
+    root_path: ResolvedVc<FileSystemPath>,
     node_root: ResolvedVc<FileSystemPath>,
     client_root: ResolvedVc<FileSystemPath>,
     asset_prefix: ResolvedVc<Option<RcStr>>,
@@ -987,7 +987,7 @@ pub async fn get_server_chunking_context_with_client_assets(
     // different server chunking contexts. OR the build chunking context should
     // support both production and development modes.
     let mut builder = NodeJsChunkingContext::builder(
-        project_path,
+        root_path,
         node_root,
         client_root,
         node_root
@@ -1019,7 +1019,7 @@ pub async fn get_server_chunking_context_with_client_assets(
 #[turbo_tasks::function]
 pub async fn get_server_chunking_context(
     mode: Vc<NextMode>,
-    project_path: ResolvedVc<FileSystemPath>,
+    root_path: ResolvedVc<FileSystemPath>,
     node_root: ResolvedVc<FileSystemPath>,
     environment: ResolvedVc<Environment>,
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
@@ -1030,7 +1030,7 @@ pub async fn get_server_chunking_context(
     // different server chunking contexts. OR the build chunking context should
     // support both production and development modes.
     let mut builder = NodeJsChunkingContext::builder(
-        project_path,
+        root_path,
         node_root,
         node_root,
         node_root.join("server/chunks".into()).to_resolved().await?,

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -275,7 +275,8 @@ export interface StackFrame {
 }
 export declare function projectTraceSource(
   project: { __napiType: 'Project' },
-  frame: StackFrame
+  frame: StackFrame,
+  currentDirectoryFileUrl: string
 ): Promise<StackFrame | null>
 export declare function projectGetSourceForAsset(
   project: { __napiType: 'Project' },

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -746,9 +746,14 @@ function bindingToApi(
     }
 
     traceSource(
-      stackFrame: TurbopackStackFrame
+      stackFrame: TurbopackStackFrame,
+      currentDirectoryFileUrl: string
     ): Promise<TurbopackStackFrame | null> {
-      return binding.projectTraceSource(this._nativeProject, stackFrame)
+      return binding.projectTraceSource(
+        this._nativeProject,
+        stackFrame,
+        currentDirectoryFileUrl
+      )
     }
 
     getSourceForAsset(filePath: string): Promise<string | null> {

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -169,6 +169,7 @@ export interface TurbopackStackFrame {
   isServer: boolean
   isInternal?: boolean
   file: string
+  originalFile?: string
   /** 1-indexed, unlike source map tokens */
   line?: number
   /** 1-indexed, unlike source map tokens */

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -207,7 +207,8 @@ export interface Project {
   getSourceMapSync(filePath: string): string | null
 
   traceSource(
-    stackFrame: TurbopackStackFrame
+    stackFrame: TurbopackStackFrame,
+    currentDirectoryFileUrl: string
   ): Promise<TurbopackStackFrame | null>
 
   updateInfoSubscribe(

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
@@ -19,7 +19,6 @@ import type { Project, TurbopackStackFrame } from '../../../../build/swc/types'
 import { getSourceMapFromFile } from '../internal/helpers/get-source-map-from-file'
 import { findSourceMap, type SourceMapPayload } from 'node:module'
 import { pathToFileURL } from 'node:url'
-import { isAbsolute } from 'node:path'
 
 function shouldIgnorePath(modulePath: string): boolean {
   return (
@@ -256,13 +255,8 @@ async function nativeTraceSource(
 
 function relativeToCwd(file: string): string {
   const relPath = path.relative(process.cwd(), url.fileURLToPath(file))
-  if (isAbsolute(relPath)) {
-    return relPath
-  }
-  if (relPath.startsWith('../')) {
-    return relPath
-  }
-  return './' + relPath
+  // TODO(sokra) include a ./ here to make it a relative path
+  return relPath
 }
 
 async function createOriginalStackFrame(

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
@@ -59,20 +59,21 @@ export async function batchedTraceSource(
   }
 
   let source = null
+  const originalFile = sourceFrame.originalFile
   // Don't look up source for node_modules or internals. These can often be large bundled files.
   const ignored =
-    shouldIgnorePath(sourceFrame.file) ||
+    shouldIgnorePath(originalFile ?? sourceFrame.file) ||
     // isInternal means resource starts with turbopack://[turbopack]
     !!sourceFrame.isInternal
-  if (sourceFrame && sourceFrame.file && !ignored) {
-    let sourcePromise = currentSourcesByFile.get(sourceFrame.file)
+  if (originalFile && !ignored) {
+    let sourcePromise = currentSourcesByFile.get(originalFile)
     if (!sourcePromise) {
-      sourcePromise = project.getSourceForAsset(sourceFrame.file)
-      currentSourcesByFile.set(sourceFrame.file, sourcePromise)
+      sourcePromise = project.getSourceForAsset(originalFile)
+      currentSourcesByFile.set(originalFile, sourcePromise)
       setTimeout(() => {
         // Cache file reads for 100ms, as frames will often reference the same
         // files and can be large.
-        currentSourcesByFile.delete(sourceFrame.file!)
+        currentSourcesByFile.delete(originalFile!)
       }, 100)
     }
     source = await sourcePromise

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
@@ -301,7 +301,7 @@ export function getOverlayMiddleware(project: Project) {
       try {
         originalStackFrame = await createOriginalStackFrame(project, frame)
       } catch (e: any) {
-        return internalServerError(res, e.message)
+        return internalServerError(res, e.stack)
       }
 
       if (!originalStackFrame) {

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
@@ -18,6 +18,7 @@ import { SourceMapConsumer } from 'next/dist/compiled/source-map08'
 import type { Project, TurbopackStackFrame } from '../../../../build/swc/types'
 import { getSourceMapFromFile } from '../internal/helpers/get-source-map-from-file'
 import { findSourceMap, type SourceMapPayload } from 'node:module'
+import { pathToFileURL } from 'node:url'
 
 function shouldIgnorePath(modulePath: string): boolean {
   return (
@@ -40,7 +41,9 @@ export async function batchedTraceSource(
     : undefined
   if (!file) return
 
-  const sourceFrame = await project.traceSource(frame)
+  const currentDirectoryFileUrl = pathToFileURL(process.cwd()).href
+
+  const sourceFrame = await project.traceSource(frame, currentDirectoryFileUrl)
   if (!sourceFrame) {
     return {
       frame: {

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
@@ -19,6 +19,7 @@ import type { Project, TurbopackStackFrame } from '../../../../build/swc/types'
 import { getSourceMapFromFile } from '../internal/helpers/get-source-map-from-file'
 import { findSourceMap, type SourceMapPayload } from 'node:module'
 import { pathToFileURL } from 'node:url'
+import { isAbsolute } from 'node:path'
 
 function shouldIgnorePath(modulePath: string): boolean {
   return (
@@ -235,10 +236,7 @@ async function nativeTraceSource(
           '<unknown>',
         column: (originalPosition.column ?? 0) + 1,
         file: originalPosition.source?.startsWith('file://')
-          ? path.relative(
-              process.cwd(),
-              url.fileURLToPath(originalPosition.source)
-            )
+          ? relativeToCwd(originalPosition.source)
           : originalPosition.source,
         lineNumber: originalPosition.line ?? 0,
         // TODO: c&p from async createOriginalStackFrame but why not frame.arguments?
@@ -254,6 +252,17 @@ async function nativeTraceSource(
   }
 
   return undefined
+}
+
+function relativeToCwd(file: string): string {
+  const relPath = path.relative(process.cwd(), url.fileURLToPath(file))
+  if (isAbsolute(relPath)) {
+    return relPath
+  }
+  if (relPath.startsWith('../')) {
+    return relPath
+  }
+  return './' + relPath
 }
 
 async function createOriginalStackFrame(

--- a/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/layout.tsx
+++ b/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/monorepo-package-rsc/page.tsx
+++ b/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/monorepo-package-rsc/page.tsx
@@ -1,0 +1,5 @@
+import { text } from 'my-package/typescript.ts'
+
+export default function Page() {
+  return <p>{text}</p>
+}

--- a/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/monorepo-package-rsc/page.tsx
+++ b/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/monorepo-package-rsc/page.tsx
@@ -1,4 +1,4 @@
-import { text } from 'my-package/typescript.ts'
+import { text } from 'my-package/typescript'
 
 export default function Page() {
   return <p>{text}</p>

--- a/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/monorepo-package-ssr/page.tsx
+++ b/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/monorepo-package-ssr/page.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { text } from 'my-package/typescript.ts'
+
+export default function Page() {
+  return <p>{text}</p>
+}

--- a/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/monorepo-package-ssr/page.tsx
+++ b/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/monorepo-package-ssr/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { text } from 'my-package/typescript.ts'
+import { text } from 'my-package/typescript'
 
 export default function Page() {
   return <p>{text}</p>

--- a/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/page.tsx
+++ b/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/separate-file.ts
+++ b/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/separate-file.ts
@@ -1,0 +1,1 @@
+throw new Error('Expected error')

--- a/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/source-maps-client/page.tsx
+++ b/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/source-maps-client/page.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export default function Page() {
+  useEffect(function effectCallback() {
+    innerFunction()
+  })
+  return <p>Hello Source Maps</p>
+}
+
+function innerFunction() {
+  innerArrowFunction()
+}
+
+const innerArrowFunction = () => {
+  require('../separate-file')
+}

--- a/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/source-maps-rsc/page.tsx
+++ b/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/source-maps-rsc/page.tsx
@@ -1,0 +1,11 @@
+export default async function Page({ searchParams }) {
+  innerFunction()
+}
+
+function innerFunction() {
+  innerArrowFunction()
+}
+
+const innerArrowFunction = () => {
+  require('../separate-file')
+}

--- a/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/source-maps-rsc/page.tsx
+++ b/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/source-maps-rsc/page.tsx
@@ -1,5 +1,9 @@
 export default async function Page({ searchParams }) {
-  innerFunction()
+  // We don't want the build to fail in production
+  if (process.env.NODE_ENV === 'development') {
+    innerFunction()
+  }
+  return <p>Hello Source Maps</p>
 }
 
 function innerFunction() {

--- a/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/source-maps-ssr/page.tsx
+++ b/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/source-maps-ssr/page.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+export default function Page() {
+  innerFunction()
+}
+
+function innerFunction() {
+  innerArrowFunction()
+}
+
+const innerArrowFunction = () => {
+  require('../separate-file')
+}

--- a/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/source-maps-ssr/page.tsx
+++ b/test/e2e/app-dir/non-root-project-monorepo/apps/web/app/source-maps-ssr/page.tsx
@@ -1,7 +1,11 @@
 'use client'
 
 export default function Page() {
-  innerFunction()
+  // We don't want the build to fail in production
+  if (process.env.NODE_ENV === 'development') {
+    innerFunction()
+  }
+  return <p>Hello Source Maps</p>
 }
 
 function innerFunction() {

--- a/test/e2e/app-dir/non-root-project-monorepo/apps/web/next.config.js
+++ b/test/e2e/app-dir/non-root-project-monorepo/apps/web/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/non-root-project-monorepo/apps/web/package.json
+++ b/test/e2e/app-dir/non-root-project-monorepo/apps/web/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "web",
+  "version": "0.0.0",
+  "dependencies": {
+    "my-package": "workspace:*"
+  },
+  "scripts": {
+    "dev": "next dev",
+    "start": "next start",
+    "build": "next build"
+  }
+}

--- a/test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts
+++ b/test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts
@@ -66,7 +66,7 @@ describe('non-root-project-monorepo', () => {
         if (isTurbopack) {
           // TODO the function name should be hidden
           expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-            "./app/source-maps-rsc/page.tsx (9:28) @ innerArrowFunction
+            "app/source-maps-rsc/page.tsx (9:28) @ innerArrowFunction
 
                7 | }
                8 |
@@ -82,9 +82,9 @@ describe('non-root-project-monorepo', () => {
             "<unknown>
             [project]/apps/web/app/separate-file.ts [app-rsc] (ecmascript) (rsc://React/Server/file://<full-path>/apps/web/.next/server/chunks/ssr/apps_web_8d1c0a._.js (7:7)
             innerFunction
-            ./app/source-maps-rsc/page.tsx (6:3)
+            app/source-maps-rsc/page.tsx (6:3)
             Page
-            ./app/source-maps-rsc/page.tsx (2:3)"
+            app/source-maps-rsc/page.tsx (2:3)"
           `)
         } else {
           // TODO the function name is incorrect
@@ -120,7 +120,7 @@ describe('non-root-project-monorepo', () => {
         if (isTurbopack) {
           // TODO the function name should be hidden
           expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-            "./app/separate-file.ts (1:7) @ [project]/apps/web/app/separate-file.ts [app-client] (ecmascript)
+            "app/separate-file.ts (1:7) @ [project]/apps/web/app/separate-file.ts [app-client] (ecmascript)
 
             > 1 | throw new Error('Expected error')
                 |       ^
@@ -129,11 +129,11 @@ describe('non-root-project-monorepo', () => {
           expect(normalizeStackTrace(await getRedboxCallStack(browser)))
             .toMatchInlineSnapshot(`
             "innerArrowFunction
-            ./app/source-maps-ssr/page.tsx (11:28)
+            app/source-maps-ssr/page.tsx (11:28)
             innerFunction
-            ./app/source-maps-ssr/page.tsx (8:3)
+            app/source-maps-ssr/page.tsx (8:3)
             Page
-            ./app/source-maps-ssr/page.tsx (4:3)"
+            app/source-maps-ssr/page.tsx (4:3)"
           `)
         } else {
           // TODO the function name should be hidden
@@ -173,7 +173,7 @@ describe('non-root-project-monorepo', () => {
         if (isTurbopack) {
           // TODO the function name should be hidden
           expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-            "./app/separate-file.ts (1:7) @ [project]/apps/web/app/separate-file.ts [app-client] (ecmascript)
+            "app/separate-file.ts (1:7) @ [project]/apps/web/app/separate-file.ts [app-client] (ecmascript)
 
             > 1 | throw new Error('Expected error')
                 |       ^
@@ -182,11 +182,11 @@ describe('non-root-project-monorepo', () => {
           expect(normalizeStackTrace(await getRedboxCallStack(browser)))
             .toMatchInlineSnapshot(`
             "innerArrowFunction
-            ./app/source-maps-client/page.tsx (16:28)
+            app/source-maps-client/page.tsx (16:28)
             innerFunction
-            ./app/source-maps-client/page.tsx (13:3)
+            app/source-maps-client/page.tsx (13:3)
             effectCallback
-            ./app/source-maps-client/page.tsx (7:5)"
+            app/source-maps-client/page.tsx (7:5)"
           `)
         } else {
           // TODO the function name should be hidden

--- a/test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts
+++ b/test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts
@@ -66,25 +66,25 @@ describe('non-root-project-monorepo', () => {
         if (isTurbopack) {
           // TODO the function name should be hidden
           expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-            "app/source-maps-rsc/page.tsx (9:28) @ innerArrowFunction
+           "app/source-maps-rsc/page.tsx (13:28) @ innerArrowFunction
 
-               7 | }
-               8 |
-            >  9 | const innerArrowFunction = () => {
-                 |                            ^
-              10 |   require('../separate-file')
-              11 | }
-              12 |"
+             11 | }
+             12 |
+           > 13 | const innerArrowFunction = () => {
+                |                            ^
+             14 |   require('../separate-file')
+             15 | }
+             16 |"
           `)
           // TODO stacktrace-parser breaks in some cases with the rsc:// protocol
           expect(normalizeStackTrace(await getRedboxCallStack(browser)))
             .toMatchInlineSnapshot(`
-            "<unknown>
-            [project]/apps/web/app/separate-file.ts [app-rsc] (ecmascript) (rsc://React/Server/file://<full-path>/apps/web/.next/server/chunks/ssr/apps_web_8d1c0a._.js (7:7)
-            innerFunction
-            app/source-maps-rsc/page.tsx (6:3)
-            Page
-            app/source-maps-rsc/page.tsx (2:3)"
+           "<unknown>
+           [project]/apps/web/app/separate-file.ts [app-rsc] (ecmascript) (rsc://React/Server/file://<full-path>/apps/web/.next/server/chunks/ssr/apps_web_8d1c0a._.js (7:7)
+           innerFunction
+           app/source-maps-rsc/page.tsx (10:3)
+           Page
+           app/source-maps-rsc/page.tsx (4:5)"
           `)
         } else {
           // TODO the function name is incorrect
@@ -98,16 +98,16 @@ describe('non-root-project-monorepo', () => {
           // TODO webpack runtime code shouldn't be included in stack trace
           expect(normalizeStackTrace(await getRedboxCallStack(browser)))
             .toMatchInlineSnapshot(`
-            "<unknown>
-            rsc)/./app/separate-file.ts (rsc://React/Server/file://<full-path>/apps/web/.next/server/app/source-maps-rsc/page.js
-            __webpack_require__
-            file://<full-path>/apps/web/.next/server/webpack-runtime.js
-            require
-            app/source-maps-rsc/page.tsx (10:3)
-            innerArrowFunction
-            app/source-maps-rsc/page.tsx (6:3)
-            innerFunction
-            app/source-maps-rsc/page.tsx (2:3)"
+           "<unknown>
+           rsc)/./app/separate-file.ts (rsc://React/Server/file://<full-path>/apps/web/.next/server/app/source-maps-rsc/page.js
+           __webpack_require__
+           file://<full-path>/apps/web/.next/server/webpack-runtime.js
+           require
+           app/source-maps-rsc/page.tsx (14:3)
+           innerArrowFunction
+           app/source-maps-rsc/page.tsx (10:3)
+           innerFunction
+           app/source-maps-rsc/page.tsx (4:5)"
           `)
         }
         await browser.close()
@@ -128,12 +128,12 @@ describe('non-root-project-monorepo', () => {
           `)
           expect(normalizeStackTrace(await getRedboxCallStack(browser)))
             .toMatchInlineSnapshot(`
-            "innerArrowFunction
-            app/source-maps-ssr/page.tsx (11:28)
-            innerFunction
-            app/source-maps-ssr/page.tsx (8:3)
-            Page
-            app/source-maps-ssr/page.tsx (4:3)"
+           "innerArrowFunction
+           app/source-maps-ssr/page.tsx (15:28)
+           innerFunction
+           app/source-maps-ssr/page.tsx (12:3)
+           Page
+           app/source-maps-ssr/page.tsx (6:5)"
           `)
         } else {
           // TODO the function name should be hidden
@@ -147,20 +147,20 @@ describe('non-root-project-monorepo', () => {
           // TODO webpack runtime code shouldn't be included in stack trace
           expect(normalizeStackTrace(await getRedboxCallStack(browser)))
             .toMatchInlineSnapshot(`
-            "./app/separate-file.ts
-            file://<full-path>/apps/web/.next/static/chunks/app/source-maps-ssr/page.js (27:1)
-            options.factory
-            file://<full-path>/apps/web/.next/static/chunks/webpack.js (700:31)
-            __webpack_require__
-            file://<full-path>/apps/web/.next/static/chunks/webpack.js (37:33)
-            fn
-            file://<full-path>/apps/web/.next/static/chunks/webpack.js (357:21)
-            require
-            app/source-maps-ssr/page.tsx (12:3)
-            innerArrowFunction
-            app/source-maps-ssr/page.tsx (8:3)
-            innerFunction
-            app/source-maps-ssr/page.tsx (4:3)"
+           "./app/separate-file.ts
+           file://<full-path>/apps/web/.next/static/chunks/app/source-maps-ssr/page.js (27:1)
+           options.factory
+           file://<full-path>/apps/web/.next/static/chunks/webpack.js (700:31)
+           __webpack_require__
+           file://<full-path>/apps/web/.next/static/chunks/webpack.js (37:33)
+           fn
+           file://<full-path>/apps/web/.next/static/chunks/webpack.js (357:21)
+           require
+           app/source-maps-ssr/page.tsx (16:3)
+           innerArrowFunction
+           app/source-maps-ssr/page.tsx (12:3)
+           innerFunction
+           app/source-maps-ssr/page.tsx (6:5)"
           `)
         }
         await browser.close()

--- a/test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts
+++ b/test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts
@@ -1,0 +1,223 @@
+import { nextTestSetup, FileRef } from 'e2e-utils'
+import {
+  assertHasRedbox,
+  assertNoRedbox,
+  getRedboxCallStack,
+  getRedboxSource,
+} from 'next-test-utils'
+import * as path from 'path'
+
+describe('non-root-project-monorepo', () => {
+  const { next, skipped, isTurbopack, isNextDev } = nextTestSetup({
+    files: {
+      apps: new FileRef(path.resolve(__dirname, 'apps')),
+      packages: new FileRef(path.resolve(__dirname, 'packages')),
+      'pnpm-workspace.yaml': `packages:
+      - 'apps/*'
+      - 'packages/*'
+      `,
+    },
+    packageJson: require('./package.json'),
+    buildCommand: 'pnpm build',
+    startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
+    installCommand: 'pnpm i',
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  describe('monorepo-package', () => {
+    it('should work during RSC', async () => {
+      const $ = await next.render$('/monorepo-package-rsc')
+      expect($('p').text()).toBe('Hello Typescript')
+    })
+
+    it('should work during SSR', async () => {
+      const $ = await next.render$('/monorepo-package-ssr')
+      expect($('p').text()).toBe('Hello Typescript')
+    })
+
+    it('should work on client-side', async () => {
+      const browser = await next.browser('/monorepo-package-ssr')
+      expect(await browser.elementByCss('p').text()).toBe('Hello Typescript')
+      await assertNoRedbox(browser)
+      expect(await browser.elementByCss('p').text()).toBe('Hello Typescript')
+      await browser.close()
+    })
+  })
+
+  if (isNextDev) {
+    describe('source-maps', () => {
+      function normalizeStackTrace(stack: string): string {
+        const isolatedPath = /file:\/\/.*\/next-install-[^/]+\//g
+        const nonIsolatedPath =
+          /file:\/\/.*\/test\/e2e\/app-dir\/non-root-project-monorepo\//g
+        return stack
+          .replaceAll(nonIsolatedPath, 'file://<full-path>/')
+          .replaceAll(isolatedPath, 'file://<full-path>/')
+      }
+
+      it('should work on RSC', async () => {
+        const browser = await next.browser('/source-maps-rsc')
+        await assertHasRedbox(browser)
+
+        if (isTurbopack) {
+          // TODO the function name should be hidden
+          expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
+            "./app/source-maps-rsc/page.tsx (9:28) @ innerArrowFunction
+
+               7 | }
+               8 |
+            >  9 | const innerArrowFunction = () => {
+                 |                            ^
+              10 |   require('../separate-file')
+              11 | }
+              12 |"
+          `)
+          // TODO stacktrace-parser breaks in some cases with the rsc:// protocol
+          expect(normalizeStackTrace(await getRedboxCallStack(browser)))
+            .toMatchInlineSnapshot(`
+            "<unknown>
+            [project]/apps/web/app/separate-file.ts [app-rsc] (ecmascript) (rsc://React/Server/file://<full-path>/apps/web/.next/server/chunks/ssr/apps_web_8d1c0a._.js (7:7)
+            innerFunction
+            ./app/source-maps-rsc/page.tsx (6:3)
+            Page
+            ./app/source-maps-rsc/page.tsx (2:3)"
+          `)
+        } else {
+          // TODO the function name is incorrect
+          expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
+            "app/separate-file.ts (1:11) @ Error
+
+            > 1 | throw new Error('Expected error')
+                |           ^
+              2 |"
+          `)
+          // TODO webpack runtime code shouldn't be included in stack trace
+          expect(normalizeStackTrace(await getRedboxCallStack(browser)))
+            .toMatchInlineSnapshot(`
+            "<unknown>
+            rsc)/./app/separate-file.ts (rsc://React/Server/file://<full-path>/apps/web/.next/server/app/source-maps-rsc/page.js
+            __webpack_require__
+            file://<full-path>/apps/web/.next/server/webpack-runtime.js
+            require
+            app/source-maps-rsc/page.tsx (10:3)
+            innerArrowFunction
+            app/source-maps-rsc/page.tsx (6:3)
+            innerFunction
+            app/source-maps-rsc/page.tsx (2:3)"
+          `)
+        }
+        await browser.close()
+      })
+
+      it('should work on SSR', async () => {
+        const browser = await next.browser('/source-maps-ssr')
+        await assertHasRedbox(browser)
+
+        if (isTurbopack) {
+          // TODO the function name should be hidden
+          expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
+            "./app/separate-file.ts (1:7) @ [project]/apps/web/app/separate-file.ts [app-client] (ecmascript)
+
+            > 1 | throw new Error('Expected error')
+                |       ^
+              2 |"
+          `)
+          expect(normalizeStackTrace(await getRedboxCallStack(browser)))
+            .toMatchInlineSnapshot(`
+            "innerArrowFunction
+            ./app/source-maps-ssr/page.tsx (11:28)
+            innerFunction
+            ./app/source-maps-ssr/page.tsx (8:3)
+            Page
+            ./app/source-maps-ssr/page.tsx (4:3)"
+          `)
+        } else {
+          // TODO the function name should be hidden
+          expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
+            "app/separate-file.ts (1:7) @ eval
+
+            > 1 | throw new Error('Expected error')
+                |       ^
+              2 |"
+          `)
+          // TODO webpack runtime code shouldn't be included in stack trace
+          expect(normalizeStackTrace(await getRedboxCallStack(browser)))
+            .toMatchInlineSnapshot(`
+            "./app/separate-file.ts
+            file://<full-path>/apps/web/.next/static/chunks/app/source-maps-ssr/page.js (27:1)
+            options.factory
+            file://<full-path>/apps/web/.next/static/chunks/webpack.js (700:31)
+            __webpack_require__
+            file://<full-path>/apps/web/.next/static/chunks/webpack.js (37:33)
+            fn
+            file://<full-path>/apps/web/.next/static/chunks/webpack.js (357:21)
+            require
+            app/source-maps-ssr/page.tsx (12:3)
+            innerArrowFunction
+            app/source-maps-ssr/page.tsx (8:3)
+            innerFunction
+            app/source-maps-ssr/page.tsx (4:3)"
+          `)
+        }
+        await browser.close()
+      })
+
+      it('should work on client-side', async () => {
+        const browser = await next.browser('/source-maps-client')
+        await assertHasRedbox(browser)
+
+        if (isTurbopack) {
+          // TODO the function name should be hidden
+          expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
+            "./app/separate-file.ts (1:7) @ [project]/apps/web/app/separate-file.ts [app-client] (ecmascript)
+
+            > 1 | throw new Error('Expected error')
+                |       ^
+              2 |"
+          `)
+          expect(normalizeStackTrace(await getRedboxCallStack(browser)))
+            .toMatchInlineSnapshot(`
+            "innerArrowFunction
+            ./app/source-maps-client/page.tsx (16:28)
+            innerFunction
+            ./app/source-maps-client/page.tsx (13:3)
+            effectCallback
+            ./app/source-maps-client/page.tsx (7:5)"
+          `)
+        } else {
+          // TODO the function name should be hidden
+          expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
+            "app/separate-file.ts (1:7) @ eval
+
+            > 1 | throw new Error('Expected error')
+                |       ^
+              2 |"
+          `)
+          // TODO webpack runtime code shouldn't be included in stack trace
+          expect(normalizeStackTrace(await getRedboxCallStack(browser)))
+            .toMatchInlineSnapshot(`
+            "./app/separate-file.ts
+            file://<full-path>/apps/web/.next/static/chunks/app/source-maps-client/page.js (27:1)
+            options.factory
+            file://<full-path>/apps/web/.next/static/chunks/webpack.js (712:31)
+            __webpack_require__
+            file://<full-path>/apps/web/.next/static/chunks/webpack.js (37:33)
+            fn
+            file://<full-path>/apps/web/.next/static/chunks/webpack.js (369:21)
+            require
+            app/source-maps-client/page.tsx (17:3)
+            innerArrowFunction
+            app/source-maps-client/page.tsx (13:3)
+            innerFunction
+            app/source-maps-client/page.tsx (7:5)"
+          `)
+        }
+        await browser.close()
+      })
+    })
+  }
+})

--- a/test/e2e/app-dir/non-root-project-monorepo/package.json
+++ b/test/e2e/app-dir/non-root-project-monorepo/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "monorepo-root",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "pnpm i && pnpm run --dir apps/web build",
+    "start": "pnpm run --dir apps/web start",
+    "dev": "pnpm i && pnpm run --dir apps/web dev"
+  }
+}

--- a/test/e2e/app-dir/non-root-project-monorepo/packages/my-package/package.json
+++ b/test/e2e/app-dir/non-root-project-monorepo/packages/my-package/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "my-package",
+  "version": "0.0.0"
+}

--- a/test/e2e/app-dir/non-root-project-monorepo/packages/my-package/typescript.ts
+++ b/test/e2e/app-dir/non-root-project-monorepo/packages/my-package/typescript.ts
@@ -1,0 +1,1 @@
+export const text: string = 'Hello Typescript'

--- a/test/integration/css-minify/test/index.test.js
+++ b/test/integration/css-minify/test/index.test.js
@@ -25,7 +25,7 @@ function runTests() {
         "/* [project]/test/integration/css-minify/styles/global.css [client] (css) */
         .a{--var-1:0;--var-2:0;--var-1:-50%;--var-2:-50%}.b{--var-1:0;--var-2:0;--var-2:-50%}
 
-        /*# sourceMappingURL=styles_global_411632.css.map*/
+        /*# sourceMappingURL=test_integration_css-minify_styles_global_411632.css.map*/
         "
       `)
     } else {

--- a/test/integration/server-side-dev-errors/test/index.test.js
+++ b/test/integration/server-side-dev-errors/test/index.test.js
@@ -66,6 +66,10 @@ describe('server-side dev errors', () => {
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
       if (isTurbopack) {
+        expect(stderrOutput).toStartWith(
+          ' ⨯ ../../test/integration/server-side-dev-errors/pages/gsp.js (6:3) @ getStaticProps' +
+            '\n ⨯ ../../test/integration/server-side-dev-errors/pages/gsp.js (6:3) @ getStaticProps'
+        )
         expect(stderrOutput).toContain(
           ' ⨯ ReferenceError: missingVar is not defined' +
             '\n    at getStaticProps (../../test/integration/server-side-dev-errors/pages/gsp.js:6:2)' +
@@ -117,6 +121,10 @@ describe('server-side dev errors', () => {
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
       if (isTurbopack) {
+        expect(stderrOutput).toStartWith(
+          ' ⨯ ../../test/integration/server-side-dev-errors/pages/gssp.js (6:3) @ getServerSideProps' +
+            '\n ⨯ ../../test/integration/server-side-dev-errors/pages/gssp.js (6:3) @ getServerSideProps'
+        )
         expect(stderrOutput).toContain(
           ' ⨯ ReferenceError: missingVar is not defined' +
             '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/gssp.js:6:2)' +
@@ -168,6 +176,10 @@ describe('server-side dev errors', () => {
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
       if (isTurbopack) {
+        expect(stderrOutput).toStartWith(
+          ' ⨯ ../../test/integration/server-side-dev-errors/pages/blog/[slug].js (6:3) @ getServerSideProps' +
+            '\n ⨯ ../../test/integration/server-side-dev-errors/pages/blog/[slug].js (6:3) @ getServerSideProps'
+        )
         expect(stderrOutput).toContain(
           ' ⨯ ReferenceError: missingVar is not defined' +
             '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/blog/[slug].js:6:2)' +
@@ -219,6 +231,10 @@ describe('server-side dev errors', () => {
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
       if (isTurbopack) {
+        expect(stderrOutput).toStartWith(
+          ' ⨯ ../../test/integration/server-side-dev-errors/pages/api/hello.js (2:3) @ handler' +
+            '\n ⨯ ../../test/integration/server-side-dev-errors/pages/api/hello.js (2:3) @ handler'
+        )
         expect(stderrOutput).toContain(
           ' ⨯ ReferenceError: missingVar is not defined' +
             '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/hello.js:2:2)' +
@@ -271,6 +287,10 @@ describe('server-side dev errors', () => {
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
       // FIXME(veil): error repeated
       if (isTurbopack) {
+        expect(stderrOutput).toStartWith(
+          ' ⨯ ../../test/integration/server-side-dev-errors/pages/api/blog/[slug].js (2:3) @ handler' +
+            '\n ⨯ ../../test/integration/server-side-dev-errors/pages/api/blog/[slug].js (2:3) @ handler'
+        )
         expect(stderrOutput).toContain(
           ' ⨯ ReferenceError: missingVar is not defined' +
             '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/blog/[slug].js:2:2)' +

--- a/test/integration/server-side-dev-errors/test/index.test.js
+++ b/test/integration/server-side-dev-errors/test/index.test.js
@@ -66,10 +66,9 @@ describe('server-side dev errors', () => {
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
       if (isTurbopack) {
-        // FIXME(veil): Paths include root twice. Bug in generated Turbopack sourcemaps.
         expect(stderrOutput).toContain(
           ' ⨯ ReferenceError: missingVar is not defined' +
-            '\n    at getStaticProps (../../test/integration/server-side-dev-errors/test/integration/server-side-dev-errors/pages/gsp.js:6:2)' +
+            '\n    at getStaticProps (../../test/integration/server-side-dev-errors/pages/gsp.js:6:2)' +
             // Next.js internal frame. Feel free to adjust.
             // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
             '\n    at fn'
@@ -118,11 +117,9 @@ describe('server-side dev errors', () => {
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
       if (isTurbopack) {
-        // FIXME(veil): Paths include root twice. Bug in generated Turbopack sourcemaps.
         expect(stderrOutput).toContain(
           ' ⨯ ReferenceError: missingVar is not defined' +
-            // FIXME(veil): Paths include root twice. Bug in generated Turbopack sourcemaps.
-            '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/test/integration/server-side-dev-errors/pages/gssp.js:6:2)' +
+            '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/gssp.js:6:2)' +
             // Next.js internal frame. Feel free to adjust.
             // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
             '\n    at fn'
@@ -171,11 +168,9 @@ describe('server-side dev errors', () => {
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
       if (isTurbopack) {
-        // FIXME(veil): Paths include root twice. Bug in generated Turbopack sourcemaps.
         expect(stderrOutput).toContain(
           ' ⨯ ReferenceError: missingVar is not defined' +
-            // FIXME(veil): Paths include root twice. Bug in generated Turbopack sourcemaps.
-            '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/test/integration/server-side-dev-errors/pages/blog/[slug].js:6:2)' +
+            '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/blog/[slug].js:6:2)' +
             // Next.js internal frame. Feel free to adjust.
             // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
             '\n    at fn'
@@ -224,11 +219,9 @@ describe('server-side dev errors', () => {
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
       if (isTurbopack) {
-        // FIXME(veil): Paths include root twice. Bug in generated Turbopack sourcemaps.
         expect(stderrOutput).toContain(
           ' ⨯ ReferenceError: missingVar is not defined' +
-            // FIXME(veil): Paths include root twice. Bug in generated Turbopack sourcemaps.
-            '\n    at handler (../../test/integration/server-side-dev-errors/test/integration/server-side-dev-errors/pages/api/hello.js:2:2)' +
+            '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/hello.js:2:2)' +
             // Next.js internal frame. Feel free to adjust.
             // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
             '\n    at async'
@@ -278,11 +271,9 @@ describe('server-side dev errors', () => {
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
       // FIXME(veil): error repeated
       if (isTurbopack) {
-        // FIXME(veil): Paths include root twice. Bug in generated Turbopack sourcemaps.
         expect(stderrOutput).toContain(
           ' ⨯ ReferenceError: missingVar is not defined' +
-            // FIXME(veil): Paths include root twice. Bug in generated Turbopack sourcemaps.
-            '\n    at handler (../../test/integration/server-side-dev-errors/test/integration/server-side-dev-errors/pages/api/blog/[slug].js:2:2)' +
+            '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/blog/[slug].js:2:2)' +
             // Next.js internal frame. Feel free to adjust.
             // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
             '\n    at'
@@ -329,10 +320,9 @@ describe('server-side dev errors', () => {
       .trim()
     // FIXME(veil): error repeated
     if (isTurbopack) {
-      // FIXME(veil): Paths include root twice. Bug in generated Turbopack sourcemaps.
       expect(stderrOutput).toMatchInlineSnapshot(`
         "Error: catch this rejection
-            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/test/integration/server-side-dev-errors/pages/uncaught-rejection.js:7:19)
+            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/pages/uncaught-rejection.js:7:19)
            5 | export async function getServerSideProps() {
            6 |   setTimeout(() => {
         >  7 |     Promise.reject(new Error('catch this rejection'))
@@ -341,7 +331,7 @@ describe('server-side dev errors', () => {
            9 |   return {
           10 |     props: {},
          ⨯ unhandledRejection: Error: catch this rejection
-            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/test/integration/server-side-dev-errors/pages/uncaught-rejection.js:7:19)
+            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/pages/uncaught-rejection.js:7:19)
            5 | export async function getServerSideProps() {
            6 |   setTimeout(() => {
         >  7 |     Promise.reject(new Error('catch this rejection'))
@@ -350,7 +340,7 @@ describe('server-side dev errors', () => {
            9 |   return {
           10 |     props: {},
          ⨯ unhandledRejection:  Error: catch this rejection
-            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/test/integration/server-side-dev-errors/pages/uncaught-rejection.js:7:19)
+            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/pages/uncaught-rejection.js:7:19)
            5 | export async function getServerSideProps() {
            6 |   setTimeout(() => {
         >  7 |     Promise.reject(new Error('catch this rejection'))
@@ -411,7 +401,7 @@ describe('server-side dev errors', () => {
     if (isTurbopack) {
       expect(stderrOutput).toMatchInlineSnapshot(`
         "Error: 
-            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/test/integration/server-side-dev-errors/pages/uncaught-empty-rejection.js:7:19)
+            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/pages/uncaught-empty-rejection.js:7:19)
            5 | export async function getServerSideProps() {
            6 |   setTimeout(() => {
         >  7 |     Promise.reject(new Error())
@@ -420,7 +410,7 @@ describe('server-side dev errors', () => {
            9 |   return {
           10 |     props: {},
          ⨯ unhandledRejection: Error: 
-            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/test/integration/server-side-dev-errors/pages/uncaught-empty-rejection.js:7:19)
+            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/pages/uncaught-empty-rejection.js:7:19)
            5 | export async function getServerSideProps() {
            6 |   setTimeout(() => {
         >  7 |     Promise.reject(new Error())
@@ -429,7 +419,7 @@ describe('server-side dev errors', () => {
            9 |   return {
           10 |     props: {},
          ⨯ unhandledRejection:  Error: 
-            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/test/integration/server-side-dev-errors/pages/uncaught-empty-rejection.js:7:19)
+            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/pages/uncaught-empty-rejection.js:7:19)
            5 | export async function getServerSideProps() {
            6 |   setTimeout(() => {
         >  7 |     Promise.reject(new Error())
@@ -489,7 +479,7 @@ describe('server-side dev errors', () => {
     if (isTurbopack) {
       expect(stderrOutput).toMatchInlineSnapshot(`
         "Error: catch this exception
-            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/test/integration/server-side-dev-errors/pages/uncaught-exception.js:7:10)
+            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/pages/uncaught-exception.js:7:10)
            5 | export async function getServerSideProps() {
            6 |   setTimeout(() => {
         >  7 |     throw new Error('catch this exception')
@@ -498,7 +488,7 @@ describe('server-side dev errors', () => {
            9 |   return {
           10 |     props: {},
          ⨯ uncaughtException: Error: catch this exception
-            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/test/integration/server-side-dev-errors/pages/uncaught-exception.js:7:10)
+            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/pages/uncaught-exception.js:7:10)
            5 | export async function getServerSideProps() {
            6 |   setTimeout(() => {
         >  7 |     throw new Error('catch this exception')
@@ -507,7 +497,7 @@ describe('server-side dev errors', () => {
            9 |   return {
           10 |     props: {},
          ⨯ uncaughtException:  Error: catch this exception
-            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/test/integration/server-side-dev-errors/pages/uncaught-exception.js:7:10)
+            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/pages/uncaught-exception.js:7:10)
            5 | export async function getServerSideProps() {
            6 |   setTimeout(() => {
         >  7 |     throw new Error('catch this exception')
@@ -567,7 +557,7 @@ describe('server-side dev errors', () => {
     if (isTurbopack) {
       expect(stderrOutput).toMatchInlineSnapshot(`
         "Error: 
-            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/test/integration/server-side-dev-errors/pages/uncaught-empty-exception.js:7:10)
+            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/pages/uncaught-empty-exception.js:7:10)
            5 | export async function getServerSideProps() {
            6 |   setTimeout(() => {
         >  7 |     throw new Error()
@@ -576,7 +566,7 @@ describe('server-side dev errors', () => {
            9 |   return {
           10 |     props: {},
          ⨯ uncaughtException: Error: 
-            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/test/integration/server-side-dev-errors/pages/uncaught-empty-exception.js:7:10)
+            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/pages/uncaught-empty-exception.js:7:10)
            5 | export async function getServerSideProps() {
            6 |   setTimeout(() => {
         >  7 |     throw new Error()
@@ -585,7 +575,7 @@ describe('server-side dev errors', () => {
            9 |   return {
           10 |     props: {},
          ⨯ uncaughtException:  Error: 
-            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/test/integration/server-side-dev-errors/pages/uncaught-empty-exception.js:7:10)
+            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/pages/uncaught-empty-exception.js:7:10)
            5 | export async function getServerSideProps() {
            6 |   setTimeout(() => {
         >  7 |     throw new Error()

--- a/test/integration/server-side-dev-errors/test/index.test.js
+++ b/test/integration/server-side-dev-errors/test/index.test.js
@@ -66,10 +66,6 @@ describe('server-side dev errors', () => {
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
       if (isTurbopack) {
-        expect(stderrOutput).toStartWith(
-          ' ⨯ ../../test/integration/server-side-dev-errors/pages/gsp.js (6:3) @ getStaticProps' +
-            '\n ⨯ ../../test/integration/server-side-dev-errors/pages/gsp.js (6:3) @ getStaticProps'
-        )
         expect(stderrOutput).toContain(
           ' ⨯ ReferenceError: missingVar is not defined' +
             '\n    at getStaticProps (../../test/integration/server-side-dev-errors/pages/gsp.js:6:2)' +
@@ -121,10 +117,6 @@ describe('server-side dev errors', () => {
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
       if (isTurbopack) {
-        expect(stderrOutput).toStartWith(
-          ' ⨯ ../../test/integration/server-side-dev-errors/pages/gssp.js (6:3) @ getServerSideProps' +
-            '\n ⨯ ../../test/integration/server-side-dev-errors/pages/gssp.js (6:3) @ getServerSideProps'
-        )
         expect(stderrOutput).toContain(
           ' ⨯ ReferenceError: missingVar is not defined' +
             '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/gssp.js:6:2)' +
@@ -176,10 +168,6 @@ describe('server-side dev errors', () => {
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
       if (isTurbopack) {
-        expect(stderrOutput).toStartWith(
-          ' ⨯ ../../test/integration/server-side-dev-errors/pages/blog/[slug].js (6:3) @ getServerSideProps' +
-            '\n ⨯ ../../test/integration/server-side-dev-errors/pages/blog/[slug].js (6:3) @ getServerSideProps'
-        )
         expect(stderrOutput).toContain(
           ' ⨯ ReferenceError: missingVar is not defined' +
             '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/blog/[slug].js:6:2)' +
@@ -231,10 +219,6 @@ describe('server-side dev errors', () => {
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
       if (isTurbopack) {
-        expect(stderrOutput).toStartWith(
-          ' ⨯ ../../test/integration/server-side-dev-errors/pages/api/hello.js (2:3) @ handler' +
-            '\n ⨯ ../../test/integration/server-side-dev-errors/pages/api/hello.js (2:3) @ handler'
-        )
         expect(stderrOutput).toContain(
           ' ⨯ ReferenceError: missingVar is not defined' +
             '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/hello.js:2:2)' +
@@ -287,10 +271,6 @@ describe('server-side dev errors', () => {
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
       // FIXME(veil): error repeated
       if (isTurbopack) {
-        expect(stderrOutput).toStartWith(
-          ' ⨯ ../../test/integration/server-side-dev-errors/pages/api/blog/[slug].js (2:3) @ handler' +
-            '\n ⨯ ../../test/integration/server-side-dev-errors/pages/api/blog/[slug].js (2:3) @ handler'
-        )
         expect(stderrOutput).toContain(
           ' ⨯ ReferenceError: missingVar is not defined' +
             '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/blog/[slug].js:2:2)' +

--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -174,10 +174,6 @@ async function createNextInstall({
           .traceAsyncFn(() => installDependencies(installDir, tmpDir))
       }
 
-      if (!keepRepoDir && tmpRepoDir) {
-        await fs.remove(tmpRepoDir)
-      }
-
       return {
         installDir,
         pkgPaths,

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -944,6 +944,38 @@ impl ValueToString for DiskFileSystem {
     }
 }
 
+pub fn get_relative_path_to(path: &str, other_path: &str) -> String {
+    fn split(s: &str) -> impl Iterator<Item = &str> {
+        let empty = s.is_empty();
+        let mut iterator = s.split('/');
+        if empty {
+            iterator.next();
+        }
+        iterator
+    }
+
+    let mut self_segments = split(path).peekable();
+    let mut other_segments = split(other_path).peekable();
+    while self_segments.peek() == other_segments.peek() {
+        self_segments.next();
+        if other_segments.next().is_none() {
+            return ".".to_string();
+        }
+    }
+    let mut result = Vec::new();
+    if self_segments.peek().is_none() {
+        result.push(".");
+    } else {
+        while self_segments.next().is_some() {
+            result.push("..");
+        }
+    }
+    for segment in other_segments {
+        result.push(segment);
+    }
+    result.join("/")
+}
+
 #[turbo_tasks::value]
 #[derive(Debug, Clone)]
 pub struct FileSystemPath {
@@ -1004,34 +1036,8 @@ impl FileSystemPath {
         if self.fs != other.fs {
             return None;
         }
-        fn split(s: &str) -> impl Iterator<Item = &str> {
-            let empty = s.is_empty();
-            let mut iterator = s.split('/');
-            if empty {
-                iterator.next();
-            }
-            iterator
-        }
-        let mut self_segments = split(&self.path).peekable();
-        let mut other_segments = split(&other.path).peekable();
-        while self_segments.peek() == other_segments.peek() {
-            self_segments.next();
-            if other_segments.next().is_none() {
-                return Some(".".into());
-            }
-        }
-        let mut result = Vec::new();
-        if self_segments.peek().is_none() {
-            result.push(".");
-        } else {
-            while self_segments.next().is_some() {
-                result.push("..");
-            }
-        }
-        for segment in other_segments {
-            result.push(segment);
-        }
-        Some(result.join("/").into())
+
+        Some(get_relative_path_to(&self.path, &other.path).into())
     }
 
     /// Returns the final component of the FileSystemPath, or an empty string
@@ -2352,6 +2358,22 @@ pub fn register() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_get_relative_path_to() {
+        assert_eq!(get_relative_path_to("a/b/c", "a/b/c").as_str(), ".");
+        assert_eq!(get_relative_path_to("a/c/d", "a/b/c").as_str(), "../../b/c");
+        assert_eq!(get_relative_path_to("", "a/b/c").as_str(), "./a/b/c");
+        assert_eq!(get_relative_path_to("a/b/c", "").as_str(), "../../..");
+        assert_eq!(
+            get_relative_path_to("a/b/c", "c/b/a").as_str(),
+            "../../../c/b/a"
+        );
+        assert_eq!(
+            get_relative_path_to("file:///a/b/c", "file:///c/b/a").as_str(),
+            "../../../c/b/a"
+        );
+    }
 
     #[tokio::test]
     async fn with_extension() {

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -112,9 +112,8 @@ impl BrowserChunkingContextBuilder {
 #[derive(Debug, Clone, Hash)]
 pub struct BrowserChunkingContext {
     name: Option<RcStr>,
-    /// This path get stripped off of chunk paths before generating output asset
-    /// paths.
-    context_path: ResolvedVc<FileSystemPath>,
+    /// The root path of the project
+    root_path: ResolvedVc<FileSystemPath>,
     /// Whether to write file sources as file:// paths in source maps
     should_use_file_source_map_uris: bool,
     /// This path is used to compute the url to request chunks from
@@ -153,7 +152,7 @@ pub struct BrowserChunkingContext {
 
 impl BrowserChunkingContext {
     pub fn builder(
-        context_path: ResolvedVc<FileSystemPath>,
+        root_path: ResolvedVc<FileSystemPath>,
         output_root: ResolvedVc<FileSystemPath>,
         client_root: ResolvedVc<FileSystemPath>,
         chunk_root_path: ResolvedVc<FileSystemPath>,
@@ -164,7 +163,7 @@ impl BrowserChunkingContext {
         BrowserChunkingContextBuilder {
             chunking_context: BrowserChunkingContext {
                 name: None,
-                context_path,
+                root_path,
                 output_root,
                 client_root,
                 chunk_root_path,
@@ -278,8 +277,8 @@ impl ChunkingContext for BrowserChunkingContext {
     }
 
     #[turbo_tasks::function]
-    fn context_path(&self) -> Vc<FileSystemPath> {
-        *self.context_path
+    fn root_path(&self) -> Vc<FileSystemPath> {
+        *self.root_path
     }
 
     #[turbo_tasks::function]
@@ -299,7 +298,7 @@ impl ChunkingContext for BrowserChunkingContext {
         extension: RcStr,
     ) -> Result<Vc<FileSystemPath>> {
         let root_path = self.chunk_root_path;
-        let name = ident.output_name(*self.context_path, extension).await?;
+        let name = ident.output_name(*self.root_path, extension).await?;
         Ok(root_path.join(name.clone_value()))
     }
 

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -32,13 +32,13 @@ use crate::{
 
 #[turbo_tasks::function]
 pub async fn get_client_chunking_context(
-    project_path: ResolvedVc<FileSystemPath>,
+    root_path: ResolvedVc<FileSystemPath>,
     server_root: ResolvedVc<FileSystemPath>,
     environment: ResolvedVc<Environment>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
     Ok(Vc::upcast(
         BrowserChunkingContext::builder(
-            project_path,
+            root_path,
             server_root,
             server_root,
             server_root.join("/_chunks".into()).to_resolved().await?,
@@ -92,7 +92,7 @@ pub async fn get_client_runtime_entries(
 
 #[turbo_tasks::function]
 pub async fn create_web_entry_source(
-    project_path: Vc<FileSystemPath>,
+    root_path: Vc<FileSystemPath>,
     execution_context: Vc<ExecutionContext>,
     entry_requests: Vec<Vc<Request>>,
     server_root: Vc<FileSystemPath>,
@@ -103,14 +103,14 @@ pub async fn create_web_entry_source(
 ) -> Result<Vc<Box<dyn ContentSource>>> {
     let compile_time_info = get_client_compile_time_info(browserslist_query, node_env);
     let asset_context =
-        get_client_asset_context(project_path, execution_context, compile_time_info, node_env);
+        get_client_asset_context(root_path, execution_context, compile_time_info, node_env);
     let chunking_context =
-        get_client_chunking_context(project_path, server_root, compile_time_info.environment());
-    let entries = get_client_runtime_entries(project_path, node_env);
+        get_client_chunking_context(root_path, server_root, compile_time_info.environment());
+    let entries = get_client_runtime_entries(root_path, node_env);
 
     let runtime_entries = entries.resolve_entries(asset_context);
 
-    let origin = PlainResolveOrigin::new(asset_context, project_path.join("_".into()));
+    let origin = PlainResolveOrigin::new(asset_context, root_path.join("_".into()));
     let entries = entry_requests
         .into_iter()
         .map(|request| async move {

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -71,8 +71,8 @@ pub struct EntryChunkGroupResult {
 pub trait ChunkingContext {
     fn name(self: Vc<Self>) -> Vc<RcStr>;
     fn should_use_file_source_map_uris(self: Vc<Self>) -> Vc<bool>;
-    // Often the project root
-    fn context_path(self: Vc<Self>) -> Vc<FileSystemPath>;
+    // The root path of the project
+    fn root_path(self: Vc<Self>) -> Vc<FileSystemPath>;
     fn output_root(self: Vc<Self>) -> Vc<FileSystemPath>;
 
     // TODO remove this, a chunking context should not be bound to a specific

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -84,10 +84,9 @@ impl CssChunk {
             {
                 let source_map = content.source_map.map(|m| m.generate_source_map());
                 match source_map {
-                    Some(map) => {
-                        (*(fileify_source_map(map, self.chunking_context().context_path()).await?))
-                            .map(ResolvedVc::upcast)
-                    }
+                    Some(map) => (*(fileify_source_map(map, self.chunking_context().root_path())
+                        .await?))
+                        .map(ResolvedVc::upcast),
                     None => None,
                 }
             } else {

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -48,7 +48,7 @@ impl EcmascriptChunkItemContent {
 
         Ok(EcmascriptChunkItemContent {
             rewrite_source_path: if *chunking_context.should_use_file_source_map_uris().await? {
-                Some(chunking_context.context_path().to_resolved().await?)
+                Some(chunking_context.root_path().to_resolved().await?)
             } else {
                 None
             },

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -251,7 +251,7 @@ pub async fn get_evaluate_pool(
         env.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
         assets_for_source_mapping,
         output_root,
-        chunking_context.context_path().root().to_resolved().await?,
+        chunking_context.root_path().to_resolved().await?,
         available_parallelism().map_or(1, |v| v.get()),
         debug,
     );
@@ -612,12 +612,7 @@ impl EvaluateContext for BasicEvaluateContext {
             context_ident: self.context_ident_for_issue,
             assets_for_source_mapping: pool.assets_for_source_mapping,
             assets_root: pool.assets_root,
-            project_dir: self
-                .chunking_context
-                .context_path()
-                .root()
-                .to_resolved()
-                .await?,
+            root_path: self.chunking_context.root_path().to_resolved().await?,
         }
         .resolved_cell()
         .emit();
@@ -668,7 +663,7 @@ pub struct EvaluationIssue {
     pub error: StructuredError,
     pub assets_for_source_mapping: ResolvedVc<AssetsForSourceMapping>,
     pub assets_root: ResolvedVc<FileSystemPath>,
-    pub project_dir: ResolvedVc<FileSystemPath>,
+    pub root_path: ResolvedVc<FileSystemPath>,
 }
 
 #[turbo_tasks::value_impl]
@@ -696,7 +691,7 @@ impl Issue for EvaluationIssue {
                     .print(
                         *self.assets_for_source_mapping,
                         *self.assets_root,
-                        *self.project_dir,
+                        *self.root_path,
                         FormattingMode::Plain,
                     )
                     .await?

--- a/turbopack/crates/turbopack-node/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-node/src/source_map/mod.rs
@@ -275,7 +275,7 @@ impl StructuredError {
         &self,
         assets_for_source_mapping: Vc<AssetsForSourceMapping>,
         root: Vc<FileSystemPath>,
-        project_dir: Vc<FileSystemPath>,
+        root_path: Vc<FileSystemPath>,
         formatting_mode: FormattingMode,
     ) -> Result<String> {
         let mut message = String::new();
@@ -295,8 +295,7 @@ impl StructuredError {
         for frame in &self.stack {
             let frame = frame.unmangle_identifiers(magic);
             let resolved =
-                resolve_source_mapping(assets_for_source_mapping, root, project_dir.root(), &frame)
-                    .await;
+                resolve_source_mapping(assets_for_source_mapping, root, root_path, &frame).await;
             write_resolved(
                 &mut message,
                 resolved,
@@ -310,13 +309,8 @@ impl StructuredError {
         if let Some(cause) = &self.cause {
             message.write_str("\nCaused by: ")?;
             message.write_str(
-                &Box::pin(cause.print(
-                    assets_for_source_mapping,
-                    root,
-                    project_dir,
-                    formatting_mode,
-                ))
-                .await?,
+                &Box::pin(cause.print(assets_for_source_mapping, root, root_path, formatting_mode))
+                    .await?,
             )?;
         }
 

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -449,12 +449,7 @@ impl EvaluateContext for WebpackLoaderContext {
             context_ident: self.context_ident_for_issue,
             assets_for_source_mapping: pool.assets_for_source_mapping,
             assets_root: pool.assets_root,
-            project_dir: self
-                .chunking_context
-                .context_path()
-                .root()
-                .to_resolved()
-                .await?,
+            root_path: self.chunking_context.root_path().to_resolved().await?,
         }
         .resolved_cell()
         .emit();
@@ -499,12 +494,7 @@ impl EvaluateContext for WebpackLoaderContext {
                     severity: severity.resolved_cell(),
                     assets_for_source_mapping: pool.assets_for_source_mapping,
                     assets_root: pool.assets_root,
-                    project_dir: self
-                        .chunking_context
-                        .context_path()
-                        .root()
-                        .to_resolved()
-                        .await?,
+                    project_dir: self.chunking_context.root_path().to_resolved().await?,
                 }
                 .resolved_cell()
                 .emit();
@@ -595,12 +585,7 @@ impl EvaluateContext for WebpackLoaderContext {
                 },
                 assets_for_source_mapping: pool.assets_for_source_mapping,
                 assets_root: pool.assets_root,
-                project_dir: self
-                    .chunking_context
-                    .context_path()
-                    .root()
-                    .to_resolved()
-                    .await?,
+                project_dir: self.chunking_context.root_path().to_resolved().await?,
             }
             .resolved_cell()
             .emit();

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -83,9 +83,8 @@ impl NodeJsChunkingContextBuilder {
 #[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(Debug, Clone, Hash)]
 pub struct NodeJsChunkingContext {
-    /// This path get stripped off of chunk paths before generating output asset
-    /// paths.
-    context_path: ResolvedVc<FileSystemPath>,
+    /// The root path of the project
+    root_path: ResolvedVc<FileSystemPath>,
     /// This path is used to compute the url to request chunks or assets from
     output_root: ResolvedVc<FileSystemPath>,
     /// This path is used to compute the url to request chunks or assets from
@@ -115,7 +114,7 @@ pub struct NodeJsChunkingContext {
 impl NodeJsChunkingContext {
     /// Creates a new chunking context builder.
     pub fn builder(
-        context_path: ResolvedVc<FileSystemPath>,
+        root_path: ResolvedVc<FileSystemPath>,
         output_root: ResolvedVc<FileSystemPath>,
         client_root: ResolvedVc<FileSystemPath>,
         chunk_root_path: ResolvedVc<FileSystemPath>,
@@ -125,7 +124,7 @@ impl NodeJsChunkingContext {
     ) -> NodeJsChunkingContextBuilder {
         NodeJsChunkingContextBuilder {
             chunking_context: NodeJsChunkingContext {
-                context_path,
+                root_path,
                 output_root,
                 client_root,
                 chunk_root_path,
@@ -199,8 +198,8 @@ impl ChunkingContext for NodeJsChunkingContext {
     }
 
     #[turbo_tasks::function]
-    fn context_path(&self) -> Vc<FileSystemPath> {
-        *self.context_path
+    fn root_path(&self) -> Vc<FileSystemPath> {
+        *self.root_path
     }
 
     #[turbo_tasks::function]
@@ -247,7 +246,7 @@ impl ChunkingContext for NodeJsChunkingContext {
         extension: RcStr,
     ) -> Result<Vc<FileSystemPath>> {
         let root_path = *self.chunk_root_path;
-        let name = ident.output_name(*self.context_path, extension).await?;
+        let name = ident.output_name(*self.root_path, extension).await?;
         Ok(root_path.join(name.clone_value()))
     }
 


### PR DESCRIPTION
### What?

Improved trace source maps to return relative paths and always relative to process.cwd.

`turbopack://` urls in SourceMaps are always relative to the project root.

`file://` urls do no longer contain duplicate path segments.

Add a test case

Also:
* improve error when sourcemap lookup throws


Closes PACK-3671