### PR TITLE
Bump `examples/**` Eslint to v9

### DIFF
--- a/examples/cms-buttercms/package.json
+++ b/examples/cms-buttercms/package.json
@@ -21,7 +21,7 @@
     "typescript": "^3.3.1"
   },
   "devDependencies": {
-    "eslint": "^8.12.0",
+    "eslint": "^9",
     "eslint-config-next": "^12.1.4"
   }
 }

--- a/examples/cms-sitecore-xmcloud/package.json
+++ b/examples/cms-sitecore-xmcloud/package.json
@@ -55,7 +55,7 @@
     "constant-case": "^3.0.4",
     "cross-env": "~7.0.3",
     "dotenv": "^16.0.3",
-    "eslint": "^8.32.0",
+    "eslint": "^9",
     "eslint-config-next": "^13.1.5",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-prettier": "^4.2.1",

--- a/examples/cms-wordpress/package.json
+++ b/examples/cms-wordpress/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "eslint": "^8",
+    "eslint": "^9",
     "eslint-config-next": "latest",
     "typescript": "^5"
   }

--- a/examples/middleware/package.json
+++ b/examples/middleware/package.json
@@ -15,7 +15,7 @@
     "@types/node": "18.0.0",
     "@types/react": "18.2.8",
     "@types/react-dom": "18.0.5",
-    "eslint": "8.18.0",
+    "eslint": "^9",
     "eslint-config-next": "12.2.0",
     "typescript": "4.7.4"
   }

--- a/examples/with-eslint/package.json
+++ b/examples/with-eslint/package.json
@@ -15,7 +15,7 @@
     "@types/node": "^22.5.4",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
-    "eslint": "^8.57.0",
+    "eslint": "^9",
     "eslint-config-next": "latest"
   }
 }

--- a/examples/with-flow/package.json
+++ b/examples/with-flow/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "eslint": "7.30.0",
+    "eslint": "^9",
     "eslint-config-next": "latest",
     "babel-plugin-transform-flow-strip-types": "6.22.0",
     "flow-bin": "0.77.0"

--- a/examples/with-jotai/package.json
+++ b/examples/with-jotai/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@types/node": "20.11.28",
     "@types/react": "17.0.16",
-    "eslint": "7.32.0",
+    "eslint": "^9",
     "eslint-config-next": "11.0.1",
     "typescript": "4.3.5"
   }

--- a/examples/with-mongodb/package.json
+++ b/examples/with-mongodb/package.json
@@ -16,7 +16,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.0.1",
-    "eslint": "^8",
+    "eslint": "^9",
     "eslint-config-next": "14.0.4",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",

--- a/examples/with-particles/package.json
+++ b/examples/with-particles/package.json
@@ -18,7 +18,7 @@
     "@types/node": "17.0.33",
     "@types/react": "18.2.8",
     "@types/react-dom": "18.0.4",
-    "eslint": "8.15.0",
+    "eslint": "^9",
     "eslint-config-next": "latest",
     "typescript": "4.6.4"
   }

--- a/examples/with-supertokens/package.json
+++ b/examples/with-supertokens/package.json
@@ -20,7 +20,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "eslint": "^8",
+    "eslint": "^9",
     "eslint-config-next": "13.5.4",
     "typescript": "^5"
   }

--- a/examples/with-turso/package.json
+++ b/examples/with-turso/package.json
@@ -17,7 +17,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.0.1",
-    "eslint": "^8",
+    "eslint": "^9",
     "eslint-config-next": "14.1.0",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",

--- a/examples/with-xata/package.json
+++ b/examples/with-xata/package.json
@@ -11,7 +11,7 @@
     "@types/node": "18.11.10",
     "@types/react": "18.2.8",
     "@types/react-dom": "18.0.9",
-    "eslint": "8.28.0",
+    "eslint": "^9",
     "eslint-config-next": "latest",
     "typescript": "4.9.3"
   },


### PR DESCRIPTION
### Why?

ESLint v8 is deprecated. Also, it's deprecated dependencies spam npm warning.

![image](https://github.com/user-attachments/assets/856a70a5-3185-44d6-9fa9-c773f898dc25)