### PR TITLE
next-upgrade: Ensure highest versions are used not latest

### DIFF
--- a/packages/next-codemod/bin/__testfixtures__/next-14-installed/README.md
+++ b/packages/next-codemod/bin/__testfixtures__/next-14-installed/README.md
@@ -3,6 +3,7 @@ Suggests adding `--turbopack` to `next dev` script
 Suggests `app-dir-runtime-config-experimental-edge` transform
 Suggests `next-async-request-api` transform
 Suggests `next-request-geo-ip` transform
+
 ```diff
 diff --git a/packages/next-codemod/bin/__testfixtures__/next-14-installed/package.json b/packages/next-codemod/bin/__testfixtures__/next-14-installed/package.json
 index 5ec4c37f0b..131f5b9f4a 100644

--- a/packages/next-codemod/bin/__testfixtures__/next-14-installed/README.md
+++ b/packages/next-codemod/bin/__testfixtures__/next-14-installed/README.md
@@ -20,13 +20,13 @@ index 5ec4c37f0b..131f5b9f4a 100644
 +    "next": "15.0.4-canary.43",
 +    "react": "19.0.0",
 +    "react-dom": "19.0.0",
-+    "@types/react": "18.3.2",
-+    "@types/react-dom": "18.3.2"
++    "@types/react": "19.0.0",
++    "@types/react-dom": "19.0.0"
 +  },
 +  "pnpm": {
 +    "overrides": {
-+      "@types/react": "18.3.2",
-+      "@types/react-dom": "18.3.2"
++      "@types/react": "19.0.0",
++      "@types/react-dom": "19.0.0"
 +    }
    }
  }

--- a/packages/next-codemod/bin/__testfixtures__/next-14-installed/README.md
+++ b/packages/next-codemod/bin/__testfixtures__/next-14-installed/README.md
@@ -3,3 +3,31 @@ Suggests adding `--turbopack` to `next dev` script
 Suggests `app-dir-runtime-config-experimental-edge` transform
 Suggests `next-async-request-api` transform
 Suggests `next-request-geo-ip` transform
+```diff
+diff --git a/packages/next-codemod/bin/__testfixtures__/next-14-installed/package.json b/packages/next-codemod/bin/__testfixtures__/next-14-installed/package.json
+index 5ec4c37f0b..131f5b9f4a 100644
+--- a/packages/next-codemod/bin/__testfixtures__/next-14-installed/package.json
++++ b/packages/next-codemod/bin/__testfixtures__/next-14-installed/package.json
+@@ -4,10 +4,16 @@
+     "dev": "next dev"
+   },
+   "dependencies": {
+-    "next": "14.3.0-canary.44",
+-    "react": "18.2.0",
+-    "react-dom": "18.2.0",
+-    "@types/react": "^18.2.0",
+-    "@types/react-dom": "^18.2.0"
++    "next": "15.0.4-canary.43",
++    "react": "19.0.0",
++    "react-dom": "19.0.0",
++    "@types/react": "18.3.2",
++    "@types/react-dom": "18.3.2"
++  },
++  "pnpm": {
++    "overrides": {
++      "@types/react": "18.3.2",
++      "@types/react-dom": "18.3.2"
++    }
+   }
+ }
+```

--- a/packages/next-codemod/bin/__testfixtures__/next-14-installed/package.json
+++ b/packages/next-codemod/bin/__testfixtures__/next-14-installed/package.json
@@ -6,6 +6,8 @@
   "dependencies": {
     "next": "14.3.0-canary.44",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"
   }
 }

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -53,6 +53,8 @@ async function loadHighestNPMVersionMatching(query: string) {
   // npm-view returns an array if there are multiple versions matching the query.
   if (Array.isArray(versionOrVersions)) {
     // The last entry will be the latest version published.
+    // But we want the highest version.
+    versionOrVersions.sort(compareVersions)
     return versionOrVersions[versionOrVersions.length - 1]
   }
   return versionOrVersions


### PR DESCRIPTION
`npm view <package>@<query>` returns packages in publish order. But we want the highest.