### PR TITLE
docs: fix forbidden file paths

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/forbidden.mdx
+++ b/docs/01-app/03-api-reference/04-functions/forbidden.mdx
@@ -33,7 +33,7 @@ module.exports = {
 
 `forbidden` can be invoked in [Server Components](/docs/app/building-your-application/rendering/server-components), [Server Actions](/docs/app/building-your-application/data-fetching/server-actions-and-mutations), and [Route Handlers](/docs/app/building-your-application/routing/route-handlers).
 
-```tsx filename="app/auth/route.tsx" switcher
+```tsx filename="app/auth/page.tsx" switcher
 import { verifySession } from '@/app/lib/dal'
 import { forbidden } from 'next/navigation'
 
@@ -50,7 +50,7 @@ export default async function AdminPage() {
 }
 ```
 
-```jsx filename="app/auth/route.js" switcher
+```jsx filename="app/auth/page.js" switcher
 import { verifySession } from '@/app/lib/dal'
 import { forbidden } from 'next/navigation'
 
@@ -125,7 +125,7 @@ export default async function AdminPage() {
 
 When implementing mutations in Server Actions, you can use `forbidden` to only allow users with a specific role to update sensitive data.
 
-```tsx filename="app/auth/route.tsx" switcher
+```tsx filename="app/actions/update-role.ts" switcher
 'use server'
 
 import { verifySession } from '@/app/lib/dal'
@@ -145,7 +145,7 @@ export async function updateRole(formData: FormData) {
 }
 ```
 
-```jsx filename="app/auth/route.js" switcher
+```jsx filename="app/actions/update-role.js" switcher
 'use server'
 
 import { verifySession } from '@/app/lib/dal'


### PR DESCRIPTION
Noticed this while reviewing the docs -- unauthorized is fine, but forbidden has incorrect file paths for the examples. 