### PR TITLE
docs(composition-patterns): add missing React.ReactNode type in layout.tsx example

### DIFF
--- a/docs/01-app/02-building-your-application/03-rendering/03-composition-patterns.mdx
+++ b/docs/01-app/02-building-your-application/03-rendering/03-composition-patterns.mdx
@@ -246,7 +246,11 @@ import { createContext } from 'react'
 //  createContext is not supported in Server Components
 export const ThemeContext = createContext({})
 
-export default function RootLayout({ children }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
   return (
     <html>
       <body>


### PR DESCRIPTION
Hi Team,

Added missing `children: React.ReactNode` type annotation in the TSX version of the Root Layout example to ensure type consistency between JSX and TSX examples in the documentation.

Thank you.