### PR TITLE
Turbopack: hide useless method names

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/code-frame/code-frame.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/code-frame/code-frame.tsx
@@ -9,6 +9,7 @@ import {
   groupCodeFrameLines,
   parseLineNumberFromCodeFrameLine,
 } from './parse-code-frame'
+import { isHiddenMethodName } from 'next/src/shared/lib/stack-trace-utils'
 
 export type CodeFrameProps = {
   stackFrame: StackFrame
@@ -48,10 +49,14 @@ export function CodeFrame({ stackFrame, codeFrame }: CodeFrameProps) {
           <span className="code-frame-icon">
             <FileIcon lang={fileExtension} />
           </span>
-          <span data-text>
-            {getFrameSource(stackFrame)} @{' '}
-            <HotlinkedText text={stackFrame.methodName} />
-          </span>
+          {isHiddenMethodName(stackFrame.methodName) ? (
+            <span data-text>{getFrameSource(stackFrame)}</span>
+          ) : (
+            <span data-text>
+              {getFrameSource(stackFrame)} @{' '}
+              <HotlinkedText text={stackFrame.methodName} />
+            </span>
+          )}
           <button
             aria-label="Open in editor"
             data-with-open-in-editor-link-source-file

--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -13,6 +13,7 @@ import { parseStack, type StackFrame } from './lib/parse-stack'
 import { getOriginalCodeFrame } from '../next-devtools/server/shared'
 import { workUnitAsyncStorage } from './app-render/work-unit-async-storage.external'
 import { dim } from '../lib/picocolors'
+import { isHiddenMethodName } from '../shared/lib/stack-trace-utils'
 
 type FindSourceMapPayload = (
   sourceURL: string
@@ -66,7 +67,7 @@ function frameToString(
     fileLocation = sourceURL
   }
 
-  return methodName
+  return methodName && !isHiddenMethodName(methodName)
     ? `    at ${methodName} (${fileLocation}${sourceLocation})`
     : `    at ${fileLocation}${sourceLocation}`
 }

--- a/packages/next/src/shared/lib/stack-trace-utils.ts
+++ b/packages/next/src/shared/lib/stack-trace-utils.ts
@@ -1,0 +1,6 @@
+// Hide the method name when showing a stack trace in the error overlay or when displaying a stack trace in the console.
+export function isHiddenMethodName(methodName: string) {
+  return /^(?:Object\.|Module\.)?(?:<anonymous>|eval|__TURBOPACK__module__evaluation__)$/.test(
+    methodName
+  )
+}

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -93,12 +93,12 @@ describe('ReactRefreshLogBox app', () => {
          "description": "no",
          "environmentLabel": null,
          "label": "Runtime Error",
-         "source": "index.js (3:7) @ {module evaluation}
+         "source": "index.js (3:7)
        > 3 | throw new Error('no')
            |       ^",
          "stack": [
-           "{module evaluation} index.js (3:7)",
-           "{module evaluation} app/page.js (2:1)",
+           "index.js (3:7)",
+           "app/page.js (2:1)",
          ],
        }
       `)
@@ -109,13 +109,13 @@ describe('ReactRefreshLogBox app', () => {
            "description": "no",
            "environmentLabel": null,
            "label": "Runtime Error",
-           "source": "index.js (3:7) @ eval
+           "source": "index.js (3:7)
        > 3 | throw new Error('no')
            |       ^",
            "stack": [
-             "eval index.js (3:7)",
+             "index.js (3:7)",
              "<FIXME-next-dist-dir>",
-             "eval ./app/page.js",
+             "./app/page.js",
              "<FIXME-next-dist-dir>",
            ],
          },
@@ -123,13 +123,13 @@ describe('ReactRefreshLogBox app', () => {
            "description": "no",
            "environmentLabel": null,
            "label": "Runtime Error",
-           "source": "index.js (3:7) @ eval
+           "source": "index.js (3:7)
        > 3 | throw new Error('no')
            |       ^",
            "stack": [
-             "eval index.js (3:7)",
+             "index.js (3:7)",
              "<FIXME-next-dist-dir>",
-             "eval ./app/page.js",
+             "./app/page.js",
              "<FIXME-next-dist-dir>",
            ],
          },
@@ -1165,7 +1165,7 @@ describe('ReactRefreshLogBox app', () => {
         "description": "This is an error from an anonymous function",
         "environmentLabel": "Server",
         "label": "Runtime Error",
-        "source": "app/page.js (4:13) @ ${isTurbopack ? '<anonymous>' : 'eval'}
+        "source": "app/page.js (4:13)
       > 4 |       throw new Error("This is an error from an anonymous function");
           |             ^",
         "stack": [
@@ -1419,13 +1419,13 @@ describe('ReactRefreshLogBox app', () => {
            "description": "module error",
            "environmentLabel": null,
            "label": "Runtime Error",
-           "source": "index.js (1:7) @ eval
+           "source": "index.js (1:7)
          > 1 | throw new Error('module error')
              |       ^",
            "stack": [
-             "eval index.js (1:7)",
+             "index.js (1:7)",
              "<FIXME-next-dist-dir>",
-             "eval ./app/server/page.js",
+             "./app/server/page.js",
              "<FIXME-next-dist-dir>",
            ],
          }
@@ -1569,12 +1569,12 @@ export default function Home() {
          "description": "utils error",
          "environmentLabel": null,
          "label": "Runtime Error",
-         "source": "app/utils.ts (1:7) @ {module evaluation}
+         "source": "app/utils.ts (1:7)
        > 1 | throw new Error('utils error')
            |       ^",
          "stack": [
-           "{module evaluation} app/utils.ts (1:7)",
-           "{module evaluation} app/page.js (2:1)",
+           "app/utils.ts (1:7)",
+           "app/page.js (2:1)",
          ],
        }
       `)
@@ -1586,13 +1586,13 @@ export default function Home() {
            "description": "utils error",
            "environmentLabel": null,
            "label": "Runtime Error",
-           "source": "app/utils.ts (1:7) @ eval
+           "source": "app/utils.ts (1:7)
        > 1 | throw new Error('utils error')
            |       ^",
            "stack": [
-             "eval app/utils.ts (1:7)",
+             "app/utils.ts (1:7)",
              "<FIXME-next-dist-dir>",
-             "eval ./app/page.js",
+             "./app/page.js",
              "<FIXME-next-dist-dir>",
            ],
          },
@@ -1600,13 +1600,13 @@ export default function Home() {
            "description": "utils error",
            "environmentLabel": null,
            "label": "Runtime Error",
-           "source": "app/utils.ts (1:7) @ eval
+           "source": "app/utils.ts (1:7)
        > 1 | throw new Error('utils error')
            |       ^",
            "stack": [
-             "eval app/utils.ts (1:7)",
+             "app/utils.ts (1:7)",
              "<FIXME-next-dist-dir>",
-             "eval ./app/page.js",
+             "./app/page.js",
              "<FIXME-next-dist-dir>",
            ],
          },

--- a/test/development/acceptance-app/error-recovery.test.ts
+++ b/test/development/acceptance-app/error-recovery.test.ts
@@ -573,11 +573,11 @@ describe('Error recovery app', () => {
            "description": "no 1",
            "environmentLabel": null,
            "label": "Runtime Error",
-           "source": "index.js (7:11) @ eval
+           "source": "index.js (7:11)
          > 7 |     throw Error('no ' + i)
              |           ^",
            "stack": [
-             "eval index.js (7:11)",
+             "index.js (7:11)",
            ],
          }
         `)
@@ -587,11 +587,11 @@ describe('Error recovery app', () => {
          "description": "no 1",
          "environmentLabel": null,
          "label": "Runtime Error",
-         "source": "index.js (7:11) @ eval
+         "source": "index.js (7:11)
        >  7 |     throw Error('no ' + i)
             |           ^",
          "stack": [
-           "eval index.js (7:11)",
+           "index.js (7:11)",
          ],
        }
       `)

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -121,13 +121,13 @@ describe('ReactRefreshLogBox', () => {
            "description": "no",
            "environmentLabel": null,
            "label": "Runtime Error",
-           "source": "index.js (3:7) @ {module evaluation}
+           "source": "index.js (3:7)
          > 3 | throw new Error('no')
              |       ^",
            "stack": [
-             "{module evaluation} index.js (3:7)",
-             "{module evaluation} pages/index.js (1:1)",
-             "{module evaluation} pages/index.js (1:1)",
+             "index.js (3:7)",
+             "pages/index.js (1:1)",
+             "pages/index.js (1:1)",
              "<FIXME-next-dist-dir>",
            ],
          }
@@ -138,13 +138,13 @@ describe('ReactRefreshLogBox', () => {
            "description": "no",
            "environmentLabel": null,
            "label": "Runtime Error",
-           "source": "index.js (3:7) @ eval
+           "source": "index.js (3:7)
          > 3 | throw new Error('no')
              |       ^",
            "stack": [
-             "eval index.js (3:7)",
+             "index.js (3:7)",
              "<FIXME-next-dist-dir>",
-             "eval ./pages/index.js",
+             "./pages/index.js",
              "<FIXME-next-dist-dir>",
              "<FIXME-next-dist-dir>",
              "<FIXME-next-dist-dir>",
@@ -162,13 +162,13 @@ describe('ReactRefreshLogBox', () => {
            "description": "no",
            "environmentLabel": null,
            "label": "Runtime Error",
-           "source": "index.js (3:7) @ {module evaluation}
+           "source": "index.js (3:7)
          > 3 | throw new Error('no')
              |       ^",
            "stack": [
-             "{module evaluation} index.js (3:7)",
-             "{module evaluation} pages/index.js (1:1)",
-             "{module evaluation} pages/index.js (1:1)",
+             "index.js (3:7)",
+             "pages/index.js (1:1)",
+             "pages/index.js (1:1)",
              "<FIXME-next-dist-dir>",
            ],
          }
@@ -179,13 +179,13 @@ describe('ReactRefreshLogBox', () => {
            "description": "no",
            "environmentLabel": null,
            "label": "Runtime Error",
-           "source": "index.js (3:7) @ eval
+           "source": "index.js (3:7)
          > 3 | throw new Error('no')
              |       ^",
            "stack": [
-             "eval index.js (3:7)",
+             "index.js (3:7)",
              "<FIXME-next-dist-dir>",
-             "eval ./pages/index.js",
+             "./pages/index.js",
              "<FIXME-next-dist-dir>",
              "<FIXME-next-dist-dir>",
              "<FIXME-next-dist-dir>",
@@ -1249,11 +1249,11 @@ describe('ReactRefreshLogBox', () => {
          "description": "anonymous error!",
          "environmentLabel": null,
          "label": "Runtime Error",
-         "source": "pages/index.js (3:11) @ eval
+         "source": "pages/index.js (3:11)
        > 3 |     throw new Error("anonymous error!");
            |           ^",
          "stack": [
-           "eval pages/index.js (3:11)",
+           "pages/index.js (3:11)",
            "Array.map <anonymous>",
            "Page pages/index.js (2:13)",
          ],

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -793,11 +793,11 @@ describe('pages/ error recovery', () => {
               "description": "no 1",
               "environmentLabel": null,
               "label": "Runtime Error",
-              "source": "index.js (5:9) @ eval
+              "source": "index.js (5:9)
             > 5 |   throw Error('no ' + i)
                 |         ^",
               "stack": [
-                "eval index.js (5:9)",
+                "index.js (5:9)",
               ],
             }
           `)
@@ -807,11 +807,11 @@ describe('pages/ error recovery', () => {
          "description": "no 1",
          "environmentLabel": null,
          "label": "Runtime Error",
-         "source": "index.js (5:9) @ eval
+         "source": "index.js (5:9)
        > 5 |   throw Error('no ' + i)
            |         ^",
          "stack": [
-           "eval index.js (5:9)",
+           "index.js (5:9)",
          ],
        }
       `)

--- a/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
+++ b/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
@@ -58,7 +58,7 @@ describe('error-ignored-frames', () => {
       `)
     } else {
       expect(defaultStack).toMatchInlineSnapshot(`
-       "at eval (app/interleaved/page.tsx (7:11))
+       "at app/interleaved/page.tsx (7:11)
        at Page (app/interleaved/page.tsx (6:36))"
       `)
     }

--- a/test/development/app-dir/owner-stack-react-missing-key-prop/owner-stack-react-missing-key-prop.test.ts
+++ b/test/development/app-dir/owner-stack-react-missing-key-prop/owner-stack-react-missing-key-prop.test.ts
@@ -25,7 +25,7 @@ describe('app-dir - owner-stack-react-missing-key-prop', () => {
        at Page (app/rsc/page.tsx (6:13))"
       `)
       expect(source).toMatchInlineSnapshot(`
-         "app/rsc/page.tsx (7:9) @ <anonymous>
+         "app/rsc/page.tsx (7:9)
 
             5 |     <div>
             6 |       {list.map((item, index) => (
@@ -38,12 +38,12 @@ describe('app-dir - owner-stack-react-missing-key-prop', () => {
     } else {
       expect(stackFramesContent).toMatchInlineSnapshot(`
        "at span ()
-       at eval (app/rsc/page.tsx (7:9))
+       at app/rsc/page.tsx (7:9)
        at Array.map ()
        at Page (app/rsc/page.tsx (6:13))"
       `)
       expect(source).toMatchInlineSnapshot(`
-          "app/rsc/page.tsx (7:9) @ eval
+          "app/rsc/page.tsx (7:9)
 
              5 |     <div>
              6 |       {list.map((item, index) => (
@@ -83,12 +83,12 @@ describe('app-dir - owner-stack-react-missing-key-prop', () => {
     } else {
       expect(stackFramesContent).toMatchInlineSnapshot(`
          "at p ()
-         at eval (app/ssr/page.tsx (9:9))
+         at app/ssr/page.tsx (9:9)
          at Array.map ()
          at Page (app/ssr/page.tsx (8:13))"
         `)
       expect(source).toMatchInlineSnapshot(`
-          "app/ssr/page.tsx (9:9) @ eval
+          "app/ssr/page.tsx (9:9)
 
              7 |     <div>
              8 |       {list.map((item, index) => (

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -358,7 +358,7 @@ describe('react-dom/server in React Server environment', () => {
         expect(redbox).toMatchInlineSnapshot(`
           {
             "description": "Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
-            "source": "app/exports/app-code/react-dom-server-node-explicit/page.js (1:1) @ {module evaluation}
+            "source": "app/exports/app-code/react-dom-server-node-explicit/page.js (1:1)
 
           > 1 | import * as ReactDOMServerNode from 'react-dom/server.node'
               | ^
@@ -371,7 +371,7 @@ describe('react-dom/server in React Server environment', () => {
         expect(redbox).toMatchInlineSnapshot(`
          {
            "description": "react-dom/server is not supported in React Server Components.",
-           "source": "app/exports/app-code/react-dom-server-node-explicit/page.js (1:1) @ {module evaluation}
+           "source": "app/exports/app-code/react-dom-server-node-explicit/page.js (1:1)
 
          > 1 | import * as ReactDOMServerNode from 'react-dom/server.node'
              | ^
@@ -498,7 +498,7 @@ describe('react-dom/server in React Server environment', () => {
         expect(redbox).toMatchInlineSnapshot(`
           {
             "description": "Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
-            "source": "internal-pkg/server.node.js (1:1) @ {module evaluation}
+            "source": "internal-pkg/server.node.js (1:1)
 
           > 1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
               | ^
@@ -511,7 +511,7 @@ describe('react-dom/server in React Server environment', () => {
         expect(redbox).toMatchInlineSnapshot(`
          {
            "description": "react-dom/server is not supported in React Server Components.",
-           "source": "internal-pkg/server.node.js (1:1) @ {module evaluation}
+           "source": "internal-pkg/server.node.js (1:1)
 
          > 1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
              | ^
@@ -796,7 +796,7 @@ describe('react-dom/server in React Server environment', () => {
         expect(redbox).toMatchInlineSnapshot(`
          {
            "description": "Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
-           "source": "internal-pkg/server.node.js (1:1) @ {module evaluation}
+           "source": "internal-pkg/server.node.js (1:1)
 
          > 1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
              | ^
@@ -809,7 +809,7 @@ describe('react-dom/server in React Server environment', () => {
         expect(redbox).toMatchInlineSnapshot(`
          {
            "description": "react-dom/server is not supported in React Server Components.",
-           "source": "internal-pkg/server.node.js (1:1) @ {module evaluation}
+           "source": "internal-pkg/server.node.js (1:1)
 
          > 1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
              | ^
@@ -854,7 +854,7 @@ describe('react-dom/server in React Server environment', () => {
         expect(redbox).toMatchInlineSnapshot(`
           {
             "description": "Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
-            "source": "internal-pkg/server.node.js (1:1) @ {module evaluation}
+            "source": "internal-pkg/server.node.js (1:1)
 
           > 1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
               | ^
@@ -867,7 +867,7 @@ describe('react-dom/server in React Server environment', () => {
         expect(redbox).toMatchInlineSnapshot(`
          {
            "description": "react-dom/server is not supported in React Server Components.",
-           "source": "internal-pkg/server.node.js (1:1) @ {module evaluation}
+           "source": "internal-pkg/server.node.js (1:1)
 
          > 1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
              | ^

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -171,14 +171,14 @@ describe('middleware - development errors', () => {
       expect(stripAnsi(next.cliOutput)).toContain(
         isTurbopack
           ? '\n ⨯ Error [ReferenceError]: test is not defined' +
-              '\n    at eval (middleware.js:4:9)' +
+              '\n    at middleware.js:4:9' +
               '\n    at <unknown> (middleware.js:4:9)' +
               // TODO(veil): Should be sourcemapped
               '\n    at __TURBOPACK__default__export__ ('
           : '\n ⨯ Error [ReferenceError]: test is not defined' +
               // TODO(veil): Redundant and not clickable
-              '\n    at eval (file://webpack-internal:///(middleware)/./middleware.js)' +
-              '\n    at eval (middleware.js:4:9)' +
+              '\n    at file://webpack-internal:///(middleware)/./middleware.js' +
+              '\n    at middleware.js:4:9' +
               '\n    at default (middleware.js:4:9)' +
               "\n  2 |       import { NextResponse } from 'next/server'"
       )
@@ -204,11 +204,11 @@ describe('middleware - development errors', () => {
            "description": "test is not defined",
            "environmentLabel": null,
            "label": "Runtime ReferenceError",
-           "source": "middleware.js (4:9) @ eval
+           "source": "middleware.js (4:9)
          > 4 |         eval('test')
              |         ^",
            "stack": [
-             "eval middleware.js (4:9)",
+             "middleware.js (4:9)",
              "<unknown> middleware.js (4:9)",
              "{default export} middleware.js (3:22)",
            ],
@@ -220,12 +220,12 @@ describe('middleware - development errors', () => {
            "description": "test is not defined",
            "environmentLabel": null,
            "label": "Runtime ReferenceError",
-           "source": "middleware.js (4:9) @ eval
+           "source": "middleware.js (4:9)
          > 4 |         eval('test')
              |         ^",
            "stack": [
              "<FIXME-file-protocol>",
-             "eval middleware.js (4:9)",
+             "middleware.js (4:9)",
              "default middleware.js (4:9)",
            ],
          }
@@ -267,12 +267,12 @@ describe('middleware - development errors', () => {
         isTurbopack
           ? '\n ⨯ Error: booooom!' +
               // TODO(veil): Should be sourcemapped
-              '\n    at __TURBOPACK__module__evaluation__ (middleware.js:3:13)'
+              '\n    at middleware.js:3:12'
           : '\n ⨯ Error: booooom!' +
               // TODO: Should be anonymous method without a method name
               '\n    at <unknown> (middleware.js:3)' +
               // TODO: Should be ignore-listed
-              '\n    at eval (middleware.js:3:13)' +
+              '\n    at middleware.js:3:13' +
               '\n    at (middleware)/./middleware.js (.next/server/middleware.js:18:1)' +
               '\n    at __webpack_require__ '
       )
@@ -287,11 +287,11 @@ describe('middleware - development errors', () => {
            "description": "booooom!",
            "environmentLabel": null,
            "label": "Runtime Error",
-           "source": "middleware.js (3:13) @ {module evaluation}
+           "source": "middleware.js (3:13)
          > 3 |       throw new Error('booooom!')
              |             ^",
            "stack": [
-             "{module evaluation} middleware.js (3:13)",
+             "middleware.js (3:13)",
            ],
          }
         `)
@@ -301,12 +301,12 @@ describe('middleware - development errors', () => {
            "description": "booooom!",
            "environmentLabel": null,
            "label": "Runtime Error",
-           "source": "middleware.js (3:13) @ eval
+           "source": "middleware.js (3:13)
          > 3 |       throw new Error('booooom!')
              |             ^",
            "stack": [
              "<unknown> middleware.js (3)",
-             "eval middleware.js (3:13)",
+             "middleware.js (3:13)",
              "<FIXME-next-dist-dir>",
              "<FIXME-next-dist-dir>",
              "<FIXME-next-dist-dir>",

--- a/test/development/pages-dir/client-navigation/index.test.ts
+++ b/test/development/pages-dir/client-navigation/index.test.ts
@@ -353,11 +353,11 @@ describe('Client Navigation', () => {
              "description": "An Expected error occurred",
              "environmentLabel": null,
              "label": "Runtime Error",
-             "source": "pages/error-in-the-browser-global-scope.js (2:9) @ {module evaluation}
+             "source": "pages/error-in-the-browser-global-scope.js (2:9)
            > 2 |   throw new Error('An Expected error occurred')
                |         ^",
              "stack": [
-               "{module evaluation} pages/error-in-the-browser-global-scope.js (2:9)",
+               "pages/error-in-the-browser-global-scope.js (2:9)",
              ],
            }
           `)
@@ -367,11 +367,11 @@ describe('Client Navigation', () => {
              "description": "An Expected error occurred",
              "environmentLabel": null,
              "label": "Runtime Error",
-             "source": "pages/error-in-the-browser-global-scope.js (2:9) @ eval
+             "source": "pages/error-in-the-browser-global-scope.js (2:9)
            > 2 |   throw new Error('An Expected error occurred')
                |         ^",
              "stack": [
-               "eval pages/error-in-the-browser-global-scope.js (2:9)",
+               "pages/error-in-the-browser-global-scope.js (2:9)",
                "<FIXME-next-dist-dir>",
              ],
            }

--- a/test/development/pages-dir/client-navigation/rendering.test.ts
+++ b/test/development/pages-dir/client-navigation/rendering.test.ts
@@ -273,11 +273,11 @@ describe('Client Navigation rendering', () => {
            "description": "aa is not defined",
            "environmentLabel": null,
            "label": "Runtime ReferenceError",
-           "source": "pages/error-in-the-global-scope.js (1:1) @ {module evaluation}
+           "source": "pages/error-in-the-global-scope.js (1:1)
          > 1 | aa = 10 //eslint-disable-line
              | ^",
            "stack": [
-             "{module evaluation} pages/error-in-the-global-scope.js (1:1)",
+             "pages/error-in-the-global-scope.js (1:1)",
              "<FIXME-next-dist-dir>",
            ],
          }
@@ -288,11 +288,11 @@ describe('Client Navigation rendering', () => {
            "description": "aa is not defined",
            "environmentLabel": null,
            "label": "Runtime ReferenceError",
-           "source": "pages/error-in-the-global-scope.js (1:1) @ eval
+           "source": "pages/error-in-the-global-scope.js (1:1)
          > 1 | aa = 10 //eslint-disable-line
              | ^",
            "stack": [
-             "eval pages/error-in-the-global-scope.js (1:1)",
+             "pages/error-in-the-global-scope.js (1:1)",
              "<FIXME-next-dist-dir>",
              "<FIXME-next-dist-dir>",
              "<FIXME-next-dist-dir>",

--- a/test/e2e/app-dir/cache-components-allow-otel-spans/cache-components-allow-otel-spans.test.ts
+++ b/test/e2e/app-dir/cache-components-allow-otel-spans/cache-components-allow-otel-spans.test.ts
@@ -31,11 +31,11 @@ describe('hello-world', () => {
                   "description": "A Cache Function (\`use cache\`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.",
                   "environmentLabel": "Cache",
                   "label": "Console Error",
-                  "source": "app/traced-work.tsx (26:19) @ eval
+                  "source": "app/traced-work.tsx (26:19)
                 > 26 |     return tracer.startActiveSpan('span-active-span', fn)
                      |                   ^",
                   "stack": [
-                    "eval app/traced-work.tsx (26:19)",
+                    "app/traced-work.tsx (26:19)",
                     "Inner app/traced-work.tsx (97:26)",
                     "Page <anonymous>",
                   ],
@@ -79,11 +79,11 @@ describe('hello-world', () => {
                   "description": "A Cache Function (\`use cache\`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.",
                   "environmentLabel": "Cache",
                   "label": "Console Error",
-                  "source": "app/traced-work.tsx (26:19) @ eval
+                  "source": "app/traced-work.tsx (26:19)
                 > 26 |     return tracer.startActiveSpan('span-active-span', fn)
                      |                   ^",
                   "stack": [
-                    "eval app/traced-work.tsx (26:19)",
+                    "app/traced-work.tsx (26:19)",
                     "Inner app/traced-work.tsx (97:26)",
                     "Page <anonymous>",
                   ],
@@ -127,11 +127,11 @@ describe('hello-world', () => {
                   "description": "A Cache Function (\`use cache\`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.",
                   "environmentLabel": "Prerender",
                   "label": "Console Error",
-                  "source": "app/traced-work.tsx (26:19) @ eval
+                  "source": "app/traced-work.tsx (26:19)
                 > 26 |     return tracer.startActiveSpan('span-active-span', fn)
                      |                   ^",
                   "stack": [
-                    "eval app/traced-work.tsx (26:19)",
+                    "app/traced-work.tsx (26:19)",
                     "Inner app/traced-work.tsx (97:26)",
                     "CachedInnerTraceActiveSpan app/traced-work.tsx (104:9)",
                     "Page app/[slug]/server/page.tsx (29:7)",
@@ -177,11 +177,11 @@ describe('hello-world', () => {
                   "description": "A Cache Function (\`use cache\`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.",
                   "environmentLabel": "Prerender",
                   "label": "Console Error",
-                  "source": "app/traced-work.tsx (26:19) @ eval
+                  "source": "app/traced-work.tsx (26:19)
                 > 26 |     return tracer.startActiveSpan('span-active-span', fn)
                      |                   ^",
                   "stack": [
-                    "eval app/traced-work.tsx (26:19)",
+                    "app/traced-work.tsx (26:19)",
                     "Inner app/traced-work.tsx (97:26)",
                     "CachedInnerTraceActiveSpan app/traced-work.tsx (104:9)",
                     "Page app/[slug]/server/page.tsx (29:7)",

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -2425,11 +2425,11 @@ describe('Cache Components Errors', () => {
                  "description": ""use cache: private" must not be used within \`unstable_cache()\`.",
                  "environmentLabel": null,
                  "label": "Runtime Error",
-                 "source": "app/use-cache-private-in-unstable-cache/page.tsx (21:38) @ {module evaluation}
+                 "source": "app/use-cache-private-in-unstable-cache/page.tsx (21:38)
                > 21 | const getCachedData = unstable_cache(async () => {
                     |                                      ^",
                  "stack": [
-                   "{module evaluation} app/use-cache-private-in-unstable-cache/page.tsx (21:38)",
+                   "app/use-cache-private-in-unstable-cache/page.tsx (21:38)",
                    "<FIXME-file-protocol>",
                    "<FIXME-file-protocol>",
                    "<FIXME-next-dist-dir>",
@@ -2442,11 +2442,11 @@ describe('Cache Components Errors', () => {
                  "description": ""use cache: private" must not be used within \`unstable_cache()\`.",
                  "environmentLabel": null,
                  "label": "Runtime Error",
-                 "source": "app/use-cache-private-in-unstable-cache/page.tsx (21:38) @ eval
+                 "source": "app/use-cache-private-in-unstable-cache/page.tsx (21:38)
                > 21 | const getCachedData = unstable_cache(async () => {
                     |                                      ^",
                  "stack": [
-                   "eval app/use-cache-private-in-unstable-cache/page.tsx (21:38)",
+                   "app/use-cache-private-in-unstable-cache/page.tsx (21:38)",
                    "<FIXME-next-dist-dir>",
                    "<FIXME-next-dist-dir>",
                  ],
@@ -2458,11 +2458,11 @@ describe('Cache Components Errors', () => {
                  "description": ""use cache: private" must not be used within \`unstable_cache()\`.",
                  "environmentLabel": null,
                  "label": "Runtime Error",
-                 "source": "app/use-cache-private-in-unstable-cache/page.tsx (21:38) @ eval
+                 "source": "app/use-cache-private-in-unstable-cache/page.tsx (21:38)
                > 21 | const getCachedData = unstable_cache(async () => {
                     |                                      ^",
                  "stack": [
-                   "eval app/use-cache-private-in-unstable-cache/page.tsx (21:38)",
+                   "app/use-cache-private-in-unstable-cache/page.tsx (21:38)",
                    "<FIXME-next-dist-dir>",
                  ],
                }
@@ -2486,7 +2486,7 @@ describe('Cache Components Errors', () => {
               if (isDebugPrerender) {
                 expect(output).toMatchInlineSnapshot(`
                  "Error: "use cache: private" must not be used within \`unstable_cache()\`.
-                     at __TURBOPACK__module__evaluation__ (bundler:///app/use-cache-private-in-unstable-cache/page.tsx:21:38)
+                     at bundler:///app/use-cache-private-in-unstable-cache/page.tsx:21:38
                      at a (<next-dist-dir>)
                      at b (<next-dist-dir>)
                    19 | }
@@ -2505,7 +2505,7 @@ describe('Cache Components Errors', () => {
               } else {
                 expect(output).toMatchInlineSnapshot(`
                  "Error: "use cache: private" must not be used within \`unstable_cache()\`.
-                     at __TURBOPACK__module__evaluation__ (bundler:///app/use-cache-private-in-unstable-cache/page.tsx:21:38)
+                     at bundler:///app/use-cache-private-in-unstable-cache/page.tsx:21:38
                      at a (<next-dist-dir>)
                    19 | }
                    20 |
@@ -2569,11 +2569,11 @@ describe('Cache Components Errors', () => {
                  "description": ""use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".",
                  "environmentLabel": null,
                  "label": "Runtime Error",
-                 "source": "app/use-cache-private-in-use-cache/page.tsx (15:1) @ {module evaluation}
+                 "source": "app/use-cache-private-in-use-cache/page.tsx (15:1)
                > 15 | async function Private() {
                     | ^",
                  "stack": [
-                   "{module evaluation} app/use-cache-private-in-use-cache/page.tsx (15:1)",
+                   "app/use-cache-private-in-use-cache/page.tsx (15:1)",
                    "<FIXME-file-protocol>",
                    "<FIXME-file-protocol>",
                    "<FIXME-next-dist-dir>",
@@ -2586,11 +2586,11 @@ describe('Cache Components Errors', () => {
                  "description": ""use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".",
                  "environmentLabel": null,
                  "label": "Runtime Error",
-                 "source": "app/use-cache-private-in-use-cache/page.tsx (15:1) @ eval
+                 "source": "app/use-cache-private-in-use-cache/page.tsx (15:1)
                > 15 | async function Private() {
                     | ^",
                  "stack": [
-                   "eval app/use-cache-private-in-use-cache/page.tsx (15:1)",
+                   "app/use-cache-private-in-use-cache/page.tsx (15:1)",
                    "<FIXME-next-dist-dir>",
                    "<FIXME-next-dist-dir>",
                  ],
@@ -2602,11 +2602,11 @@ describe('Cache Components Errors', () => {
                  "description": ""use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".",
                  "environmentLabel": null,
                  "label": "Runtime Error",
-                 "source": "app/use-cache-private-in-use-cache/page.tsx (15:1) @ eval
+                 "source": "app/use-cache-private-in-use-cache/page.tsx (15:1)
                > 15 | async function Private() {
                     | ^",
                  "stack": [
-                   "eval app/use-cache-private-in-use-cache/page.tsx (15:1)",
+                   "app/use-cache-private-in-use-cache/page.tsx (15:1)",
                    "<FIXME-next-dist-dir>",
                  ],
                }
@@ -2631,7 +2631,7 @@ describe('Cache Components Errors', () => {
               if (isDebugPrerender) {
                 expect(output).toMatchInlineSnapshot(`
                  "Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
-                     at __TURBOPACK__module__evaluation__ (bundler:///app/use-cache-private-in-use-cache/page.tsx:15:1)
+                     at bundler:///app/use-cache-private-in-use-cache/page.tsx:15:1
                      at a (<next-dist-dir>)
                      at b (<next-dist-dir>)
                    13 | }
@@ -2642,7 +2642,7 @@ describe('Cache Components Errors', () => {
                    17 |
                    18 |   return <p>Private</p>
                  Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
-                     at __TURBOPACK__module__evaluation__ (bundler:///app/use-cache-private-in-use-cache/page.tsx:15:1)
+                     at bundler:///app/use-cache-private-in-use-cache/page.tsx:15:1
                      at c (<next-dist-dir>)
                      at d (<next-dist-dir>)
                    13 | }
@@ -2661,8 +2661,8 @@ describe('Cache Components Errors', () => {
               } else {
                 expect(output).toMatchInlineSnapshot(`
                  "Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
-                     at __TURBOPACK__module__evaluation__ (bundler:///app/use-cache-private-in-use-cache/page.tsx:15:1)
-                     at __TURBOPACK__module__evaluation__ (bundler:///app/use-cache-private-in-use-cache/page.tsx:15:16)
+                     at bundler:///app/use-cache-private-in-use-cache/page.tsx:15:1
+                     at bundler:///app/use-cache-private-in-use-cache/page.tsx:15:16
                      at a (<next-dist-dir>)
                    13 | }
                    14 |
@@ -2672,8 +2672,8 @@ describe('Cache Components Errors', () => {
                    17 |
                    18 |   return <p>Private</p>
                  Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
-                     at __TURBOPACK__module__evaluation__ (bundler:///app/use-cache-private-in-use-cache/page.tsx:15:1)
-                     at __TURBOPACK__module__evaluation__ (bundler:///app/use-cache-private-in-use-cache/page.tsx:15:16)
+                     at bundler:///app/use-cache-private-in-use-cache/page.tsx:15:1
+                     at bundler:///app/use-cache-private-in-use-cache/page.tsx:15:16
                      at b (<next-dist-dir>)
                    13 | }
                    14 |

--- a/test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts
+++ b/test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts
@@ -89,7 +89,7 @@ describe('non-root-project-monorepo', () => {
         if (isTurbopack) {
           // TODO the function name should be hidden
           expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-           "app/separate-file.ts (1:7) @ {module evaluation}
+           "app/separate-file.ts (1:7)
 
            > 1 | throw new Error('Expected error')
                |       ^
@@ -97,7 +97,7 @@ describe('non-root-project-monorepo', () => {
           `)
           expect(await getRedboxCallStack(browser)).toMatchInlineSnapshot(`
            [
-             "{module evaluation} app/separate-file.ts (1:7)",
+             "app/separate-file.ts (1:7)",
              "innerArrowFunction app/source-maps-rsc/page.tsx (13:28)",
              "innerFunction app/source-maps-rsc/page.tsx (10:3)",
              "Page app/source-maps-rsc/page.tsx (4:5)",
@@ -106,7 +106,7 @@ describe('non-root-project-monorepo', () => {
         } else {
           // TODO the function name is incorrect
           expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-           "app/separate-file.ts (1:11) @ eval
+           "app/separate-file.ts (1:11)
 
            > 1 | throw new Error('Expected error')
                |           ^
@@ -116,7 +116,7 @@ describe('non-root-project-monorepo', () => {
           // TODO(veil): https://linear.app/vercel/issue/NDX-677
           expect(await getRedboxCallStack(browser)).toMatchInlineSnapshot(`
            [
-             "eval app/separate-file.ts (1:11)",
+             "app/separate-file.ts (1:11)",
              "<FIXME-file-protocol>",
              "innerArrowFunction app/source-maps-rsc/page.tsx (14:3)",
              "innerFunction app/source-maps-rsc/page.tsx (10:3)",
@@ -134,7 +134,7 @@ describe('non-root-project-monorepo', () => {
         if (isTurbopack) {
           // TODO the function name should be hidden
           expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-           "app/separate-file.ts (1:7) @ {module evaluation}
+           "app/separate-file.ts (1:7)
 
            > 1 | throw new Error('Expected error')
                |       ^
@@ -142,7 +142,7 @@ describe('non-root-project-monorepo', () => {
           `)
           expect(await getRedboxCallStack(browser)).toMatchInlineSnapshot(`
            [
-             "{module evaluation} app/separate-file.ts (1:7)",
+             "app/separate-file.ts (1:7)",
              "innerArrowFunction app/source-maps-ssr/page.tsx (15:28)",
              "innerFunction app/source-maps-ssr/page.tsx (12:3)",
              "Page app/source-maps-ssr/page.tsx (6:5)",
@@ -151,7 +151,7 @@ describe('non-root-project-monorepo', () => {
         } else {
           // TODO the function name should be hidden
           expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-            "app/separate-file.ts (1:7) @ eval
+            "app/separate-file.ts (1:7)
 
             > 1 | throw new Error('Expected error')
                 |       ^
@@ -160,7 +160,7 @@ describe('non-root-project-monorepo', () => {
           // TODO(veil): webpack runtime code shouldn't be included in stack trace (see https://linear.app/vercel/issue/NDX-509)
           expect(await getRedboxCallStack(browser)).toMatchInlineSnapshot(`
            [
-             "eval app/separate-file.ts (1:7)",
+             "app/separate-file.ts (1:7)",
              "<FIXME-next-dist-dir>",
              "innerArrowFunction app/source-maps-ssr/page.tsx (16:3)",
              "innerFunction app/source-maps-ssr/page.tsx (12:3)",
@@ -178,7 +178,7 @@ describe('non-root-project-monorepo', () => {
         if (isTurbopack) {
           // TODO the function name should be hidden
           expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-           "app/separate-file.ts (1:7) @ {module evaluation}
+           "app/separate-file.ts (1:7)
 
            > 1 | throw new Error('Expected error')
                |       ^
@@ -186,7 +186,7 @@ describe('non-root-project-monorepo', () => {
           `)
           expect(await getRedboxCallStack(browser)).toMatchInlineSnapshot(`
            [
-             "{module evaluation} app/separate-file.ts (1:7)",
+             "app/separate-file.ts (1:7)",
              "innerArrowFunction app/source-maps-client/page.tsx (16:28)",
              "innerFunction app/source-maps-client/page.tsx (13:3)",
              "effectCallback app/source-maps-client/page.tsx (7:5)",
@@ -195,7 +195,7 @@ describe('non-root-project-monorepo', () => {
         } else {
           // TODO the function name should be hidden
           expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-            "app/separate-file.ts (1:7) @ eval
+            "app/separate-file.ts (1:7)
 
             > 1 | throw new Error('Expected error')
                 |       ^
@@ -204,7 +204,7 @@ describe('non-root-project-monorepo', () => {
           // TODO(veil): webpack runtime code shouldn't be included in stack trace (see https://linear.app/vercel/issue/NDX-509)
           expect(await getRedboxCallStack(browser)).toMatchInlineSnapshot(`
            [
-             "eval app/separate-file.ts (1:7)",
+             "app/separate-file.ts (1:7)",
              "<FIXME-next-dist-dir>",
              "innerArrowFunction app/source-maps-client/page.tsx (17:3)",
              "innerFunction app/source-maps-client/page.tsx (13:3)",

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -448,18 +448,17 @@ describe('app-dir - server source maps', () => {
           '' +
             '\nError: module-evaluation' +
             // TODO(veil): Should map to no name like you'd get with native stacks without a bundler.
-            '\n    at __TURBOPACK__module__evaluation__ (app/module-evaluation/module.js:1:22)' +
+            '\n    at app/module-evaluation/module.js:1:22' +
             // TODO(veil): Added frames from bundler should be sourcemapped (https://linear.app/vercel/issue/NDX-509/)
-            '\n    at __TURBOPACK__module__evaluation__ (app/module-evaluation/page.js:1:1)' +
-            '\n    at __TURBOPACK__module__evaluation__ (.next'
+            '\n    at app/module-evaluation/page.js:1:1' +
+            '\n    at .next'
         )
       } else {
         expect(cliOutput).toContain(
           '' +
             '\nError: module-evaluation' +
-            // TODO(veil): Should map to no name like you'd get with native stacks without a bundler.
             // TODO(veil): Location should be sourcemapped
-            '\n    at eval (app/module-evaluation/module.js:1:22)' +
+            '\n    at app/module-evaluation/module.js:1:22' +
             // TODO(veil): Added frames from bundler should be sourcemapped (https://linear.app/vercel/issue/NDX-509/)
             '\n    at <unknown> (rsc)/.'
         )
@@ -477,13 +476,13 @@ describe('app-dir - server source maps', () => {
            "description": "module-evaluation",
            "environmentLabel": "Prerender",
            "label": "Console Error",
-           "source": "app/module-evaluation/module.js (1:22) @ {module evaluation}
+           "source": "app/module-evaluation/module.js (1:22)
          > 1 | export const error = new Error('module-evaluation')
              |                      ^",
            "stack": [
-             "{module evaluation} app/module-evaluation/module.js (1:22)",
-             "{module evaluation} app/module-evaluation/page.js (1:1)",
-             "{module evaluation} app/module-evaluation/page.js (6:1)",
+             "app/module-evaluation/module.js (1:22)",
+             "app/module-evaluation/page.js (1:1)",
+             "app/module-evaluation/page.js (6:1)",
              "<FIXME-next-dist-dir>",
              "Page <anonymous>",
            ],
@@ -495,13 +494,13 @@ describe('app-dir - server source maps', () => {
            "description": "module-evaluation",
            "environmentLabel": "Prerender",
            "label": "Console Error",
-           "source": "app/module-evaluation/module.js (1:22) @ eval
+           "source": "app/module-evaluation/module.js (1:22)
          > 1 | export const error = new Error('module-evaluation')
              |                      ^",
            "stack": [
-             "eval app/module-evaluation/module.js (1:22)",
+             "app/module-evaluation/module.js (1:22)",
              "<FIXME-file-protocol>",
-             "eval about:/Prerender/webpack-internal:///(rsc)/app/module-evaluation/page.js (5:65)",
+             "about:/Prerender/webpack-internal:///(rsc)/app/module-evaluation/page.js (5:65)",
              "<FIXME-file-protocol>",
              "Function.all <anonymous>",
              "Function.all <anonymous>",
@@ -515,7 +514,7 @@ describe('app-dir - server source maps', () => {
         expect(normalizeCliOutput(next.cliOutput)).toContain(
           '' +
             '\nError: module-evaluation' +
-            '\n    at __TURBOPACK__module__evaluation__ (bundler:///app/module-evaluation/module.js:1:22)' +
+            '\n    at bundler:///app/module-evaluation/module.js:1:22' +
             // TODO(veil): Turbopack internals. Feel free to update. Tracked in https://linear.app/vercel/issue/NEXT-4362
             '\n    at Object.<anonymous>'
         )
@@ -605,10 +604,10 @@ describe('app-dir - server source maps', () => {
          > 6 |   runHiddenSetOfSetsInternal('rsc-anonymous-stack-frame-sandwich: internal')
              |                             ^",
              "stack": [
-               "eval webpack-internal:/(rsc)/internal-pkg/ignored.ts (18:54)",
-               "eval webpack-internal:/(rsc)/internal-pkg/ignored.ts (12:7)",
+               "webpack-internal:/(rsc)/internal-pkg/ignored.ts (18:54)",
+               "webpack-internal:/(rsc)/internal-pkg/ignored.ts (12:7)",
                "Set.forEach <anonymous>",
-               "eval webpack-internal:/(rsc)/internal-pkg/ignored.ts (11:9)",
+               "webpack-internal:/(rsc)/internal-pkg/ignored.ts (11:9)",
                "Set.forEach <anonymous>",
                "runSetOfSets webpack-internal:/(rsc)/internal-pkg/ignored.ts (10:13)",
                "runHiddenSetOfSets webpack-internal:/(rsc)/internal-pkg/ignored.ts (18:3)",
@@ -706,10 +705,10 @@ describe('app-dir - server source maps', () => {
          >  7 |   runHiddenSetOfSetsInternal('ssr-anonymous-stack-frame-sandwich: internal')
               |                             ^",
              "stack": [
-               "eval sourcemapped.ts (18:43)",
-               "eval sourcemapped.ts (11:7)",
+               "sourcemapped.ts (18:43)",
+               "sourcemapped.ts (11:7)",
                "Set.forEach <anonymous>",
-               "eval sourcemapped.ts (10:9)",
+               "sourcemapped.ts (10:9)",
                "Set.forEach <anonymous>",
                "runSetOfSets sourcemapped.ts (9:13)",
                "runHiddenSetOfSets sourcemapped.ts (17:3)",

--- a/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
+++ b/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
@@ -99,13 +99,13 @@ describe('use-cache-close-over-function', () => {
               '\n  [function fn]' +
               '\n   ^^^^^^^^^^^' +
               '\n    at createCachedFn (app/server/page.tsx:6:3)' +
-              '\n    at __TURBOPACK__module__evaluation__ (app/server/page.tsx:12:24)'
+              '\n    at app/server/page.tsx:12:24'
           : '' +
               'Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.' +
               '\n  [function fn]' +
               '\n   ^^^^^^^^^^^' +
               '\n    at createCachedFn (app/server/page.tsx:6:3)' +
-              '\n    at eval (app/server/page.tsx:12:24)' +
+              '\n    at app/server/page.tsx:12:24' +
               // TODO(veil): Should be source-mapped.
               '\n    at <unknown> (rsc)'
       )

--- a/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
@@ -48,7 +48,7 @@ describe('use-cache-hanging-inputs', () => {
 
         if (isTurbopack) {
           expect(errorSource).toMatchInlineSnapshot(`
-           "app/search-params/page.tsx (3:16) @ {module evaluation}
+           "app/search-params/page.tsx (3:16)
 
              1 | 'use cache'
              2 |
@@ -63,7 +63,7 @@ describe('use-cache-hanging-inputs', () => {
     at __TURBOPACK__module__evaluation__`)
         } else {
           expect(errorSource).toMatchInlineSnapshot(`
-           "app/search-params/page.tsx (3:16) @ eval
+           "app/search-params/page.tsx (3:16)
 
              1 | 'use cache'
              2 |
@@ -75,7 +75,7 @@ describe('use-cache-hanging-inputs', () => {
           `)
 
           expect(cliOutput).toContain(`Error: ${expectedTimeoutErrorMessage}
-    at eval (app/search-params/page.tsx:3:16)`)
+    at app/search-params/page.tsx:3:16`)
         }
       }, 180_000)
     })
@@ -102,7 +102,7 @@ describe('use-cache-hanging-inputs', () => {
 
         if (isTurbopack) {
           expect(errorSource).toMatchInlineSnapshot(`
-           "app/search-params-caught/page.tsx (1:1) @ {module evaluation}
+           "app/search-params-caught/page.tsx (1:1)
 
            > 1 | async function getSearchParam({
                | ^
@@ -115,7 +115,7 @@ describe('use-cache-hanging-inputs', () => {
     at __TURBOPACK__module__evaluation__`)
         } else {
           expect(errorSource).toMatchInlineSnapshot(`
-           "app/search-params-caught/page.tsx (1:1) @ eval
+           "app/search-params-caught/page.tsx (1:1)
 
            > 1 | async function getSearchParam({
                | ^
@@ -125,7 +125,7 @@ describe('use-cache-hanging-inputs', () => {
           `)
 
           expect(cliOutput).toContain(`Error: ${expectedTimeoutErrorMessage}
-    at eval (app/search-params-caught/page.tsx:1:1)`)
+    at app/search-params-caught/page.tsx:1:1`)
         }
       }, 180_000)
     })
@@ -165,7 +165,7 @@ describe('use-cache-hanging-inputs', () => {
 
         if (isTurbopack) {
           expect(errorSource).toMatchInlineSnapshot(`
-           "app/uncached-promise/page.tsx (10:13) @ {module evaluation}
+           "app/uncached-promise/page.tsx (10:13)
 
               8 | }
               9 |
@@ -180,7 +180,7 @@ describe('use-cache-hanging-inputs', () => {
     at __TURBOPACK__module__evaluation__`)
         } else {
           expect(errorSource).toMatchInlineSnapshot(`
-           "app/uncached-promise/page.tsx (10:13) @ eval
+           "app/uncached-promise/page.tsx (10:13)
 
               8 | }
               9 |
@@ -192,7 +192,7 @@ describe('use-cache-hanging-inputs', () => {
           `)
 
           expect(cliOutput).toContain(`Error: ${expectedTimeoutErrorMessage}
-    at eval (app/uncached-promise/page.tsx:10:13)`)
+    at app/uncached-promise/page.tsx:10:13`)
         }
       }, 180_000)
     })
@@ -219,7 +219,7 @@ describe('use-cache-hanging-inputs', () => {
 
         if (isTurbopack) {
           expect(errorSource).toMatchInlineSnapshot(`
-           "app/uncached-promise-nested/page.tsx (16:1) @ {module evaluation}
+           "app/uncached-promise-nested/page.tsx (16:1)
 
              14 | }
              15 |
@@ -234,7 +234,7 @@ describe('use-cache-hanging-inputs', () => {
     at __TURBOPACK__module__evaluation__`)
         } else {
           expect(errorSource).toMatchInlineSnapshot(`
-           "app/uncached-promise-nested/page.tsx (16:1) @ eval
+           "app/uncached-promise-nested/page.tsx (16:1)
 
              14 | }
              15 |
@@ -246,7 +246,7 @@ describe('use-cache-hanging-inputs', () => {
           `)
 
           expect(cliOutput).toContain(`Error: ${expectedTimeoutErrorMessage}
-    at eval (app/uncached-promise-nested/page.tsx:16:1)`)
+    at app/uncached-promise-nested/page.tsx:16:1`)
         }
       }, 180_000)
     })
@@ -274,7 +274,7 @@ describe('use-cache-hanging-inputs', () => {
 
         if (isTurbopack) {
           expect(errorSource).toMatchInlineSnapshot(`
-           "app/bound-args/page.tsx (13:15) @ {module evaluation}
+           "app/bound-args/page.tsx (13:15)
 
              11 |   const uncachedDataPromise = fetchUncachedData()
              12 |
@@ -289,7 +289,7 @@ describe('use-cache-hanging-inputs', () => {
     at __TURBOPACK__module__evaluation__`)
         } else {
           expect(errorSource).toMatchInlineSnapshot(`
-            "app/bound-args/page.tsx (13:15) @ eval
+            "app/bound-args/page.tsx (13:15)
 
               11 |   const uncachedDataPromise = fetchUncachedData()
               12 |
@@ -301,7 +301,7 @@ describe('use-cache-hanging-inputs', () => {
           `)
 
           expect(cliOutput).toContain(`Error: ${expectedTimeoutErrorMessage}
-    at eval (app/bound-args/page.tsx:13:15)`)
+    at app/bound-args/page.tsx:13:15`)
         }
       }, 180_000)
     })

--- a/test/integration/edge-runtime-dynamic-code/test/index.test.js
+++ b/test/integration/edge-runtime-dynamic-code/test/index.test.js
@@ -117,7 +117,7 @@ describe.each([
                     '\n    at middleware (../../test/integration/edge-runtime-dynamic-code/middleware.js:12:54)' +
                     // Next.js internal frame. Feel free to adjust.
                     // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-                    '\n    at eval (../packages/next/dist'
+                    '\n    at ../packages/next/dist'
             )
           } else {
             expect(output).toContain(

--- a/test/lib/add-redbox-matchers.ts
+++ b/test/lib/add-redbox-matchers.ts
@@ -100,7 +100,7 @@ async function createErrorSnapshot(
   // Here we focus on the cursor position of the top most frame
   // From
   //
-  // pages/index.js (3:11) @ eval
+  // pages/index.js (3:11)
   //
   //   1 | export default function Page() {
   //   2 |   [1, 2, 3].map(() => {

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1740,7 +1740,7 @@ export async function getStackFramesContent(browser) {
         const source = sourceEl ? await sourceEl.innerText() : ''
 
         if (!functionName) {
-          return ''
+          return source ? `at ${source}` : ''
         }
         return `at ${functionName} (${source})`
       })


### PR DESCRIPTION
### What?

Hide confusing method names like `@ eval` `@ {module evaluation}` `@ anonymous`. They don't give any value and can overwhelm the user

Closes PACK-5225