### PR TITLE
Dynamic IO: Improve error handling

### DIFF
--- a/packages/next/src/server/app-render/prospective-render-utils.ts
+++ b/packages/next/src/server/app-render/prospective-render-utils.ts
@@ -1,7 +1,14 @@
+import { getDigestForWellKnownError } from './create-error-handler'
+
 export function printDebugThrownValueForProspectiveRender(
   thrownValue: unknown,
   route: string
 ) {
+  // We don't need to print well-known Next.js errors.
+  if (getDigestForWellKnownError(thrownValue)) {
+    return
+  }
+
   let message: undefined | string
   if (
     typeof thrownValue === 'object' &&

--- a/test/development/app-dir/dynamic-io-dev-errors/app/top-level-error/page.tsx
+++ b/test/development/app-dir/dynamic-io-dev-errors/app/top-level-error/page.tsx
@@ -1,0 +1,5 @@
+export default async function Page() {
+  throw new Error('Kaputt!')
+
+  return <p>This page always errors.</p>
+}

--- a/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
+++ b/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
@@ -43,6 +43,21 @@ describe('Dynamic IO Dev Errors', () => {
     )
   })
 
+  it('should not log unhandled rejections for persistently thrown top-level errors', async () => {
+    const cliOutputLength = next.cliOutput.length
+    const res = await next.fetch('/top-level-error')
+    expect(res.status).toBe(500)
+
+    await retry(() => {
+      const cliOutput = next.cliOutput.slice(cliOutputLength)
+      expect(cliOutput).toContain('GET /top-level-error 500')
+    })
+
+    expect(next.cliOutput.slice(cliOutputLength)).not.toContain(
+      'unhandledRejection'
+    )
+  })
+
   // NOTE: when update this snapshot, use `pnpm build` in packages/next to avoid next source code get mapped to source.
   it('should display error when component accessed data without suspense boundary', async () => {
     const outputIndex = next.cliOutput.length

--- a/test/e2e/app-dir/dynamic-io/app/cases/not-found/not-found.tsx
+++ b/test/e2e/app-dir/dynamic-io/app/cases/not-found/not-found.tsx
@@ -1,0 +1,14 @@
+import { getSentinelValue } from '../../getSentinelValue'
+
+export default function NotFound() {
+  return (
+    <>
+      <p>
+        This 404 page is made up of entirely static content in a sync function.
+      </p>
+      <p>With PPR this page should be entirely static.</p>
+      <p>Without PPR this page should be static.</p>
+      <div id="page">{getSentinelValue()}</div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io/app/cases/not-found/page.tsx
+++ b/test/e2e/app-dir/dynamic-io/app/cases/not-found/page.tsx
@@ -1,0 +1,7 @@
+import { notFound } from 'next/navigation'
+
+export default async function Page() {
+  notFound()
+
+  return <p>This will never render</p>
+}

--- a/test/e2e/app-dir/use-cache/app/(no-suspense)/not-found/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(no-suspense)/not-found/page.tsx
@@ -1,4 +1,3 @@
-// TODO: This should not need the suspense boundary in the root layout.
 'use cache'
 
 import { notFound } from 'next/navigation'


### PR DESCRIPTION
This PR improves error handling when `dynamicIO` is enabled.

- prevents well-known errors from being logged
- avoids unhandled rejections being logged during prerendering in dev mode
- avoids hanging responses when well-known or unexpected errors are thrown
- ensures pages with `notFound` used in the top level can be prerendered statically

addresses https://github.com/vercel/next.js/pull/73210#issuecomment-2515179765
closes NAR-48