### PR TITLE
[Turbopack] replace EnvLayer with a faster filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9262,6 +9262,7 @@ dependencies = [
  "crossbeam-channel",
  "once_cell",
  "postcard",
+ "rustc-hash 1.1.0",
  "serde",
  "tokio",
  "tracing",

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -318,7 +318,7 @@ pub async fn project_new(
 
         let subscriber = Registry::default();
 
-        let subscriber = subscriber.with(FilterLayer::try_new(trace).unwrap());
+        let subscriber = subscriber.with(FilterLayer::try_new(&trace).unwrap());
         let dist_dir = options.dist_dir.clone();
 
         let internal_dir = PathBuf::from(&options.project_path).join(dist_dir);

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -22,7 +22,7 @@ use once_cell::sync::Lazy;
 use rand::Rng;
 use tokio::{io::AsyncWriteExt, time::Instant};
 use tracing::Instrument;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Registry};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     get_effects, Completion, Effects, ReadRef, ResolvedVc, TransientInstance, UpdateInfo, Vc,
@@ -41,6 +41,7 @@ use turbopack_core::{
 use turbopack_ecmascript_hmr_protocol::{ClientUpdateInstruction, ResourceIdentifier};
 use turbopack_trace_utils::{
     exit::{ExitHandler, ExitReceiver},
+    filter_layer::FilterLayer,
     raw_trace::RawTraceLayer,
     trace_writer::TraceWriter,
 };
@@ -317,7 +318,7 @@ pub async fn project_new(
 
         let subscriber = Registry::default();
 
-        let subscriber = subscriber.with(EnvFilter::builder().parse(trace).unwrap());
+        let subscriber = subscriber.with(FilterLayer::try_new(trace).unwrap());
         let dist_dir = options.dist_dir.clone();
 
         let internal_dir = PathBuf::from(&options.project_path).join(dist_dir);

--- a/crates/next-build-test/src/main.rs
+++ b/crates/next-build-test/src/main.rs
@@ -101,7 +101,7 @@ fn main() {
 
                         let subscriber = Registry::default();
 
-                        let subscriber = subscriber.with(FilterLayer::try_new(trace).unwrap());
+                        let subscriber = subscriber.with(FilterLayer::try_new(&trace).unwrap());
                         let trace_file = "trace.log";
                         let trace_writer = std::fs::File::create(trace_file).unwrap();
                         let (trace_writer, guard) = TraceWriter::new(trace_writer);

--- a/crates/next-build-test/src/main.rs
+++ b/crates/next-build-test/src/main.rs
@@ -6,11 +6,13 @@ use next_core::tracing_presets::{
     TRACING_NEXT_OVERVIEW_TARGETS, TRACING_NEXT_TARGETS, TRACING_NEXT_TURBOPACK_TARGETS,
     TRACING_NEXT_TURBO_TASKS_TARGETS,
 };
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Registry};
 use turbo_tasks::TurboTasks;
 use turbo_tasks_malloc::TurboMalloc;
 use turbo_tasks_memory::MemoryBackend;
-use turbopack_trace_utils::{exit::ExitGuard, raw_trace::RawTraceLayer, trace_writer::TraceWriter};
+use turbopack_trace_utils::{
+    exit::ExitGuard, filter_layer::FilterLayer, raw_trace::RawTraceLayer, trace_writer::TraceWriter,
+};
 
 #[global_allocator]
 static ALLOC: TurboMalloc = TurboMalloc;
@@ -99,8 +101,7 @@ fn main() {
 
                         let subscriber = Registry::default();
 
-                        let subscriber =
-                            subscriber.with(EnvFilter::builder().parse(trace).unwrap());
+                        let subscriber = subscriber.with(FilterLayer::try_new(trace).unwrap());
                         let trace_file = "trace.log";
                         let trace_writer = std::fs::File::create(trace_file).unwrap();
                         let (trace_writer, guard) = TraceWriter::new(trace_writer);

--- a/turbopack/crates/turbopack-cli/src/main.rs
+++ b/turbopack/crates/turbopack-cli/src/main.rs
@@ -5,11 +5,12 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Registry};
 use turbo_tasks_malloc::TurboMalloc;
 use turbopack_cli::{arguments::Arguments, register};
 use turbopack_trace_utils::{
     exit::ExitHandler,
+    filter_layer::FilterLayer,
     raw_trace::RawTraceLayer,
     trace_writer::TraceWriter,
     tracing_presets::{
@@ -55,7 +56,7 @@ async fn main_inner(args: Arguments) -> Result<()> {
 
         let subscriber = Registry::default();
 
-        let subscriber = subscriber.with(EnvFilter::builder().parse(trace).unwrap());
+        let subscriber = subscriber.with(FilterLayer::try_new(&trace).unwrap());
 
         let internal_dir = args
             .dir()

--- a/turbopack/crates/turbopack-trace-utils/Cargo.toml
+++ b/turbopack/crates/turbopack-trace-utils/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = { workspace = true }
 crossbeam-channel = { workspace = true }
 once_cell = { workspace = true }
 postcard = { workspace = true, features = ["alloc", "use-std"] }
+rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["macros", "signal", "sync", "rt"] }
 tracing = { workspace = true }

--- a/turbopack/crates/turbopack-trace-utils/src/filter_layer.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/filter_layer.rs
@@ -1,0 +1,47 @@
+use std::{collections::HashMap, str::FromStr};
+
+use anyhow::{Context, Result};
+use tracing::{level_filters::LevelFilter, Subscriber};
+use tracing_subscriber::Layer;
+
+pub struct FilterLayer {
+    config: HashMap<String, LevelFilter>,
+}
+
+impl FilterLayer {
+    pub fn try_new(config: &str) -> Result<Self> {
+        let mut map = HashMap::new();
+        for entry in config.split(',') {
+            if entry.is_empty() {
+                continue;
+            }
+            let mut parts = entry.splitn(2, '=');
+            let target = parts.next().unwrap();
+            let level = parts
+                .next()
+                .context("Invalid filter syntax, expected `target=level`")?;
+            let level = LevelFilter::from_str(level).unwrap();
+            map.insert(target.to_string(), level);
+        }
+        Ok(Self { config: map })
+    }
+}
+
+impl<S: Subscriber> Layer<S> for FilterLayer {
+    fn enabled(
+        &self,
+        metadata: &tracing::Metadata<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) -> bool {
+        let target = metadata.target().split("::").next().unwrap();
+        let Some(filter) = self.config.get(target) else {
+            return false;
+        };
+        let level = metadata.level();
+        return level <= filter;
+    }
+
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        self.config.values().copied().min()
+    }
+}

--- a/turbopack/crates/turbopack-trace-utils/src/filter_layer.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/filter_layer.rs
@@ -1,17 +1,18 @@
-use std::{collections::HashMap, str::FromStr};
+use std::{collections::HashMap, hash::BuildHasherDefault, str::FromStr};
 
 use anyhow::Result;
+use rustc_hash::FxHasher;
 use tracing::{level_filters::LevelFilter, Subscriber};
 use tracing_subscriber::Layer;
 
 pub struct FilterLayer {
-    config: HashMap<String, LevelFilter>,
+    config: HashMap<String, LevelFilter, BuildHasherDefault<FxHasher>>,
     global_level: LevelFilter,
 }
 
 impl FilterLayer {
     pub fn try_new(input: &str) -> Result<Self> {
-        let mut config = HashMap::new();
+        let mut config = HashMap::default();
         let mut global_level = LevelFilter::OFF;
         for entry in input.split(',') {
             if entry.is_empty() {

--- a/turbopack/crates/turbopack-trace-utils/src/filter_layer.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/filter_layer.rs
@@ -47,7 +47,7 @@ impl<S: Subscriber> Layer<S> for FilterLayer {
         let target = metadata.target().split("::").next().unwrap();
         let filter = self.config.get(target).unwrap_or(&self.global_level);
         let level = metadata.level();
-        return level <= filter;
+       level <= filter
     }
 
     fn max_level_hint(&self) -> Option<LevelFilter> {

--- a/turbopack/crates/turbopack-trace-utils/src/filter_layer.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/filter_layer.rs
@@ -47,7 +47,7 @@ impl<S: Subscriber> Layer<S> for FilterLayer {
         let target = metadata.target().split("::").next().unwrap();
         let filter = self.config.get(target).unwrap_or(&self.global_level);
         let level = metadata.level();
-       level <= filter
+        level <= filter
     }
 
     fn max_level_hint(&self) -> Option<LevelFilter> {

--- a/turbopack/crates/turbopack-trace-utils/src/lib.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(arbitrary_self_types_pointers)]
 
 pub mod exit;
+pub mod filter_layer;
 mod flavor;
 pub mod raw_trace;
 pub mod trace_writer;


### PR DESCRIPTION
### What?

The default `EnvFilter` is very flexible, but also very slow.

This replaces it with a custom one that is a lot faster.

Closes PACK-3624