### PR TITLE
[Turbopack] use thread local trace collecting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,12 +1546,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crossterm"
@@ -9260,10 +9257,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
+ "crossbeam-utils",
  "once_cell",
+ "parking_lot",
  "postcard",
  "rustc-hash 1.1.0",
  "serde",
+ "thread_local",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/turbopack/crates/turbopack-trace-utils/Cargo.toml
+++ b/turbopack/crates/turbopack-trace-utils/Cargo.toml
@@ -13,12 +13,15 @@ bench = false
 
 [dependencies]
 anyhow = { workspace = true }
+crossbeam-utils = { version = "0.8.20" }
 crossbeam-channel = { workspace = true }
 once_cell = { workspace = true }
+parking_lot = { workspace = true }
 postcard = { workspace = true, features = ["alloc", "use-std"] }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["macros", "signal", "sync", "rt"] }
+thread_local = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 turbo-tasks-malloc = { workspace = true }

--- a/turbopack/crates/turbopack-trace-utils/src/flavor.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/flavor.rs
@@ -1,23 +1,25 @@
 use postcard::ser_flavors::Flavor;
 
-pub struct BufFlavor {
-    pub buf: Vec<u8>,
+use crate::trace_writer::WriteGuard;
+
+pub struct WriteGuardFlavor<'l> {
+    pub guard: WriteGuard<'l>,
 }
 
-impl Flavor for BufFlavor {
-    type Output = Vec<u8>;
+impl Flavor for WriteGuardFlavor<'_> {
+    type Output = ();
 
     fn try_push(&mut self, data: u8) -> postcard::Result<()> {
-        self.buf.push(data);
+        self.guard.push(data);
         Ok(())
     }
 
     fn finalize(self) -> postcard::Result<Self::Output> {
-        Ok(self.buf)
+        Ok(())
     }
 
     fn try_extend(&mut self, data: &[u8]) -> postcard::Result<()> {
-        self.buf.extend_from_slice(data);
+        self.guard.extend(data);
         Ok(())
     }
 }

--- a/turbopack/crates/turbopack-trace-utils/src/raw_trace.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/raw_trace.rs
@@ -25,7 +25,7 @@ fn get_id<S: Subscriber + for<'a> LookupSpan<'a>>(
     ctx: tracing_subscriber::layer::Context<'_, S>,
     id: &span::Id,
 ) -> u64 {
-    ctx.span(&id)
+    ctx.span(id)
         .unwrap()
         .extensions()
         .get::<RawTraceLayerExtension>()
@@ -93,9 +93,9 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for RawTraceLayer<S> {
             ts,
             id: external_id,
             parent: if attrs.is_contextual() {
-                ctx.current_span().id().map(|p| get_id(ctx, &p))
+                ctx.current_span().id().map(|p| get_id(ctx, p))
             } else {
-                attrs.parent().map(|p| get_id(ctx, &p))
+                attrs.parent().map(|p| get_id(ctx, p))
             },
             name: attrs.metadata().name().into(),
             target: attrs.metadata().target().into(),
@@ -140,9 +140,9 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for RawTraceLayer<S> {
         self.write(TraceRow::Event {
             ts,
             parent: if event.is_contextual() {
-                ctx.current_span().id().map(|p| get_id(ctx, &p))
+                ctx.current_span().id().map(|p| get_id(ctx, p))
             } else {
-                event.parent().map(|p| get_id(ctx, &p))
+                event.parent().map(|p| get_id(ctx, p))
             },
             values: values.values,
         });

--- a/turbopack/crates/turbopack-trace-utils/src/raw_trace.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/raw_trace.rs
@@ -1,4 +1,6 @@
-use std::{borrow::Cow, fmt::Write, marker::PhantomData, thread, time::Instant};
+use std::{
+    borrow::Cow, fmt::Write, marker::PhantomData, sync::atomic::AtomicU64, thread, time::Instant,
+};
 
 use tracing::{
     field::{display, Visit},
@@ -15,11 +17,28 @@ use crate::{
 
 pub struct RawTraceLayerOptions {}
 
+struct RawTraceLayerExtension {
+    id: u64,
+}
+
+fn get_id<S: Subscriber + for<'a> LookupSpan<'a>>(
+    ctx: tracing_subscriber::layer::Context<'_, S>,
+    id: &span::Id,
+) -> u64 {
+    ctx.span(&id)
+        .unwrap()
+        .extensions()
+        .get::<RawTraceLayerExtension>()
+        .unwrap()
+        .id
+}
+
 /// A tracing layer that writes raw trace data to a writer. The data format is
 /// defined by [FullTraceRow].
 pub struct RawTraceLayer<S: Subscriber + for<'a> LookupSpan<'a>> {
     trace_writer: TraceWriter,
     start: Instant,
+    next_id: AtomicU64,
     _phantom: PhantomData<fn(S)>,
 }
 
@@ -28,6 +47,7 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> RawTraceLayer<S> {
         Self {
             trace_writer,
             start: Instant::now(),
+            next_id: AtomicU64::new(1),
             _phantom: PhantomData,
         }
     }
@@ -62,13 +82,20 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for RawTraceLayer<S> {
         let ts = self.start.elapsed().as_micros() as u64;
         let mut values = ValuesVisitor::new();
         attrs.values().record(&mut values);
+        let external_id = self
+            .next_id
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        ctx.span(id)
+            .unwrap()
+            .extensions_mut()
+            .insert(RawTraceLayerExtension { id: external_id });
         self.write(TraceRow::Start {
             ts,
-            id: id.into_u64(),
+            id: external_id,
             parent: if attrs.is_contextual() {
-                ctx.current_span().id().map(|p| p.into_u64())
+                ctx.current_span().id().map(|p| get_id(ctx, &p))
             } else {
-                attrs.parent().map(|p| p.into_u64())
+                attrs.parent().map(|p| get_id(ctx, &p))
             },
             name: attrs.metadata().name().into(),
             target: attrs.metadata().target().into(),
@@ -76,32 +103,32 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for RawTraceLayer<S> {
         });
     }
 
-    fn on_close(&self, id: span::Id, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+    fn on_close(&self, id: span::Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
         let ts = self.start.elapsed().as_micros() as u64;
         self.write(TraceRow::End {
             ts,
-            id: id.into_u64(),
+            id: get_id(ctx, &id),
         });
     }
 
-    fn on_enter(&self, id: &span::Id, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+    fn on_enter(&self, id: &span::Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
         let ts = self.start.elapsed().as_micros() as u64;
         let thread_id = thread::current().id().as_u64().into();
         self.report_allocations(ts, thread_id);
         self.write(TraceRow::Enter {
             ts,
-            id: id.into_u64(),
+            id: get_id(ctx, id),
             thread_id,
         });
     }
 
-    fn on_exit(&self, id: &span::Id, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+    fn on_exit(&self, id: &span::Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
         let ts = self.start.elapsed().as_micros() as u64;
         let thread_id = thread::current().id().as_u64().into();
         self.report_allocations(ts, thread_id);
         self.write(TraceRow::Exit {
             ts,
-            id: id.into_u64(),
+            id: get_id(ctx, id),
             thread_id,
         });
     }
@@ -113,9 +140,9 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for RawTraceLayer<S> {
         self.write(TraceRow::Event {
             ts,
             parent: if event.is_contextual() {
-                ctx.current_span().id().map(|p| p.into_u64())
+                ctx.current_span().id().map(|p| get_id(ctx, &p))
             } else {
-                event.parent().map(|p| p.into_u64())
+                event.parent().map(|p| get_id(ctx, &p))
             },
             values: values.values,
         });
@@ -125,12 +152,12 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for RawTraceLayer<S> {
         &self,
         id: &span::Id,
         record: &span::Record<'_>,
-        _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
         let mut values = ValuesVisitor::new();
         record.record(&mut values);
         self.write(TraceRow::Record {
-            id: id.into_u64(),
+            id: get_id(ctx, id),
             values: values.values,
         });
     }

--- a/turbopack/crates/turbopack-trace-utils/src/trace_writer.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/trace_writer.rs
@@ -5,18 +5,42 @@ use crossbeam_utils::CachePadded;
 use parking_lot::{Mutex, MutexGuard};
 use thread_local::ThreadLocal;
 
-type ThreadLocalState = CachePadded<Mutex<Option<Vec<u8>>>>;
+type ThreadLocalState = CachePadded<Mutex<Option<TraceInfoBuffer>>>;
 
 /// The amount of data that is accumulated in the thread local buffer before it is sent to the
 /// writer. The buffer might grow if a single write is larger than this size.
-const THEAD_LOCAL_INITIAL_BUFFER_SIZE: usize = 1024 * 1024;
+const THREAD_LOCAL_INITIAL_BUFFER_SIZE: usize = 1024 * 1024;
 /// Data buffered by the write thread before issuing a filesystem write
 const WRITE_BUFFER_SIZE: usize = 100 * 1024 * 1024;
 
-#[derive(Clone, Debug)]
+struct TraceInfoBuffer {
+    buffer: Vec<u8>,
+}
+
+impl TraceInfoBuffer {
+    fn new(capacity: usize) -> Self {
+        Self {
+            buffer: Vec::with_capacity(capacity),
+        }
+    }
+
+    fn push(&mut self, data: u8) {
+        self.buffer.push(data);
+    }
+
+    fn extend(&mut self, data: &[u8]) {
+        self.buffer.extend_from_slice(data);
+    }
+
+    fn clear(&mut self) {
+        self.buffer.clear();
+    }
+}
+
+#[derive(Clone)]
 pub struct TraceWriter {
-    data_tx: Sender<Vec<u8>>,
-    return_rx: Receiver<Vec<u8>>,
+    data_tx: Sender<Option<TraceInfoBuffer>>,
+    return_rx: Receiver<TraceInfoBuffer>,
     thread_locals: Arc<ThreadLocal<ThreadLocalState>>,
 }
 
@@ -30,8 +54,8 @@ impl TraceWriter {
     /// * It issues less writes by buffering the data into chunks of WRITE_BUFFER_SIZE, when
     ///   possible.
     pub fn new<W: Write + Send + 'static>(mut writer: W) -> (Self, TraceWriterGuard) {
-        let (data_tx, data_rx) = unbounded::<Vec<u8>>();
-        let (return_tx, return_rx) = bounded::<Vec<u8>>(1024);
+        let (data_tx, data_rx) = unbounded::<Option<TraceInfoBuffer>>();
+        let (return_tx, return_rx) = bounded::<TraceInfoBuffer>(1024);
         let thread_locals: Arc<ThreadLocal<ThreadLocalState>> = Default::default();
 
         let trace_writer = Self {
@@ -40,71 +64,103 @@ impl TraceWriter {
             thread_locals: thread_locals.clone(),
         };
 
-        let data_tx_for_guard = data_tx.clone();
+        fn steal_from_thread_locals(
+            thread_locals: &Arc<ThreadLocal<ThreadLocalState>>,
+            stolen_buffers: &mut Vec<TraceInfoBuffer>,
+        ) {
+            for state in thread_locals.iter() {
+                let mut buffer = state.lock();
+                if let Some(buffer) = buffer.take() {
+                    stolen_buffers.push(buffer);
+                }
+            }
+        }
 
         let handle: std::thread::JoinHandle<()> = std::thread::spawn(move || {
             let _ = writer.write(b"TRACEv0");
             let mut buf = Vec::with_capacity(WRITE_BUFFER_SIZE);
+            let mut stolen_buffers = Vec::new();
+            let mut should_exit = false;
             'outer: loop {
                 if !buf.is_empty() {
                     let _ = writer.write_all(&buf);
                     let _ = writer.flush();
                     buf.clear();
                 }
-                let mut data = match data_rx.recv_timeout(Duration::from_secs(1)) {
-                    Ok(data) => data,
-                    Err(e) => {
+
+                let recv = if should_exit {
+                    Ok(None)
+                } else {
+                    data_rx.recv_timeout(Duration::from_secs(1))
+                };
+
+                let mut data = match recv {
+                    Ok(Some(data)) => data,
+                    result => {
+                        if result.is_ok() {
+                            // On exit signal
+                            should_exit = true;
+                        }
                         // When we receive no data for a second or we want to exit we poll the
                         // thread local buffers to steal some data. This
                         // prevents unsend data if a thread is hanging or the
                         // system just go into idle.
-                        for state in thread_locals.iter() {
-                            let mut buffer = state.lock();
-                            if let Some(buffer) = buffer.take() {
-                                let _ = data_tx.send(buffer);
+                        steal_from_thread_locals(&thread_locals, &mut stolen_buffers);
+                        if let Some(data) = stolen_buffers.pop() {
+                            data
+                        } else {
+                            match result {
+                                Ok(Some(_)) => unreachable!(),
+                                Ok(None) | Err(RecvTimeoutError::Disconnected) => {
+                                    // We should exit.
+                                    break 'outer;
+                                }
+                                Err(RecvTimeoutError::Timeout) => {
+                                    // No data stolen, wait again
+                                    continue;
+                                }
                             }
-                        }
-                        match e {
-                            RecvTimeoutError::Disconnected => {
-                                // The TraceWriteGuard has been dropped and we should exit.
-                                break 'outer;
-                            }
-                            RecvTimeoutError::Timeout => continue,
                         }
                     }
                 };
-                if data.is_empty() {
-                    break 'outer;
-                }
-                if data.len() > buf.capacity() {
-                    let _ = writer.write_all(&data);
+                if data.buffer.len() > buf.capacity() {
+                    let _ = writer.write_all(&data.buffer);
                 } else {
-                    buf.extend_from_slice(&data);
+                    buf.extend_from_slice(&data.buffer);
                 }
                 data.clear();
                 let _ = return_tx.try_send(data);
                 loop {
-                    match data_rx.try_recv() {
-                        Ok(mut data) => {
-                            if data.is_empty() {
+                    let recv = stolen_buffers.pop().map(Some).ok_or(()).or_else(|_| {
+                        if should_exit {
+                            Ok(None)
+                        } else {
+                            data_rx.try_recv()
+                        }
+                    });
+                    match recv {
+                        Ok(Some(mut data)) => {
+                            let data_buffer = &data.buffer;
+                            if data_buffer.is_empty() {
                                 break 'outer;
                             }
-                            if buf.len() + data.len() > buf.capacity() {
+                            if buf.len() + data_buffer.len() > buf.capacity() {
                                 let _ = writer.write_all(&buf);
                                 buf.clear();
-                                if data.len() > buf.capacity() {
-                                    let _ = writer.write_all(&data);
+                                if data_buffer.len() > buf.capacity() {
+                                    let _ = writer.write_all(&data_buffer);
                                 } else {
-                                    buf.extend_from_slice(&data);
+                                    buf.extend_from_slice(&data_buffer);
                                 }
                             } else {
-                                buf.extend_from_slice(&data);
+                                buf.extend_from_slice(&data_buffer);
                             }
                             data.clear();
                             let _ = return_tx.try_send(data);
                         }
-                        Err(TryRecvError::Disconnected) => {
-                            break 'outer;
+                        Ok(None) | Err(TryRecvError::Disconnected) => {
+                            should_exit = true;
+                            break;
                         }
                         Err(TryRecvError::Empty) => {
                             break;
@@ -112,27 +168,29 @@ impl TraceWriter {
                     }
                 }
             }
-            if !buf.is_empty() {
-                let _ = writer.write_all(&buf);
-            }
-            let _ = writer.flush();
             drop(writer);
         });
 
         let guard = TraceWriterGuard {
-            data_tx: Some(data_tx_for_guard),
+            data_tx: Some(data_tx),
             return_rx: Some(return_rx),
             handle: Some(handle),
         };
         (trace_writer, guard)
     }
 
-    fn send(&self, data: Vec<u8>) {
-        debug_assert!(!data.is_empty());
-        let _ = self.data_tx.send(data);
+    fn send(&self, data: TraceInfoBuffer) {
+        debug_assert!(!data.buffer.is_empty());
+        let _ = self.data_tx.send(Some(data));
     }
 
-    #[inline(never)]
+    fn get_empty_buffer(&self, capacity: usize) -> TraceInfoBuffer {
+        self.return_rx
+            .try_recv()
+            .ok()
+            .unwrap_or_else(|| TraceInfoBuffer::new(capacity))
+    }
+
     pub fn start_write(&self) -> WriteGuard<'_> {
         let thread_local_buffer = self.thread_locals.get_or_default();
         let buffer = thread_local_buffer.lock();
@@ -141,98 +199,63 @@ impl TraceWriter {
 }
 
 pub struct TraceWriterGuard {
-    data_tx: Option<Sender<Vec<u8>>>,
-    return_rx: Option<Receiver<Vec<u8>>>,
+    data_tx: Option<Sender<Option<TraceInfoBuffer>>>,
+    return_rx: Option<Receiver<TraceInfoBuffer>>,
     handle: Option<JoinHandle<()>>,
 }
 
 impl Drop for TraceWriterGuard {
     fn drop(&mut self) {
-        let _ = self.data_tx.take().unwrap().send(Vec::new());
+        // Send exit signal, we can't use disconnect since there is another instance in TraceWriter
+        let _ = self.data_tx.take().unwrap().send(None);
+        // Receive all return buffers and drop them here. The thread is already busy writing.
         let return_rx = self.return_rx.take().unwrap();
         while return_rx.recv().is_ok() {}
+        // Wait for the thread to finish completely
         let _ = self.handle.take().unwrap().join();
     }
 }
 
 pub struct WriteGuard<'l> {
     // Safety: The buffer must not be None
-    buffer: MutexGuard<'l, Option<Vec<u8>>>,
-    start_len: usize,
+    buffer: MutexGuard<'l, Option<TraceInfoBuffer>>,
     trace_writer: &'l TraceWriter,
 }
 
 impl<'l> WriteGuard<'l> {
-    fn new(mut buffer: MutexGuard<'l, Option<Vec<u8>>>, trace_writer: &'l TraceWriter) -> Self {
+    fn new(
+        mut buffer: MutexGuard<'l, Option<TraceInfoBuffer>>,
+        trace_writer: &'l TraceWriter,
+    ) -> Self {
         // Safety: The buffer must not be None, so we initialize it here
-        let start_len = if let Some(buffer) = buffer.as_ref() {
-            buffer.len()
-        } else {
-            *buffer = Some(
-                trace_writer
-                    .return_rx
-                    .try_recv()
-                    .ok()
-                    .unwrap_or_else(|| Vec::with_capacity(THEAD_LOCAL_INITIAL_BUFFER_SIZE)),
-            );
-            0
+        if buffer.is_none() {
+            *buffer = Some(trace_writer.get_empty_buffer(THREAD_LOCAL_INITIAL_BUFFER_SIZE));
         };
         Self {
-            start_len,
             buffer,
             trace_writer,
         }
     }
 
-    fn buffer(&mut self) -> &mut Vec<u8> {
+    fn buffer(&mut self) -> &mut TraceInfoBuffer {
         // Safety: The struct invariant ensures that the buffer is not None
         unsafe { self.buffer.as_mut().unwrap_unchecked() }
     }
 
     pub fn push(&mut self, data: u8) {
-        // self.check_flush(1);
         self.buffer().push(data);
     }
 
     pub fn extend(&mut self, data: &[u8]) {
-        // self.check_flush(data.len());
-        self.buffer().extend_from_slice(data);
-    }
-
-    fn check_flush(&mut self, additional: usize) {
-        if self.start_len > 0 {
-            let buffer = self.buffer();
-            if buffer.capacity() - buffer.len() < additional {
-                self.flush();
-            }
-        }
-    }
-
-    fn flush(&mut self) {
-        let capacity = self.buffer().capacity();
-        let mut new_buffer = self.get_buffer(capacity);
-        let start_len = self.start_len;
-        new_buffer.extend_from_slice(&self.buffer()[start_len..]);
-        self.buffer().truncate(start_len);
-        self.start_len = 0;
-        let buffer = std::mem::replace(self.buffer(), new_buffer);
-        self.trace_writer.send(buffer);
-    }
-
-    fn get_buffer(&self, capacity: usize) -> Vec<u8> {
-        self.trace_writer
-            .return_rx
-            .try_recv()
-            .ok()
-            .unwrap_or_else(|| Vec::with_capacity(capacity))
+        self.buffer().extend(data);
     }
 }
 
 impl Drop for WriteGuard<'_> {
     fn drop(&mut self) {
-        if self.buffer().capacity() * 2 < self.buffer().len() * 3 {
-            let capacity = self.buffer().capacity();
-            let new_buffer = self.get_buffer(capacity);
+        if self.buffer().buffer.capacity() * 2 < self.buffer().buffer.len() * 3 {
+            let capacity = self.buffer().buffer.capacity();
+            let new_buffer = self.trace_writer.get_empty_buffer(capacity);
             let buffer = std::mem::replace(self.buffer(), new_buffer);
             self.trace_writer.send(buffer);
         }

--- a/turbopack/crates/turbopack-trace-utils/src/trace_writer.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/trace_writer.rs
@@ -148,12 +148,12 @@ impl TraceWriter {
                                 let _ = writer.write_all(&buf);
                                 buf.clear();
                                 if data_buffer.len() > buf.capacity() {
-                                    let _ = writer.write_all(&data_buffer);
+                                    let _ = writer.write_all(data_buffer);
                                 } else {
-                                    buf.extend_from_slice(&data_buffer);
+                                    buf.extend_from_slice(data_buffer);
                                 }
                             } else {
-                                buf.extend_from_slice(&data_buffer);
+                                buf.extend_from_slice(data_buffer);
                             }
                             data.clear();
                             let _ = return_tx.try_send(data);


### PR DESCRIPTION
### What?

Collect trace events in a thread local buffer first and then send a batch of events to the writer thread.

But there are some challenges to that:

Events might be out of order in the trace file. Usually that should be fine since they have a timestamp, but

* span ids might be reused faster than all events are send to the file. So we assign our own globally unique ids instead.
* the trace server need to be able to process events out of order. So we queue up events when they are received for spans that are not created yet.

And the thread local buffer might also have a problem when the thread is idle or hanging. This would cause events to never be written to the file.
To fix that the writer thread will steal the outstanding events from the thread local buffers when it is idle for a second. This ensures that all events are eventually written, even in case of hanging threads.

Closes PACK-3631