### PR TITLE
docs: fix code block language on forbidden

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/forbidden.mdx
+++ b/docs/01-app/03-api-reference/04-functions/forbidden.mdx
@@ -125,7 +125,7 @@ export default async function AdminPage() {
 
 When implementing mutations in Server Actions, you can use `forbidden` to only allow users with a specific role to update sensitive data.
 
-```tsx filename="app/actions/update-role.ts" switcher
+```ts filename="app/actions/update-role.ts" switcher
 'use server'
 
 import { verifySession } from '@/app/lib/dal'
@@ -145,7 +145,7 @@ export async function updateRole(formData: FormData) {
 }
 ```
 
-```jsx filename="app/actions/update-role.js" switcher
+```js filename="app/actions/update-role.js" switcher
 'use server'
 
 import { verifySession } from '@/app/lib/dal'


### PR DESCRIPTION
## Summary

Change `tsx` and `jsx` to `ts` and `js` code block.

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide