### PR TITLE
test: replace duplicate test utils to next instance

### DIFF
--- a/test/development/basic/hmr/run-error-recovery-hmr-test.util.ts
+++ b/test/development/basic/hmr/run-error-recovery-hmr-test.util.ts
@@ -6,7 +6,6 @@ import {
   getRedboxHeader,
   getRedboxDescription,
   getRedboxSource,
-  renderViaHTTP,
   retry,
   waitFor,
   trimEndMultiline,
@@ -245,7 +244,7 @@ export function runErrorRecoveryHmrTest(nextConfig: {
       const aboutContent = await next.readFile(aboutPage)
       const browser = await next.browser(basePath + '/hmr/contact')
       try {
-        await renderViaHTTP(next.url, basePath + '/hmr/about2')
+        await next.render(basePath + '/hmr/about2')
 
         await next.patchFile(aboutPage, aboutContent.replace('</div>', 'div'))
 

--- a/test/development/basic/hmr/run-hot-module-reload-hmr-test.util.ts
+++ b/test/development/basic/hmr/run-hot-module-reload-hmr-test.util.ts
@@ -1,11 +1,5 @@
 import { join } from 'path'
-import cheerio from 'cheerio'
-import {
-  getBrowserBodyText,
-  renderViaHTTP,
-  retry,
-  waitFor,
-} from 'next-test-utils'
+import { getBrowserBodyText, retry, waitFor } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 
 export function runHotModuleReloadHmrTest(nextConfig: {
@@ -197,13 +191,15 @@ export function runHotModuleReloadHmrTest(nextConfig: {
 
         expect(initialFontSize).toBe('100px')
 
-        const initialHtml = await renderViaHTTP(
+        const initialHtml = await next.render(
           next.url,
           basePath + '/hmr/style-dynamic-component'
         )
         expect(initialHtml.includes('100px')).toBeTruthy()
 
-        const $initialHtml = cheerio.load(initialHtml)
+        const $initialHtml = await next.render$(
+          basePath + '/hmr/style-dynamic-component'
+        )
         const initialServerClassName =
           $initialHtml('#dynamic-component').attr('class')
 
@@ -229,12 +225,14 @@ export function runHotModuleReloadHmrTest(nextConfig: {
         expect(browserHtml.includes('font-size:200px')).toBe(true)
         expect(browserHtml.includes('font-size:100px')).toBe(false)
 
-        const editedHtml = await renderViaHTTP(
+        const editedHtml = await next.render(
           next.url,
           basePath + '/hmr/style-dynamic-component'
         )
         expect(editedHtml.includes('200px')).toBeTruthy()
-        const $editedHtml = cheerio.load(editedHtml)
+        const $editedHtml = await next.render$(
+          basePath + '/hmr/style-dynamic-component'
+        )
         const editedServerClassName =
           $editedHtml('#dynamic-component').attr('class')
 

--- a/test/development/basic/hmr/run-hot-module-reload-hmr-test.util.ts
+++ b/test/development/basic/hmr/run-hot-module-reload-hmr-test.util.ts
@@ -192,7 +192,6 @@ export function runHotModuleReloadHmrTest(nextConfig: {
         expect(initialFontSize).toBe('100px')
 
         const initialHtml = await next.render(
-          next.url,
           basePath + '/hmr/style-dynamic-component'
         )
         expect(initialHtml.includes('100px')).toBeTruthy()
@@ -226,7 +225,6 @@ export function runHotModuleReloadHmrTest(nextConfig: {
         expect(browserHtml.includes('font-size:100px')).toBe(false)
 
         const editedHtml = await next.render(
-          next.url,
           basePath + '/hmr/style-dynamic-component'
         )
         expect(editedHtml.includes('200px')).toBeTruthy()


### PR DESCRIPTION
This PR replaces:
- `renderViaHTTP -> next.render`
- `cheerio.load -> next.render$`
- ~~`process.env.TURBOPACK` -> `isTurbopack`~~ (left as `process.env.IS_TURBOPACK_TEST`)