### PR TITLE
[Segment Cache] Skip prefetched segments on server

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -335,7 +335,8 @@ export function navigateReducer(
                 // version of the next page. This can be rendered instantly.
                 mutable.cache = newCache
               }
-              if (task.needsDynamicRequest) {
+              const dynamicRequestTree = task.dynamicRequestTree
+              if (dynamicRequestTree !== null) {
                 // The prefetched tree has dynamic holes in it. We initiate a
                 // dynamic request to fill them in.
                 //
@@ -350,7 +351,7 @@ export function navigateReducer(
                 // a different response than we expected. For now, we revert back
                 // to the lazy fetching mechanism in that case.)
                 const dynamicRequest = fetchServerResponse(url, {
-                  flightRouterState: currentTree,
+                  flightRouterState: dynamicRequestTree,
                   nextUrl: state.nextUrl,
                 })
 

--- a/test/e2e/app-dir/segment-cache/basic/app/partially-static/page.tsx
+++ b/test/e2e/app-dir/segment-cache/basic/app/partially-static/page.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link'
+
+export default function FullyStaticStart() {
+  return (
+    <>
+      <p>
+        Demonstrates that when navigating to a partially static route, the
+        server does not render static layouts that were already prefetched.
+      </p>
+      <ul>
+        <li>
+          <Link href="/partially-static/target-page">Target</Link>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/basic/app/partially-static/target-page/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/basic/app/partially-static/target-page/layout.tsx
@@ -1,0 +1,12 @@
+export default function StaticLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <>
+      <div id="static-layout">Static layout</div>
+      <div>{children}</div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/basic/app/partially-static/target-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/basic/app/partially-static/target-page/page.tsx
@@ -1,0 +1,17 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+async function Content() {
+  await connection()
+  return 'Dynamic page'
+}
+
+export default function DynamicPage() {
+  return (
+    <div id="dynamic-page">
+      <Suspense fallback="Loading...">
+        <Content />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
+++ b/test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
@@ -167,6 +167,53 @@ describe('segment cache (basic tests)', () => {
     const numberOfNavigationRequests = (await navigationsLock.release()).size
     expect(numberOfNavigationRequests).toBe(0)
   })
+
+  it('skips static layouts during partially static navigation', async () => {
+    const interceptor = createRequestInterceptor()
+    let page: Playwright.Page
+    const browser = await next.browser('/partially-static', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+        page.route('**/*', async (route: Playwright.Route) => {
+          await interceptor.interceptRoute(page, route)
+        })
+      },
+    })
+
+    // Rendering the link triggers a prefetch of the test page.
+    const link = await browser.elementByCss(
+      'a[href="/partially-static/target-page"]'
+    )
+    const navigationsLock = interceptor.lockNavigations()
+    await link.click()
+
+    // The static layout and the loading state of the dynamic page should render
+    // immediately because they were prefetched.
+    const layoutMarkerId = 'static-layout'
+    const layoutMarker = await browser.elementById(layoutMarkerId)
+    const layoutMarkerContent = await layoutMarker.innerHTML()
+    expect(layoutMarkerContent).toBe('Static layout')
+    const dynamicDiv = await browser.elementById('dynamic-page')
+    expect(await dynamicDiv.innerHTML()).toBe('Loading...')
+
+    // Unblock the navigation request to allow the dynamic content to stream in.
+    const navigationRoutes = await navigationsLock.release()
+
+    // Check that the navigation response does not include the static layout,
+    // since it was already prefetched. Because this is not observable in the
+    // UI, we check the navigation response body.
+    const numberOfNavigationRequests = navigationRoutes.size
+    expect(numberOfNavigationRequests).toBe(1)
+    for (const route of navigationRoutes) {
+      const response = await page.request.fetch(route.request())
+      const responseText = await response.text()
+      expect(responseText).not.toContain(layoutMarkerId)
+      expect(responseText).not.toContain(layoutMarkerContent)
+    }
+
+    // The dynamic content has streamed in.
+    expect(await dynamicDiv.innerHTML()).toBe('Dynamic page')
+  })
 })
 
 function createRequestInterceptor() {


### PR DESCRIPTION
Based on:
- #73540

---

Currently if you navigate to a partially static route, the server will always start rendering at the first segment that's not present on the previous page. However, it should really start rendering at the first *dynamic* segment — if the client has already prefetched a segment, and it's fully static, there's no reason to render it again during the dynamic server render.

We can do this by sending a more specific Next-Router-State-Tree request header. Rather than send a tree that represents the previous route, we sent the tree of the target route, but with a `refetch` marker added to the first dynamic segment. (Without the refetch marker, the server would send back an empty response.) This is determined by diffing against both the previous route *and* the prefetch cache.

For now, this only works up to the first dynamic segment inside the new subtree; once the server starts rendering along a path, it renders everything else along that path. We could improve this in the future to also omit static segments that appear inside a dynamic layout, though this would likely require a change to the Next-Router-State-Tree protocol.