### PR TITLE
Turbopack: next/dynamic use transitions instead of AST analysis

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -70,7 +70,9 @@ use turbopack_core::{
 use turbopack_ecmascript::resolve::cjs_resolve;
 
 use crate::{
-    dynamic_imports::{collect_chunk_group, collect_evaluated_chunk_group},
+    dynamic_imports::{
+        collect_next_dynamic_chunks, DynamicImportedChunks, NextDynamicChunkAvailability,
+    },
     font::create_font_manifest,
     loadable_manifest::create_react_loadable_manifest,
     module_graph::get_reduced_graphs_for_endpoint,
@@ -324,8 +326,12 @@ impl AppProject {
             ),
             (
                 "next-dynamic".into(),
+                ResolvedVc::upcast(NextDynamicTransition::new_marker().to_resolved().await?),
+            ),
+            (
+                "next-dynamic-client".into(),
                 ResolvedVc::upcast(
-                    NextDynamicTransition::new(Vc::upcast(self.client_transition()))
+                    NextDynamicTransition::new_client(Vc::upcast(self.client_transition()))
                         .to_resolved()
                         .await?,
                 ),
@@ -373,8 +379,12 @@ impl AppProject {
             ),
             (
                 "next-dynamic".into(),
+                ResolvedVc::upcast(NextDynamicTransition::new_marker().to_resolved().await?),
+            ),
+            (
+                "next-dynamic-client".into(),
                 ResolvedVc::upcast(
-                    NextDynamicTransition::new(Vc::upcast(self.client_transition()))
+                    NextDynamicTransition::new_client(Vc::upcast(self.client_transition()))
                         .to_resolved()
                         .await?,
                 ),
@@ -420,8 +430,12 @@ impl AppProject {
             ),
             (
                 "next-dynamic".into(),
+                ResolvedVc::upcast(NextDynamicTransition::new_marker().to_resolved().await?),
+            ),
+            (
+                "next-dynamic-client".into(),
                 ResolvedVc::upcast(
-                    NextDynamicTransition::new(Vc::upcast(self.client_transition()))
+                    NextDynamicTransition::new_client(Vc::upcast(self.client_transition()))
                         .to_resolved()
                         .await?,
                 ),
@@ -466,8 +480,12 @@ impl AppProject {
             ),
             (
                 "next-dynamic".into(),
+                ResolvedVc::upcast(NextDynamicTransition::new_marker().to_resolved().await?),
+            ),
+            (
+                "next-dynamic-client".into(),
                 ResolvedVc::upcast(
-                    NextDynamicTransition::new(Vc::upcast(self.client_transition()))
+                    NextDynamicTransition::new_client(Vc::upcast(self.client_transition()))
                         .to_resolved()
                         .await?,
                 ),
@@ -501,14 +519,30 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    fn client_module_context(self: Vc<Self>) -> Vc<ModuleAssetContext> {
-        ModuleAssetContext::new(
-            Default::default(),
+    async fn client_module_context(self: Vc<Self>) -> Result<Vc<ModuleAssetContext>> {
+        let transitions = [
+            (
+                "next-dynamic".into(),
+                ResolvedVc::upcast(NextDynamicTransition::new_marker().to_resolved().await?),
+            ),
+            (
+                "next-dynamic-client".into(),
+                ResolvedVc::upcast(NextDynamicTransition::new_marker().to_resolved().await?),
+            ),
+        ]
+        .into_iter()
+        .collect();
+        Ok(ModuleAssetContext::new(
+            TransitionOptions {
+                named_transitions: transitions,
+                ..Default::default()
+            }
+            .cell(),
             self.project().client_compile_time_info(),
             self.client_module_options_context(),
             self.client_resolve_options_context(),
             Vc::cell("app-client".into()),
-        )
+        ))
     }
 
     #[turbo_tasks::function]
@@ -948,11 +982,8 @@ impl AppEndpoint {
                 }
                 let client_shared_availability_info = client_shared_chunk_group.availability_info;
 
-                let reduced_graphs = get_reduced_graphs_for_endpoint(
-                    this.app_project.project(),
-                    *rsc_entry,
-                    Vc::upcast(this.app_project.client_module_context()),
-                );
+                let reduced_graphs =
+                    get_reduced_graphs_for_endpoint(this.app_project.project(), *rsc_entry);
                 let next_dynamic_imports = reduced_graphs
                     .get_next_dynamic_imports_for_endpoint(*rsc_entry)
                     .await?;
@@ -1140,11 +1171,8 @@ impl AppEndpoint {
             };
 
         let server_action_manifest_loader = if process_client_components {
-            let reduced_graphs = get_reduced_graphs_for_endpoint(
-                this.app_project.project(),
-                *rsc_entry,
-                Vc::upcast(this.app_project.client_module_context()),
-            );
+            let reduced_graphs =
+                get_reduced_graphs_for_endpoint(this.app_project.project(), *rsc_entry);
             let actions = reduced_graphs.get_server_actions_for_endpoint(
                 *rsc_entry,
                 match runtime {
@@ -1242,7 +1270,6 @@ impl AppEndpoint {
                 let mut file_paths_from_root = vec![
                     "server/server-reference-manifest.js".into(),
                     "server/middleware-build-manifest.js".into(),
-                    "server/middleware-react-loadable-manifest.js".into(),
                     "server/next-font-manifest.js".into(),
                     "server/interception-route-rewrite-manifest.js".into(),
                 ];
@@ -1268,6 +1295,39 @@ impl AppEndpoint {
                 let entry_file = "app-edge-has-no-entrypoint".into();
 
                 if emit_manifests {
+                    let dynamic_import_entries =
+                        if let (Some(next_dynamic_imports), Some(client_references_chunks)) =
+                            (next_dynamic_imports, client_references_chunks)
+                        {
+                            collect_next_dynamic_chunks(
+                                Vc::upcast(client_chunking_context),
+                                next_dynamic_imports,
+                                NextDynamicChunkAvailability::ClientReferences(
+                                    &*(client_references_chunks.await?),
+                                ),
+                            )
+                            .await?
+                        } else {
+                            DynamicImportedChunks::default().resolved_cell()
+                        };
+                    let loadable_manifest_output = create_react_loadable_manifest(
+                        *dynamic_import_entries,
+                        client_relative_path,
+                        node_root.join(
+                            format!(
+                                "server/app{}/react-loadable-manifest",
+                                &app_entry.original_name
+                            )
+                            .into(),
+                        ),
+                        NextRuntime::Edge,
+                    )
+                    .await?;
+                    server_assets.extend(loadable_manifest_output.iter().copied());
+                    file_paths_from_root.extend(
+                        get_js_paths_from_root(&node_root_value, &loadable_manifest_output).await?,
+                    );
+
                     // create middleware manifest
                     let named_regex = get_named_middleware_regex(&app_entry.pathname);
                     let matchers = MiddlewareMatcher {
@@ -1323,26 +1383,6 @@ impl AppEndpoint {
                         create_app_paths_manifest(node_root, &app_entry.original_name, entry_file)
                             .await?;
                     server_assets.insert(app_paths_manifest_output);
-
-                    let dynamic_import_entries = collect_evaluated_chunk_group(
-                        Vc::upcast(client_chunking_context),
-                        next_dynamic_imports
-                            .as_deref()
-                            .unwrap_or(&Default::default()),
-                    )
-                    .await?;
-                    let loadable_manifest_output = create_react_loadable_manifest(
-                        dynamic_import_entries,
-                        client_relative_path,
-                        node_root.join(
-                            format!(
-                                "server/app{}/react-loadable-manifest.json",
-                                &app_entry.original_name
-                            )
-                            .into(),
-                        ),
-                    );
-                    server_assets.extend(loadable_manifest_output.await?.iter().copied());
                 }
 
                 AppEndpointOutput::Edge {
@@ -1357,7 +1397,7 @@ impl AppEndpoint {
                 // For node, there will be exactly one asset in this
                 let rsc_chunk = *app_entry_chunks_ref.first().unwrap();
 
-                if emit_manifests {
+                let loadable_manifest_output = if emit_manifests {
                     // create app paths manifest
                     let app_paths_manifest_output = create_app_paths_manifest(
                         node_root,
@@ -1374,28 +1414,39 @@ impl AppEndpoint {
                     server_assets.insert(app_paths_manifest_output);
 
                     // create react-loadable-manifest for next/dynamic
-                    let availability_info = Value::new(AvailabilityInfo::Root);
-                    let dynamic_import_entries = collect_chunk_group(
-                        Vc::upcast(client_chunking_context),
-                        next_dynamic_imports
-                            .as_deref()
-                            .unwrap_or(&Default::default()),
-                        availability_info,
-                    )
-                    .await?;
+                    let dynamic_import_entries =
+                        if let (Some(next_dynamic_imports), Some(client_references_chunks)) =
+                            (next_dynamic_imports, client_references_chunks)
+                        {
+                            collect_next_dynamic_chunks(
+                                Vc::upcast(client_chunking_context),
+                                next_dynamic_imports,
+                                NextDynamicChunkAvailability::ClientReferences(
+                                    &*(client_references_chunks.await?),
+                                ),
+                            )
+                            .await?
+                        } else {
+                            DynamicImportedChunks::default().resolved_cell()
+                        };
                     let loadable_manifest_output = create_react_loadable_manifest(
-                        dynamic_import_entries,
+                        *dynamic_import_entries,
                         client_relative_path,
                         node_root.join(
                             format!(
-                                "server/app{}/react-loadable-manifest.json",
+                                "server/app{}/react-loadable-manifest",
                                 &app_entry.original_name
                             )
                             .into(),
                         ),
-                    );
-                    server_assets.extend(loadable_manifest_output.await?.iter().copied());
-                }
+                        NextRuntime::NodeJs,
+                    )
+                    .await?;
+                    server_assets.extend(loadable_manifest_output.iter().copied());
+                    Some(loadable_manifest_output)
+                } else {
+                    None
+                };
 
                 if this
                     .app_project
@@ -1408,7 +1459,12 @@ impl AppEndpoint {
                         NftJsonAsset::new(
                             this.app_project.project(),
                             *rsc_chunk,
-                            client_reference_manifest.iter().map(|m| **m).collect(),
+                            client_reference_manifest
+                                .iter()
+                                .copied()
+                                .chain(loadable_manifest_output.iter().flat_map(|m| &**m).copied())
+                                .map(|m| *m)
+                                .collect(),
                         )
                         .to_resolved()
                         .await?,

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -1,308 +1,163 @@
-use std::collections::HashMap;
+//! If an import is specified as dynamic, next.js does few things:
+//! - Runs a next_dynamic [transform to the source file](https://github.com/vercel/next.js/blob/ae1b89984d26b2af3658001fa19a19e1e77c312d/packages/next-swc/crates/next-transform-dynamic/src/lib.rs#L22)
+//!   - This transform will [inject `loadableGenerated` property](https://github.com/vercel/next.js/blob/ae1b89984d26b2af3658001fa19a19e1e77c312d/packages/next-swc/crates/next-transform-dynamic/tests/fixture/wrapped-import/output-webpack-dev.js#L5),
+//!     which contains the list of the import ids in the form of `${origin} -> ${imported}`.
+//! - Emits `react-loadable-manifest.json` which contains the mapping of the import ids to the chunk
+//!   ids.
+//!   - Webpack: [implementation](https://github.com/vercel/next.js/blob/ae1b89984d26b2af3658001fa19a19e1e77c312d/packages/next/src/build/webpack/plugins/react-loadable-plugin.ts)
+//!   - Turbopack: [implementation 1](https://github.com/vercel/next.js/pull/56389/files#diff-3cac9d9bfe73e0619e6407f21f6fe652da0719d0ec9074ff813ad3e416d0eb1a),
+//!     [implementation 2](https://github.com/vercel/next.js/pull/56389/files#diff-791951bbe1fa09bcbad9be9173412d0848168f7d658758f11b6e8888a021552c),
+//!     [implementation 3](https://github.com/vercel/next.js/pull/56389/files#diff-c33f6895801329243dd3f627c69da259bcab95c2c9d12993152842591931ff01R557)
+//! - When running an application,
+//!    - Server reads generated `react-loadable-manifest.json`, sets dynamicImportIds with the mapping of the import ids, and dynamicImports to the actual corresponding chunks.
+//!         [implementation 1](https://github.com/vercel/next.js/blob/ad42b610c25b72561ad367b82b1c7383fd2a5dd2/packages/next/src/server/load-components.ts#L119),
+//!         [implementation 2](https://github.com/vercel/next.js/blob/ad42b610c25b72561ad367b82b1c7383fd2a5dd2/packages/next/src/server/render.tsx#L1417C7-L1420)
+//!    - Server embeds those into __NEXT_DATA__ and [send to the client.](https://github.com/vercel/next.js/blob/ad42b610c25b72561ad367b82b1c7383fd2a5dd2/packages/next/src/server/render.tsx#L1453)
+//!    - When client boots up, pass it to the [client preload](https://github.com/vercel/next.js/blob/ad42b610c25b72561ad367b82b1c7383fd2a5dd2/packages/next/src/client/index.tsx#L943)
+//!    - Loadable runtime [injects preload fn](https://github.com/vercel/next.js/blob/ad42b610c25b72561ad367b82b1c7383fd2a5dd2/packages/next/src/shared/lib/loadable.shared-runtime.tsx#L281)
+//!      to wait until all the dynamic components are being loaded, this ensures hydration mismatch
+//!      won't occur
 
-use anyhow::{bail, Result};
-use futures::Future;
-use swc_core::ecma::{
-    ast::{CallExpr, Callee, Expr, Ident, Lit},
-    visit::{Visit, VisitWith},
+use anyhow::Result;
+use next_core::{
+    next_app::ClientReferencesChunks, next_client_reference::EcmascriptClientReferenceModule,
+    next_dynamic::NextDynamicEntryModule,
 };
-use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, ResolvedVc, TryFlatJoinIterExt, Value, Vc};
+use serde::{Deserialize, Serialize};
+use turbo_tasks::{
+    debug::ValueDebugFormat, trace::TraceRawVcs, FxIndexMap, NonLocalValue, ReadRef, ResolvedVc,
+    TryFlatJoinIterExt, TryJoinIterExt, Value, Vc,
+};
 use turbopack_core::{
     chunk::{
-        availability_info::AvailabilityInfo, ChunkableModule, ChunkingContext, ChunkingContextExt,
-        EvaluatableAsset,
+        availability_info::AvailabilityInfo, ChunkItem, ChunkItemExt, ChunkableModule,
+        ChunkingContext, ModuleId,
     },
-    context::AssetContext,
     module::Module,
-    output::OutputAssets,
-    reference_type::EcmaScriptModulesReferenceSubType,
-    resolve::{origin::PlainResolveOrigin, parse::Request, pattern::Pattern},
+    output::{OutputAsset, OutputAssets},
+    reference::ModuleReference,
 };
-use turbopack_ecmascript::{parse::ParseResult, resolve::esm_resolve, EcmascriptParsable};
 
-use crate::module_graph::SingleModuleGraph;
+use crate::module_graph::{DynamicImportEntriesWithImporter, SingleModuleGraph};
 
-async fn collect_chunk_group_inner<F, Fu>(
-    dynamic_import_entries: &FxIndexMap<ResolvedVc<Box<dyn Module>>, DynamicImportedModules>,
-    mut build_chunk: F,
-) -> Result<Vc<DynamicImportedChunks>>
-where
-    F: FnMut(Vc<Box<dyn ChunkableModule>>) -> Fu,
-    Fu: Future<Output = Result<Vc<OutputAssets>>> + Send,
-{
-    let mut chunks_hash: HashMap<RcStr, ResolvedVc<OutputAssets>> = HashMap::new();
-    let mut dynamic_import_chunks = FxIndexMap::default();
+pub(crate) enum NextDynamicChunkAvailability<'a> {
+    /// In App Router, the client references
+    ClientReferences(&'a ClientReferencesChunks),
+    /// In Pages Router, the base page chunk group
+    AvailabilityInfo(AvailabilityInfo),
+}
 
-    // Iterate over the collected import mappings, and create a chunk for each
-    // dynamic import.
-    for (origin_module, dynamic_imports) in dynamic_import_entries {
-        for (imported_raw_str, imported_module) in dynamic_imports {
-            let chunk = if let Some(chunk) = chunks_hash.get(imported_raw_str) {
-                *chunk
-            } else {
-                let Some(module) =
-                    ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(*imported_module).await?
-                else {
-                    bail!("module must be evaluatable");
-                };
+pub(crate) async fn collect_next_dynamic_chunks(
+    chunking_context: Vc<Box<dyn ChunkingContext>>,
+    dynamic_import_entries: ReadRef<DynamicImportEntriesWithImporter>,
+    chunking_availability: NextDynamicChunkAvailability<'_>,
+) -> Result<ResolvedVc<DynamicImportedChunks>> {
+    let chunking_availability = &chunking_availability;
+    let dynamic_import_chunks = dynamic_import_entries
+        .iter()
+        .map(|(dynamic_entry, parent_client_reference)| async move {
+            let module = ResolvedVc::upcast::<Box<dyn ChunkableModule>>(*dynamic_entry);
 
-                // [Note]: this seems to create duplicated chunks for the same module to the original import() call
-                // and the explicit chunk we ask in here. So there'll be at least 2
-                // chunks for the same module, relying on
-                // naive hash to have additional
-                // chunks in case if there are same modules being imported in different
-                // origins.
-                let chunk_group = build_chunk(*module).await?.to_resolved().await?;
-                chunks_hash.insert(imported_raw_str.clone(), chunk_group);
-                chunk_group
+            // This is the availability info for the parent chunk group, i.e. the client reference
+            // containing the next/dynamic imports
+            let availability_info = match chunking_availability {
+                NextDynamicChunkAvailability::ClientReferences(client_reference_chunks) => {
+                    client_reference_chunks
+                        .client_component_client_chunks
+                        .get(&parent_client_reference.unwrap())
+                        .unwrap()
+                        .1
+                }
+                NextDynamicChunkAvailability::AvailabilityInfo(availability_info) => {
+                    *availability_info
+                }
             };
 
-            dynamic_import_chunks
-                .entry(*origin_module)
-                .or_insert_with(Vec::new)
-                .push((imported_raw_str.clone(), chunk));
-        }
-    }
+            let async_loader =
+                chunking_context.async_loader_chunk_item(*module, Value::new(availability_info));
+            let async_chunk_group = async_loader
+                .references()
+                .await?
+                .iter()
+                .map(|reference| reference.resolve_reference().primary_output_assets())
+                .try_join()
+                .await?;
+            let async_chunk_group: Vec<ResolvedVc<Box<dyn OutputAsset>>> =
+                async_chunk_group.iter().flatten().copied().collect();
 
-    Ok(Vc::cell(dynamic_import_chunks))
-}
+            let module_id = dynamic_entry
+                .as_chunk_item(Vc::upcast(chunking_context))
+                .id()
+                .to_resolved()
+                .await?;
 
-pub(crate) async fn collect_chunk_group(
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
-    dynamic_import_entries: &FxIndexMap<ResolvedVc<Box<dyn Module>>, DynamicImportedModules>,
-    availability_info: Value<AvailabilityInfo>,
-) -> Result<Vc<DynamicImportedChunks>> {
-    collect_chunk_group_inner(dynamic_import_entries, |module| async move {
-        Ok(chunking_context.chunk_group_assets(module, availability_info))
-    })
-    .await
-}
-
-pub(crate) async fn collect_evaluated_chunk_group(
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
-    dynamic_import_entries: &FxIndexMap<ResolvedVc<Box<dyn Module>>, DynamicImportedModules>,
-) -> Result<Vc<DynamicImportedChunks>> {
-    collect_chunk_group_inner(dynamic_import_entries, |module| async move {
-        if let Some(module) = Vc::try_resolve_downcast::<Box<dyn EvaluatableAsset>>(module).await? {
-            Ok(chunking_context.evaluated_chunk_group_assets(
-                module.ident(),
-                Vc::cell(vec![ResolvedVc::upcast(module.to_resolved().await?)]),
-                Value::new(AvailabilityInfo::Root),
+            Ok((
+                *dynamic_entry,
+                (module_id, ResolvedVc::cell(async_chunk_group)),
             ))
-        } else {
-            Ok(chunking_context.chunk_group_assets(module, Value::new(AvailabilityInfo::Root)))
-        }
-    })
-    .await
-}
-
-/// Returns a mapping of the dynamic imports for the module, if the import is
-/// wrapped in `next/dynamic`'s `dynamic()`. Refer [documentation](https://nextjs.org/docs/pages/building-your-application/optimizing/lazy-loading#with-named-exports) for the usecases.
-///
-/// If an import is specified as dynamic, next.js does few things:
-/// - Runs a next_dynamic [transform to the source file](https://github.com/vercel/next.js/blob/ae1b89984d26b2af3658001fa19a19e1e77c312d/packages/next-swc/crates/next-transform-dynamic/src/lib.rs#L22)
-///   - This transform will [inject `loadableGenerated` property](https://github.com/vercel/next.js/blob/ae1b89984d26b2af3658001fa19a19e1e77c312d/packages/next-swc/crates/next-transform-dynamic/tests/fixture/wrapped-import/output-webpack-dev.js#L5),
-///     which contains the list of the import ids in the form of `${origin} -> ${imported}`.
-/// - Emits `react-loadable-manifest.json` which contains the mapping of the import ids to the chunk
-///   ids.
-///   - Webpack: [implementation](https://github.com/vercel/next.js/blob/ae1b89984d26b2af3658001fa19a19e1e77c312d/packages/next/src/build/webpack/plugins/react-loadable-plugin.ts)
-///   - Turbopack: [implementation 1](https://github.com/vercel/next.js/pull/56389/files#diff-3cac9d9bfe73e0619e6407f21f6fe652da0719d0ec9074ff813ad3e416d0eb1a),
-///     [implementation 2](https://github.com/vercel/next.js/pull/56389/files#diff-791951bbe1fa09bcbad9be9173412d0848168f7d658758f11b6e8888a021552c),
-///     [implementation 3](https://github.com/vercel/next.js/pull/56389/files#diff-c33f6895801329243dd3f627c69da259bcab95c2c9d12993152842591931ff01R557)
-/// - When running an application,
-///    - Server reads generated `react-loadable-manifest.json`, sets dynamicImportIds with the mapping of the import ids, and dynamicImports to the actual corresponding chunks.
-///         [implementation 1](https://github.com/vercel/next.js/blob/ad42b610c25b72561ad367b82b1c7383fd2a5dd2/packages/next/src/server/load-components.ts#L119),
-///         [implementation 2](https://github.com/vercel/next.js/blob/ad42b610c25b72561ad367b82b1c7383fd2a5dd2/packages/next/src/server/render.tsx#L1417C7-L1420)
-///    - Server embeds those into __NEXT_DATA__ and [send to the client.](https://github.com/vercel/next.js/blob/ad42b610c25b72561ad367b82b1c7383fd2a5dd2/packages/next/src/server/render.tsx#L1453)
-///    - When client boots up, pass it to the [client preload](https://github.com/vercel/next.js/blob/ad42b610c25b72561ad367b82b1c7383fd2a5dd2/packages/next/src/client/index.tsx#L943)
-///    - Loadable runtime [injects preload fn](https://github.com/vercel/next.js/blob/ad42b610c25b72561ad367b82b1c7383fd2a5dd2/packages/next/src/shared/lib/loadable.shared-runtime.tsx#L281)
-///      to wait until all the dynamic components are being loaded, this ensures hydration mismatch
-///      won't occur
-#[turbo_tasks::function]
-pub async fn build_dynamic_imports_map_for_module(
-    client_asset_context: Vc<Box<dyn AssetContext>>,
-    server_module: ResolvedVc<Box<dyn Module>>,
-) -> Result<Vc<OptionDynamicImportsMap>> {
-    let Some(ecmascript_asset) =
-        ResolvedVc::try_sidecast::<Box<dyn EcmascriptParsable>>(server_module).await?
-    else {
-        return Ok(Vc::cell(None));
-    };
-
-    // https://github.com/vercel/next.js/pull/56389#discussion_r1349336374
-    // don't emit specific error as we expect there's a parse error already reported
-    let ParseResult::Ok { program, .. } = &*ecmascript_asset.failsafe_parse().await? else {
-        return Ok(Vc::cell(None));
-    };
-
-    // Reading the Program AST, collect raw imported module str if it's wrapped in
-    // dynamic()
-    let mut visitor = DynamicImportVisitor::new();
-    program.visit_with(&mut visitor);
-
-    if visitor.import_sources.is_empty() {
-        return Ok(Vc::cell(None));
-    }
-
-    let mut import_sources = vec![];
-    for import in visitor.import_sources.drain(..) {
-        // Using the given `Module` which is the origin of the dynamic import, trying to
-        // resolve the module that is being imported.
-        let dynamic_imported_resolved_module = *esm_resolve(
-            Vc::upcast(PlainResolveOrigin::new(
-                client_asset_context,
-                server_module.ident().path(),
-            )),
-            Request::parse(Value::new(Pattern::Constant(import.clone()))),
-            Value::new(EcmaScriptModulesReferenceSubType::DynamicImport),
-            false,
-            None,
-        )
-        .first_module()
+        })
+        .try_join()
         .await?;
 
-        if let Some(dynamic_imported_resolved_module) = dynamic_imported_resolved_module {
-            import_sources.push((import, dynamic_imported_resolved_module));
-        }
-    }
-
-    Ok(Vc::cell(Some(ResolvedVc::cell((
-        server_module,
-        import_sources,
-    )))))
+    Ok(ResolvedVc::cell(FxIndexMap::from_iter(
+        dynamic_import_chunks,
+    )))
 }
-
-/// A visitor to check if there's import to `next/dynamic`, then collecting the
-/// import wrapped with dynamic() via CollectImportSourceVisitor.
-struct DynamicImportVisitor {
-    dynamic_ident: Option<Ident>,
-    pub import_sources: Vec<RcStr>,
-}
-
-impl DynamicImportVisitor {
-    fn new() -> Self {
-        Self {
-            import_sources: vec![],
-            dynamic_ident: None,
-        }
-    }
-}
-
-impl Visit for DynamicImportVisitor {
-    fn visit_import_decl(&mut self, decl: &swc_core::ecma::ast::ImportDecl) {
-        // find import decl from next/dynamic, i.e import dynamic from 'next/dynamic'
-        if decl.src.value == *"next/dynamic" {
-            if let Some(specifier) = decl.specifiers.first().and_then(|s| s.as_default()) {
-                self.dynamic_ident = Some(specifier.local.clone());
-            }
-        }
-    }
-
-    fn visit_call_expr(&mut self, call_expr: &CallExpr) {
-        // Collect imports if the import call is wrapped in the call dynamic()
-        if let Callee::Expr(ident) = &call_expr.callee {
-            if let Expr::Ident(ident) = &**ident {
-                if let Some(dynamic_ident) = &self.dynamic_ident {
-                    if ident.sym == *dynamic_ident.sym {
-                        let mut collect_import_source_visitor = CollectImportSourceVisitor::new();
-                        call_expr.visit_children_with(&mut collect_import_source_visitor);
-
-                        if let Some(import_source) = collect_import_source_visitor.import_source {
-                            self.import_sources.push(import_source);
-                        }
-                    }
-                }
-            }
-        }
-
-        call_expr.visit_children_with(self);
-    }
-}
-
-/// A visitor to collect import source string from import('path/to/module')
-struct CollectImportSourceVisitor {
-    import_source: Option<RcStr>,
-}
-
-impl CollectImportSourceVisitor {
-    fn new() -> Self {
-        Self {
-            import_source: None,
-        }
-    }
-}
-
-impl Visit for CollectImportSourceVisitor {
-    fn visit_call_expr(&mut self, call_expr: &CallExpr) {
-        // find import source from import('path/to/module')
-        // [NOTE]: Turbopack does not support webpack-specific comment directives, i.e
-        // import(/* webpackChunkName: 'hello1' */ '../../components/hello3')
-        // Renamed chunk in the comment will be ignored.
-        if let Callee::Import(_import) = call_expr.callee {
-            if let Some(arg) = call_expr.args.first() {
-                if let Expr::Lit(Lit::Str(str_)) = &*arg.expr {
-                    self.import_source = Some(str_.value.as_str().into());
-                }
-            }
-        }
-
-        // Don't need to visit children, we expect import() won't have any
-        // nested calls as dynamic() should be statically analyzable import.
-    }
-}
-
-pub type DynamicImportedModules = Vec<(RcStr, ResolvedVc<Box<dyn Module>>)>;
-pub type DynamicImportedOutputAssets = Vec<(RcStr, ResolvedVc<OutputAssets>)>;
-
-/// A struct contains mapping for the dynamic imports to construct chunk per
-/// each individual module (Origin Module, Vec<(ImportSourceString, Module)>)
-#[turbo_tasks::value(transparent)]
-pub struct DynamicImportsMap(pub (ResolvedVc<Box<dyn Module>>, DynamicImportedModules));
-
-/// An Option wrapper around [DynamicImportsMap].
-#[turbo_tasks::value(transparent)]
-pub struct OptionDynamicImportsMap(Option<ResolvedVc<DynamicImportsMap>>);
 
 #[turbo_tasks::value(transparent)]
+#[derive(Default)]
 pub struct DynamicImportedChunks(
-    pub FxIndexMap<ResolvedVc<Box<dyn Module>>, DynamicImportedOutputAssets>,
+    pub  FxIndexMap<
+        ResolvedVc<NextDynamicEntryModule>,
+        (ResolvedVc<ModuleId>, ResolvedVc<OutputAssets>),
+    >,
 );
 
-/// "app/client.js [app-ssr] (ecmascript)" ->
-///      [("./dynamic", "app/dynamic.js [app-client] (ecmascript)")])]
+#[derive(
+    Clone, PartialEq, Eq, ValueDebugFormat, Serialize, Deserialize, TraceRawVcs, NonLocalValue,
+)]
+pub enum DynamicImportEntriesMapType {
+    DynamicEntry(ResolvedVc<NextDynamicEntryModule>),
+    ClientReference(ResolvedVc<EcmascriptClientReferenceModule>),
+}
+
 #[turbo_tasks::value(transparent)]
-pub struct DynamicImports(pub FxIndexMap<ResolvedVc<Box<dyn Module>>, DynamicImportedModules>);
+pub struct DynamicImportEntries(
+    pub FxIndexMap<ResolvedVc<Box<dyn Module>>, DynamicImportEntriesMapType>,
+);
 
 #[turbo_tasks::function]
-pub async fn map_next_dynamic(
-    graph: Vc<SingleModuleGraph>,
-    client_asset_context: Vc<Box<dyn AssetContext>>,
-) -> Result<Vc<DynamicImports>> {
-    let data = graph
+pub async fn map_next_dynamic(graph: Vc<SingleModuleGraph>) -> Result<Vc<DynamicImportEntries>> {
+    let actions = graph
         .await?
-        .enumerate_nodes()
-        .map(|(_, node)| {
-            async move {
-                // TODO: compare module contexts instead?
-                let is_browser = node
-                    .layer
-                    .as_ref()
-                    .is_some_and(|layer| &**layer == "app-client" || &**layer == "client");
-                if !is_browser {
-                    // Only collect in RSC and SSR
-                    if let Some(v) =
-                        &*build_dynamic_imports_map_for_module(client_asset_context, *node.module)
-                            .await?
-                    {
-                        return Ok(Some(v.await?.clone_value()));
-                    }
+        .iter_nodes()
+        .map(|node| async move {
+            let module = node.module;
+            let layer = node.layer.as_ref();
+            if layer.is_some_and(|layer| &**layer == "app-client" || &**layer == "client") {
+                if let Some(dynamic_entry_module) =
+                    ResolvedVc::try_downcast_type::<NextDynamicEntryModule>(module).await?
+                {
+                    return Ok(Some((
+                        module,
+                        DynamicImportEntriesMapType::DynamicEntry(dynamic_entry_module),
+                    )));
                 }
-                Ok(None)
             }
+            // TODO add this check once these modules have the correct layer
+            // if layer.is_some_and(|layer| &**layer == "app-rsc") {
+            if let Some(client_reference_module) =
+                ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(module).await?
+            {
+                return Ok(Some((
+                    module,
+                    DynamicImportEntriesMapType::ClientReference(client_reference_module),
+                )));
+            }
+            // }
+            Ok(None)
         })
         .try_flat_join()
         .await?;
-
-    Ok(Vc::cell(data.into_iter().collect()))
+    Ok(Vc::cell(actions.into_iter().collect()))
 }

--- a/crates/next-api/src/loadable_manifest.rs
+++ b/crates/next-api/src/loadable_manifest.rs
@@ -1,16 +1,16 @@
 use std::collections::HashMap;
 
 use anyhow::Result;
-use next_core::next_manifests::LoadableManifest;
+use next_core::{next_manifests::LoadableManifest, util::NextRuntime};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, TryFlatJoinIterExt, Vc};
+use turbo_tasks::{ResolvedVc, TryFlatJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
-    module::Module,
     output::{OutputAsset, OutputAssets},
     virtual_output::VirtualOutputAsset,
 };
+use turbopack_ecmascript::utils::StringifyJs;
 
 use crate::dynamic_imports::DynamicImportedChunks;
 
@@ -19,56 +19,73 @@ pub async fn create_react_loadable_manifest(
     dynamic_import_entries: Vc<DynamicImportedChunks>,
     client_relative_path: Vc<FileSystemPath>,
     output_path: Vc<FileSystemPath>,
+    runtime: NextRuntime,
 ) -> Result<Vc<OutputAssets>> {
     let dynamic_import_entries = &*dynamic_import_entries.await?;
 
-    let mut output = vec![];
     let mut loadable_manifest: HashMap<RcStr, LoadableManifest> = Default::default();
 
-    for (origin, dynamic_imports) in dynamic_import_entries.into_iter() {
-        let origin_path = &*origin.ident().path().await?;
+    for (_, (module_id, chunk_output)) in dynamic_import_entries.into_iter() {
+        let chunk_output = chunk_output.await?;
 
-        for (import, chunk_output) in dynamic_imports {
-            let chunk_output = chunk_output.await?;
-            output.extend(chunk_output.iter().copied());
+        let id = module_id.to_string().await?.clone_value();
 
-            let id: RcStr = format!("{} -> {}", origin_path, import).into();
+        let client_relative_path_value = client_relative_path.await?;
+        let files = chunk_output
+            .iter()
+            .map(move |&file| {
+                let client_relative_path_value = client_relative_path_value.clone();
+                async move {
+                    Ok(client_relative_path_value
+                        .get_path_to(&*file.ident().path().await?)
+                        .map(|path| path.into()))
+                }
+            })
+            .try_flat_join()
+            .await?;
 
-            let client_relative_path_value = client_relative_path.await?;
-            let files = chunk_output
-                .iter()
-                .map(move |&file| {
-                    let client_relative_path_value = client_relative_path_value.clone();
-                    async move {
-                        Ok(client_relative_path_value
-                            .get_path_to(&*file.ident().path().await?)
-                            .map(|path| path.into()))
-                    }
-                })
-                .try_flat_join()
-                .await?;
+        let manifest_item = LoadableManifest {
+            id: id.clone(),
+            files,
+        };
 
-            let manifest_item = LoadableManifest {
-                id: id.clone(),
-                files,
-            };
-
-            loadable_manifest.insert(id, manifest_item);
-        }
+        loadable_manifest.insert(id, manifest_item);
     }
 
-    let loadable_manifest = VirtualOutputAsset::new(
-        output_path,
-        AssetContent::file(
-            FileContent::Content(File::from(serde_json::to_string_pretty(
-                &loadable_manifest,
-            )?))
-            .cell(),
-        ),
-    )
-    .to_resolved()
-    .await?;
+    let manifest_json = serde_json::to_string_pretty(&loadable_manifest)?;
 
-    output.push(ResolvedVc::upcast(loadable_manifest));
-    Ok(Vc::cell(output))
+    Ok(Vc::cell(match runtime {
+        NextRuntime::NodeJs => vec![ResolvedVc::upcast(
+            VirtualOutputAsset::new(
+                output_path.with_extension("json".into()),
+                AssetContent::file(FileContent::Content(File::from(manifest_json)).cell()),
+            )
+            .to_resolved()
+            .await?,
+        )],
+        NextRuntime::Edge => vec![
+            ResolvedVc::upcast(
+                VirtualOutputAsset::new(
+                    output_path.with_extension("js".into()),
+                    AssetContent::file(
+                        FileContent::Content(File::from(format!(
+                            "self.__REACT_LOADABLE_MANIFEST={};",
+                            StringifyJs(&manifest_json)
+                        )))
+                        .cell(),
+                    ),
+                )
+                .to_resolved()
+                .await?,
+            ),
+            ResolvedVc::upcast(
+                VirtualOutputAsset::new(
+                    output_path.with_extension("json".into()),
+                    AssetContent::file(FileContent::Content(File::from(manifest_json)).cell()),
+                )
+                .to_resolved()
+                .await?,
+            ),
+        ],
+    }))
 }

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -13,6 +13,7 @@ use next_core::{
         find_server_entries, ClientReference, ClientReferenceGraphResult, ClientReferenceType,
         ServerEntries, VisitedClientReferenceGraphNodes,
     },
+    next_dynamic::NextDynamicEntryModule,
     next_manifests::ActionLayer,
 };
 use petgraph::{
@@ -39,7 +40,7 @@ use turbopack_core::{
 
 use crate::{
     client_references::{map_client_references, ClientReferenceMapType, ClientReferencesSet},
-    dynamic_imports::{map_next_dynamic, DynamicImports},
+    dynamic_imports::{map_next_dynamic, DynamicImportEntries, DynamicImportEntriesMapType},
     project::Project,
     server_actions::{map_server_actions, to_rsc_context, AllActions, AllModuleActions},
 };
@@ -621,9 +622,17 @@ async fn get_module_graph_for_endpoint(
 pub struct NextDynamicGraph {
     is_single_page: bool,
     graph: ResolvedVc<SingleModuleGraph>,
-    /// RSC/SSR importer -> dynamic imports (specifier and client module)
-    data: ResolvedVc<DynamicImports>,
+    /// list of NextDynamicEntryModules
+    data: ResolvedVc<DynamicImportEntries>,
 }
+
+#[turbo_tasks::value(transparent)]
+pub struct DynamicImportEntriesWithImporter(
+    pub  Vec<(
+        ResolvedVc<NextDynamicEntryModule>,
+        Option<ClientReferenceType>,
+    )>,
+);
 
 #[turbo_tasks::value_impl]
 impl NextDynamicGraph {
@@ -631,13 +640,8 @@ impl NextDynamicGraph {
     pub async fn new_with_entries(
         graph: ResolvedVc<SingleModuleGraph>,
         is_single_page: bool,
-        client_asset_context: Vc<Box<dyn AssetContext>>,
     ) -> Result<Vc<Self>> {
-        let mapped = map_next_dynamic(*graph, client_asset_context);
-        mapped.strongly_consistent().await?;
-        // TODO this can be removed once next/dynamic collection is moved to the transition instead
-        // of AST traversal
-        let _ = mapped.take_collectibles::<Box<dyn Issue>>();
+        let mapped = map_next_dynamic(*graph);
 
         // TODO shrink graph here, using the information from
         //  - `mapped` (which lists the relevant nodes)
@@ -675,26 +679,71 @@ impl NextDynamicGraph {
     pub async fn get_next_dynamic_imports_for_endpoint(
         &self,
         entry: ResolvedVc<Box<dyn Module>>,
-    ) -> Result<Vc<DynamicImports>> {
+    ) -> Result<Vc<DynamicImportEntriesWithImporter>> {
         let span = tracing::info_span!("collect next/dynamic imports for endpoint");
         async move {
-            if self.is_single_page {
-                // The graph contains the endpoint (= `entry`) only, no need to filter.
-                Ok(*self.data)
-            } else {
-                // The graph contains the whole app, traverse and collect all reachable imports.
-                let graph = &*self.graph.await?;
-                let data = &self.data.await?;
+            let data = &*self.data.await?;
+            let graph = &*self.graph.await?;
 
-                let mut result = FxIndexMap::default();
-                graph.traverse_from_entry(entry, |node| {
-                    let module = node.module;
-                    if let Some(node_data) = data.get(&module) {
-                        result.insert(module, node_data.clone());
-                    }
-                })?;
-                Ok(Vc::cell(result))
+            #[derive(Clone, PartialEq, Eq)]
+            enum VisitState {
+                Entry,
+                InClientReference(ClientReferenceType),
             }
+
+            let mut result = vec![];
+
+            // module -> the client reference entry (if any)
+            let mut state_map = HashMap::new();
+            graph.traverse_edges_from_entry(entry, |(parent_node, node)| {
+                let module = node.module;
+                let Some(parent_node) = parent_node else {
+                    state_map.insert(module, VisitState::Entry);
+                    return GraphTraversalAction::Continue;
+                };
+                let parent_module = parent_node.module;
+
+                let module_type = data.get(&module);
+                let parent_state = state_map.get(&parent_module).unwrap().clone();
+                let parent_client_reference =
+                    if let Some(DynamicImportEntriesMapType::ClientReference(module)) = module_type
+                    {
+                        Some(ClientReferenceType::EcmascriptClientReference {
+                            parent_module,
+                            module: *module,
+                        })
+                    } else if let VisitState::InClientReference(ty) = parent_state {
+                        Some(ty)
+                    } else {
+                        None
+                    };
+
+                match module_type {
+                    Some(DynamicImportEntriesMapType::DynamicEntry(dynamic_entry)) => {
+                        result.push((*dynamic_entry, parent_client_reference));
+
+                        state_map.insert(module, parent_state);
+                        GraphTraversalAction::Skip
+                    }
+                    Some(DynamicImportEntriesMapType::ClientReference(client_reference)) => {
+                        state_map.insert(
+                            module,
+                            VisitState::InClientReference(
+                                ClientReferenceType::EcmascriptClientReference {
+                                    parent_module,
+                                    module: *client_reference,
+                                },
+                            ),
+                        );
+                        GraphTraversalAction::Continue
+                    }
+                    None => {
+                        state_map.insert(module, parent_state);
+                        GraphTraversalAction::Continue
+                    }
+                }
+            })?;
+            Ok(Vc::cell(result))
         }
         .instrument(span)
         .await
@@ -931,12 +980,13 @@ pub struct ReducedGraphs {
 
 #[turbo_tasks::value_impl]
 impl ReducedGraphs {
-    /// Returns the dynamic imports in RSC and SSR modules for the given endpoint.
+    /// Returns the next/dynamic-ally imported (client) modules (from RSC and SSR modules) for the
+    /// given endpoint.
     #[turbo_tasks::function]
     pub async fn get_next_dynamic_imports_for_endpoint(
         &self,
         entry: Vc<Box<dyn Module>>,
-    ) -> Result<Vc<DynamicImports>> {
+    ) -> Result<Vc<DynamicImportEntriesWithImporter>> {
         let span = tracing::info_span!("collect all next/dynamic imports for endpoint");
         async move {
             if let [graph] = &self.next_dynamic[..] {
@@ -950,8 +1000,8 @@ impl ReducedGraphs {
                         Ok(graph
                             .get_next_dynamic_imports_for_endpoint(entry)
                             .await?
-                            .iter()
-                            .map(|(k, v)| (*k, v.clone()))
+                            .into_iter()
+                            .map(|(k, v)| (*k, *v))
                             // TODO remove this collect and return an iterator instead
                             .collect::<Vec<_>>())
                     })
@@ -1050,8 +1100,6 @@ impl ReducedGraphs {
 async fn get_reduced_graphs_for_endpoint_inner(
     project: Vc<Project>,
     entry: ResolvedVc<Box<dyn Module>>,
-    // TODO should this happen globally or per endpoint? Do they all have the same context?
-    client_asset_context: Vc<Box<dyn AssetContext>>,
 ) -> Result<Vc<ReducedGraphs>> {
     let (is_single_page, graphs) = match &*project.next_mode().await? {
         NextMode::Development => (
@@ -1078,10 +1126,7 @@ async fn get_reduced_graphs_for_endpoint_inner(
     let next_dynamic = async {
         graphs
             .iter()
-            .map(|graph| {
-                NextDynamicGraph::new_with_entries(**graph, is_single_page, client_asset_context)
-                    .to_resolved()
-            })
+            .map(|graph| NextDynamicGraph::new_with_entries(**graph, is_single_page).to_resolved())
             .try_join()
             .await
     }
@@ -1127,12 +1172,10 @@ async fn get_reduced_graphs_for_endpoint_inner(
 pub async fn get_reduced_graphs_for_endpoint(
     project: Vc<Project>,
     entry: Vc<Box<dyn Module>>,
-    // TODO should this happen globally or per endpoint? Do they all have the same context?
-    client_asset_context: Vc<Box<dyn AssetContext>>,
 ) -> Result<Vc<ReducedGraphs>> {
     // TODO get rid of this function once everything inside of
     // `get_reduced_graphs_for_endpoint_inner` calls `take_collectibles()` when needed
-    let result = get_reduced_graphs_for_endpoint_inner(project, entry, client_asset_context);
+    let result = get_reduced_graphs_for_endpoint_inner(project, entry);
     if project.next_mode().await?.is_production() {
         result.strongly_consistent().await?;
         let _issues = result.take_collectibles::<Box<dyn Issue>>();

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -47,7 +47,7 @@ use turbopack::{
 use turbopack_core::{
     asset::AssetContent,
     chunk::{
-        availability_info::AvailabilityInfo, ChunkingContext, ChunkingContextExt,
+        availability_info::AvailabilityInfo, ChunkGroupResult, ChunkingContext, ChunkingContextExt,
         EntryChunkGroupResult, EvaluatableAsset, EvaluatableAssets,
     },
     context::AssetContext,
@@ -64,7 +64,9 @@ use turbopack_ecmascript::resolve::esm_resolve;
 use turbopack_nodejs::NodeJsChunkingContext;
 
 use crate::{
-    dynamic_imports::{collect_chunk_group, collect_evaluated_chunk_group, DynamicImportedChunks},
+    dynamic_imports::{
+        collect_next_dynamic_chunks, DynamicImportedChunks, NextDynamicChunkAvailability,
+    },
     font::create_font_manifest,
     loadable_manifest::create_react_loadable_manifest,
     module_graph::get_reduced_graphs_for_endpoint,
@@ -286,14 +288,20 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn transitions(self: Vc<Self>) -> Result<Vc<TransitionOptions>> {
         Ok(TransitionOptions {
-            named_transitions: [(
-                "next-dynamic".into(),
-                ResolvedVc::upcast(
-                    NextDynamicTransition::new(Vc::upcast(self.client_transition()))
-                        .to_resolved()
-                        .await?,
+            named_transitions: [
+                (
+                    "next-dynamic".into(),
+                    ResolvedVc::upcast(NextDynamicTransition::new_marker().to_resolved().await?),
                 ),
-            )]
+                (
+                    "next-dynamic-client".into(),
+                    ResolvedVc::upcast(
+                        NextDynamicTransition::new_client(Vc::upcast(self.client_transition()))
+                            .to_resolved()
+                            .await?,
+                    ),
+                ),
+            ]
             .into_iter()
             .collect(),
             ..Default::default()
@@ -720,7 +728,7 @@ impl PageEndpoint {
     }
 
     #[turbo_tasks::function]
-    async fn client_chunks(self: Vc<Self>) -> Result<Vc<OutputAssets>> {
+    async fn client_chunks(self: Vc<Self>) -> Result<Vc<ChunkGroupResult>> {
         async move {
             let this = self.await?;
 
@@ -741,7 +749,7 @@ impl PageEndpoint {
 
             let client_chunking_context = this.pages_project.project().client_chunking_context();
 
-            let client_chunks = client_chunking_context.evaluated_chunk_group_assets(
+            let client_chunk_group = client_chunking_context.evaluated_chunk_group(
                 AssetIdent::from_path(*this.page.await?.base_path),
                 this.pages_project
                     .client_runtime_entries()
@@ -750,7 +758,7 @@ impl PageEndpoint {
                 Value::new(AvailabilityInfo::Root),
             );
 
-            Ok(client_chunks)
+            Ok(client_chunk_group)
         }
         .instrument(tracing::info_span!("page client side rendering"))
         .await
@@ -865,14 +873,51 @@ impl PageEndpoint {
                 runtime,
             } = *self.internal_ssr_chunk_module().await?;
 
-            let reduced_graphs = get_reduced_graphs_for_endpoint(
-                this.pages_project.project(),
-                *ssr_module,
-                Vc::upcast(this.pages_project.client_module_context()),
-            );
-            let next_dynamic_imports = reduced_graphs
-                .get_next_dynamic_imports_for_endpoint(*ssr_module)
-                .await?;
+            let next_dynamic_imports = if let PageEndpointType::Html = this.ty {
+                // The SSR and Client Graphs are not connected in Pages Router.
+                // We are only interested in get_next_dynamic_imports_for_endpoint at the
+                // moment, which only needs the client graph anyway.
+                //
+                // If we do want to change this to have both included. We'd need to create a
+                // `IncludeModulesModule` that includes both SSR and Client (and use that both
+                // there and in Project::get_all_entries):
+                // let client_module = self.client_module().to_resolved().await?;
+                // let ssr_module = self.internal_ssr_chunk_module().await?.ssr_module;
+                // Ok(Vc::upcast(IncludeModulesModule::new(
+                //     self.source()
+                //         .ident()
+                //         .with_modifier(Vc::cell("unified entrypoint".into())),
+                //     vec![*client_module, *ssr_module],
+                // )))
+
+                let client_availability_info = self.client_chunks().await?.availability_info;
+
+                let reduced_graphs = get_reduced_graphs_for_endpoint(
+                    this.pages_project.project(),
+                    self.client_module(),
+                );
+                let next_dynamic_imports = reduced_graphs
+                    .get_next_dynamic_imports_for_endpoint(self.client_module())
+                    .await?;
+                Some((next_dynamic_imports, client_availability_info))
+            } else {
+                None
+            };
+
+            let dynamic_import_entries = if let Some((
+                next_dynamic_imports,
+                client_availability_info,
+            )) = next_dynamic_imports
+            {
+                collect_next_dynamic_chunks(
+                    Vc::upcast(this.pages_project.project().client_chunking_context()),
+                    next_dynamic_imports,
+                    NextDynamicChunkAvailability::AvailabilityInfo(client_availability_info),
+                )
+                .await?
+            } else {
+                DynamicImportedChunks::default().resolved_cell()
+            };
 
             let is_edge = matches!(runtime, NextRuntime::Edge);
             if is_edge {
@@ -890,16 +935,6 @@ impl PageEndpoint {
                     )
                     .to_resolved()
                     .await?;
-
-                let client_chunking_context =
-                    this.pages_project.project().client_chunking_context();
-                let dynamic_import_entries = collect_evaluated_chunk_group(
-                    Vc::upcast(client_chunking_context),
-                    &next_dynamic_imports,
-                )
-                .await?
-                .to_resolved()
-                .await?;
 
                 Ok(SsrChunk::Edge {
                     files: edge_files,
@@ -926,17 +961,6 @@ impl PageEndpoint {
                     )
                     .await?;
 
-                let client_chunking_context =
-                    this.pages_project.project().client_chunking_context();
-                let dynamic_import_entries = collect_chunk_group(
-                    Vc::upcast(client_chunking_context),
-                    &next_dynamic_imports,
-                    Value::new(AvailabilityInfo::Root),
-                )
-                .await?
-                .to_resolved()
-                .await?;
-
                 let server_asset_trace_file = if this
                     .pages_project
                     .project()
@@ -944,10 +968,21 @@ impl PageEndpoint {
                     .await?
                     .is_production()
                 {
+                    let loadable_manifest_output =
+                        self.react_loadable_manifest(*dynamic_import_entries, NextRuntime::NodeJs);
+
                     ResolvedVc::cell(Some(ResolvedVc::upcast(
-                        NftJsonAsset::new(this.pages_project.project(), *ssr_entry_chunk, vec![])
-                            .to_resolved()
-                            .await?,
+                        NftJsonAsset::new(
+                            this.pages_project.project(),
+                            *ssr_entry_chunk,
+                            loadable_manifest_output
+                                .await?
+                                .iter()
+                                .map(|m| **m)
+                                .collect(),
+                        )
+                        .to_resolved()
+                        .await?,
                     )))
                 } else {
                     ResolvedVc::cell(None)
@@ -1049,6 +1084,7 @@ impl PageEndpoint {
     async fn react_loadable_manifest(
         &self,
         dynamic_import_entries: Vc<DynamicImportedChunks>,
+        runtime: NextRuntime,
     ) -> Result<Vc<OutputAssets>> {
         let node_root = self.pages_project.project().node_root();
         let client_relative_path = self.pages_project.project().client_relative_path();
@@ -1056,9 +1092,9 @@ impl PageEndpoint {
         Ok(create_react_loadable_manifest(
             dynamic_import_entries,
             client_relative_path,
-            node_root.join(
-                format!("server/pages{loadable_path_prefix}/react-loadable-manifest.json").into(),
-            ),
+            node_root
+                .join(format!("server/pages{loadable_path_prefix}/react-loadable-manifest").into()),
+            runtime,
         ))
     }
 
@@ -1100,7 +1136,7 @@ impl PageEndpoint {
 
         let ssr_chunk = match this.ty {
             PageEndpointType::Html => {
-                let client_chunks = self.client_chunks();
+                let client_chunks = *self.client_chunks().await?.assets;
                 client_assets.extend(client_chunks.await?.iter().map(|asset| **asset));
                 let build_manifest = self.build_manifest(client_chunks).to_resolved().await?;
                 let page_loader = self.page_loader(client_chunks);
@@ -1170,7 +1206,7 @@ impl PageEndpoint {
                     server_assets.push(pages_manifest);
 
                     let loadable_manifest_output =
-                        self.react_loadable_manifest(*dynamic_import_entries);
+                        self.react_loadable_manifest(*dynamic_import_entries, NextRuntime::NodeJs);
                     server_assets.extend(loadable_manifest_output.await?.iter().copied());
                 }
 
@@ -1193,6 +1229,11 @@ impl PageEndpoint {
                     }
                     server_assets.extend(files_value.iter().copied());
 
+                    let loadable_manifest_output = self
+                        .react_loadable_manifest(*dynamic_import_entries, NextRuntime::Edge)
+                        .await?;
+                    server_assets.extend(loadable_manifest_output.iter().copied());
+
                     // the next-edge-ssr-loader templates expect the manifests to be stored in
                     // global variables defined in these files
                     //
@@ -1200,12 +1241,15 @@ impl PageEndpoint {
                     let mut file_paths_from_root = vec![
                         "server/server-reference-manifest.js".into(),
                         "server/middleware-build-manifest.js".into(),
-                        "server/middleware-react-loadable-manifest.js".into(),
                         "server/next-font-manifest.js".into(),
                     ];
                     let mut wasm_paths_from_root = vec![];
 
                     let node_root_value = node_root.await?;
+
+                    file_paths_from_root.extend(
+                        get_js_paths_from_root(&node_root_value, &loadable_manifest_output).await?,
+                    );
 
                     file_paths_from_root
                         .extend(get_js_paths_from_root(&node_root_value, &files_value).await?);
@@ -1261,10 +1305,6 @@ impl PageEndpoint {
                     .await?;
                     server_assets.push(ResolvedVc::upcast(middleware_manifest_v2));
                 }
-
-                let loadable_manifest_output =
-                    self.react_loadable_manifest(*dynamic_import_entries);
-                server_assets.extend(loadable_manifest_output.await?.iter().copied());
 
                 PageEndpointOutput::Edge {
                     files,

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -4,7 +4,6 @@ use anyhow::{bail, Result};
 use indoc::formatdoc;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkItemExt, ChunkType, ChunkableModule, ChunkingContext},
@@ -39,16 +38,6 @@ impl NextDynamicEntryModule {
     pub fn new(module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>) -> Vc<Self> {
         NextDynamicEntryModule { module }.cell()
     }
-
-    #[turbo_tasks::function]
-    pub fn server_path(&self) -> Vc<FileSystemPath> {
-        self.module.ident().path()
-    }
-}
-
-#[turbo_tasks::function]
-fn dynamic_modifier() -> Vc<RcStr> {
-    Vc::cell("next/dynamic entry".into())
 }
 
 #[turbo_tasks::function]

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -1,66 +1,78 @@
+use std::collections::BTreeMap;
+
 use anyhow::{bail, Result};
+use indoc::formatdoc;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{ChunkableModule, ChunkingContext, ChunkingContextExt},
+    chunk::{ChunkItem, ChunkItemExt, ChunkType, ChunkableModule, ChunkingContext},
     ident::AssetIdent,
     module::Module,
-    output::OutputAssets,
-    reference::ModuleReferences,
+    reference::{ModuleReferences, SingleChunkableModuleReference},
 };
+use turbopack_ecmascript::{
+    chunk::{
+        EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
+        EcmascriptChunkType, EcmascriptExports,
+    },
+    references::esm::{EsmExport, EsmExports},
+    utils::StringifyJs,
+};
+
+#[turbo_tasks::function]
+fn modifier() -> Vc<RcStr> {
+    Vc::cell("next/dynamic entry".into())
+}
 
 /// A [`NextDynamicEntryModule`] is a marker asset used to indicate which
 /// dynamic assets should appear in the dynamic manifest.
-#[turbo_tasks::value]
+#[turbo_tasks::value(shared)]
 pub struct NextDynamicEntryModule {
-    pub client_entry_module: ResolvedVc<Box<dyn Module>>,
+    module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
 }
 
 #[turbo_tasks::value_impl]
 impl NextDynamicEntryModule {
-    /// Create a new [`NextDynamicEntryModule`] from the given source CSS
-    /// asset.
     #[turbo_tasks::function]
-    pub fn new(client_entry_module: ResolvedVc<Box<dyn Module>>) -> Vc<NextDynamicEntryModule> {
-        NextDynamicEntryModule {
-            client_entry_module,
-        }
-        .cell()
+    pub fn new(module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>) -> Vc<Self> {
+        NextDynamicEntryModule { module }.cell()
     }
 
     #[turbo_tasks::function]
-    pub async fn client_chunks(
-        &self,
-        client_chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<OutputAssets>> {
-        let Some(client_entry_module) =
-            ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(self.client_entry_module).await?
-        else {
-            bail!("dynamic client asset must be chunkable");
-        };
-
-        Ok(client_chunking_context.root_chunk_group_assets(*client_entry_module))
+    pub fn server_path(&self) -> Vc<FileSystemPath> {
+        self.module.ident().path()
     }
 }
 
 #[turbo_tasks::function]
 fn dynamic_modifier() -> Vc<RcStr> {
-    Vc::cell("dynamic".into())
+    Vc::cell("next/dynamic entry".into())
+}
+
+#[turbo_tasks::function]
+fn dynamic_ref_description() -> Vc<RcStr> {
+    Vc::cell("next/dynamic reference".into())
 }
 
 #[turbo_tasks::value_impl]
 impl Module for NextDynamicEntryModule {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        self.client_entry_module
-            .ident()
-            .with_modifier(dynamic_modifier())
+        self.module.ident().with_modifier(modifier())
     }
 
     #[turbo_tasks::function]
-    fn references(self: Vc<Self>) -> Vc<ModuleReferences> {
-        ModuleReferences::empty()
+    async fn references(&self) -> Result<Vc<ModuleReferences>> {
+        Ok(Vc::cell(vec![ResolvedVc::upcast(
+            SingleChunkableModuleReference::new(
+                Vc::upcast(*self.module),
+                dynamic_ref_description(),
+            )
+            .to_resolved()
+            .await?,
+        )]))
     }
 }
 
@@ -68,7 +80,113 @@ impl Module for NextDynamicEntryModule {
 impl Asset for NextDynamicEntryModule {
     #[turbo_tasks::function]
     fn content(&self) -> Result<Vc<AssetContent>> {
-        // The client reference asset only serves as a marker asset.
-        bail!("NextDynamicEntryModule has no content")
+        bail!("Next.js server component module has no content")
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ChunkableModule for NextDynamicEntryModule {
+    #[turbo_tasks::function]
+    fn as_chunk_item(
+        self: ResolvedVc<Self>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        Vc::upcast(
+            NextDynamicEntryChunkItem {
+                chunking_context,
+                inner: self,
+            }
+            .cell(),
+        )
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl EcmascriptChunkPlaceable for NextDynamicEntryModule {
+    #[turbo_tasks::function]
+    async fn get_exports(&self) -> Result<Vc<EcmascriptExports>> {
+        let module_reference = Vc::upcast(SingleChunkableModuleReference::new(
+            Vc::upcast(*self.module),
+            dynamic_ref_description(),
+        ));
+
+        let mut exports = BTreeMap::new();
+        exports.insert(
+            "default".into(),
+            EsmExport::ImportedBinding(module_reference, "default".into(), false),
+        );
+
+        Ok(EcmascriptExports::EsmExports(
+            EsmExports {
+                exports,
+                star_exports: vec![module_reference.to_resolved().await?],
+            }
+            .resolved_cell(),
+        )
+        .cell())
+    }
+}
+
+#[turbo_tasks::value]
+struct NextDynamicEntryChunkItem {
+    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    inner: ResolvedVc<NextDynamicEntryModule>,
+}
+
+#[turbo_tasks::value_impl]
+impl EcmascriptChunkItem for NextDynamicEntryChunkItem {
+    #[turbo_tasks::function]
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+        *self.chunking_context
+    }
+
+    #[turbo_tasks::function]
+    async fn content(&self) -> Result<Vc<EcmascriptChunkItemContent>> {
+        let inner = self.inner.await?;
+
+        let module_id = inner
+            .module
+            .as_chunk_item(Vc::upcast(*self.chunking_context))
+            .id()
+            .await?;
+        Ok(EcmascriptChunkItemContent {
+            inner_code: formatdoc!(
+                r#"
+                    __turbopack_export_namespace__(__turbopack_import__({}));
+                "#,
+                StringifyJs(&module_id),
+            )
+            .into(),
+            ..Default::default()
+        }
+        .cell())
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ChunkItem for NextDynamicEntryChunkItem {
+    #[turbo_tasks::function]
+    fn asset_ident(&self) -> Vc<AssetIdent> {
+        self.inner.ident()
+    }
+
+    #[turbo_tasks::function]
+    fn references(&self) -> Vc<ModuleReferences> {
+        self.inner.references()
+    }
+
+    #[turbo_tasks::function]
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+        *self.chunking_context
+    }
+
+    #[turbo_tasks::function]
+    fn ty(&self) -> Vc<Box<dyn ChunkType>> {
+        Vc::upcast(Vc::<EcmascriptChunkType>::default())
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        Vc::upcast(*self.inner)
     }
 }

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -171,11 +171,6 @@ impl ChunkItem for NextDynamicEntryChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn references(&self) -> Vc<ModuleReferences> {
-        self.inner.references()
-    }
-
-    #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         *self.chunking_context
     }

--- a/crates/next-core/src/next_dynamic/dynamic_transition.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_transition.rs
@@ -1,26 +1,45 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbopack::{transition::Transition, ModuleAssetContext};
-use turbopack_core::{context::ProcessResult, reference_type::ReferenceType, source::Source};
+use turbopack_core::{
+    context::{AssetContext, ProcessResult},
+    reference_type::ReferenceType,
+    source::Source,
+};
+use turbopack_ecmascript::chunk::EcmascriptChunkPlaceable;
 
 use super::NextDynamicEntryModule;
 
 /// This transition is used to create the marker asset for a next/dynamic
-/// import.
+/// import. Optionally, it can also apply another transition (i.e. to the client context).
 ///
 /// This will get picked up during module processing and will be used to
 /// create the dynamic entry, and the dynamic manifest entry.
 #[turbo_tasks::value]
 pub struct NextDynamicTransition {
-    client_transition: ResolvedVc<Box<dyn Transition>>,
+    client_transition: Option<ResolvedVc<Box<dyn Transition>>>,
 }
 
 #[turbo_tasks::value_impl]
 impl NextDynamicTransition {
+    /// Create a transition that only add a marker `NextDynamicEntryModule`.
     #[turbo_tasks::function]
-    pub fn new(client_transition: ResolvedVc<Box<dyn Transition>>) -> Vc<Self> {
-        NextDynamicTransition { client_transition }.cell()
+    pub fn new_marker() -> Vc<Self> {
+        NextDynamicTransition {
+            client_transition: None,
+        }
+        .cell()
+    }
+
+    /// Create a transition that applies `client_transiton` and adds a marker
+    /// `NextDynamicEntryModule`.
+    #[turbo_tasks::function]
+    pub fn new_client(client_transition: ResolvedVc<Box<dyn Transition>>) -> Vc<Self> {
+        NextDynamicTransition {
+            client_transition: Some(client_transition),
+        }
+        .cell()
     }
 }
 
@@ -39,24 +58,30 @@ impl Transition for NextDynamicTransition {
         _reference_type: Value<ReferenceType>,
     ) -> Result<Vc<ProcessResult>> {
         let module_asset_context = self.process_context(module_asset_context);
-
-        let this = self.await?;
-
-        Ok(match *this
-            .client_transition
-            .process(
+        let module = match self.await?.client_transition {
+            Some(client_transition) => client_transition.process(
                 source,
                 module_asset_context,
                 Value::new(ReferenceType::Undefined),
-            )
-            .try_into_module()
-            .await?
-        {
-            Some(client_module) => ProcessResult::Module(ResolvedVc::upcast(
-                NextDynamicEntryModule::new(*client_module)
-                    .to_resolved()
-                    .await?,
-            )),
+            ),
+            None => module_asset_context.process(source, Value::new(ReferenceType::Undefined)),
+        };
+
+        Ok(match &*module.try_into_module().await? {
+            Some(client_module) => {
+                let Some(client_module) =
+                    ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(*client_module)
+                        .await?
+                else {
+                    bail!("not an ecmascript client_module");
+                };
+
+                ProcessResult::Module(ResolvedVc::upcast(
+                    NextDynamicEntryModule::new(*client_module)
+                        .to_resolved()
+                        .await?,
+                ))
+            }
             None => ProcessResult::Ignore,
         }
         .cell())

--- a/crates/next-core/src/next_shared/transforms/next_dynamic.rs
+++ b/crates/next-core/src/next_shared/transforms/next_dynamic.rs
@@ -50,7 +50,10 @@ impl CustomTransformer for NextJsDynamic {
             self.is_server_compiler,
             self.is_react_server_layer,
             self.is_app_dir,
-            NextDynamicMode::Webpack,
+            NextDynamicMode::Turbopack {
+                dynamic_client_transition_name: "next-dynamic-client".to_string(),
+                dynamic_transition_name: "next-dynamic".to_string(),
+            },
             FileName::Real(ctx.file_path_str.into()).into(),
             None,
         ));

--- a/crates/next-custom-transforms/src/transforms/dynamic.rs
+++ b/crates/next-custom-transforms/src/transforms/dynamic.rs
@@ -5,16 +5,17 @@ use std::{
 
 use pathdiff::diff_paths;
 use swc_core::{
+    atoms::Atom,
     common::{errors::HANDLER, FileName, Span, DUMMY_SP},
     ecma::{
         ast::{
             op, ArrayLit, ArrowExpr, BinExpr, BlockStmt, BlockStmtOrExpr, Bool, CallExpr, Callee,
-            Expr, ExprOrSpread, ExprStmt, Id, Ident, IdentName, ImportDecl, ImportDefaultSpecifier,
-            ImportNamedSpecifier, ImportSpecifier, KeyValueProp, Lit, ModuleDecl, ModuleItem,
-            ObjectLit, Pass, Prop, PropName, PropOrSpread, Stmt, Str, Tpl, UnaryExpr, UnaryOp,
+            Expr, ExprOrSpread, ExprStmt, Id, Ident, IdentName, ImportDecl, ImportNamedSpecifier,
+            ImportSpecifier, KeyValueProp, Lit, ModuleDecl, ModuleItem, ObjectLit, Pass, Prop,
+            PropName, PropOrSpread, Stmt, Str, Tpl, UnaryExpr, UnaryOp,
         },
         utils::{private_ident, quote_ident, ExprFactory},
-        visit::{fold_pass, Fold, FoldWith},
+        visit::{fold_pass, Fold, FoldWith, VisitMut, VisitMutWith},
     },
     quote,
 };
@@ -46,8 +47,10 @@ pub fn next_dynamic(
         state: match mode {
             NextDynamicMode::Webpack => NextDynamicPatcherState::Webpack,
             NextDynamicMode::Turbopack {
+                dynamic_client_transition_name,
                 dynamic_transition_name,
             } => NextDynamicPatcherState::Turbopack {
+                dynamic_client_transition_name,
                 dynamic_transition_name,
                 imports: vec![],
             },
@@ -69,12 +72,13 @@ pub enum NextDynamicMode {
     /// the React Loadable Webpack plugin.
     Webpack,
     /// In Turbopack mode:
-    /// * in development, each `dynamic()` call will generate a key containing both the imported
-    ///   module id and the chunks it needs. This removes the need for a manifest entry
-    /// * during build, each `dynamic()` call will import the module through the given transition,
-    ///   which takes care of adding an entry to the manifest and returning an asset that exports
-    ///   the entry's key.
-    Turbopack { dynamic_transition_name: String },
+    /// * each dynamic import is amended with a transition to `dynamic_transition_name`
+    /// * the ident of the client module (via `dynamic_client_transition_name`) is added to the
+    ///   metadata
+    Turbopack {
+        dynamic_client_transition_name: String,
+        dynamic_transition_name: String,
+    },
 }
 
 #[derive(Debug)]
@@ -87,7 +91,7 @@ struct NextDynamicPatcher {
     filename: Arc<FileName>,
     dynamic_bindings: Vec<Id>,
     is_next_dynamic_first_arg: bool,
-    dynamically_imported_specifier: Option<(String, Span)>,
+    dynamically_imported_specifier: Option<(Atom, Span)>,
     state: NextDynamicPatcherState,
 }
 
@@ -98,6 +102,7 @@ enum NextDynamicPatcherState {
     /// the given transition under a particular ident.
     #[allow(unused)]
     Turbopack {
+        dynamic_client_transition_name: String,
         dynamic_transition_name: String,
         imports: Vec<TurbopackImport>,
     },
@@ -105,23 +110,8 @@ enum NextDynamicPatcherState {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 enum TurbopackImport {
-    DevelopmentTransition {
-        id_ident: Ident,
-        chunks_ident: Ident,
-        specifier: String,
-    },
-    DevelopmentId {
-        id_ident: Ident,
-        specifier: String,
-    },
-    BuildTransition {
-        id_ident: Ident,
-        specifier: String,
-    },
-    BuildId {
-        id_ident: Ident,
-        specifier: String,
-    },
+    // TODO do we need more variants? server vs client vs dev vs prod?
+    Import { id_ident: Ident, specifier: Atom },
 }
 
 impl Fold for NextDynamicPatcher {
@@ -155,11 +145,11 @@ impl Fold for NextDynamicPatcher {
             if let Callee::Import(..) = &expr.callee {
                 match &*expr.args[0].expr {
                     Expr::Lit(Lit::Str(Str { value, span, .. })) => {
-                        self.dynamically_imported_specifier = Some((value.to_string(), *span));
+                        self.dynamically_imported_specifier = Some((value.clone(), *span));
                     }
                     Expr::Tpl(Tpl { exprs, quasis, .. }) if exprs.is_empty() => {
                         self.dynamically_imported_specifier =
-                            Some((quasis[0].raw.to_string(), quasis[0].span));
+                            Some((quasis[0].raw.clone(), quasis[0].span));
                     }
                     _ => {}
                 }
@@ -223,18 +213,19 @@ impl Fold for NextDynamicPatcher {
                         _ => None,
                     };
 
-                    // dev client or server:
-                    // loadableGenerated: {
-                    //   modules:
-                    // ["/project/src/file-being-transformed.js -> " + '../components/hello'] }
-
-                    // prod client
-                    // loadableGenerated: {
-                    //   webpack: () => [require.resolveWeak('../components/hello')],
                     let generated = Box::new(Expr::Object(ObjectLit {
                         span: DUMMY_SP,
                         props: match &mut self.state {
                             NextDynamicPatcherState::Webpack => {
+                                // dev client or server:
+                                // loadableGenerated: {
+                                //   modules:
+                                // ["/project/src/file-being-transformed.js -> " +
+                                // '../components/hello'] }
+                                //
+                                // prod client
+                                // loadableGenerated: {
+                                //   webpack: () => [require.resolveWeak('../components/hello')],
                                 if self.is_development || self.is_server_compiler {
                                     module_id_options(quote!(
                                         "$left + $right" as Expr,
@@ -252,76 +243,20 @@ impl Fold for NextDynamicPatcher {
                                     ))
                                 }
                             }
+
                             NextDynamicPatcherState::Turbopack { imports, .. } => {
+                                // loadableGenerated: { modules: [
+                                // ".../client.js [app-client] (ecmascript, next/dynamic entry)"
+                                // ]}
                                 let id_ident =
                                     private_ident!(dynamically_imported_specifier_span, "id");
 
-                                match (self.is_development, self.is_server_compiler) {
-                                    (true, true) => {
-                                        let chunks_ident = private_ident!(
-                                            dynamically_imported_specifier_span,
-                                            "chunks"
-                                        );
+                                imports.push(TurbopackImport::Import {
+                                    id_ident: id_ident.clone(),
+                                    specifier: dynamically_imported_specifier.clone(),
+                                });
 
-                                        imports.push(TurbopackImport::DevelopmentTransition {
-                                            id_ident: id_ident.clone(),
-                                            chunks_ident: chunks_ident.clone(),
-                                            specifier: dynamically_imported_specifier.clone(),
-                                        });
-
-                                        // On the server, the key needs to be serialized because it
-                                        // will be used to index the React Loadable Manifest, which
-                                        // is a normal JS object. In Turbo mode, this is a proxy,
-                                        // but the key will still be coerced to a string.
-                                        module_id_options(quote!(
-                                            r#"
-                                            JSON.stringify({
-                                                id: $id,
-                                                chunks: $chunks
-                                            })
-                                            "# as Expr,
-                                            id = id_ident,
-                                            chunks = chunks_ident,
-                                        ))
-                                    }
-                                    (true, false) => {
-                                        imports.push(TurbopackImport::DevelopmentId {
-                                            id_ident: id_ident.clone(),
-                                            specifier: dynamically_imported_specifier.clone(),
-                                        });
-
-                                        // On the client, we only need the target module ID, which
-                                        // will be reported under the `dynamicIds` property of Next
-                                        // data.
-                                        module_id_options(Expr::Ident(id_ident))
-                                    }
-                                    (false, true) => {
-                                        let id_ident = private_ident!(
-                                            dynamically_imported_specifier_span,
-                                            "id"
-                                        );
-
-                                        imports.push(TurbopackImport::BuildTransition {
-                                            id_ident: id_ident.clone(),
-                                            specifier: dynamically_imported_specifier.clone(),
-                                        });
-
-                                        module_id_options(Expr::Ident(id_ident))
-                                    }
-                                    (false, false) => {
-                                        let id_ident = private_ident!(
-                                            dynamically_imported_specifier_span,
-                                            "id"
-                                        );
-
-                                        imports.push(TurbopackImport::BuildId {
-                                            id_ident: id_ident.clone(),
-                                            specifier: dynamically_imported_specifier.clone(),
-                                        });
-
-                                        module_id_options(Expr::Ident(id_ident))
-                                    }
-                                }
+                                module_id_options(Expr::Ident(id_ident))
                             }
                         },
                     }));
@@ -371,58 +306,74 @@ impl Fold for NextDynamicPatcher {
                         }
                     }
 
-                    if has_ssr_false
-                        && self.is_server_compiler
-                        && !self.is_react_server_layer
-                        // When it's not prefer to picking up ESM, as it's in the pages router, we don't need to do it as it doesn't need to enter the non-ssr module.
-                        // Also transforming it to `require.resolveWeak` and with ESM import, like require.resolveWeak(esm asset) is not available as it's commonjs importing ESM.
-                        && self.prefer_esm
+                    match &self.state {
+                        NextDynamicPatcherState::Webpack => {
+                            // Only use `require.resolveWebpack` to decouple modules for webpack,
+                            // turbopack doesn't need this
 
-                        // Only use `require.resolveWebpack` to decouple modules for webpack,
-                        // turbopack doesn't need this
-                        && self.state == NextDynamicPatcherState::Webpack
-                    {
-                        // if it's server components SSR layer
-                        // Transform 1st argument `expr.args[0]` aka the module loader from:
-                        // dynamic(() => import('./client-mod'), { ssr: false }))`
-                        // into:
-                        // dynamic(async () => {
-                        //   require.resolveWeak('./client-mod')
-                        // }, { ssr: false }))`
+                            // When it's not prefering to picking up ESM (in the pages router), we
+                            // don't need to do it as it doesn't need to enter the non-ssr module.
+                            //
+                            // Also transforming it to `require.resolveWeak` doesn't work with ESM
+                            // imports ( i.e. require.resolveWeak(esm asset)).
+                            if has_ssr_false
+                                && self.is_server_compiler
+                                && !self.is_react_server_layer
+                                && self.prefer_esm
+                            {
+                                // if it's server components SSR layer
+                                // Transform 1st argument `expr.args[0]` aka the module loader from:
+                                // dynamic(() => import('./client-mod'), { ssr: false }))`
+                                // into:
+                                // dynamic(async () => {
+                                //   require.resolveWeak('./client-mod')
+                                // }, { ssr: false }))`
 
-                        let require_resolve_weak_expr = Expr::Call(CallExpr {
-                            span: DUMMY_SP,
-                            callee: quote_ident!("require.resolveWeak").as_callee(),
-                            args: vec![ExprOrSpread {
-                                spread: None,
-                                expr: Box::new(Expr::Lit(Lit::Str(Str {
+                                let require_resolve_weak_expr = Expr::Call(CallExpr {
                                     span: DUMMY_SP,
-                                    value: dynamically_imported_specifier.clone().into(),
-                                    raw: None,
-                                }))),
-                            }],
-                            ..Default::default()
-                        });
+                                    callee: quote_ident!("require.resolveWeak").as_callee(),
+                                    args: vec![ExprOrSpread {
+                                        spread: None,
+                                        expr: Box::new(Expr::Lit(Lit::Str(Str {
+                                            span: DUMMY_SP,
+                                            value: dynamically_imported_specifier.clone(),
+                                            raw: None,
+                                        }))),
+                                    }],
+                                    ..Default::default()
+                                });
 
-                        let side_effect_free_loader_arg = Expr::Arrow(ArrowExpr {
-                            span: DUMMY_SP,
-                            params: vec![],
-                            body: Box::new(BlockStmtOrExpr::BlockStmt(BlockStmt {
-                                span: DUMMY_SP,
-                                stmts: vec![Stmt::Expr(ExprStmt {
+                                let side_effect_free_loader_arg = Expr::Arrow(ArrowExpr {
                                     span: DUMMY_SP,
-                                    expr: Box::new(exec_expr_when_resolve_weak_available(
-                                        &require_resolve_weak_expr,
-                                    )),
-                                })],
-                                ..Default::default()
-                            })),
-                            is_async: true,
-                            is_generator: false,
-                            ..Default::default()
-                        });
+                                    params: vec![],
+                                    body: Box::new(BlockStmtOrExpr::BlockStmt(BlockStmt {
+                                        span: DUMMY_SP,
+                                        stmts: vec![Stmt::Expr(ExprStmt {
+                                            span: DUMMY_SP,
+                                            expr: Box::new(exec_expr_when_resolve_weak_available(
+                                                &require_resolve_weak_expr,
+                                            )),
+                                        })],
+                                        ..Default::default()
+                                    })),
+                                    is_async: true,
+                                    is_generator: false,
+                                    ..Default::default()
+                                });
 
-                        expr.args[0] = side_effect_free_loader_arg.as_arg();
+                                expr.args[0] = side_effect_free_loader_arg.as_arg();
+                            }
+                        }
+                        NextDynamicPatcherState::Turbopack {
+                            dynamic_transition_name,
+                            ..
+                        } => {
+                            // Add `{with:{turbopack-transition: ...}}` to the dynamic import
+                            let mut visitor = DynamicImportTransitionAdder {
+                                transition_name: dynamic_transition_name,
+                            };
+                            expr.args[0].visit_mut_with(&mut visitor);
+                        }
                     }
 
                     let second_arg = ExprOrSpread {
@@ -442,6 +393,37 @@ impl Fold for NextDynamicPatcher {
             }
         }
         expr
+    }
+}
+
+struct DynamicImportTransitionAdder<'a> {
+    transition_name: &'a str,
+}
+// Add `{with:{turbopack-transition: <self.transition_name>}}` to any dynamic imports
+impl VisitMut for DynamicImportTransitionAdder<'_> {
+    fn visit_mut_call_expr(&mut self, expr: &mut CallExpr) {
+        if let Callee::Import(..) = &expr.callee {
+            let options = ExprOrSpread {
+                expr: Box::new(
+                    ObjectLit {
+                        span: DUMMY_SP,
+                        props: vec![PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+                            key: PropName::Ident(IdentName::new("with".into(), DUMMY_SP)),
+                            value: with_transition(self.transition_name).into(),
+                        })))],
+                    }
+                    .into(),
+                ),
+                spread: None,
+            };
+
+            match expr.args.get_mut(1) {
+                Some(arg) => *arg = options,
+                None => expr.args.push(options),
+            }
+        } else {
+            expr.visit_mut_children_with(self);
+        }
     }
 }
 
@@ -481,8 +463,9 @@ fn webpack_options(module_id: Expr) -> Vec<PropOrSpread> {
 impl NextDynamicPatcher {
     fn maybe_add_dynamically_imported_specifier(&mut self, items: &mut Vec<ModuleItem>) {
         let NextDynamicPatcherState::Turbopack {
-            dynamic_transition_name,
+            dynamic_client_transition_name,
             imports,
+            ..
         } = &mut self.state
         else {
             return;
@@ -492,37 +475,7 @@ impl NextDynamicPatcher {
 
         for import in std::mem::take(imports) {
             match import {
-                TurbopackImport::DevelopmentTransition {
-                    id_ident,
-                    chunks_ident,
-                    specifier,
-                } => {
-                    new_items.push(ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
-                        span: DUMMY_SP,
-                        specifiers: vec![
-                            ImportSpecifier::Default(ImportDefaultSpecifier {
-                                span: DUMMY_SP,
-                                local: id_ident,
-                            }),
-                            ImportSpecifier::Named(ImportNamedSpecifier {
-                                span: DUMMY_SP,
-                                local: chunks_ident,
-                                imported: Some(
-                                    Ident::new("chunks".into(), DUMMY_SP, Default::default())
-                                        .into(),
-                                ),
-                                is_type_only: false,
-                            }),
-                        ],
-                        src: Box::new(specifier.into()),
-                        type_only: false,
-                        // The transition should return both the target module's id
-                        // and the chunks it needs to run.
-                        with: Some(with_transition(dynamic_transition_name)),
-                        phase: Default::default(),
-                    })));
-                }
-                TurbopackImport::DevelopmentId {
+                TurbopackImport::Import {
                     id_ident,
                     specifier,
                 } => {
@@ -545,69 +498,10 @@ impl NextDynamicPatcher {
                         })],
                         src: Box::new(specifier.into()),
                         type_only: false,
-                        // We don't want this import to cause the imported module to be considered
-                        // for chunking through this import; we only need
-                        // the module id.
-                        with: Some(with_chunking_type("none")),
-                        phase: Default::default(),
-                    })));
-                }
-                TurbopackImport::BuildTransition {
-                    id_ident,
-                    specifier,
-                } => {
-                    // Turbopack will automatically transform the imported `__turbopack_module_id__`
-                    // identifier into the imported module's id.
-                    new_items.push(ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
-                        span: DUMMY_SP,
-                        specifiers: vec![ImportSpecifier::Named(ImportNamedSpecifier {
-                            span: DUMMY_SP,
-                            local: id_ident,
-                            imported: Some(
-                                Ident::new(
-                                    "__turbopack_module_id__".into(),
-                                    DUMMY_SP,
-                                    Default::default(),
-                                )
-                                .into(),
-                            ),
-                            is_type_only: false,
-                        })],
-                        src: Box::new(specifier.into()),
-                        type_only: false,
-                        // The transition should make sure the imported module ends up in the
-                        // dynamic manifest.
-                        with: Some(with_transition(dynamic_transition_name)),
-                        phase: Default::default(),
-                    })));
-                }
-                TurbopackImport::BuildId {
-                    id_ident,
-                    specifier,
-                } => {
-                    // Turbopack will automatically transform the imported `__turbopack_module_id__`
-                    // identifier into the imported module's id.
-                    new_items.push(ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
-                        span: DUMMY_SP,
-                        specifiers: vec![ImportSpecifier::Named(ImportNamedSpecifier {
-                            span: DUMMY_SP,
-                            local: id_ident,
-                            imported: Some(
-                                Ident::new(
-                                    "__turbopack_module_id__".into(),
-                                    DUMMY_SP,
-                                    Default::default(),
-                                )
-                                .into(),
-                            ),
-                            is_type_only: false,
-                        })],
-                        src: Box::new(specifier.into()),
-                        type_only: false,
-                        // We don't want this import to cause the imported module to be considered
-                        // for chunking through this import; we only need
-                        // the module id.
-                        with: Some(with_chunking_type("none")),
+                        with: Some(with_transition_chunking_type(
+                            dynamic_client_transition_name,
+                            "none",
+                        )),
                         phase: Default::default(),
                     })));
                 }
@@ -673,19 +567,22 @@ fn rel_filename(base: Option<&Path>, file: &FileName) -> String {
     rel_path.display().to_string()
 }
 
-fn with_chunking_type(chunking_type: &str) -> Box<ObjectLit> {
-    with_clause(&[("chunking-type", chunking_type)])
+fn with_transition(transition_name: &str) -> ObjectLit {
+    with_clause(&[("turbopack-transition", transition_name)])
 }
 
-fn with_transition(transition_name: &str) -> Box<ObjectLit> {
-    with_clause(&[("transition", transition_name)])
+fn with_transition_chunking_type(transition_name: &str, chunking_type: &str) -> Box<ObjectLit> {
+    Box::new(with_clause(&[
+        ("turbopack-transition", transition_name),
+        ("turbopack-chunking-type", chunking_type),
+    ]))
 }
 
-fn with_clause<'a>(entries: impl IntoIterator<Item = &'a (&'a str, &'a str)>) -> Box<ObjectLit> {
-    Box::new(ObjectLit {
+fn with_clause<'a>(entries: impl IntoIterator<Item = &'a (&'a str, &'a str)>) -> ObjectLit {
+    ObjectLit {
         span: DUMMY_SP,
         props: entries.into_iter().map(|(k, v)| with_prop(k, v)).collect(),
-    })
+    }
 }
 
 fn with_prop(key: &str, value: &str) -> PropOrSpread {

--- a/crates/next-custom-transforms/tests/fixture.rs
+++ b/crates/next-custom-transforms/tests/fixture.rs
@@ -44,6 +44,7 @@ use testing::fixture;
 fn syntax() -> Syntax {
     Syntax::Es(EsSyntax {
         jsx: true,
+        import_attributes: true,
         ..Default::default()
     })
 }
@@ -65,6 +66,9 @@ fn next_dynamic_fixture(input: PathBuf) {
     let output_dev = input.parent().unwrap().join("output-dev.js");
     let output_prod = input.parent().unwrap().join("output-prod.js");
     let output_server = input.parent().unwrap().join("output-server.js");
+    let output_turbo_dev = input.parent().unwrap().join("output-turbo-dev.js");
+    let output_turbo_prod = input.parent().unwrap().join("output-turbo-prod.js");
+    let output_turbo_server = input.parent().unwrap().join("output-turbo-server.js");
     test_fixture(
         syntax(),
         &|_tr| {
@@ -116,6 +120,66 @@ fn next_dynamic_fixture(input: PathBuf) {
         &output_server,
         Default::default(),
     );
+    test_fixture(
+        syntax(),
+        &|_tr| {
+            next_dynamic(
+                true,
+                false,
+                false,
+                false,
+                NextDynamicMode::Turbopack {
+                    dynamic_client_transition_name: "next-client-dynamic".to_string(),
+                    dynamic_transition_name: "next-dynamic".to_string(),
+                },
+                FileName::Real(PathBuf::from("/some-project/src/some-file.js")).into(),
+                Some("/some-project/src".into()),
+            )
+        },
+        &input,
+        &output_turbo_dev,
+        Default::default(),
+    );
+    test_fixture(
+        syntax(),
+        &|_tr| {
+            next_dynamic(
+                false,
+                false,
+                false,
+                false,
+                NextDynamicMode::Turbopack {
+                    dynamic_client_transition_name: "next-client-dynamic".to_string(),
+                    dynamic_transition_name: "next-dynamic".to_string(),
+                },
+                FileName::Real(PathBuf::from("/some-project/src/some-file.js")).into(),
+                Some("/some-project/src".into()),
+            )
+        },
+        &input,
+        &output_turbo_prod,
+        Default::default(),
+    );
+    test_fixture(
+        syntax(),
+        &|_tr| {
+            next_dynamic(
+                false,
+                true,
+                false,
+                false,
+                NextDynamicMode::Turbopack {
+                    dynamic_client_transition_name: "next-client-dynamic".to_string(),
+                    dynamic_transition_name: "next-dynamic".to_string(),
+                },
+                FileName::Real(PathBuf::from("/some-project/src/some-file.js")).into(),
+                Some("/some-project/src".into()),
+            )
+        },
+        &input,
+        &output_turbo_server,
+        Default::default(),
+    );
 }
 
 #[fixture("tests/fixture/next-dynamic-app-dir/**/input.js")]
@@ -127,6 +191,13 @@ fn app_dir_next_dynamic_fixture(input: PathBuf) {
         .parent()
         .unwrap()
         .join("output-server-client-layer.js");
+    let output_turbo_dev = input.parent().unwrap().join("output-turbo-dev.js");
+    let output_turbo_prod = input.parent().unwrap().join("output-turbo-prod.js");
+    let output_turbo_server: PathBuf = input.parent().unwrap().join("output-turbo-server.js");
+    let output_turbo_server_client_layer = input
+        .parent()
+        .unwrap()
+        .join("output-turbo-server-client-layer.js");
     test_fixture(
         syntax(),
         &|_tr| {
@@ -193,6 +264,86 @@ fn app_dir_next_dynamic_fixture(input: PathBuf) {
         },
         &input,
         &output_server_client_layer,
+        Default::default(),
+    );
+    test_fixture(
+        syntax(),
+        &|_tr| {
+            next_dynamic(
+                true,
+                false,
+                true,
+                false,
+                NextDynamicMode::Turbopack {
+                    dynamic_client_transition_name: "next-client-dynamic".to_string(),
+                    dynamic_transition_name: "next-dynamic".to_string(),
+                },
+                FileName::Real(PathBuf::from("/some-project/src/some-file.js")).into(),
+                Some("/some-project/src".into()),
+            )
+        },
+        &input,
+        &output_turbo_dev,
+        Default::default(),
+    );
+    test_fixture(
+        syntax(),
+        &|_tr| {
+            next_dynamic(
+                false,
+                false,
+                true,
+                false,
+                NextDynamicMode::Turbopack {
+                    dynamic_client_transition_name: "next-client-dynamic".to_string(),
+                    dynamic_transition_name: "next-dynamic".to_string(),
+                },
+                FileName::Real(PathBuf::from("/some-project/src/some-file.js")).into(),
+                Some("/some-project/src".into()),
+            )
+        },
+        &input,
+        &output_turbo_prod,
+        Default::default(),
+    );
+    test_fixture(
+        syntax(),
+        &|_tr| {
+            next_dynamic(
+                false,
+                true,
+                true,
+                false,
+                NextDynamicMode::Turbopack {
+                    dynamic_client_transition_name: "next-client-dynamic".to_string(),
+                    dynamic_transition_name: "next-dynamic".to_string(),
+                },
+                FileName::Real(PathBuf::from("/some-project/src/some-file.js")).into(),
+                Some("/some-project/src".into()),
+            )
+        },
+        &input,
+        &output_turbo_server,
+        Default::default(),
+    );
+    test_fixture(
+        syntax(),
+        &|_tr| {
+            next_dynamic(
+                false,
+                true,
+                false,
+                false,
+                NextDynamicMode::Turbopack {
+                    dynamic_client_transition_name: "next-client-dynamic".to_string(),
+                    dynamic_transition_name: "next-dynamic".to_string(),
+                },
+                FileName::Real(PathBuf::from("/some-project/src/some-file.js")).into(),
+                Some("/some-project/src".into()),
+            )
+        },
+        &input,
+        &output_turbo_server_client_layer,
         Default::default(),
     );
 }

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-dev.js
@@ -1,0 +1,17 @@
+import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    },
+    ssr: false
+});

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-prod.js
@@ -1,0 +1,17 @@
+import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    },
+    ssr: false
+});

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-server-client-layer.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-server-client-layer.js
@@ -1,0 +1,17 @@
+import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    },
+    ssr: false
+});

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-server.js
@@ -1,0 +1,17 @@
+import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    },
+    ssr: false
+});

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/duplicated-imports/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/duplicated-imports/output-turbo-dev.js
@@ -1,0 +1,32 @@
+import { __turbopack_module_id__ as id } from "../components/hello1" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import { __turbopack_module_id__ as id1 } from "../components/hello2" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic1 from 'next/dynamic';
+import dynamic2 from 'next/dynamic';
+const DynamicComponent1 = dynamic1(()=>import('../components/hello1', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    }
+});
+const DynamicComponent2 = dynamic2(()=>import('../components/hello2', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id1
+        ]
+    }
+});

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/duplicated-imports/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/duplicated-imports/output-turbo-prod.js
@@ -1,0 +1,32 @@
+import { __turbopack_module_id__ as id } from "../components/hello1" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import { __turbopack_module_id__ as id1 } from "../components/hello2" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic1 from 'next/dynamic';
+import dynamic2 from 'next/dynamic';
+const DynamicComponent1 = dynamic1(()=>import('../components/hello1', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    }
+});
+const DynamicComponent2 = dynamic2(()=>import('../components/hello2', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id1
+        ]
+    }
+});

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/duplicated-imports/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/duplicated-imports/output-turbo-server.js
@@ -1,0 +1,32 @@
+import { __turbopack_module_id__ as id } from "../components/hello1" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import { __turbopack_module_id__ as id1 } from "../components/hello2" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic1 from 'next/dynamic';
+import dynamic2 from 'next/dynamic';
+const DynamicComponent1 = dynamic1(()=>import('../components/hello1', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    }
+});
+const DynamicComponent2 = dynamic2(()=>import('../components/hello2', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id1
+        ]
+    }
+});

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/issue-48098/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/issue-48098/output-turbo-dev.js
@@ -1,0 +1,17 @@
+import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    },
+    ssr: false
+});

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/issue-48098/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/issue-48098/output-turbo-prod.js
@@ -1,0 +1,17 @@
+import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    },
+    ssr: false
+});

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/issue-48098/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/issue-48098/output-turbo-server.js
@@ -1,0 +1,17 @@
+import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    },
+    ssr: false
+});

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/member-with-same-name/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/member-with-same-name/output-turbo-dev.js
@@ -1,0 +1,18 @@
+import { __turbopack_module_id__ as id } from "../components/hello" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+import somethingElse from 'something-else';
+const DynamicComponent = dynamic(()=>import('../components/hello', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    }
+});
+somethingElse.dynamic('should not be transformed');

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/member-with-same-name/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/member-with-same-name/output-turbo-prod.js
@@ -1,0 +1,18 @@
+import { __turbopack_module_id__ as id } from "../components/hello" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+import somethingElse from 'something-else';
+const DynamicComponent = dynamic(()=>import('../components/hello', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    }
+});
+somethingElse.dynamic('should not be transformed');

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/member-with-same-name/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/member-with-same-name/output-turbo-server.js
@@ -1,0 +1,18 @@
+import { __turbopack_module_id__ as id } from "../components/hello" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+import somethingElse from 'something-else';
+const DynamicComponent = dynamic(()=>import('../components/hello', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    }
+});
+somethingElse.dynamic('should not be transformed');

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/no-options/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/no-options/output-turbo-dev.js
@@ -1,0 +1,16 @@
+import { __turbopack_module_id__ as id } from "../components/hello" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+const DynamicComponent = dynamic(()=>import('../components/hello', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    }
+});

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/no-options/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/no-options/output-turbo-prod.js
@@ -1,0 +1,16 @@
+import { __turbopack_module_id__ as id } from "../components/hello" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+const DynamicComponent = dynamic(()=>import('../components/hello', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    }
+});

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/no-options/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/no-options/output-turbo-server.js
@@ -1,0 +1,16 @@
+import { __turbopack_module_id__ as id } from "../components/hello" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+const DynamicComponent = dynamic(()=>import('../components/hello', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    }
+});

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/template-literal/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/template-literal/output-turbo-dev.js
@@ -1,0 +1,19 @@
+import { __turbopack_module_id__ as id } from "../components/hello" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+const DynamicComponent = dynamic(()=>import(`../components/hello`, {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    }
+});
+const componentRoot = '@/some-components';
+const Component1 = dynamic(()=>import(`${componentRoot}/component1`));
+const Component2 = dynamic(()=>import(`${componentRoot}/component2`));

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/template-literal/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/template-literal/output-turbo-prod.js
@@ -1,0 +1,19 @@
+import { __turbopack_module_id__ as id } from "../components/hello" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+const DynamicComponent = dynamic(()=>import(`../components/hello`, {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    }
+});
+const componentRoot = '@/some-components';
+const Component1 = dynamic(()=>import(`${componentRoot}/component1`));
+const Component2 = dynamic(()=>import(`${componentRoot}/component2`));

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/template-literal/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/template-literal/output-turbo-server.js
@@ -1,0 +1,19 @@
+import { __turbopack_module_id__ as id } from "../components/hello" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+const DynamicComponent = dynamic(()=>import(`../components/hello`, {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    }
+});
+const componentRoot = '@/some-components';
+const Component1 = dynamic(()=>import(`${componentRoot}/component1`));
+const Component2 = dynamic(()=>import(`${componentRoot}/component2`));

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/with-options/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/with-options/output-turbo-dev.js
@@ -1,0 +1,50 @@
+import { __turbopack_module_id__ as id } from "../components/hello" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import { __turbopack_module_id__ as id1 } from "../components/hello" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import { __turbopack_module_id__ as id2 } from "../components/hello" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+const DynamicComponentWithCustomLoading = dynamic(()=>import('../components/hello', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    },
+    loading: ()=><p>...</p>
+});
+const DynamicClientOnlyComponent = dynamic(()=>import('../components/hello', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id1
+        ]
+    },
+    ssr: false
+});
+const DynamicClientOnlyComponentWithSuspense = dynamic(()=>import('../components/hello', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id2
+        ]
+    },
+    ssr: false,
+    suspense: true
+});

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/with-options/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/with-options/output-turbo-prod.js
@@ -1,0 +1,50 @@
+import { __turbopack_module_id__ as id } from "../components/hello" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import { __turbopack_module_id__ as id1 } from "../components/hello" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import { __turbopack_module_id__ as id2 } from "../components/hello" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+const DynamicComponentWithCustomLoading = dynamic(()=>import('../components/hello', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    },
+    loading: ()=><p>...</p>
+});
+const DynamicClientOnlyComponent = dynamic(()=>import('../components/hello', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id1
+        ]
+    },
+    ssr: false
+});
+const DynamicClientOnlyComponentWithSuspense = dynamic(()=>import('../components/hello', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id2
+        ]
+    },
+    ssr: false,
+    suspense: true
+});

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/with-options/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/with-options/output-turbo-server.js
@@ -1,0 +1,50 @@
+import { __turbopack_module_id__ as id } from "../components/hello" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import { __turbopack_module_id__ as id1 } from "../components/hello" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import { __turbopack_module_id__ as id2 } from "../components/hello" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+const DynamicComponentWithCustomLoading = dynamic(()=>import('../components/hello', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    },
+    loading: ()=><p>...</p>
+});
+const DynamicClientOnlyComponent = dynamic(()=>import('../components/hello', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id1
+        ]
+    },
+    ssr: false
+});
+const DynamicClientOnlyComponentWithSuspense = dynamic(()=>import('../components/hello', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }), {
+    loadableGenerated: {
+        modules: [
+            id2
+        ]
+    },
+    ssr: false,
+    suspense: true
+});

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/input.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/input.js
@@ -1,8 +1,14 @@
 import dynamic from 'next/dynamic'
-const DynamicComponent = dynamic(
-  () => handleImport(import('./components/hello')),
+const DynamicComponent1 = dynamic(
+  () => handleImport(import('./components/hello1')),
   {
     loading: () => null,
     ssr: false,
   }
+)
+
+const DynamicComponent2 = dynamic(() =>
+  import('./components/hello2').then((mod) => {
+    return mod.Button
+  })
 )

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-dev.js
@@ -1,10 +1,19 @@
 import dynamic from 'next/dynamic';
-const DynamicComponent = dynamic(()=>handleImport(import('./components/hello')), {
+const DynamicComponent1 = dynamic(()=>handleImport(import('./components/hello1')), {
     loadableGenerated: {
         modules: [
-            "src/some-file.js -> " + "./components/hello"
+            "src/some-file.js -> " + "./components/hello1"
         ]
     },
     loading: ()=>null,
     ssr: false
+});
+const DynamicComponent2 = dynamic(()=>import('./components/hello2').then((mod)=>{
+        return mod.Button;
+    }), {
+    loadableGenerated: {
+        modules: [
+            "src/some-file.js -> " + "./components/hello2"
+        ]
+    }
 });

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-prod.js
@@ -1,12 +1,19 @@
 import dynamic from 'next/dynamic';
-const DynamicComponent = dynamic(()=>handleImport(import('./components/hello'))
-, {
+const DynamicComponent1 = dynamic(()=>handleImport(import('./components/hello1')), {
     loadableGenerated: {
         webpack: ()=>[
-                require.resolveWeak("./components/hello")
+                require.resolveWeak("./components/hello1")
             ]
     },
-    loading: ()=>null
-    ,
+    loading: ()=>null,
     ssr: false
+});
+const DynamicComponent2 = dynamic(()=>import('./components/hello2').then((mod)=>{
+        return mod.Button;
+    }), {
+    loadableGenerated: {
+        webpack: ()=>[
+                require.resolveWeak("./components/hello2")
+            ]
+    }
 });

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-server.js
@@ -1,10 +1,19 @@
 import dynamic from 'next/dynamic';
-const DynamicComponent = dynamic(()=>handleImport(import('./components/hello')), {
+const DynamicComponent1 = dynamic(()=>handleImport(import('./components/hello1')), {
     loadableGenerated: {
         modules: [
-            "src/some-file.js -> " + "./components/hello"
+            "src/some-file.js -> " + "./components/hello1"
         ]
     },
     loading: ()=>null,
     ssr: false
+});
+const DynamicComponent2 = dynamic(()=>import('./components/hello2').then((mod)=>{
+        return mod.Button;
+    }), {
+    loadableGenerated: {
+        modules: [
+            "src/some-file.js -> " + "./components/hello2"
+        ]
+    }
 });

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-turbo-dev.js
@@ -1,0 +1,35 @@
+import { __turbopack_module_id__ as id } from "./components/hello1" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import { __turbopack_module_id__ as id1 } from "./components/hello2" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+const DynamicComponent1 = dynamic(()=>handleImport(import('./components/hello1', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    })), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    },
+    loading: ()=>null,
+    ssr: false
+});
+const DynamicComponent2 = dynamic(()=>import('./components/hello2', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }).then((mod)=>{
+        return mod.Button;
+    }), {
+    loadableGenerated: {
+        modules: [
+            id1
+        ]
+    }
+});

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-turbo-prod.js
@@ -1,0 +1,35 @@
+import { __turbopack_module_id__ as id } from "./components/hello1" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import { __turbopack_module_id__ as id1 } from "./components/hello2" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+const DynamicComponent1 = dynamic(()=>handleImport(import('./components/hello1', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    })), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    },
+    loading: ()=>null,
+    ssr: false
+});
+const DynamicComponent2 = dynamic(()=>import('./components/hello2', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }).then((mod)=>{
+        return mod.Button;
+    }), {
+    loadableGenerated: {
+        modules: [
+            id1
+        ]
+    }
+});

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-turbo-server.js
@@ -1,0 +1,35 @@
+import { __turbopack_module_id__ as id } from "./components/hello1" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import { __turbopack_module_id__ as id1 } from "./components/hello2" with {
+    "turbopack-transition": "next-client-dynamic",
+    "turbopack-chunking-type": "none"
+};
+import dynamic from 'next/dynamic';
+const DynamicComponent1 = dynamic(()=>handleImport(import('./components/hello1', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    })), {
+    loadableGenerated: {
+        modules: [
+            id
+        ]
+    },
+    loading: ()=>null,
+    ssr: false
+});
+const DynamicComponent2 = dynamic(()=>import('./components/hello2', {
+        with: {
+            "turbopack-transition": "next-dynamic"
+        }
+    }).then((mod)=>{
+        return mod.Button;
+    }), {
+    loadableGenerated: {
+        modules: [
+            id1
+        ]
+    }
+});

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2484,10 +2484,15 @@ export default async function build(
               PRERENDER_MANIFEST,
               path.join(SERVER_DIRECTORY, MIDDLEWARE_MANIFEST),
               path.join(SERVER_DIRECTORY, MIDDLEWARE_BUILD_MANIFEST + '.js'),
-              path.join(
-                SERVER_DIRECTORY,
-                MIDDLEWARE_REACT_LOADABLE_MANIFEST + '.js'
-              ),
+              ...(!process.env.TURBOPACK
+                ? [
+                    path.join(
+                      SERVER_DIRECTORY,
+                      MIDDLEWARE_REACT_LOADABLE_MANIFEST + '.js'
+                    ),
+                    REACT_LOADABLE_MANIFEST,
+                  ]
+                : []),
               ...(appDir
                 ? [
                     ...(config.experimental.sri
@@ -2521,7 +2526,6 @@ export default async function build(
                     path.join(SERVER_DIRECTORY, DYNAMIC_CSS_MANIFEST + '.js'),
                   ]
                 : []),
-              REACT_LOADABLE_MANIFEST,
               BUILD_ID_FILE,
               path.join(SERVER_DIRECTORY, NEXT_FONT_MANIFEST + '.js'),
               path.join(SERVER_DIRECTORY, NEXT_FONT_MANIFEST + '.json'),

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -448,7 +448,6 @@ export async function handleRouteType({
         }
         await manifestLoader.loadFontManifest('/_app', 'pages')
         await manifestLoader.loadFontManifest(page, 'pages')
-        await manifestLoader.loadLoadableManifest(page, 'pages')
 
         if (shouldCreateWebpackStats) {
           await manifestLoader.loadWebpackStats(page, 'pages')
@@ -544,7 +543,6 @@ export async function handleRouteType({
       } else {
         manifestLoader.deleteMiddlewareManifest(key)
       }
-      await manifestLoader.loadLoadableManifest(page, 'pages')
 
       await manifestLoader.writeManifests({
         devRewrites,
@@ -601,7 +599,6 @@ export async function handleRouteType({
       await manifestLoader.loadBuildManifest(page, 'app')
       await manifestLoader.loadAppPathsManifest(page)
       await manifestLoader.loadActionManifest(page)
-      await manifestLoader.loadLoadableManifest(page, 'app')
       await manifestLoader.loadFontManifest(page, 'app')
 
       if (shouldCreateWebpackStats) {

--- a/test/development/basic/next-dynamic/next-dynamic.test.ts
+++ b/test/development/basic/next-dynamic/next-dynamic.test.ts
@@ -66,7 +66,9 @@ describe('next/dynamic', () => {
         const $ = await get$(basePath + '/dynamic/ssr')
         // Make sure the client side knows it has to wait for the bundle
         expect(JSON.parse($('#__NEXT_DATA__').html()).dynamicIds).toContain(
-          'pages/dynamic/ssr.js -> ../../components/hello1'
+          process.env.TURBOPACK
+            ? '[project]/components/hello1.js [client] (ecmascript, next/dynamic entry)'
+            : 'pages/dynamic/ssr.js -> ../../components/hello1'
         )
         expect($('body').text()).toMatch(/Hello World 1/)
       })
@@ -75,7 +77,9 @@ describe('next/dynamic', () => {
         const $ = await get$(basePath + '/dynamic/function')
         // Make sure the client side knows it has to wait for the bundle
         expect(JSON.parse($('#__NEXT_DATA__').html()).dynamicIds).toContain(
-          'pages/dynamic/function.js -> ../../components/hello1'
+          process.env.TURBOPACK
+            ? '[project]/components/hello1.js [client] (ecmascript, next/dynamic entry)'
+            : 'pages/dynamic/function.js -> ../../components/hello1'
         )
         expect($('body').text()).toMatch(/Hello World 1/)
       })

--- a/test/development/pages-dir/client-navigation/rendering.test.ts
+++ b/test/development/pages-dir/client-navigation/rendering.test.ts
@@ -225,15 +225,22 @@ describe('Client Navigation rendering', () => {
 
       const buildManifest = await next.readJSON(`.next/${BUILD_MANIFEST}`)
       const reactLoadableManifest = await next.readJSON(
-        `.next/${REACT_LOADABLE_MANIFEST}`
+        process.env.TURBOPACK
+          ? `.next/server/pages/dynamic/ssr/${REACT_LOADABLE_MANIFEST}`
+          : `.next/${REACT_LOADABLE_MANIFEST}`
       )
       const resources = []
 
       const manifestKey = Object.keys(reactLoadableManifest).find((item) => {
         return item
           .replace(/\\/g, '/')
-          .endsWith('ssr.js -> ../../components/hello1')
+          .endsWith(
+            process.env.TURBOPACK
+              ? 'components/hello1.js [client] (ecmascript, next/dynamic entry)'
+              : 'ssr.js -> ../../components/hello1'
+          )
       })
+      expect(manifestKey).toBeString()
 
       // test dynamic chunk
       resources.push('/_next/' + reactLoadableManifest[manifestKey].files[0])

--- a/test/integration/i18n-support/test/shared.js
+++ b/test/integration/i18n-support/test/shared.js
@@ -62,9 +62,12 @@ export function runTests(ctx) {
       cwd: join(ctx.appDir, '.next/static'),
     })
 
-    for (const locale of locales) {
+    // Only use a subset of the locales to speed up the test
+    for (const locale of [
+      ...nonDomainLocales.slice(0, 2),
+      ...domainLocales.slice(0, 2),
+    ]) {
       for (const asset of assets) {
-        require('console').log({ locale, asset })
         // _next/static asset
         const res = await fetchViaHTTP(
           ctx.appPort,

--- a/test/integration/react-current-version/test/index.test.js
+++ b/test/integration/react-current-version/test/index.test.js
@@ -58,7 +58,11 @@ describe('Basics', () => {
         if (env === 'dev') {
           expect(
             dynamicIds.find((id) =>
-              id.includes(`pages/${page}.js -> ../components/foo`)
+              process.env.TURBOPACK
+                ? id.endsWith(
+                    'app/components/foo.js [client] (ecmascript, next/dynamic entry)'
+                  )
+                : id === `pages/${page}.js -> ../components/foo`
             )
           ).toBeTruthy()
         } else {

--- a/test/production/generate-middleware-source-maps/index.test.ts
+++ b/test/production/generate-middleware-source-maps/index.test.ts
@@ -35,7 +35,12 @@ describe('Middleware source maps', () => {
       )) {
         const filePath = path.join(next.testDir, '.next', file)
         expect(await fs.pathExists(filePath)).toEqual(true)
-        expect(await fs.pathExists(`${filePath}.map`)).toEqual(true)
+        if (
+          filePath.endsWith('.js') &&
+          !filePath.endsWith('/react-loadable-manifest.js')
+        ) {
+          expect(await fs.pathExists(`${filePath}.map`)).toEqual(true)
+        }
       }
     }
   })

--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -572,7 +572,9 @@ describe('Production Usage', () => {
     it('should set Cache-Control header', async () => {
       const buildManifest = await next.readJSON(`.next/${BUILD_MANIFEST}`)
       const reactLoadableManifest = await next.readJSON(
-        join('./.next', REACT_LOADABLE_MANIFEST)
+        process.env.TURBOPACK
+          ? `.next/server/pages/dynamic/css/${REACT_LOADABLE_MANIFEST}`
+          : `.next/${REACT_LOADABLE_MANIFEST}`
       )
       const url = `http://localhost:${next.appPort}`
 
@@ -581,8 +583,13 @@ describe('Production Usage', () => {
       const manifestKey = Object.keys(reactLoadableManifest).find((item) => {
         return item
           .replace(/\\/g, '/')
-          .endsWith('dynamic/css.js -> ../../components/dynamic-css/with-css')
+          .endsWith(
+            process.env.TURBOPACK
+              ? 'components/dynamic-css/with-css.js [client] (ecmascript, next/dynamic entry)'
+              : 'dynamic/css.js -> ../../components/dynamic-css/with-css'
+          )
       })
+      expect(manifestKey).toBeString()
 
       // test dynamic chunk
       reactLoadableManifest[manifestKey].files.forEach((f) => {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -18,6 +18,7 @@ use turbopack_core::{issue::IssueSource, source::Source};
 
 use super::{top_level_await::has_top_level_await, JsValue, ModuleValue};
 use crate::{
+    analyzer::{ConstantValue, ObjectPart},
     tree_shake::{find_turbopack_part_id_in_asserts, PartId},
     SpecifiedModuleType,
 };
@@ -72,6 +73,31 @@ impl ImportAnnotations {
         }
 
         ImportAnnotations { map }
+    }
+
+    pub fn parse_dynamic(with: &JsValue) -> Option<ImportAnnotations> {
+        let mut map = BTreeMap::new();
+
+        let JsValue::Object { parts, .. } = with else {
+            return None;
+        };
+
+        for part in parts.iter() {
+            let ObjectPart::KeyValue(key, value) = part else {
+                continue;
+            };
+            let (
+                JsValue::Constant(ConstantValue::Str(key)),
+                JsValue::Constant(ConstantValue::Str(value)),
+            ) = (key, value)
+            else {
+                continue;
+            };
+
+            map.insert(key.as_str().into(), value.as_str().into());
+        }
+
+        Some(ImportAnnotations { map })
     }
 
     /// Returns the content on the transition annotation

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -114,11 +114,11 @@ pub struct EsmAssetReference {
 
 impl EsmAssetReference {
     fn get_origin(&self) -> Vc<Box<dyn ResolveOrigin>> {
-        let mut origin = *self.origin;
         if let Some(transition) = self.annotations.transition() {
-            origin = self.origin.with_transition(transition.into());
+            self.origin.with_transition(transition.into())
+        } else {
+            *self.origin
         }
-        origin
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -12,12 +12,17 @@ use turbopack_core::{
     issue::IssueSource,
     reference::ModuleReference,
     reference_type::EcmaScriptModulesReferenceSubType,
-    resolve::{origin::ResolveOrigin, parse::Request, ModuleResolveResult},
+    resolve::{
+        origin::{ResolveOrigin, ResolveOriginExt},
+        parse::Request,
+        ModuleResolveResult,
+    },
 };
 use turbopack_resolve::ecmascript::esm_resolve;
 
 use super::super::pattern_mapping::{PatternMapping, ResolveType};
 use crate::{
+    analyzer::imports::ImportAnnotations,
     code_gen::{CodeGenerateable, CodeGeneration},
     create_visitor,
     references::AstPath,
@@ -29,9 +34,20 @@ pub struct EsmAsyncAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,
     pub path: ResolvedVc<AstPath>,
+    pub annotations: ImportAnnotations,
     pub issue_source: ResolvedVc<IssueSource>,
     pub in_try: bool,
     pub import_externals: bool,
+}
+
+impl EsmAsyncAssetReference {
+    fn get_origin(&self) -> Vc<Box<dyn ResolveOrigin>> {
+        if let Some(transition) = self.annotations.transition() {
+            self.origin.with_transition(transition.into())
+        } else {
+            *self.origin
+        }
+    }
 }
 
 #[turbo_tasks::value_impl]
@@ -42,6 +58,7 @@ impl EsmAsyncAssetReference {
         request: ResolvedVc<Request>,
         path: ResolvedVc<AstPath>,
         issue_source: ResolvedVc<IssueSource>,
+        annotations: Value<ImportAnnotations>,
         in_try: bool,
         import_externals: bool,
     ) -> Vc<Self> {
@@ -50,6 +67,7 @@ impl EsmAsyncAssetReference {
             request,
             path,
             issue_source,
+            annotations: annotations.into_value(),
             in_try,
             import_externals,
         })
@@ -59,14 +77,14 @@ impl EsmAsyncAssetReference {
 #[turbo_tasks::value_impl]
 impl ModuleReference for EsmAsyncAssetReference {
     #[turbo_tasks::function]
-    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        esm_resolve(
-            *self.origin,
+    async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
+        Ok(esm_resolve(
+            self.get_origin().resolve().await?,
             *self.request,
             Value::new(EcmaScriptModulesReferenceSubType::DynamicImport),
             self.in_try,
             Some(*self.issue_source),
-        )
+        ))
     }
 }
 
@@ -100,7 +118,7 @@ impl CodeGenerateable for EsmAsyncAssetReference {
             *self.origin,
             Vc::upcast(chunking_context),
             esm_resolve(
-                *self.origin,
+                self.get_origin().resolve().await?,
                 *self.request,
                 Value::new(EcmaScriptModulesReferenceSubType::DynamicImport),
                 self.in_try,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -56,6 +56,10 @@ pub async fn is_export_missing(
     module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
     export_name: RcStr,
 ) -> Result<Vc<bool>> {
+    if export_name == "__turbopack_module_id__" {
+        return Ok(Vc::cell(false));
+    }
+
     let exports = module.get_exports().await?;
     let exports = match &*exports {
         EcmascriptExports::None => return Ok(Vc::cell(true)),

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/module-id/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/module-id/input/index.js
@@ -1,0 +1,5 @@
+import { __turbopack_module_id__ as id } from "./module.js";
+
+it("should support importing __turbopack_module_id__", () => {
+  expect(id.endsWith("input/module.js [test] (ecmascript)")).toBe(true);
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/module-id/input/module.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/module-id/input/module.js
@@ -1,0 +1,1 @@
+console.log("this is the content of module.js")


### PR DESCRIPTION
- Before, there was a separate AST traversal that collected `next-dynamic` imports
- Now, we use transitions (which are inserted by the existing next-custom-transform) to tell Turbopack about the next-dynamic imports
	- Unlike Webpack (where the react-loadable identifiers are `path/to/parent-module -> ./imported-client`), Turbopack just uses the module id: `[project]/path/to/imported-client.js [app-client] (ecmascript, next/dynamic entry)`
	- the `next-dynamic` transition only inserts the marker module (i.e. for the SSR `import()`) 
	- the `next-dynamic-client` transition inserts the marker module and changes the module context (used to get the client module name)
- Now, we use the correct `AvailabilityInfo` for the next/dynamic chunks to preload, and they are not explicitly emitted. If they are for some reason not the same chunks that are actually emitted for the dynamic import, you get a hard error. (Previously, they didn't use the same `AvailabilityInfo` as the real async chunks, so they usually bundled another copy of React, and also had a different chunk name hash)
- For Turbopack, react-loadable manifests are now scoped per page instead of globally

Closes PACK-3670