### PR TITLE
fix(turbopack): Fix deprecation warnings from unnecessary `.to_resolved()` calls

### DIFF
--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -77,7 +77,7 @@ pub async fn get_app_client_references_chunks(
 
                                 (
                                     (
-                                        client_chunk_group.assets.to_resolved().await?,
+                                        client_chunk_group.assets,
                                         client_chunk_group.availability_info,
                                     ),
                                     if let Some(ssr_chunking_context) = ssr_chunking_context {
@@ -88,7 +88,7 @@ pub async fn get_app_client_references_chunks(
                                             .await?;
 
                                         Some((
-                                            ssr_chunk_group.assets.to_resolved().await?,
+                                            ssr_chunk_group.assets,
                                             ssr_chunk_group.availability_info,
                                         ))
                                     } else {
@@ -103,7 +103,7 @@ pub async fn get_app_client_references_chunks(
 
                                 (
                                     (
-                                        client_chunk_group.assets.to_resolved().await?,
+                                        client_chunk_group.assets,
                                         client_chunk_group.availability_info,
                                     ),
                                     None,

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -404,9 +404,7 @@ async fn graph_node_to_referenced_nodes(
                         return Ok((
                             Some(ChunkGraphEdge {
                                 key: None,
-                                node: ChunkContentGraphNode::ExternalModuleReference(
-                                    reference.to_resolved().await?,
-                                ),
+                                node: ChunkContentGraphNode::ExternalModuleReference(reference),
                             }),
                             None,
                         ));
@@ -622,7 +620,7 @@ async fn chunk_content_internal_parallel(
                 return Ok(None);
             };
             Ok(Some(ChunkGraphEdge {
-                key: Some(entry.to_resolved().await?),
+                key: Some(entry),
                 node: ChunkContentGraphNode::ChunkItem {
                     item: chunkable_module.as_chunk_item(chunking_context),
                     ident: chunkable_module.ident().to_string().await?,

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -637,11 +637,6 @@ async fn source_pos(
         return Ok(None);
     };
 
-    let (content_1, content_2) = (
-        content_1.to_resolved().await?,
-        content_2.to_resolved().await?,
-    );
-
     if content_1 != content_2 {
         return Ok(None);
     }

--- a/turbopack/crates/turbopack-core/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/mod.rs
@@ -502,9 +502,6 @@ impl SourceMap {
                         .await?;
                     sections.push(SourceMapSection::new(section.offset, map));
                 }
-                for section in &mut sections {
-                    section.map = section.map.to_resolved().await?;
-                }
                 SourceMap::new_sectioned(sections)
             }
         }

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -233,7 +233,7 @@ impl CssChunkItem for CssModuleChunkItem {
                             Vc::try_resolve_downcast::<Box<dyn CssChunkItem>>(item).await?
                         {
                             imports.push(CssImport::Internal(
-                                import_ref.to_resolved().await?,
+                                import_ref,
                                 css_item.to_resolved().await?,
                             ));
                         }


### PR DESCRIPTION
A follow-up to #73428.

Likely these callsites (or changes to the field types they're referencing) were merged after some of the other cleanup PRs had landed.

Closes PACK-3623