### PR TITLE
test: fix next-sass test

### DIFF
--- a/test/e2e/yarn-pnp/test/with-sass.test.ts
+++ b/test/e2e/yarn-pnp/test/with-sass.test.ts
@@ -2,7 +2,7 @@ import { runTests } from './utils'
 
 // Skip in Turbopack as Yarn PnP is not supported.
 ;(process.env.TURBOPACK ? describe.skip : describe)('yarn PnP', () => {
-  runTests('with-next-sass', '/', [
+  runTests('with-sass', '/', [
     'Hello World, I am being styled using SCSS Modules',
   ])
 })


### PR DESCRIPTION
## Why?

This [PR](https://github.com/vercel/next.js/pull/73548) updated the directory of an example (it's now `examples/with-sass`), and it broke a test.