### PR TITLE
[Segment Cache] Respond with 204 on cache miss

### DIFF
--- a/test/e2e/app-dir/ppr-navigations/simple/per-segment-prefetching.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/simple/per-segment-prefetching.test.ts
@@ -64,9 +64,9 @@ describe('per segment prefetching', () => {
     expect(childResponseText).toInclude('"rsc"')
   })
 
-  it('respond with 404 if the segment does not have prefetch data', async () => {
+  it('respond with 204 if the segment does not have prefetch data', async () => {
     const response = await prefetch('/en', '/does-not-exist')
-    expect(response.status).toBe(404)
+    expect(response.status).toBe(204)
     const responseText = await response.text()
     expect(responseText.trim()).toBe('')
   })

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/page.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <ul>
+      <li>
+        <Link href="/ppr-enabled">Page with PPR enabled</Link>
+      </li>
+      <li>
+        <Link href="/ppr-enabled/dynamic-param">
+          Page with PPR enabled but has dynamic param
+        </Link>
+      </li>
+      <li>
+        <Link href="/ppr-disabled">Page with PPR disabled</Link>
+      </li>
+    </ul>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/ppr-disabled/page.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/ppr-disabled/page.tsx
@@ -1,0 +1,3 @@
+export default function PPRDisabled() {
+  return '(intentionally empty)'
+}

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/ppr-enabled/[dynamic-param]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/ppr-enabled/[dynamic-param]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return '(intentionally empty)'
+}

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/ppr-enabled/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/ppr-enabled/layout.tsx
@@ -1,0 +1,9 @@
+export const experimental_ppr = true
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/ppr-enabled/page.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/ppr-enabled/page.tsx
@@ -1,0 +1,3 @@
+export default function PPREnabled() {
+  return '(intentionally empty)'
+}

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/next.config.js
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    ppr: 'incremental',
+    dynamicIO: true,
+    clientSegmentCache: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
@@ -1,0 +1,25 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('segment cache (incremental opt in)', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+  if (isNextDev || skipped) {
+    test('ppr is disabled', () => {})
+    return
+  }
+
+  // TODO: Replace with e2e test once the client part is implemented
+  it('prefetch responds with 204 if PPR is disabled for a route', async () => {
+    await next.browser('/')
+    const response = await next.fetch('/ppr-disabled', {
+      headers: {
+        RSC: '1',
+        'Next-Router-Prefetch': '1',
+        'Next-Router-Segment-Prefetch': '/_tree',
+      },
+    })
+    expect(response.status).toBe(204)
+  })
+})


### PR DESCRIPTION
Currently, when the client prefetches a segment, the server responds with a 404 if it cannot fulfill the request. This updates it to respond with a 204 No Content instead, since it's not an error for the client to request a segment whose prefetch hasn't been generated.

When responding with 204, the server also sends the 'x-nextjs-postponed' header, but only if PPR is enabled for the route. The client can use the absence of this header to distinguish between a regular cache miss and a miss due to PPR being disabled. In a later PR, I will update the client to use this information to fall back to the non-PPR behavior.