### PR TITLE
docs: Fix image component API reference parsing

### DIFF
--- a/docs/01-app/03-api-reference/02-components/image.mdx
+++ b/docs/01-app/03-api-reference/02-components/image.mdx
@@ -414,7 +414,7 @@ unoptimized = {false} // {false} | {true}
 
 When true, the source image will be served as-is from the `src` instead of changing quality, size, or format. Defaults to `false`.
 
-This is useful for images that do not benefit from optimization such as small images (<1KB), vector images (SVG), or animated images (GIF).
+This is useful for images that do not benefit from optimization such as small images (less than 1KB), vector images (SVG), or animated images (GIF).
 
 ```js
 import Image from 'next/image'

--- a/docs/02-pages/03-api-reference/01-components/image-legacy.mdx
+++ b/docs/02-pages/03-api-reference/01-components/image-legacy.mdx
@@ -315,7 +315,7 @@ const Example = () => {
 
 When true, the source image will be served as-is from the `src` instead of changing quality, size, or format. Defaults to `false`.
 
-This is useful for images that do not benefit from optimization such as small images (<1KB), vector images (SVG), or animated images (GIF).
+This is useful for images that do not benefit from optimization such as small images (less than 1KB), vector images (SVG), or animated images (GIF).
 
 ```js
 import Image from 'next/image'


### PR DESCRIPTION
Fixes 
```
Error: R] Unexpected character `1` (U+0031) before name, expected a character that can start a name, such as a letter, `$`, or `_` [plugin @mdx-js/esbuild]

    _mdx_bundler_entry_point-e5aea7a2-5548-4d5e-a760-72baa71b269a.mdx:318:87:
      318 │ ...ization such as small images (<1KB), vector images (SVG), or a...
```

-- https://github.com/vercel/front/actions/runs/12223101782/job/34094208064?pr=39684

`<` is signalling JSX syntax. `{"<"}` might've also fixed it but testing this is hard so I just went with the save bet. We also never use `{""}` nor `&lt;` at the moment so this may not even work.