### PR TITLE
Skip `build_and_deploy` on docs-only changes

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -45,6 +45,9 @@ jobs:
           elif [ '${{ github.event_name }}' == 'workflow_dispatch' ]
           then
             echo "value=force-preview" >> $GITHUB_OUTPUT
+          elif [[ $(node scripts/run-for-change.js --not --type docs --exec echo 'false') != 'false' ]];
+          then
+            echo "value=skipped" >> $GITHUB_OUTPUT
           else
             echo "value=automated-preview" >> $GITHUB_OUTPUT
           fi
@@ -52,6 +55,9 @@ jobs:
         run: echo "Deploy target is '${{ steps.deploy-target.outputs.value }}'"
 
   build:
+    if: ${{ needs.deploy-target.outputs.value != 'skipped' }}
+    needs:
+      - deploy-target
     runs-on: ubuntu-latest
     env:
       NEXT_TELEMETRY_DISABLED: 1
@@ -96,6 +102,7 @@ jobs:
 
   # Build binaries for publishing
   build-native:
+    if: ${{ needs.deploy-target.outputs.value != 'skipped' }}
     needs:
       - deploy-target
     defaults:
@@ -380,6 +387,9 @@ jobs:
           path: .turbo/runs
 
   build-wasm:
+    if: ${{ needs.deploy-target.outputs.value != 'skipped' }}
+    needs:
+      - deploy-target
     strategy:
       matrix:
         target: [web, nodejs]


### PR DESCRIPTION
## Test plan

- [x] build_and_deploy still runs on branch

```
if [[ $(node ./scripts/check-is-release.js 2> /dev/null || :) = v* ]];
then
  echo "value=production"
elif [ '${{ github.ref }}' == 'refs/heads/canary' ]
then
  echo "value=staging"
elif [ '${{ github.event_name }}' == 'workflow_dispatch' ]
then
  echo "value=force-preview"
elif [[ $(node scripts/run-for-change.js --not --type docs --exec echo 'false') != 'false' ]];
then
  echo "value=skipped"
else
  echo "value=automated-preview"
fi
```
on https://github.com/vercel/next.js/pull/73658 printed `value=skipped`