### PR TITLE
[Segment Cache] Add CacheStatus.Empty

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -22,7 +22,6 @@ import {
   trackPrefetchRequestBandwidth,
   pingPrefetchTask,
   type PrefetchTask,
-  spawnPrefetchSubtask,
 } from './scheduler'
 import { getAppBuildId } from '../../app-build-id'
 import { createHrefFromUrl } from '../router-reducer/create-href-from-url'
@@ -69,14 +68,20 @@ type RouteCacheEntryShared = {
   size: number
 }
 
+/**
+ * Tracks the status of a cache entry as it progresses from no data (Empty),
+ * waiting for server data (Pending), and finished (either Fulfilled or
+ * Rejected depending on the response from the server.
+ */
 export const enum EntryStatus {
+  Empty,
   Pending,
   Rejected,
   Fulfilled,
 }
 
 type PendingRouteCacheEntry = RouteCacheEntryShared & {
-  status: EntryStatus.Pending
+  status: EntryStatus.Empty | EntryStatus.Pending
   blockedTasks: Set<PrefetchTask> | null
   canonicalUrl: null
   tree: null
@@ -118,7 +123,7 @@ type SegmentCacheEntryShared = {
 }
 
 type PendingSegmentCacheEntry = SegmentCacheEntryShared & {
-  status: EntryStatus.Pending
+  status: EntryStatus.Empty | EntryStatus.Pending
   rsc: null
   loading: null
   isPartial: true
@@ -257,41 +262,29 @@ export function waitForSegmentCacheEntry(
 }
 
 /**
- * Reads the route cache for a matching entry *and* spawns a request if there's
- * no match. Because this may issue a network request, it should only be called
- * from within the context of a prefetch task.
+ * Checks if an entry for a route exists in the cache. If so, it returns the
+ * entry, If not, it adds an empty entry to the cache and returns it.
  */
-export function requestRouteCacheEntryFromCache(
+export function readOrCreateRouteCacheEntry(
   now: number,
   task: PrefetchTask
 ): RouteCacheEntry {
   const key = task.key
-  // First check if there's a non-intercepted entry. Most routes cannot be
-  // intercepted, so this is the common case.
-  const nonInterceptedEntry = readExactRouteCacheEntry(now, key.href, null)
-  if (nonInterceptedEntry !== null && !nonInterceptedEntry.couldBeIntercepted) {
-    // Found a match, and the route cannot be intercepted. We can reuse it.
-    return nonInterceptedEntry
+  const existingEntry = readRouteCacheEntry(now, key)
+  if (existingEntry !== null) {
+    return existingEntry
   }
-  // There was no match. Check again but include the Next-Url this time.
-  const exactEntry = readExactRouteCacheEntry(now, key.href, key.nextUrl)
-  if (exactEntry !== null) {
-    return exactEntry
-  }
-  // Create a pending entry and spawn a request for its data.
+  // Create a pending entry and add it to the cache.
   const pendingEntry: PendingRouteCacheEntry = {
     canonicalUrl: null,
-    status: EntryStatus.Pending,
+    status: EntryStatus.Empty,
     blockedTasks: null,
     tree: null,
     head: null,
     isHeadPartial: true,
-    // If the request takes longer than a minute, a subsequent request should
-    // retry instead of waiting for this one.
-    //
-    // When the response is received, this value will be replaced by a new value
-    // based on the stale time sent from the server.
-    staleAt: now + 60 * 1000,
+    // Since this is an empty entry, there's no reason to ever evict it. It will
+    // be updated when the data is populated.
+    staleAt: Infinity,
     // This is initialized to true because we don't know yet whether the route
     // could be intercepted. It's only set to false once we receive a response
     // from the server.
@@ -303,7 +296,6 @@ export function requestRouteCacheEntryFromCache(
     prev: null,
     size: 0,
   }
-  spawnPrefetchSubtask(fetchRouteOnCacheMiss(pendingEntry, task))
   const keypath: Prefix<RouteCacheKeypath> =
     key.nextUrl === null ? [key.href] : [key.href, key.nextUrl]
   routeCacheMap.set(keypath, pendingEntry)
@@ -315,24 +307,21 @@ export function requestRouteCacheEntryFromCache(
 }
 
 /**
- * Reads the route cache for a matching entry *and* spawns a request if there's
- * no match. Because this may issue a network request, it should only be called
- * from within the context of a prefetch task.
+ * Checks if an entry for a segment exists in the cache. If so, it returns the
+ * entry, If not, it adds an empty entry to the cache and returns it.
  */
-export function requestSegmentEntryFromCache(
+export function readOrCreateSegmentCacheEntry(
   now: number,
-  task: PrefetchTask,
   route: FulfilledRouteCacheEntry,
-  path: string,
-  accessToken: string
+  path: string
 ): SegmentCacheEntry {
   const existingEntry = readSegmentCacheEntry(now, path)
   if (existingEntry !== null) {
     return existingEntry
   }
-  // Create a pending entry and spawn a request for its data.
+  // Create a pending entry and add it to the cache.
   const pendingEntry: PendingSegmentCacheEntry = {
-    status: EntryStatus.Pending,
+    status: EntryStatus.Empty,
     rsc: null,
     loading: null,
     staleAt: route.staleAt,
@@ -345,15 +334,6 @@ export function requestSegmentEntryFromCache(
     prev: null,
     size: 0,
   }
-  spawnPrefetchSubtask(
-    fetchSegmentEntryOnCacheMiss(
-      route,
-      pendingEntry,
-      task.key,
-      path,
-      accessToken
-    )
-  )
   segmentCacheMap.set(path, pendingEntry)
   // Stash the keypath on the entry so we know how to remove it from the map
   // if it gets evicted from the LRU.
@@ -488,7 +468,7 @@ function rejectSegmentCacheEntry(
   }
 }
 
-async function fetchRouteOnCacheMiss(
+export async function fetchRouteOnCacheMiss(
   entry: PendingRouteCacheEntry,
   task: PrefetchTask
 ): Promise<void> {
@@ -589,7 +569,7 @@ async function fetchRouteOnCacheMiss(
   }
 }
 
-async function fetchSegmentEntryOnCacheMiss(
+export async function fetchSegmentOnCacheMiss(
   route: FulfilledRouteCacheEntry,
   segmentCacheEntry: PendingSegmentCacheEntry,
   routeKey: RouteCacheKey,

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -209,6 +209,7 @@ function readRenderSnapshotFromCache(
         isPartial = segmentEntry.isPartial
         break
       }
+      case EntryStatus.Empty:
       case EntryStatus.Pending: {
         // We haven't received data for this segment yet, but there's already
         // an in-progress request. Since it's extremely likely to arrive


### PR DESCRIPTION
This is a small refactor to allow creating a cache empty entry without also triggering a server request. Currently these are combined into the same phase, because there's no case where one operation happens without the other.

However, I need to implement additional prefetching strategies. For example, sometimes a segment's data will already be available as part of a different server response.

To support this, I've split the Pending CacheStatus into two separate fields:

- Empty: The cache entry has no data, and there's no pending request to fetch it.
- Pending: The cache entry has no data, and there _is_ a pending request to fetch it.

This is a refactor only, so there should be no change to external behavior.