### PR TITLE
chore: update `next-config-js` document path

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -129,13 +129,13 @@ pub struct NextConfig {
     /// Enables the bundling of node_modules packages (externals) for pages
     /// server-side bundles.
     ///
-    /// [API Reference](https://nextjs.org/docs/pages/api-reference/next-config-js/bundlePagesRouterDependencies)
+    /// [API Reference](https://nextjs.org/docs/pages/api-reference/config/next-config-js/bundlePagesRouterDependencies)
     bundle_pages_router_dependencies: Option<bool>,
 
     /// A list of packages that should be treated as external on the server
     /// build.
     ///
-    /// [API Reference](https://nextjs.org/docs/app/api-reference/next-config-js/serverExternalPackages)
+    /// [API Reference](https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages)
     server_external_packages: Option<Vec<RcStr>>,
 
     #[serde(rename = "_originalRedirects")]
@@ -952,7 +952,7 @@ pub struct ExperimentalConfig {
     fetch_cache_key_prefix: Option<RcStr>,
     isr_flush_to_disk: Option<bool>,
     /// For use with `@next/mdx`. Compile MDX files using the new Rust compiler.
-    /// @see [api reference](https://nextjs.org/docs/app/api-reference/next-config-js/mdxRs)
+    /// @see [api reference](https://nextjs.org/docs/app/api-reference/config/next-config-js/mdxRs)
     mdx_rs: Option<MdxRsOptions>,
     strict_next_head: Option<bool>,
     #[bincode(with = "turbo_bincode::serde_json")]

--- a/packages/next/src/experimental/testing/server/README.md
+++ b/packages/next/src/experimental/testing/server/README.md
@@ -6,4 +6,4 @@ verify the behavior of redirects, rewrites, adding headers, or middleware logic
 before code reaches to production.
 
 See https://nextjs.org/docs/app/building-your-application/routing/middleware
-and https://nextjs.org/docs/app/api-reference/next-config-js for more details.
+and https://nextjs.org/docs/app/api-reference/config/next-config-js for more details.

--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -155,7 +155,7 @@ export async function validateTurboNextConfig({
 
    NOTE: your \`webpack\` config may have been added by a configuration plugin.
 
-   To configure Turbopack, see https://nextjs.org/docs/app/api-reference/next-config-js/turbopack
+   To configure Turbopack, see https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack
 
    TIP: Many applications work fine under Turbopack with no configuration,
    if that is the case for you, you can silence this error by passing the

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -837,7 +837,7 @@ export async function handleAction({
                   new ApiError(
                     413,
                     `Body exceeded ${bodySizeLimit} limit.\n` +
-                      `To configure the body size limit for Server Actions, see: https://nextjs.org/docs/app/api-reference/next-config-js/serverActions#bodysizelimit`
+                      `To configure the body size limit for Server Actions, see: https://nextjs.org/docs/app/api-reference/config/next-config-js/serverActions#bodysizelimit`
                   )
                 )
                 return

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -515,7 +515,7 @@ export interface ExperimentalConfig {
 
   /**
    * For use with `@next/mdx`. Compile MDX files using the new Rust compiler.
-   * @see https://nextjs.org/docs/app/api-reference/next-config-js/mdxRs
+   * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/mdxRs
    */
   mdxRs?:
     | boolean
@@ -1031,7 +1031,7 @@ export interface NextConfig {
   /**
    * The default cache handler for the Pages and App Router uses the filesystem cache. This requires no configuration, however, you can customize the cache handler if you prefer.
    *
-   * @see [Configuring Caching](https://nextjs.org/docs/app/building-your-application/deploying#configuring-caching) and the [API Reference](https://nextjs.org/docs/app/api-reference/next-config-js/incrementalCacheHandlerPath).
+   * @see [Configuring Caching](https://nextjs.org/docs/app/building-your-application/deploying#configuring-caching) and the [API Reference](https://nextjs.org/docs/app/api-reference/config/next-config-js/incrementalCacheHandlerPath).
    */
   cacheHandler?: string | undefined
 
@@ -1076,7 +1076,7 @@ export interface NextConfig {
   /** @see [Disabling x-powered-by](https://nextjs.org/docs/app/api-reference/config/next-config-js/poweredByHeader) */
   poweredByHeader?: boolean
 
-  /** @see [Using the Image Component](https://nextjs.org/docs/app/api-reference/next-config-js/images) */
+  /** @see [Using the Image Component](https://nextjs.org/docs/app/api-reference/config/next-config-js/images) */
   images?: ImageConfig
 
   /** Configure indicators in development environment */
@@ -1114,7 +1114,7 @@ export interface NextConfig {
    */
   basePath?: string
 
-  /** @see [Customizing sass options](https://nextjs.org/docs/app/api-reference/next-config-js/sassOptions) */
+  /** @see [Customizing sass options](https://nextjs.org/docs/app/api-reference/config/next-config-js/sassOptions) */
   sassOptions?: {
     implementation?: string
     [key: string]: any
@@ -1159,7 +1159,7 @@ export interface NextConfig {
    * Next.js enables HTTP Keep-Alive by default.
    * You may want to disable HTTP Keep-Alive for certain `fetch()` calls or globally.
    *
-   * @see [Disabling HTTP Keep-Alive](https://nextjs.org/docs/app/api-reference/next-config-js/httpAgentOptions)
+   * @see [Disabling HTTP Keep-Alive](https://nextjs.org/docs/app/api-reference/config/next-config-js/httpAgentOptions)
    */
   httpAgentOptions?: { keepAlive?: boolean }
 
@@ -1324,13 +1324,13 @@ export interface NextConfig {
 
   /**
    * Enables the bundling of node_modules packages (externals) for pages server-side bundles.
-   * @see https://nextjs.org/docs/pages/api-reference/next-config-js/bundlePagesRouterDependencies
+   * @see https://nextjs.org/docs/pages/api-reference/config/next-config-js/bundlePagesRouterDependencies
    */
   bundlePagesRouterDependencies?: boolean
 
   /**
    * A list of packages that should be treated as external in the server build.
-   * @see https://nextjs.org/docs/app/api-reference/next-config-js/serverExternalPackages
+   * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages
    */
   serverExternalPackages?: string[]
 

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -758,7 +758,7 @@ function assignDefaultsAndValidate(
     )
     if (isNaN(value) || value < 1) {
       throw new Error(
-        'Server Actions Size Limit must be a valid number or filesize format larger than 1MB: https://nextjs.org/docs/app/api-reference/next-config-js/serverActions#bodysizelimit'
+        'Server Actions Size Limit must be a valid number or filesize format larger than 1MB: https://nextjs.org/docs/app/api-reference/config/next-config-js/serverActions#bodysizelimit'
       )
     }
   }

--- a/packages/next/src/server/web/spec-extension/unstable-no-store.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-no-store.ts
@@ -7,8 +7,8 @@ import { markCurrentScopeAsDynamic } from '../../app-render/dynamic-rendering'
  *
  * It marks the current scope as dynamic.
  *
- * - In [non-PPR](https://nextjs.org/docs/app/api-reference/next-config-js/partial-prerendering) cases this will make a static render
- * halt and mark the page as dynamic.
+ * - In [non-PPR](https://nextjs.org/docs/app/api-reference/config/next-config-js/partial-prerendering) cases this will make a static
+ * render halt and mark the page as dynamic.
  * - In PPR cases this will postpone the render at this location.
  *
  * If we are inside a cache scope then this function does nothing.

--- a/test/development/basic/hmr/run-error-recovery-hmr-test.util.ts
+++ b/test/development/basic/hmr/run-error-recovery-hmr-test.util.ts
@@ -438,7 +438,7 @@ export function runErrorRecoveryHmrTest(nextConfig: {
               Unknown module type
               This module doesn't have an associated type. Use a known file extension, or register a loader for it.
 
-              Read more: https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders"
+              Read more: https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#configuring-webpack-loaders"
             `)
         } else if (process.env.NEXT_RSPACK) {
           expect(trimEndMultiline(await getRedboxSource(browser)))

--- a/turbopack/crates/turbopack-core/src/issue/module.rs
+++ b/turbopack/crates/turbopack-core/src/issue/module.rs
@@ -73,7 +73,7 @@ pub async fn emit_unknown_module_type_error(source: Vc<Box<dyn Source>>) -> Resu
         description: StyledString::Text(
             r"This module doesn't have an associated type. Use a known file extension, or register a loader for it.
 
-Read more: https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders".into(),
+Read more: https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#configuring-webpack-loaders".into(),
         )
         .resolved_cell(),
         source: Some(IssueSource::from_source_only(source.to_resolved().await?)),


### PR DESCRIPTION
## Description
### 1. Update `next-config-js` path

Follow up #72465.
Update [`next-config-js` document](https://nextjs.org/docs/canary/app/api-reference/config/next-config-js) URL.

### 2. Update turbo anchor path

At #70031, [turbo docs](https://nextjs.org/docs/app/api-reference/next-config-js/turbo) was update.
Then I update the reference path to it.

| Before | After |
|--------|--------|
| https://nextjs.org/docs/app/api-reference/next-config-js | https://nextjs.org/docs/app/api-reference/config/next-config-js |
| https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders | https://nextjs.org/docs/app/api-reference/next-config-js/turbopack#configuring-webpack-loaders | 