### PR TITLE
next-codemod(upgrade): handle absence of scripts in package.json

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -426,7 +426,7 @@ async function suggestTurbopack(
   packageJson: any,
   targetNextVersion: string
 ): Promise<void> {
-  const devScript: string = packageJson.scripts['dev']
+  const devScript: string | undefined = packageJson.scripts?.['dev']
   // Turbopack flag was changed from `--turbo` to `--turbopack` in v15.0.1-canary.3
   // PR: https://github.com/vercel/next.js/pull/71657
   // Release: https://github.com/vercel/next.js/releases/tag/v15.0.1-canary.3


### PR DESCRIPTION
### What?
As an extension of #71598, I'm adding an optional chain on the `scripts` it self.

### Why?

If the package.json does not have a scripts field the codemod fails with the error "Cannot read properties of undefined (reading 'dev')". 
