### PR TITLE
Ignore-list stack frames in node_modules even if not explicitly ignore-listed by their sourcemaps

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -45,6 +45,8 @@ test/development/basic/hmr/components/parse-error.js
 packages/next-swc/docs/assets/**/*
 test/lib/amp-validator-wasm.js
 test/production/pages-dir/production/fixture/amp-validator-wasm.js
+test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.js
+test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.js
 test/e2e/async-modules/amp-validator-wasm.js
 test/development/next-lint-eslint-formatter-compact/**/*.js
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -47,6 +47,8 @@ bench/nested-deps/components/**/*
 **/.tina/__generated__/**
 test/lib/amp-validator-wasm.js
 test/production/pages-dir/production/fixture/amp-validator-wasm.js
+test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.js
+test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.js
 test/e2e/async-modules/amp-validator-wasm.js
 
 # turbopack crates

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -42,26 +42,16 @@ describe('middleware - development errors', () => {
           ? '\n ⨯ Error: boom' +
               // TODO(veil): Sourcemap to original name i.e. "default"
               '\n    at __TURBOPACK__default__export__ (middleware.js:3:14)' +
-              '\n  1 |' +
-              '\n  2 |       export default function () {' +
-              "\n> 3 |         throw new Error('boom')" +
-              '\n    |              ^' +
-              '\n  4 |       }' +
-              '\n'
+              '\n  1 |'
           : '\n ⨯ Error: boom' +
               '\n    at default (middleware.js:3:14)' +
-              // TODO(veil): Should be ignore-listed
-              '\n    at eval (webpack'
+              '\n  1 |'
       )
-      if (isTurbopack) {
-        // already asserted on codeframe earlier
-      } else {
-        expect(stripAnsi(next.cliOutput)).toContain(
-          '' +
-            "\n> 3 |         throw new Error('boom')" +
-            '\n    |              ^'
-        )
-      }
+      expect(stripAnsi(next.cliOutput)).toContain(
+        '' +
+          "\n> 3 |         throw new Error('boom')" +
+          '\n    |              ^'
+      )
     })
 
     it('renders the error correctly and recovers', async () => {
@@ -104,28 +94,17 @@ describe('middleware - development errors', () => {
               '\n    at throwError (middleware.js:4:14)' +
               // TODO(veil): Sourcemap to original name i.e. "default"
               '\n    at __TURBOPACK__default__export__ (middleware.js:7:8)' +
-              "\n  2 |       import { NextResponse } from 'next/server'" +
-              '\n  3 |       async function throwError() {' +
-              "\n> 4 |         throw new Error('async boom!')" +
-              '\n    |              ^' +
-              '\n  5 |       }' +
-              '\n  6 |       export default function () {' +
-              '\n  7 |         throwError()'
+              "\n  2 |       import { NextResponse } from 'next/server'"
           : '\n ⨯ unhandledRejection:  Error: async boom!' +
               '\n    at throwError (middleware.js:4:14)' +
               '\n    at throwError (middleware.js:7:8)' +
-              // TODO(veil): Should be ignore-listed
-              '\n    at eval (webpack'
+              "\n  2 |       import { NextResponse } from 'next/server'"
       )
-      if (isTurbopack) {
-        // already asserted on codeframe earlier
-      } else {
-        expect(stripAnsi(next.cliOutput)).toContain(
-          '' +
-            "\n> 4 |         throw new Error('async boom!')" +
-            '\n    |              ^'
-        )
-      }
+      expect(stripAnsi(next.cliOutput)).toContain(
+        '' +
+          "\n> 4 |         throw new Error('async boom!')" +
+          '\n    |              ^'
+      )
     })
 
     it('does not render the error', async () => {
@@ -169,14 +148,15 @@ describe('middleware - development errors', () => {
           ? '\n ⨯ Error [ReferenceError]: test is not defined' +
               '\n    at eval (middleware.js:4:8)' +
               '\n    at <unknown> (middleware.js:4:8)' +
-              // TODO(veil): Should be ignore-listed
-              '\n    at fn (node_modules'
+              // TODO(veil): Should be sourcemapped
+              '\n    at __TURBOPACK__default__export__ ('
           : '\n ⨯ Error [ReferenceError]: test is not defined' +
               // TODO(veil): Redundant and not clickable
               '\n    at eval (file://webpack-internal:///(middleware)/./middleware.js)' +
               '\n    at eval (middleware.js:4:8)' +
-              // TODO(veil): Should be ignore-listed
-              '\n    at fn (node_modules'
+              // TODO(veil): Redundant
+              '\n    at eval (middleware.js:4:8)' +
+              "\n  2 |       import { NextResponse } from 'next/server'"
       )
       expect(stripAnsi(next.cliOutput)).toContain(
         isTurbopack
@@ -187,8 +167,7 @@ describe('middleware - development errors', () => {
           : "\n ⚠ DynamicCodeEvaluationWarning: Dynamic Code Evaluation (e. g. 'eval', 'new Function') not allowed in Edge Runtime" +
               '\nLearn More: https://nextjs.org/docs/messages/edge-dynamic-code-evaluation' +
               '\n    at eval (middleware.js:4:8)' +
-              // TODO(veil): Should be ignore-listed
-              '\n    at eval (webpack'
+              "\n  2 |       import { NextResponse } from 'next/server'"
       )
     })
 

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/app/rsc-error-log-ignore-listed/page.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/app/rsc-error-log-ignore-listed/page.js
@@ -1,5 +1,8 @@
 import { connection } from 'next/server'
-import { run } from 'internal-pkg'
+import { run as runInternal } from 'internal-pkg'
+import { run as runInternalSourceMapped } from 'internal-pkg/sourcemapped'
+import { run as runExternal } from 'external-pkg'
+import { run as runExternalSourceMapped } from 'external-pkg/sourcemapped'
 
 function logError() {
   const error = new Error('Boom')
@@ -9,6 +12,14 @@ function logError() {
 export default async function Page() {
   await connection()
 
-  run(() => logError())
+  runInternal(function runWithInternal() {
+    runInternalSourceMapped(function runWithInternalSourceMapped() {
+      runExternal(function runWithExternal() {
+        runExternalSourceMapped(function runWithExternalSourceMapped() {
+          logError()
+        })
+      })
+    })
+  })
   return null
 }

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/app/ssr-error-log-ignore-listed/page.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/app/ssr-error-log-ignore-listed/page.js
@@ -1,5 +1,8 @@
 'use client'
-import { run } from 'internal-pkg'
+import { run as runInternal } from 'internal-pkg'
+import { run as runInternalSourceMapped } from 'internal-pkg/sourcemapped'
+import { run as runExternal } from 'external-pkg'
+import { run as runExternalSourceMapped } from 'external-pkg/sourcemapped'
 
 function logError() {
   const error = new Error('Boom')
@@ -7,6 +10,14 @@ function logError() {
 }
 
 export default function Page() {
-  run(() => logError())
+  runInternal(function runWithInternal() {
+    runInternalSourceMapped(function runWithInternalSourceMapped() {
+      runExternal(function runWithExternal() {
+        runExternalSourceMapped(function runWithExternalSourceMapped() {
+          logError()
+        })
+      })
+    })
+  })
   return null
 }

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/index.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/index.js
@@ -1,0 +1,3 @@
+export function run(fn) {
+  return fn()
+}

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/package.json
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "internal-pkg",
+  "name": "external-pkg",
   "private": true,
   "type": "module",
   "exports": {

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.js
@@ -1,0 +1,4 @@
+export function run(fn) {
+    return fn();
+}
+//# sourceMappingURL=sourcemapped.js.map

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.js.map
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"sourcemapped.js","sourceRoot":"","sources":["sourcemapped.ts"],"names":[],"mappings":"AAGA,MAAM,UAAU,GAAG,CAAI,EAAS;IAC9B,OAAO,EAAE,EAAE,CAAA;AACb,CAAC"}

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.ts
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.ts
@@ -1,0 +1,6 @@
+// Compile with pnpm tsc test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.ts --sourceMap --target esnext
+// tsc compile errors can be ignored
+type Fn<T> = () => T
+export function run<T>(fn: Fn<T>): T {
+  return fn()
+}

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.js
@@ -1,0 +1,4 @@
+export function run(fn) {
+    return fn();
+}
+//# sourceMappingURL=sourcemapped.js.map

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.js.map
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"sourcemapped.js","sourceRoot":"","sources":["sourcemapped.ts"],"names":[],"mappings":"AAGA,MAAM,UAAU,GAAG,CAAI,EAAS;IAC9B,OAAO,EAAE,EAAE,CAAA;AACb,CAAC"}

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.ts
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.ts
@@ -1,0 +1,6 @@
+// Compile with p tsc test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.ts --sourceMap --target esnext
+// tsc compile errors can be ignored
+type Fn<T> = () => T
+export function run<T>(fn: Fn<T>): T {
+  return fn()
+}

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/next.config.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/next.config.js
@@ -6,6 +6,7 @@ const nextConfig = {
     dynamicIO: true,
     serverSourceMaps: true,
   },
+  serverExternalPackages: ['external-pkg'],
 }
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/package.json
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "internal-pkg": "file:./internal-pkg"
+    "internal-pkg": "file:./internal-pkg",
+    "external-pkg": "file:./external-pkg"
   }
 }

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -111,10 +111,14 @@ describe('app-dir - server source maps', () => {
               "Module not found: Can't resolve 'internal-pkg'"
             : '\nError: Boom' +
                 '\n    at logError (app/ssr-error-log-ignore-listed/page.js:8:16)' +
-                // TODO(veil): Method name should be "Page"
+                // TODO(veil): Method name should be "runWithExternalSourceMapped"
                 '\n    at logError (app/ssr-error-log-ignore-listed/page.js:17:10)' +
-                // TODO(veil): Should be ignore-listed
-                '\n    at run (node_modules'
+                '\n    at runWithExternal (app/ssr-error-log-ignore-listed/page.js:16:32)' +
+                '\n    at runWithInternalSourceMapped (app/ssr-error-log-ignore-listed/page.js:15:18)' +
+                '\n    at runWithInternal (app/ssr-error-log-ignore-listed/page.js:14:28)' +
+                '\n    at Page (app/ssr-error-log-ignore-listed/page.js:13:14)' +
+                '\n   6 |' +
+                '\n'
         )
       } else {
         // TODO: Test `next build` with `--enable-source-maps`.
@@ -142,10 +146,14 @@ describe('app-dir - server source maps', () => {
               "Module not found: Can't resolve 'internal-pkg'"
             : '\nError: Boom' +
                 '\n    at logError (app/rsc-error-log-ignore-listed/page.js:8:16)' +
-                // TODO(veil): Method name should be "Page"
+                // TODO(veil): Method name should be "runWithExternalSourceMapped"
                 '\n    at logError (app/rsc-error-log-ignore-listed/page.js:19:10)' +
-                // TODO(veil): Should be ignore-listed
-                '\n    at run (node_modules'
+                '\n    at runWithExternal (app/rsc-error-log-ignore-listed/page.js:18:32)' +
+                '\n    at runWithInternalSourceMapped (app/rsc-error-log-ignore-listed/page.js:17:18)' +
+                '\n    at runWithInternal (app/rsc-error-log-ignore-listed/page.js:16:28)' +
+                '\n    at Page (app/rsc-error-log-ignore-listed/page.js:15:14)' +
+                '\n   6 |' +
+                '\n'
         )
       } else {
         // TODO: Test `next build` with `--enable-source-maps`.

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -10,10 +10,11 @@ function normalizeCliOutput(output: string) {
 
 describe('app-dir - server source maps', () => {
   const dependencies =
-    // 'link:' is not suitable for this test since this makes internal-pkg
+    // 'link:' is not suitable for this test since this makes packages
     // not appear in node_modules.
     {
       'internal-pkg': `file:${path.resolve(__dirname, 'fixtures/default/internal-pkg')}`,
+      'external-pkg': `file:${path.resolve(__dirname, 'fixtures/default/external-pkg')}`,
     }
   const { skipped, next, isNextDev, isTurbopack } = nextTestSetup({
     dependencies,
@@ -109,11 +110,11 @@ describe('app-dir - server source maps', () => {
             ? // TODO(veil): Turbopack resolver bug
               "Module not found: Can't resolve 'internal-pkg'"
             : '\nError: Boom' +
-                '\n    at logError (app/ssr-error-log-ignore-listed/page.js:5:16)' +
+                '\n    at logError (app/ssr-error-log-ignore-listed/page.js:8:16)' +
                 // TODO(veil): Method name should be "Page"
-                '\n    at logError (app/ssr-error-log-ignore-listed/page.js:10:12)' +
-                '\n    at Page (app/ssr-error-log-ignore-listed/page.js:10:6)' +
-                '\n  3 |'
+                '\n    at logError (app/ssr-error-log-ignore-listed/page.js:17:10)' +
+                // TODO(veil): Should be ignore-listed
+                '\n    at run (node_modules'
         )
       } else {
         // TODO: Test `next build` with `--enable-source-maps`.
@@ -140,11 +141,11 @@ describe('app-dir - server source maps', () => {
             ? // TODO(veil): Turbopack resolver bug
               "Module not found: Can't resolve 'internal-pkg'"
             : '\nError: Boom' +
-                '\n    at logError (app/rsc-error-log-ignore-listed/page.js:5:16)' +
+                '\n    at logError (app/rsc-error-log-ignore-listed/page.js:8:16)' +
                 // TODO(veil): Method name should be "Page"
-                '\n    at logError (app/rsc-error-log-ignore-listed/page.js:12:12)' +
-                '\n    at Page (app/rsc-error-log-ignore-listed/page.js:12:6)' +
-                '\n  3 |'
+                '\n    at logError (app/rsc-error-log-ignore-listed/page.js:19:10)' +
+                // TODO(veil): Should be ignore-listed
+                '\n    at run (node_modules'
         )
       } else {
         // TODO: Test `next build` with `--enable-source-maps`.


### PR DESCRIPTION
We now ignore-list frames in `node_modules` when we can't sourcemap them (e.g. missing sourcemaps) and even if we can sourcemap but they're not ignore-listed.

Ignore-listing sourcemapped frames in `node_modules` may be controversial since it removes control from libraries. But right now it's  more likely that `ignoreList` wasn't even filled since bundlers and transpilers don't enforce that configuration. In the future, we could start using an empty `ignoreList` as a signal that the frame really shouldn't be ignore-listed.

PR is split into current behavior and fix to make it easier to spot what actually changed.