### PR TITLE
Ensure pnpm doesn't randomly change the `babel-plugin-react-compiler` version

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -216,6 +216,7 @@
     "assert": "2.0.0",
     "async-retry": "1.2.3",
     "async-sema": "3.0.0",
+    "babel-plugin-react-compiler": "19.0.0-beta-df7b47d-20241124",
     "babel-plugin-transform-define": "2.0.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
     "browserify-zlib": "0.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -852,9 +852,6 @@ importers:
       '@swc/helpers':
         specifier: 0.5.15
         version: 0.5.15
-      babel-plugin-react-compiler:
-        specifier: '*'
-        version: 19.0.0-beta-37ed2a7-20241206
       busboy:
         specifier: 1.6.0
         version: 1.6.0
@@ -1136,6 +1133,9 @@ importers:
       async-sema:
         specifier: 3.0.0
         version: 3.0.0
+      babel-plugin-react-compiler:
+        specifier: 19.0.0-beta-df7b47d-20241124
+        version: 19.0.0-beta-df7b47d-20241124
       babel-plugin-transform-define:
         specifier: 2.0.0
         version: 2.0.0
@@ -6150,8 +6150,8 @@ packages:
   babel-plugin-react-compiler@0.0.0-experimental-c23de8d-20240515:
     resolution: {integrity: sha512-0XN2gmpT55QtAz5n7d5g91y1AuO9tRhWBaLgCRyc4ExHrlr7+LfxW+YTb3mOwxngkkiggwM8HyYsaEK9MqhnlQ==}
 
-  babel-plugin-react-compiler@19.0.0-beta-37ed2a7-20241206:
-    resolution: {integrity: sha512-nnkrHpeDKM8A5laq9tmFvvGbbDQ7laGfQLp50cvCkCXmWrPcZdCtaQpNh8UJS/yLREJnv2R4JDL5ADfxyAn+yQ==}
+  babel-plugin-react-compiler@19.0.0-beta-df7b47d-20241124:
+    resolution: {integrity: sha512-93iSASR20HNsotcOTQ+KPL0zpgfRFVWL86AtXpmHp995HuMVnC9femd8Winr3GxkPEh8lEOyaw3nqY4q2HUm5w==}
 
   babel-plugin-transform-async-to-promises@0.8.15:
     resolution: {integrity: sha512-fDXP68ZqcinZO2WCiimCL9zhGjGXOnn3D33zvbh+yheZ/qOrNVVDDIBtAaM3Faz8TRvQzHiRKsu3hfrBAhEncQ==}
@@ -20793,7 +20793,7 @@ snapshots:
       zod: 3.23.8
       zod-validation-error: 2.1.0(zod@3.23.8)
 
-  babel-plugin-react-compiler@19.0.0-beta-37ed2a7-20241206:
+  babel-plugin-react-compiler@19.0.0-beta-df7b47d-20241124:
     dependencies:
       '@babel/types': 7.22.5
 


### PR DESCRIPTION
Missing peer dependency in dev dependencies in the `next` package can result in unrelated updates.
This happened to me when installing `@babel/plugin-proposal-explicit-resource-management`