### PR TITLE
Fix failing tests

### DIFF
--- a/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
+++ b/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
@@ -50,7 +50,8 @@ describe('use-cache-unknown-cache-kind', () => {
 
 
 
-              at <unknown> (./app/page.tsx:1:1)"
+              at <unknown> (./app/page.tsx:1:1)
+          "
         `)
       } else {
         expect(buildOutput).toMatchInlineSnapshot(`

--- a/test/e2e/app-dir/use-cache-without-dynamic-io/use-cache-without-dynamic-io.test.ts
+++ b/test/e2e/app-dir/use-cache-without-dynamic-io/use-cache-without-dynamic-io.test.ts
@@ -47,7 +47,8 @@ describe('use-cache-without-dynamic-io', () => {
 
 
 
-              at <unknown> (./app/page.tsx:1:1)"
+              at <unknown> (./app/page.tsx:1:1)
+          "
         `)
       } else {
         expect(buildOutput).toMatchInlineSnapshot(`


### PR DESCRIPTION
Oversight in https://github.com/vercel/next.js/pull/73689

These tests are affected because we fallback to the bundler for retrieving sourcemaps if the native variant fails (which it does because we don't run with `--enable-source-maps` in `next build`).