### PR TITLE
Fix TypeScript Errors by Pinning @types/react

### DIFF
--- a/examples/with-supabase/package.json
+++ b/examples/with-supabase/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/node": "22.9.0",
-    "@types/react": "^18.3.12",
+    "@types/react": "18.3.13",
     "@types/react-dom": "18.3.1",
     "postcss": "8.4.49",
     "tailwind-merge": "^2.5.2",


### PR DESCRIPTION
See https://github.com/vercel/next.js/discussions/72778#discussioncomment-11513634

Problem
The current Supabase Next.js template is broken due to TypeScript errors when using the latest @types/react. Upgrading @types/react causes type conflicts with formAction props, preventing the template from building correctly.

Solution
Pin the @types/react in package.json to 18.3.12. This ensures compatibility and resolves the TypeScript errors.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
