### PR TITLE
Current behavior for module evaluation sourcemapping

### DIFF
--- a/test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts
+++ b/test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts
@@ -82,13 +82,6 @@ describe('non-root-project-monorepo', () => {
 
   if (isNextDev) {
     describe('source-maps', () => {
-      function normalizeStackTrace(stack: string[] | null): string | null {
-        if (stack === null) {
-          return null
-        }
-        return stack.join('\n')
-      }
-
       it('should work on RSC', async () => {
         const browser = await next.browser('/source-maps-rsc')
         await assertHasRedbox(browser)
@@ -102,17 +95,13 @@ describe('non-root-project-monorepo', () => {
                |       ^
              2 |"
           `)
-          // TODO stacktrace-parser breaks in some cases with the rsc:// protocol
-          expect(
-            normalizeStackTrace(await getRedboxCallStack(browser)).replace(
-              /\/apps_web_\w+._.js /,
-              '/apps_web_XXXXXX._.js '
-            )
-          ).toMatchInlineSnapshot(`
-           "[project]/apps/web/app/separate-file.ts [app-rsc] (ecmascript) app/separate-file.ts (1:7)
-           innerArrowFunction app/source-maps-rsc/page.tsx (13:28)
-           innerFunction app/source-maps-rsc/page.tsx (10:3)
-           Page app/source-maps-rsc/page.tsx (4:5)"
+          expect(await getRedboxCallStack(browser)).toMatchInlineSnapshot(`
+           [
+             "[project]/apps/web/app/separate-file.ts [app-rsc] (ecmascript) app/separate-file.ts (1:7)",
+             "innerArrowFunction app/source-maps-rsc/page.tsx (13:28)",
+             "innerFunction app/source-maps-rsc/page.tsx (10:3)",
+             "Page app/source-maps-rsc/page.tsx (4:5)",
+           ]
           `)
         } else {
           // TODO the function name is incorrect
@@ -123,16 +112,17 @@ describe('non-root-project-monorepo', () => {
                |           ^
              2 |"
           `)
-          // TODO webpack runtime code shouldn't be included in stack trace
+          // TODO(veil): webpack runtime code shouldn't be included in stack trace (see https://linear.app/vercel/issue/NDX-509)
           // TODO(veil): https://linear.app/vercel/issue/NDX-677
-          expect(normalizeStackTrace(await getRedboxCallStack(browser)))
-            .toMatchInlineSnapshot(`
-           "eval app/separate-file.ts (1:11)
-           <FIXME-file-protocol>
-           <FIXME-file-protocol>
-           innerArrowFunction app/source-maps-rsc/page.tsx (14:3)
-           innerFunction app/source-maps-rsc/page.tsx (10:3)
-           Page app/source-maps-rsc/page.tsx (4:5)"
+          expect(await getRedboxCallStack(browser)).toMatchInlineSnapshot(`
+           [
+             "eval app/separate-file.ts (1:11)",
+             "<FIXME-file-protocol>",
+             "<FIXME-file-protocol>",
+             "innerArrowFunction app/source-maps-rsc/page.tsx (14:3)",
+             "innerFunction app/source-maps-rsc/page.tsx (10:3)",
+             "Page app/source-maps-rsc/page.tsx (4:5)",
+           ]
           `)
         }
         await browser.close()
@@ -151,12 +141,13 @@ describe('non-root-project-monorepo', () => {
                |       ^
              2 |"
           `)
-          expect(normalizeStackTrace(await getRedboxCallStack(browser)))
-            .toMatchInlineSnapshot(`
-           "[project]/apps/web/app/separate-file.ts [app-client] (ecmascript) app/separate-file.ts (1:7)
-           innerArrowFunction app/source-maps-ssr/page.tsx (15:28)
-           innerFunction app/source-maps-ssr/page.tsx (12:3)
-           Page app/source-maps-ssr/page.tsx (6:5)"
+          expect(await getRedboxCallStack(browser)).toMatchInlineSnapshot(`
+           [
+             "[project]/apps/web/app/separate-file.ts [app-client] (ecmascript) app/separate-file.ts (1:7)",
+             "innerArrowFunction app/source-maps-ssr/page.tsx (15:28)",
+             "innerFunction app/source-maps-ssr/page.tsx (12:3)",
+             "Page app/source-maps-ssr/page.tsx (6:5)",
+           ]
           `)
         } else {
           // TODO the function name should be hidden
@@ -167,17 +158,18 @@ describe('non-root-project-monorepo', () => {
                 |       ^
               2 |"
           `)
-          // TODO webpack runtime code shouldn't be included in stack trace
-          expect(normalizeStackTrace(await getRedboxCallStack(browser)))
-            .toMatchInlineSnapshot(`
-           "eval app/separate-file.ts (1:7)
-           <FIXME-next-dist-dir>
-           <FIXME-next-dist-dir>
-           <FIXME-next-dist-dir>
-           <FIXME-next-dist-dir>
-           innerArrowFunction app/source-maps-ssr/page.tsx (16:3)
-           innerFunction app/source-maps-ssr/page.tsx (12:3)
-           Page app/source-maps-ssr/page.tsx (6:5)"
+          // TODO(veil): webpack runtime code shouldn't be included in stack trace (see https://linear.app/vercel/issue/NDX-509)
+          expect(await getRedboxCallStack(browser)).toMatchInlineSnapshot(`
+           [
+             "eval app/separate-file.ts (1:7)",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "innerArrowFunction app/source-maps-ssr/page.tsx (16:3)",
+             "innerFunction app/source-maps-ssr/page.tsx (12:3)",
+             "Page app/source-maps-ssr/page.tsx (6:5)",
+           ]
           `)
         }
         await browser.close()
@@ -196,12 +188,13 @@ describe('non-root-project-monorepo', () => {
                |       ^
              2 |"
           `)
-          expect(normalizeStackTrace(await getRedboxCallStack(browser)))
-            .toMatchInlineSnapshot(`
-           "[project]/apps/web/app/separate-file.ts [app-client] (ecmascript) app/separate-file.ts (1:7)
-           innerArrowFunction app/source-maps-client/page.tsx (16:28)
-           innerFunction app/source-maps-client/page.tsx (13:3)
-           effectCallback app/source-maps-client/page.tsx (7:5)"
+          expect(await getRedboxCallStack(browser)).toMatchInlineSnapshot(`
+           [
+             "[project]/apps/web/app/separate-file.ts [app-client] (ecmascript) app/separate-file.ts (1:7)",
+             "innerArrowFunction app/source-maps-client/page.tsx (16:28)",
+             "innerFunction app/source-maps-client/page.tsx (13:3)",
+             "effectCallback app/source-maps-client/page.tsx (7:5)",
+           ]
           `)
         } else {
           // TODO the function name should be hidden
@@ -212,17 +205,18 @@ describe('non-root-project-monorepo', () => {
                 |       ^
               2 |"
           `)
-          // TODO webpack runtime code shouldn't be included in stack trace
-          expect(normalizeStackTrace(await getRedboxCallStack(browser)))
-            .toMatchInlineSnapshot(`
-           "eval app/separate-file.ts (1:7)
-           <FIXME-next-dist-dir>
-           <FIXME-next-dist-dir>
-           <FIXME-next-dist-dir>
-           <FIXME-next-dist-dir>
-           innerArrowFunction app/source-maps-client/page.tsx (17:3)
-           innerFunction app/source-maps-client/page.tsx (13:3)
-           effectCallback app/source-maps-client/page.tsx (7:5)"
+          // TODO(veil): webpack runtime code shouldn't be included in stack trace (see https://linear.app/vercel/issue/NDX-509)
+          expect(await getRedboxCallStack(browser)).toMatchInlineSnapshot(`
+           [
+             "eval app/separate-file.ts (1:7)",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "innerArrowFunction app/source-maps-client/page.tsx (17:3)",
+             "innerFunction app/source-maps-client/page.tsx (13:3)",
+             "effectCallback app/source-maps-client/page.tsx (7:5)",
+           ]
           `)
         }
         await browser.close()

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/app/module-evaluation/module.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/app/module-evaluation/module.js
@@ -1,0 +1,1 @@
+export const error = new Error('module-evaluation')

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/app/module-evaluation/page.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/app/module-evaluation/page.js
@@ -1,0 +1,6 @@
+import { error } from './module'
+
+export default function Page() {
+  console.error(error)
+  return null
+}


### PR DESCRIPTION
Looks pretty bad. Most of it is due to added functions by bundlers that aren't sourcemapped.