### PR TITLE
cna: bump tailwindcss version

### DIFF
--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -221,7 +221,7 @@ export const installTemplate = async ({
     packageJson.devDependencies = {
       ...packageJson.devDependencies,
       postcss: "^8",
-      tailwindcss: "^3.4.1",
+      tailwindcss: "^3.4.17",
     };
   }
 


### PR DESCRIPTION
### What?

Update tailwindcss version from [`3.4.1`](https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.4.1) to [`3.4.17`](https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.4.17) 

### Why?

Running `pnpm create next-app` shows the below logs.

```bash
dependencies:
+ next 15.0.4
+ react 19.0.0
+ react-dom 19.0.0

devDependencies:
+ @types/node 20.17.9 (22.10.1 is available)
+ @types/react 19.0.1
+ @types/react-dom 19.0.2
+ postcss 8.4.49
+ tailwindcss 3.4.16
+ typescript 5.7.2
```

Next, check the package.json.

```json
  "dependencies": {
    "react": "^19.0.0",
    "react-dom": "^19.0.0",
    "next": "15.0.4"
  },
  "devDependencies": {
    "typescript": "^5",
    "@types/node": "^20",
    "@types/react": "^19",
    "@types/react-dom": "^19",
    "postcss": "^8",
    "tailwindcss": "^3.4.1"
  }
```

Only tailwindcss has a different version between logs and package.json.
This PR fix it since it would be inconvenience.