### PR TITLE
Apply SWC transforms for Middleware also to 3rd-party code

### DIFF
--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -893,6 +893,9 @@ pub async fn get_server_module_options_context(
                 ));
             }
 
+            foreign_next_server_rules.extend(custom_source_transform_rules.iter().cloned());
+            foreign_next_server_rules.extend(internal_custom_rules);
+
             custom_source_transform_rules.push(
                 get_next_react_server_components_transform_rule(
                     next_config,
@@ -901,8 +904,6 @@ pub async fn get_server_module_options_context(
                 )
                 .await?,
             );
-
-            internal_custom_rules.extend(custom_source_transform_rules.iter().cloned());
 
             next_server_rules.extend(custom_source_transform_rules);
             next_server_rules.extend(source_transform_rules);
@@ -915,7 +916,7 @@ pub async fn get_server_module_options_context(
                 ..module_options_context
             };
             let foreign_code_module_options_context = ModuleOptionsContext {
-                module_rules: internal_custom_rules.clone(),
+                module_rules: foreign_next_server_rules.clone(),
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
@@ -929,7 +930,7 @@ pub async fn get_server_module_options_context(
                     ),
                     ..module_options_context.ecmascript.clone()
                 },
-                module_rules: internal_custom_rules,
+                module_rules: foreign_next_server_rules,
                 ..module_options_context.clone()
             };
             ModuleOptionsContext {

--- a/test/integration/edge-runtime-configurable-guards/test/index.test.js
+++ b/test/integration/edge-runtime-configurable-guards/test/index.test.js
@@ -213,19 +213,14 @@ describe('Edge runtime configurable guards', () => {
           }
         `)
       },
-      // TODO: Re-enable when Turbopack applies the middleware dynamic code
-      // evaluation transforms also to code in node_modules.
-      skip: Boolean(process.env.TURBOPACK),
     },
   ])('$title with allowed, used dynamic code', ({ init, url, skip }) => {
     beforeEach(() => init())
-    ;(skip ? it.skip : it)('still warns in dev at runtime', async () => {
+    it('still warns in dev at runtime', async () => {
       context.app = await launchApp(context.appDir, context.appPort, appOption)
       const res = await fetchViaHTTP(context.appPort, url)
       await waitFor(500)
-      // eslint-disable-next-line jest/no-standalone-expect
       expect(res.status).toBe(200)
-      // eslint-disable-next-line jest/no-standalone-expect
       expect(context.logs.output).toContain(
         `Dynamic Code Evaluation (e. g. 'eval', 'new Function') not allowed in Edge Runtime`
       )
@@ -382,9 +377,6 @@ describe('Edge runtime configurable guards', () => {
           }
         `)
       },
-      // TODO: Re-enable when Turbopack applies the edge runtime transforms also
-      // to code in node_modules.
-      skip: Boolean(process.env.TURBOPACK),
     },
     {
       title: 'Middleware using lib',
@@ -407,24 +399,21 @@ describe('Edge runtime configurable guards', () => {
           }
         `)
       },
-      // TODO: Re-enable when Turbopack applies the middleware dynamic code
-      // evaluation transforms also to code in node_modules.
-      skip: Boolean(process.env.TURBOPACK),
     },
-  ])('$title with unallowed, used dynamic code', ({ init, url, skip }) => {
+  ])('$title with unallowed, used dynamic code', ({ init, url }) => {
     beforeEach(() => init())
-    ;(skip ? it.skip : it)('warns in dev at runtime', async () => {
+    it('warns in dev at runtime', async () => {
       context.app = await launchApp(context.appDir, context.appPort, appOption)
       const res = await fetchViaHTTP(context.appPort, url)
       await waitFor(500)
-      // eslint-disable-next-line jest/no-standalone-expect
       expect(res.status).toBe(200)
-      // eslint-disable-next-line jest/no-standalone-expect
       expect(context.logs.output).toContain(
         `Dynamic Code Evaluation (e. g. 'eval', 'new Function') not allowed in Edge Runtime`
       )
     })
-    ;(skip || process.env.TURBOPACK_DEV ? describe.skip : describe)(
+    // TODO: Re-enable when Turbopack applies the middleware dynamic code
+    // evaluation transforms also to code in node_modules in production mode.
+    ;(process.env.TURBOPACK ? describe.skip : describe)(
       'production mode',
       () => {
         it('fails to build because of dynamic code evaluation', async () => {


### PR DESCRIPTION
This aligns Turbopack with what Webpack is already doing in this regard.

What this doesn't enable though is emitting build errors when using the disallowed APIs. Just enabling it for 3rd-party code in the SWC transforms wouldn't be sufficient. This would lead to too many false positives, because it's applied before tree shaking. We would need to change that first so that the detection and emitting errors is done after tree-shaking, as is already the case with Webpack.