### PR TITLE
Limit the number of concurrently open file watchers on macos

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -291,6 +291,11 @@ const nextDev = async (
             ? startServerOptions.selfSignedCertificate.rootCA
             : defaultEnv.NODE_EXTRA_CA_CERTS,
           NODE_OPTIONS: formatNodeOptions(nodeOptions),
+          // There is a node.js bug on MacOS which causes closing file watchers to be really slow.
+          // This limits the number of watchers to mitigate the issue.
+          // https://github.com/nodejs/node/issues/29949
+          WATCHPACK_WATCHER_LIMIT:
+            os.platform() === 'darwin' ? '20' : undefined,
         },
       })
 


### PR DESCRIPTION
### What?

This adds a workaround for a Node.js bug on MacOS which causes closing file watchers to be really slow:
https://github.com/nodejs/node/issues/29949

It was fixed before here: https://github.com/vercel/next.js/pull/51826
But accidentically removed here: https://github.com/vercel/next.js/commit/c5a8e0989ea13af8d04bf6dda8d741c79b964abb#diff-0ff576bd02e76f96680accff48ecbe4126a7f6bc4eafa547b6d44dee49bab770L88


Closes PACK-3636