### PR TITLE
fix: `warnOnce()` lru

### DIFF
--- a/packages/next/src/build/output/log.ts
+++ b/packages/next/src/build/output/log.ts
@@ -77,12 +77,11 @@ export function trace(...message: any[]) {
   prefixedLog('trace', ...message)
 }
 
-const warnOnceCache = new LRUCache<string>(10_000, (message) => message.length)
-
+const warnOnceCache = new LRUCache<string>(10_000, (value) => value.length)
 export function warnOnce(...message: any[]) {
   const key = message.join(' ')
   if (!warnOnceCache.has(key)) {
-    warnOnceCache.set(key)
+    warnOnceCache.set(key, key)
     warn(...message)
   }
 }

--- a/test/unit/build-output-log.test.ts
+++ b/test/unit/build-output-log.test.ts
@@ -1,0 +1,27 @@
+import { warnOnce } from 'next/dist/build/output/log'
+
+describe('build/output/log', () => {
+  it('warnOnce', () => {
+    const original = console.warn
+    try {
+      const messages = []
+      console.warn = (m: any) => messages.push(m)
+      warnOnce('test')
+      expect(messages.length).toEqual(1)
+      warnOnce('test again')
+      expect(messages.length).toEqual(2)
+      warnOnce('test', 'more')
+      expect(messages.length).toEqual(3)
+      warnOnce('test')
+      expect(messages.length).toEqual(3)
+      warnOnce('test again')
+      expect(messages.length).toEqual(3)
+      warnOnce('test', 'more')
+      expect(messages.length).toEqual(3)
+      warnOnce('test', 'should', 'add', 'another')
+      expect(messages.length).toEqual(4)
+    } finally {
+      console.warn = original
+    }
+  })
+})


### PR DESCRIPTION
We regressed in https://github.com/vercel/next.js/pull/73483 since the LRU calculates the value based on the value, not the key (and we were not setting the value).