### PR TITLE
re-enable middleware deploy tests

### DIFF
--- a/test/e2e/app-dir/app-middleware/app-middleware.test.ts
+++ b/test/e2e/app-dir/app-middleware/app-middleware.test.ts
@@ -6,7 +6,7 @@ import { nextTestSetup, FileRef } from 'e2e-utils'
 import type { Response } from 'node-fetch'
 
 describe('app-dir with middleware', () => {
-  const { next, isNextDeploy } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
 
@@ -187,28 +187,25 @@ describe('app-dir with middleware', () => {
     await browser.deleteCookies()
   })
 
-  // TODO: Re-enable this test in deploy mode once Vercel has proper handling
-  if (!isNextDeploy) {
-    it('should omit internal headers for middleware cookies', async () => {
-      const response = await next.fetch('/rsc-cookies/cookie-options')
-      expect(response.status).toBe(200)
-      expect(response.headers.get('x-middleware-set-cookie')).toBeNull()
-    })
+  it('should omit internal headers for middleware cookies', async () => {
+    const response = await next.fetch('/rsc-cookies/cookie-options')
+    expect(response.status).toBe(200)
+    expect(response.headers.get('x-middleware-set-cookie')).toBeNull()
+  })
 
-    it('should ignore x-middleware-set-cookie as a request header', async () => {
-      const $ = await next.render$(
-        '/cookies',
-        {},
-        {
-          headers: {
-            'x-middleware-set-cookie': 'test',
-          },
-        }
-      )
+  it('should ignore x-middleware-set-cookie as a request header', async () => {
+    const $ = await next.render$(
+      '/cookies',
+      {},
+      {
+        headers: {
+          'x-middleware-set-cookie': 'test',
+        },
+      }
+    )
 
-      expect($('#cookies').text()).toBe('cookies: 0')
-    })
-  }
+    expect($('#cookies').text()).toBe('cookies: 0')
+  })
 
   it('should be possible to read cookies that are set during the middleware handling of a server action', async () => {
     const browser = await next.browser('/rsc-cookies')


### PR DESCRIPTION
This was fixed upstream, so we can re-enable the deployment tests for it. 