### PR TITLE
Add NEXT_PRIVATE_SKIP_CANARY_CHECK env for bench job

### DIFF
--- a/scripts/devlow-bench.mjs
+++ b/scripts/devlow-bench.mjs
@@ -39,6 +39,7 @@ const nextBuildWorkflow =
         HOSTNAME: process.env.HOSTNAME,
         PWD: process.env.PWD,
         NEXT_TRACE_UPLOAD_DISABLED: 'true',
+        NEXT_PRIVATE_SKIP_CANARY_CHECK: 'true',
       }
 
       const serverEnv = {


### PR DESCRIPTION
Fixes: https://github.com/vercel/next.js/actions/runs/12263653936/job/34217267903