### PR TITLE
refactor(turbo-tasks): Derive NonLocalValue by default in value/value_trait macros

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -621,7 +621,7 @@ struct NapiEntrypoints {
     pub pages_error_endpoint: External<ExternalEndpoint>,
 }
 
-#[turbo_tasks::value(serialization = "none")]
+#[turbo_tasks::value(serialization = "none", local)]
 struct EntrypointsWithIssues {
     entrypoints: ReadRef<Entrypoints>,
     issues: Arc<Vec<ReadRef<PlainIssue>>>,

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -781,7 +781,7 @@ enum AppEndpointType {
     },
 }
 
-#[turbo_tasks::value]
+#[turbo_tasks::value(local)]
 struct AppEndpoint {
     ty: AppEndpointType,
     app_project: ResolvedVc<AppProject>,

--- a/crates/next-api/src/entrypoints.rs
+++ b/crates/next-api/src/entrypoints.rs
@@ -6,7 +6,7 @@ use crate::{
     route::{Endpoint, Route},
 };
 
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, local)]
 pub struct Entrypoints {
     pub routes: FxIndexMap<RcStr, Route>,
     pub middleware: Option<Middleware>,

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -95,7 +95,7 @@ impl<N: TraceRawVcs, E: TraceRawVcs> Deref for TracedDiGraph<N, E> {
     }
 }
 
-#[turbo_tasks::value(cell = "new", eq = "manual", into = "new")]
+#[turbo_tasks::value(cell = "new", eq = "manual", into = "new", local)]
 #[derive(Clone, Default)]
 pub struct SingleModuleGraph {
     graph: TracedDiGraph<SingleModuleGraphNode, ()>,

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -212,7 +212,7 @@ pub struct Instrumentation {
     pub edge: Vc<Box<dyn Endpoint>>,
 }
 
-#[turbo_tasks::value]
+#[turbo_tasks::value(local)]
 pub struct ProjectContainer {
     name: RcStr,
     options_state: State<Option<ProjectOptions>>,

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -28,7 +28,7 @@ impl AppPageRoute {
     }
 }
 
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, local)]
 #[derive(Clone, Debug)]
 pub enum Route {
     Page {
@@ -58,7 +58,7 @@ impl Route {
     }
 }
 
-#[turbo_tasks::value_trait]
+#[turbo_tasks::value_trait(local)]
 pub trait Endpoint {
     fn write_to_disk(self: Vc<Self>) -> Vc<WrittenEndpoint>;
     fn server_changed(self: Vc<Self>) -> Vc<Completion>;
@@ -83,5 +83,5 @@ pub enum WrittenEndpoint {
 
 /// The routes as map from pathname to route. (pathname includes the leading
 /// slash)
-#[turbo_tasks::value(transparent)]
+#[turbo_tasks::value(transparent, local)]
 pub struct Routes(FxIndexMap<RcStr, Route>);

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -19,7 +19,7 @@ use turbopack_core::{
 /// An unresolved output assets operation. We need to pass an operation here as
 /// it's stored for later usage and we want to reconnect this operation when
 /// it's received from the map again.
-#[turbo_tasks::value(transparent)]
+#[turbo_tasks::value(transparent, local)]
 pub struct OutputAssetsOperation(Vc<OutputAssets>);
 
 #[derive(Clone, TraceRawVcs, PartialEq, Eq, ValueDebugFormat, Serialize, Deserialize, Debug)]
@@ -30,14 +30,14 @@ struct MapEntry {
     path_to_asset: HashMap<ResolvedVc<FileSystemPath>, Vc<Box<dyn OutputAsset>>>,
 }
 
-#[turbo_tasks::value(transparent)]
+#[turbo_tasks::value(transparent, local)]
 struct OptionMapEntry(Option<MapEntry>);
 
 type PathToOutputOperation = HashMap<ResolvedVc<FileSystemPath>, FxIndexSet<Vc<OutputAssets>>>;
 // A precomputed map for quick access to output asset by filepath
 type OutputOperationToComputeEntry = HashMap<Vc<OutputAssets>, Vc<OptionMapEntry>>;
 
-#[turbo_tasks::value]
+#[turbo_tasks::value(local)]
 pub struct VersionedContentMap {
     // TODO: turn into a bi-directional multimap, OutputAssets -> FxIndexSet<FileSystemPath>
     map_path_to_op: State<PathToOutputOperation>,

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 
 /// A final route in the app directory.
-#[turbo_tasks::value]
+#[turbo_tasks::value(local)]
 #[derive(Default, Debug, Clone)]
 pub struct AppDirModules {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -180,7 +180,7 @@ impl Metadata {
 }
 
 /// Metadata files that can be placed in the root of the app directory.
-#[turbo_tasks::value]
+#[turbo_tasks::value(local)]
 #[derive(Default, Clone, Debug)]
 pub struct GlobalMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -202,7 +202,7 @@ impl GlobalMetadata {
     }
 }
 
-#[turbo_tasks::value]
+#[turbo_tasks::value(local)]
 #[derive(Debug)]
 pub struct DirectoryTree {
     /// key is e.g. "dashboard", "(dashboard)", "@slot"
@@ -210,7 +210,7 @@ pub struct DirectoryTree {
     pub modules: AppDirModules,
 }
 
-#[turbo_tasks::value]
+#[turbo_tasks::value(local)]
 #[derive(Clone, Debug)]
 struct PlainDirectoryTree {
     /// key is e.g. "dashboard", "(dashboard)", "@slot"
@@ -400,7 +400,7 @@ async fn get_directory_tree_internal(
     .cell())
 }
 
-#[turbo_tasks::value]
+#[turbo_tasks::value(local)]
 #[derive(Debug, Clone)]
 pub struct AppPageLoaderTree {
     pub page: AppPage,
@@ -523,7 +523,7 @@ impl Entrypoint {
     }
 }
 
-#[turbo_tasks::value(transparent)]
+#[turbo_tasks::value(transparent, local)]
 pub struct Entrypoints(FxIndexMap<AppPath, Entrypoint>);
 
 fn is_parallel_route(name: &str) -> bool {
@@ -1411,7 +1411,7 @@ pub async fn get_global_metadata(
     Ok(metadata.cell())
 }
 
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, local)]
 struct DirectoryTreeIssue {
     pub severity: ResolvedVc<IssueSeverity>,
     // no-resolved-vc(kdy1): I'll resolve this later because it's a complex case.

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -95,7 +95,7 @@ impl Default for ClientReferenceGraphResult {
     }
 }
 
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, local)]
 pub struct VisitedClientReferenceGraphNodes(HashSet<VisitClientReferenceNode>);
 
 #[turbo_tasks::value_impl]

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -448,7 +448,7 @@ pub enum LoaderItem {
     LoaderOptions(WebpackLoaderItem),
 }
 
-#[turbo_tasks::value(non_local)]
+#[turbo_tasks::value]
 #[derive(Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub enum ModuleIdStrategy {
@@ -466,7 +466,7 @@ pub enum MdxRsOptions {
     Option(MdxTransformOptions),
 }
 
-#[turbo_tasks::value(shared, non_local)]
+#[turbo_tasks::value(shared)]
 #[derive(Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub enum ReactCompilerMode {
@@ -476,7 +476,7 @@ pub enum ReactCompilerMode {
 }
 
 /// Subset of react compiler options
-#[turbo_tasks::value(shared, non_local)]
+#[turbo_tasks::value(shared)]
 #[derive(Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ReactCompilerOptions {

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -435,7 +435,7 @@ pub struct PackagesGlobs {
 }
 
 // TODO move that to turbo
-#[turbo_tasks::value(transparent)]
+#[turbo_tasks::value(transparent, local)]
 pub struct OptionPackagesGlobs(Option<PackagesGlobs>);
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-fs/src/attach.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/attach.rs
@@ -12,7 +12,7 @@ use crate::{
 /// "subdirectory" in the given root [FileSystem].
 ///
 /// Caveat: The `child_path` itself is not visible as a directory entry.
-#[turbo_tasks::value(non_local)]
+#[turbo_tasks::value]
 pub struct AttachedFileSystem {
     root_fs: ResolvedVc<Box<dyn FileSystem>>,
     // we turn this into a string because creating a FileSystemPath requires the filesystem which

--- a/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
@@ -9,7 +9,7 @@ use crate::{
     LinkContent,
 };
 
-#[turbo_tasks::value(serialization = "none", cell = "new", eq = "manual", non_local)]
+#[turbo_tasks::value(serialization = "none", cell = "new", eq = "manual")]
 pub struct EmbeddedFileSystem {
     name: RcStr,
     #[turbo_tasks(trace_ignore)]

--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -42,7 +42,7 @@ enum GlobPart {
 // Note: a/**/b does match a/b, so we need some special logic about path
 // separators
 
-#[turbo_tasks::value(non_local)]
+#[turbo_tasks::value]
 #[derive(Debug, Clone)]
 pub struct Glob {
     expression: Vec<GlobPart>,

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -173,7 +173,7 @@ pub fn validate_path_length(path: &Path) -> Result<Cow<'_, Path>> {
     })
 }
 
-#[turbo_tasks::value_trait(non_local)]
+#[turbo_tasks::value_trait]
 pub trait FileSystem: ValueToString {
     /// Returns the path to the root of the file system.
     fn root(self: Vc<Self>) -> Vc<FileSystemPath> {
@@ -348,7 +348,7 @@ impl DiskFileSystemInner {
     }
 }
 
-#[turbo_tasks::value(cell = "new", eq = "manual", non_local)]
+#[turbo_tasks::value(cell = "new", eq = "manual")]
 pub struct DiskFileSystem {
     inner: Arc<DiskFileSystemInner>,
 }
@@ -944,7 +944,7 @@ impl ValueToString for DiskFileSystem {
     }
 }
 
-#[turbo_tasks::value(non_local)]
+#[turbo_tasks::value]
 #[derive(Debug, Clone)]
 pub struct FileSystemPath {
     pub fs: ResolvedVc<Box<dyn FileSystem>>,
@@ -2100,7 +2100,7 @@ impl FileContent {
 }
 
 /// A file's content interpreted as a JSON value.
-#[turbo_tasks::value(shared, serialization = "none", non_local)]
+#[turbo_tasks::value(shared, serialization = "none")]
 pub enum FileJsonContent {
     Content(Value),
     Unparseable(Box<UnparseableJson>),
@@ -2279,7 +2279,7 @@ impl DirectoryContent {
     }
 }
 
-#[turbo_tasks::value(shared, non_local)]
+#[turbo_tasks::value(shared)]
 pub struct NullFileSystem;
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1702,7 +1702,7 @@ impl FileContent {
 }
 
 bitflags! {
-  #[derive(Default, Serialize, Deserialize, TraceRawVcs)]
+  #[derive(Default, Serialize, Deserialize, TraceRawVcs, NonLocalValue)]
   pub struct LinkType: u8 {
       const DIRECTORY = 0b00000001;
       const ABSOLUTE = 0b00000010;

--- a/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
@@ -4,7 +4,7 @@ use turbo_tasks::{Completion, ValueDefault, ValueToString, Vc};
 
 use super::{DirectoryContent, FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent};
 
-#[turbo_tasks::value(non_local)]
+#[turbo_tasks::value]
 pub struct VirtualFileSystem {
     pub name: RcStr,
 }

--- a/turbopack/crates/turbo-tasks-macros-shared/src/value_trait_arguments.rs
+++ b/turbopack/crates/turbo-tasks-macros-shared/src/value_trait_arguments.rs
@@ -12,11 +12,9 @@ pub struct ValueTraitArguments {
     /// Whether the macro should generate a `ValueDebug`-like `dbg()`
     /// implementation on the trait's `Vc`.
     pub debug: bool,
-    /// Should the trait have a `turbo_tasks::NonLocalValue` constraint?
-    ///
-    /// `Some(...)` if enabled, containing the span that enabled the constraint.
-    pub non_local: Option<Span>,
-    /// Should the trait have a `turbo_tasks::OperationValue` constraint?
+    /// By default, traits have a `turbo_tasks::NonLocalValue` supertype. Should we skip this?
+    pub local: bool,
+    /// Should the trait have a `turbo_tasks::OperationValue` supertype?
     pub operation: Option<Span>,
 }
 
@@ -24,7 +22,7 @@ impl Default for ValueTraitArguments {
     fn default() -> Self {
         Self {
             debug: true,
-            non_local: None,
+            local: false,
             operation: None,
         }
     }
@@ -43,8 +41,8 @@ impl Parse for ValueTraitArguments {
                 Some("no_debug") => {
                     result.debug = false;
                 }
-                Some("non_local") => {
-                    result.non_local = Some(meta.span());
+                Some("local") => {
+                    result.local = true;
                 }
                 Some("operation") => {
                     result.operation = Some(meta.span());

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args.rs
@@ -3,7 +3,7 @@
 
 use turbo_tasks::{ResolvedVc, Vc};
 
-#[turbo_tasks::value(transparent, non_local)]
+#[turbo_tasks::value(transparent)]
 struct IntegersVec(Vec<ResolvedVc<u32>>);
 
 #[turbo_tasks::function(invalid_argument)]

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args_inherent_impl.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args_inherent_impl.rs
@@ -6,7 +6,7 @@ use turbo_tasks::{ResolvedVc, Vc};
 #[turbo_tasks::value]
 struct ExampleStruct;
 
-#[turbo_tasks::value(transparent, non_local)]
+#[turbo_tasks::value(transparent)]
 struct IntegersVec(Vec<ResolvedVc<u32>>);
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_non_local_inherent_impl.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_non_local_inherent_impl.rs
@@ -7,7 +7,7 @@ use turbo_tasks::Vc;
 #[turbo_tasks::value]
 struct ExampleStruct;
 
-#[turbo_tasks::value(transparent)]
+#[turbo_tasks::value(transparent, local)]
 struct IntegersVec(Vec<Vc<u32>>);
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_non_local_static.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_non_local_static.rs
@@ -4,7 +4,7 @@
 
 use turbo_tasks::Vc;
 
-#[turbo_tasks::value(transparent)]
+#[turbo_tasks::value(transparent, local)]
 struct IntegersVec(Vec<Vc<u32>>);
 
 #[turbo_tasks::function(non_local_return)]

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_non_local_trait_impl.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_non_local_trait_impl.rs
@@ -7,7 +7,7 @@ use turbo_tasks::Vc;
 #[turbo_tasks::value]
 struct ExampleStruct;
 
-#[turbo_tasks::value(transparent)]
+#[turbo_tasks::value(transparent, local)]
 struct IntegersVec(Vec<Vc<u32>>);
 
 #[turbo_tasks::value_trait]

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_non_local_inherent_impl.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_non_local_inherent_impl.rs
@@ -7,7 +7,7 @@ use turbo_tasks::{ResolvedVc, Vc};
 #[turbo_tasks::value]
 struct ExampleStruct;
 
-#[turbo_tasks::value(transparent, non_local)]
+#[turbo_tasks::value(transparent)]
 struct IntegersVec(Vec<ResolvedVc<u32>>);
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_non_local_static.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_non_local_static.rs
@@ -4,7 +4,7 @@
 
 use turbo_tasks::{ResolvedVc, Vc};
 
-#[turbo_tasks::value(transparent, non_local)]
+#[turbo_tasks::value(transparent)]
 struct IntegersVec(Vec<ResolvedVc<u32>>);
 
 #[turbo_tasks::function(non_local_return)]

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_non_local_trait_impl.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_non_local_trait_impl.rs
@@ -7,7 +7,7 @@ use turbo_tasks::{ResolvedVc, Vc};
 #[turbo_tasks::value]
 struct ExampleStruct;
 
-#[turbo_tasks::value(transparent, non_local)]
+#[turbo_tasks::value(transparent)]
 struct IntegersVec(Vec<ResolvedVc<u32>>);
 
 #[turbo_tasks::value_trait]

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_non_local_vc_input.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_non_local_vc_input.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use turbo_tasks::{ResolvedVc, Vc};
 
 #[derive(Clone)]
-#[turbo_tasks::value(non_local)]
+#[turbo_tasks::value]
 struct ExampleStruct {
     items: Vec<ResolvedVc<u32>>,
 }
@@ -41,7 +41,7 @@ impl ExampleStruct {
     fn non_turbo_method_with_resolved_vc_self(self: ResolvedVc<Self>) {}
 }
 
-#[turbo_tasks::value(non_local, transparent)]
+#[turbo_tasks::value(, transparent)]
 struct MaybeExampleStruct(Option<ExampleStruct>);
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_non_local_vc_input.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_non_local_vc_input.rs
@@ -41,7 +41,7 @@ impl ExampleStruct {
     fn non_turbo_method_with_resolved_vc_self(self: ResolvedVc<Self>) {}
 }
 
-#[turbo_tasks::value(, transparent)]
+#[turbo_tasks::value(transparent)]
 struct MaybeExampleStruct(Option<ExampleStruct>);
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/value/fail_non_local.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/value/fail_non_local.rs
@@ -3,7 +3,7 @@
 
 use turbo_tasks::Vc;
 
-#[turbo_tasks::value(non_local)]
+#[turbo_tasks::value]
 struct MyValue {
     value: Vc<i32>,
 }

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/value/fail_non_local.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/value/fail_non_local.stderr
@@ -15,8 +15,8 @@ error[E0277]: the trait bound `Vc<i32>: NonLocalValue` is not satisfied
             (E, D, C, B, A, Z, Y, X, W, V, U, T)
           and $N others
 note: required by a bound in `DeriveNonLocalValueAssertion::assert_impl_NonLocalValue`
- --> tests/value/fail_non_local.rs:6:22
+ --> tests/value/fail_non_local.rs:6:1
   |
 6 | #[turbo_tasks::value]
-  |                      ^^^^^^^^^ required by this bound in `DeriveNonLocalValueAssertion::assert_impl_NonLocalValue`
+  | ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DeriveNonLocalValueAssertion::assert_impl_NonLocalValue`
   = note: this error originates in the derive macro `turbo_tasks::NonLocalValue` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/value/fail_non_local.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/value/fail_non_local.stderr
@@ -17,6 +17,6 @@ error[E0277]: the trait bound `Vc<i32>: NonLocalValue` is not satisfied
 note: required by a bound in `DeriveNonLocalValueAssertion::assert_impl_NonLocalValue`
  --> tests/value/fail_non_local.rs:6:22
   |
-6 | #[turbo_tasks::value(non_local)]
+6 | #[turbo_tasks::value]
   |                      ^^^^^^^^^ required by this bound in `DeriveNonLocalValueAssertion::assert_impl_NonLocalValue`
   = note: this error originates in the derive macro `turbo_tasks::NonLocalValue` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/value/pass_non_local.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/value/pass_non_local.rs
@@ -1,7 +1,7 @@
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
 
-#[turbo_tasks::value(non_local)]
+#[turbo_tasks::value]
 struct MyValue {
     value: i32,
 }

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/value_trait/pass_non_local.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/value_trait/pass_non_local.rs
@@ -1,7 +1,7 @@
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
 
-#[turbo_tasks::value_trait(non_local)]
+#[turbo_tasks::value_trait]
 trait MyTrait {}
 
 fn expects_non_local<T: turbo_tasks::NonLocalValue + ?Sized>() {}

--- a/turbopack/crates/turbo-tasks-macros/src/assert_fields.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/assert_fields.rs
@@ -40,12 +40,12 @@ pub fn assert_fields_impl_trait(
             }
         });
     quote! {
+        #[allow(non_snake_case)]
+        #[allow(clippy::type_complexity)]
         const _: fn() = || {
             // create this struct just to hold onto our generics...
             // we reproduce the field types here to ensure any generics get used
             struct #assertion_struct_ident #impl_generics (#(#field_types),*) #where_clause;
-
-            #[allow(non_snake_case)]
             impl #impl_generics #assertion_struct_ident #ty_generics #where_clause {
                 fn #assertion_fn_ident<
                     Expected: #trait_path + ?Sized

--- a/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -14,7 +14,7 @@ use crate::func::{DefinitionContext, FunctionArguments, NativeFn, TurboFn};
 pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
     let ValueTraitArguments {
         debug,
-        non_local,
+        local,
         operation,
     } = parse_macro_input!(args as ValueTraitArguments);
 
@@ -200,9 +200,9 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
     };
 
     let mut extended_supertraits = vec![quote!(::std::marker::Send), quote!(::std::marker::Sync)];
-    if let Some(span) = non_local {
-        extended_supertraits.push(quote_spanned! {
-            span => turbo_tasks::NonLocalValue
+    if !local {
+        extended_supertraits.push(quote! {
+            turbo_tasks::NonLocalValue
         });
     }
     if let Some(span) = operation {

--- a/turbopack/crates/turbo-tasks-testing/tests/detached.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/detached.rs
@@ -106,7 +106,7 @@ async fn test_spawns_detached_changing() -> anyhow::Result<()> {
     .await
 }
 
-#[turbo_tasks::value]
+#[turbo_tasks::value(local)]
 struct ChangingInput {
     state: State<u32>,
 }

--- a/turbopack/crates/turbo-tasks-testing/tests/dirty_in_progress.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/dirty_in_progress.rs
@@ -47,7 +47,7 @@ async fn dirty_in_progress() {
     .unwrap()
 }
 
-#[turbo_tasks::value]
+#[turbo_tasks::value(local)]
 struct ChangingInput {
     state: State<u32>,
 }

--- a/turbopack/crates/turbo-tasks-testing/tests/emptied_cells.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/emptied_cells.rs
@@ -44,7 +44,7 @@ async fn recompute() {
     .unwrap();
 }
 
-#[turbo_tasks::value]
+#[turbo_tasks::value(local)]
 struct ChangingInput {
     state: State<u32>,
 }

--- a/turbopack/crates/turbo-tasks-testing/tests/local_cell.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/local_cell.rs
@@ -4,8 +4,7 @@
 
 use anyhow::Result;
 use turbo_tasks::{
-    debug::ValueDebug, test_helpers::current_task_for_testing, NonLocalValue, ResolvedVc,
-    ValueDefault, Vc,
+    debug::ValueDebug, test_helpers::current_task_for_testing, ResolvedVc, ValueDefault, Vc,
 };
 use turbo_tasks_testing::{register, run, Registration};
 
@@ -114,8 +113,6 @@ struct Untracked {
     #[serde(skip)]
     cell: ResolvedVc<u32>,
 }
-
-unsafe impl NonLocalValue for Untracked {}
 
 impl PartialEq for Untracked {
     fn eq(&self, other: &Self) -> bool {

--- a/turbopack/crates/turbo-tasks-testing/tests/recompute.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/recompute.rs
@@ -58,7 +58,7 @@ async fn recompute() {
     .unwrap()
 }
 
-#[turbo_tasks::value]
+#[turbo_tasks::value(local)]
 struct ChangingInput {
     state: State<u32>,
 }

--- a/turbopack/crates/turbo-tasks-testing/tests/recompute_collectibles.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/recompute_collectibles.rs
@@ -33,7 +33,7 @@ async fn recompute() {
     .unwrap()
 }
 
-#[turbo_tasks::value]
+#[turbo_tasks::value(local)]
 struct ChangingInput {
     state: State<u32>,
 }

--- a/turbopack/crates/turbo-tasks/src/debug/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/debug/mod.rs
@@ -54,7 +54,7 @@ impl ValueDebugString {
 /// ```ignore
 /// dbg!(any_vc.dbg().await?);
 /// ```
-#[turbo_tasks::value_trait(no_debug)]
+#[turbo_tasks::value_trait(no_debug, local)]
 pub trait ValueDebug {
     fn dbg(self: Vc<Self>) -> Vc<ValueDebugString>;
 

--- a/turbopack/crates/turbo-tasks/src/display.rs
+++ b/turbopack/crates/turbo-tasks/src/display.rs
@@ -3,7 +3,7 @@ use turbo_tasks::Vc;
 
 use crate::{self as turbo_tasks};
 
-#[turbo_tasks::value_trait]
+#[turbo_tasks::value_trait(local)]
 pub trait ValueToString {
     fn to_string(self: Vc<Self>) -> Vc<RcStr>;
 }

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -263,13 +263,14 @@ macro_rules! fxindexset {
 ///
 /// [repr-transparent]: https://doc.rust-lang.org/nomicon/other-reprs.html#reprtransparent
 ///
-/// ## `non_local`
+/// ## `local`
 ///
-/// Applies the [`#[derive(NonLocalValue)]`][macro@NonLocalValue] macro.
+/// Skip the implementation of [`NonLocalValue`] for this type.
 ///
-/// Indicates that this struct has no fields containing [`Vc`] by implementing the [`NonLocalValue`]
-/// marker trait. In order to safely implement [`NonLocalValue`], this inserts compile-time
-/// assertions that every field in this struct has a type that is also a [`NonLocalValue`].
+/// If not specified, we apply the [`#[derive(NonLocalValue)]`][macro@NonLocalValue] macro, which
+/// asserts that this struct has no fields containing [`Vc`] by implementing the [`NonLocalValue`]
+/// marker trait. Compile-time assertions are generated on every field, checking that they are also
+/// [`NonLocalValue`]s.
 #[rustfmt::skip]
 pub use turbo_tasks_macros::value;
 

--- a/turbopack/crates/turbo-tasks/src/marker_trait.rs
+++ b/turbopack/crates/turbo-tasks/src/marker_trait.rs
@@ -12,7 +12,8 @@
 macro_rules! impl_auto_marker_trait {
     ($trait:ident) => {
         $crate::marker_trait::impl_marker_trait!(
-            $trait: i8, u8, i16, u16, i32, u32, i64, u64, f32, f64, char, bool, usize,
+            $trait:
+            i8, u8, i16, u16, i32, u32, i64, u64, i128, u128, isize, usize, f32, f64, char, bool,
         );
         $crate::marker_trait::impl_marker_trait!(
             $trait:

--- a/turbopack/crates/turbo-tasks/src/vc/default.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/default.rs
@@ -11,7 +11,7 @@ use crate::{self as turbo_tasks};
 /// 1. Annotating with `#[turbo_tasks::value_impl]`: this will make `Vc::default()` always return
 ///    the same underlying value (i.e. a singleton).
 /// 2. No annotations: this will make `Vc::default()` always return a different value.
-#[turbo_tasks::value_trait]
+#[turbo_tasks::value_trait(local)]
 pub trait ValueDefault {
     fn value_default() -> Vc<Self>;
 }

--- a/turbopack/crates/turbo-tasks/src/vc/local.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/local.rs
@@ -17,9 +17,13 @@ use crate::{marker_trait::impl_auto_marker_trait, OperationVc, ResolvedVc};
 ///
 /// # Safety
 ///
-/// This trait is marked as unsafe. You should not derive it yourself, but instead you should rely
-/// on [`#[turbo_tasks::value(non_local)]`][macro@crate::value] or [the derive
-/// macro][macro@NonLocalValue] to do it for you.
+/// This trait is marked as unsafe. You should not implement it yourself, but instead you should
+/// rely on [`#[turbo_tasks::value]`][macro@crate::value] or
+/// [`#[derive(NonLocalValue)]`][macro@NonLocalValue] to do it for you.
+///
+/// There may be a few rare cases (e.g. custom generic bounds) where you cannot use
+/// `#[turbo_tasks::value]`. In these cases, it is your responsibility to ensure that no fields can
+/// contain a [`Vc`] or a transitive reference to a [`Vc`].
 ///
 /// There are currently runtime assertions in place as a fallback to ensure memory safety, but those
 /// assertions may become debug-only in the future if it significantly improves performance.

--- a/turbopack/crates/turbopack-core/src/asset.rs
+++ b/turbopack/crates/turbopack-core/src/asset.rs
@@ -8,7 +8,7 @@ use turbo_tasks_fs::{
 use crate::version::{VersionedAssetContent, VersionedContent};
 
 /// An asset. It also forms a graph when following [Asset::references].
-#[turbo_tasks::value_trait]
+#[turbo_tasks::value_trait(local)]
 pub trait Asset {
     /// The content of the [Asset].
     fn content(self: Vc<Self>) -> Vc<AssetContent>;

--- a/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
@@ -14,7 +14,7 @@ use crate::{
 ///
 /// The chunking context implementation will resolve the dynamic entry to a
 /// well-known value or trait object.
-#[turbo_tasks::value_trait]
+#[turbo_tasks::value_trait(local)]
 pub trait EvaluatableAsset: Asset + Module + ChunkableModule {}
 
 pub trait EvaluatableAssetExt {

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -89,7 +89,7 @@ impl ModuleId {
 pub struct ModuleIds(Vec<ResolvedVc<ModuleId>>);
 
 /// A [Module] that can be converted into a [Chunk].
-#[turbo_tasks::value_trait]
+#[turbo_tasks::value_trait(local)]
 pub trait ChunkableModule: Module + Asset {
     fn as_chunk_item(
         self: Vc<Self>,
@@ -292,7 +292,7 @@ struct ChunkGraphEdge {
 }
 
 #[derive(Debug, Clone)]
-#[turbo_tasks::value(transparent)]
+#[turbo_tasks::value(transparent, local)]
 struct ChunkGraphEdges(Vec<ChunkGraphEdge>);
 
 #[turbo_tasks::function]
@@ -805,7 +805,7 @@ impl AsyncModuleInfo {
 
 pub type ChunkItemWithAsyncModuleInfo = (Vc<Box<dyn ChunkItem>>, Option<Vc<AsyncModuleInfo>>);
 
-#[turbo_tasks::value(transparent)]
+#[turbo_tasks::value(transparent, local)]
 pub struct ChunkItemsWithAsyncModuleInfo(Vec<ChunkItemWithAsyncModuleInfo>);
 
 pub trait ChunkItemExt {

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -50,7 +50,7 @@ use crate::{
 };
 
 /// A module id, which can be a number or string
-#[turbo_tasks::value(shared, non_local)]
+#[turbo_tasks::value(shared)]
 #[derive(Debug, Clone, Hash, Ord, PartialOrd, DeterministicHash)]
 #[serde(untagged)]
 pub enum ModuleId {

--- a/turbopack/crates/turbopack-core/src/code_builder.rs
+++ b/turbopack/crates/turbopack-core/src/code_builder.rs
@@ -24,7 +24,7 @@ use crate::{
 pub type Mapping = (usize, Option<Vc<Box<dyn GenerateSourceMap>>>);
 
 /// Code stores combined output code and the source map of that output code.
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, local)]
 #[derive(Debug, Clone)]
 pub struct Code {
     code: Rope,

--- a/turbopack/crates/turbopack-core/src/context.rs
+++ b/turbopack/crates/turbopack-core/src/context.rs
@@ -12,7 +12,7 @@ use crate::{
     source::Source,
 };
 
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, local)]
 pub enum ProcessResult {
     /// A module was created.
     Module(ResolvedVc<Box<dyn Module>>),

--- a/turbopack/crates/turbopack-core/src/introspect/mod.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/mod.rs
@@ -8,10 +8,10 @@ use turbo_tasks::{FxIndexSet, ResolvedVc, Vc};
 
 type VcDynIntrospectable = Vc<Box<dyn Introspectable>>;
 
-#[turbo_tasks::value(transparent)]
+#[turbo_tasks::value(transparent, local)]
 pub struct IntrospectableChildren(FxIndexSet<(ResolvedVc<RcStr>, VcDynIntrospectable)>);
 
-#[turbo_tasks::value_trait]
+#[turbo_tasks::value_trait(local)]
 pub trait Introspectable {
     fn ty(self: Vc<Self>) -> Vc<RcStr>;
     fn title(self: Vc<Self>) -> Vc<RcStr> {

--- a/turbopack/crates/turbopack-core/src/introspect/module.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/module.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::{asset::Asset, module::Module};
 
-#[turbo_tasks::value]
+#[turbo_tasks::value(local)]
 pub struct IntrospectableModule(Vc<Box<dyn Module>>);
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-core/src/introspect/source.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/source.rs
@@ -5,7 +5,7 @@ use turbo_tasks::{ValueToString, Vc};
 use super::{utils::content_to_details, Introspectable};
 use crate::{asset::Asset, source::Source};
 
-#[turbo_tasks::value]
+#[turbo_tasks::value(local)]
 pub struct IntrospectableSource(Vc<Box<dyn Source>>);
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -97,7 +97,7 @@ pub enum StyledString {
     Strong(RcStr),
 }
 
-#[turbo_tasks::value_trait]
+#[turbo_tasks::value_trait(local)]
 pub trait Issue {
     /// Severity allows the user to filter out unimportant issues, with Bug
     /// being the highest priority and Info being the lowest.

--- a/turbopack/crates/turbopack-core/src/module.rs
+++ b/turbopack/crates/turbopack-core/src/module.rs
@@ -4,7 +4,7 @@ use crate::{asset::Asset, ident::AssetIdent, reference::ModuleReferences};
 
 /// A module. This usually represents parsed source code, which has references
 /// to other modules.
-#[turbo_tasks::value_trait]
+#[turbo_tasks::value_trait(local)]
 pub trait Module: Asset {
     /// The identifier of the [Module]. It's expected to be unique and capture
     /// all properties of the [Module].

--- a/turbopack/crates/turbopack-core/src/output.rs
+++ b/turbopack/crates/turbopack-core/src/output.rs
@@ -8,7 +8,7 @@ pub struct OptionOutputAsset(Option<ResolvedVc<Box<dyn OutputAsset>>>);
 
 /// An asset that should be outputted, e. g. written to disk or served from a
 /// server.
-#[turbo_tasks::value_trait]
+#[turbo_tasks::value_trait(local)]
 pub trait OutputAsset: Asset {
     // TODO change this to path() -> Vc<FileSystemPath>
     /// The identifier of the [OutputAsset]. It's expected to be unique and

--- a/turbopack/crates/turbopack-core/src/reference_type.rs
+++ b/turbopack/crates/turbopack-core/src/reference_type.rs
@@ -27,20 +27,20 @@ impl InnerAssets {
 // TODO when plugins are supported, replace u8 with a trait that defines the
 // behavior.
 
-#[turbo_tasks::value(serialization = "auto_for_input", non_local)]
+#[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(Debug, Clone, Hash)]
 pub enum CommonJsReferenceSubType {
     Custom(u8),
     Undefined,
 }
 
-#[turbo_tasks::value(serialization = "auto_for_input", non_local)]
+#[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(Debug, Clone, Hash)]
 pub enum ImportWithType {
     Json,
 }
 
-#[turbo_tasks::value(serialization = "auto_for_input", non_local)]
+#[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(Debug, Default, Clone, Hash)]
 pub enum EcmaScriptModulesReferenceSubType {
     ImportPart(ResolvedVc<ModulePart>),
@@ -163,7 +163,7 @@ impl ImportContext {
     }
 }
 
-#[turbo_tasks::value(serialization = "auto_for_input", non_local)]
+#[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(Debug, Clone, Hash)]
 pub enum CssReferenceSubType {
     AtImport(Option<ResolvedVc<ImportContext>>),
@@ -178,7 +178,7 @@ pub enum CssReferenceSubType {
     Undefined,
 }
 
-#[turbo_tasks::value(serialization = "auto_for_input", non_local)]
+#[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(Debug, Clone, Hash)]
 pub enum UrlReferenceSubType {
     EcmaScriptNewUrl,
@@ -187,14 +187,14 @@ pub enum UrlReferenceSubType {
     Undefined,
 }
 
-#[turbo_tasks::value(serialization = "auto_for_input", non_local)]
+#[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(Debug, Clone, Hash)]
 pub enum TypeScriptReferenceSubType {
     Custom(u8),
     Undefined,
 }
 
-#[turbo_tasks::value(serialization = "auto_for_input", non_local)]
+#[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(Debug, Clone, Hash)]
 pub enum WorkerReferenceSubType {
     WebWorker,
@@ -206,7 +206,7 @@ pub enum WorkerReferenceSubType {
 
 // TODO(sokra) this was next.js specific values. We want to solve this in a
 // different way.
-#[turbo_tasks::value(serialization = "auto_for_input", non_local)]
+#[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(Debug, Clone, Hash)]
 pub enum EntryReferenceSubType {
     Web,
@@ -222,7 +222,7 @@ pub enum EntryReferenceSubType {
     Undefined,
 }
 
-#[turbo_tasks::value(serialization = "auto_for_input", non_local)]
+#[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(Debug, Clone, Hash)]
 pub enum ReferenceType {
     CommonJs(CommonJsReferenceSubType),

--- a/turbopack/crates/turbopack-core/src/resolve/alias_map.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/alias_map.rs
@@ -124,6 +124,8 @@ where
     }
 }
 
+unsafe impl<T: NonLocalValue> NonLocalValue for AliasMap<T> {}
+
 impl<T> ValueDebugFormat for AliasMap<T>
 where
     T: ValueDebugFormat,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -64,7 +64,7 @@ pub use remap::{ResolveAliasMap, SubpathValue};
 
 use crate::{error::PrettyPrintError, issue::IssueSeverity};
 
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, local)]
 #[derive(Clone, Debug)]
 pub enum ModuleResolveResultItem {
     Module(ResolvedVc<Box<dyn Module>>),
@@ -100,7 +100,7 @@ impl ModuleResolveResultItem {
     }
 }
 
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, local)]
 #[derive(Clone, Debug)]
 pub struct ModuleResolveResult {
     pub primary: FxIndexMap<RequestKey, ModuleResolveResultItem>,
@@ -414,7 +414,7 @@ impl Display for ExternalType {
     }
 }
 
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, local)]
 #[derive(Clone)]
 pub enum ResolveResultItem {
     Source(ResolvedVc<Box<dyn Source>>),
@@ -473,7 +473,7 @@ impl RequestKey {
     }
 }
 
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, local)]
 #[derive(Clone)]
 pub struct ResolveResult {
     pub primary: FxIndexMap<RequestKey, ResolveResultItem>,

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -21,7 +21,7 @@ use crate::resolve::{parse::Request, plugin::AfterResolvePlugin, ExternalTraced}
 #[derive(Hash, Debug)]
 pub struct LockedVersions {}
 
-#[turbo_tasks::value(transparent, non_local)]
+#[turbo_tasks::value(transparent)]
 #[derive(Debug)]
 pub struct ExcludedExtensions(pub FxIndexSet<RcStr>);
 

--- a/turbopack/crates/turbopack-core/src/resolve/origin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/origin.rs
@@ -8,7 +8,7 @@ use crate::{context::AssetContext, module::OptionModule, reference_type::Referen
 
 /// A location where resolving can occur from. It carries some meta information
 /// that are needed for resolving from here.
-#[turbo_tasks::value_trait]
+#[turbo_tasks::value_trait(local)]
 pub trait ResolveOrigin {
     /// The origin path where resolving starts. This is pointing to a file,
     /// since that might be needed to infer custom resolving options for that

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -6,7 +6,7 @@ use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, ValueToString, Vc};
 
 use super::pattern::Pattern;
 
-#[turbo_tasks::value(shared, non_local)]
+#[turbo_tasks::value(shared)]
 #[derive(Hash, Clone, Debug)]
 pub enum Request {
     Raw {

--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -1322,7 +1322,7 @@ impl PatternMatch {
 
 // TODO this isn't super efficient
 // avoid storing a large list of matches
-#[turbo_tasks::value(transparent)]
+#[turbo_tasks::value(transparent, local)]
 pub struct PatternMatches(Vec<PatternMatch>);
 
 /// Find all files or directories that match the provided `pattern` with the

--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -18,7 +18,7 @@ use turbo_tasks_fs::{
     LinkContent, LinkType,
 };
 
-#[turbo_tasks::value(shared, serialization = "auto_for_input", non_local)]
+#[turbo_tasks::value(shared, serialization = "auto_for_input")]
 #[derive(Hash, Clone, Debug, Default)]
 pub enum Pattern {
     Constant(RcStr),

--- a/turbopack/crates/turbopack-core/src/server_fs.rs
+++ b/turbopack/crates/turbopack-core/src/server_fs.rs
@@ -5,7 +5,7 @@ use turbo_tasks_fs::{
     DirectoryContent, FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent,
 };
 
-#[turbo_tasks::value(non_local)]
+#[turbo_tasks::value]
 pub struct ServerFileSystem {}
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-core/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/mod.rs
@@ -27,7 +27,7 @@ pub use source_map_asset::SourceMapAsset;
 static SOURCEMAP_CRATE_NONE_U32: u32 = !0;
 
 /// Allows callers to generate source maps.
-#[turbo_tasks::value_trait]
+#[turbo_tasks::value_trait(local)]
 pub trait GenerateSourceMap {
     /// Generates a usable source map, capable of both tracing and stringifying.
     fn generate_source_map(self: Vc<Self>) -> Vc<OptionSourceMap>;

--- a/turbopack/crates/turbopack-core/src/version.rs
+++ b/turbopack/crates/turbopack-core/src/version.rs
@@ -121,7 +121,7 @@ impl VersionedContentExt for AssetContent {
 
 /// Describes the current version of an object, and how to update them from an
 /// earlier version.
-#[turbo_tasks::value_trait]
+#[turbo_tasks::value_trait(local)]
 pub trait Version {
     /// Get a unique identifier of the version as a string. There is no way
     /// to convert an id back to its original `Version`, so the original object

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -27,7 +27,7 @@ type DevHtmlEntry = (
 /// The HTML entry point of the dev server.
 ///
 /// Generates an HTML page that includes the ES and CSS chunks.
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, local)]
 #[derive(Clone)]
 pub struct DevHtmlAsset {
     path: ResolvedVc<FileSystemPath>,

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -27,7 +27,7 @@ struct OutputAssetsMap(FxIndexMap<RcStr, ResolvedVc<Box<dyn OutputAsset>>>);
 
 type ExpandedState = State<HashSet<RcStr>>;
 
-#[turbo_tasks::value(serialization = "none", eq = "manual", cell = "new")]
+#[turbo_tasks::value(serialization = "none", eq = "manual", cell = "new", local)]
 pub struct AssetGraphContentSource {
     root_path: ResolvedVc<FileSystemPath>,
     root_assets: ResolvedVc<OutputAssetsSet>,

--- a/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
@@ -21,7 +21,7 @@ use crate::source::{ContentSourceContent, ContentSources};
 /// pages. Here HTML and "other assets" are in different content sources. So we
 /// use this source to only serve (and process) "other assets" when the HTML was
 /// served once.
-#[turbo_tasks::value(serialization = "none", eq = "manual", cell = "new")]
+#[turbo_tasks::value(serialization = "none", eq = "manual", cell = "new", local)]
 pub struct ConditionalContentSource {
     activator: ResolvedVc<Box<dyn ContentSource>>,
     action: ResolvedVc<Box<dyn ContentSource>>,

--- a/turbopack/crates/turbopack-dev-server/src/source/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/mod.rs
@@ -408,7 +408,7 @@ impl ContentSourceDataVary {
 }
 
 /// A source of content that the dev server uses to respond to http requests.
-#[turbo_tasks::value_trait]
+#[turbo_tasks::value_trait(local)]
 pub trait ContentSource {
     fn get_routes(self: Vc<Self>) -> Vc<RouteTree>;
 
@@ -500,7 +500,7 @@ pub enum RewriteType {
 
 /// A rewrite returned from a [ContentSource]. This tells the dev server to
 /// update its parsed url, path, and queries with this new information.
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, local)]
 #[derive(Debug)]
 pub struct Rewrite {
     pub ty: RewriteType,

--- a/turbopack/crates/turbopack-dev-server/src/source/resolve.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/resolve.rs
@@ -22,7 +22,7 @@ use super::{
 /// The result of [`resolve_source_request`]. Similar to a
 /// `ContentSourceContent`, but without the `Rewrite` variant as this is taken
 /// care in the function.
-#[turbo_tasks::value(serialization = "none")]
+#[turbo_tasks::value(serialization = "none", local)]
 pub enum ResolveSourceRequestResult {
     NotFound,
     Static(ResolvedVc<StaticContent>, ResolvedVc<HeaderList>),

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
@@ -27,7 +27,7 @@ pub enum EmotionLabelKind {
 
 //[TODO]: need to support importmap, there are type mismatch between
 //next.config.js to swc's emotion options
-#[turbo_tasks::value(shared, non_local)]
+#[turbo_tasks::value(shared)]
 #[derive(Default, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct EmotionTransformConfig {

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/styled_components.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/styled_components.rs
@@ -9,7 +9,7 @@ use swc_core::{
 use turbo_tasks::{ValueDefault, Vc};
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
 
-#[turbo_tasks::value(shared, non_local)]
+#[turbo_tasks::value(shared)]
 #[derive(Clone, Debug)]
 #[serde(default, rename_all = "camelCase")]
 pub struct StyledComponentsTransformConfig {

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/content.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/content.rs
@@ -8,7 +8,7 @@ type EcmascriptChunkItemWithAsyncInfo = (
     Option<Vc<AsyncModuleInfo>>,
 );
 
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, local)]
 pub struct EcmascriptChunkContent {
     pub chunk_items: Vec<EcmascriptChunkItemWithAsyncInfo>,
     pub referenced_output_assets: Vec<ResolvedVc<Box<dyn OutputAsset>>>,

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -15,7 +15,7 @@ use crate::references::{
     esm::{EsmExport, EsmExports},
 };
 
-#[turbo_tasks::value_trait]
+#[turbo_tasks::value_trait(local)]
 pub trait EcmascriptChunkPlaceable: ChunkableModule + Module + Asset {
     fn get_exports(self: Vc<Self>) -> Vc<EcmascriptExports>;
     fn get_async_module(self: Vc<Self>) -> Vc<OptionAsyncModule> {

--- a/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
@@ -89,7 +89,7 @@ pub trait VisitorFactory: Send + Sync {
     fn create<'a>(&'a self) -> Box<dyn VisitMut + Send + Sync + 'a>;
 }
 
-#[turbo_tasks::value_trait]
+#[turbo_tasks::value_trait(local)]
 pub trait CodeGenerateable {
     fn code_generation(
         self: Vc<Self>,
@@ -112,7 +112,7 @@ pub enum CodeGen {
     CodeGenerateableWithAsyncModuleInfo(ResolvedVc<Box<dyn CodeGenerateableWithAsyncModuleInfo>>),
 }
 
-#[turbo_tasks::value(transparent)]
+#[turbo_tasks::value(transparent, local)]
 pub struct CodeGenerateables(Vec<CodeGen>);
 
 pub fn path_to(

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -236,7 +236,7 @@ impl EcmascriptModuleAssetBuilder {
     }
 }
 
-#[turbo_tasks::value]
+#[turbo_tasks::value(local)]
 pub struct EcmascriptModuleAsset {
     pub source: ResolvedVc<Box<dyn Source>>,
     pub asset_context: ResolvedVc<Box<dyn AssetContext>>,
@@ -249,7 +249,7 @@ pub struct EcmascriptModuleAsset {
     last_successful_parse: turbo_tasks::TransientState<ReadRef<ParseResult>>,
 }
 
-#[turbo_tasks::value_trait]
+#[turbo_tasks::value_trait(local)]
 pub trait EcmascriptParsable {
     fn failsafe_parse(self: Vc<Self>) -> Result<Vc<ParseResult>>;
 
@@ -258,7 +258,7 @@ pub trait EcmascriptParsable {
     fn ty(self: Vc<Self>) -> Result<Vc<EcmascriptModuleAssetType>>;
 }
 
-#[turbo_tasks::value_trait]
+#[turbo_tasks::value_trait(local)]
 pub trait EcmascriptAnalyzable {
     fn analyze(self: Vc<Self>) -> Vc<AnalyzeEcmascriptModuleResult>;
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -423,7 +423,7 @@ async fn emit_star_exports_issue(source_ident: Vc<AssetIdent>, message: RcStr) -
     Ok(())
 }
 
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, local)]
 #[derive(Hash, Debug)]
 pub struct EsmExports {
     pub exports: BTreeMap<RcStr, EsmExport>,
@@ -435,7 +435,7 @@ pub struct EsmExports {
 ///
 /// `star_exports` that could not be (fully) expanded end up in
 /// `dynamic_exports`.
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, local)]
 #[derive(Hash, Debug)]
 pub struct ExpandedExports {
     pub exports: BTreeMap<RcStr, EsmExport>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -3217,7 +3217,7 @@ async fn resolve_as_webpack_runtime(
 }
 
 // TODO enable serialization
-#[turbo_tasks::value(transparent, serialization = "none", non_local)]
+#[turbo_tasks::value(transparent, serialization = "none")]
 pub struct AstPath(#[turbo_tasks(trace_ignore)] Vec<AstParentKind>);
 
 pub static TURBOPACK_HELPER: Lazy<JsWord> = Lazy::new(|| "__turbopack-helper__".into());

--- a/turbopack/crates/turbopack-mdx/src/lib.rs
+++ b/turbopack/crates/turbopack-mdx/src/lib.rs
@@ -24,7 +24,7 @@ fn modifier() -> Vc<RcStr> {
     Vc::cell("mdx".into())
 }
 
-#[turbo_tasks::value(shared, non_local)]
+#[turbo_tasks::value(shared)]
 #[derive(Hash, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum MdxParseConstructs {
@@ -35,7 +35,7 @@ pub enum MdxParseConstructs {
 /// Subset of mdxjs::Options to allow to inherit turbopack's jsx-related configs
 /// into mdxjs. This is thin, near straightforward subset of mdxjs::Options to
 /// enable turbo tasks.
-#[turbo_tasks::value(shared, non_local)]
+#[turbo_tasks::value(shared)]
 #[derive(Hash, Debug, Clone)]
 #[serde(rename_all = "camelCase", default)]
 pub struct MdxTransformOptions {

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -82,7 +82,7 @@ pub struct WebpackLoaderItem {
 }
 
 #[derive(Debug, Clone)]
-#[turbo_tasks::value(shared, transparent, non_local)]
+#[turbo_tasks::value(shared, transparent)]
 pub struct WebpackLoaderItems(pub Vec<WebpackLoaderItem>);
 
 #[turbo_tasks::value]

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
@@ -12,7 +12,7 @@ use turbopack_ecmascript::chunk::EcmascriptChunkContent;
 
 use super::content::chunk_items;
 
-#[turbo_tasks::value(serialization = "none")]
+#[turbo_tasks::value(serialization = "none", local)]
 pub(super) struct EcmascriptBuildNodeChunkVersion {
     chunk_path: String,
     chunk_items: Vec<(ReadRef<ModuleId>, ReadRef<Code>)>,

--- a/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
@@ -11,7 +11,7 @@ use turbopack_core::{
     },
 };
 
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, local)]
 #[derive(Default, Clone)]
 pub struct ResolveOptionsContext {
     #[serde(default)]

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -953,7 +953,7 @@ pub async fn emit_asset_into_dir(
 
 type OutputAssetSet = HashSet<Vc<Box<dyn OutputAsset>>>;
 
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, local)]
 struct ReferencesList {
     referenced_by: HashMap<ResolvedVc<Box<dyn OutputAsset>>, OutputAssetSet>,
 }

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -107,7 +107,7 @@ pub struct JsxTransformOptions {
     pub runtime: Option<RcStr>,
 }
 
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, local)]
 #[derive(Clone, Default)]
 #[serde(default)]
 pub struct ModuleOptionsContext {

--- a/turbopack/crates/turbopack/src/module_options/module_rule.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_rule.rs
@@ -61,7 +61,7 @@ impl ModuleRule {
     }
 }
 
-#[turbo_tasks::value(shared, non_local)]
+#[turbo_tasks::value(shared)]
 #[derive(Debug, Clone)]
 pub enum ModuleRuleEffect {
     ModuleType(ModuleType),
@@ -75,7 +75,7 @@ pub enum ModuleRuleEffect {
     SourceTransforms(ResolvedVc<SourceTransforms>),
 }
 
-#[turbo_tasks::value(serialization = "auto_for_input", shared, non_local)]
+#[turbo_tasks::value(serialization = "auto_for_input", shared)]
 #[derive(Hash, Debug, Copy, Clone)]
 pub enum ModuleType {
     Ecmascript {

--- a/turbopack/crates/turbopack/src/transition/mod.rs
+++ b/turbopack/crates/turbopack/src/transition/mod.rs
@@ -109,7 +109,7 @@ pub trait Transition {
     }
 }
 
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, local)]
 #[derive(Default)]
 pub struct TransitionOptions {
     pub named_transitions: HashMap<RcStr, ResolvedVc<Box<dyn Transition>>>,


### PR DESCRIPTION
**Recommendation:** Review [the individual commits](https://github.com/vercel/next.js/pull/73766/commits) in order!

**What is NonLocalValue?** https://turbopack-rust-docs.vercel.sh/rustdoc/turbo_tasks/trait.NonLocalValue.html

1. Switches the default behavior of `#[turbo_tasks::value]` and `#[turbo_tasks::value_trait]` to derive `NonLocalValue`, with an opt-out (previously, this was just opt-in).
2. *(Automated, codemod)* Remove pre-existing opt-ins to `NonLocalValue` (as this is now the default behavior)
3. Manually add `NonLocalValue` to a couple more common types.
4. *(Automated, codemod)* Add `local` annotations to structs and traits with errors.

Normally I'd split this sort of thing up across a few PRs, but steps 1, 2, and 4 must be atomic (must land together).

---

Removing pre-existing opt-ins was done with a couple regexes:

```
fastmod --accept-all '#\[turbo_tasks::value(?<trait>_trait)?\(((?<prefix>.*), )?non_local(?<suffix>.*)\)\]' '#[turbo_tasks::value${trait}(${prefix}${suffix})]'
fastmod --accept-all '#\[turbo_tasks::value(?<trait>_trait)?\(\)\]' '#[turbo_tasks::value${trait}]'
```

Adding `local` annotations to structs/enums and traits was done with this kludge (partially sourced from chatgpt):

```
cargo check --message-format=json 2>/dev/null | jq -r '. | select(.message.children != null) | .message.children[] | select(.spans != null) | .spans[] | select(.expansion.macro_decl_name == "#[derive(turbo_tasks::NonLocalValue)]") | .file_name + " " + (.line_start|tostring) + " " + (.line_end|tostring)' | sort -u | xargs -I{} bash -c 'args=($1); file="${args[0]}"; line="${args[1]}"; echo "Processing: $file $line" >&2; sed -i "${line}s/#\[turbo_tasks::value(\([^)]*\))\]/#[turbo_tasks::value(\1, local)]/; ${line}s/#\[turbo_tasks::value\]/#[turbo_tasks::value(local)]/" "$file"' -- {} && \
cargo check --message-format=json 2>/dev/null | jq -r '. | select(.message.children != null) | .message.children[] | select(.spans != null) | .spans[] | select(.expansion.macro_decl_name == "#[turbo_tasks::value_trait]") | .file_name + " " + (.line_start|tostring) + " " + (.line_end|tostring)' | sort -u | xargs -I{} bash -c 'args=($1); file="${args[0]}"; line="${args[1]}"; echo "Processing: $file $line" >&2; sed -i "${line}s/#\[turbo_tasks::value_trait(\([^)]*\))\]/#[turbo_tasks::value_trait(\1, local)]/; ${line}s/#\[turbo_tasks::value_trait\]/#[turbo_tasks::value_trait(local)]/" "$file"' -- {}
```

Which I just ran a bunch of times until `cargo check` no longer generated any errors.

Closes PACK-3647