### PR TITLE
[Segment Cache] No data on tree prefetch if no PPR

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -53,6 +53,7 @@ import {
   NEXT_ROUTER_STALE_TIME_HEADER,
   NEXT_URL,
   RSC_HEADER,
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
 } from '../../client/components/app-router-headers'
 import {
   createTrackedMetadataContext,
@@ -234,6 +235,7 @@ interface ParsedRequestHeaders {
    */
   readonly flightRouterState: FlightRouterState | undefined
   readonly isPrefetchRequest: boolean
+  readonly isRouteTreePrefetchRequest: boolean
   readonly isDevWarmupRequest: boolean
   readonly isHmrRefresh: boolean
   readonly isRSCRequest: boolean
@@ -267,6 +269,10 @@ function parseRequestHeaders(
       )
     : undefined
 
+  // Checks if this is a prefetch of the Route Tree by the Segment Cache
+  const isRouteTreePrefetchRequest =
+    headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER.toLowerCase()] === '/_tree'
+
   const csp =
     headers['content-security-policy'] ||
     headers['content-security-policy-report-only']
@@ -277,6 +283,7 @@ function parseRequestHeaders(
   return {
     flightRouterState,
     isPrefetchRequest,
+    isRouteTreePrefetchRequest,
     isHmrRefresh,
     isRSCRequest,
     isDevWarmupRequest,

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -62,6 +62,7 @@ export async function walkTreeWithFlightRouterState({
     query,
     isPrefetch,
     getDynamicParamFromSegment,
+    parsedRequestHeaders,
   } = ctx
 
   const [segment, parallelRoutes, modules] = loaderTreeToFilter
@@ -115,9 +116,13 @@ export async function walkTreeWithFlightRouterState({
   // somewhere in the tree, we'll recursively render the component tree up until we encounter that loading component, and then stop.
   const shouldSkipComponentTree =
     !experimental.isRoutePPREnabled &&
-    isPrefetch &&
-    !Boolean(modules.loading) &&
-    !hasLoadingComponentInTree(loaderTreeToFilter)
+    // If PPR is disabled, and this is a request for the route tree, then we
+    // never render any components. Only send the router state.
+    (parsedRequestHeaders.isRouteTreePrefetchRequest ||
+      // Otherwise, check for the presence of a `loading` component.
+      (isPrefetch &&
+        !Boolean(modules.loading) &&
+        !hasLoadingComponentInTree(loaderTreeToFilter)))
 
   if (!parentRendered && renderComponentsOnThisLevel) {
     const overriddenSegment =

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/ppr-disabled-with-loading-boundary/loading.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/ppr-disabled-with-loading-boundary/loading.tsx
@@ -1,0 +1,15 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+async function Content() {
+  await connection()
+  return 'Dynamic Content'
+}
+
+export default function PPRDisabled() {
+  return (
+    <Suspense fallback="Loading...">
+      <Content />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/ppr-disabled-with-loading-boundary/page.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/ppr-disabled-with-loading-boundary/page.tsx
@@ -1,0 +1,6 @@
+import { connection } from 'next/server'
+
+export default async function PPRDisabledWithLoadingBoundary() {
+  await connection()
+  return 'Dynamic Content'
+}


### PR DESCRIPTION
When the client Segment Cache attempts to prefetch a route tree, and it the route does not have PPR enabled, the server falls through to the old implementation, which sends back a FlightRouterState.

This is fine, since the client can use the FlightRouterState to recreate the non-PPR behavior.

However, when loading.tsx is present in the route, the server will not just send back the FlightRouterState, but also render the page up to the first loading boundary. This is not what we want in the Segment Cache implementation — we want the route tree only, so we can determine which parts the client already has before sending a second request for the rest.

So this PR disables the loading.tsx mechanism when prefetching the route tree, by checking the Next-Router-Segment-Prefetch header.