### PR TITLE
Turbopack chunking: store modules instead of chunk items on `ChunkContentGraphNode`s

### DIFF
--- a/turbopack/crates/turbopack-core/src/chunk/availability_info.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/availability_info.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use turbo_tasks::{ResolvedVc, Vc};
 
-use super::available_chunk_items::{AvailableChunkItemInfoMap, AvailableChunkItems};
+use super::available_modules::{AvailableModuleInfoMap, AvailableModules};
 
 #[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(Hash, Clone, Copy, Debug)]
@@ -12,12 +12,12 @@ pub enum AvailabilityInfo {
     Root,
     /// There are modules already available.
     Complete {
-        available_chunk_items: ResolvedVc<AvailableChunkItems>,
+        available_chunk_items: ResolvedVc<AvailableModules>,
     },
 }
 
 impl AvailabilityInfo {
-    pub fn available_chunk_items(&self) -> Option<Vc<AvailableChunkItems>> {
+    pub fn available_chunk_items(&self) -> Option<Vc<AvailableModules>> {
         match self {
             Self::Untracked => None,
             Self::Root => None,
@@ -28,14 +28,11 @@ impl AvailabilityInfo {
         }
     }
 
-    pub async fn with_chunk_items(
-        self,
-        chunk_items: Vc<AvailableChunkItemInfoMap>,
-    ) -> Result<Self> {
+    pub async fn with_chunk_items(self, chunk_items: Vc<AvailableModuleInfoMap>) -> Result<Self> {
         Ok(match self {
             AvailabilityInfo::Untracked => AvailabilityInfo::Untracked,
             AvailabilityInfo::Root => AvailabilityInfo::Complete {
-                available_chunk_items: AvailableChunkItems::new(chunk_items).to_resolved().await?,
+                available_chunk_items: AvailableModules::new(chunk_items).to_resolved().await?,
             },
             AvailabilityInfo::Complete {
                 available_chunk_items,

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
@@ -34,17 +34,7 @@ impl AsyncLoaderChunkItem {
     pub(super) async fn chunks(&self) -> Result<Vc<OutputAssets>> {
         let module = self.module.await?;
         if let Some(chunk_items) = module.availability_info.available_chunk_items() {
-            if chunk_items
-                .get(
-                    module
-                        .inner
-                        .as_chunk_item(*ResolvedVc::upcast(self.chunking_context))
-                        .resolve()
-                        .await?,
-                )
-                .await?
-                .is_some()
-            {
+            if chunk_items.get(*module.inner).await?.is_some() {
                 return Ok(Vc::cell(vec![]));
             }
         }

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -65,16 +65,7 @@ impl ManifestAsyncModule {
     pub async fn manifest_chunks(self: Vc<Self>) -> Result<Vc<OutputAssets>> {
         let this = self.await?;
         if let Some(chunk_items) = this.availability_info.available_chunk_items() {
-            if chunk_items
-                .get(
-                    this.inner
-                        .as_chunk_item(*ResolvedVc::upcast(this.chunking_context))
-                        .resolve()
-                        .await?,
-                )
-                .await?
-                .is_some()
-            {
+            if chunk_items.get(*this.inner).await?.is_some() {
                 return Ok(Vc::cell(vec![]));
             }
         }


### PR DESCRIPTION
This:

- Stores `Module`s (specifically `ChunkableModule`s) instead of `ChunkItem`s on `ChunkContentGraphNode`s. This will make the transition to the upcoming single module graph simpler, as it only uses modules internally, not chunk items.
- Renames `AvailableChunkItems` to `AvailableModules` (a key structure in determining availability information for a chunk) and has it store and look up values by modules instead of chunk items.

Test Plan: No behavior change, use the CI suite to test.


Closes PACK-3653