### PR TITLE
Create Jest project for Turbopack

### DIFF
--- a/contributing/core/testing.md
+++ b/contributing/core/testing.md
@@ -115,6 +115,12 @@ To run the test suite using Turbopack, you can use the `TURBOPACK=1` environment
 TURBOPACK=1 pnpm test-dev test/e2e/app-dir/app/
 ```
 
+If you want to run a test again both Turbopack and Webpack, use Jest's `--projects` flag:
+
+```sh
+pnpm test-dev test/e2e/app-dir/app/ --projects jest.config.*
+```
+
 ## Integration testing outside the repository with local builds
 
 You can locally generate tarballs for each package in this repository with:

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ const createJestConfig = nextJest()
 // Any custom config you want to pass to Jest
 /** @type {import('jest').Config} */
 const customJestConfig = {
+  displayName: 'default',
   testMatch: ['**/*.test.js', '**/*.test.ts', '**/*.test.jsx', '**/*.test.tsx'],
   setupFilesAfterEnv: ['<rootDir>/jest-setup-after-env.ts'],
   verbose: true,

--- a/jest.config.turbopack.js
+++ b/jest.config.turbopack.js
@@ -1,0 +1,16 @@
+const createJestDefaultConfig = require('./jest.config.js')
+
+module.exports = async function createConfig() {
+  const jestDefaultConfig = await createJestDefaultConfig()
+  /** @type {import('jest').Config} */
+  const customConfig = {
+    ...jestDefaultConfig,
+    displayName: 'Turbopack',
+    setupFiles: [
+      ...(jestDefaultConfig.setupFiles ?? []),
+      '<rootDir>/jest-setup-files.turbopack.js',
+    ],
+  }
+
+  return customConfig
+}

--- a/test/jest-setup-files.turbopack.js
+++ b/test/jest-setup-files.turbopack.js
@@ -1,0 +1,1 @@
+process.env.TURBOPACK = '1'


### PR DESCRIPTION
This allows running a tests for both bundlers via
`pnpm test-dev test/e2e/app --projects jest.config.*`.

Ideally, we'd have a `test-dev-all` shortcut.
However, we can't add the test files after the `--projects` flag since it's now ambiguous whether you specified a test or project config. So the `--projects` flag must come after the specified test making an NPM script using `--projects` impossible.

This is mostly helpful if you want to update snapshots that are different between bundlers.