### PR TITLE
refactor(turbo-tasks): Implement `NonLocalValue` for `State<T>` where `T: NonLocalValue`

### DIFF
--- a/turbopack/crates/turbo-tasks-testing/tests/detached.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/detached.rs
@@ -106,7 +106,7 @@ async fn test_spawns_detached_changing() -> anyhow::Result<()> {
     .await
 }
 
-#[turbo_tasks::value(local)]
+#[turbo_tasks::value]
 struct ChangingInput {
     state: State<u32>,
 }

--- a/turbopack/crates/turbo-tasks-testing/tests/dirty_in_progress.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/dirty_in_progress.rs
@@ -47,7 +47,7 @@ async fn dirty_in_progress() {
     .unwrap()
 }
 
-#[turbo_tasks::value(local)]
+#[turbo_tasks::value]
 struct ChangingInput {
     state: State<u32>,
 }

--- a/turbopack/crates/turbo-tasks-testing/tests/emptied_cells.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/emptied_cells.rs
@@ -44,7 +44,7 @@ async fn recompute() {
     .unwrap();
 }
 
-#[turbo_tasks::value(local)]
+#[turbo_tasks::value]
 struct ChangingInput {
     state: State<u32>,
 }

--- a/turbopack/crates/turbo-tasks-testing/tests/recompute.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/recompute.rs
@@ -58,7 +58,7 @@ async fn recompute() {
     .unwrap()
 }
 
-#[turbo_tasks::value(local)]
+#[turbo_tasks::value]
 struct ChangingInput {
     state: State<u32>,
 }

--- a/turbopack/crates/turbo-tasks-testing/tests/recompute_collectibles.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/recompute_collectibles.rs
@@ -33,7 +33,7 @@ async fn recompute() {
     .unwrap()
 }
 
-#[turbo_tasks::value(local)]
+#[turbo_tasks::value]
 struct ChangingInput {
     state: State<u32>,
 }

--- a/turbopack/crates/turbo-tasks/src/marker_trait.rs
+++ b/turbopack/crates/turbo-tasks/src/marker_trait.rs
@@ -72,6 +72,7 @@ macro_rules! impl_auto_marker_trait {
             T: $crate::VcValueType,
             <<T as $crate::VcValueType>::Read as $crate::VcRead<T>>::Target: $trait
         {}
+        unsafe impl<T: $trait> $trait for $crate::State<T> {}
 
         unsafe impl<T: $trait + ?Sized> $trait for &T {}
         unsafe impl<T: $trait + ?Sized> $trait for &mut T {}

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -27,7 +27,7 @@ struct OutputAssetsMap(FxIndexMap<RcStr, ResolvedVc<Box<dyn OutputAsset>>>);
 
 type ExpandedState = State<HashSet<RcStr>>;
 
-#[turbo_tasks::value(serialization = "none", eq = "manual", cell = "new", local)]
+#[turbo_tasks::value(serialization = "none", eq = "manual", cell = "new")]
 pub struct AssetGraphContentSource {
     root_path: ResolvedVc<FileSystemPath>,
     root_assets: ResolvedVc<OutputAssetsSet>,

--- a/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
@@ -21,7 +21,7 @@ use crate::source::{ContentSourceContent, ContentSources};
 /// pages. Here HTML and "other assets" are in different content sources. So we
 /// use this source to only serve (and process) "other assets" when the HTML was
 /// served once.
-#[turbo_tasks::value(serialization = "none", eq = "manual", cell = "new", local)]
+#[turbo_tasks::value(serialization = "none", eq = "manual", cell = "new")]
 pub struct ConditionalContentSource {
     activator: ResolvedVc<Box<dyn ContentSource>>,
     action: ResolvedVc<Box<dyn ContentSource>>,

--- a/turbopack/crates/turbopack-dev-server/src/source/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/mod.rs
@@ -408,7 +408,7 @@ impl ContentSourceDataVary {
 }
 
 /// A source of content that the dev server uses to respond to http requests.
-#[turbo_tasks::value_trait(local)]
+#[turbo_tasks::value_trait]
 pub trait ContentSource {
     fn get_routes(self: Vc<Self>) -> Vc<RouteTree>;
 


### PR DESCRIPTION
Title says it all. This lets us implement `NonLocalValue` on more structs.

**What is NonLocalValue?** https://turbopack-rust-docs.vercel.sh/rustdoc/turbo_tasks/trait.NonLocalValue.html

Closes PACK-3648