### PR TITLE
chore(turbopack-browser): Pedantically fix minor typos in comments about TraitRef

### DIFF
--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/update.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/update.rs
@@ -70,10 +70,9 @@ pub(super) async fn update_chunk_list(
     let to = to_version.await?;
     let from = from_version.await?;
 
-    // When to and from point to the same value we can skip comparing them.
-    // This will happen since `TraitRef<Vc<Box<dyn Version>>>::cell` will not clone
-    // the value, but only make the cell point to the same immutable value
-    // (Arc).
+    // When to and from point to the same value we can skip comparing them. This will happen since
+    // `TraitRef::<Box<dyn Version>>::cell` will not clone the value, but only make the cell point
+    // to the same immutable value (`Arc`).
     if from.ptr_eq(&to) {
         return Ok(Update::None.cell());
     }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/merged/update.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/merged/update.rs
@@ -158,10 +158,9 @@ pub(super) async fn update_ecmascript_merged_chunk(
     let to = to_merged_version.await?;
     let from = from_merged_version.await?;
 
-    // When to and from point to the same value we can skip comparing them.
-    // This will happen since `TraitRef<Vc<Box<dyn Version>>>::cell` will not clone
-    // the value, but only make the cell point to the same immutable value
-    // (Arc).
+    // When to and from point to the same value we can skip comparing them. This will happen since
+    // `TraitRef::<Box<dyn Version>>::cell` will not clone the value, but only make the cell point
+    // to the same immutable value (`Arc`).
     if from.ptr_eq(&to) {
         return Ok(Update::None);
     }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/update.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/update.rs
@@ -22,10 +22,9 @@ pub(super) async fn update_ecmascript_chunk(
 ) -> Result<EcmascriptChunkUpdate> {
     let to = content.own_version().await?;
 
-    // When to and from point to the same value we can skip comparing them.
-    // This will happen since `TraitRef<Vc<Box<dyn Version>>>::cell` will not clone
-    // the value, but only make the cell point to the same immutable value
-    // (Arc).
+    // When to and from point to the same value we can skip comparing them. This will happen since
+    // `TraitRef::<Box<dyn Version>>::cell` will not clone the value, but only make the cell point
+    // to the same immutable value (`Arc`).
     if from.ptr_eq(&to) {
         return Ok(EcmascriptChunkUpdate::None);
     }


### PR DESCRIPTION
I was looking for callsites of `TraitRef` and found these minor typos, which annoyed me a bit, so I'm fixing them:

- It's `TraitRef<Box<dyn Foo>>`, not `TraitRef<Vc<Box<dyn Foo>>>`.
- This is a reference to an associated function, so it should use a turbofish.
- Re-wrap with the newer fixed 120 column line wrap for columns.

Closes PACK-3652