### PR TITLE
Turbopack: resolve some to-resolved-in-loop

### DIFF
--- a/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -36,7 +36,7 @@ pub async fn get_swc_ecma_transform_rule_impl(
     enable_mdx_rs: bool,
 ) -> Result<Option<ModuleRule>> {
     use anyhow::{bail, Context};
-    use turbo_tasks::Value;
+    use turbo_tasks::{TryJoinIterExt, Value};
     use turbo_tasks_fs::FileContent;
     use turbopack::{resolve_options, resolve_options_context::ResolveOptionsContext};
     use turbopack_core::{
@@ -50,56 +50,59 @@ pub async fn get_swc_ecma_transform_rule_impl(
 
     use crate::next_shared::transforms::get_ecma_transform_rule;
 
-    let mut plugins = vec![];
-    for (name, config) in plugin_configs.iter() {
-        // [TODO]: SWC's current experimental config supports
-        // two forms of plugin path,
-        // one for implicit package name resolves to node_modules,
-        // and one for explicit path to a .wasm binary.
-        // Current resolve will fail with latter.
-        let request = Request::parse(Value::new(Pattern::Constant(name.as_str().into())));
-        let resolve_options = resolve_options(
-            *project_path,
-            ResolveOptionsContext {
-                enable_node_modules: Some(project_path.root().to_resolved().await?),
-                enable_node_native_modules: true,
-                ..Default::default()
-            }
-            .cell(),
-        );
-
-        let plugin_wasm_module_resolve_result = handle_resolve_error(
-            resolve(
+    let plugins = plugin_configs
+        .iter()
+        .map(|(name, config)| async move {
+            // [TODO]: SWC's current experimental config supports
+            // two forms of plugin path,
+            // one for implicit package name resolves to node_modules,
+            // and one for explicit path to a .wasm binary.
+            // Current resolve will fail with latter.
+            let request = Request::parse(Value::new(Pattern::Constant(name.as_str().into())));
+            let resolve_options = resolve_options(
                 *project_path,
+                ResolveOptionsContext {
+                    enable_node_modules: Some(project_path.root().to_resolved().await?),
+                    enable_node_native_modules: true,
+                    ..Default::default()
+                }
+                .cell(),
+            );
+
+            let plugin_wasm_module_resolve_result = handle_resolve_error(
+                resolve(
+                    *project_path,
+                    Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
+                    request,
+                    resolve_options,
+                )
+                .as_raw_module_result(),
                 Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
+                *project_path,
                 request,
                 resolve_options,
+                false,
+                None,
             )
-            .as_raw_module_result(),
-            Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
-            *project_path,
-            request,
-            resolve_options,
-            false,
-            None,
-        )
+            .await?;
+            let plugin_module = plugin_wasm_module_resolve_result
+                .first_module()
+                .await?
+                .context("Expected to find module")?;
+
+            let content = &*plugin_module.content().file_content().await?;
+
+            let FileContent::Content(file) = content else {
+                bail!("Expected file content for plugin module");
+            };
+
+            Ok((
+                SwcPluginModule::new(name, file.content().to_bytes()?.to_vec()).resolved_cell(),
+                config.clone(),
+            ))
+        })
+        .try_join()
         .await?;
-        let plugin_module = plugin_wasm_module_resolve_result
-            .first_module()
-            .await?
-            .context("Expected to find module")?;
-
-        let content = &*plugin_module.content().file_content().await?;
-
-        let FileContent::Content(file) = content else {
-            bail!("Expected file content for plugin module");
-        };
-
-        plugins.push((
-            SwcPluginModule::new(name, file.content().to_bytes()?.to_vec()).resolved_cell(),
-            config.clone(),
-        ));
-    }
 
     Ok(Some(get_ecma_transform_rule(
         Box::new(SwcEcmaTransformPluginsTransformer::new(plugins)),

--- a/turbopack/crates/turbopack-core/src/code_builder.rs
+++ b/turbopack/crates/turbopack-core/src/code_builder.rs
@@ -164,6 +164,7 @@ impl GenerateSourceMap for Code {
 
         let mut sections = Vec::with_capacity(self.mappings.len());
         let mut read = self.code.read();
+        // ast-grep-ignore: to-resolved-in-loop
         for (byte_pos, map) in &self.mappings {
             let mut want = byte_pos - last_byte_pos;
             while want > 0 {

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1069,11 +1069,18 @@ async fn type_exists(
     refs: &mut Vec<ResolvedVc<Box<dyn Source>>>,
 ) -> Result<Option<ResolvedVc<FileSystemPath>>> {
     let result = fs_path.resolve().await?.realpath_with_links().await?;
-    for path in result.symlinks.iter() {
-        refs.push(ResolvedVc::upcast(
-            FileSource::new(**path).to_resolved().await?,
-        ));
-    }
+    refs.extend(
+        result
+            .symlinks
+            .iter()
+            .map(|path| async move {
+                Ok(ResolvedVc::upcast(
+                    FileSource::new(**path).to_resolved().await?,
+                ))
+            })
+            .try_join()
+            .await?,
+    );
     let path = result.path;
     Ok(if *path.get_type().await? == ty {
         Some(path)
@@ -1087,11 +1094,18 @@ async fn any_exists(
     refs: &mut Vec<ResolvedVc<Box<dyn Source>>>,
 ) -> Result<Option<(FileSystemEntryType, Vc<FileSystemPath>)>> {
     let result = fs_path.resolve().await?.realpath_with_links().await?;
-    for path in result.symlinks.iter() {
-        refs.push(ResolvedVc::upcast(
-            FileSource::new(**path).to_resolved().await?,
-        ));
-    }
+    refs.extend(
+        result
+            .symlinks
+            .iter()
+            .map(|path| async move {
+                Ok(ResolvedVc::upcast(
+                    FileSource::new(**path).to_resolved().await?,
+                ))
+            })
+            .try_join()
+            .await?,
+    );
     let path = result.path;
     let ty = *path.get_type().await?;
     Ok(
@@ -2263,6 +2277,7 @@ async fn apply_in_package(
     fragment: Vc<RcStr>,
 ) -> Result<Option<Vc<ResolveResult>>> {
     // Check alias field for module aliases first
+    // ast-grep-ignore: to-resolved-in-loop
     for in_package in options_value.in_package.iter() {
         // resolve_module_request is called when importing a node
         // module, not a PackageInternal one, so the imports field

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -598,6 +598,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
 
     let mut evaluation_references = Vec::new();
 
+    // ast-grep-ignore: to-resolved-in-loop
     for (i, r) in eval_context.imports.references().enumerate() {
         let r = EsmAssetReference::new(
             *origin,


### PR DESCRIPTION
- Parallelize some lints by using `collection.extend(...try_join().await?)` instead of `for ...{ collection.push(.await?); }`
- Add ignore comments in non-parallelizable loops (which mutate some other variables)



Closes PACK-3644