### PR TITLE
Increase test retries from 1 to 2

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -1,6 +1,5 @@
 //@ts-check
 
-const os = require('os')
 const path = require('path')
 const _glob = require('glob')
 const { existsSync } = require('fs')
@@ -52,7 +51,7 @@ const ENDGROUP = process.env.CI ? '##[endgroup]' : ''
 const externalTestsFilter = getTestFilter()
 
 const timings = []
-const DEFAULT_NUM_RETRIES = os.platform() === 'win32' ? 2 : 1
+const DEFAULT_NUM_RETRIES = 2
 const DEFAULT_CONCURRENCY = 2
 const RESULTS_EXT = `.results.json`
 const isTestJob = !!process.env.NEXT_TEST_JOB


### PR DESCRIPTION
Let's see how this affects the failure rate and duration of our tests in CI.

Test times for any given group might increase a bit, while hopefully at least increasing the chance that the whole test group succeeds. This would in theory reduce the number of times we have to re-run a whole failed test group, which is quite time consuming.

A possible downside of this change is that flaky tests which have a chance of getting fixed with a better implementation might be harder to detect.