### PR TITLE
fix(turbopack): Enable `explicit_resource_management` transform

### DIFF
--- a/test/e2e/app-dir/ecmascript-features/app/layout.tsx
+++ b/test/e2e/app-dir/ecmascript-features/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/ecmascript-features/app/page.tsx
+++ b/test/e2e/app-dir/ecmascript-features/app/page.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from 'react'
-
 class Disposer {
   [Symbol.dispose]() {
     console.log('Disposed')
@@ -7,9 +5,7 @@ class Disposer {
 }
 
 export default function Page({ children }) {
-  useEffect(() => {
-    using _disposer = new Disposer()
-  }, [])
+  using _disposer = new Disposer()
 
   return <p>hello world</p>
 }

--- a/test/e2e/app-dir/ecmascript-features/app/page.tsx
+++ b/test/e2e/app-dir/ecmascript-features/app/page.tsx
@@ -1,0 +1,15 @@
+import { useEffect } from 'react'
+
+class Disposer {
+  [Symbol.dispose]() {
+    console.log('Disposed')
+  }
+}
+
+export default function Page({ children }) {
+  useEffect(() => {
+    using _disposer = new Disposer()
+  }, [])
+
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/ecmascript-features/app/page.tsx
+++ b/test/e2e/app-dir/ecmascript-features/app/page.tsx
@@ -4,7 +4,7 @@ class Disposer {
   }
 }
 
-export default function Page({ children }) {
+export default function Page() {
   using _disposer = new Disposer()
 
   return <p>hello world</p>

--- a/test/e2e/app-dir/ecmascript-features/ecmascript-features.test.ts
+++ b/test/e2e/app-dir/ecmascript-features/ecmascript-features.test.ts
@@ -1,0 +1,14 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('ecmascript-features', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // In case you need to test the response object
+  it('should work with fetch', async () => {
+    const res = await next.fetch('/')
+    const html = await res.text()
+    expect(html).toContain('hello world')
+  })
+})

--- a/test/e2e/app-dir/ecmascript-features/next.config.js
+++ b/test/e2e/app-dir/ecmascript-features/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -385,6 +385,8 @@ async fn parse_file_content(
             parsed_program.mutate(swc_core::ecma::lints::rules::lint_to_fold(rules));
             drop(span);
 
+            parsed_program.mutate(swc_core::ecma::transforms::proposal::explicit_resource_management::explicit_resource_management());
+
             let transform_context = TransformContext {
                 comments: &comments,
                 source_map: &source_map,


### PR DESCRIPTION
### What?

Enable ERM transform unconditionally, to avoid creating non-standard code.

### Why?

It's nearly standard (stage 3) and supported by TypeScript with default config. But as it's stage 3, runtimes cannot support it  right now. So we workaround it using SWC transform.

### How?

 - Closes PACK-3637
 - Closes https://github.com/vercel/next.js/issues/73739
