### PR TITLE
[CI] Prominent error message for check_error_codes

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -523,6 +523,5 @@
   "522": "invariant did not get entry from image response cache",
   "523": "[%s]: experimental.useLightningcss does not work with postcss plugins. Please remove 'useLightningcss: true' from your configuration.",
   "524": "A default cacheLife profile must always be provided. This is a bug in Next.js.",
-  "525": "cache: 'no-store' used on fetch for %s with 'export const fetchCache = 'only-cache'",
-  "526": "Invariant: did not expect response writer to be written to for upgrade request"
+  "525": "cache: 'no-store' used on fetch for %s with 'export const fetchCache = 'only-cache'"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -523,5 +523,6 @@
   "522": "invariant did not get entry from image response cache",
   "523": "[%s]: experimental.useLightningcss does not work with postcss plugins. Please remove 'useLightningcss: true' from your configuration.",
   "524": "A default cacheLife profile must always be provided. This is a bug in Next.js.",
-  "525": "cache: 'no-store' used on fetch for %s with 'export const fetchCache = 'only-cache'"
+  "525": "cache: 'no-store' used on fetch for %s with 'export const fetchCache = 'only-cache'",
+  "526": "Invariant: did not expect response writer to be written to for upgrade request"
 }

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -2720,6 +2720,12 @@ export async function check_error_codes(task, opts) {
     })
   } catch (err) {
     if (process.env.CI) {
+      await execa.command(
+        'echo check_error_codes FAILED: There are new errors introduced but no corresponding error codes are found in errors.json file, so make sure you run `pnpm build` and then commit the change in errors.json.',
+        {
+          stdio: 'inherit',
+        }
+      )
       process.exit(1)
     }
     await task.start('compile', opts)


### PR DESCRIPTION
This pull request adds a more prominent error message to the CI build failure message when a new error message is added through `new Error(...)` but `pnpm build` has not been run locally to update `errors.json`.


**Example**

![CleanShot 2024-12-11 at 13 38 52@2x](https://github.com/user-attachments/assets/6ab89823-4dc9-4bf2-a8a5-eae9a53e1fd0)
