### PR TITLE
feat: added partial shell generation using root params

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -613,5 +613,10 @@
   "612": "ServerPrerenderStreamResult cannot be consumed as a stream because it is not yet complete. status: %s",
   "613": "Expected the input to be `string | string[]`",
   "614": "Route %s used \"unstable_rootParams\" inside \"use cache\". This is not currently supported.",
-  "615": "Missing workStore in unstable_rootParams"
+  "615": "Missing workStore in unstable_rootParams",
+  "616": "App config not found",
+  "617": "A required parameter (%s) was not provided as a string received %s in generateStaticParams for %s",
+  "618": "A required parameter (%s) was not provided as an array received %s in generateStaticParams for %s",
+  "619": "Page not found",
+  "620": "A required parameter (%s) was not provided as %s received %s in getStaticPaths for %s"
 }

--- a/packages/next/src/build/manifests/formatter/format-manifest.ts
+++ b/packages/next/src/build/manifests/formatter/format-manifest.ts
@@ -4,9 +4,5 @@
  * JSON string, otherwise it will return a minified JSON string.
  */
 export function formatManifest<T extends object>(manifest: T): string {
-  if (process.env.NODE_ENV === 'development') {
-    return JSON.stringify(manifest, null, 2)
-  }
-
-  return JSON.stringify(manifest)
+  return JSON.stringify(manifest, null, 2)
 }

--- a/packages/next/src/build/segment-config/app/app-segments.ts
+++ b/packages/next/src/build/segment-config/app/app-segments.ts
@@ -92,15 +92,15 @@ async function collectAppPageSegments(routeModule: AppPageRouteModule) {
     // Process current node
     const { mod: userland, filePath } = await getLayoutOrPageModule(loaderTree)
     const isClientComponent = userland && isClientReference(userland)
-    const isDynamicSegment = /\[.*\]$/.test(name)
-    const param = isDynamicSegment ? getSegmentParam(name)?.param : undefined
+
+    const param = getSegmentParam(name)?.param
 
     const segment: AppSegment = {
       name,
       param,
       filePath,
       config: undefined,
-      isDynamicSegment,
+      isDynamicSegment: !!param,
       generateStaticParams: undefined,
     }
 
@@ -157,14 +157,13 @@ function collectAppRouteSegments(
 
   // Generate all the segments.
   const segments: AppSegment[] = parts.map((name) => {
-    const isDynamicSegment = /^\[.*\]$/.test(name)
-    const param = isDynamicSegment ? getSegmentParam(name)?.param : undefined
+    const param = getSegmentParam(name)?.param
 
     return {
       name,
       param,
       filePath: undefined,
-      isDynamicSegment,
+      isDynamicSegment: !!param,
       config: undefined,
       generateStaticParams: undefined,
     }

--- a/packages/next/src/build/segment-config/app/collect-root-param-keys.ts
+++ b/packages/next/src/build/segment-config/app/collect-root-param-keys.ts
@@ -1,0 +1,65 @@
+import { getSegmentParam } from '../../../server/app-render/get-segment-param'
+import type { LoadComponentsReturnType } from '../../../server/load-components'
+import type { AppPageModule } from '../../../server/route-modules/app-page/module'
+import type AppPageRouteModule from '../../../server/route-modules/app-page/module'
+import type { AppRouteModule } from '../../../server/route-modules/app-route/module'
+import {
+  isAppPageRouteModule,
+  isAppRouteRouteModule,
+} from '../../../server/route-modules/checks'
+import { InvariantError } from '../../../shared/lib/invariant-error'
+
+function collectAppPageRootParamKeys(
+  routeModule: AppPageRouteModule
+): readonly string[] {
+  let rootParams: string[] = []
+
+  let current = routeModule.userland.loaderTree
+  while (current) {
+    const [name, parallelRoutes, modules] = current
+
+    // If this is a dynamic segment, then we collect the param.
+    const param = getSegmentParam(name)?.param
+    if (param) {
+      rootParams.push(param)
+    }
+
+    // If this has a layout module, then we've found the root layout because
+    // we return once we found the first layout.
+    if (typeof modules.layout !== 'undefined') {
+      return rootParams
+    }
+
+    // This didn't include a root layout, so we need to continue. We don't need
+    // to collect from other parallel routes because we can't have a parallel
+    // route above a root layout.
+    current = parallelRoutes.children
+  }
+
+  // If we didn't find a root layout, then we don't have any params.
+  return []
+}
+
+/**
+ * Collects the segments for a given route module.
+ *
+ * @param components the loaded components
+ * @returns the segments for the route module
+ */
+export function collectRootParamKeys({
+  routeModule,
+}: LoadComponentsReturnType<
+  AppPageModule | AppRouteModule
+>): readonly string[] {
+  if (isAppRouteRouteModule(routeModule)) {
+    return []
+  }
+
+  if (isAppPageRouteModule(routeModule)) {
+    return collectAppPageRootParamKeys(routeModule)
+  }
+
+  throw new InvariantError(
+    'Expected a route module to be one of app route or page'
+  )
+}

--- a/packages/next/src/build/static-paths/types.ts
+++ b/packages/next/src/build/static-paths/types.ts
@@ -1,15 +1,19 @@
 import type { FallbackMode } from '../../lib/fallback'
 
 type StaticPrerenderedRoute = {
-  path: string
-  encoded: string
+  pathname: string
+  encodedPathname: string
   fallbackRouteParams: undefined
+  fallbackMode: FallbackMode | undefined
+  fallbackRootParams: undefined
 }
 
 type FallbackPrerenderedRoute = {
-  path: string
-  encoded: string
+  pathname: string
+  encodedPathname: string
   fallbackRouteParams: readonly string[]
+  fallbackMode: FallbackMode | undefined
+  fallbackRootParams: readonly string[]
 }
 
 export type PrerenderedRoute = StaticPrerenderedRoute | FallbackPrerenderedRoute

--- a/packages/next/src/build/static-paths/utils.ts
+++ b/packages/next/src/build/static-paths/utils.ts
@@ -1,0 +1,30 @@
+/**
+ * Encodes a parameter value using the provided encoder.
+ *
+ * @param value - The value to encode.
+ * @param encoder - The encoder to use.
+ * @returns The encoded value.
+ */
+export function encodeParam(
+  value: string | string[],
+  encoder: (value: string) => string
+) {
+  let replaceValue: string
+  if (Array.isArray(value)) {
+    replaceValue = value.map(encoder).join('/')
+  } else {
+    replaceValue = encoder(value)
+  }
+
+  return replaceValue
+}
+
+/**
+ * Normalizes a pathname to a consistent format.
+ *
+ * @param pathname - The pathname to normalize.
+ * @returns The normalized pathname.
+ */
+export function normalizePathname(pathname: string) {
+  return pathname.replace(/\\/g, '/').replace(/(?!^)\/$/, '')
+}

--- a/packages/next/src/lib/fallback.ts
+++ b/packages/next/src/lib/fallback.ts
@@ -91,23 +91,3 @@ export function parseStaticPathsResult(
     return FallbackMode.NOT_FOUND
   }
 }
-
-/**
- * Converts the fallback mode to a static paths result.
- *
- * @param fallback The fallback mode.
- * @returns The static paths fallback result.
- */
-export function fallbackModeToStaticPathsResult(
-  fallback: FallbackMode
-): GetStaticPathsFallback {
-  switch (fallback) {
-    case FallbackMode.PRERENDER:
-      return true
-    case FallbackMode.BLOCKING_STATIC_RENDER:
-      return 'blocking'
-    case FallbackMode.NOT_FOUND:
-    default:
-      return false
-  }
-}

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -808,7 +808,7 @@ export default class DevServer extends Server {
           staticPaths: string[] | undefined
           fallbackMode: FallbackMode | undefined
         } = {
-          staticPaths: staticPaths?.map((route) => route.path),
+          staticPaths: staticPaths?.map((route) => route.pathname),
           fallbackMode: fallback,
         }
         this.staticPathsCache.set(pathname, value)

--- a/packages/next/src/server/dev/static-paths-worker.ts
+++ b/packages/next/src/server/dev/static-paths-worker.ts
@@ -15,8 +15,9 @@ import {
   type ExperimentalPPRConfig,
 } from '../lib/experimental/ppr'
 import { InvariantError } from '../../shared/lib/invariant-error'
+import { collectRootParamKeys } from '../../build/segment-config/app/collect-root-param-keys'
 import { buildAppStaticPaths } from '../../build/static-paths/app'
-import { buildStaticPaths } from '../../build/static-paths/pages'
+import { buildPagesStaticPaths } from '../../build/static-paths/pages'
 
 type RuntimeConfig = {
   pprConfig: ExperimentalPPRConfig | undefined
@@ -91,12 +92,13 @@ export async function loadStaticPaths({
       isAppPageRouteModule(components.routeModule) &&
       checkIsRoutePPREnabled(config.pprConfig, reduceAppConfig(segments))
 
+    const rootParamKeys = collectRootParamKeys(components)
+
     return buildAppStaticPaths({
       dir,
       page: pathname,
       dynamicIO: config.dynamicIO,
       segments,
-      configFileName: config.configFileName,
       distDir,
       requestHeaders,
       cacheHandler,
@@ -109,6 +111,7 @@ export async function loadStaticPaths({
       isRoutePPREnabled,
       buildId,
       authInterrupts,
+      rootParamKeys,
     })
   } else if (!components.getStaticPaths) {
     // We shouldn't get to this point since the worker should only be called for
@@ -118,7 +121,7 @@ export async function loadStaticPaths({
     )
   }
 
-  return buildStaticPaths({
+  return buildPagesStaticPaths({
     page: pathname,
     getStaticPaths: components.getStaticPaths,
     configFileName: config.configFileName,

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -22,7 +22,8 @@ import { makeHangingPromise } from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
 import { scheduleImmediate } from '../../lib/scheduler'
 
-export type Params = Record<string, string | Array<string> | undefined>
+export type ParamValue = string | Array<string> | undefined
+export type Params = Record<string, ParamValue>
 
 /**
  * In this version of Next.js the `params` prop passed to Layouts, Pages, and other Segments is a Promise.

--- a/packages/next/src/server/request/root-params.ts
+++ b/packages/next/src/server/request/root-params.ts
@@ -174,7 +174,6 @@ function makeErroringRootParams(
 }
 
 function makeUntrackedRootParams(underlyingParams: Params): Promise<Params> {
-  console.log('makeUntrackedRootParams', underlyingParams)
   const cachedParams = CachedParams.get(underlyingParams)
   if (cachedParams) {
     return cachedParams


### PR DESCRIPTION
This enables the generation of partial shells when using with partial prerendering, aided by the new `rootParams()` API. Essentially, when your application only returns partial routes (where not all the route parameters are known), Next.js will now build route shells for these pages. We call these shells, fallback shells. They represent the partial state of the page that once served to the user, will provide a more complete loading experience as fast as possible.

We'll also take every permutation of the provided root params and generate a shell just for them to ensure that any future calls to those routes will be able to use the more specific fallback shell that's generated rather than having to rely on a blank shell by default.