### PR TITLE
[E2E] Fix config file conflict

### DIFF
--- a/test/integration/telemetry/test/config.test.js
+++ b/test/integration/telemetry/test/config.test.js
@@ -135,7 +135,7 @@ describe('config telemetry', () => {
 
       it('detects output config for session start', async () => {
         await fs.writeFile(
-          './next.config.js',
+          path.join(appDir, 'next.config.js'),
           'module.exports = { output: "export" }'
         )
         try {
@@ -155,7 +155,7 @@ describe('config telemetry', () => {
             throw err
           }
         } finally {
-          await fs.remove('./next.config.js')
+          await fs.remove(path.join(appDir, 'next.config.js'))
         }
       })
 


### PR DESCRIPTION
## Background

1. `next start` finds a `next.config` upwards in the file system from the current directory
2. `/test/integration/telemetry` test outputs a `next.config` to the E2E root directory
3. Tests run in parallel in CI
4. This is Part 2 of https://github.com/vercel/next.js/pull/73105

## Problem

After `/test/integration/telemetry` generates the config at the root but before it completes to clean it up, other tests might be running and kicking off `next start` which happens to locate the config generated by `/test/integration/telemetry`, since it was misplaced at the root. (This PR fixes it by placing it at the project itself)

Notably, `/test/integration/telemetry` generates a config with `module.exports = { output: "export" }`, so when conflict occurs, `next start` would exit with error like:

```
Error: "next start" does not work with "output: export" configuration. Use "npx serve@latest out" instead.
```
https://github.com/vercel/next.js/actions/runs/12272870280/job/34244194091?pr=73322 