### PR TITLE
Rename variables in LayoutRouter for clarity

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -564,14 +564,13 @@ function Router({
 
   const layoutRouterContext = useMemo(() => {
     return {
-      childNodes: cache.parallelRoutes,
-      tree,
+      parentTree: tree,
+      parentCacheNode: cache,
       // Root node always has `url`
       // Provided in AppTreeContext to ensure it can be overwritten in layout-router
       url: canonicalUrl,
-      loading: cache.loading,
     }
-  }, [cache.parallelRoutes, tree, canonicalUrl, cache.loading])
+  }, [tree, cache, canonicalUrl])
 
   const globalLayoutRouterContext = useMemo(() => {
     return {

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -221,7 +221,7 @@ export function useSelectedLayoutSegments(
   // @ts-expect-error This only happens in `pages`. Type is overwritten in navigation.d.ts
   if (!context) return null
 
-  return getSelectedLayoutSegmentPath(context.tree, parallelRouteKey)
+  return getSelectedLayoutSegmentPath(context.parentTree, parallelRouteKey)
 }
 
 /**

--- a/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
@@ -146,10 +146,9 @@ export const AppRouterContext = React.createContext<AppRouterInstance | null>(
   null
 )
 export const LayoutRouterContext = React.createContext<{
-  childNodes: CacheNode['parallelRoutes']
-  tree: FlightRouterState
+  parentTree: FlightRouterState
+  parentCacheNode: CacheNode
   url: string
-  loading: LoadingModuleData | Promise<LoadingModuleData>
 } | null>(null)
 
 export const GlobalLayoutRouterContext = React.createContext<{

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -425,27 +425,27 @@ describe('Error overlay for hydration errors in App router', () => {
     expect(await getRedboxTotalErrorCount(browser)).toBe(1)
 
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
-      "In HTML, whitespace text nodes cannot be a child of <table>. Make sure you don't have any extra whitespace between tags on each line of your source code.
-      This will cause a hydration error.
+     "In HTML, whitespace text nodes cannot be a child of <table>. Make sure you don't have any extra whitespace between tags on each line of your source code.
+     This will cause a hydration error.
 
-        ...
-          <RenderFromTemplateContext>
-            <ScrollAndFocusHandler segmentPath={[...]}>
-              <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-                <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                  <LoadingBoundary loading={null}>
-                    <HTTPAccessFallbackBoundary notFound={[...]} forbidden={undefined} unauthorized={undefined}>
-                      <HTTPAccessFallbackErrorBoundary pathname="/" notFound={[...]} forbidden={undefined} ...>
-                        <RedirectBoundary>
-                          <RedirectErrorBoundary router={{...}}>
-                            <InnerLayoutRouter parallelRouterKey="children" url="/" tree={[...]} childNodes={Map} ...>
-                              <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
-                                <Page params={Promise} searchParams={Promise}>
-      >                           <table>
-      >                             {" "}
-                                    ...
-                              ...
-      "
+       ...
+         <RenderFromTemplateContext>
+           <ScrollAndFocusHandler segmentPath={[...]}>
+             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                 <LoadingBoundary loading={null}>
+                   <HTTPAccessFallbackBoundary notFound={[...]} forbidden={undefined} unauthorized={undefined}>
+                     <HTTPAccessFallbackErrorBoundary pathname="/" notFound={[...]} forbidden={undefined} ...>
+                       <RedirectBoundary>
+                         <RedirectErrorBoundary router={{...}}>
+                           <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                             <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                               <Page params={Promise} searchParams={Promise}>
+     >                           <table>
+     >                             {" "}
+                                   ...
+                             ...
+     "
     `)
 
     // FIXME: fix the `pseudoHtml` should be extracted from the description
@@ -887,43 +887,43 @@ describe('Error overlay for hydration errors in App router', () => {
     const fullPseudoHtml = await session.getRedboxComponentStack()
     if (isTurbopack) {
       expect(fullPseudoHtml).toMatchInlineSnapshot(`
-        "...
-          <HTTPAccessFallbackErrorBoundary pathname="/" notFound={[...]} forbidden={undefined} unauthorized={undefined} ...>
-            <RedirectBoundary>
-              <RedirectErrorBoundary router={{...}}>
-                <InnerLayoutRouter parallelRouterKey="children" url="/" tree={[...]} childNodes={Map} segmentPath={[...]} ...>
-                  <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
-                    <Page params={Promise} searchParams={Promise}>
-                      <div>
-                        <div>
-                          <div>
-                            <div>
-                              <Mismatch>
-                                <p>
-                                  <span>
-                                    ...
-        +                            client
-        -                            server"
+       "...
+         <HTTPAccessFallbackErrorBoundary pathname="/" notFound={[...]} forbidden={undefined} unauthorized={undefined} ...>
+           <RedirectBoundary>
+             <RedirectErrorBoundary router={{...}}>
+               <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                 <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                   <Page params={Promise} searchParams={Promise}>
+                     <div>
+                       <div>
+                         <div>
+                           <div>
+                             <Mismatch>
+                               <p>
+                                 <span>
+                                   ...
+       +                            client
+       -                            server"
       `)
     } else {
       expect(fullPseudoHtml).toMatchInlineSnapshot(`
-        "...
-          <HTTPAccessFallbackErrorBoundary pathname="/" notFound={[...]} forbidden={undefined} unauthorized={undefined} ...>
-            <RedirectBoundary>
-              <RedirectErrorBoundary router={{...}}>
-                <InnerLayoutRouter parallelRouterKey="children" url="/" tree={[...]} childNodes={Map} segmentPath={[...]} ...>
-                  <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
-                    <Page params={Promise} searchParams={Promise}>
-                      <div>
-                        <div>
-                          <div>
-                            <div>
-                              <Mismatch>
-                                <p>
-                                  <span>
-                                    ...
-        +                            client
-        -                            server"
+       "...
+         <HTTPAccessFallbackErrorBoundary pathname="/" notFound={[...]} forbidden={undefined} unauthorized={undefined} ...>
+           <RedirectBoundary>
+             <RedirectErrorBoundary router={{...}}>
+               <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                 <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                   <Page params={Promise} searchParams={Promise}>
+                     <div>
+                       <div>
+                         <div>
+                           <div>
+                             <Mismatch>
+                               <p>
+                                 <span>
+                                   ...
+       +                            client
+       -                            server"
       `)
     }
   })

--- a/test/development/app-dir/dynamic-error-trace/index.test.ts
+++ b/test/development/app-dir/dynamic-error-trace/index.test.ts
@@ -2,8 +2,6 @@ import { nextTestSetup } from 'e2e-utils'
 import { assertHasRedbox, getRedboxSource } from 'next-test-utils'
 import { outdent } from 'outdent'
 
-const isReactExperimental = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
-
 function normalizeStackTrace(trace) {
   return trace.replace(/ \(.*\)/g, '')
 }
@@ -37,14 +35,7 @@ describe('app dir - dynamic error trace', () => {
 
     // TODO: Show useful stack
     const normalizedStack = normalizeStackTrace(stackFramesContent)
-    if (isReactExperimental) {
-      expect(normalizedStack).toMatchInlineSnapshot(`
-        "Array.map
-        <anonymous>"
-      `)
-    } else {
-      expect(normalizedStack).toMatchInlineSnapshot(`""`)
-    }
+    expect(normalizedStack).toMatchInlineSnapshot(`""`)
 
     const codeframe = await getRedboxSource(browser)
     expect(codeframe).toEqual(

--- a/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
+++ b/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
@@ -77,7 +77,7 @@ describe('Dynamic IO Dev Errors', () => {
             '\n    at html (<anonymous>)' +
             '\n    at Root [Server] (<anonymous>)'
           : // TODO(veil): Should be ignore-listed (see https://linear.app/vercel/issue/NDX-464/next-internals-not-ignore-listed-in-terminal-in-webpack#comment-1164a36a)
-            '\n    at parallelRouterKey (..')
+            '\n    at tree (..')
     )
 
     const description = await getRedboxDescription(browser)


### PR DESCRIPTION
LayoutRouter has changed significantly since it was originally written and the structure has become harder to follow. One thing I always find confusing whenever I'm reading this code is that some of the values correspond the the *parent* segment, while others correspond to the *current* segment. So this moves the code around a bit and updates the names so it's clearer which parts belong to which segments.

While working on this, I noticed a funny thing about how loading boundaries work that was made more obvious by the revised naming. I've left a TODO comment to follow up on whether this was intentional.