### PR TITLE
docs: fix file extension and missing export

### DIFF
--- a/docs/01-app/01-getting-started/04-images-and-fonts.mdx
+++ b/docs/01-app/01-getting-started/04-images-and-fonts.mdx
@@ -99,7 +99,7 @@ Next.js will automatically determine the intrinsic [`width`](/docs/app/api-refer
 
 To use a remote image, you can provide a URL string for the `src` property.
 
-```tsx filename="app/page.ts" switcher
+```tsx filename="app/page.tsx" switcher
 import Image from 'next/image'
 
 export default function Page() {

--- a/docs/01-app/01-getting-started/05-css-and-styling.mdx
+++ b/docs/01-app/01-getting-started/05-css-and-styling.mdx
@@ -244,7 +244,7 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-```js filename="next.config.js" switcher
+```js filename="next.config.mjs" switcher
 /** @type {import('next').NextConfig} */
 
 const nextConfig = {
@@ -253,7 +253,7 @@ const nextConfig = {
   },
 }
 
-module.exports = nextConfig
+export default nextConfig
 ```
 
 ## CSS-in-JS
@@ -392,13 +392,16 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-```js filename="next.config.js" switcher
+```js filename="next.config.mjs" switcher
 /** @type {import('next').NextConfig} */
+
 const nextConfig = {
   compiler: {
     styledComponents: true,
   },
 }
+
+export default nextConfig
 ```
 
 Then, use the `styled-components` API to create a global registry component to collect all CSS style rules generated during a render, and a function to return those rules. Then use the `useServerInsertedHTML` hook to inject the styles collected in the registry into the `<head>` HTML tag in the root layout.


### PR DESCRIPTION
## Description

1. Change `app/page.ts` to `app/page.tsx` at [Remote images section](https://nextjs.org/docs/app/getting-started/images-and-fonts#remote-images) in the [Images and Fonts docs](https://nextjs.org/docs/app/getting-started/images-and-fonts).
2. Use ESM export instead of CJS at [Customizing Sass options](https://nextjs.org/docs/app/getting-started/css-and-styling#customizing-sass-options) section to sync [cna template](https://github.com/vercel/next.js/blob/canary/packages/create-next-app/templates/app/js/next.config.mjs).
3. Add missing `export default nextConfig` line to `next.config.js` code and adjust next.config.ts format at [`styled-components`](https://nextjs.org/docs/app/getting-started/css-and-styling#styled-components) section in [Css and Styling](https://nextjs.org/docs/app/getting-started/css-and-styling) docs.

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide