### PR TITLE
fix: path escaping issue on windows

### DIFF
--- a/packages/next/src/build/load-entrypoint.ts
+++ b/packages/next/src/build/load-entrypoint.ts
@@ -53,7 +53,7 @@ export async function loadEntrypoint(
     for (const [innerKey, importPath] of Object.entries(
       importMaps?.[key] || {}
     )) {
-      file = `import ${key}_${innerKey} from "${importPath}"\n${file}`
+      file = `import ${key}_${innerKey} from ${JSON.stringify(importPath)}\n${file}`
       importMapItems[key][innerKey] = `${key}_${innerKey}`
     }
   }


### PR DESCRIPTION
if we're on windows and the path happens to be absolute, not escaping the path can lead to generating invalid code. for example, with a path like `C:\Users\notgood\...`, the `\n` **will be interpreted as a newline** when the module is parsed, and thus blow up multiple things downstream