### PR TITLE
docs: fix code block extension on `after` and `error handling`

### DIFF
--- a/docs/01-app/02-building-your-application/01-routing/05-error-handling.mdx
+++ b/docs/01-app/02-building-your-application/01-routing/05-error-handling.mdx
@@ -19,7 +19,7 @@ Expected errors are those that can occur during the normal operation of the appl
 
 Use the `useActionState` hook to manage the state of Server Actions, including handling errors. This approach avoids `try`/`catch` blocks for expected errors, which should be modeled as return values rather than thrown exceptions.
 
-```tsx filename="app/actions.ts" switcher
+```ts filename="app/actions.ts" switcher
 'use server'
 
 import { redirect } from 'next/navigation'
@@ -36,7 +36,7 @@ export async function createUser(prevState: any, formData: FormData) {
 }
 ```
 
-```jsx filename="app/actions.js" switcher
+```js filename="app/actions.js" switcher
 'use server'
 
 import { redirect } from 'next/navigation'

--- a/docs/01-app/03-api-reference/04-functions/after.mdx
+++ b/docs/01-app/03-api-reference/04-functions/after.mdx
@@ -70,7 +70,7 @@ We recommend using `after` as it has been designed to consider other Next.js API
 
 You can use request APIs such as [`cookies`](/docs/app/api-reference/functions/cookies) and [`headers`](/docs/app/api-reference/functions/headers) inside `after` in [Server Actions](/docs/app/building-your-application/data-fetching/server-actions-and-mutations) and [Route Handlers](/docs/app/api-reference/file-conventions/route). This is useful for logging activity after a mutation. For example:
 
-```tsx filename="app/api/route.ts" highlight={2,7-9} switcher
+```ts filename="app/api/route.ts" highlight={2,7-9} switcher
 import { after } from 'next/server'
 import { cookies, headers } from 'next/headers'
 import { logUserAction } from '@/app/utils'
@@ -95,7 +95,7 @@ export async function POST(request: Request) {
 }
 ```
 
-```jsx filename="app/api/route.js" highlight={2,7-9} switcher
+```js filename="app/api/route.js" highlight={2,7-9} switcher
 import { after } from 'next/server'
 import { cookies, headers } from 'next/headers'
 import { logUserAction } from '@/app/utils'


### PR DESCRIPTION
## Summary

Both `app/actions.ts` and `app/action.js` aren't JSX in [error handling](https://nextjs.org/docs/app/building-your-application/routing/error-handling) docs.
`app/api/route.ts` and `app/api/route.js` aren't also JSX in [after](https://nextjs.org/docs/app/api-reference/functions/after) docs.

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide