### PR TITLE
Turbopack: don't search for layout segments in routes

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -728,41 +728,43 @@ impl AppProject {
         &self,
         endpoint: Vc<AppEndpoint>,
         rsc_entry: ResolvedVc<Box<dyn Module>>,
+        has_layout_segments: bool,
     ) -> Result<Vc<ModuleGraphs>> {
         if *self.project.per_page_module_graph().await? {
             // Implements layout segment optimization to compute a graph "chain" for each layout
             // segment
             async move {
-                let ServerEntries {
-                    server_utils,
-                    server_component_entries,
-                } = &*find_server_entries(*rsc_entry).await?;
-
                 let mut graphs = vec![];
-
                 let mut visited_modules = VisitedModules::empty();
 
-                if !server_utils.is_empty() {
-                    let graph = SingleModuleGraph::new_with_entries_visited(
-                        server_utils.iter().map(|m| **m).collect(),
-                        visited_modules,
-                    );
-                    graphs.push(graph);
-                    visited_modules = VisitedModules::from_graph(graph)
-                }
+                if has_layout_segments {
+                    let ServerEntries {
+                        server_utils,
+                        server_component_entries,
+                    } = &*find_server_entries(*rsc_entry).await?;
+                    if !server_utils.is_empty() {
+                        let graph = SingleModuleGraph::new_with_entries_visited(
+                            server_utils.iter().map(|m| **m).collect(),
+                            visited_modules,
+                        );
+                        graphs.push(graph);
+                        visited_modules = VisitedModules::from_graph(graph)
+                    }
 
-                for module in server_component_entries.iter() {
-                    let graph = SingleModuleGraph::new_with_entries_visited(
-                        vec![Vc::upcast(**module)],
-                        visited_modules,
-                    );
-                    graphs.push(graph);
-                    let is_layout =
-                        module.server_path().file_stem().await?.as_deref() == Some("layout");
-                    if is_layout {
-                        // Only propagate the visited_modules of the parent layout(s), not across
-                        // siblings such as loading.js and page.js.
-                        visited_modules = visited_modules.concatenate(graph);
+                    for module in server_component_entries.iter() {
+                        let graph = SingleModuleGraph::new_with_entries_visited(
+                            vec![Vc::upcast(**module)],
+                            visited_modules,
+                        );
+                        graphs.push(graph);
+                        let is_layout =
+                            module.server_path().file_stem().await?.as_deref() == Some("layout");
+                        if is_layout {
+                            // Only propagate the visited_modules of the parent layout(s), not
+                            // across siblings such as loading.js and
+                            // page.js.
+                            visited_modules = visited_modules.concatenate(graph);
+                        }
                     }
                 }
 
@@ -1014,7 +1016,14 @@ impl AppEndpoint {
         let runtime = app_entry.config.await?.runtime.unwrap_or_default();
 
         let rsc_entry = app_entry.rsc_entry;
-        let module_graphs = this.app_project.app_module_graphs(self, *rsc_entry).await?;
+        let module_graphs = this
+            .app_project
+            .app_module_graphs(
+                self,
+                *rsc_entry,
+                matches!(this.ty, AppEndpointType::Page { .. }),
+            )
+            .await?;
 
         let client_chunking_context = project.client_chunking_context();
 

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1067,7 +1067,10 @@ impl AppEndpoint {
             .get_next_dynamic_imports_for_endpoint(*rsc_entry)
             .await?;
 
-        let client_references = reduced_graphs.get_client_references_for_endpoint(*rsc_entry);
+        let client_references = reduced_graphs.get_client_references_for_endpoint(
+            *rsc_entry,
+            matches!(this.ty, AppEndpointType::Page { .. }),
+        );
 
         let client_references_chunks = get_app_client_references_chunks(
             client_references,

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -521,6 +521,7 @@ impl ReducedGraphs {
     pub async fn get_client_references_for_endpoint(
         &self,
         entry: Vc<Box<dyn Module>>,
+        has_layout_segments: bool,
     ) -> Result<Vc<ClientReferenceGraphResult>> {
         let span = tracing::info_span!("collect all client references for endpoint");
         async move {
@@ -549,14 +550,16 @@ impl ReducedGraphs {
                 result
             };
 
-            // Do this separately for now, because the graph traversal order messes up the order of
-            // the server_component_entries.
-            let ServerEntries {
-                server_utils,
-                server_component_entries,
-            } = &*find_server_entries(entry).await?;
-            result.server_utils = server_utils.clone();
-            result.server_component_entries = server_component_entries.clone();
+            if has_layout_segments {
+                // Do this separately for now, because the graph traversal order messes up the order
+                // of the server_component_entries.
+                let ServerEntries {
+                    server_utils,
+                    server_component_entries,
+                } = &*find_server_entries(entry).await?;
+                result.server_utils = server_utils.clone();
+                result.server_component_entries = server_component_entries.clone();
+            }
 
             Ok(result.cell())
         }


### PR DESCRIPTION
[You should view the diff without whitespaces](https://github.com/vercel/next.js/pull/73847/files?w=1)

For routes, `find_server_entries` previously traversed over all modules trying to find server components and server utils, even though there weren't any.

I was not able to measure the total impact of this change. But this makes routes, for example

![Bildschirmfoto 2025-01-17 um 14 11 15](https://github.com/user-attachments/assets/c5b1c89f-b0a4-4902-9ab6-c89014916268)

![Bildschirmfoto 2025-01-17 um 14 31 36](https://github.com/user-attachments/assets/eeaf408f-ad93-4d41-a3fe-aeaf594c24b6)


Closes PACK-3760