### PR TITLE
build: better error if fetching AMP validator fails

### DIFF
--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -2272,7 +2272,9 @@ export async function precompile(task, opts) {
 
   const validatorRes = await fetch(
     'https://cdn.ampproject.org/v0/validator_wasm.js'
-  )
+  ).catch((err) => {
+    throw new Error('Failed to fetch AMP validator', { cause: err })
+  })
 
   if (!validatorRes.ok) {
     throw new Error(


### PR DESCRIPTION
if this `fetch` fails it's kinda annoying to find, because it just gets printed as
```
│ [17:05:40] precompile failed because fetch failed     
```
this change should at least make it easier to find the cause by searching for the error message:
```
│ [17:20:27] precompile failed because Failed to fetch AMP validator
```