### PR TITLE
[Segment Cache] Move cache key creation to client 

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -3,6 +3,7 @@ import type {
   RootTreePrefetch,
   SegmentPrefetch,
 } from '../../../server/app-render/collect-segment-data'
+import type { Segment as FlightRouterStateSegment } from '../../../server/app-render/types'
 import type {
   HeadData,
   LoadingModuleData,
@@ -35,6 +36,11 @@ import type {
 } from './cache-key'
 import { createTupleMap, type TupleMap, type Prefix } from './tuple-map'
 import { createLRU, type LRU } from './lru'
+import {
+  encodeChildSegmentKey,
+  encodeSegment,
+  ROOT_SEGMENT_KEY,
+} from '../../../server/app-render/segment-value-encoding'
 
 // A note on async/await when working in the prefetch cache:
 //
@@ -56,6 +62,16 @@ import { createLRU, type LRU } from './lru'
 // parent segments are still cached. If the segment is no longer reachable from
 // the root, then it's effectively canceled. This is similar to the design of
 // Rust Futures, or React Suspense.
+
+export type RouteTree = {
+  key: string
+  token: string
+  segment: FlightRouterStateSegment
+  slots: null | {
+    [parallelRouteKey: string]: RouteTree
+  }
+  isRootLayout: boolean
+}
 
 type RouteCacheEntryShared = {
   staleAt: number
@@ -88,7 +104,7 @@ type PendingRouteCacheEntry = RouteCacheEntryShared & {
   blockedTasks: Set<PrefetchTask> | null
   canonicalUrl: null
   tree: null
-  head: [null, null]
+  head: HeadData | null
   isHeadPartial: true
 }
 
@@ -97,7 +113,7 @@ type RejectedRouteCacheEntry = RouteCacheEntryShared & {
   blockedTasks: Set<PrefetchTask> | null
   canonicalUrl: null
   tree: null
-  head: [null, null]
+  head: null
   isHeadPartial: true
 }
 
@@ -105,7 +121,7 @@ export type FulfilledRouteCacheEntry = RouteCacheEntryShared & {
   status: EntryStatus.Fulfilled
   blockedTasks: null
   canonicalUrl: string
-  tree: TreePrefetch
+  tree: RouteTree
   head: HeadData
   isHeadPartial: boolean
 }
@@ -406,7 +422,7 @@ function pingBlockedTasks(entry: {
 
 function fulfillRouteCacheEntry(
   entry: PendingRouteCacheEntry,
-  tree: TreePrefetch,
+  tree: RouteTree,
   head: HeadData,
   isHeadPartial: boolean,
   staleAt: number,
@@ -468,6 +484,49 @@ function rejectSegmentCacheEntry(
     // but we could by accepting a `reason` argument.
     entry.promise.resolve(null)
     entry.promise = null
+  }
+}
+
+function convertRootTreePrefetchToRouteTree(rootTree: RootTreePrefetch) {
+  return convertTreePrefetchToRouteTree(rootTree.tree, ROOT_SEGMENT_KEY)
+}
+
+function convertTreePrefetchToRouteTree(
+  prefetch: TreePrefetch,
+  key: string
+): RouteTree {
+  // Converts the route tree sent by the server into the format used by the
+  // cache. The cached version of the tree includes additional fields, such as a
+  // cache key for each segment. Since this is frequently accessed, we compute
+  // it once instead of on every access. This same cache key is also used to
+  // request the segment from the server.
+  let slots: { [parallelRouteKey: string]: RouteTree } | null = null
+  const prefetchSlots = prefetch.slots
+  if (prefetchSlots !== null) {
+    slots = {}
+    for (let parallelRouteKey in prefetchSlots) {
+      const childPrefetch = prefetchSlots[parallelRouteKey]
+      const childSegment = childPrefetch.segment
+      // TODO: Eventually, the param values will not be included in the response
+      // from the server. We'll instead fill them in on the client by parsing
+      // the URL. This is where we'll do that.
+      const childKey = encodeChildSegmentKey(
+        key,
+        parallelRouteKey,
+        encodeSegment(childSegment)
+      )
+      slots[parallelRouteKey] = convertTreePrefetchToRouteTree(
+        childPrefetch,
+        childKey
+      )
+    }
+  }
+  return {
+    key,
+    token: prefetch.token,
+    segment: prefetch.segment,
+    slots,
+    isRootLayout: prefetch.isRootLayout,
   }
 }
 
@@ -534,7 +593,7 @@ export async function fetchRouteOnCacheMiss(
 
     fulfillRouteCacheEntry(
       entry,
-      serverData.tree,
+      convertRootTreePrefetchToRouteTree(serverData),
       serverData.head,
       serverData.isHeadPartial,
       Date.now() + serverData.staleTime,
@@ -576,7 +635,7 @@ export async function fetchSegmentOnCacheMiss(
   route: FulfilledRouteCacheEntry,
   segmentCacheEntry: PendingSegmentCacheEntry,
   routeKey: RouteCacheKey,
-  segmentPath: string,
+  segmentKeyPath: string,
   accessToken: string | null
 ): Promise<void> {
   // This function is allowed to use async/await because it contains the actual
@@ -589,7 +648,7 @@ export async function fetchSegmentOnCacheMiss(
   try {
     const response = await fetchSegmentPrefetchResponse(
       href,
-      accessToken === '' ? segmentPath : `${segmentPath}.${accessToken}`,
+      accessToken === '' ? segmentKeyPath : `${segmentKeyPath}.${accessToken}`,
       routeKey.nextUrl
     )
     if (

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -21,8 +21,8 @@ import {
   readRouteCacheEntry,
   readSegmentCacheEntry,
   waitForSegmentCacheEntry,
+  type RouteTree,
 } from './cache'
-import type { TreePrefetch } from '../../../server/app-render/collect-segment-data'
 import { createCacheKey } from './cache-key'
 
 export const enum NavigationResultTag {
@@ -180,7 +180,7 @@ function navigationTaskToResult(
 
 function readRenderSnapshotFromCache(
   now: number,
-  tree: TreePrefetch
+  tree: RouteTree
 ): { flightRouterState: FlightRouterState; seedData: CacheNodeSeedData } {
   let childRouterStates: { [parallelRouteKey: string]: FlightRouterState } = {}
   let childSeedDatas: {
@@ -200,7 +200,7 @@ function readRenderSnapshotFromCache(
   let loading: LoadingModuleData | Promise<LoadingModuleData> = null
   let isPartial: boolean = true
 
-  const segmentEntry = readSegmentCacheEntry(now, tree.path)
+  const segmentEntry = readSegmentCacheEntry(now, tree.key)
   if (segmentEntry !== null) {
     switch (segmentEntry.status) {
       case EntryStatus.Fulfilled: {
@@ -237,25 +237,15 @@ function readRenderSnapshotFromCache(
     }
   }
 
-  const extra = tree.extra
-  const flightRouterStateSegment = extra[0]
-  const isRootLayout = extra[1]
-
   return {
     flightRouterState: [
-      flightRouterStateSegment,
+      tree.segment,
       childRouterStates,
       null,
       null,
-      isRootLayout,
+      tree.isRootLayout,
     ],
-    seedData: [
-      flightRouterStateSegment,
-      rsc,
-      childSeedDatas,
-      loading,
-      isPartial,
-    ],
+    seedData: [tree.segment, rsc, childSeedDatas, loading, isPartial],
   }
 }
 

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -2,7 +2,7 @@ import type {
   CacheNodeSeedData,
   FlightRouterState,
   InitialRSCPayload,
-  Segment,
+  Segment as FlightRouterStateSegment,
 } from './types'
 import type { ManifestNode } from '../../build/webpack/plugins/flight-manifest-plugin'
 
@@ -15,12 +15,16 @@ import {
   streamFromBuffer,
   streamToBuffer,
 } from '../stream-utils/node-web-streams-helper'
-import { UNDERSCORE_NOT_FOUND_ROUTE } from '../../api/constants'
 import { waitAtLeastOneReactRenderTask } from '../../lib/scheduler'
 import type {
   HeadData,
   LoadingModuleData,
 } from '../../shared/lib/app-router-context.shared-runtime'
+import {
+  encodeChildSegmentKey,
+  encodeSegment,
+  ROOT_SEGMENT_KEY,
+} from './segment-value-encoding'
 
 // Contains metadata about the route tree. The client must fetch this before
 // it can fetch any actual segment data.
@@ -39,12 +43,8 @@ export type TreePrefetch = {
   // order to get the access token.
   token: string
 
-  // The path to use when requesting the data for this segment (analogous to a
-  // URL). Also used as a cache key, although the server may specify a different
-  // cache key when it responds (analagous to a Vary header), like to omit
-  // params if they aren't used to compute the response. (This part not
-  // yet implemented)
-  path: string
+  // The segment, in the format expected by a FlightRouterState.
+  segment: FlightRouterStateSegment
 
   // Child segments.
   slots: null | {
@@ -56,7 +56,7 @@ export type TreePrefetch = {
   // after some refactoring, but in the meantime it would be wasteful to add a
   // bunch of new prefetch-only fields to FlightRouterState. So think of
   // TreePrefetch as a superset of FlightRouterState.
-  extra: [segment: Segment, isRootLayout: boolean]
+  isRootLayout: boolean
 }
 
 export type SegmentPrefetch = {
@@ -193,7 +193,7 @@ async function PrefetchTreeData({
     fullPageDataBuffer,
     clientModules,
     serverConsumerManifest,
-    '',
+    ROOT_SEGMENT_KEY,
     '',
     segmentTasks
   )
@@ -223,7 +223,7 @@ async function collectSegmentDataImpl(
   fullPageDataBuffer: Buffer,
   clientModules: ManifestNode,
   serverConsumerManifest: any,
-  segmentPathStr: string,
+  key: string,
   accessToken: string,
   segmentTasks: Array<Promise<[string, Buffer]>>
 ): Promise<TreePrefetch> {
@@ -238,14 +238,14 @@ async function collectSegmentDataImpl(
     const childSegment = childRoute[0]
     const childSeedData =
       seedDataChildren !== null ? seedDataChildren[parallelRouteKey] : null
-    const childSegmentPathStr =
-      segmentPathStr +
-      '/' +
-      encodeChildSegmentAsFilesystemSafePathname(parallelRouteKey, childSegment)
-
+    const childKey = encodeChildSegmentKey(
+      key,
+      parallelRouteKey,
+      encodeSegment(childSegment)
+    )
     // Create an access token for each child slot.
     const childAccessToken = await createSegmentAccessToken(
-      segmentPathStr,
+      key,
       parallelRouteKey
     )
     const childTree = await collectSegmentDataImpl(
@@ -255,7 +255,7 @@ async function collectSegmentDataImpl(
       fullPageDataBuffer,
       clientModules,
       serverConsumerManifest,
-      childSegmentPathStr,
+      childKey,
       childAccessToken,
       segmentTasks
     )
@@ -274,7 +274,7 @@ async function collectSegmentDataImpl(
         renderSegmentPrefetch(
           buildId,
           seedData,
-          segmentPathStr,
+          key,
           accessToken,
           clientModules
         )
@@ -290,20 +290,18 @@ async function collectSegmentDataImpl(
 
   // Metadata about the segment. Sent to the client as part of the
   // tree prefetch.
-  const segment = route[0]
-  const isRootLayout = route[4]
   return {
-    path: segmentPathStr === '' ? '/' : segmentPathStr,
+    segment: route[0],
     token: accessToken,
     slots: slotMetadata,
-    extra: [segment, isRootLayout === true],
+    isRootLayout: route[4] === true,
   }
 }
 
 async function renderSegmentPrefetch(
   buildId: string,
   seedData: CacheNodeSeedData,
-  segmentPathStr: string,
+  key: string,
   accessToken: string,
   clientModules: ManifestNode
 ): Promise<[string, Buffer]> {
@@ -336,8 +334,8 @@ async function renderSegmentPrefetch(
   )
   const segmentBuffer = await streamToBuffer(segmentStream)
   // Add the buffer to the result map.
-  if (segmentPathStr === '') {
-    return ['/', segmentBuffer]
+  if (key === ROOT_SEGMENT_KEY) {
+    return [ROOT_SEGMENT_KEY, segmentBuffer]
   } else {
     // The access token is appended to the end of the segment name. To request
     // a segment, the client sends a header like:
@@ -346,7 +344,7 @@ async function renderSegmentPrefetch(
     //
     // The segment path is provided by the tree prefetch, and the access
     // token is provided in the parent layout's data.
-    const fullPath = `${segmentPathStr}.${accessToken}`
+    const fullPath = `${key}.${accessToken}`
     return [fullPath, segmentBuffer]
   }
 }
@@ -373,86 +371,6 @@ async function isPartialRSCData(
     onError() {},
   })
   return isPartial
-}
-
-// TODO: Consider updating or unifying this encoding logic for segments with
-// createRouterCacheKey on the client, perhaps by including it as part of
-// the FlightRouterState. Theoretically the client should never have to do its
-// own encoding of segment keys; it can pass back whatever the server gave it.
-function encodeChildSegmentAsFilesystemSafePathname(
-  parallelRouteKey: string,
-  segment: Segment
-): string {
-  // Encode a child segment and its corresponding parallel route key to a
-  // filesystem-safe pathname. The format is internal-only and can be somewhat
-  // arbitrary as long as there are no collisions, because these will be used
-  // as filenames during build and in the incremental cache. They will also
-  // be sent by the client to request the corresponding segment, but they
-  // do not need to be decodable. The server will merely look for a matching
-  // file in the cache.
-  //
-  // For ease of debugging, the format looks roughly similar to the App Router
-  // convention for defining routes in the source, but again the exact format is
-  // not important as long as it's consistent between the client and server and
-  // meets the above requirements.
-  //
-  // TODO: If the segment did not read from params, then we can omit the
-  // params from the cache key. Need to track this during the prerender somehow.
-  let safeSegmentValue
-  if (typeof segment === 'string') {
-    safeSegmentValue = encodeParamValue(segment)
-  } else {
-    // Parameterized segments.
-    const [paramName, paramValue, paramType] = segment
-    let paramPrefix
-    switch (paramType) {
-      case 'c':
-      case 'ci':
-        paramPrefix = `[...${paramName}]`
-        break
-      case 'oc':
-        paramPrefix = `[[...${paramName}]]`
-        break
-      case 'd':
-      case 'di':
-        paramPrefix = `[${paramName}]`
-        break
-      default:
-        throw new Error('Unknown dynamic param type')
-    }
-    safeSegmentValue = `${paramPrefix}-${encodeParamValue(paramValue)}`
-  }
-  let result
-  if (parallelRouteKey === 'children') {
-    // Omit the parallel route key for children, since this is the most
-    // common case. Saves some bytes.
-    result = `${safeSegmentValue}`
-  } else {
-    result = `@${parallelRouteKey}/${safeSegmentValue}`
-  }
-  return result
-}
-
-// Define a regex pattern to match the most common characters found in a route
-// param. It excludes anything that might not be cross-platform filesystem
-// compatible, like |. It does not need to be precise because the fallback is to
-// just base64url-encode the whole parameter, which is fine; we just don't do it
-// by default for compactness, and for easier debugging.
-const simpleParamValueRegex = /^[a-zA-Z0-9\-_@]+$/
-
-function encodeParamValue(segment: string): string {
-  if (segment === UNDERSCORE_NOT_FOUND_ROUTE) {
-    // TODO: FlightRouterState encodes Not Found routes as "/_not-found". But
-    // params typically don't include the leading slash. We should use a
-    // different encoding to avoid this special case.
-    return '_not-found'
-  }
-  if (simpleParamValueRegex.test(segment)) {
-    return segment
-  }
-  // If there are any unsafe characters, base64url-encode the entire segment.
-  // We also add a $ prefix so it doesn't collide with the simple case.
-  return '$' + Buffer.from(segment, 'utf-8').toString('base64url')
 }
 
 async function createSegmentAccessToken(

--- a/packages/next/src/server/app-render/segment-value-encoding.ts
+++ b/packages/next/src/server/app-render/segment-value-encoding.ts
@@ -1,0 +1,77 @@
+import type { Segment as FlightRouterStateSegment } from './types'
+
+// TypeScript trick to simulate opaque types, like in Flow.
+type Opaque<K, T> = T & { __brand: K }
+
+export type EncodedSegment = Opaque<'EncodedSegment', string>
+
+export function encodeSegment(
+  segment: FlightRouterStateSegment
+): EncodedSegment {
+  if (typeof segment === 'string') {
+    const safeName =
+      // TODO: FlightRouterState encodes Not Found routes as "/_not-found".
+      // But params typically don't include the leading slash. We should use
+      // a different encoding to avoid this special case.
+      segment === '/_not-found'
+        ? '_not-found'
+        : encodeToFilesystemAndURLSafeString(segment)
+    // Since this is not a dynamic segment, it's fully encoded. It does not
+    // need to be "hydrated" with a param value.
+    return safeName as EncodedSegment
+  }
+  const name = segment[0]
+  const paramValue = segment[1]
+  const paramType = segment[2]
+  const safeName = encodeToFilesystemAndURLSafeString(name)
+  const safeValue = encodeToFilesystemAndURLSafeString(paramValue)
+
+  const encodedName = '$' + paramType + '$' + safeName + '$' + safeValue
+  return encodedName as EncodedSegment
+}
+
+export const ROOT_SEGMENT_KEY = '/'
+
+export function encodeChildSegmentKey(
+  // TODO: Make segment keys an opaque type, too?
+  parentSegmentKey: string,
+  parallelRouteKey: string,
+  segment: EncodedSegment
+): string {
+  // Aside from being filesystem safe, segment keys are also designed so that
+  // each segment and parallel route creates its own subdirectory. Roughly in
+  // the same shape as the source app directory. This is mostly just for easier
+  // debugging (you can open up the build folder and navigate the output); if
+  // we wanted to do we could just use a flat structure.
+
+  // Omit the parallel route key for children, since this is the most
+  // common case. Saves some bytes (and it's what the app directory does).
+  const slotKey =
+    parallelRouteKey === 'children'
+      ? segment
+      : `@${encodeToFilesystemAndURLSafeString(parallelRouteKey)}/${segment}`
+
+  return parentSegmentKey === ROOT_SEGMENT_KEY
+    ? '/' + slotKey
+    : parentSegmentKey + '/' + slotKey
+}
+
+// Define a regex pattern to match the most common characters found in a route
+// param. It excludes anything that might not be cross-platform filesystem
+// compatible, like |. It does not need to be precise because the fallback is to
+// just base64url-encode the whole parameter, which is fine; we just don't do it
+// by default for compactness, and for easier debugging.
+const simpleParamValueRegex = /^[a-zA-Z0-9\-_@]+$/
+
+function encodeToFilesystemAndURLSafeString(value: string) {
+  if (simpleParamValueRegex.test(value)) {
+    return value
+  }
+  // If there are any unsafe characters, base64url-encode the entire value.
+  // We also add a ! prefix so it doesn't collide with the simple case.
+  const base64url = btoa(value)
+    .replace(/\+/g, '-') // Replace '+' with '-'
+    .replace(/\//g, '_') // Replace '/' with '_'
+    .replace(/=+$/, '') // Remove trailing '='
+  return '!' + base64url
+}

--- a/test/e2e/app-dir/ppr-navigations/simple/per-segment-prefetching.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/simple/per-segment-prefetching.test.ts
@@ -36,12 +36,16 @@ describe('per segment prefetching', () => {
     return null
   }
 
-  it('basic prefetching flow', async () => {
+  it('basic route tree prefetch', async () => {
     // To perform a prefetch a page, the client first fetches the route tree.
     // The response is used to construct prefetches of individual segments.
     const routeTreeResponse = await prefetch('/en', '/_tree')
     const routeTreeResponseText = await routeTreeResponse.text()
     const routeTree = extractPseudoJSONFromFlightResponse(routeTreeResponseText)
+
+    // Confirm that the prefetch was successful. This is a basic check to ensure
+    // that the name of an expected field is present in the response.
+    expect(typeof routeTree.staleTime).toBe('number')
 
     // The root segment is a shared segment. Demonstrate that fetching the root
     // segment for two different pages results in the same response.
@@ -50,18 +54,6 @@ describe('per segment prefetching', () => {
     const frResponse = await prefetch('/fr', '/')
     const frResponseText = await frResponse.text()
     expect(enResponseText).toEqual(frResponseText)
-
-    // Now use the route tree to construct a request for the child segment.
-    const child = routeTree.tree.slots.children
-
-    // The access token is appended to the end of the segment path.
-    const fullChildSegmentPath = `${child.path}.${child.token}`
-    const childResponse = await prefetch('/en', fullChildSegmentPath)
-    const childResponseText = await childResponse.text()
-
-    // Confirm that the prefetch was successful. This is a basic check to ensure
-    // that the name of an expected field is somewhere in the Flight stream.
-    expect(childResponseText).toInclude('"rsc"')
   })
 
   it('respond with 204 if the segment does not have prefetch data', async () => {


### PR DESCRIPTION
Based on:

- #73667

---

When I originally set up the Segment Cache transport types, I had the notion that the client should never have to compute the request key that is sent to the server. That way we could, say, encrypt the keys on the server to make them unguessable.

But once we added the concept of access tokens for that purpose, this motivation was gone. The remaining motivation was to keep the contract as simple as possible.

However, there's a lot of existing code that relies on manipulating the "decoded" form of the segment values. Since we're sending the full segment value anyway, it's wasteful to also send the encoded form, given that it can be trivially re-derived by the client.

My immediate motivation is that, I need to be able to construct a cache key from a FlightRouterState. As a bonus, this will also get us closer to being able to remove the dynamic param values from the server response, a separate goal that we're currently working on.

We can revisit this once if/when we're able to remove the existing cases where the full segment is needed by the client.