### PR TITLE
refactor(turbo-tasks): Make State require OperationValue

### DIFF
--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -244,15 +244,16 @@ struct InstrumentationCoreModules {
 #[turbo_tasks::value_impl]
 impl Endpoint for InstrumentationEndpoint {
     #[turbo_tasks::function]
-    async fn write_to_disk(self: Vc<Self>) -> Result<Vc<WrittenEndpoint>> {
+    async fn write_to_disk(self: ResolvedVc<Self>) -> Result<Vc<WrittenEndpoint>> {
         let span = tracing::info_span!("instrumentation endpoint");
         async move {
             let this = self.await?;
-            let output_assets = self.output_assets();
+            let output_assets_op = output_assets_operation(self);
+            let output_assets = output_assets_op.connect();
             let _ = output_assets.resolve().await?;
             let _ = this
                 .project
-                .emit_all_output_assets(Vc::cell(output_assets))
+                .emit_all_output_assets(output_assets_op)
                 .resolve()
                 .await?;
 
@@ -293,4 +294,9 @@ impl Endpoint for InstrumentationEndpoint {
             core_modules.edge_entry_module,
         ]))
     }
+}
+
+#[turbo_tasks::function(operation)]
+fn output_assets_operation(endpoint: ResolvedVc<InstrumentationEndpoint>) -> Vc<OutputAssets> {
+    endpoint.output_assets()
 }

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -5,8 +5,9 @@ use next_core::emit_assets;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    debug::ValueDebugFormat, trace::TraceRawVcs, FxIndexSet, ResolvedVc, State, TryFlatJoinIterExt,
-    TryJoinIterExt, ValueDefault, ValueToString, Vc,
+    debug::ValueDebugFormat, trace::TraceRawVcs, FxIndexSet, NonLocalValue, OperationValue,
+    OperationVc, ResolvedVc, State, TryFlatJoinIterExt, TryJoinIterExt, ValueDefault,
+    ValueToString, Vc,
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -16,28 +17,50 @@ use turbopack_core::{
     version::OptionVersionedContent,
 };
 
-/// An unresolved output assets operation. We need to pass an operation here as
-/// it's stored for later usage and we want to reconnect this operation when
-/// it's received from the map again.
-#[turbo_tasks::value(transparent, local)]
-pub struct OutputAssetsOperation(Vc<OutputAssets>);
-
-#[derive(Clone, TraceRawVcs, PartialEq, Eq, ValueDebugFormat, Serialize, Deserialize, Debug)]
+#[derive(
+    Clone,
+    TraceRawVcs,
+    PartialEq,
+    Eq,
+    ValueDebugFormat,
+    Serialize,
+    Deserialize,
+    Debug,
+    NonLocalValue,
+)]
 struct MapEntry {
     // must not be resolved
-    assets_operation: Vc<OutputAssets>,
+    assets_operation: OperationVc<OutputAssets>,
     /// Precomputed map for quick access to output asset by filepath
-    path_to_asset: HashMap<ResolvedVc<FileSystemPath>, Vc<Box<dyn OutputAsset>>>,
+    path_to_asset: HashMap<ResolvedVc<FileSystemPath>, ResolvedVc<Box<dyn OutputAsset>>>,
 }
 
-#[turbo_tasks::value(transparent, local)]
+// HACK: This is technically incorrect because `path_to_asset` contains `ResolvedVc`...
+unsafe impl OperationValue for MapEntry {}
+
+#[turbo_tasks::value(transparent, operation)]
 struct OptionMapEntry(Option<MapEntry>);
 
-type PathToOutputOperation = HashMap<ResolvedVc<FileSystemPath>, FxIndexSet<Vc<OutputAssets>>>;
-// A precomputed map for quick access to output asset by filepath
-type OutputOperationToComputeEntry = HashMap<Vc<OutputAssets>, Vc<OptionMapEntry>>;
+#[turbo_tasks::value]
+#[derive(Debug)]
+pub struct PathToOutputOperation(
+    /// We need to use an operation for outputs as it's stored for later usage and we want to
+    /// reconnect this operation when it's received from the map again.
+    ///
+    /// It may not be 100% correct for the key (`FileSystemPath`) to be in a `ResolvedVc` here, but
+    /// it's impractical to make it an `OperationVc`/`OperationValue`, and it's unlikely to
+    /// change/break?
+    HashMap<ResolvedVc<FileSystemPath>, FxIndexSet<OperationVc<OutputAssets>>>,
+);
 
-#[turbo_tasks::value(local)]
+// HACK: This is technically incorrect because the map's key is a `ResolvedVc`...
+unsafe impl OperationValue for PathToOutputOperation {}
+
+// A precomputed map for quick access to output asset by filepath
+type OutputOperationToComputeEntry =
+    HashMap<OperationVc<OutputAssets>, OperationVc<OptionMapEntry>>;
+
+#[turbo_tasks::value]
 pub struct VersionedContentMap {
     // TODO: turn into a bi-directional multimap, OutputAssets -> FxIndexSet<FileSystemPath>
     map_path_to_op: State<PathToOutputOperation>,
@@ -46,19 +69,19 @@ pub struct VersionedContentMap {
 
 impl ValueDefault for VersionedContentMap {
     fn value_default() -> Vc<Self> {
-        VersionedContentMap {
-            map_path_to_op: State::new(HashMap::new()),
-            map_op_to_compute_entry: State::new(HashMap::new()),
-        }
-        .cell()
+        *VersionedContentMap::new()
     }
 }
 
 impl VersionedContentMap {
     // NOTE(alexkirsz) This must not be a `#[turbo_tasks::function]` because it
     // should be a singleton for each project.
-    pub fn new() -> Vc<Self> {
-        Self::value_default()
+    pub fn new() -> ResolvedVc<Self> {
+        VersionedContentMap {
+            map_path_to_op: State::new(PathToOutputOperation(HashMap::new())),
+            map_op_to_compute_entry: State::new(HashMap::new()),
+        }
+        .resolved_cell()
     }
 }
 
@@ -68,23 +91,24 @@ impl VersionedContentMap {
     /// awaited will emit the assets that were inserted.
     #[turbo_tasks::function]
     pub async fn insert_output_assets(
-        self: Vc<Self>,
+        self: ResolvedVc<Self>,
         // Output assets to emit
-        assets_operation: Vc<OutputAssetsOperation>,
-        node_root: Vc<FileSystemPath>,
-        client_relative_path: Vc<FileSystemPath>,
-        client_output_path: Vc<FileSystemPath>,
+        assets_operation: OperationVc<OutputAssets>,
+        node_root: ResolvedVc<FileSystemPath>,
+        client_relative_path: ResolvedVc<FileSystemPath>,
+        client_output_path: ResolvedVc<FileSystemPath>,
     ) -> Result<()> {
         let this = self.await?;
-        let compute_entry = self.compute_entry(
+        let compute_entry = compute_entry_operation(
+            self,
             assets_operation,
             node_root,
             client_relative_path,
             client_output_path,
         );
-        let assets = *assets_operation.await?;
-        this.map_op_to_compute_entry
-            .update_conditionally(|map| map.insert(assets, compute_entry) != Some(compute_entry));
+        this.map_op_to_compute_entry.update_conditionally(|map| {
+            map.insert(assets_operation, compute_entry) != Some(compute_entry)
+        });
         Ok(())
     }
 
@@ -93,21 +117,21 @@ impl VersionedContentMap {
     #[turbo_tasks::function]
     async fn compute_entry(
         &self,
-        assets_operation: Vc<OutputAssetsOperation>,
+        assets_operation: OperationVc<OutputAssets>,
         node_root: Vc<FileSystemPath>,
         client_relative_path: Vc<FileSystemPath>,
         client_output_path: Vc<FileSystemPath>,
     ) -> Result<Vc<OptionMapEntry>> {
-        let assets = *assets_operation.await?;
+        let assets = assets_operation.connect();
         async fn get_entries(
             assets: Vc<OutputAssets>,
-        ) -> Result<Vec<(ResolvedVc<FileSystemPath>, Vc<Box<dyn OutputAsset>>)>> {
+        ) -> Result<Vec<(ResolvedVc<FileSystemPath>, ResolvedVc<Box<dyn OutputAsset>>)>> {
             let assets_ref = assets.await?;
             let entries = assets_ref
                 .iter()
                 .map(|&asset| async move {
                     let path = asset.ident().path().to_resolved().await?;
-                    Ok((path, *asset))
+                    Ok((path, asset))
                 })
                 .try_join()
                 .await?;
@@ -119,10 +143,10 @@ impl VersionedContentMap {
             let mut changed = false;
 
             // get current map's keys, subtract keys that don't exist in operation
-            let mut stale_assets = map.keys().copied().collect::<HashSet<_>>();
+            let mut stale_assets = map.0.keys().copied().collect::<HashSet<_>>();
 
             for (k, _) in entries.iter() {
-                let res = map.entry(*k).or_default().insert(assets);
+                let res = map.0.entry(*k).or_default().insert(assets_operation);
                 stale_assets.remove(k);
                 changed = changed || res;
             }
@@ -130,10 +154,11 @@ impl VersionedContentMap {
             // Make more efficient with reverse map
             for k in &stale_assets {
                 let res = map
+                    .0
                     .get_mut(k)
                     // guaranteed
                     .unwrap()
-                    .swap_remove(&assets);
+                    .swap_remove(&assets_operation);
                 changed = changed || res
             }
             changed
@@ -144,7 +169,7 @@ impl VersionedContentMap {
             .resolve()
             .await?;
         let map_entry = Vc::cell(Some(MapEntry {
-            assets_operation: assets,
+            assets_operation,
             path_to_asset: entries.into_iter().collect(),
         }));
         Ok(map_entry)
@@ -196,8 +221,8 @@ impl VersionedContentMap {
             path_to_asset,
         }) = &*result
         {
-            if let Some(asset) = path_to_asset.get(&path) {
-                return Ok(Vc::cell(Some(asset.to_resolved().await?)));
+            if let Some(&asset) = path_to_asset.get(&path) {
+                return Ok(Vc::cell(Some(asset)));
             } else {
                 let path = path.to_string().await?;
                 bail!(
@@ -213,7 +238,7 @@ impl VersionedContentMap {
     #[turbo_tasks::function]
     pub async fn keys_in_path(&self, root: Vc<FileSystemPath>) -> Result<Vc<Vec<RcStr>>> {
         let keys = {
-            let map = self.map_path_to_op.get();
+            let map = &self.map_path_to_op.get().0;
             map.keys().copied().collect::<Vec<_>>()
         };
         let root = &root.await?;
@@ -228,14 +253,14 @@ impl VersionedContentMap {
     #[turbo_tasks::function]
     fn raw_get(&self, path: ResolvedVc<FileSystemPath>) -> Vc<OptionMapEntry> {
         let assets = {
-            let map = self.map_path_to_op.get();
+            let map = &self.map_path_to_op.get().0;
             map.get(&path).and_then(|m| m.iter().next().copied())
         };
         let Some(assets) = assets else {
             return Vc::cell(None);
         };
         // Need to reconnect the operation to the map
-        Vc::connect(assets);
+        let _ = assets.connect();
 
         let compute_entry = {
             let map = self.map_op_to_compute_entry.get();
@@ -244,9 +269,22 @@ impl VersionedContentMap {
         let Some(compute_entry) = compute_entry else {
             return Vc::cell(None);
         };
-        // Need to reconnect the operation to the map
-        Vc::connect(compute_entry);
-
-        compute_entry
+        compute_entry.connect()
     }
+}
+
+#[turbo_tasks::function(operation)]
+fn compute_entry_operation(
+    map: ResolvedVc<VersionedContentMap>,
+    assets_operation: OperationVc<OutputAssets>,
+    node_root: ResolvedVc<FileSystemPath>,
+    client_relative_path: ResolvedVc<FileSystemPath>,
+    client_output_path: ResolvedVc<FileSystemPath>,
+) -> Vc<OptionMapEntry> {
+    map.compute_entry(
+        assets_operation,
+        *node_root,
+        *client_relative_path,
+        *client_output_path,
+    )
 }

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -29,7 +29,6 @@ use turbopack_core::{
     NonLocalValue,
 )]
 struct MapEntry {
-    // must not be resolved
     assets_operation: OperationVc<OutputAssets>,
     /// Precomputed map for quick access to output asset by filepath
     path_to_asset: HashMap<ResolvedVc<FileSystemPath>, ResolvedVc<Box<dyn OutputAsset>>>,

--- a/turbopack/crates/turbo-tasks-fs/src/rope.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/rope.rs
@@ -27,7 +27,7 @@ static EMPTY_BUF: &[u8] = &[];
 /// sharing the contents of one Rope can be done by just cloning an Arc.
 ///
 /// Ropes are immutable, in order to construct one see [RopeBuilder].
-#[turbo_tasks::value(shared, serialization = "custom", eq = "manual")]
+#[turbo_tasks::value(shared, serialization = "custom", eq = "manual", operation)]
 #[derive(Clone, Debug, Default)]
 pub struct Rope {
     /// Total length of all held bytes.

--- a/turbopack/crates/turbo-tasks/src/state.rs
+++ b/turbopack/crates/turbo-tasks/src/state.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     get_invalidator, mark_session_dependent, mark_stateful, trace::TraceRawVcs, Invalidator,
-    SerializationInvalidator,
+    OperationValue, SerializationInvalidator,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -135,7 +135,7 @@ impl<T: TraceRawVcs> TraceRawVcs for State<T> {
     }
 }
 
-impl<T: Default> Default for State<T> {
+impl<T: Default + OperationValue> Default for State<T> {
     fn default() -> Self {
         // Need to be explicit to ensure marking as stateful.
         Self::new(Default::default())
@@ -150,7 +150,10 @@ impl<T> PartialEq for State<T> {
 impl<T> Eq for State<T> {}
 
 impl<T> State<T> {
-    pub fn new(value: T) -> Self {
+    pub fn new(value: T) -> Self
+    where
+        T: OperationValue,
+    {
         Self {
             serialization_invalidator: mark_stateful(),
             inner: Mutex::new(StateInner::new(value)),

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/version.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/version.rs
@@ -15,6 +15,10 @@ pub(super) struct EcmascriptDevChunkListVersion {
     #[turbo_tasks(trace_ignore)]
     pub by_path: FxIndexMap<String, VersionTraitRef>,
     /// A map from chunk merger to the version of the merged contents of chunks.
+    //
+    // TODO: This trace_ignore is *very* wrong, and could cause problems if/when we add a GC!
+    // Version is also expected not to contain `Vc`/`ResolvedVc`/`OperationVc`, and
+    // `turbopack_core::version::TotalUpdate` assumes it doesn't.
     #[turbo_tasks(trace_ignore)]
     pub by_merger: FxIndexMap<ResolvedVc<Box<dyn VersionedContentMerger>>, VersionTraitRef>,
 }

--- a/turbopack/crates/turbopack-cli/src/dev/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/mod.rs
@@ -226,7 +226,7 @@ impl TurbopackDevServerBuilder {
     }
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation)]
 async fn source(
     root_dir: RcStr,
     project_dir: RcStr,

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -50,7 +50,7 @@ use crate::{
 };
 
 /// A module id, which can be a number or string
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, operation)]
 #[derive(Debug, Clone, Hash, Ord, PartialOrd, DeterministicHash)]
 #[serde(untagged)]
 pub enum ModuleId {

--- a/turbopack/crates/turbopack-core/src/version.rs
+++ b/turbopack/crates/turbopack-core/src/version.rs
@@ -119,8 +119,10 @@ impl VersionedContentExt for AssetContent {
     }
 }
 
-/// Describes the current version of an object, and how to update them from an
-/// earlier version.
+/// Describes the current version of an object, and how to update them from an earlier version.
+///
+/// **Important:** Implementations must not contain instances of [`Vc`]! This should describe a
+/// specific version, and the value of a [`Vc`] can change due to invalidations or cache eviction.
 #[turbo_tasks::value_trait]
 pub trait Version {
     /// Get a unique identifier of the version as a string. There is no way
@@ -191,7 +193,10 @@ pub enum Update {
 #[derive(PartialEq, Eq, Debug, Clone, TraceRawVcs, ValueDebugFormat, NonLocalValue)]
 pub struct TotalUpdate {
     /// The version this update will bring the object to.
-    // TODO: This trace_ignore is *very* wrong, and could cause problems if/when we add a GC
+    //
+    // TODO: This trace_ignore is wrong, and could cause problems if/when we add a GC. While
+    // `Version` assumes the implementation does not contain `Vc`, `EcmascriptDevChunkListVersion`
+    // is broken and violates this assumption.
     #[turbo_tasks(trace_ignore)]
     pub to: TraitRef<Box<dyn Version>>,
 }

--- a/turbopack/crates/turbopack-dev-server/src/http.rs
+++ b/turbopack/crates/turbopack-dev-server/src/http.rs
@@ -11,7 +11,8 @@ use hyper::{
 use mime::Mime;
 use tokio_util::io::{ReaderStream, StreamReader};
 use turbo_tasks::{
-    apply_effects, util::SharedError, CollectiblesSource, ReadRef, TransientInstance, Vc,
+    apply_effects, util::SharedError, CollectiblesSource, OperationVc, ReadRef, TransientInstance,
+    Vc,
 };
 use turbo_tasks_bytes::Bytes;
 use turbo_tasks_fs::FileContent;
@@ -41,37 +42,39 @@ enum GetFromSourceResult {
 
 /// Resolves a [SourceRequest] within a [super::ContentSource], returning the
 /// corresponding content as a
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation)]
 async fn get_from_source(
-    source: Vc<Box<dyn ContentSource>>,
+    source: OperationVc<Box<dyn ContentSource>>,
     request: TransientInstance<SourceRequest>,
 ) -> Result<Vc<GetFromSourceResult>> {
-    Ok(match &*resolve_source_request(source, request).await? {
-        ResolveSourceRequestResult::Static(static_content_vc, header_overwrites) => {
-            let static_content = static_content_vc.await?;
-            if let AssetContent::File(file) = &*static_content.content.content().await? {
-                GetFromSourceResult::Static {
-                    content: file.await?,
-                    status_code: static_content.status_code,
-                    headers: static_content.headers.await?,
-                    header_overwrites: header_overwrites.await?,
+    Ok(
+        match &*resolve_source_request(source, request).connect().await? {
+            ResolveSourceRequestResult::Static(static_content_vc, header_overwrites) => {
+                let static_content = static_content_vc.await?;
+                if let AssetContent::File(file) = &*static_content.content.content().await? {
+                    GetFromSourceResult::Static {
+                        content: file.await?,
+                        status_code: static_content.status_code,
+                        headers: static_content.headers.await?,
+                        header_overwrites: header_overwrites.await?,
+                    }
+                } else {
+                    GetFromSourceResult::NotFound
                 }
-            } else {
-                GetFromSourceResult::NotFound
             }
+            ResolveSourceRequestResult::HttpProxy(proxy) => {
+                GetFromSourceResult::HttpProxy(proxy.await?)
+            }
+            ResolveSourceRequestResult::NotFound => GetFromSourceResult::NotFound,
         }
-        ResolveSourceRequestResult::HttpProxy(proxy) => {
-            GetFromSourceResult::HttpProxy(proxy.await?)
-        }
-        ResolveSourceRequestResult::NotFound => GetFromSourceResult::NotFound,
-    }
-    .cell())
+        .cell(),
+    )
 }
 
 /// Processes an HTTP request within a given content source and returns the
 /// response.
 pub async fn process_request_with_content_source(
-    source: Vc<Box<dyn ContentSource>>,
+    source: OperationVc<Box<dyn ContentSource>>,
     request: Request<hyper::Body>,
     issue_reporter: Vc<Box<dyn IssueReporter>>,
 ) -> Result<(
@@ -80,12 +83,13 @@ pub async fn process_request_with_content_source(
 )> {
     let original_path = request.uri().path().to_string();
     let request = http_request_to_source_request(request).await?;
-    let result = get_from_source(source, TransientInstance::new(request));
-    let resolved_result = result.resolve_strongly_consistent().await?;
-    apply_effects(result).await?;
-    let side_effects: AutoSet<Vc<Box<dyn ContentSourceSideEffect>>> = result.peek_collectibles();
+    let result_op = get_from_source(source, TransientInstance::new(request));
+    let result_vc = result_op.connect();
+    let resolved_result = result_vc.resolve_strongly_consistent().await?;
+    apply_effects(result_op).await?;
+    let side_effects: AutoSet<Vc<Box<dyn ContentSourceSideEffect>>> = result_op.peek_collectibles();
     handle_issues(
-        result,
+        result_op,
         issue_reporter,
         IssueSeverity::Fatal.cell(),
         Some(&original_path),

--- a/turbopack/crates/turbopack-dev-server/src/source/resolve.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/resolve.rs
@@ -9,7 +9,7 @@ use hyper::{
     Uri,
 };
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, TransientInstance, Value, Vc};
+use turbo_tasks::{OperationVc, ResolvedVc, TransientInstance, Value, Vc};
 
 use super::{
     headers::{HeaderValue, Headers},
@@ -37,9 +37,9 @@ pub enum ResolveSourceRequestResult {
 /// version of the content. We don't make resolve_source_request strongly
 /// consistent as we want get_routes and get to be independent consistent and
 /// any side effect in get should not wait for recomputing of get_routes.
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation)]
 pub async fn resolve_source_request(
-    source: Vc<Box<dyn ContentSource>>,
+    source: OperationVc<Box<dyn ContentSource>>,
     request: TransientInstance<SourceRequest>,
 ) -> Result<Vc<ResolveSourceRequestResult>> {
     let original_path = request.uri.path().to_string();
@@ -47,7 +47,11 @@ pub async fn resolve_source_request(
     let mut current_asset_path: RcStr = urlencoding::decode(&original_path[1..])?.into();
     let mut request_overwrites = (*request).clone();
     let mut response_header_overwrites = Vec::new();
-    let mut route_tree = source.get_routes().resolve_strongly_consistent().await?;
+    let mut route_tree = source
+        .connect()
+        .get_routes()
+        .resolve_strongly_consistent()
+        .await?;
     'routes: loop {
         let mut sources = route_tree.get(current_asset_path.clone());
         'sources: loop {


### PR DESCRIPTION
I started writing this PR by requiring `OperationValue` in `State`:

```diff
  impl<T> State<T> {
-     pub fn new(value: T) -> Self {
+     pub fn new(value: T) -> Self
+    where
+        T: OperationValue,
+    {
```

And then went through changing every compilation error that occurred as a result.

## Hacks

**There are some hacks in a number of places here where we incorrectly convert `ResolvedVc` to `OperationValue`.**

Unfortunately these have to exist because it's impractical to convert everything to `OperationValue`. `OperationValues` are harder to construct as they must be created directly from the return value of an unresolved function call.

## Why does `State<T>` need `T: OperationValue`?

`OperationVc` types require that `.connect()` is called before their value can be read.

As an internally-mutable type, `State` allows `Vc`s to be passed in ways that we cannot track. `.connect()` re-connects the `Vc` to the dependency graph so that strong resolution is possible.

Without this, you might end up with stale results when reading a `Vc` inside of `State`, which can be very hard to debug.

Fundamentally, I think `State` is unsound, but this is a band-aid on it until we can migrate to a better solution (likely effect-style `Collectibles` for `VersionedContentMap`).

Closes PACK-3675