### PR TITLE
Remove parentRendered argument

### DIFF
--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -30,7 +30,6 @@ export async function walkTreeWithFlightRouterState({
   loaderTreeToFilter,
   parentParams,
   flightRouterState,
-  parentRendered,
   rscHead,
   injectedCSS,
   injectedJS,
@@ -44,7 +43,6 @@ export async function walkTreeWithFlightRouterState({
   loaderTreeToFilter: LoaderTree
   parentParams: { [key: string]: string | string[] }
   flightRouterState?: FlightRouterState
-  parentRendered?: boolean
   rscHead: HeadData
   injectedCSS: Set<string>
   injectedJS: Set<string>
@@ -122,7 +120,7 @@ export async function walkTreeWithFlightRouterState({
         !Boolean(modules.loading) &&
         !hasLoadingComponentInTree(loaderTreeToFilter)))
 
-  if (!parentRendered && renderComponentsOnThisLevel) {
+  if (renderComponentsOnThisLevel) {
     const overriddenSegment =
       flightRouterState &&
       canSegmentBeOverridden(actualSegment, flightRouterState[0])
@@ -219,7 +217,6 @@ export async function walkTreeWithFlightRouterState({
       parentParams: currentParams,
       flightRouterState:
         flightRouterState && flightRouterState[1][parallelRouteKey],
-      parentRendered: parentRendered || renderComponentsOnThisLevel,
       rscHead,
       injectedCSS: injectedCSSWithCurrentLayout,
       injectedJS: injectedJSWithCurrentLayout,


### PR DESCRIPTION
It doesn't look like this argument is logically needed. No callers pass it as an option except for the recursive call, and the recursive call will never set it to `true` because of the `renderComponentsOnThisLevel` branch that happens earlier in the function.

I'm guessing it was needed at one point but then the logic changed.