### PR TITLE
Docs: fix typo in `examples` page

### DIFF
--- a/docs/01-app/02-examples/index.mdx
+++ b/docs/01-app/02-examples/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Examples
-descriptions: Learn how to implement common UI patterns and use cases  using Next.js
+description: Learn how to implement common UI patterns and use cases  using Next.js
 ---
 
 ### Data Fetching


### PR DESCRIPTION
Fix typo in examples page