### PR TITLE
Add a test to prevent breaking URI encoded spaces in RSC requests

### DIFF
--- a/test/e2e/app-dir/app-prefetch/app/uri-encoded-prefetch/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/uri-encoded-prefetch/page.js
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default async function Page() {
+  return (
+    <>
+      <p id="uri-encoded-prefetch">URI Encoded Prefetch</p>
+      <p>
+        <Link href="/?param=with%20space" id="prefetch-via-link">
+          Prefetch Via Link
+        </Link>
+      </p>
+    </>
+  )
+}


### PR DESCRIPTION
This adds a test to prevent https://github.com/vercel/next.js/issues/72927 from happening again - it was accidentally fixed [here](https://github.com/vercel/next.js/pull/72861/files#r1854732597), so adding a test will prevent it from being accidentally re-introduced just as easily.

In summary, we expect any RSC request that's made with query parameters containing a URI encoded space (%20) to make that request with the %20 and not change it to a +. (See the linked issue above for more details and why this is a problem).