### PR TITLE
chore(next-custom-transforms): Mark fixture outputs as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,8 @@ packages/next/compiled/** -text linguist-vendored
 # Make next/src/build folder indexable for github search
 build/** linguist-generated=false
 
+crates/next-custom-transforms/tests/fixture/**/output* linguist-generated=true
+
 turbopack/crates/turbo-tasks-macros-tests/tests/**/*.stderr linguist-generated=true
 turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/**/output.md linguist-generated=true
 turbopack/crates/turbopack-tests/tests/snapshot/**/output/** linguist-generated=true


### PR DESCRIPTION
This should let GitHub (and Graphite) collapse these files by default in code review.

```
$ git check-attr --all crates/next-custom-transforms/tests/fixture/strip-page-exports/getInitialProps/class/*
crates/next-custom-transforms/tests/fixture/strip-page-exports/getInitialProps/class/output-data.js: linguist-generated: true
crates/next-custom-transforms/tests/fixture/strip-page-exports/getInitialProps/class/output-default.js: linguist-generated: true
```

Closes PACK-3656