### PR TITLE
docs: update `tailwind.config.ts` to use `satisfies` operator

### DIFF
--- a/docs/01-app/01-getting-started/05-css-and-styling.mdx
+++ b/docs/01-app/01-getting-started/05-css-and-styling.mdx
@@ -117,7 +117,7 @@ Inside your Tailwind configuration file, add paths to the files that will use th
 ```ts filename="tailwind.config.ts" highlight={5-7} switcher
 import type { Config } from 'tailwindcss'
 
-const config: Config = {
+export default {
   content: [
     './app/**/*.{js,ts,jsx,tsx,mdx}',
     // Or if using `src` directory:
@@ -127,8 +127,7 @@ const config: Config = {
     extend: {},
   },
   plugins: [],
-}
-export default config
+} satisfies Config
 ```
 
 ```js filename="tailwind.config.js" highlight={4-6} switcher

--- a/docs/01-app/03-building-your-application/05-styling/02-tailwind-css.mdx
+++ b/docs/01-app/03-building-your-application/05-styling/02-tailwind-css.mdx
@@ -20,10 +20,10 @@ npx tailwindcss init -p
 
 Inside your Tailwind configuration file, add paths to the files that will use Tailwind class names:
 
-```ts filename="tailwind.config.ts" switcher
+```ts filename="tailwind.config.ts" highlight={5-10} switcher
 import type { Config } from 'tailwindcss'
 
-const config: Config = {
+export default {
   content: [
     './app/**/*.{js,ts,jsx,tsx,mdx}', // Note the addition of the `app` directory.
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
@@ -36,11 +36,10 @@ const config: Config = {
     extend: {},
   },
   plugins: [],
-}
-export default config
+} satisfies Config
 ```
 
-```js filename="tailwind.config.js" switcher
+```js filename="tailwind.config.js" highlight={4-9} switcher
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [


### PR DESCRIPTION
## What?

Use [satisfies](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#the-satisfies-operator) operator for reference tailwindcss configuration.

## Why?

1. To refer to tailwind extended type.
<details><summary>use <code>satisfies</code> operator instead of type in <code>tailwind.config.ts</code></summary>

Tailwind provides a [resolveConfig](https://tailwindcss.com/docs/configuration#referencing-in-java-script) helper you can use to generate a fully merged version of your configuration object:

```typescript
// type.ts
import type resolveConfig from "tailwindcss/resolveConfig";
import type config from "./tailwind.config";

type ResolveConfig = ReturnType<typeof resolveConfig<typeof config>>;

type ResolveConfigTheme = ResolveConfig["theme"];

type Color = keyof ResolveConfigTheme["colors"];
// type Color = "primary" | "secondary" | "tertiary" | keyof DefaultColors
// --- DefaultColors contain ... ---
// type Color = "primary" | "secondary" | "tertiary" | "inherit" | "current" |
//              "transparent" | "black" | "white" | "slate" | "gray" | "zinc" | 
//              "neutral" | "stone" | "red" | "orange" | ... 20 more

type FontSize = keyof ResolveConfigTheme["fontSize"];
// type FontSize = "xs" | "sm" | "base" | "lg" | "xl" | "2xl" | "3xl" | 
//                 "4xl" | "5xl" | "6xl" | "7xl" | "8xl" | "9xl"

type ZIndex = keyof ResolveConfigTheme["zIndex"];
// type ZIndex = "0" | "10" | "20" | "30" | "40" | "50" | "auto"
``` 
However, the type information cannot be successfully obtained by using Config types.

```typescript
// tailwind.config.ts
import type { Config } from "tailwindcss";

// ❌ can't get type info
const config: Config = {
// ...
};

// ✔️ can get type info
const config = {
// ...
} satisfies Config;

export default config
```

That's why I introduced satisfies operator.
In addition, [official tailwind configuration](https://tailwindcss.com/docs/configuration#using-esm-or-type-script) uses satisfies operator.

```typescript
// tailwind.config.ts
import type { Config } from 'tailwindcss'

export default {
  content: [],
  theme: {
    extend: {},
  },
  plugins: [],
} satisfies Config
```

</details> 

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide