### PR TITLE
chore(turbo-tasks-macros): Remove use of associated items for NativeFunction construction

### DIFF
--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -979,10 +979,18 @@ impl NativeFn {
     }
 
     pub fn ty(&self) -> Type {
-        parse_quote! { turbo_tasks::macro_helpers::Lazy<turbo_tasks::NativeFunction> }
+        parse_quote! { turbo_tasks::NativeFunction }
     }
 
-    pub fn definition(&self) -> Expr {
+    pub fn definition_signature(&self, fn_name: &Ident) -> TokenStream {
+        quote! {
+            #[doc(hidden)]
+            #[allow(non_snake_case)]
+            fn #fn_name() -> turbo_tasks::NativeFunction;
+        }
+    }
+
+    pub fn definition(&self, fn_name: &Ident) -> TokenStream {
         let Self {
             function_path_string,
             function_path,
@@ -996,8 +1004,10 @@ impl NativeFn {
             quote! { new_function }
         };
 
-        parse_quote! {
-            turbo_tasks::macro_helpers::Lazy::new(|| {
+        quote! {
+            #[doc(hidden)]
+            #[allow(non_snake_case)]
+            fn #fn_name() -> turbo_tasks::NativeFunction {
                 #[allow(deprecated)]
                 turbo_tasks::NativeFunction::#constructor(
                     #function_path_string.to_owned(),
@@ -1006,19 +1016,29 @@ impl NativeFn {
                     },
                     #function_path,
                 )
-            })
+            }
         }
     }
 
     pub fn id_ty(&self) -> Type {
-        parse_quote! { turbo_tasks::macro_helpers::Lazy<turbo_tasks::FunctionId> }
+        parse_quote! { turbo_tasks::FunctionId }
     }
 
-    pub fn id_definition(&self, native_function_id_path: &Path) -> Expr {
-        parse_quote! {
-            turbo_tasks::macro_helpers::Lazy::new(|| {
+    pub fn id_definition_signature(&self, fn_name: &Ident) -> TokenStream {
+        quote! {
+            #[doc(hidden)]
+            #[allow(non_snake_case)]
+            fn #fn_name() -> turbo_tasks::FunctionId;
+        }
+    }
+
+    pub fn id_definition(&self, fn_name: &Ident, native_function_id_path: &Path) -> TokenStream {
+        quote! {
+            #[doc(hidden)]
+            #[allow(non_snake_case)]
+            fn #fn_name() -> turbo_tasks::FunctionId {
                 turbo_tasks::registry::get_function_id(&*#native_function_id_path)
-            })
+            }
         }
     }
 }

--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -982,15 +982,7 @@ impl NativeFn {
         parse_quote! { turbo_tasks::NativeFunction }
     }
 
-    pub fn definition_signature(&self, fn_name: &Ident) -> TokenStream {
-        quote! {
-            #[doc(hidden)]
-            #[allow(non_snake_case)]
-            fn #fn_name() -> turbo_tasks::NativeFunction;
-        }
-    }
-
-    pub fn definition(&self, fn_name: &Ident) -> TokenStream {
+    pub fn definition(&self) -> TokenStream {
         let Self {
             function_path_string,
             function_path,
@@ -1005,9 +997,7 @@ impl NativeFn {
         };
 
         quote! {
-            #[doc(hidden)]
-            #[allow(non_snake_case)]
-            fn #fn_name() -> turbo_tasks::NativeFunction {
+            {
                 #[allow(deprecated)]
                 turbo_tasks::NativeFunction::#constructor(
                     #function_path_string.to_owned(),
@@ -1024,21 +1014,9 @@ impl NativeFn {
         parse_quote! { turbo_tasks::FunctionId }
     }
 
-    pub fn id_definition_signature(&self, fn_name: &Ident) -> TokenStream {
+    pub fn id_definition(&self, native_function_id_path: &Path) -> TokenStream {
         quote! {
-            #[doc(hidden)]
-            #[allow(non_snake_case)]
-            fn #fn_name() -> turbo_tasks::FunctionId;
-        }
-    }
-
-    pub fn id_definition(&self, fn_name: &Ident, native_function_id_path: &Path) -> TokenStream {
-        quote! {
-            #[doc(hidden)]
-            #[allow(non_snake_case)]
-            fn #fn_name() -> turbo_tasks::FunctionId {
-                turbo_tasks::registry::get_function_id(&*#native_function_id_path)
-            }
+            turbo_tasks::registry::get_function_id(&*#native_function_id_path)
         }
     }
 }

--- a/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
@@ -59,11 +59,14 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
     );
     let native_function_ident = get_native_function_ident(ident);
     let native_function_ty = native_fn.ty();
-    let native_function_def = native_fn.definition();
+    let native_function_def = native_fn.definition(&native_function_ident);
 
     let native_function_id_ident = get_native_function_id_ident(ident);
     let native_function_id_ty = native_fn.id_ty();
-    let native_function_id_def = native_fn.id_definition(&native_function_ident.clone().into());
+    let native_function_id_def = native_fn.id_definition(
+        &native_function_id_ident,
+        &native_function_ident.clone().into(),
+    );
 
     let exposed_signature = turbo_fn.signature();
     let exposed_block = turbo_fn.static_block(&native_function_id_ident);
@@ -77,10 +80,20 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
         #inline_signature #inline_block
 
         #[doc(hidden)]
-        pub(crate) static #native_function_ident: #native_function_ty = #native_function_def;
+        pub(crate) static #native_function_ident:
+            turbo_tasks::macro_helpers::Lazy<#native_function_ty> =
+                turbo_tasks::macro_helpers::Lazy::new({
+                    #native_function_def
+                    #native_function_ident
+                });
 
         #[doc(hidden)]
-        pub(crate) static #native_function_id_ident: #native_function_id_ty = #native_function_id_def;
+        pub(crate) static #native_function_id_ident:
+            turbo_tasks::macro_helpers::Lazy<#native_function_id_ty> =
+                turbo_tasks::macro_helpers::Lazy::new({
+                    #native_function_id_def
+                    #native_function_id_ident
+                });
 
         #(#errors)*
     }

--- a/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
@@ -59,14 +59,11 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
     );
     let native_function_ident = get_native_function_ident(ident);
     let native_function_ty = native_fn.ty();
-    let native_function_def = native_fn.definition(&native_function_ident);
+    let native_function_def = native_fn.definition();
 
     let native_function_id_ident = get_native_function_id_ident(ident);
     let native_function_id_ty = native_fn.id_ty();
-    let native_function_id_def = native_fn.id_definition(
-        &native_function_id_ident,
-        &native_function_ident.clone().into(),
-    );
+    let native_function_id_def = native_fn.id_definition(&native_function_ident.clone().into());
 
     let exposed_signature = turbo_fn.signature();
     let exposed_block = turbo_fn.static_block(&native_function_id_ident);
@@ -82,18 +79,12 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
         #[doc(hidden)]
         pub(crate) static #native_function_ident:
             turbo_tasks::macro_helpers::Lazy<#native_function_ty> =
-                turbo_tasks::macro_helpers::Lazy::new({
-                    #native_function_def
-                    #native_function_ident
-                });
+                turbo_tasks::macro_helpers::Lazy::new(|| #native_function_def);
 
         #[doc(hidden)]
         pub(crate) static #native_function_id_ident:
             turbo_tasks::macro_helpers::Lazy<#native_function_id_ty> =
-                turbo_tasks::macro_helpers::Lazy::new({
-                    #native_function_id_def
-                    #native_function_id_ident
-                });
+                turbo_tasks::macro_helpers::Lazy::new(|| #native_function_id_def);
 
         #(#errors)*
     }

--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -140,12 +140,14 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
 
                 let native_function_ident = get_inherent_impl_function_ident(ty_ident, ident);
                 let native_function_ty = native_fn.ty();
-                let native_function_def = native_fn.definition();
+                let native_function_def = native_fn.definition(&native_function_ident);
+
                 let native_function_id_ident = get_inherent_impl_function_id_ident(ty_ident, ident);
                 let native_function_id_ty = native_fn.id_ty();
-                let native_function_id_def = native_fn.id_definition(&parse_quote! {
-                    #native_function_ident
-                });
+                let native_function_id_def = native_fn.id_definition(
+                    &native_function_id_ident,
+                    &native_function_ident.clone().into(),
+                );
 
                 let turbo_signature = turbo_fn.signature();
                 let turbo_block = turbo_fn.static_block(&native_function_id_ident);
@@ -157,15 +159,11 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                 all_definitions.push(quote! {
                     #[doc(hidden)]
                     impl #ty {
-                        // By declaring the native function's body within an `impl` block, we ensure that `Self` refers
-                        // to `#ty`. This is necessary because the function's body is originally declared within an
-                        // `impl` block already.
-                        #[allow(declare_interior_mutable_const)]
-                        #[doc(hidden)]
-                        const #native_function_ident: #native_function_ty = #native_function_def;
-                        #[allow(declare_interior_mutable_const)]
-                        #[doc(hidden)]
-                        const #native_function_id_ident: #native_function_id_ty = #native_function_id_def;
+                        // By declaring the native function's body within an `impl` block, we ensure
+                        // that `Self` refers to `#ty`. This is necessary because the function's
+                        // body is originally declared within an `impl` block already.
+                        #native_function_def
+                        #native_function_id_def
 
                         #(#attrs)*
                         #[doc(hidden)]
@@ -174,9 +172,13 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     }
 
                     #[doc(hidden)]
-                    pub(crate) static #native_function_ident: #native_function_ty = <#ty>::#native_function_ident;
+                    pub(crate) static #native_function_ident:
+                        turbo_tasks::macro_helpers::Lazy<#native_function_ty> =
+                            turbo_tasks::macro_helpers::Lazy::new(<#ty>::#native_function_ident);
                     #[doc(hidden)]
-                    pub(crate) static #native_function_id_ident: #native_function_id_ty = <#ty>::#native_function_id_ident;
+                    pub(crate) static #native_function_id_ident:
+                        turbo_tasks::macro_helpers::Lazy<#native_function_id_ty> =
+                            turbo_tasks::macro_helpers::Lazy::new(<#ty>::#native_function_id_ident);
                 })
             }
         }
@@ -252,15 +254,20 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
 
                 let native_function_ident =
                     get_trait_impl_function_ident(ty_ident, &trait_ident, ident);
-
                 let native_function_ty = native_fn.ty();
-                let native_function_def = native_fn.definition();
+                let native_function_def_sig =
+                    native_fn.definition_signature(&native_function_ident);
+                let native_function_def = native_fn.definition(&native_function_ident);
+
                 let native_function_id_ident =
                     get_trait_impl_function_id_ident(ty_ident, &trait_ident, ident);
                 let native_function_id_ty = native_fn.id_ty();
-                let native_function_id_def = native_fn.id_definition(&parse_quote! {
-                    #native_function_ident
-                });
+                let native_function_id_def_sig =
+                    native_fn.id_definition_signature(&native_function_id_ident);
+                let native_function_id_def = native_fn.id_definition(
+                    &native_function_id_ident,
+                    &native_function_ident.clone().into(),
+                );
 
                 let turbo_signature = turbo_fn.signature();
                 let turbo_block = turbo_fn.static_block(&native_function_id_ident);
@@ -274,12 +281,8 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     #[doc(hidden)]
                     #[allow(non_camel_case_types)]
                     trait #inline_extension_trait_ident: std::marker::Send {
-                        #[allow(declare_interior_mutable_const)]
-                        #[doc(hidden)]
-                        const #native_function_ident: #native_function_ty;
-                        #[allow(declare_interior_mutable_const)]
-                        #[doc(hidden)]
-                        const #native_function_id_ident: #native_function_id_ty;
+                        #native_function_def_sig
+                        #native_function_id_def_sig
 
                         #(#attrs)*
                         #[doc(hidden)]
@@ -288,12 +291,8 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
 
                     #[doc(hidden)]
                     impl #impl_generics #inline_extension_trait_ident for #ty #where_clause  {
-                        #[allow(declare_interior_mutable_const)]
-                        #[doc(hidden)]
-                        const #native_function_ident: #native_function_ty = #native_function_def;
-                        #[allow(declare_interior_mutable_const)]
-                        #[doc(hidden)]
-                        const #native_function_id_ident: #native_function_id_ty = #native_function_id_def;
+                        #native_function_def
+                        #native_function_id_def
 
                         #(#attrs)*
                         #[doc(hidden)]
@@ -302,9 +301,17 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     }
 
                     #[doc(hidden)]
-                    pub(crate) static #native_function_ident: #native_function_ty = <#ty as #inline_extension_trait_ident>::#native_function_ident;
+                    pub(crate) static #native_function_ident:
+                        turbo_tasks::macro_helpers::Lazy<#native_function_ty> =
+                            turbo_tasks::macro_helpers::Lazy::new(
+                                <#ty as #inline_extension_trait_ident>::#native_function_ident
+                            );
                     #[doc(hidden)]
-                    pub(crate) static #native_function_id_ident: #native_function_id_ty = <#ty as #inline_extension_trait_ident>::#native_function_id_ident;
+                    pub(crate) static #native_function_id_ident:
+                        turbo_tasks::macro_helpers::Lazy<#native_function_id_ty> =
+                            turbo_tasks::macro_helpers::Lazy::new(
+                                <#ty as #inline_extension_trait_ident>::#native_function_id_ident
+                            );
                 });
 
                 trait_registers.push(quote! {

--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -140,14 +140,12 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
 
                 let native_function_ident = get_inherent_impl_function_ident(ty_ident, ident);
                 let native_function_ty = native_fn.ty();
-                let native_function_def = native_fn.definition(&native_function_ident);
+                let native_function_def = native_fn.definition();
 
                 let native_function_id_ident = get_inherent_impl_function_id_ident(ty_ident, ident);
                 let native_function_id_ty = native_fn.id_ty();
-                let native_function_id_def = native_fn.id_definition(
-                    &native_function_id_ident,
-                    &native_function_ident.clone().into(),
-                );
+                let native_function_id_def =
+                    native_fn.id_definition(&native_function_ident.clone().into());
 
                 let turbo_signature = turbo_fn.signature();
                 let turbo_block = turbo_fn.static_block(&native_function_id_ident);
@@ -162,9 +160,6 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                         // By declaring the native function's body within an `impl` block, we ensure
                         // that `Self` refers to `#ty`. This is necessary because the function's
                         // body is originally declared within an `impl` block already.
-                        #native_function_def
-                        #native_function_id_def
-
                         #(#attrs)*
                         #[doc(hidden)]
                         #[deprecated(note = "This function is only exposed for use in macros. Do not call it directly.")]
@@ -174,11 +169,11 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     #[doc(hidden)]
                     pub(crate) static #native_function_ident:
                         turbo_tasks::macro_helpers::Lazy<#native_function_ty> =
-                            turbo_tasks::macro_helpers::Lazy::new(<#ty>::#native_function_ident);
+                            turbo_tasks::macro_helpers::Lazy::new(|| #native_function_def);
                     #[doc(hidden)]
                     pub(crate) static #native_function_id_ident:
                         turbo_tasks::macro_helpers::Lazy<#native_function_id_ty> =
-                            turbo_tasks::macro_helpers::Lazy::new(<#ty>::#native_function_id_ident);
+                            turbo_tasks::macro_helpers::Lazy::new(|| #native_function_id_def);
                 })
             }
         }
@@ -255,19 +250,13 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                 let native_function_ident =
                     get_trait_impl_function_ident(ty_ident, &trait_ident, ident);
                 let native_function_ty = native_fn.ty();
-                let native_function_def_sig =
-                    native_fn.definition_signature(&native_function_ident);
-                let native_function_def = native_fn.definition(&native_function_ident);
+                let native_function_def = native_fn.definition();
 
                 let native_function_id_ident =
                     get_trait_impl_function_id_ident(ty_ident, &trait_ident, ident);
                 let native_function_id_ty = native_fn.id_ty();
-                let native_function_id_def_sig =
-                    native_fn.id_definition_signature(&native_function_id_ident);
-                let native_function_id_def = native_fn.id_definition(
-                    &native_function_id_ident,
-                    &native_function_ident.clone().into(),
-                );
+                let native_function_id_def =
+                    native_fn.id_definition(&native_function_ident.clone().into());
 
                 let turbo_signature = turbo_fn.signature();
                 let turbo_block = turbo_fn.static_block(&native_function_id_ident);
@@ -281,9 +270,6 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     #[doc(hidden)]
                     #[allow(non_camel_case_types)]
                     trait #inline_extension_trait_ident: std::marker::Send {
-                        #native_function_def_sig
-                        #native_function_id_def_sig
-
                         #(#attrs)*
                         #[doc(hidden)]
                         #inline_signature;
@@ -291,9 +277,6 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
 
                     #[doc(hidden)]
                     impl #impl_generics #inline_extension_trait_ident for #ty #where_clause  {
-                        #native_function_def
-                        #native_function_id_def
-
                         #(#attrs)*
                         #[doc(hidden)]
                         #[deprecated(note = "This function is only exposed for use in macros. Do not call it directly.")]
@@ -303,15 +286,11 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     #[doc(hidden)]
                     pub(crate) static #native_function_ident:
                         turbo_tasks::macro_helpers::Lazy<#native_function_ty> =
-                            turbo_tasks::macro_helpers::Lazy::new(
-                                <#ty as #inline_extension_trait_ident>::#native_function_ident
-                            );
+                            turbo_tasks::macro_helpers::Lazy::new(|| #native_function_def);
                     #[doc(hidden)]
                     pub(crate) static #native_function_id_ident:
                         turbo_tasks::macro_helpers::Lazy<#native_function_id_ty> =
-                            turbo_tasks::macro_helpers::Lazy::new(
-                                <#ty as #inline_extension_trait_ident>::#native_function_id_ident
-                            );
+                            turbo_tasks::macro_helpers::Lazy::new(|| #native_function_id_def);
                 });
 
                 trait_registers.push(quote! {


### PR DESCRIPTION
After the toolchain upgrade, causing a compilation error in a `#[turbo_tasks::value]` (or somewhere adjacent) can cause this additional non-fatal compilation warning/note:

```
note: erroneous constant encountered
   --> crates/next-api/src/project.rs:580:1
    |
580 | #[turbo_tasks::value_impl]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ in this procedural macro expansion
    |
   ::: /home/bgw.linux/next.js/turbopack/crates/turbo-tasks-macros/src/lib.rs:119:1
    |
119 | #[proc_macro_error]
    | ------------------- in this expansion of `#[turbo_tasks::value_impl]`
```

The use of const expressions here was a little whacky. This removes the need for the const associated items by inlining their (one and only) use later when creating the `Lazy` static.

This simplifies the macro implementation, reduces the total resulting code size, and makes the expanded output a little more legible.

## Before

```
// ===========================================
// Recursive expansion of the value_impl macro
// ===========================================

impl Completion {
    #[doc = " This will always be the same and never invalidates the reading task."]
    pub fn immutable() -> Vc<Self> {
        let inputs = std::boxed::Box::new(());
        let persistence =
            turbo_tasks::macro_helpers::get_non_local_persistence_from_inputs(&*inputs);
        <Vc<Self> as turbo_tasks::task::TaskOutput>::try_from_raw_vc(turbo_tasks::dynamic_call(
            *COMPLETION_IMPL_IMMUTABLE_FUNCTION_ID,
            inputs as std::boxed::Box<dyn turbo_tasks::MagicAny>,
            persistence,
        ))
    }
}
#[doc(hidden)]
impl Completion {
    #[allow(declare_interior_mutable_const)]
    #[doc(hidden)]
    const COMPLETION_IMPL_IMMUTABLE_FUNCTION: turbo_tasks::macro_helpers::Lazy<
        turbo_tasks::NativeFunction,
    > = turbo_tasks::macro_helpers::Lazy::new(|| {
        #[allow(deprecated)]
        turbo_tasks::NativeFunction::new_function(
            "Completion::immutable".to_owned(),
            turbo_tasks::FunctionMeta { local_cells: false },
            <Completion>::immutable_turbo_tasks_function_inline,
        )
    });
    #[allow(declare_interior_mutable_const)]
    #[doc(hidden)]
    const COMPLETION_IMPL_IMMUTABLE_FUNCTION_ID: turbo_tasks::macro_helpers::Lazy<
        turbo_tasks::FunctionId,
    > = turbo_tasks::macro_helpers::Lazy::new(|| {
        turbo_tasks::registry::get_function_id(&*COMPLETION_IMPL_IMMUTABLE_FUNCTION)
    });
    #[doc = " This will always be the same and never invalidates the reading task."]
    #[doc(hidden)]
    #[deprecated(
        note = "This function is only exposed for use in macros. Do not call it directly."
    )]
    pub(self) fn immutable_turbo_tasks_function_inline() -> Vc<Self> {
        Completion::cell(Completion)
    }
}
#[doc(hidden)]
pub(crate) static COMPLETION_IMPL_IMMUTABLE_FUNCTION: turbo_tasks::macro_helpers::Lazy<
    turbo_tasks::NativeFunction,
> = <Completion>::COMPLETION_IMPL_IMMUTABLE_FUNCTION;
#[doc(hidden)]
pub(crate) static COMPLETION_IMPL_IMMUTABLE_FUNCTION_ID: turbo_tasks::macro_helpers::Lazy<
    turbo_tasks::FunctionId,
> = <Completion>::COMPLETION_IMPL_IMMUTABLE_FUNCTION_ID;
```

## After

```
// ===========================================
// Recursive expansion of the value_impl macro
// ===========================================

impl Completion {
    #[doc = " This will always be the same and never invalidates the reading task."]
    pub fn immutable() -> Vc<Self> {
        let inputs = std::boxed::Box::new(());
        let persistence =
            turbo_tasks::macro_helpers::get_non_local_persistence_from_inputs(&*inputs);
        <Vc<Self> as turbo_tasks::task::TaskOutput>::try_from_raw_vc(turbo_tasks::dynamic_call(
            *COMPLETION_IMPL_IMMUTABLE_FUNCTION_ID,
            inputs as std::boxed::Box<dyn turbo_tasks::MagicAny>,
            persistence,
        ))
    }
}
#[doc(hidden)]
impl Completion {
    #[doc = " This will always be the same and never invalidates the reading task."]
    #[doc(hidden)]
    #[deprecated(
        note = "This function is only exposed for use in macros. Do not call it directly."
    )]
    pub(self) fn immutable_turbo_tasks_function_inline() -> Vc<Self> {
        Completion::cell(Completion)
    }
}
#[doc(hidden)]
pub(crate) static COMPLETION_IMPL_IMMUTABLE_FUNCTION: turbo_tasks::macro_helpers::Lazy<
    turbo_tasks::NativeFunction,
> = turbo_tasks::macro_helpers::Lazy::new(|| {
    #[allow(deprecated)]
    turbo_tasks::NativeFunction::new_function(
        "Completion::immutable".to_owned(),
        turbo_tasks::FunctionMeta { local_cells: false },
        <Completion>::immutable_turbo_tasks_function_inline,
    )
});
#[doc(hidden)]
pub(crate) static COMPLETION_IMPL_IMMUTABLE_FUNCTION_ID: turbo_tasks::macro_helpers::Lazy<
    turbo_tasks::FunctionId,
> = turbo_tasks::macro_helpers::Lazy::new(|| {
    turbo_tasks::registry::get_function_id(&*COMPLETION_IMPL_IMMUTABLE_FUNCTION)
});
```

Closes PACK-3659