### PR TITLE
refactor(turbo-tasks-macros): Strip (already hidden) doc attributes from inline function signatures

### DIFF
--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -10,9 +10,9 @@ use syn::{
     spanned::Spanned,
     token::Paren,
     visit_mut::VisitMut,
-    AngleBracketedGenericArguments, Block, Expr, ExprBlock, ExprPath, FnArg, GenericArgument,
-    Local, Meta, Pat, PatIdent, PatType, Path, PathArguments, PathSegment, Receiver, ReturnType,
-    Signature, Stmt, Token, Type, TypeGroup, TypePath, TypeTuple,
+    AngleBracketedGenericArguments, Attribute, Block, Expr, ExprBlock, ExprPath, FnArg,
+    GenericArgument, Local, Meta, Pat, PatIdent, PatType, Path, PathArguments, PathSegment,
+    Receiver, ReturnType, Signature, Stmt, Token, Type, TypeGroup, TypePath, TypeTuple,
 };
 
 #[derive(Debug)]
@@ -1019,4 +1019,14 @@ impl NativeFn {
             turbo_tasks::registry::get_function_id(&*#native_function_id_path)
         }
     }
+}
+
+pub fn filter_inline_attributes<'a>(
+    attrs: impl IntoIterator<Item = &'a Attribute>,
+) -> Vec<&'a Attribute> {
+    // inline functions use #[doc(hidden)], so it's not useful to preserve/duplicate docs
+    attrs
+        .into_iter()
+        .filter(|attr| attr.path.get_ident().is_none_or(|id| id != "doc"))
+        .collect()
 }

--- a/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
@@ -3,7 +3,9 @@ use quote::quote;
 use syn::{parse_macro_input, parse_quote, ItemFn};
 use turbo_tasks_macros_shared::{get_native_function_id_ident, get_native_function_ident};
 
-use crate::func::{DefinitionContext, FunctionArguments, NativeFn, TurboFn};
+use crate::func::{
+    filter_inline_attributes, DefinitionContext, FunctionArguments, NativeFn, TurboFn,
+};
 
 /// This macro generates the virtual function that powers turbo tasks.
 /// An annotated task is replaced with a stub function that returns a
@@ -50,6 +52,7 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
 
     let inline_function_ident = turbo_fn.inline_ident();
     let (inline_signature, inline_block) = turbo_fn.inline_signature_and_block(&block);
+    let inline_attrs = filter_inline_attributes(&attrs[..]);
 
     let native_fn = NativeFn::new(
         &ident.to_string(),
@@ -72,7 +75,7 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
         #(#attrs)*
         #vis #exposed_signature #exposed_block
 
-        #(#attrs)*
+        #(#inline_attrs)*
         #[doc(hidden)]
         #inline_signature #inline_block
 

--- a/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -9,7 +9,9 @@ use turbo_tasks_macros_shared::{
     get_trait_type_id_ident, get_trait_type_ident, ValueTraitArguments,
 };
 
-use crate::func::{DefinitionContext, FunctionArguments, NativeFn, TurboFn};
+use crate::func::{
+    filter_inline_attributes, DefinitionContext, FunctionArguments, NativeFn, TurboFn,
+};
 
 pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
     let ValueTraitArguments {
@@ -114,6 +116,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
             let inline_extension_trait_ident =
                 Ident::new(&format!("{}_{}_inline", trait_ident, ident), ident.span());
             let (inline_signature, inline_block) = turbo_fn.inline_signature_and_block(default);
+            let inline_attrs = filter_inline_attributes(&attrs[..]);
 
             let native_function = NativeFn::new(
                 &format!("{trait_ident}::{ident}"),
@@ -146,7 +149,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
                 #[doc(hidden)]
                 #[allow(non_camel_case_types)]
                 trait #inline_extension_trait_ident: std::marker::Send {
-                    #(#attrs)*
+                    #(#inline_attrs)*
                     #inline_signature;
                 }
 
@@ -155,7 +158,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
                 // in the inline signature.
                 impl #inline_extension_trait_ident for Box<dyn #trait_ident> {
                     // put the function body here so that `Self` points to `Box<dyn ...>`
-                    #(#attrs)*
+                    #(#inline_attrs)*
                     #inline_signature #inline_block
                 }
 


### PR DESCRIPTION
A minor optimization to the generated code. We were duplicating doc comments on the hidden `_turbo_tasks_function_inline` versions of functions.

We only need the docs on the public function.

This change should mean *slightly* less code for the macro to emit, and *slightly* less code for rustc to parse.

## Before

```
// ===========================================
// Recursive expansion of the value_impl macro
// ===========================================

impl Completion {
    #[doc = " This will always be the same and never invalidates the reading task."]
    pub fn immutable() -> Vc<Self> {
        let inputs = std::boxed::Box::new(());
        let persistence =
            turbo_tasks::macro_helpers::get_non_local_persistence_from_inputs(&*inputs);
        <Vc<Self> as turbo_tasks::task::TaskOutput>::try_from_raw_vc(turbo_tasks::dynamic_call(
            *COMPLETION_IMPL_IMMUTABLE_FUNCTION_ID,
            inputs as std::boxed::Box<dyn turbo_tasks::MagicAny>,
            persistence,
        ))
    }
}
#[doc(hidden)]
impl Completion {
    #[doc = " This will always be the same and never invalidates the reading task."]
    #[doc(hidden)]
    #[deprecated(
        note = "This function is only exposed for use in macros. Do not call it directly."
    )]
    pub(self) fn immutable_turbo_tasks_function_inline() -> Vc<Self> {
        Completion::cell(Completion)
    }
}
#[doc(hidden)]
pub(crate) static COMPLETION_IMPL_IMMUTABLE_FUNCTION: turbo_tasks::macro_helpers::Lazy<
    turbo_tasks::NativeFunction,
> = turbo_tasks::macro_helpers::Lazy::new(|| {
    #[allow(deprecated)]
    turbo_tasks::NativeFunction::new_function(
        "Completion::immutable".to_owned(),
        turbo_tasks::FunctionMeta { local_cells: false },
        <Completion>::immutable_turbo_tasks_function_inline,
    )
});
#[doc(hidden)]
pub(crate) static COMPLETION_IMPL_IMMUTABLE_FUNCTION_ID: turbo_tasks::macro_helpers::Lazy<
    turbo_tasks::FunctionId,
> = turbo_tasks::macro_helpers::Lazy::new(|| {
    turbo_tasks::registry::get_function_id(&*COMPLETION_IMPL_IMMUTABLE_FUNCTION)
});
```

## After

```
// ===========================================
// Recursive expansion of the value_impl macro
// ===========================================

impl Completion {
    #[doc = " This will always be the same and never invalidates the reading task."]
    pub fn immutable() -> Vc<Self> {
        let inputs = std::boxed::Box::new(());
        let persistence =
            turbo_tasks::macro_helpers::get_non_local_persistence_from_inputs(&*inputs);
        <Vc<Self> as turbo_tasks::task::TaskOutput>::try_from_raw_vc(turbo_tasks::dynamic_call(
            *COMPLETION_IMPL_IMMUTABLE_FUNCTION_ID,
            inputs as std::boxed::Box<dyn turbo_tasks::MagicAny>,
            persistence,
        ))
    }
}
#[doc(hidden)]
impl Completion {
    #[doc(hidden)]
    #[deprecated(
        note = "This function is only exposed for use in macros. Do not call it directly."
    )]
    pub(self) fn immutable_turbo_tasks_function_inline() -> Vc<Self> {
        Completion::cell(Completion)
    }
}
#[doc(hidden)]
pub(crate) static COMPLETION_IMPL_IMMUTABLE_FUNCTION: turbo_tasks::macro_helpers::Lazy<
    turbo_tasks::NativeFunction,
> = turbo_tasks::macro_helpers::Lazy::new(|| {
    #[allow(deprecated)]
    turbo_tasks::NativeFunction::new_function(
        "Completion::immutable".to_owned(),
        turbo_tasks::FunctionMeta { local_cells: false },
        <Completion>::immutable_turbo_tasks_function_inline,
    )
});
#[doc(hidden)]
pub(crate) static COMPLETION_IMPL_IMMUTABLE_FUNCTION_ID: turbo_tasks::macro_helpers::Lazy<
    turbo_tasks::FunctionId,
> = turbo_tasks::macro_helpers::Lazy::new(|| {
    turbo_tasks::registry::get_function_id(&*COMPLETION_IMPL_IMMUTABLE_FUNCTION)
});
```

Closes PACK-3660