### PR TITLE
fix(turbo): sassOptions `silenceDeprecations` was not overwritten with user options

### DIFF
--- a/crates/next-core/src/next_shared/webpack_rules/sass.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/sass.rs
@@ -16,10 +16,13 @@ pub async fn maybe_add_sass_loader(
         bail!("sass_options must be an object");
     };
     // TODO: Remove this once we upgrade to sass-loader 16
-    sass_options.insert(
-        "silenceDeprecations".into(),
-        serde_json::json!(["legacy-js-api"]),
-    );
+    let silence_deprecations = if let Some(v) = sass_options.get("silenceDeprecations") {
+        v.clone()
+    } else {
+        serde_json::json!(["legacy-js-api"])
+    };
+
+    sass_options.insert("silenceDeprecations".into(), silence_deprecations);
     let mut rules = if let Some(webpack_rules) = webpack_rules {
         webpack_rules.await?.clone_value()
     } else {


### PR DESCRIPTION
### Why?

The user's `silenceDeprecations` option was not overwritten in turbopack, only the `legacy-js-api` was passed.

Thanks to @mzronek for reporting at https://github.com/vercel/next.js/issues/71638#issuecomment-2539967913!