### PR TITLE
docs: fixed regex for parsing base64String, and updated subscribeToPush function.

### DIFF
--- a/docs/01-app/03-building-your-application/07-configuring/16-progressive-web-apps.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/16-progressive-web-apps.mdx
@@ -103,9 +103,7 @@ import { subscribeUser, unsubscribeUser, sendNotification } from './actions'
 
 function urlBase64ToUint8Array(base64String: string) {
   const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
-  const base64 = (base64String + padding)
-    .replace(/-/g, '+')
-    .replace(/_/g, '/')
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
 
   const rawData = window.atob(base64)
   const outputArray = new Uint8Array(rawData.length)

--- a/docs/01-app/03-building-your-application/07-configuring/16-progressive-web-apps.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/16-progressive-web-apps.mdx
@@ -104,7 +104,7 @@ import { subscribeUser, unsubscribeUser, sendNotification } from './actions'
 function urlBase64ToUint8Array(base64String: string) {
   const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
   const base64 = (base64String + padding)
-    .replace(/\\-/g, '+')
+    .replace(/-/g, '+')
     .replace(/_/g, '/')
 
   const rawData = window.atob(base64)
@@ -174,7 +174,8 @@ function PushNotificationManager() {
       ),
     })
     setSubscription(sub)
-    await subscribeUser(sub)
+    const serializedSub = JSON.parse(JSON.stringify(sub))
+    await subscribeUser(serializedSub)
   }
 
   async function unsubscribeFromPush() {


### PR DESCRIPTION
### What?

Change 1:
At line 107, the regex code is now fixed to replace all "-" with "+", which wasn't as expected with previous code, window.atob() would throw an error saying the string is not encoded properly. The variable base64 will now have a URL safe base64String.

Change 2:
At line 177 and 178, the function is now updated to call the server action subscribeUser() with a serialized object instead of a PushSubscription object, as server actions can only be called with serialized objects.

### Why?

I followed to docs to setup a PWA project with next, and I encountered issues with the code mentioned in the documentation.

### How?

The fixed code snippets will work as expected, and anyone following the docs later can find them helpful.
