### PR TITLE
docs(redirect): add typescript example and fix params as promise

### DIFF
--- a/docs/01-app/04-api-reference/04-functions/redirect.mdx
+++ b/docs/01-app/04-api-reference/04-functions/redirect.mdx
@@ -44,7 +44,32 @@ The `type` parameter has no effect when used in Server Components.
 
 Invoking the `redirect()` function throws a `NEXT_REDIRECT` error and terminates rendering of the route segment in which it was thrown.
 
-```jsx filename="app/team/[id]/page.js"
+```tsx filename="app/team/[id]/page.tsx" switcher
+import { redirect } from 'next/navigation'
+
+async function fetchTeam(id: string) {
+  const res = await fetch('https://...')
+  if (!res.ok) return undefined
+  return res.json()
+}
+
+export default async function Profile({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const team = await fetchTeam(id)
+
+  if (!team) {
+    redirect('/login')
+  }
+
+  // ...
+}
+```
+
+```jsx filename="app/team/[id]/page.js" switcher
 import { redirect } from 'next/navigation'
 
 async function fetchTeam(id) {
@@ -54,7 +79,9 @@ async function fetchTeam(id) {
 }
 
 export default async function Profile({ params }) {
-  const team = await fetchTeam(params.id)
+  const { id } = await params
+  const team = await fetchTeam(id)
+
   if (!team) {
     redirect('/login')
   }


### PR DESCRIPTION
Hi Team.

This PR enhances the redirect function documentation by adding TypeScript examples, and fixing the examples where the params object was destructured without being awaited.