### PR TITLE
Add feature flag for new dev overlay

### DIFF
--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -288,6 +288,8 @@ export function getDefineEnv({
             needsExperimentalReact(config),
         }
       : undefined),
+    'process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY':
+      config.experimental.newDevOverlay ?? false,
   }
 
   const userDefines = config.compiler?.define ?? {}

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -439,6 +439,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         typedEnv: z.boolean().optional(),
         serverComponentsHmrCache: z.boolean().optional(),
         authInterrupts: z.boolean().optional(),
+        newDevOverlay: z.boolean().optional(),
       })
       .optional(),
     exportPathMap: z

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -562,6 +562,11 @@ export interface ExperimentalConfig {
    * This config allows you to enable the experimental navigation API `forbidden` and `unauthorized`.
    */
   authInterrupts?: boolean
+
+  /**
+   * Enables the new dev overlay.
+   */
+  newDevOverlay?: boolean
 }
 
 export type ExportPathMap = {
@@ -1163,6 +1168,7 @@ export const defaultConfig: NextConfig = {
     staticGenerationMinPagesPerWorker: 25,
     dynamicIO: false,
     inlineCss: false,
+    newDevOverlay: false,
   },
   bundlePagesRouterDependencies: false,
 }


### PR DESCRIPTION
This PR enabled feature flag for the new dev overlay, no behavioral change.

- Added `experimental.newDevOverlay` Next.js option, which handles `__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY` env value.
- Added `__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY` env to be resolved at build time so that it can be used to render the overlay conditionally 

Closes NDX-560