### PR TITLE
Restore RSC fetch error handling after navigating back

### DIFF
--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -93,22 +93,23 @@ function doMpaNavigation(url: string): FetchServerResponseResult {
   }
 }
 
-// TODO: Figure out why this module is included in server page bundles.
-const win = typeof window === 'undefined' ? undefined : window
 let abortController = new AbortController()
 
-// Abort any in-flight requests when the page is unloaded, e.g. due to reloading
-// the page or performing hard navigations. This allows us to ignore what would
-// otherwise be a thrown TypeError when the browser cancels the requests.
-win?.addEventListener('pagehide', () => {
-  abortController.abort()
-})
+if (typeof window !== 'undefined') {
+  // Abort any in-flight requests when the page is unloaded, e.g. due to
+  // reloading the page or performing hard navigations. This allows us to ignore
+  // what would otherwise be a thrown TypeError when the browser cancels the
+  // requests.
+  window.addEventListener('pagehide', () => {
+    abortController.abort()
+  })
 
-// Use a fresh AbortController instance on pageshow, e.g. when navigating back
-// and the JavaScript execution context is restored by the browser.
-win?.addEventListener('pageshow', () => {
-  abortController = new AbortController()
-})
+  // Use a fresh AbortController instance on pageshow, e.g. when navigating back
+  // and the JavaScript execution context is restored by the browser.
+  window.addEventListener('pageshow', () => {
+    abortController = new AbortController()
+  })
+}
 
 /**
  * Fetch the flight data for the provided url. Takes in the current router state

--- a/test/e2e/app-dir/app-prefetch/app/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/page.js
@@ -14,6 +14,9 @@ export default function HomePage() {
       <Link href="/prefetch-auto/foobar" id="to-dynamic-page">
         To Dynamic Slug Page
       </Link>
+      <a href="/static-page" id="to-static-page-hard">
+        Hard Nav to Static Page
+      </a>
     </>
   )
 }

--- a/test/e2e/app-dir/app-prefetch/app/static-page/back-button.js
+++ b/test/e2e/app-dir/app-prefetch/app/static-page/back-button.js
@@ -1,0 +1,15 @@
+'use client'
+
+export function BackButton() {
+  return (
+    <button
+      type="button"
+      id="go-back"
+      onClick={() => {
+        window.history.back()
+      }}
+    >
+      Go back
+    </button>
+  )
+}

--- a/test/e2e/app-dir/app-prefetch/app/static-page/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/static-page/page.js
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { BackButton } from './back-button'
 
 export default async function Page() {
   return (
@@ -13,6 +14,9 @@ export default async function Page() {
         <Link href="/static-page" prefetch>
           To Same Page
         </Link>
+      </p>
+      <p>
+        <BackButton />
       </p>
     </>
   )


### PR DESCRIPTION
As a follow-up to #73975, we're now restoring the error handling for failed RSC fetch calls when the user navigates back after a hard navigation. In this case the browser uses the bfcache to restore the previous JavaScript execution context, and thus the abort controller will still be in the aborted state. To take this into account, we're now creating a new `AbortController` instance on `'pageshow'` events.

In addition, the abort controller's `signal` is now actually passed to the `fetch` call, and not only used for the error handling, so that the requests are aborted on `'pagehide'`. This was an oversight in the original PR. With that, it's even more important to create a fresh abort controller, otherwise RSC fetching would be disabled after back navigation.

The added e2e test can only run in headed mode unfortunately, as the bfcache is not available in headless mode. (Using the same approach as in #54081.)