### PR TITLE
Fix double rendering of ReactDevOverlay when required root tags are missing

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -239,19 +239,26 @@ export function hydrate() {
     </StrictModeIfEnabled>
   )
 
-  if (shouldRenderRootLevelErrorOverlay()) {
-    if (process.env.NODE_ENV !== 'production') {
+  if (
+    document.documentElement.id === '__next_error__' ||
+    !!window.__next_root_layout_missing_tags?.length
+  ) {
+    let element = reactEl
+    // Server rendering failed, fall back to client-side rendering
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      shouldRenderRootLevelErrorOverlay()
+    ) {
       const { createRootLevelDevOverlayElement } =
         require('./components/react-dev-overlay/client-entry') as typeof import('./components/react-dev-overlay/client-entry')
-      const errorTree = createRootLevelDevOverlayElement(reactEl)
-      ReactDOMClient.createRoot(appElement as any, reactRootOptions).render(
-        errorTree
-      )
-    } else {
-      ReactDOMClient.createRoot(appElement as any, reactRootOptions).render(
-        reactEl
-      )
+
+      // Note this won't cause hydration mismatch because we are doing CSR w/o hydration
+      element = createRootLevelDevOverlayElement(element)
     }
+
+    ReactDOMClient.createRoot(appElement as any, reactRootOptions).render(
+      element
+    )
   } else {
     React.startTransition(() =>
       (ReactDOMClient as any).hydrateRoot(appElement, reactEl, {

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -25,6 +25,7 @@ import type { InitialRSCPayload } from '../server/app-render/types'
 import { createInitialRouterState } from './components/router-reducer/create-initial-router-state'
 import { MissingSlotContext } from '../shared/lib/app-router-context.shared-runtime'
 import { setAppBuildId } from './app-build-id'
+import { isErrorThrownWhileRenderingRsc } from './lib/is-error-thrown-while-rendering-rsc'
 
 /// <reference types="react-dom/experimental" />
 
@@ -238,13 +239,7 @@ export function hydrate() {
     </StrictModeIfEnabled>
   )
 
-  const rootLayoutMissingTags = window.__next_root_layout_missing_tags
-  const hasMissingTags = !!rootLayoutMissingTags?.length
-
-  const isError =
-    document.documentElement.id === '__next_error__' || hasMissingTags
-
-  if (isError) {
+  if (isErrorThrownWhileRenderingRsc()) {
     if (process.env.NODE_ENV !== 'production') {
       const createDevOverlayElement =
         require('./components/react-dev-overlay/client-entry').createDevOverlayElement

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -25,7 +25,8 @@ import type { InitialRSCPayload } from '../server/app-render/types'
 import { createInitialRouterState } from './components/router-reducer/create-initial-router-state'
 import { MissingSlotContext } from '../shared/lib/app-router-context.shared-runtime'
 import { setAppBuildId } from './app-build-id'
-import { isErrorThrownWhileRenderingRsc } from './lib/is-error-thrown-while-rendering-rsc'
+import { shouldRenderRootLevelErrorOverlay } from './lib/is-error-thrown-while-rendering-rsc'
+import type * as ReactDevOverlayClientEntryModule from './components/react-dev-overlay/client-entry'
 
 /// <reference types="react-dom/experimental" />
 
@@ -239,11 +240,11 @@ export function hydrate() {
     </StrictModeIfEnabled>
   )
 
-  if (isErrorThrownWhileRenderingRsc()) {
+  if (shouldRenderRootLevelErrorOverlay()) {
     if (process.env.NODE_ENV !== 'production') {
-      const createDevOverlayElement =
-        require('./components/react-dev-overlay/client-entry').createDevOverlayElement
-      const errorTree = createDevOverlayElement(reactEl)
+      const { createRootLevelDevOverlayElement } =
+        require('./components/react-dev-overlay/client-entry') as typeof ReactDevOverlayClientEntryModule
+      const errorTree = createRootLevelDevOverlayElement(reactEl)
       ReactDOMClient.createRoot(appElement as any, reactRootOptions).render(
         errorTree
       )

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -26,7 +26,6 @@ import { createInitialRouterState } from './components/router-reducer/create-ini
 import { MissingSlotContext } from '../shared/lib/app-router-context.shared-runtime'
 import { setAppBuildId } from './app-build-id'
 import { shouldRenderRootLevelErrorOverlay } from './lib/is-error-thrown-while-rendering-rsc'
-import type * as ReactDevOverlayClientEntryModule from './components/react-dev-overlay/client-entry'
 
 /// <reference types="react-dom/experimental" />
 
@@ -243,7 +242,7 @@ export function hydrate() {
   if (shouldRenderRootLevelErrorOverlay()) {
     if (process.env.NODE_ENV !== 'production') {
       const { createRootLevelDevOverlayElement } =
-        require('./components/react-dev-overlay/client-entry') as typeof ReactDevOverlayClientEntryModule
+        require('./components/react-dev-overlay/client-entry') as typeof import('./components/react-dev-overlay/client-entry')
       const errorTree = createRootLevelDevOverlayElement(reactEl)
       ReactDOMClient.createRoot(appElement as any, reactRootOptions).render(
         errorTree

--- a/packages/next/src/client/components/react-dev-overlay/client-entry.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/client-entry.tsx
@@ -6,7 +6,7 @@ import { HMR_ACTIONS_SENT_TO_BROWSER } from '../../../server/dev/hot-reloader-ty
 
 // if an error is thrown while rendering an RSC stream, this will catch it in dev
 // and show the error overlay
-export function createDevOverlayElement(reactEl: React.ReactElement) {
+export function createRootLevelDevOverlayElement(reactEl: React.ReactElement) {
   const rootLayoutMissingTags = window.__next_root_layout_missing_tags
   const hasMissingTags = !!rootLayoutMissingTags?.length
   const socketUrl = getSocketUrl(process.env.__NEXT_ASSET_PREFIX || '')

--- a/packages/next/src/client/lib/is-error-thrown-while-rendering-rsc.ts
+++ b/packages/next/src/client/lib/is-error-thrown-while-rendering-rsc.ts
@@ -1,0 +1,6 @@
+export const isErrorThrownWhileRenderingRsc = () => {
+  return (
+    window.document.documentElement.id === '__next_error__' ||
+    !!window.__next_root_layout_missing_tags?.length
+  )
+}

--- a/packages/next/src/client/lib/is-error-thrown-while-rendering-rsc.ts
+++ b/packages/next/src/client/lib/is-error-thrown-while-rendering-rsc.ts
@@ -1,6 +1,3 @@
-export const isErrorThrownWhileRenderingRsc = () => {
-  return (
-    window.document.documentElement.id === '__next_error__' ||
-    !!window.__next_root_layout_missing_tags?.length
-  )
+export const shouldRenderRootLevelErrorOverlay = () => {
+  return !!window.__next_root_layout_missing_tags?.length
 }

--- a/test/development/app-dir/missing-required-html-tags/index.test.ts
+++ b/test/development/app-dir/missing-required-html-tags/index.test.ts
@@ -13,6 +13,13 @@ describe('app-dir - missing required html tags', () => {
   it('should show error overlay', async () => {
     const browser = await next.browser('/')
 
+    // There was a bug where multiple dialogs were being rendered when required
+    // html tags were missing. This test ensures there is no regression.
+    await retry(async () => {
+      const dialogs = await browser.elementsByCss('nextjs-portal')
+      expect(dialogs).toHaveLength(1)
+    })
+
     await assertHasRedbox(browser)
     expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(`
       "The following tags are missing in the Root Layout: <html>, <body>.


### PR DESCRIPTION
When required tags like `<html>` are missing in the root layout, two identical `ReactDevOverlay` components are rendered. The issue was that `ReactDevOverlay` is rendered as usual under `HotReload`, while `createDevOverlayElement` also renders it at the root of the application. The fix is to not render the second `ReactDevOverlay`.

Confirmed that the test would break for the unfixed version:

![CleanShot 2024-12-16 at 15 19 34@2x](https://github.com/user-attachments/assets/d2507042-3e0f-47f7-9ea1-b81518dc03ed)
