### PR TITLE
[metadata] Separate bots detection utils

### DIFF
--- a/packages/next/src/shared/lib/router/utils/is-bot.ts
+++ b/packages/next/src/shared/lib/router/utils/is-bot.ts
@@ -2,9 +2,8 @@
 const HEADLESS_BOT_UA_RE =
   /Googlebot|Google-PageRenderer|AdsBot-Google|googleweblight|Storebot-Google/i
 
-// This regex contains the bots that we need to do static rendering for.
-// - Static fetcher bot crawler that doesn't spin up a headless browser or execute JS
-// - Bots that possible can do headless browser crawling but the crawler is limited to some restrictions.
+// This regex contains the bots that we need to do a blocking render for and can't safely stream the response
+// due to how they parse the DOM. For example, they might explicitly check for metadata in the `head` tag, so we can't stream metadata tags after the `head` was sent.
 const HTML_LIMITED_BOT_UA_RE =
   /Mediapartners-Google|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview/i
 

--- a/packages/next/src/shared/lib/router/utils/is-bot.ts
+++ b/packages/next/src/shared/lib/router/utils/is-bot.ts
@@ -1,19 +1,21 @@
-// Bot crawler that will spin up a headless browser
+// Bot crawler that will spin up a headless browser and execute JS
 const HEADLESS_BOT_UA_RE =
-  /Googlebot|Google-PageRenderer|AdsBot-Google|googleweblight|Storebot-Google|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview/i
+  /Googlebot|Google-PageRenderer|AdsBot-Google|googleweblight|Storebot-Google/i
 
-// Static fetcher bot crawler that doesn't spin up a headless browser or execute JS
-const STATIC_FETCHER_BOT_UA_RE =
-  /Mediapartners-Google|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver/i
+// This regex contains the bots that we need to do static rendering for.
+// - Static fetcher bot crawler that doesn't spin up a headless browser or execute JS
+// - Bots that possible can do headless browser crawling but the crawler is limited to some restrictions.
+const HTML_LIMITED_BOT_UA_RE =
+  /Mediapartners-Google|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview/i
 
 function isHeadlessBrowserBot(userAgent: string) {
   return HEADLESS_BOT_UA_RE.test(userAgent)
 }
 
-function isNonBrowserBot(userAgent: string) {
-  return STATIC_FETCHER_BOT_UA_RE.test(userAgent)
+function isHtmlLimitedBot(userAgent: string) {
+  return HTML_LIMITED_BOT_UA_RE.test(userAgent)
 }
 
 export function isBot(userAgent: string): boolean {
-  return isHeadlessBrowserBot(userAgent) || isNonBrowserBot(userAgent)
+  return isHeadlessBrowserBot(userAgent) || isHtmlLimitedBot(userAgent)
 }

--- a/packages/next/src/shared/lib/router/utils/is-bot.ts
+++ b/packages/next/src/shared/lib/router/utils/is-bot.ts
@@ -1,6 +1,19 @@
-const BOT_UA_RE =
-  /Googlebot|Mediapartners-Google|AdsBot-Google|googleweblight|Storebot-Google|Google-PageRenderer|Bingbot|BingPreview|Slurp|DuckDuckBot|baiduspider|yandex|sogou|LinkedInBot|bitlybot|tumblr|vkShare|quora link preview|facebookexternalhit|facebookcatalog|Twitterbot|applebot|redditbot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|ia_archiver/i
+// Bot crawler that will spin up a headless browser
+const HEADLESS_BOT_UA_RE =
+  /Googlebot|Google-PageRenderer|AdsBot-Google|googleweblight|Storebot-Google|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview/i
+
+// Static fetcher bot crawler that doesn't spin up a headless browser or execute JS
+const STATIC_FETCHER_BOT_UA_RE =
+  /Mediapartners-Google|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver/i
+
+function isHeadlessBrowserBot(userAgent: string) {
+  return HEADLESS_BOT_UA_RE.test(userAgent)
+}
+
+function isNonBrowserBot(userAgent: string) {
+  return STATIC_FETCHER_BOT_UA_RE.test(userAgent)
+}
 
 export function isBot(userAgent: string): boolean {
-  return BOT_UA_RE.test(userAgent)
+  return isHeadlessBrowserBot(userAgent) || isNonBrowserBot(userAgent)
 }


### PR DESCRIPTION
### What

We have two types of bots as crawlers, headless browser bots and static fetcher bots. 

- The headless browser ones they're able to spin up a headless browser to open the website and execute javascript. If there's any JS manipulated metadata, it can still handle it.
- The static fetcher ones can only handle the static html, rather than parsing and executing the JS code.

This PR separates the existing util we got for bot detection into 2: one for headless browsers and one for static fetcher. Since currently we only have bots detection in pages router and it's simply just need to ensure if it's the bot. So the final exported bot util didn't change its own implementation, still checking if it's either a headless browser or static fetcher. We'll use them for later implementation

Closes NDX-538