### PR TITLE
Turbopack: use old client reference collection implementation

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -18,7 +18,10 @@ use next_core::{
         get_client_module_options_context, get_client_resolve_options_context,
         get_client_runtime_entries, ClientContextType, RuntimeEntries,
     },
-    next_client_reference::{ClientReferenceGraphResult, NextEcmascriptClientReferenceTransition},
+    next_client_reference::{
+        client_reference_graph, find_server_entries, ClientReferenceGraphResult,
+        NextEcmascriptClientReferenceTransition, ServerEntries, VisitedClientReferenceGraphNodes,
+    },
     next_config::NextConfig,
     next_dynamic::NextDynamicTransition,
     next_edge::route_regex::get_named_middleware_regex,
@@ -954,8 +957,36 @@ impl AppEndpoint {
                     .get_next_dynamic_imports_for_endpoint(*rsc_entry)
                     .await?;
 
-                let client_references_cell =
-                    reduced_graphs.get_client_references_for_endpoint(*rsc_entry);
+                let client_references_old = {
+                    let ServerEntries {
+                        server_component_entries,
+                        server_utils,
+                    } = &*find_server_entries(*rsc_entry).await?;
+
+                    let mut client_references = client_reference_graph(
+                        server_utils.iter().map(|&v| *v).collect(),
+                        VisitedClientReferenceGraphNodes::empty(),
+                    )
+                    .await?
+                    .clone_value();
+
+                    for module in server_component_entries
+                        .iter()
+                        .map(|m| ResolvedVc::upcast::<Box<dyn Module>>(*m))
+                        .chain(std::iter::once(rsc_entry))
+                    {
+                        let current_client_references =
+                            client_reference_graph(vec![*module], *client_references.visited_nodes)
+                                .await?;
+
+                        client_references.extend(&current_client_references);
+                    }
+                    client_references
+                };
+                let client_references_cell = client_references_old.cell();
+                // TODO revert this once client references shared between layout segments work.
+                // let client_references_cell =
+                //     reduced_graphs.get_client_references_for_endpoint(*rsc_entry);
 
                 let client_references_chunks = get_app_client_references_chunks(
                     client_references_cell,

--- a/test/e2e/app-dir/app-css/app/css/css-page-shared-loading/loading.js
+++ b/test/e2e/app-dir/app-css/app/css/css-page-shared-loading/loading.js
@@ -1,0 +1,12 @@
+import styles from './style.module.css'
+
+export default function Page() {
+  return (
+    <>
+      <h1>Loading</h1>
+      <div id="cssm" className={styles.mod}>
+        CSSM
+      </div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-css/app/css/css-page-shared-loading/page.js
+++ b/test/e2e/app-dir/app-css/app/css/css-page-shared-loading/page.js
@@ -1,0 +1,12 @@
+import styles from './style.module.css'
+
+export default function Page() {
+  return (
+    <>
+      <h1>Page</h1>
+      <div id="cssm" className={styles.mod}>
+        CSSM
+      </div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-css/app/css/css-page-shared-loading/style.module.css
+++ b/test/e2e/app-dir/app-css/app/css/css-page-shared-loading/style.module.css
@@ -1,0 +1,3 @@
+.mod {
+  color: blue;
+}

--- a/test/e2e/app-dir/app-css/index.test.ts
+++ b/test/e2e/app-dir/app-css/index.test.ts
@@ -92,6 +92,17 @@ describe('app dir - css', () => {
         const html = await next.render('/css/css-page')
         expect(html).not.toContain('/pages/_app.css')
       })
+
+      it('should support css modules shared between server pages', async () => {
+        const browser = await next.browser('/css/css-page-shared-loading')
+        await check(
+          async () =>
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('#cssm')).color`
+            ),
+          'rgb(0, 0, 255)'
+        )
+      })
     })
 
     describe('client layouts', () => {


### PR DESCRIPTION
The client reference manifest has to contain all client references for all layout segments. Currently it just contains all client references but they are attributed to the first server component that uses it.

Reverts the approach of https://github.com/vercel/next.js/pull/73322 and use the old implementation again

Closes PACK-3661