### PR TITLE
refactor: cache lowercasing all the locales

### DIFF
--- a/packages/next/src/shared/lib/i18n/normalize-locale-path.ts
+++ b/packages/next/src/shared/lib/i18n/normalize-locale-path.ts
@@ -39,7 +39,7 @@ export function normalizeLocalePath(
   // there is no further segment, there is no locale (or it's the default).
   const segments = pathname.split('/', 2)
 
-  // If there's no first segment (ie, the pathname is just `/`), there's no
+  // If there's no second segment (ie, the pathname is just `/`), there's no
   // locale.
   if (!segments[1]) return { pathname }
 

--- a/packages/next/src/shared/lib/i18n/normalize-locale-path.ts
+++ b/packages/next/src/shared/lib/i18n/normalize-locale-path.ts
@@ -4,6 +4,13 @@ export interface PathLocale {
 }
 
 /**
+ * A cache of lowercased locales for each list of locales. This is stored as a
+ * WeakMap so if the locales are garbage collected, the cache entry will be
+ * removed as well.
+ */
+const cache = new WeakMap<readonly string[], readonly string[]>()
+
+/**
  * For a pathname that may include a locale from a list of locales, it
  * removes the locale from the pathname returning it alongside with the
  * detected locale.
@@ -16,25 +23,39 @@ export function normalizeLocalePath(
   pathname: string,
   locales?: readonly string[]
 ): PathLocale {
-  let detectedLocale: string | undefined
-  // first item will be empty string from splitting at first char
-  const pathnameParts = pathname.split('/')
+  // If locales is undefined, return the pathname as is.
+  if (!locales) return { pathname }
 
-  ;(locales || []).some((locale) => {
-    if (
-      pathnameParts[1] &&
-      pathnameParts[1].toLowerCase() === locale.toLowerCase()
-    ) {
-      detectedLocale = locale
-      pathnameParts.splice(1, 1)
-      pathname = pathnameParts.join('/') || '/'
-      return true
-    }
-    return false
-  })
-
-  return {
-    pathname,
-    detectedLocale,
+  // Get the cached lowercased locales or create a new cache entry.
+  let lowercasedLocales = cache.get(locales)
+  if (!lowercasedLocales) {
+    lowercasedLocales = locales.map((locale) => locale.toLowerCase())
+    cache.set(locales, lowercasedLocales)
   }
+
+  let detectedLocale: string | undefined
+
+  // The first segment will be empty, because it has a leading `/`. If
+  // there is no further segment, there is no locale (or it's the default).
+  const segments = pathname.split('/', 2)
+
+  // If there's no first segment (ie, the pathname is just `/`), there's no
+  // locale.
+  if (!segments[1]) return { pathname }
+
+  // The second segment will contain the locale part if any.
+  const segment = segments[1].toLowerCase()
+
+  // See if the segment matches one of the locales. If it doesn't, there is
+  // no locale (or it's the default).
+  const index = lowercasedLocales.indexOf(segment)
+  if (index < 0) return { pathname }
+
+  // Return the case-sensitive locale.
+  detectedLocale = locales[index]
+
+  // Remove the `/${locale}` part of the pathname.
+  pathname = pathname.slice(detectedLocale.length + 1) || '/'
+
+  return { pathname, detectedLocale }
 }


### PR DESCRIPTION
This improves the locale normalization method used in several looping functions. This caches the lowercasing of locales so the operation is only performed once.

It also duplicates the logic from the `I18nProvider` for the more efficient locale handling.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
