### PR TITLE
fix: skip rendering dynamic root segment routes

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2788,6 +2788,16 @@ export default async function build(
                   : undefined
 
                 routes.forEach((route) => {
+                  // If the route has any dynamic root segments, we need to skip
+                  // rendering the route. This is because we don't support
+                  // revalidating the shells without the parameters present.
+                  if (
+                    route.fallbackRootParams &&
+                    route.fallbackRootParams.length > 0
+                  ) {
+                    return
+                  }
+
                   defaultMap[route.pathname] = {
                     page: originalAppPath,
                     query: { __nextSsgPath: route.encodedPathname },


### PR DESCRIPTION
Routes that contain dynamic root segments (those where the root parameter is not known at build time) should not have shells generated. This is because today there's no way to revalidate the shell for that page and it would cause cache posioning.
