### PR TITLE
Turbopack chunking: use ChunkableModules in `chunk_content`, not ChunkItems

### DIFF
--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -166,7 +166,7 @@ async fn build_manifest(
             &key,
             ActionManifestWorkerEntry {
                 module_id: ActionManifestModuleId::String(loader_id.as_str()),
-                is_async: *chunk_item.is_self_async().await?,
+                is_async: *chunk_item.module().is_self_async().await?,
             },
         );
         entry.layer.insert(&key, *layer);

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -382,7 +382,7 @@ async fn is_item_async(
         return Ok(false);
     };
 
-    let Some(info) = &*available_modules.get(module).await? else {
+    let Some(info) = &*available_modules.get(*module).await? else {
         return Ok(false);
     };
 

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -6,8 +6,8 @@ use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
-        availability_info::AvailabilityInfo, ChunkItem, ChunkItemExt, ChunkableModule,
-        ChunkingContext, ModuleId as TurbopackModuleId,
+        availability_info::AvailabilityInfo, ChunkItemExt, ChunkableModule, ChunkingContext,
+        ModuleId as TurbopackModuleId,
     },
     output::{OutputAsset, OutputAssets},
     virtual_output::VirtualOutputAsset,
@@ -75,8 +75,8 @@ impl ClientReferenceManifest {
 
                 let server_path = ecmascript_client_reference.server_ident.to_string().await?;
 
-                let client_chunk_item = ecmascript_client_reference
-                    .client_module
+                let client_module = ecmascript_client_reference.client_module;
+                let client_chunk_item = client_module
                     .as_chunk_item(Vc::upcast(client_chunking_context))
                     .to_resolved()
                     .await?;
@@ -107,8 +107,11 @@ impl ClientReferenceManifest {
                             .map(RcStr::from)
                             .collect::<Vec<_>>();
 
-                        let is_async =
-                            is_item_async(client_availability_info, client_chunk_item).await?;
+                        let is_async = is_item_async(
+                            client_availability_info,
+                            ResolvedVc::upcast(client_module),
+                        )
+                        .await?;
 
                         (chunk_paths, is_async)
                     } else {
@@ -116,19 +119,20 @@ impl ClientReferenceManifest {
                     };
 
                 if let Some(ssr_chunking_context) = ssr_chunking_context {
-                    let ssr_chunk_item = ecmascript_client_reference
-                        .ssr_module
+                    let ssr_module = ecmascript_client_reference.ssr_module;
+                    let ssr_chunk_item = ssr_module
                         .as_chunk_item(Vc::upcast(ssr_chunking_context))
                         .to_resolved()
                         .await?;
                     let ssr_module_id = ssr_chunk_item.id().await?;
 
-                    let rsc_chunk_item: ResolvedVc<Box<dyn ChunkItem>> =
-                        ResolvedVc::try_downcast_type::<EcmascriptClientReferenceProxyModule>(
-                            parent_module,
-                        )
-                        .await?
-                        .unwrap()
+                    let rsc_module = ResolvedVc::try_downcast_type::<
+                        EcmascriptClientReferenceProxyModule,
+                    >(parent_module)
+                    .await?
+                    .expect("Expected EcmascriptClientReferenceProxyModule");
+
+                    let rsc_chunk_item = rsc_module
                         .as_chunk_item(Vc::upcast(ssr_chunking_context))
                         .to_resolved()
                         .await?;
@@ -161,7 +165,9 @@ impl ClientReferenceManifest {
                             .map(RcStr::from)
                             .collect::<Vec<_>>();
 
-                        let is_async = is_item_async(ssr_availability_info, ssr_chunk_item).await?;
+                        let is_async =
+                            is_item_async(ssr_availability_info, ResolvedVc::upcast(ssr_module))
+                                .await?;
 
                         (chunk_paths, is_async)
                     } else {
@@ -188,9 +194,11 @@ impl ClientReferenceManifest {
                             .map(RcStr::from)
                             .collect::<Vec<_>>();
 
-                        let is_async =
-                            is_item_async(&rsc_app_entry_chunks_availability, rsc_chunk_item)
-                                .await?;
+                        let is_async = is_item_async(
+                            &rsc_app_entry_chunks_availability,
+                            ResolvedVc::upcast(rsc_module),
+                        )
+                        .await?;
 
                         (chunk_paths, is_async)
                     };
@@ -368,13 +376,13 @@ pub fn get_client_reference_module_key(server_path: &str, export_name: &str) -> 
 
 async fn is_item_async(
     availability_info: &AvailabilityInfo,
-    chunk_item: ResolvedVc<Box<dyn ChunkItem>>,
+    module: ResolvedVc<Box<dyn ChunkableModule>>,
 ) -> Result<bool> {
-    let Some(available_chunk_items) = availability_info.available_chunk_items() else {
+    let Some(available_chunk_items) = availability_info.available_modules() else {
         return Ok(false);
     };
 
-    let Some(info) = available_chunk_items.await?.get(chunk_item).await? else {
+    let Some(info) = *available_chunk_items.get(*module).await? else {
         return Ok(false);
     };
 

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use indoc::formatdoc;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexSet, ResolvedVc, TryJoinIterExt, Value, ValueToString, Vc};
@@ -130,7 +130,7 @@ impl ClientReferenceManifest {
                         EcmascriptClientReferenceProxyModule,
                     >(parent_module)
                     .await?
-                    .expect("Expected EcmascriptClientReferenceProxyModule");
+                    .context("Expected EcmascriptClientReferenceProxyModule")?;
 
                     let rsc_chunk_item = rsc_module
                         .as_chunk_item(Vc::upcast(ssr_chunking_context))
@@ -378,11 +378,11 @@ async fn is_item_async(
     availability_info: &AvailabilityInfo,
     module: ResolvedVc<Box<dyn ChunkableModule>>,
 ) -> Result<bool> {
-    let Some(available_chunk_items) = availability_info.available_modules() else {
+    let Some(available_modules) = availability_info.available_modules() else {
         return Ok(false);
     };
 
-    let Some(info) = *available_chunk_items.get(*module).await? else {
+    let Some(info) = &*available_modules.get(module).await? else {
         return Ok(false);
     };
 

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -422,11 +422,9 @@ impl ChunkingContext for BrowserChunkingContext {
                     AvailabilityInfo::Untracked => {
                         ident = ident.with_modifier(Vc::cell("untracked".into()));
                     }
-                    AvailabilityInfo::Complete {
-                        available_chunk_items,
-                    } => {
+                    AvailabilityInfo::Complete { available_modules } => {
                         ident = ident.with_modifier(Vc::cell(
-                            available_chunk_items.hash().await?.to_string().into(),
+                            available_modules.hash().await?.to_string().into(),
                         ));
                     }
                 }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content_entry.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content_entry.rs
@@ -56,7 +56,7 @@ impl EcmascriptDevChunkContentEntries {
             .chunk_items
             .iter()
             .map(|(ty, item, async_info)| async move {
-                if matches!(*ty.await?, ChunkItemTy::Included) {
+                if matches!(ty, ChunkItemTy::Included) {
                     Ok(Some((item, async_info)))
                 } else {
                     Ok(None)

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content_entry.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content_entry.rs
@@ -11,6 +11,7 @@ use turbopack_core::{
 };
 use turbopack_ecmascript::chunk::{
     EcmascriptChunkContent, EcmascriptChunkItem, EcmascriptChunkItemExt,
+    EcmascriptChunkItemWithAsyncInfo,
 };
 
 /// A chunk item's content entry.
@@ -55,13 +56,19 @@ impl EcmascriptDevChunkContentEntries {
         let included_chunk_items = chunk_content
             .chunk_items
             .iter()
-            .map(|(ty, item, async_info)| async move {
-                if matches!(ty, ChunkItemTy::Included) {
-                    Ok(Some((item, async_info)))
-                } else {
-                    Ok(None)
-                }
-            })
+            .map(
+                async |EcmascriptChunkItemWithAsyncInfo {
+                           ty,
+                           chunk_item,
+                           async_info,
+                       }| {
+                    if matches!(ty, ChunkItemTy::Included) {
+                        Ok(Some((chunk_item, async_info)))
+                    } else {
+                        Ok(None)
+                    }
+                },
+            )
             .try_join()
             .await?
             .into_iter()

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content_entry.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content_entry.rs
@@ -28,7 +28,7 @@ pub struct EcmascriptDevChunkContentEntry {
 
 impl EcmascriptDevChunkContentEntry {
     pub async fn new(
-        chunk_item: Vc<Box<dyn EcmascriptChunkItem>>,
+        chunk_item: ResolvedVc<Box<dyn EcmascriptChunkItem>>,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Self> {
         let code = chunk_item.code(async_module_info).to_resolved().await?;

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content_entry.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content_entry.rs
@@ -80,7 +80,7 @@ impl EcmascriptDevChunkContentEntries {
                     Ok((
                         chunk_item.id().await?,
                         EcmascriptDevChunkContentEntry::new(
-                            *chunk_item,
+                            chunk_item,
                             async_module_info.map(|info| *info),
                         )
                         .await?,

--- a/turbopack/crates/turbopack-browser/src/lib.rs
+++ b/turbopack/crates/turbopack-browser/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(async_closure)]
 #![feature(iter_intersperse)]
 #![feature(int_roundings)]
 #![feature(arbitrary_self_types)]

--- a/turbopack/crates/turbopack-core/src/chunk/availability_info.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/availability_info.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use turbo_tasks::{ResolvedVc, Vc};
 
-use super::available_chunk_items::{AvailableChunkItemInfoMap, AvailableChunkItems};
+use super::available_modules::{AvailableModuleInfoMap, AvailableModules};
 
 #[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(Hash, Clone, Copy, Debug)]
@@ -12,36 +12,30 @@ pub enum AvailabilityInfo {
     Root,
     /// There are modules already available.
     Complete {
-        available_chunk_items: ResolvedVc<AvailableChunkItems>,
+        available_modules: ResolvedVc<AvailableModules>,
     },
 }
 
 impl AvailabilityInfo {
-    pub fn available_chunk_items(&self) -> Option<ResolvedVc<AvailableChunkItems>> {
+    pub fn available_modules(&self) -> Option<ResolvedVc<AvailableModules>> {
         match self {
             Self::Untracked => None,
             Self::Root => None,
             Self::Complete {
-                available_chunk_items,
-                ..
-            } => Some(*available_chunk_items),
+                available_modules, ..
+            } => Some(*available_modules),
         }
     }
 
-    pub async fn with_chunk_items(
-        self,
-        chunk_items: Vc<AvailableChunkItemInfoMap>,
-    ) -> Result<Self> {
+    pub async fn with_modules(self, modules: Vc<AvailableModuleInfoMap>) -> Result<Self> {
         Ok(match self {
             AvailabilityInfo::Untracked => AvailabilityInfo::Untracked,
             AvailabilityInfo::Root => AvailabilityInfo::Complete {
-                available_chunk_items: AvailableChunkItems::new(chunk_items).to_resolved().await?,
+                available_modules: AvailableModules::new(modules).to_resolved().await?,
             },
-            AvailabilityInfo::Complete {
-                available_chunk_items,
-            } => AvailabilityInfo::Complete {
-                available_chunk_items: available_chunk_items
-                    .with_chunk_items(chunk_items)
+            AvailabilityInfo::Complete { available_modules } => AvailabilityInfo::Complete {
+                available_modules: available_modules
+                    .with_modules(modules)
                     .to_resolved()
                     .await?,
             },

--- a/turbopack/crates/turbopack-core/src/chunk/available_modules.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/available_modules.rs
@@ -1,0 +1,101 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use turbo_tasks::{
+    debug::ValueDebugFormat, trace::TraceRawVcs, FxIndexMap, NonLocalValue, ResolvedVc,
+    TryFlatJoinIterExt, TryJoinIterExt, ValueToString, Vc,
+};
+use turbo_tasks_hash::Xxh3Hash64Hasher;
+
+use super::ChunkableModule;
+use crate::module::Module;
+
+#[derive(
+    PartialEq, Eq, TraceRawVcs, Copy, Clone, Serialize, Deserialize, ValueDebugFormat, NonLocalValue,
+)]
+pub struct AvailableModulesInfo {
+    pub is_async: bool,
+}
+
+#[turbo_tasks::value(transparent)]
+pub struct OptionAvailableModulesInfo(Option<AvailableModulesInfo>);
+
+#[turbo_tasks::value(transparent)]
+pub struct AvailableModuleInfoMap(
+    FxIndexMap<ResolvedVc<Box<dyn ChunkableModule>>, AvailableModulesInfo>,
+);
+
+/// Allows to gather information about which assets are already available.
+/// Adding more roots will form a linked list like structure to allow caching
+/// `include` queries.
+#[turbo_tasks::value]
+pub struct AvailableModules {
+    parent: Option<ResolvedVc<AvailableModules>>,
+    modules: ResolvedVc<AvailableModuleInfoMap>,
+}
+
+#[turbo_tasks::value_impl]
+impl AvailableModules {
+    #[turbo_tasks::function]
+    pub fn new(modules: ResolvedVc<AvailableModuleInfoMap>) -> Vc<Self> {
+        AvailableModules {
+            parent: None,
+            modules,
+        }
+        .cell()
+    }
+
+    #[turbo_tasks::function]
+    pub async fn with_modules(
+        self: ResolvedVc<Self>,
+        modules: ResolvedVc<AvailableModuleInfoMap>,
+    ) -> Result<Vc<Self>> {
+        let modules = modules
+            .await?
+            .into_iter()
+            .map(|(&module, &info)| async move {
+                Ok(self.get(*module).await?.is_none().then_some((module, info)))
+            })
+            .try_flat_join()
+            .await?;
+        Ok(AvailableModules {
+            parent: Some(self),
+            modules: ResolvedVc::cell(modules.into_iter().collect()),
+        }
+        .cell())
+    }
+
+    #[turbo_tasks::function]
+    pub async fn hash(&self) -> Result<Vc<u64>> {
+        let mut hasher = Xxh3Hash64Hasher::new();
+        if let Some(parent) = self.parent {
+            hasher.write_value(parent.hash().await?);
+        } else {
+            hasher.write_value(0u64);
+        }
+        let item_idents = self
+            .modules
+            .await?
+            .iter()
+            .map(|(&module, _)| module.ident().to_string())
+            .try_join()
+            .await?;
+        for ident in item_idents {
+            hasher.write_value(ident);
+        }
+        Ok(Vc::cell(hasher.finish()))
+    }
+
+    #[turbo_tasks::function]
+    pub async fn get(
+        &self,
+        module: ResolvedVc<Box<dyn ChunkableModule>>,
+    ) -> Result<Vc<OptionAvailableModulesInfo>> {
+        if let Some(&info) = self.modules.await?.get(&module) {
+            return Ok(Vc::cell(Some(info)));
+        };
+        if let Some(parent) = self.parent {
+            return Ok(parent.get(*module));
+        }
+        Ok(Vc::cell(None))
+    }
+}

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -154,7 +154,7 @@ pub async fn make_chunk_group(
     let has_async_loaders = !async_loaders.is_empty();
     let async_loader_chunk_items = async_loaders
         .iter()
-        .map(|&chunk_item| (ChunkItemTy::Included.resolved_cell(), chunk_item, None));
+        .map(|&chunk_item| (ChunkItemTy::Included, chunk_item, None));
 
     // And also add output assets referenced by async chunk loaders
     let async_loader_references = async_loaders

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -2,15 +2,17 @@ use std::collections::HashSet;
 
 use anyhow::Result;
 use auto_hash_map::AutoSet;
+use futures::future::Either;
 use turbo_tasks::{FxIndexMap, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Value, Vc};
 
 use super::{
-    availability_info::AvailabilityInfo, available_chunk_items::AvailableChunkItemInfo,
-    chunk_content, chunking::make_chunks, AsyncModuleInfo, Chunk, ChunkContentResult, ChunkItem,
-    ChunkingContext,
+    availability_info::AvailabilityInfo, available_modules::AvailableModulesInfo, chunk_content,
+    chunking::make_chunks, AsyncModuleInfo, Chunk, ChunkContentResult, ChunkItem, ChunkItemTy,
+    ChunkableModule, ChunkingContext,
 };
 use crate::{
-    module::Module, output::OutputAssets, rebase::RebasedAsset, reference::ModuleReference,
+    environment::ChunkLoading, module::Module, output::OutputAssets, rebase::RebasedAsset,
+    reference::ModuleReference,
 };
 
 pub struct MakeChunkGroupResult {
@@ -24,40 +26,50 @@ pub async fn make_chunk_group(
     chunk_group_entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
     availability_info: AvailabilityInfo,
 ) -> Result<MakeChunkGroupResult> {
+    let can_split_async = !matches!(
+        *chunking_context.environment().chunk_loading().await?,
+        ChunkLoading::Edge
+    );
+
     let ChunkContentResult {
-        chunk_items,
-        external_output_assets,
-        external_module_references,
+        chunkable_modules,
         async_modules,
         traced_modules,
+        passthrough_modules,
         forward_edges_inherit_async,
         local_back_edges_inherit_async,
         available_async_modules_back_edges_inherit_async,
-    } = chunk_content(chunking_context, chunk_group_entries, availability_info).await?;
+    } = chunk_content(
+        chunk_group_entries,
+        availability_info,
+        can_split_async,
+        *chunking_context.is_tracing_enabled().await?,
+    )
+    .await?;
 
     // Find all local chunk items that are self async
-    let self_async_children = chunk_items
+    let self_async_children = chunkable_modules
         .iter()
         .copied()
-        .map(|chunk_item| async move {
-            let is_self_async = *chunk_item.is_self_async().await?;
-            Ok(is_self_async.then_some(chunk_item))
+        .map(|m| async move {
+            let is_self_async = *m.is_self_async().await?;
+            Ok(is_self_async.then_some(m))
         })
         .try_flat_join()
         .await?;
 
     // Get all available async modules and concatenate with local async modules
-    let mut async_chunk_items = available_async_modules_back_edges_inherit_async
+    let mut all_async_modules = available_async_modules_back_edges_inherit_async
         .keys()
         .copied()
         .chain(self_async_children.into_iter())
-        .map(|chunk_item| (chunk_item, AutoSet::<ResolvedVc<Box<dyn ChunkItem>>>::new()))
+        .map(|m| (m, AutoSet::<ResolvedVc<Box<dyn ChunkableModule>>>::new()))
         .collect::<FxIndexMap<_, _>>();
 
     // Propagate async inheritance
     let mut i = 0;
     loop {
-        let Some((&chunk_item, _)) = async_chunk_items.get_index(i) else {
+        let Some((&async_module, _)) = all_async_modules.get_index(i) else {
             break;
         };
         // The first few entries are from
@@ -68,26 +80,26 @@ pub async fn make_chunk_group(
         } else {
             &local_back_edges_inherit_async
         };
-        if let Some(parents) = map.get(&chunk_item) {
+        if let Some(parents) = map.get(&async_module) {
             for &parent in parents.iter() {
                 // Add item, it will be iterated by this loop too
-                async_chunk_items
+                all_async_modules
                     .entry(parent)
                     .or_default()
-                    .insert(chunk_item);
+                    .insert(async_module);
             }
         }
         i += 1;
     }
 
     // Create map for chunk items with empty [Option<Vc<AsyncModuleInfo>>]
-    let mut chunk_items = chunk_items
+    let mut all_modules = chunkable_modules
         .into_iter()
-        .map(|chunk_item| (chunk_item, None))
+        .map(|m| (m, None))
         .collect::<FxIndexMap<_, Option<ResolvedVc<AsyncModuleInfo>>>>();
 
     // Insert AsyncModuleInfo for every async module
-    for (async_item, referenced_async_modules) in async_chunk_items {
+    for (async_item, referenced_async_modules) in all_async_modules {
         let referenced_async_modules =
             if let Some(references) = forward_edges_inherit_async.get(&async_item) {
                 references
@@ -99,7 +111,7 @@ pub async fn make_chunk_group(
             } else {
                 Default::default()
             };
-        chunk_items.insert(
+        all_modules.insert(
             async_item,
             Some(
                 AsyncModuleInfo::new(referenced_async_modules)
@@ -111,12 +123,12 @@ pub async fn make_chunk_group(
 
     // Compute new [AvailabilityInfo]
     let availability_info = {
-        let map = chunk_items
+        let map = all_modules
             .iter()
-            .map(|(&chunk_item, async_info)| async move {
+            .map(|(&module, async_info)| async move {
                 Ok((
-                    chunk_item,
-                    AvailableChunkItemInfo {
+                    module,
+                    AvailableModulesInfo {
                         is_async: async_info.is_some(),
                     },
                 ))
@@ -126,7 +138,7 @@ pub async fn make_chunk_group(
             .into_iter()
             .collect();
         let map = Vc::cell(map);
-        availability_info.with_chunk_items(map).await?
+        availability_info.with_modules(map).await?
     };
 
     // Insert async chunk loaders for every referenced async module
@@ -140,7 +152,9 @@ pub async fn make_chunk_group(
         .try_join()
         .await?;
     let has_async_loaders = !async_loaders.is_empty();
-    let async_loader_chunk_items = async_loaders.iter().map(|&chunk_item| (chunk_item, None));
+    let async_loader_chunk_items = async_loaders
+        .iter()
+        .map(|&chunk_item| (ChunkItemTy::Included.resolved_cell(), chunk_item, None));
 
     // And also add output assets referenced by async chunk loaders
     let async_loader_references = async_loaders
@@ -155,36 +169,51 @@ pub async fn make_chunk_group(
             .collect(),
     );
 
-    let mut referenced_output_assets = (*external_output_assets.await?).clone();
-    referenced_output_assets.extend(
-        references_to_output_assets(&external_module_references)
-            .await?
-            .await?
-            .iter()
-            .copied(),
-    );
-
-    let rebased_modules = traced_modules
+    let traced_output_assets = traced_modules
         .into_iter()
-        .map(|module| {
-            RebasedAsset::new(
-                *module,
-                module.ident().path().root(),
-                module.ident().path().root(),
-            )
-            .to_resolved()
+        .map(|module| async move {
+            Ok(ResolvedVc::upcast(
+                RebasedAsset::new(
+                    *module,
+                    module.ident().path().root(),
+                    module.ident().path().root(),
+                )
+                .to_resolved()
+                .await?,
+            ))
         })
         .try_join()
         .await?;
 
-    referenced_output_assets.extend(rebased_modules.into_iter().map(ResolvedVc::upcast));
+    let chunk_items = all_modules
+        .iter()
+        .map(|(m, async_info)| {
+            Either::Left(async move {
+                Ok(ChunkItemWithAsyncModuleInfo {
+                    ty: ChunkItemTy::Included,
+                    chunk_item: m.as_chunk_item(chunking_context).to_resolved().await?,
+                    async_info: *async_info,
+                })
+            })
+        })
+        .chain(passthrough_modules.into_iter().map(|m| {
+            Either::Right(async move {
+                Ok(ChunkItemWithAsyncModuleInfo {
+                    ty: ChunkItemTy::Passthrough,
+                    chunk_item: m.as_chunk_item(chunking_context).to_resolved().await?,
+                    async_info: None,
+                })
+            })
+        }))
+        .try_join()
+        .await?;
 
     // Pass chunk items to chunking algorithm
     let mut chunks = make_chunks(
         *chunking_context,
-        Vc::cell(chunk_items.into_iter().collect()),
+        Vc::cell(chunk_items),
         "".into(),
-        Vc::cell(referenced_output_assets),
+        Vc::cell(traced_output_assets),
     )
     .await?
     .clone_value();

--- a/turbopack/crates/turbopack-core/src/chunk/chunking.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking.rs
@@ -49,8 +49,8 @@ pub async fn make_chunks(
     key_prefix: RcStr,
     mut referenced_output_assets: Vc<OutputAssets>,
 ) -> Result<Vc<Chunks>> {
+    let chunk_items = chunk_items.await?;
     let chunk_items = chunk_items
-        .await?
         .iter()
         .map(|&(ty, chunk_item, async_info)| async move {
             let chunk_item_info =
@@ -60,6 +60,7 @@ pub async fn make_chunks(
         })
         .try_join()
         .await?;
+
     let mut map = FxIndexMap::<_, Vec<_>>::default();
     for (ty, chunk_item, async_info, chunk_item_info) in chunk_items {
         map.entry(chunk_item_info.ty).or_default().push((
@@ -78,9 +79,9 @@ pub async fn make_chunks(
             .into_iter()
             .map(|(ty, chunk_item, async_info, chunk_item_info)| async move {
                 Ok((
-                    ty,
-                    chunk_item,
-                    async_info,
+                    *ty,
+                    *chunk_item,
+                    *async_info,
                     chunk_item_info.size,
                     chunk_item_info.name.await?,
                 ))
@@ -124,9 +125,9 @@ pub async fn make_chunks(
 }
 
 type ChunkItemWithInfo = (
-    ResolvedVc<ChunkItemTy>,
+    ChunkItemTy,
     ResolvedVc<Box<dyn ChunkItem>>,
-    Option<ResolvedVc<AsyncModuleInfo>>,
+    Option<Vc<AsyncModuleInfo>>,
     usize,
     ReadRef<RcStr>,
 );

--- a/turbopack/crates/turbopack-core/src/chunk/chunking.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking.rs
@@ -11,8 +11,8 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, ReadRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 
 use super::{
-    AsyncModuleInfo, Chunk, ChunkItem, ChunkItemsWithAsyncModuleInfo, ChunkType, ChunkingContext,
-    Chunks,
+    AsyncModuleInfo, Chunk, ChunkItem, ChunkItemTy, ChunkItemsWithAsyncModuleInfo, ChunkType,
+    ChunkingContext, Chunks,
 };
 use crate::output::OutputAssets;
 
@@ -52,19 +52,22 @@ pub async fn make_chunks(
     let chunk_items = chunk_items
         .await?
         .iter()
-        .map(|&(chunk_item, async_info)| async move {
+        .map(|&(ty, chunk_item, async_info)| async move {
             let chunk_item_info =
                 chunk_item_info(chunking_context, *chunk_item, async_info.map(|info| *info))
                     .await?;
-            Ok((chunk_item, async_info, chunk_item_info))
+            Ok((ty, chunk_item, async_info, chunk_item_info))
         })
         .try_join()
         .await?;
     let mut map = FxIndexMap::<_, Vec<_>>::default();
-    for (chunk_item, async_info, chunk_item_info) in chunk_items {
-        map.entry(chunk_item_info.ty)
-            .or_default()
-            .push((chunk_item, async_info, chunk_item_info));
+    for (ty, chunk_item, async_info, chunk_item_info) in chunk_items {
+        map.entry(chunk_item_info.ty).or_default().push((
+            ty,
+            chunk_item,
+            async_info,
+            chunk_item_info,
+        ));
     }
 
     let mut chunks = Vec::new();
@@ -73,8 +76,9 @@ pub async fn make_chunks(
 
         let chunk_items = chunk_items
             .into_iter()
-            .map(|(chunk_item, async_info, chunk_item_info)| async move {
+            .map(|(ty, chunk_item, async_info, chunk_item_info)| async move {
                 Ok((
+                    ty,
                     chunk_item,
                     async_info,
                     chunk_item_info.size,
@@ -120,6 +124,7 @@ pub async fn make_chunks(
 }
 
 type ChunkItemWithInfo = (
+    ResolvedVc<ChunkItemTy>,
     ResolvedVc<Box<dyn ChunkItem>>,
     Option<ResolvedVc<AsyncModuleInfo>>,
     usize,
@@ -169,7 +174,7 @@ async fn make_chunk(
             split_context.chunking_context,
             chunk_items
                 .into_iter()
-                .map(|(chunk_item, async_info, ..)| (chunk_item, async_info))
+                .map(|(ty, chunk_item, async_info, ..)| (ty, chunk_item, async_info))
                 .collect(),
             replace(
                 split_context.referenced_output_assets,
@@ -191,7 +196,7 @@ async fn app_vendors_split(
     let mut app_chunk_items = Vec::new();
     let mut vendors_chunk_items = Vec::new();
     for item in chunk_items {
-        let (_, _, _, asset_ident) = &item;
+        let (_, _, _, _, asset_ident) = &item;
         if is_app_code(asset_ident) {
             app_chunk_items.push(item);
         } else {
@@ -239,7 +244,7 @@ async fn package_name_split(
 ) -> Result<()> {
     let mut map = FxIndexMap::<_, Vec<ChunkItemWithInfo>>::default();
     for item in chunk_items {
-        let (_, _, _, asset_ident) = &item;
+        let (_, _, _, _, asset_ident) = &item;
         let package_name = package_name(asset_ident);
         if let Some(list) = map.get_mut(package_name) {
             list.push(item);
@@ -273,7 +278,7 @@ async fn folder_split(
     let mut map = FxIndexMap::<_, (_, Vec<ChunkItemWithInfo>)>::default();
     loop {
         for item in chunk_items {
-            let (_, _, _, asset_ident) = &item;
+            let (_, _, _, _, asset_ident) = &item;
             let (folder_name, new_location) = folder_name(asset_ident, location);
             if let Some((_, list)) = map.get_mut(folder_name) {
                 list.push(item);
@@ -316,7 +321,7 @@ async fn folder_split(
         }
     }
     if !remaining.is_empty() {
-        let (_, _, _, asset_ident) = &remaining[0];
+        let (_, _, _, _, asset_ident) = &remaining[0];
         let mut key = format!("{}-{}", name, &asset_ident[..location]);
         if !handle_split_group(&mut remaining, &mut key, split_context, None).await? {
             make_chunk(remaining, &mut key, split_context).await?;
@@ -365,7 +370,7 @@ enum ChunkSize {
 /// large or perfect fit.
 fn chunk_size(chunk_items: &[ChunkItemWithInfo]) -> ChunkSize {
     let mut total_size = 0;
-    for (_, _, size, _) in chunk_items {
+    for (_, _, _, size, _) in chunk_items {
         total_size += size;
     }
     if total_size >= LARGE_CHUNK {

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -772,11 +772,12 @@ pub enum ChunkItemTy {
     Passthrough,
 }
 
-pub type ChunkItemWithAsyncModuleInfo = (
-    ChunkItemTy,
-    ResolvedVc<Box<dyn ChunkItem>>,
-    Option<Vc<AsyncModuleInfo>>,
-);
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, TraceRawVcs, TaskInput)]
+pub struct ChunkItemWithAsyncModuleInfo {
+    pub ty: ChunkItemTy,
+    pub chunk_item: ResolvedVc<Box<dyn ChunkItem>>,
+    pub async_info: Option<ResolvedVc<AsyncModuleInfo>>,
+}
 
 #[turbo_tasks::value(transparent)]
 pub struct ChunkItemsWithAsyncModuleInfo(Vec<ChunkItemWithAsyncModuleInfo>);

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -763,7 +763,17 @@ impl AsyncModuleInfo {
 }
 
 #[derive(
-    Copy, Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, TraceRawVcs, TaskInput,
+    Copy,
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    Hash,
+    TraceRawVcs,
+    TaskInput,
+    NonLocalValue,
 )]
 pub enum ChunkItemTy {
     /// The ChunkItem should be included as content in the chunk.
@@ -772,7 +782,10 @@ pub enum ChunkItemTy {
     Passthrough,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, TraceRawVcs, TaskInput)]
+#[derive(
+    Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, TraceRawVcs, TaskInput, NonLocalValue,
+)]
+// #[turbo_tasks::value]
 pub struct ChunkItemWithAsyncModuleInfo {
     pub ty: ChunkItemTy,
     pub chunk_item: ResolvedVc<Box<dyn ChunkItem>>,

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -774,7 +774,7 @@ pub enum ChunkItemTy {
 
 pub type ChunkItemWithAsyncModuleInfo = (
     ChunkItemTy,
-    Vc<Box<dyn ChunkItem>>,
+    ResolvedVc<Box<dyn ChunkItem>>,
     Option<Vc<AsyncModuleInfo>>,
 );
 

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -762,7 +762,9 @@ impl AsyncModuleInfo {
     }
 }
 
-#[turbo_tasks::value]
+#[derive(
+    Copy, Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, TraceRawVcs, TaskInput,
+)]
 pub enum ChunkItemTy {
     /// The ChunkItem should be included as content in the chunk.
     Included,
@@ -771,9 +773,9 @@ pub enum ChunkItemTy {
 }
 
 pub type ChunkItemWithAsyncModuleInfo = (
-    ResolvedVc<ChunkItemTy>,
-    ResolvedVc<Box<dyn ChunkItem>>,
-    Option<ResolvedVc<AsyncModuleInfo>>,
+    ChunkItemTy,
+    Vc<Box<dyn ChunkItem>>,
+    Option<Vc<AsyncModuleInfo>>,
 );
 
 #[turbo_tasks::value(transparent)]

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -1,5 +1,5 @@
 pub mod availability_info;
-pub mod available_chunk_items;
+pub mod available_modules;
 pub mod chunk_group;
 pub mod chunking;
 pub(crate) mod chunking_context;
@@ -31,7 +31,7 @@ use turbo_tasks::{
 use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::DeterministicHash;
 
-use self::{availability_info::AvailabilityInfo, available_chunk_items::AvailableChunkItems};
+use self::{availability_info::AvailabilityInfo, available_modules::AvailableModules};
 pub use self::{
     chunking_context::{
         ChunkGroupResult, ChunkGroupType, ChunkingContext, ChunkingContextExt,
@@ -41,11 +41,7 @@ pub use self::{
     evaluate::{EvaluatableAsset, EvaluatableAssetExt, EvaluatableAssets},
 };
 use crate::{
-    asset::Asset,
-    environment::ChunkLoading,
-    ident::AssetIdent,
-    module::Module,
-    output::{OutputAsset, OutputAssets},
+    asset::Asset, ident::AssetIdent, module::Module, output::OutputAssets,
     reference::ModuleReference,
 };
 
@@ -209,14 +205,14 @@ pub trait ChunkableModuleReference: ModuleReference + ValueToString {
     }
 }
 
-type AsyncInfo = FxIndexMap<ResolvedVc<Box<dyn ChunkItem>>, Vec<ResolvedVc<Box<dyn ChunkItem>>>>;
+type AsyncInfo =
+    FxIndexMap<ResolvedVc<Box<dyn ChunkableModule>>, Vec<ResolvedVc<Box<dyn ChunkableModule>>>>;
 
 pub struct ChunkContentResult {
-    pub chunk_items: FxIndexSet<ResolvedVc<Box<dyn ChunkItem>>>,
+    pub chunkable_modules: FxIndexSet<ResolvedVc<Box<dyn ChunkableModule>>>,
     pub async_modules: FxIndexSet<ResolvedVc<Box<dyn ChunkableModule>>>,
     pub traced_modules: FxIndexSet<ResolvedVc<Box<dyn Module>>>,
-    pub external_output_assets: ResolvedVc<OutputAssets>,
-    pub external_module_references: FxIndexSet<ResolvedVc<Box<dyn ModuleReference>>>,
+    pub passthrough_modules: FxIndexSet<ResolvedVc<Box<dyn ChunkableModule>>>,
     /// A map from local module to all children from which the async module
     /// status is inherited
     pub forward_edges_inherit_async: AsyncInfo,
@@ -229,11 +225,18 @@ pub struct ChunkContentResult {
 }
 
 pub async fn chunk_content(
-    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     chunk_entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
     availability_info: AvailabilityInfo,
+    can_split_async: bool,
+    should_trace: bool,
 ) -> Result<ChunkContentResult> {
-    chunk_content_internal_parallel(chunking_context, chunk_entries, availability_info).await
+    chunk_content_internal_parallel(
+        chunk_entries,
+        availability_info,
+        can_split_async,
+        should_trace,
+    )
+    .await
 }
 
 #[derive(
@@ -252,14 +255,14 @@ enum InheritAsyncEdge {
 
 #[derive(Eq, PartialEq, Clone, Hash, Serialize, Deserialize, TraceRawVcs, Debug, NonLocalValue)]
 enum ChunkContentGraphNode {
-    // A chunk item not placed in the current chunk, but whose references we will
+    // A module not placed in the current chunk, but whose references we will
     // follow to find more graph nodes.
-    PassthroughChunkItem {
-        item: ResolvedVc<Box<dyn ChunkItem>>,
+    PassthroughModule {
+        module: ResolvedVc<Box<dyn ChunkableModule>>,
     },
-    // Chunk items that are placed into the current chunk group
-    ChunkItem {
-        item: ResolvedVc<Box<dyn ChunkItem>>,
+    // Modules that are placed into the current chunk group
+    Module {
+        module: ResolvedVc<Box<dyn ChunkableModule>>,
         ident: ReadRef<RcStr>,
     },
     // Async module that is referenced from the chunk group
@@ -270,21 +273,18 @@ enum ChunkContentGraphNode {
     TracedModule {
         module: ResolvedVc<Box<dyn Module>>,
     },
-    ExternalOutputAssets(ResolvedVc<OutputAssets>),
-    // ModuleReferences that are not placed in the current chunk group
-    ExternalModuleReference(ResolvedVc<Box<dyn ModuleReference>>),
-    /// A list of directly referenced chunk items from which `is_async_module`
+    /// A list of directly referenced modules from which `is_async_module`
     /// will be inherited.
     InheritAsyncInfo {
-        item: ResolvedVc<Box<dyn ChunkItem>>,
-        references: Vec<(ResolvedVc<Box<dyn ChunkItem>>, InheritAsyncEdge)>,
+        module: ResolvedVc<Box<dyn ChunkableModule>>,
+        references: Vec<(ResolvedVc<Box<dyn ChunkableModule>>, InheritAsyncEdge)>,
     },
 }
 
 #[derive(Debug, Clone, Copy, TaskInput, PartialEq, Eq, Hash, Serialize, Deserialize)]
 enum ChunkGraphNodeToReferences {
-    PassthroughChunkItem(ResolvedVc<Box<dyn ChunkItem>>),
-    ChunkItem(ResolvedVc<Box<dyn ChunkItem>>),
+    PassthroughModule(ResolvedVc<Box<dyn ChunkableModule>>),
+    Module(ResolvedVc<Box<dyn ChunkableModule>>),
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, TraceRawVcs, NonLocalValue)]
@@ -298,37 +298,37 @@ struct ChunkGraphEdge {
 struct ChunkGraphEdges(Vec<ChunkGraphEdge>);
 
 #[turbo_tasks::function]
-async fn graph_node_to_referenced_nodes_with_available_chunk_items(
+async fn graph_node_to_referenced_nodes_with_available_modules(
     node: ChunkGraphNodeToReferences,
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
-    available_chunk_items: Vc<AvailableChunkItems>,
+    available_modules: Vc<AvailableModules>,
+    can_split_async: bool,
+    should_trace: bool,
 ) -> Result<Vc<ChunkGraphEdges>> {
-    let edges = graph_node_to_referenced_nodes(node, chunking_context);
+    let edges = graph_node_to_referenced_nodes(node, can_split_async, should_trace);
     let edges_ref = edges.await?;
     for (unchanged, edge) in edges_ref.iter().enumerate() {
-        if let ChunkContentGraphNode::ChunkItem { item, .. } = edge.node {
-            let available_chunk_items = available_chunk_items.await?;
-            if let Some(info) = available_chunk_items.get(item).await? {
+        if let ChunkContentGraphNode::Module { module, .. } = edge.node {
+            if let Some(info) = *available_modules.get(*module).await? {
                 let mut new_edges = Vec::with_capacity(edges_ref.len());
                 new_edges.extend(edges_ref[0..unchanged].iter().cloned());
-                let mut available_chunk_item_info = HashMap::new();
-                available_chunk_item_info.insert(item, info);
+                let mut available_module_info = HashMap::new();
+                available_module_info.insert(module, info);
                 for edge in edges_ref[unchanged + 1..].iter() {
                     match edge.node {
-                        ChunkContentGraphNode::ChunkItem { item, .. } => {
-                            if let Some(info) = available_chunk_items.get(item).await? {
-                                available_chunk_item_info.insert(item, info);
+                        ChunkContentGraphNode::Module { module, .. } => {
+                            if let Some(info) = *available_modules.get(*module).await? {
+                                available_module_info.insert(module, info);
                                 continue;
                             }
                         }
                         ChunkContentGraphNode::InheritAsyncInfo {
-                            item,
+                            module,
                             ref references,
                         } => {
                             let new_references = references
                                 .iter()
                                 .filter_map(|&(r, _)| {
-                                    if let Some(info) = available_chunk_item_info.get(&r) {
+                                    if let Some(info) = available_module_info.get(&r) {
                                         if info.is_async {
                                             Some((r, InheritAsyncEdge::AvailableAsyncModule))
                                         } else {
@@ -342,7 +342,7 @@ async fn graph_node_to_referenced_nodes_with_available_chunk_items(
                             new_edges.push(ChunkGraphEdge {
                                 key: edge.key,
                                 node: ChunkContentGraphNode::InheritAsyncInfo {
-                                    item,
+                                    module,
                                     references: new_references,
                                 },
                             });
@@ -362,36 +362,27 @@ async fn graph_node_to_referenced_nodes_with_available_chunk_items(
 #[turbo_tasks::function]
 async fn graph_node_to_referenced_nodes(
     node: ChunkGraphNodeToReferences,
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
+    can_split_async: bool,
+    should_trace: bool,
 ) -> Result<Vc<ChunkGraphEdges>> {
-    let (parent, module_references, output_asset_references) = match &node {
-        ChunkGraphNodeToReferences::PassthroughChunkItem(item) => {
-            (None, item.module().references(), item.references())
-        }
-        ChunkGraphNodeToReferences::ChunkItem(item) => {
-            (Some(*item), item.module().references(), item.references())
-        }
+    let (parent, module_references) = match &node {
+        ChunkGraphNodeToReferences::PassthroughModule(item) => (None, item.references()),
+        ChunkGraphNodeToReferences::Module(item) => (Some(*item), item.references()),
     };
 
     let module_references = module_references.await?;
-    let mut graph_nodes = module_references
+    let graph_nodes = module_references
         .iter()
         .map(|reference| async {
             let reference = *reference;
             let Some(chunkable_module_reference) =
                 ResolvedVc::try_downcast::<Box<dyn ChunkableModuleReference>>(reference).await?
             else {
-                return Ok(vec![ChunkGraphEdge {
-                    key: None,
-                    node: ChunkContentGraphNode::ExternalModuleReference(reference),
-                }]);
+                return Ok(vec![]);
             };
 
             let Some(chunking_type) = &*chunkable_module_reference.chunking_type().await? else {
-                return Ok(vec![ChunkGraphEdge {
-                    key: None,
-                    node: ChunkContentGraphNode::ExternalModuleReference(reference),
-                }]);
+                return Ok(vec![]);
             };
 
             let module_data = reference
@@ -403,7 +394,7 @@ async fn graph_node_to_referenced_nodes(
                 .into_iter()
                 .map(|&module| async move {
                     if matches!(chunking_type, ChunkingType::Traced) {
-                        if *chunking_context.is_tracing_enabled().await? {
+                        if should_trace {
                             return Ok((
                                 Some(ChunkGraphEdge {
                                     key: None,
@@ -419,78 +410,46 @@ async fn graph_node_to_referenced_nodes(
                     let Some(chunkable_module) =
                         ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(module).await?
                     else {
-                        return Ok((
-                            Some(ChunkGraphEdge {
-                                key: None,
-                                node: ChunkContentGraphNode::ExternalModuleReference(reference),
-                            }),
-                            None,
-                        ));
+                        return Ok((None, None));
                     };
 
                     match chunking_type {
-                        ChunkingType::Parallel => {
-                            let chunk_item = chunkable_module
-                                .as_chunk_item(chunking_context)
-                                .to_resolved()
-                                .await?;
-                            Ok((
-                                Some(ChunkGraphEdge {
-                                    key: Some(module),
-                                    node: ChunkContentGraphNode::ChunkItem {
-                                        item: chunk_item,
-                                        ident: module.ident().to_string().await?,
-                                    },
-                                }),
-                                None,
-                            ))
-                        }
-                        ChunkingType::ParallelInheritAsync => {
-                            let chunk_item = chunkable_module
-                                .as_chunk_item(chunking_context)
-                                .to_resolved()
-                                .await?;
-                            Ok((
-                                Some(ChunkGraphEdge {
-                                    key: Some(module),
-                                    node: ChunkContentGraphNode::ChunkItem {
-                                        item: chunk_item,
-                                        ident: module.ident().to_string().await?,
-                                    },
-                                }),
-                                Some((chunk_item, InheritAsyncEdge::LocalModule)),
-                            ))
-                        }
-                        ChunkingType::Passthrough => {
-                            let chunk_item = chunkable_module
-                                .as_chunk_item(chunking_context)
-                                .to_resolved()
-                                .await?;
-
-                            Ok((
-                                Some(ChunkGraphEdge {
-                                    key: None,
-                                    node: ChunkContentGraphNode::PassthroughChunkItem {
-                                        item: chunk_item,
-                                    },
-                                }),
-                                None,
-                            ))
-                        }
+                        ChunkingType::Parallel => Ok((
+                            Some(ChunkGraphEdge {
+                                key: Some(module),
+                                node: ChunkContentGraphNode::Module {
+                                    module: chunkable_module,
+                                    ident: module.ident().to_string().await?,
+                                },
+                            }),
+                            None,
+                        )),
+                        ChunkingType::ParallelInheritAsync => Ok((
+                            Some(ChunkGraphEdge {
+                                key: Some(module),
+                                node: ChunkContentGraphNode::Module {
+                                    module: chunkable_module,
+                                    ident: module.ident().to_string().await?,
+                                },
+                            }),
+                            Some((chunkable_module, InheritAsyncEdge::LocalModule)),
+                        )),
+                        ChunkingType::Passthrough => Ok((
+                            Some(ChunkGraphEdge {
+                                key: None,
+                                node: ChunkContentGraphNode::PassthroughModule {
+                                    module: chunkable_module,
+                                },
+                            }),
+                            None,
+                        )),
                         ChunkingType::Async => {
-                            let chunk_loading =
-                                chunking_context.environment().chunk_loading().await?;
-                            if matches!(*chunk_loading, ChunkLoading::Edge) {
-                                let chunk_item = chunkable_module
-                                    .as_chunk_item(chunking_context)
-                                    .to_resolved()
-                                    .await?;
+                            if can_split_async {
                                 Ok((
                                     Some(ChunkGraphEdge {
-                                        key: Some(module),
-                                        node: ChunkContentGraphNode::ChunkItem {
-                                            item: chunk_item,
-                                            ident: module.ident().to_string().await?,
+                                        key: None,
+                                        node: ChunkContentGraphNode::AsyncModule {
+                                            module: chunkable_module,
                                         },
                                     }),
                                     None,
@@ -498,9 +457,10 @@ async fn graph_node_to_referenced_nodes(
                             } else {
                                 Ok((
                                     Some(ChunkGraphEdge {
-                                        key: None,
-                                        node: ChunkContentGraphNode::AsyncModule {
+                                        key: Some(module),
+                                        node: ChunkContentGraphNode::Module {
                                             module: chunkable_module,
+                                            ident: module.ident().to_string().await?,
                                         },
                                     }),
                                     None,
@@ -535,7 +495,7 @@ async fn graph_node_to_referenced_nodes(
                     graph_nodes.push(ChunkGraphEdge {
                         key: None,
                         node: ChunkContentGraphNode::InheritAsyncInfo {
-                            item: parent,
+                            module: parent,
                             references: inherit_async_references,
                         },
                     })
@@ -547,20 +507,14 @@ async fn graph_node_to_referenced_nodes(
         .try_flat_join()
         .await?;
 
-    graph_nodes.push(ChunkGraphEdge {
-        key: None,
-        node: ChunkContentGraphNode::ExternalOutputAssets(
-            output_asset_references.to_resolved().await?,
-        ),
-    });
-
     Ok(Vc::cell(graph_nodes))
 }
 
 struct ChunkContentVisit {
-    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
-    available_chunk_items: Option<ResolvedVc<AvailableChunkItems>>,
+    available_chunk_items: Option<ResolvedVc<AvailableModules>>,
     processed_modules: HashSet<ResolvedVc<Box<dyn Module>>>,
+    should_trace: bool,
+    can_split_async: bool,
 }
 
 type ChunkItemToGraphNodesEdges = impl Iterator<Item = ChunkGraphEdge>;
@@ -575,7 +529,7 @@ impl Visit<ChunkContentGraphNode, ()> for ChunkContentVisit {
     fn visit(&mut self, edge: ChunkGraphEdge) -> VisitControlFlow<ChunkContentGraphNode, ()> {
         let ChunkGraphEdge { key, node } = edge;
         let Some(module) = key else {
-            if matches!(node, ChunkContentGraphNode::PassthroughChunkItem { .. }) {
+            if matches!(node, ChunkContentGraphNode::PassthroughModule { .. }) {
                 return VisitControlFlow::Continue(node);
             } else {
                 // All other types don't have edges
@@ -593,16 +547,17 @@ impl Visit<ChunkContentGraphNode, ()> for ChunkContentVisit {
     fn edges(&mut self, node: &ChunkContentGraphNode) -> Self::EdgesFuture {
         let node = node.clone();
 
-        let chunking_context = self.chunking_context;
         let available_chunk_items = self.available_chunk_items;
+        let can_split_async = self.can_split_async;
+        let should_trace = self.should_trace;
 
         async move {
             let node = match node {
-                ChunkContentGraphNode::PassthroughChunkItem { item } => {
-                    ChunkGraphNodeToReferences::PassthroughChunkItem(item)
+                ChunkContentGraphNode::PassthroughModule { module: item } => {
+                    ChunkGraphNodeToReferences::PassthroughModule(item)
                 }
-                ChunkContentGraphNode::ChunkItem { item, .. } => {
-                    ChunkGraphNodeToReferences::ChunkItem(item)
+                ChunkContentGraphNode::Module { module: item, .. } => {
+                    ChunkGraphNodeToReferences::Module(item)
                 }
                 _ => {
                     return Ok(None.into_iter().flatten());
@@ -610,13 +565,14 @@ impl Visit<ChunkContentGraphNode, ()> for ChunkContentVisit {
             };
 
             let nodes = if let Some(available_chunk_items) = available_chunk_items {
-                graph_node_to_referenced_nodes_with_available_chunk_items(
+                graph_node_to_referenced_nodes_with_available_modules(
                     node,
-                    *chunking_context,
                     *available_chunk_items,
+                    can_split_async,
+                    should_trace,
                 )
             } else {
-                graph_node_to_referenced_nodes(node, *chunking_context)
+                graph_node_to_referenced_nodes(node, can_split_async, should_trace)
             }
             .await?;
             Ok(Some(nodes.into_iter().cloned()).into_iter().flatten())
@@ -624,7 +580,7 @@ impl Visit<ChunkContentGraphNode, ()> for ChunkContentVisit {
     }
 
     fn span(&mut self, node: &ChunkContentGraphNode) -> Span {
-        if let ChunkContentGraphNode::ChunkItem { ident, .. } = node {
+        if let ChunkContentGraphNode::Module { ident, .. } = node {
             info_span!("chunking module", name = display(ident))
         } else {
             Span::current()
@@ -633,9 +589,10 @@ impl Visit<ChunkContentGraphNode, ()> for ChunkContentVisit {
 }
 
 async fn chunk_content_internal_parallel(
-    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     chunk_entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
     availability_info: AvailabilityInfo,
+    can_split_async: bool,
+    should_trace: bool,
 ) -> Result<ChunkContentResult> {
     let root_edges = chunk_entries
         .into_iter()
@@ -647,11 +604,8 @@ async fn chunk_content_internal_parallel(
             };
             Ok(Some(ChunkGraphEdge {
                 key: Some(entry),
-                node: ChunkContentGraphNode::ChunkItem {
-                    item: chunkable_module
-                        .as_chunk_item(*chunking_context)
-                        .to_resolved()
-                        .await?,
+                node: ChunkContentGraphNode::Module {
+                    module: chunkable_module,
                     ident: chunkable_module.ident().to_string().await?,
                 },
             }))
@@ -660,9 +614,10 @@ async fn chunk_content_internal_parallel(
         .await?;
 
     let visit = ChunkContentVisit {
-        chunking_context,
-        available_chunk_items: availability_info.available_chunk_items(),
+        available_chunk_items: availability_info.available_modules(),
         processed_modules: Default::default(),
+        can_split_async,
+        should_trace,
     };
 
     let GraphTraversalResult::Completed(traversal_result) =
@@ -673,11 +628,9 @@ async fn chunk_content_internal_parallel(
 
     let graph_nodes: Vec<_> = traversal_result?.into_reverse_topological().collect();
 
-    let mut chunk_items = FxIndexSet::default();
+    let mut chunkable_modules = FxIndexSet::default();
     let mut async_modules = FxIndexSet::default();
-    let mut external_module_references = FxIndexSet::default();
-    let mut external_output_assets: FxIndexSet<ResolvedVc<Box<dyn OutputAsset>>> =
-        FxIndexSet::default();
+    let mut passthrough_modules = FxIndexSet::default();
     let mut forward_edges_inherit_async = FxIndexMap::default();
     let mut local_back_edges_inherit_async = FxIndexMap::default();
     let mut available_async_modules_back_edges_inherit_async = FxIndexMap::default();
@@ -685,25 +638,22 @@ async fn chunk_content_internal_parallel(
 
     for graph_node in graph_nodes {
         match graph_node {
-            ChunkContentGraphNode::PassthroughChunkItem { .. } => {}
+            ChunkContentGraphNode::PassthroughModule { module } => {
+                passthrough_modules.insert(module);
+            }
             ChunkContentGraphNode::TracedModule { module } => {
                 traced_modules.insert(module);
             }
-            ChunkContentGraphNode::ChunkItem { item, .. } => {
-                chunk_items.insert(item);
+            ChunkContentGraphNode::Module { module: item, .. } => {
+                chunkable_modules.insert(item);
             }
             ChunkContentGraphNode::AsyncModule { module } => {
                 async_modules.insert(module);
             }
-            ChunkContentGraphNode::ExternalModuleReference(reference) => {
-                external_module_references.insert(reference);
-            }
-            ChunkContentGraphNode::ExternalOutputAssets(reference) => {
-                for output_asset in reference.await? {
-                    external_output_assets.insert(*output_asset);
-                }
-            }
-            ChunkContentGraphNode::InheritAsyncInfo { item, references } => {
+            ChunkContentGraphNode::InheritAsyncInfo {
+                module: item,
+                references,
+            } => {
                 for &(reference, ty) in &references {
                     match ty {
                         InheritAsyncEdge::LocalModule => local_back_edges_inherit_async
@@ -727,11 +677,10 @@ async fn chunk_content_internal_parallel(
     }
 
     Ok(ChunkContentResult {
-        chunk_items,
+        chunkable_modules,
         async_modules,
         traced_modules,
-        external_output_assets: ResolvedVc::cell(external_output_assets.into_iter().collect()),
-        external_module_references,
+        passthrough_modules,
         forward_edges_inherit_async,
         local_back_edges_inherit_async,
         available_async_modules_back_edges_inherit_async,
@@ -764,10 +713,6 @@ pub trait ChunkItem {
     fn module(self: Vc<Self>) -> Vc<Box<dyn Module>>;
 
     fn chunking_context(self: Vc<Self>) -> Vc<Box<dyn ChunkingContext>>;
-
-    fn is_self_async(self: Vc<Self>) -> Vc<bool> {
-        Vc::cell(false)
-    }
 }
 
 #[turbo_tasks::value_trait]
@@ -801,14 +746,14 @@ pub struct ChunkItems(pub Vec<ResolvedVc<Box<dyn ChunkItem>>>);
 
 #[turbo_tasks::value]
 pub struct AsyncModuleInfo {
-    pub referenced_async_modules: AutoSet<ResolvedVc<Box<dyn ChunkItem>>>,
+    pub referenced_async_modules: AutoSet<ResolvedVc<Box<dyn ChunkableModule>>>,
 }
 
 #[turbo_tasks::value_impl]
 impl AsyncModuleInfo {
     #[turbo_tasks::function]
     pub async fn new(
-        referenced_async_modules: Vec<ResolvedVc<Box<dyn ChunkItem>>>,
+        referenced_async_modules: Vec<ResolvedVc<Box<dyn ChunkableModule>>>,
     ) -> Result<Vc<Self>> {
         Ok(Self {
             referenced_async_modules: referenced_async_modules.into_iter().collect(),
@@ -817,7 +762,16 @@ impl AsyncModuleInfo {
     }
 }
 
+#[turbo_tasks::value]
+pub enum ChunkItemTy {
+    /// The ChunkItem should be included as content in the chunk.
+    Included,
+    /// The ChunkItem should be used to trace references but should not included in the chunk.
+    Passthrough,
+}
+
 pub type ChunkItemWithAsyncModuleInfo = (
+    ResolvedVc<ChunkItemTy>,
     ResolvedVc<Box<dyn ChunkItem>>,
     Option<ResolvedVc<AsyncModuleInfo>>,
 );

--- a/turbopack/crates/turbopack-core/src/module.rs
+++ b/turbopack/crates/turbopack-core/src/module.rs
@@ -19,6 +19,11 @@ pub trait Module: Asset {
     fn additional_layers_modules(self: Vc<Self>) -> Vc<Modules> {
         Vc::cell(vec![])
     }
+
+    /// Signifies the module itself is async, e.g. it uses top-level await, is a wasm module, etc.
+    fn is_self_async(self: Vc<Self>) -> Vc<bool> {
+        Vc::cell(false)
+    }
 }
 
 #[turbo_tasks::value(transparent)]

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -503,7 +503,7 @@ impl ChunkType for CssChunkType {
         let content = CssChunkContent {
             chunk_items: chunk_items
                 .iter()
-                .map(async |(_, chunk_item, _async_info)| {
+                .map(async |ChunkItemWithAsyncModuleInfo { chunk_item, .. }| {
                     let Some(chunk_item) =
                         ResolvedVc::try_downcast::<Box<dyn CssChunkItem>>(*chunk_item).await?
                     else {

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -3,7 +3,7 @@ pub mod source_map;
 
 use std::fmt::Write;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexSet, ResolvedVc, TryJoinIterExt, Value, ValueDefault, ValueToString, Vc};
 use turbo_tasks_fs::{rope::Rope, File, FileSystem};

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -503,7 +503,7 @@ impl ChunkType for CssChunkType {
         let content = CssChunkContent {
             chunk_items: chunk_items
                 .iter()
-                .map(|(chunk_item, _async_info)| async move {
+                .map(|(_, chunk_item, _async_info)| async move {
                     // CSS doesn't need to care about async_info, so we can discard it
                     ResolvedVc::try_downcast::<Box<dyn CssChunkItem>>(*chunk_item)
                         .await?

--- a/turbopack/crates/turbopack-css/src/lib.rs
+++ b/turbopack/crates/turbopack-css/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(async_closure)]
 #![feature(min_specialization)]
 #![feature(box_patterns)]
 #![feature(iter_intersperse)]

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
@@ -32,19 +32,8 @@ impl AsyncLoaderChunkItem {
     #[turbo_tasks::function]
     pub(super) async fn chunks(&self) -> Result<Vc<OutputAssets>> {
         let module = self.module.await?;
-        if let Some(chunk_items) = module.availability_info.available_chunk_items() {
-            if chunk_items
-                .await?
-                .get(
-                    module
-                        .inner
-                        .as_chunk_item(*ResolvedVc::upcast(self.chunking_context))
-                        .to_resolved()
-                        .await?,
-                )
-                .await?
-                .is_some()
-            {
+        if let Some(chunk_items) = module.availability_info.available_modules() {
+            if chunk_items.get(*module.inner).await?.is_some() {
                 return Ok(Vc::cell(vec![]));
             }
         }
@@ -168,7 +157,7 @@ impl ChunkItem for AsyncLoaderChunkItem {
     async fn content_ident(&self) -> Result<Vc<AssetIdent>> {
         let mut ident = self.module.ident();
         if let Some(available_chunk_items) =
-            self.module.await?.availability_info.available_chunk_items()
+            self.module.await?.availability_info.available_modules()
         {
             ident = ident.with_modifier(Vc::cell(
                 available_chunk_items.hash().await?.to_string().into(),

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
@@ -45,7 +45,7 @@ impl ChunkType for EcmascriptChunkType {
         let content = EcmascriptChunkContent {
             chunk_items: chunk_items
                 .iter()
-                .map(|(ty, chunk_item, async_info)| async move {
+                .map(async |(ty, chunk_item, async_info)| {
                     let Some(chunk_item) =
                         ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkItem>>(*chunk_item)
                             .await?

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
@@ -45,9 +45,9 @@ impl ChunkType for EcmascriptChunkType {
         let content = EcmascriptChunkContent {
             chunk_items: chunk_items
                 .iter()
-                .map(|&(chunk_item, async_info)| async move {
+                .map(|(ty, chunk_item, async_info)| async move {
                     let Some(chunk_item) =
-                        ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkItem>>(chunk_item)
+                        ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkItem>>(*chunk_item)
                             .await?
                     else {
                         bail!(
@@ -55,7 +55,7 @@ impl ChunkType for EcmascriptChunkType {
                              ecmascript"
                         );
                     };
-                    Ok((chunk_item, async_info))
+                    Ok((*ty, chunk_item, *async_info))
                 })
                 .try_join()
                 .await?,

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/content.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/content.rs
@@ -8,7 +8,7 @@ use turbopack_core::{
 use super::item::EcmascriptChunkItem;
 
 type EcmascriptChunkItemWithAsyncInfo = (
-    ResolvedVc<ChunkItemTy>,
+    ChunkItemTy,
     ResolvedVc<Box<dyn EcmascriptChunkItem>>,
     Option<ResolvedVc<AsyncModuleInfo>>,
 );
@@ -27,7 +27,7 @@ impl EcmascriptChunkContent {
             self.chunk_items
                 .iter()
                 .map(|(ty, item, _)| async move {
-                    if matches!(*ty.await?, ChunkItemTy::Included) {
+                    if matches!(ty, ChunkItemTy::Included) {
                         Ok(Some(item))
                     } else {
                         Ok(None)

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/content.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/content.rs
@@ -1,9 +1,14 @@
-use turbo_tasks::ResolvedVc;
-use turbopack_core::{chunk::AsyncModuleInfo, output::OutputAsset};
+use anyhow::Result;
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
+use turbopack_core::{
+    chunk::{AsyncModuleInfo, ChunkItemTy, ChunkItems},
+    output::OutputAsset,
+};
 
 use super::item::EcmascriptChunkItem;
 
 type EcmascriptChunkItemWithAsyncInfo = (
+    ResolvedVc<ChunkItemTy>,
     ResolvedVc<Box<dyn EcmascriptChunkItem>>,
     Option<ResolvedVc<AsyncModuleInfo>>,
 );
@@ -12,4 +17,30 @@ type EcmascriptChunkItemWithAsyncInfo = (
 pub struct EcmascriptChunkContent {
     pub chunk_items: Vec<EcmascriptChunkItemWithAsyncInfo>,
     pub referenced_output_assets: Vec<ResolvedVc<Box<dyn OutputAsset>>>,
+}
+
+#[turbo_tasks::value_impl]
+impl EcmascriptChunkContent {
+    #[turbo_tasks::function]
+    pub async fn included_chunk_items(&self) -> Result<Vc<ChunkItems>> {
+        Ok(ChunkItems(
+            self.chunk_items
+                .iter()
+                .map(|(ty, item, _)| async move {
+                    if matches!(*ty.await?, ChunkItemTy::Included) {
+                        Ok(Some(item))
+                    } else {
+                        Ok(None)
+                    }
+                })
+                .try_join()
+                .await?
+                .into_iter()
+                .flatten()
+                .map(|item| async move { Ok(ResolvedVc::upcast(*item)) })
+                .try_join()
+                .await?,
+        )
+        .cell())
+    }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/content.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/content.rs
@@ -1,17 +1,11 @@
 use anyhow::Result;
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::{
-    chunk::{AsyncModuleInfo, ChunkItem, ChunkItemTy, ChunkItems},
+    chunk::{ChunkItem, ChunkItemTy, ChunkItems},
     output::OutputAsset,
 };
 
-use super::item::EcmascriptChunkItem;
-
-type EcmascriptChunkItemWithAsyncInfo = (
-    ChunkItemTy,
-    ResolvedVc<Box<dyn EcmascriptChunkItem>>,
-    Option<ResolvedVc<AsyncModuleInfo>>,
-);
+use super::item::EcmascriptChunkItemWithAsyncInfo;
 
 #[turbo_tasks::value(shared)]
 pub struct EcmascriptChunkContent {
@@ -26,9 +20,9 @@ impl EcmascriptChunkContent {
         Ok(ChunkItems(
             self.chunk_items
                 .iter()
-                .filter_map(|(ty, item, _)| {
+                .filter_map(|EcmascriptChunkItemWithAsyncInfo { ty, chunk_item, .. }| {
                     if matches!(ty, ChunkItemTy::Included) {
-                        Some(item)
+                        Some(chunk_item)
                     } else {
                         None
                     }

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -2,10 +2,12 @@ use std::io::Write;
 
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{trace::TraceRawVcs, NonLocalValue, ResolvedVc, Upcast, ValueToString, Vc};
+use turbo_tasks::{
+    trace::TraceRawVcs, NonLocalValue, ResolvedVc, TaskInput, Upcast, ValueToString, Vc,
+};
 use turbo_tasks_fs::{rope::Rope, FileSystemPath};
 use turbopack_core::{
-    chunk::{AsyncModuleInfo, ChunkItem, ChunkItemExt, ChunkingContext},
+    chunk::{AsyncModuleInfo, ChunkItem, ChunkItemExt, ChunkItemTy, ChunkingContext},
     code_builder::{fileify_source_map, Code, CodeBuilder},
     error::PrettyPrintError,
     issue::{code_gen::CodeGenerationIssue, IssueExt, IssueSeverity, StyledString},
@@ -209,6 +211,13 @@ pub struct EcmascriptChunkItemOptions {
     /// `__turbopack_wasm__` to load WebAssembly.
     pub wasm: bool,
     pub placeholder_for_future_extensions: (),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, TraceRawVcs, TaskInput)]
+pub struct EcmascriptChunkItemWithAsyncInfo {
+    pub ty: ChunkItemTy,
+    pub chunk_item: ResolvedVc<Box<dyn EcmascriptChunkItem>>,
+    pub async_info: Option<Vc<AsyncModuleInfo>>,
 }
 
 #[turbo_tasks::value_trait]

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -213,11 +213,13 @@ pub struct EcmascriptChunkItemOptions {
     pub placeholder_for_future_extensions: (),
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, TraceRawVcs, TaskInput)]
+#[derive(
+    Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, TraceRawVcs, TaskInput, NonLocalValue,
+)]
 pub struct EcmascriptChunkItemWithAsyncInfo {
     pub ty: ChunkItemTy,
     pub chunk_item: ResolvedVc<Box<dyn EcmascriptChunkItem>>,
-    pub async_info: Option<Vc<AsyncModuleInfo>>,
+    pub async_info: Option<ResolvedVc<AsyncModuleInfo>>,
 }
 
 #[turbo_tasks::value_trait]

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -29,7 +29,7 @@ pub use self::{
     data::EcmascriptChunkData,
     item::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkItemExt,
-        EcmascriptChunkItemOptions,
+        EcmascriptChunkItemOptions, EcmascriptChunkItemWithAsyncInfo,
     },
     placeable::{EcmascriptChunkPlaceable, EcmascriptExports},
 };
@@ -139,8 +139,13 @@ impl Chunk for EcmascriptChunk {
         let mut referenced_output_assets: Vec<ResolvedVc<Box<dyn OutputAsset>>> = content
             .chunk_items
             .iter()
-            .map(|(_, chunk_item, _)| async move {
-                Ok(chunk_item.references().await?.into_iter().copied())
+            .map(async |with_info| {
+                Ok(with_info
+                    .chunk_item
+                    .references()
+                    .await?
+                    .into_iter()
+                    .copied())
             })
             .try_flat_join()
             .await?;

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -8,7 +8,7 @@ use std::fmt::Write;
 
 use anyhow::{bail, Result};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Value, ValueToString, Vc};
 use turbo_tasks_fs::FileSystem;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -19,7 +19,7 @@ use turbopack_core::{
         utils::{children_from_output_assets, content_to_details},
         Introspectable, IntrospectableChildren,
     },
-    output::OutputAssets,
+    output::{OutputAsset, OutputAssets},
     server_fs::ServerFileSystem,
 };
 
@@ -75,8 +75,8 @@ fn availability_root_key() -> Vc<RcStr> {
 impl Chunk for EcmascriptChunk {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
-        let EcmascriptChunkContent { chunk_items, .. } = &*self.content.await?;
-        let mut common_path = if let Some((chunk_item, _)) = chunk_items.first() {
+        let chunk_items = &*self.content.included_chunk_items().await?;
+        let mut common_path = if let Some(chunk_item) = chunk_items.first() {
             let path = chunk_item.asset_ident().path().to_resolved().await?;
             Some((path, path.await?))
         } else {
@@ -84,7 +84,7 @@ impl Chunk for EcmascriptChunk {
         };
 
         // The included chunk items describe the chunk uniquely
-        for &(chunk_item, _) in chunk_items.iter() {
+        for &chunk_item in chunk_items.iter() {
             if let Some((common_path_vc, common_path_ref)) = common_path.as_mut() {
                 let path = chunk_item.asset_ident().path().await?;
                 while !path.is_inside_or_equal_ref(common_path_ref) {
@@ -102,7 +102,7 @@ impl Chunk for EcmascriptChunk {
         let chunk_item_key = chunk_item_key().to_resolved().await?;
         let assets = chunk_items
             .iter()
-            .map(|&(chunk_item, _)| async move {
+            .map(|&chunk_item| async move {
                 Ok((
                     chunk_item_key,
                     chunk_item.content_ident().to_resolved().await?,
@@ -136,19 +136,21 @@ impl Chunk for EcmascriptChunk {
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<OutputAssets>> {
         let content = self.content.await?;
-        Ok(Vc::cell(content.referenced_output_assets.clone()))
+        let mut referenced_output_assets: Vec<ResolvedVc<Box<dyn OutputAsset>>> = content
+            .chunk_items
+            .iter()
+            .map(|(_, chunk_item, _)| async move {
+                Ok(chunk_item.references().await?.into_iter().copied())
+            })
+            .try_flat_join()
+            .await?;
+        referenced_output_assets.extend(content.referenced_output_assets.iter().copied());
+        Ok(Vc::cell(referenced_output_assets))
     }
 
     #[turbo_tasks::function]
-    async fn chunk_items(&self) -> Result<Vc<ChunkItems>> {
-        let EcmascriptChunkContent { chunk_items, .. } = &*self.content.await?;
-        Ok(ChunkItems(
-            chunk_items
-                .iter()
-                .map(|&(item, _)| ResolvedVc::upcast(item))
-                .collect(),
-        )
-        .cell())
+    async fn chunk_items(&self) -> Vc<ChunkItems> {
+        self.content.included_chunk_items()
     }
 }
 
@@ -210,9 +212,8 @@ impl Introspectable for EcmascriptChunk {
         let content = content_to_details(self.content());
         let mut details = String::new();
         let this = self.await?;
-        let chunk_content = this.content.await?;
         details += "Chunk items:\n\n";
-        for (chunk_item, _) in chunk_content.chunk_items.iter() {
+        for chunk_item in this.content.included_chunk_items().await? {
             writeln!(details, "- {}", chunk_item.asset_ident().to_string().await?)?;
         }
         details += "\nContent:\n\n";
@@ -226,7 +227,7 @@ impl Introspectable for EcmascriptChunk {
             .await?
             .clone_value();
         let chunk_item_module_key = chunk_item_module_key().to_resolved().await?;
-        for &(chunk_item, _) in self.await?.content.await?.chunk_items.iter() {
+        for chunk_item in self.await?.content.included_chunk_items().await? {
             children.insert((
                 chunk_item_module_key,
                 IntrospectableModule::new(chunk_item.module())

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -1,5 +1,6 @@
 // Needed for swc visit_ macros
 #![allow(non_local_definitions)]
+#![feature(async_closure)]
 #![feature(box_patterns)]
 #![feature(min_specialization)]
 #![feature(iter_intersperse)]

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -548,6 +548,15 @@ impl Module for EcmascriptModuleAsset {
         let references = analyze.references.await?.iter().copied().collect();
         Ok(Vc::cell(references))
     }
+
+    #[turbo_tasks::function]
+    async fn is_self_async(self: Vc<Self>) -> Result<Vc<bool>> {
+        if let Some(async_module) = *self.get_async_module().await? {
+            Ok(async_module.is_self_async(*self.analyze().await?.references))
+        } else {
+            Ok(Vc::cell(false))
+        }
+    }
 }
 
 #[turbo_tasks::value_impl]
@@ -643,15 +652,6 @@ impl ChunkItem for ModuleChunkItem {
     fn module(&self) -> Vc<Box<dyn Module>> {
         *ResolvedVc::upcast(self.module)
     }
-
-    #[turbo_tasks::function]
-    async fn is_self_async(&self) -> Result<Vc<bool>> {
-        if let Some(async_module) = *self.module.get_async_module().await? {
-            Ok(async_module.is_self_async(*self.module.analyze().await?.references))
-        } else {
-            Ok(Vc::cell(false))
-        }
-    }
 }
 
 #[turbo_tasks::value_impl]
@@ -735,11 +735,7 @@ impl EcmascriptModuleContent {
             }
         }
         if let Some(async_module) = *async_module.await? {
-            code_gens.push(async_module.code_generation(
-                chunking_context,
-                async_module_info,
-                references,
-            ));
+            code_gens.push(async_module.code_generation(async_module_info, references));
         }
         for c in code_generation.await?.iter() {
             match c {

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -64,18 +64,8 @@ impl ManifestAsyncModule {
     #[turbo_tasks::function]
     pub async fn manifest_chunks(self: Vc<Self>) -> Result<Vc<OutputAssets>> {
         let this = self.await?;
-        if let Some(chunk_items) = this.availability_info.available_chunk_items() {
-            if chunk_items
-                .await?
-                .get(
-                    this.inner
-                        .as_chunk_item(*ResolvedVc::upcast(this.chunking_context))
-                        .to_resolved()
-                        .await?,
-                )
-                .await?
-                .is_some()
-            {
+        if let Some(chunk_items) = this.availability_info.available_modules() {
+            if chunk_items.get(*this.inner).await?.is_some() {
                 return Ok(Vc::cell(vec![]));
             }
         }
@@ -92,7 +82,7 @@ impl ManifestAsyncModule {
     #[turbo_tasks::function]
     pub async fn content_ident(&self) -> Result<Vc<AssetIdent>> {
         let mut ident = self.inner.ident();
-        if let Some(available_modules) = self.availability_info.available_chunk_items() {
+        if let Some(available_modules) = self.availability_info.available_modules() {
             ident =
                 ident.with_modifier(Vc::cell(available_modules.hash().await?.to_string().into()));
         }

--- a/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
@@ -10,9 +10,7 @@ use turbo_tasks::{
     TryJoinIterExt, Vc,
 };
 use turbopack_core::{
-    chunk::{
-        AsyncModuleInfo, ChunkableModule, ChunkableModuleReference, ChunkingContext, ChunkingType,
-    },
+    chunk::{AsyncModuleInfo, ChunkableModuleReference, ChunkingType},
     reference::{ModuleReference, ModuleReferences},
     resolve::ExternalType,
 };
@@ -102,7 +100,6 @@ impl AsyncModule {
     #[turbo_tasks::function]
     async fn get_async_idents(
         &self,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
         async_module_info: Vc<AsyncModuleInfo>,
         references: Vc<ModuleReferences>,
     ) -> Result<Vc<AsyncModuleIdents>> {
@@ -124,13 +121,9 @@ impl AsyncModule {
                         }
                     }
                     ReferencedAsset::Some(placeable) => {
-                        let chunk_item = placeable
-                            .as_chunk_item(Vc::upcast(chunking_context))
-                            .to_resolved()
-                            .await?;
                         if async_module_info
                             .referenced_async_modules
-                            .contains(&chunk_item)
+                            .contains(&ResolvedVc::upcast(*placeable))
                         {
                             referenced_asset.get_ident().await?
                         } else {
@@ -194,14 +187,11 @@ impl AsyncModule {
     #[turbo_tasks::function]
     pub async fn code_generation(
         self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
         references: Vc<ModuleReferences>,
     ) -> Result<Vc<CodeGeneration>> {
         if let Some(async_module_info) = async_module_info {
-            let async_idents = self
-                .get_async_idents(chunking_context, async_module_info, references)
-                .await?;
+            let async_idents = self.get_async_idents(async_module_info, references).await?;
 
             if !async_idents.is_empty() {
                 let idents = async_idents

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -131,6 +131,13 @@ impl Module for CachedExternalModule {
     async fn references(&self) -> Result<Vc<ModuleReferences>> {
         Ok(Vc::cell(self.additional_references.clone()))
     }
+
+    #[turbo_tasks::function]
+    async fn is_self_async(&self) -> Result<Vc<bool>> {
+        Ok(Vc::cell(
+            self.external_type == CachedExternalType::EcmaScriptViaImport,
+        ))
+    }
 }
 
 #[turbo_tasks::value_impl]
@@ -228,13 +235,6 @@ impl ChunkItem for CachedExternalModuleChunkItem {
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         *self.chunking_context
-    }
-
-    #[turbo_tasks::function]
-    async fn is_self_async(&self) -> Result<Vc<bool>> {
-        Ok(Vc::cell(
-            self.module.await?.external_type == CachedExternalType::EcmaScriptViaImport,
-        ))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
@@ -80,11 +80,11 @@ impl EcmascriptChunkItem for EcmascriptModuleFacadeChunkItem {
                 code_gens.push(code_gen.code_generation(*chunking_context));
             }
         }
-        code_gens.push(self.module.async_module().code_generation(
-            *chunking_context,
-            async_module_info,
-            references,
-        ));
+        code_gens.push(
+            self.module
+                .async_module()
+                .code_generation(async_module_info, references),
+        );
         code_gens.push(exports.code_generation(*chunking_context));
         let code_gens = code_gens.into_iter().try_join().await?;
         let code_gens = code_gens.iter().map(|cg| &**cg).collect::<Vec<_>>();
@@ -149,19 +149,5 @@ impl ChunkItem for EcmascriptModuleFacadeChunkItem {
     #[turbo_tasks::function]
     fn module(&self) -> Vc<Box<dyn Module>> {
         *ResolvedVc::upcast(self.module)
-    }
-
-    #[turbo_tasks::function]
-    async fn is_self_async(&self) -> Result<Vc<bool>> {
-        let module = self.module;
-        let async_module = module.async_module();
-        let references = module.references();
-        let is_self_async = async_module
-            .resolve()
-            .await?
-            .is_self_async(references.resolve().await?)
-            .resolve()
-            .await?;
-        Ok(is_self_async)
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -151,6 +151,19 @@ impl Module for EcmascriptModuleFacadeModule {
         };
         Ok(Vc::cell(references))
     }
+
+    #[turbo_tasks::function]
+    async fn is_self_async(self: Vc<Self>) -> Result<Vc<bool>> {
+        let async_module = self.async_module();
+        let references = self.references();
+        let is_self_async = async_module
+            .resolve()
+            .await?
+            .is_self_async(references.resolve().await?)
+            .resolve()
+            .await?;
+        Ok(is_self_async)
+    }
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
@@ -97,16 +97,4 @@ impl ChunkItem for EcmascriptModuleLocalsChunkItem {
     fn module(&self) -> Vc<Box<dyn Module>> {
         *ResolvedVc::upcast(self.module)
     }
-
-    #[turbo_tasks::function]
-    async fn is_self_async(&self) -> Result<Vc<bool>> {
-        let module = self.module.await?;
-        let analyze = module.module.analyze().await?;
-        if let Some(async_module) = *analyze.async_module.await? {
-            let is_self_async = async_module.is_self_async(*analyze.local_references);
-            Ok(is_self_async)
-        } else {
-            Ok(Vc::cell(false))
-        }
-    }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -52,6 +52,17 @@ impl Module for EcmascriptModuleLocalsModule {
         let result = self.module.analyze().await?;
         Ok(*result.local_references)
     }
+
+    #[turbo_tasks::function]
+    async fn is_self_async(&self) -> Result<Vc<bool>> {
+        let analyze = self.module.analyze().await?;
+        if let Some(async_module) = *analyze.async_module.await? {
+            let is_self_async = async_module.is_self_async(*analyze.local_references);
+            Ok(is_self_async)
+        } else {
+            Ok(Vc::cell(false))
+        }
+    }
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -275,6 +275,11 @@ impl Module for EcmascriptModulePartAsset {
     }
 
     #[turbo_tasks::function]
+    fn is_self_async(self: Vc<Self>) -> Vc<bool> {
+        self.is_async_module()
+    }
+
+    #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<ModuleReferences>> {
         let split_data = split_module(*self.full_module).await?;
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
@@ -101,11 +101,6 @@ impl ChunkItem for EcmascriptModulePartChunkItem {
     fn module(&self) -> Vc<Box<dyn Module>> {
         *ResolvedVc::upcast(self.module)
     }
-
-    #[turbo_tasks::function]
-    fn is_self_async(&self) -> Vc<bool> {
-        self.module.is_async_module()
-    }
 }
 
 #[turbo_tasks::value(shared)]

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -58,7 +58,10 @@ pub(super) async fn chunk_items(
                        async_info,
                        ..
                    }| {
-                Ok((chunk_item.id().await?, chunk_item.code(async_info).await?))
+                Ok((
+                    chunk_item.id().await?,
+                    chunk_item.code(async_info.map(|info| *info)).await?,
+                ))
             },
         )
         .try_join()

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -13,7 +13,7 @@ use turbopack_core::{
     version::{Version, VersionedContent},
 };
 use turbopack_ecmascript::{
-    chunk::{EcmascriptChunkContent, EcmascriptChunkItemExt},
+    chunk::{EcmascriptChunkContent, EcmascriptChunkItemExt, EcmascriptChunkItemWithAsyncInfo},
     minify::minify,
     utils::StringifyJs,
 };
@@ -52,12 +52,15 @@ pub(super) async fn chunk_items(
         .await?
         .chunk_items
         .iter()
-        .map(|&(_, chunk_item, async_module_info)| async move {
-            Ok((
-                chunk_item.id().await?,
-                chunk_item.code(async_module_info.map(|info| *info)).await?,
-            ))
-        })
+        .map(
+            async |&EcmascriptChunkItemWithAsyncInfo {
+                       chunk_item,
+                       async_info,
+                       ..
+                   }| {
+                Ok((chunk_item.id().await?, chunk_item.code(async_info).await?))
+            },
+        )
         .try_join()
         .await
 }

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -52,7 +52,7 @@ pub(super) async fn chunk_items(
         .await?
         .chunk_items
         .iter()
-        .map(|&(chunk_item, async_module_info)| async move {
+        .map(|&(_, chunk_item, async_module_info)| async move {
             Ok((
                 chunk_item.id().await?,
                 chunk_item.code(async_module_info.map(|info| *info)).await?,

--- a/turbopack/crates/turbopack-nodejs/src/lib.rs
+++ b/turbopack/crates/turbopack-nodejs/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(async_closure)]
 #![feature(iter_intersperse)]
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -136,6 +136,11 @@ impl Module for WebAssemblyModuleAsset {
     fn references(self: Vc<Self>) -> Vc<ModuleReferences> {
         self.loader().references()
     }
+
+    #[turbo_tasks::function]
+    fn is_self_async(self: Vc<Self>) -> Vc<bool> {
+        Vc::cell(true)
+    }
 }
 
 #[turbo_tasks::value_impl]
@@ -228,11 +233,6 @@ impl ChunkItem for ModuleChunkItem {
     #[turbo_tasks::function]
     fn module(&self) -> Vc<Box<dyn Module>> {
         Vc::upcast(*self.module)
-    }
-
-    #[turbo_tasks::function]
-    fn is_self_async(self: Vc<Self>) -> Vc<bool> {
-        Vc::cell(true)
     }
 }
 


### PR DESCRIPTION
This:

- Replaces all use of chunk items in the interface for `chunk_content` with ChunkableModules
- Moves `is_self_async` from `ChunkItem` to `Module`
- Renames `AvailableChunkItems` to `AvailableModules` and all associated structs and methods, using modules in place of chunk items


Closes PACK-3706