### PR TITLE
chore(turbopack): Fix build error when CI environment variable is not supplied

### DIFF
--- a/crates/napi/src/next_api/utils.rs
+++ b/crates/napi/src/next_api/utils.rs
@@ -127,7 +127,9 @@ pub fn create_turbo_tasks(
     memory_limit: usize,
 ) -> Result<NextTurboTasks> {
     Ok(if persistent_caching {
-        let dirty_suffix = if crate::build::GIT_CLEAN || !env!("CI").is_empty() {
+        let dirty_suffix = if crate::build::GIT_CLEAN
+            || option_env!("CI").is_some_and(|value| !value.is_empty())
+        {
             ""
         } else {
             "-dirty"


### PR DESCRIPTION
Fixes:

```
error: environment variable `CI` not defined at compile time
   --> crates/napi/src/next_api/utils.rs:130:59
    |
130 |         let dirty_suffix = if crate::build::GIT_CLEAN || !env!("CI").is_empty() {
    |                                                           ^^^^^^^^^^
    |
    = help: use `std::env::var("CI")` to read the variable at run time
    = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)

error: could not compile `next-swc-napi` (lib) due to 1 previous error
```

Closes PACK-3663