### PR TITLE
Install Vercel CLI at start of E2E deploy tests

### DIFF
--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         group: [1/5, 2/5, 3/5, 4/5, 5/5, 6/6]
     with:
-      afterBuild: NEXT_E2E_TEST_TIMEOUT=240000 NEXT_TEST_MODE=deploy NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" node run-tests.js --timings -g ${{ matrix.group }} -c 2 --type e2e
+      afterBuild: npm i -g vercel@latest && NEXT_E2E_TEST_TIMEOUT=240000 NEXT_TEST_MODE=deploy NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" node run-tests.js --timings -g ${{ matrix.group }} -c 2 --type e2e
       skipNativeBuild: 'yes'
       skipNativeInstall: 'no'
       stepName: 'test-deploy-${{ matrix.group }}'


### PR DESCRIPTION
This ensures we install Vercel CLI before we start running tests so they aren't attempted to be installed during each test run which are done in parallel so could have issues from trying to do multiple installs at the same time. 

x-ref: https://github.com/vercel/next.js/actions/runs/12381595565/job/34560897615