### PR TITLE
refactor(turbopack): Rewrite CollectiblesSource callsites to use OperationVc (part 1/3)

### DIFF
--- a/turbopack/crates/turbopack-dev-server/src/source/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/mod.rs
@@ -19,8 +19,8 @@ use futures::{stream::Stream as StreamTrait, TryStreamExt};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    trace::TraceRawVcs, util::SharedError, Completion, NonLocalValue, ResolvedVc, Upcast, Value,
-    ValueDefault, Vc,
+    trace::TraceRawVcs, util::SharedError, Completion, NonLocalValue, OperationVc, ResolvedVc,
+    Upcast, Value, ValueDefault, Vc,
 };
 use turbo_tasks_bytes::{Bytes, Stream, StreamRead};
 use turbo_tasks_fs::FileSystemPath;
@@ -92,7 +92,7 @@ pub struct StaticContent {
 pub enum ContentSourceContent {
     NotFound,
     Static(ResolvedVc<StaticContent>),
-    HttpProxy(ResolvedVc<ProxyResult>),
+    HttpProxy(OperationVc<ProxyResult>),
     Rewrite(ResolvedVc<Rewrite>),
     /// Continue with the next route
     Next,

--- a/turbopack/crates/turbopack-dev-server/src/source/resolve.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/resolve.rs
@@ -26,7 +26,7 @@ use super::{
 pub enum ResolveSourceRequestResult {
     NotFound,
     Static(ResolvedVc<StaticContent>, ResolvedVc<HeaderList>),
-    HttpProxy(Vc<ProxyResult>),
+    HttpProxy(OperationVc<ProxyResult>),
 }
 
 /// Resolves a [SourceRequest] within a [super::ContentSource], returning the
@@ -120,7 +120,7 @@ pub async fn resolve_source_request(
                         .cell());
                     }
                     ContentSourceContent::HttpProxy(proxy_result) => {
-                        return Ok(ResolveSourceRequestResult::HttpProxy(**proxy_result).cell());
+                        return Ok(ResolveSourceRequestResult::HttpProxy(*proxy_result).cell());
                     }
                     ContentSourceContent::Next => continue,
                 }

--- a/turbopack/crates/turbopack-dev-server/src/update/stream.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/stream.rs
@@ -25,7 +25,7 @@ use crate::source::{resolve::ResolveSourceRequestResult, ProxyResult};
 
 type GetContentFn = Box<dyn Fn() -> OperationVc<ResolveSourceRequestResult> + Send + Sync>;
 
-async fn peek_issues<T: Send>(source: Vc<T>) -> Result<Vec<ReadRef<PlainIssue>>> {
+async fn peek_issues<T: Send>(source: OperationVc<T>) -> Result<Vec<ReadRef<PlainIssue>>> {
     let captured = source.peek_issues_with_path().await?;
 
     captured.get_plain_issues().await
@@ -41,15 +41,24 @@ fn extend_issues(issues: &mut Vec<ReadRef<PlainIssue>>, new_issues: Vec<ReadRef<
     }
 }
 
+#[turbo_tasks::function(operation)]
+fn versioned_content_update_operation(
+    content: ResolvedVc<Box<dyn VersionedContent>>,
+    from: ResolvedVc<Box<dyn Version>>,
+) -> Vc<Update> {
+    content.update(*from)
+}
+
 #[turbo_tasks::function]
 async fn get_update_stream_item(
     resource: RcStr,
     from: Vc<VersionState>,
     get_content: TransientInstance<GetContentFn>,
 ) -> Result<Vc<UpdateStreamItem>> {
-    let content_vc = get_content().connect();
+    let content_op = get_content();
+    let content_vc = content_op.connect();
     let content_result = content_vc.strongly_consistent().await;
-    let mut plain_issues = peek_issues(content_vc).await?;
+    let mut plain_issues = peek_issues(content_op).await?;
 
     let content_value = match content_result {
         Ok(content) => content,
@@ -89,27 +98,26 @@ async fn get_update_stream_item(
             }
 
             let resolved_content = static_content.content;
-            let from = from.get();
-            let update = resolved_content.update(from);
+            let from = from.get().to_resolved().await?;
+            let update_op = versioned_content_update_operation(resolved_content, from);
 
-            extend_issues(&mut plain_issues, peek_issues(update).await?);
-
-            let update = update.await?;
+            extend_issues(&mut plain_issues, peek_issues(update_op).await?);
 
             Ok(UpdateStreamItem::Found {
-                update,
+                update: update_op.connect().await?,
                 issues: plain_issues,
             }
             .cell())
         }
-        ResolveSourceRequestResult::HttpProxy(proxy_result) => {
-            let proxy_result_value = proxy_result.await?;
+        ResolveSourceRequestResult::HttpProxy(proxy_result_op) => {
+            let proxy_result_vc = proxy_result_op.connect();
+            let proxy_result_value = proxy_result_vc.await?;
 
             if proxy_result_value.status == 404 {
                 return Ok(UpdateStreamItem::NotFound.cell());
             }
 
-            extend_issues(&mut plain_issues, peek_issues(proxy_result).await?);
+            extend_issues(&mut plain_issues, peek_issues(proxy_result_op).await?);
 
             let from = from.get();
             if let Some(from) = Vc::try_resolve_downcast_type::<ProxyResult>(from).await? {
@@ -124,7 +132,7 @@ async fn get_update_stream_item(
 
             Ok(UpdateStreamItem::Found {
                 update: Update::Total(TotalUpdate {
-                    to: Vc::upcast::<Box<dyn Version>>(proxy_result)
+                    to: Vc::upcast::<Box<dyn Version>>(proxy_result_vc)
                         .into_trait_ref()
                         .await?,
                 })
@@ -195,7 +203,9 @@ impl UpdateStream {
             ResolveSourceRequestResult::Static(static_content, _) => {
                 static_content.await?.content.version()
             }
-            ResolveSourceRequestResult::HttpProxy(proxy_result) => Vc::upcast(proxy_result),
+            ResolveSourceRequestResult::HttpProxy(proxy_result) => {
+                Vc::upcast(proxy_result.connect())
+            }
             _ => Vc::upcast(NotFoundVersion::new()),
         };
         let version_state = VersionState::new(version.into_trait_ref().await?).await?;

--- a/turbopack/crates/turbopack-mdx/src/lib.rs
+++ b/turbopack/crates/turbopack-mdx/src/lib.rs
@@ -122,15 +122,20 @@ impl Source for MdxTransformedAsset {
 #[turbo_tasks::value_impl]
 impl Asset for MdxTransformedAsset {
     #[turbo_tasks::function]
-    async fn content(self: Vc<Self>) -> Result<Vc<AssetContent>> {
+    async fn content(self: ResolvedVc<Self>) -> Result<Vc<AssetContent>> {
         let this = self.await?;
-        Ok(*self
-            .process()
+        Ok(*transform_process_operation(self)
             .issue_file_path(this.source.ident().path(), "MDX processing")
             .await?
+            .connect()
             .await?
             .content)
     }
+}
+
+#[turbo_tasks::function(operation)]
+fn transform_process_operation(asset: ResolvedVc<MdxTransformedAsset>) -> Vc<MdxTransformResult> {
+    asset.process()
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -84,12 +84,12 @@ struct EmittedEvaluatePoolAssets {
     entrypoint: ResolvedVc<FileSystemPath>,
 }
 
-#[turbo_tasks::function]
-async fn emit_evaluate_pool_assets(
+#[turbo_tasks::function(operation)]
+async fn emit_evaluate_pool_assets_operation(
     module_asset: ResolvedVc<Box<dyn Module>>,
-    asset_context: Vc<Box<dyn AssetContext>>,
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
-    runtime_entries: Option<Vc<EvaluatableAssets>>,
+    asset_context: ResolvedVc<Box<dyn AssetContext>>,
+    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    runtime_entries: Option<ResolvedVc<EvaluatableAssets>>,
 ) -> Result<Vc<EmittedEvaluatePoolAssets>> {
     let runtime_asset = asset_context
         .process(
@@ -174,18 +174,18 @@ async fn emit_evaluate_pool_assets(
 
 #[turbo_tasks::function]
 async fn emit_evaluate_pool_assets_with_effects(
-    module_asset: Vc<Box<dyn Module>>,
-    asset_context: Vc<Box<dyn AssetContext>>,
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
-    runtime_entries: Option<Vc<EvaluatableAssets>>,
+    module_asset: ResolvedVc<Box<dyn Module>>,
+    asset_context: ResolvedVc<Box<dyn AssetContext>>,
+    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    runtime_entries: Option<ResolvedVc<EvaluatableAssets>>,
 ) -> Result<Vc<EmittedEvaluatePoolAssets>> {
-    let operation = emit_evaluate_pool_assets(
+    let operation = emit_evaluate_pool_assets_operation(
         module_asset,
         asset_context,
         chunking_context,
         runtime_entries,
     );
-    let result = operation.resolve_strongly_consistent().await?;
+    let result = operation.connect().resolve_strongly_consistent().await?;
     apply_effects(operation).await?;
     Ok(result)
 }

--- a/turbopack/crates/turbopack-node/src/render/node_api_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/node_api_source.rs
@@ -14,7 +14,7 @@ use turbopack_dev_server::source::{
     GetContentSourceContent,
 };
 
-use super::{render_proxy::render_proxy, RenderData};
+use super::{render_proxy::render_proxy_operation, RenderData};
 use crate::{get_intermediate_asset, node_entry::NodeEntry, route_matcher::RouteMatcher};
 
 /// Creates a [NodeApiContentSource].
@@ -128,34 +128,30 @@ impl GetContentSourceContent for NodeApiContentSource {
             anyhow::bail!("Missing request data")
         };
         let entry = (*self.entry).entry(data.clone()).await?;
-        Ok(ContentSourceContent::HttpProxy(
-            render_proxy(
-                *self.cwd,
-                *self.env,
-                self.server_root.join(path.clone()),
-                *entry.module,
-                *entry.runtime_entries,
-                *entry.chunking_context,
-                *entry.intermediate_output_path,
-                *entry.output_root,
-                *entry.project_dir,
-                RenderData {
-                    params: params.clone(),
-                    method: method.clone(),
-                    url: url.clone(),
-                    original_url: original_url.clone(),
-                    raw_query: raw_query.clone(),
-                    raw_headers: raw_headers.clone(),
-                    path: format!("/{}", path).into(),
-                    data: Some(self.render_data.await?),
-                }
-                .cell(),
-                **body,
-                self.debug,
-            )
-            .to_resolved()
-            .await?,
-        )
+        Ok(ContentSourceContent::HttpProxy(render_proxy_operation(
+            self.cwd,
+            self.env,
+            self.server_root.join(path.clone()).to_resolved().await?,
+            entry.module,
+            entry.runtime_entries,
+            entry.chunking_context,
+            entry.intermediate_output_path,
+            entry.output_root,
+            entry.project_dir,
+            RenderData {
+                params: params.clone(),
+                method: method.clone(),
+                url: url.clone(),
+                original_url: original_url.clone(),
+                raw_query: raw_query.clone(),
+                raw_headers: raw_headers.clone(),
+                path: format!("/{}", path).into(),
+                data: Some(self.render_data.await?),
+            }
+            .resolved_cell(),
+            *body,
+            self.debug,
+        ))
         .cell())
     }
 }

--- a/turbopack/crates/turbopack-node/src/render/render_proxy.rs
+++ b/turbopack/crates/turbopack-node/src/render/render_proxy.rs
@@ -32,8 +32,8 @@ use crate::{
 };
 
 /// Renders a module as static HTML in a node.js process.
-#[turbo_tasks::function]
-pub async fn render_proxy(
+#[turbo_tasks::function(operation)]
+pub async fn render_proxy_operation(
     cwd: ResolvedVc<FileSystemPath>,
     env: ResolvedVc<Box<dyn ProcessEnv>>,
     path: ResolvedVc<FileSystemPath>,

--- a/turbopack/crates/turbopack-node/src/render/render_static.rs
+++ b/turbopack/crates/turbopack-node/src/render/render_static.rs
@@ -72,8 +72,8 @@ impl StaticResult {
 }
 
 /// Renders a module as static HTML in a node.js process.
-#[turbo_tasks::function]
-pub async fn render_static(
+#[turbo_tasks::function(operation)]
+pub async fn render_static_operation(
     cwd: ResolvedVc<FileSystemPath>,
     env: ResolvedVc<Box<dyn ProcessEnv>>,
     path: ResolvedVc<FileSystemPath>,

--- a/turbopack/crates/turbopack-node/src/render/rendered_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/rendered_source.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde_json::Value as JsonValue;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexSet, ResolvedVc, Value, Vc};
+use turbo_tasks::{FxIndexSet, OperationVc, ResolvedVc, Value, Vc};
 use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -27,7 +27,7 @@ use turbopack_dev_server::{
 };
 
 use super::{
-    render_static::{render_static, StaticResult},
+    render_static::{render_static_operation, StaticResult},
     RenderData,
 };
 use crate::{
@@ -186,17 +186,17 @@ impl GetContentSourceContent for NodeRenderContentSource {
             anyhow::bail!("Missing request data")
         };
         let entry = (*self.entry).entry(data.clone()).await?;
-        let result = render_static(
-            *self.cwd,
-            *self.env,
-            self.server_root.join(path.clone()),
-            *entry.module,
-            *entry.runtime_entries,
-            *self.fallback_page,
-            *entry.chunking_context,
-            *entry.intermediate_output_path,
-            *entry.output_root,
-            *entry.project_dir,
+        let result_op = render_static_operation(
+            self.cwd,
+            self.env,
+            self.server_root.join(path.clone()).to_resolved().await?,
+            entry.module,
+            entry.runtime_entries,
+            self.fallback_page,
+            entry.chunking_context,
+            entry.intermediate_output_path,
+            entry.output_root,
+            entry.project_dir,
             RenderData {
                 params: params.clone(),
                 method: method.clone(),
@@ -207,7 +207,7 @@ impl GetContentSourceContent for NodeRenderContentSource {
                 path: pathname.as_str().into(),
                 data: Some(self.render_data.await?),
             }
-            .cell(),
+            .resolved_cell(),
             self.debug,
         )
         .issue_file_path(
@@ -215,7 +215,7 @@ impl GetContentSourceContent for NodeRenderContentSource {
             format!("server-side rendering {}", pathname),
         )
         .await?;
-        Ok(match *result.await? {
+        Ok(match *result_op.connect().await? {
             StaticResult::Content {
                 content,
                 status_code,
@@ -229,18 +229,33 @@ impl GetContentSourceContent for NodeRenderContentSource {
                 status,
                 headers,
                 ref body,
-            } => ContentSourceContent::HttpProxy(
-                ProxyResult {
-                    status,
-                    headers: headers.await?.clone_value(),
-                    body: body.clone(),
-                }
-                .resolved_cell(),
-            )
-            .cell(),
+            } => {
+                ContentSourceContent::HttpProxy(static_streamed_content_to_proxy_result_operation(
+                    result_op,
+                    ProxyResult {
+                        status,
+                        headers: headers.await?.clone_value(),
+                        body: body.clone(),
+                    }
+                    .resolved_cell(),
+                ))
+                .cell()
+            }
             StaticResult::Rewrite(rewrite) => ContentSourceContent::Rewrite(rewrite).cell(),
         })
     }
+}
+
+#[turbo_tasks::function(operation)]
+async fn static_streamed_content_to_proxy_result_operation(
+    result_op: OperationVc<StaticResult>,
+    proxy_result: ResolvedVc<ProxyResult>,
+) -> Result<Vc<ProxyResult>> {
+    // we already assume `result_op`'s value here because we're called inside of a match arm, but
+    // await `result_op` anyways, so that if it generates any collectible issues, they're captured
+    // here.
+    let _ = result_op.connect().await?;
+    Ok(*proxy_result)
 }
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -162,15 +162,22 @@ impl Source for PostCssTransformedAsset {
 #[turbo_tasks::value_impl]
 impl Asset for PostCssTransformedAsset {
     #[turbo_tasks::function]
-    async fn content(self: Vc<Self>) -> Result<Vc<AssetContent>> {
+    async fn content(self: ResolvedVc<Self>) -> Result<Vc<AssetContent>> {
         let this = self.await?;
-        Ok(*self
-            .process()
+        Ok(*transform_process_operation(self)
             .issue_file_path(this.source.ident().path(), "PostCSS processing")
             .await?
+            .connect()
             .await?
             .content)
     }
+}
+
+#[turbo_tasks::function(operation)]
+fn transform_process_operation(
+    asset: ResolvedVc<PostCssTransformedAsset>,
+) -> Vc<ProcessPostCssResult> {
+    asset.process()
 }
 
 #[turbo_tasks::value]


### PR DESCRIPTION
`OperationVc`s should be used with `CollectiblesSource` instead of `Vc`s because collectibles represent a side-effect or implicit extra return value of a function's execution.

This PR doesn't convert all callsites, just a handful.

Closes PACK-3677