### PR TITLE
[Segment Cache] Background segment revalidation

### DIFF
--- a/packages/next/src/client/components/segment-cache/lru.ts
+++ b/packages/next/src/client/components/segment-cache/lru.ts
@@ -64,14 +64,15 @@ export function createLRU<T extends LRUNode>(
   }
 
   function updateSize(node: T, newNodeSize: number) {
-    // This is a separate function so that we can resize the entry after it's
-    // already been inserted.
-    if (node.next === null) {
-      // No longer part of LRU.
-      return
-    }
+    // This is a separate function from `put` so that we can resize the entry
+    // regardless of whether it's currently being tracked by the LRU.
     const prevNodeSize = node.size
     node.size = newNodeSize
+    if (node.next === null) {
+      // This entry is not currently being tracked by the LRU.
+      return
+    }
+    // Update the total LRU size
     lruSize = lruSize - prevNodeSize + newNodeSize
     ensureCleanupIsScheduled()
   }

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -213,7 +213,6 @@ function readRenderSnapshotFromCache(
         isPartial = segmentEntry.isPartial
         break
       }
-      case EntryStatus.Empty:
       case EntryStatus.Pending: {
         // We haven't received data for this segment yet, but there's already
         // an in-progress request. Since it's extremely likely to arrive
@@ -231,12 +230,11 @@ function readRenderSnapshotFromCache(
         isPartial = true
         break
       }
+      case EntryStatus.Empty:
       case EntryStatus.Rejected:
         break
-      default: {
-        const _exhaustiveCheck: never = segmentEntry
-        break
-      }
+      default:
+        segmentEntry satisfies never
     }
   }
 

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -16,6 +16,11 @@ import {
   fetchSegmentPrefetchesForPPRDisabledRoute,
   type PendingSegmentCacheEntry,
   convertRouteTreeToFlightRouterState,
+  FetchStrategy,
+  readOrCreateRevalidatingSegmentEntry,
+  upsertSegmentEntry,
+  type FulfilledSegmentCacheEntry,
+  upgradeToPendingSegment,
 } from './cache'
 import type { RouteCacheKey } from './cache-key'
 
@@ -50,7 +55,7 @@ export type PrefetchTask = {
    * heuristics, like removing prefetches once a link leaves the viewport.
    *
    * The sortId is assigned when the prefetch is initiated, and reassigned if
-   * the same URL is prefetched again (effectively bumping it to the top of
+   * the same task is prefetched again (effectively bumping it to the top of
    * the queue).
    *
    * TODO: We can add additional fields here to indicate what kind of prefetch
@@ -63,6 +68,19 @@ export type PrefetchTask = {
    * increase the priority of its prefetch.
    */
   sortId: number
+
+  /**
+   * The priority of the task. Like sortId, this affects the task's position in
+   * the queue, so it must never be updated without resifting the heap.
+   */
+  priority: PrefetchPriority
+
+  /**
+   * Temporary state for tracking the currently running task. This is currently
+   * used to track whether a task deferred some work to run background at
+   * priority, but we might need it for additional state in the future.
+   */
+  hasBackgroundWork: boolean
 
   /**
    * True if the prefetch is blocked by network data. We remove tasks from the
@@ -105,6 +123,14 @@ const enum PrefetchTaskExitStatus {
   Done,
 }
 
+/**
+ * The priority of the prefetch task. Higher numbers are higher priority.
+ */
+const enum PrefetchPriority {
+  Default = 1,
+  Background = 0,
+}
+
 export type PrefetchSubtaskResult<T> = {
   /**
    * A promise that resolves when the network connection is closed.
@@ -141,6 +167,8 @@ export function schedulePrefetchTask(
   const task: PrefetchTask = {
     key,
     treeAtTimeOfPrefetch,
+    priority: PrefetchPriority.Default,
+    hasBackgroundWork: false,
     sortId: sortIdCounter++,
     isBlocked: false,
     _heapIndex: -1,
@@ -196,16 +224,16 @@ function spawnPrefetchSubtask<T>(
   // and limiting the number of concurrent requests.
   inProgressRequests++
   return prefetchSubtask.then((result) => {
-      if (result === null) {
-        // The prefetch task errored before it could start processing the
-        // network stream. Assume the connection is closed.
+    if (result === null) {
+      // The prefetch task errored before it could start processing the
+      // network stream. Assume the connection is closed.
       onPrefetchConnectionClosed()
       return null
-      }
-      // Wait for the connection to close before freeing up more bandwidth.
+    }
+    // Wait for the connection to close before freeing up more bandwidth.
     result.closed.then(onPrefetchConnectionClosed)
     return result.value
-    })
+  })
 }
 
 function onPrefetchConnectionClosed(): void {
@@ -246,6 +274,12 @@ function processQueueInMicrotask() {
   while (task !== null && hasNetworkBandwidth()) {
     const route = readOrCreateRouteCacheEntry(now, task)
     const exitStatus = pingRootRouteTree(now, task, route)
+
+    // The `hasBackgroundWork` field is only valid for a single attempt. Reset
+    // it immediately upon exit.
+    const hasBackgroundWork = task.hasBackgroundWork
+    task.hasBackgroundWork = false
+
     switch (exitStatus) {
       case PrefetchTaskExitStatus.InProgress:
         // The task yielded because there are too many requests in progress.
@@ -261,16 +295,39 @@ function processQueueInMicrotask() {
         task = heapPeek(taskHeap)
         continue
       case PrefetchTaskExitStatus.Done:
-        // The prefetch is complete. Continue to the next task.
-        heapPop(taskHeap)
+        if (hasBackgroundWork) {
+          // The task spawned additional background work. Reschedule the task
+          // at background priority.
+          task.priority = PrefetchPriority.Background
+          heapResift(taskHeap, task)
+        } else {
+          // The prefetch is complete. Continue to the next task.
+          heapPop(taskHeap)
+        }
         task = heapPeek(taskHeap)
         continue
-      default: {
-        const _exhaustiveCheck: never = exitStatus
-        return
-      }
+      default:
+        exitStatus satisfies never
     }
   }
+}
+
+/**
+ * Check this during a prefetch task to determine if background work can be
+ * performed. If so, it evaluates to `true`. Otherwise, it returns `false`,
+ * while also scheduling a background task to run later. Usage:
+ *
+ * @example
+ * if (background(task)) {
+ *   // Perform background-pri work
+ * }
+ */
+function background(task: PrefetchTask): boolean {
+  if (task.priority === PrefetchPriority.Background) {
+    return true
+  }
+  task.hasBackgroundWork = true
+  return false
 }
 
 function pingRootRouteTree(
@@ -388,7 +445,7 @@ function pingRouteTree(
   tree: RouteTree
 ): PrefetchTaskExitStatus.InProgress | PrefetchTaskExitStatus.Done {
   const segment = readOrCreateSegmentCacheEntry(now, route, tree.key)
-  pingSegment(route, segment, task.key, tree.key, tree.token)
+  pingSegment(now, task, route, segment, task.key, tree.key, tree.token)
   if (tree.slots !== null) {
     if (!hasNetworkBandwidth()) {
       // Stop prefetching segments until there's more bandwidth.
@@ -504,9 +561,18 @@ function createDynamicRequestTreeForPartiallyCachedSegments(
       // already work even without any updates to the server. For consistency,
       // though, I'll send the full tree and we'll look into this later as part
       // of a larger redesign of the request protocol.
+
       // Add the pending cache entry to the result map.
-      segment.status = EntryStatus.Pending
-      spawnedEntries.set(tree.key, segment)
+      spawnedEntries.set(
+        tree.key,
+        upgradeToPendingSegment(
+          segment,
+          // Set the fetch strategy to LoadingBoundary to indicate that the server
+          // might not include it in the pending response. If another route is able
+          // to issue a per-segment request, we'll do that in the background.
+          FetchStrategy.LoadingBoundary
+        )
+      )
       if (refetchMarkerContext !== 'refetch') {
         refetchMarker = refetchMarkerContext = 'refetch'
       } else {
@@ -525,6 +591,12 @@ function createDynamicRequestTreeForPartiallyCachedSegments(
         // path. We can bail out.
         return convertRouteTreeToFlightRouterState(tree)
       }
+      // NOTE: If the cached segment were fetched using PPR, then it might be
+      // partial. We could get a more complete version of the segment by
+      // including it in this non-PPR request.
+      //
+      // We're intentionally choosing not to, though, because it's generally
+      // better to avoid doing a dynamic prefetch whenever possible.
       break
     }
     case EntryStatus.Pending: {
@@ -565,34 +637,102 @@ function createDynamicRequestTreeForPartiallyCachedSegments(
 }
 
 function pingSegment(
+  now: number,
+  task: PrefetchTask,
   route: FulfilledRouteCacheEntry,
   segment: SegmentCacheEntry,
   routeKey: RouteCacheKey,
   segmentKey: string,
   accessToken: string | null
 ): void {
-  if (segment.status === EntryStatus.Empty) {
-    if (accessToken === null) {
-      // We don't have an access token for this segment, which means we can't
-      // do a per-segment prefetch. This happens when the route tree was
-      // returned by a dynamic server response. Or if the server has decided
-      // not to grant access to this segment.
-    } else {
-      // Segment is not yet cached, and there's no request already in progress.
-      // Spawn a task to request the segment and load it into the cache.
-
+  if (accessToken === null) {
+    // We don't have an access token for this segment, which means we can't
+    // do a per-segment prefetch. This happens when the route tree was
+    // returned by a dynamic server response. Or if the server has decided
+    // not to grant access to this segment.
+    return
+  }
+  switch (segment.status) {
+    case EntryStatus.Empty:
       // Upgrade to Pending so we know there's already a request in progress
-      segment.status = EntryStatus.Pending
       spawnPrefetchSubtask(
         fetchSegmentOnCacheMiss(
           route,
-          segment,
+          upgradeToPendingSegment(segment, FetchStrategy.PPR),
           routeKey,
           segmentKey,
           accessToken
         )
       )
+      break
+    case EntryStatus.Pending: {
+      // There's already a request in progress. Depending on what kind of
+      // request it is, we may want to
+      switch (segment.fetchStrategy) {
+        case FetchStrategy.PPR:
+          // There's already a request in progress. Don't do anything.
+          break
+        case FetchStrategy.LoadingBoundary:
+          // There's a pending request, but because it's using the old
+          // prefetching strategy, we can't be sure if it will be fulfilled by
+          // the response — it might be inside the loading boundary. Perform
+          // a revalidation, but because it's speculative, wait to do it at
+          // background priority.
+          if (background(task)) {
+            // TODO: Instead of speculatively revalidating, consider including
+            // `hasLoading` in the route tree prefetch response.
+            pingPPRSegmentRevalidation(
+              now,
+              segment,
+              route,
+              routeKey,
+              segmentKey,
+              accessToken
+            )
+          }
+          break
+        default:
+          segment.fetchStrategy satisfies never
+      }
+      break
     }
+    case EntryStatus.Rejected: {
+      // The existing entry in the cache was rejected. Depending on how it
+      // was originally fetched, we may or may not want to revalidate it.
+      switch (segment.fetchStrategy) {
+        case FetchStrategy.PPR:
+          // The previous attempt to fetch this entry failed. Don't attempt to
+          // fetch it again until the entry expires.
+          break
+        case FetchStrategy.LoadingBoundary:
+          // There's a rejected entry, but it was fetched using the loading
+          // boundary strategy. So the reason it wasn't returned by the server
+          // might just be because it was inside a loading boundary. Or because
+          // there was a dynamic rewrite. Revalidate it using the per-
+          // segment strategy.
+          //
+          // Because a rejected segment will definitely prevent the segment (and
+          // all of its children) from rendering, we perform this revalidation
+          // immediately instead of deferring it to a background task.
+          pingPPRSegmentRevalidation(
+            now,
+            segment,
+            route,
+            routeKey,
+            segmentKey,
+            accessToken
+          )
+          break
+        default:
+          segment.fetchStrategy satisfies never
+      }
+      break
+    }
+    case EntryStatus.Fulfilled:
+      // Segment is already cached. There's nothing left to prefetch.
+      break
+    default:
+      segment satisfies never
   }
 
   // Segments do not have dependent tasks, so once the prefetch is initiated,
@@ -600,8 +740,66 @@ function pingSegment(
   // entry, which is handled by `fetchSegmentOnCacheMiss`).
 }
 
+function pingPPRSegmentRevalidation(
+  now: number,
+  currentSegment: SegmentCacheEntry,
+  route: FulfilledRouteCacheEntry,
+  routeKey: RouteCacheKey,
+  segmentKey: string,
+  accessToken: string | null
+): void {
+  const revalidatingSegment = readOrCreateRevalidatingSegmentEntry(
+    now,
+    currentSegment
+  )
+  switch (revalidatingSegment.status) {
+    case EntryStatus.Empty:
+      // Spawn a prefetch request and upsert the segment into the cache
+      // upon completion.
+      upsertSegmentOnCompletion(
+        segmentKey,
+        spawnPrefetchSubtask(
+          fetchSegmentOnCacheMiss(
+            route,
+            upgradeToPendingSegment(revalidatingSegment, FetchStrategy.PPR),
+            routeKey,
+            segmentKey,
+            accessToken
+          )
+        )
+      )
+      break
+    case EntryStatus.Pending:
+      // There's already a revalidation in progress.
+      break
+    case EntryStatus.Fulfilled:
+    case EntryStatus.Rejected:
+      // A previous revalidation attempt finished, but we chose not to replace
+      // the existing entry in the cache. Don't try again until or unless the
+      // revalidation entry expires.
+      break
+    default:
+      revalidatingSegment satisfies never
+  }
+}
+
+const noop = () => {}
+
+function upsertSegmentOnCompletion(
+  key: string,
+  promise: Promise<FulfilledSegmentCacheEntry | null>
+) {
+  // Wait for a segment to finish loading, then upsert it into the cache
+  promise.then((fulfilled) => {
+    if (fulfilled !== null) {
+      // Received new data. Attempt to replace the existing entry in the cache.
+      upsertSegmentEntry(Date.now(), key, fulfilled)
+    }
+  }, noop)
+}
+
 // -----------------------------------------------------------------------------
-// The remainider of the module is a MinHeap implementation. Try not to put any
+// The remainder of the module is a MinHeap implementation. Try not to put any
 // logic below here unless it's related to the heap algorithm. We can extract
 // this to a separate module if/when we need multiple kinds of heaps.
 // -----------------------------------------------------------------------------
@@ -610,7 +808,13 @@ function compareQueuePriority(a: PrefetchTask, b: PrefetchTask) {
   // Since the queue is a MinHeap, this should return a positive number if b is
   // higher priority than a, and a negative number if a is higher priority
   // than b.
-  //
+
+  // `priority` is an integer, where higher numbers are higher priority.
+  const priorityDiff = b.priority - a.priority
+  if (priorityDiff !== 0) {
+    return priorityDiff
+  }
+
   // sortId is an incrementing counter assigned to prefetches. We want to
   // process the newest prefetches first.
   return b.sortId - a.sortId
@@ -642,22 +846,24 @@ function heapPop(heap: Array<PrefetchTask>): PrefetchTask | null {
   return first
 }
 
-// Not currently used, but will be once we add the ability to update a
-// task's priority.
-// function heapSift(heap: Array<PrefetchTask>, node: PrefetchTask) {
-//   const index = node._heapIndex
-//   if (index !== -1) {
-//     const parentIndex = (index - 1) >>> 1
-//     const parent = heap[parentIndex]
-//     if (compareQueuePriority(parent, node) > 0) {
-//       // The parent is larger. Sift up.
-//       heapSiftUp(heap, node, index)
-//     } else {
-//       // The parent is smaller (or equal). Sift down.
-//       heapSiftDown(heap, node, index)
-//     }
-//   }
-// }
+function heapResift(heap: Array<PrefetchTask>, node: PrefetchTask): void {
+  const index = node._heapIndex
+  if (index !== -1) {
+    if (index === 0) {
+      heapSiftDown(heap, node, 0)
+    } else {
+      const parentIndex = (index - 1) >>> 1
+      const parent = heap[parentIndex]
+      if (compareQueuePriority(parent, node) > 0) {
+        // The parent is larger. Sift up.
+        heapSiftUp(heap, node, index)
+      } else {
+        // The parent is smaller (or equal). Sift down.
+        heapSiftDown(heap, node, index)
+      }
+    }
+  }
+}
 
 function heapSiftUp(
   heap: Array<PrefetchTask>,

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/link-accordion.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+  id,
+}: {
+  href: string
+  children: string
+  prefetch?: boolean
+  id?: string
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+        id={id}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        `${children} (link is hidden)`
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/mixed-fetch-strategies/has-loading-boundary/a/b/shared-layout/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/mixed-fetch-strategies/has-loading-boundary/a/b/shared-layout/layout.tsx
@@ -1,0 +1,32 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+async function DynamicContentInSharedLayout() {
+  await connection()
+  return (
+    <div id="dynamic-content-in-shared-layout">
+      Dynamic content in shared layout
+    </div>
+  )
+}
+
+export default function SharedLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div id="shared-layout">
+      <Suspense
+        fallback={
+          <div id="shared-layout-ppr-boundary">
+            Loading (PPR shell of shared-layout)...
+          </div>
+        }
+      >
+        <DynamicContentInSharedLayout />
+      </Suspense>
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/mixed-fetch-strategies/has-loading-boundary/a/b/shared-layout/ppr-disabled/page.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/mixed-fetch-strategies/has-loading-boundary/a/b/shared-layout/ppr-disabled/page.tsx
@@ -1,0 +1,15 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+async function Content() {
+  await connection()
+  return <div id="page-content">Dynamic page content</div>
+}
+
+export default async function Page() {
+  return (
+    <Suspense fallback={<div id="page-loading-boundary">Loading page...</div>}>
+      <Content />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/mixed-fetch-strategies/has-loading-boundary/a/b/shared-layout/ppr-enabled/page.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/mixed-fetch-strategies/has-loading-boundary/a/b/shared-layout/ppr-enabled/page.tsx
@@ -1,0 +1,17 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+export const experimental_ppr = true
+
+async function Content() {
+  await connection()
+  return <div id="page-content">Dynamic page content</div>
+}
+
+export default async function Page() {
+  return (
+    <Suspense fallback={<div id="page-loading-boundary">Loading page...</div>}>
+      <Content />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/mixed-fetch-strategies/has-loading-boundary/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/mixed-fetch-strategies/has-loading-boundary/layout.tsx
@@ -1,0 +1,7 @@
+export default function SharedLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return <div id="has-loading-boundary">{children}</div>
+}

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/mixed-fetch-strategies/has-loading-boundary/loading.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/mixed-fetch-strategies/has-loading-boundary/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div id="loading-boundary">
+      Loading (has-loading-boundary/loading.tsx)...
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/mixed-fetch-strategies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/mixed-fetch-strategies/page.tsx
@@ -1,0 +1,33 @@
+import { LinkAccordion } from '../link-accordion'
+
+export default function MixedFetchStrategies() {
+  return (
+    <>
+      <p>
+        This page tests what happens when a shared layout belongs to both a
+        PPR-enabled route and a non-PPR enabled route. The layout data should be
+        omitted when prefetching the non-PPR enabled route, because it's inside
+        another layout that has a loading boundary. But it should be included
+        when prefetching the route that has PPR enabled.
+      </p>
+      <ul>
+        <li>
+          <LinkAccordion
+            id="ppr-enabled"
+            href="/mixed-fetch-strategies/has-loading-boundary/a/b/shared-layout/ppr-enabled"
+          >
+            Link to PPR enabled page
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion
+            id="ppr-disabled"
+            href="/mixed-fetch-strategies/has-loading-boundary/a/b/shared-layout/ppr-disabled"
+          >
+            Link to PPR disabled page
+          </LinkAccordion>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/page.tsx
@@ -1,26 +1,4 @@
-'use client'
-
-import Link from 'next/link'
-import { useState } from 'react'
-
-function LinkAccordion({ href, children }) {
-  const [isVisible, setIsVisible] = useState(false)
-  return (
-    <>
-      <input
-        type="checkbox"
-        checked={isVisible}
-        onChange={() => setIsVisible(!isVisible)}
-        data-link-accordion={href}
-      />
-      {isVisible ? (
-        <Link href={href}>{children}</Link>
-      ) : (
-        `${children} (link is hidden)`
-      )}
-    </>
-  )
-}
+import { LinkAccordion } from './link-accordion'
 
 export default function Page() {
   return (


### PR DESCRIPTION
This implements background revalidation of partial segment entries in the client Segment Cache.

Until this PR, entries were never replaced in the Segment Cache, they were only evicted upon becoming stale, or if the LRU overflowed. But there are cases where we'll want to replace an existing entry with a new one; for example, if the current segment has more dynamic holes than the new one.

Most commonly this happens when multiple fetching strategies are mixed within the same app. For example: when a shared layout belongs to both a PPR-enabled route and a non-PPR enabled route, the layout data might be omitted when prefetching the non-PPR enabled route, if it's wrapped in a loading boundary. But that shouldn't prevent it from being included when prefetching the route that has PPR enabled.

(*Another example is when a shared layout is prefetched both on viewport entry and also via `<Link prefetch={true}>`. A viewport prefetch will only include the static data, but `prefetch={true}` includes both the static and the dynamic.*

*`<Link prefetch={true}>` is not yet implemented by the Segment Cache but it will use a similar background revalidation strategy as the one implemented in this PR.*)