### PR TITLE
Fix flakey deploy test assertion

### DIFF
--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -187,7 +187,7 @@ describe('app dir - basic', () => {
         (req) =>
           req.includes(
             encodeURI(isTurbopack ? '[category]_[id]' : '/[category]/[id]')
-          ) && req.endsWith('.js')
+          ) && req.includes('.js')
       )
         ? 'found'
         : // When it fails will log out the paths.


### PR DESCRIPTION
This test is asserting that the request ends in `.js` although skew protection can add a `?dpl` query at the end which would make the assertion timeout incorrectly.

x-ref: https://github.com/vercel/next.js/actions/runs/12384759046/job/34571137789#step:28:305