### PR TITLE
exclude `.stories.` and `.test.` files from taskfile watch and error plugin

### DIFF
--- a/packages/next/taskfile-swc.js
+++ b/packages/next/taskfile-swc.js
@@ -22,7 +22,7 @@ module.exports = function (task) {
       if (file.base.endsWith('.d.ts') || file.base.endsWith('.json')) return
 
       const plugins = [
-        ...(file.base.includes('.test.')
+        ...(file.base.includes('.test.') || file.base.includes('.stories.')
           ? []
           : [[path.join(__dirname, 'next_error_code_swc_plugin.wasm'), {}]]),
       ]

--- a/packages/next/taskfile-watch.js
+++ b/packages/next/taskfile-watch.js
@@ -39,7 +39,7 @@ module.exports = function (Taskr, _utils) {
       const wp = new Watchpack({
         aggregateTimeout: 5,
         followSymlinks: true,
-        ignored: '**/.git',
+        ignored: ['**/.git', '**/*.test.*', '**/*.stories.*'],
       })
 
       names = toArr(names)


### PR DESCRIPTION
### Why?

1. Errors from `.stories.` are added to `errors.json`.
2. `pnpm dev -F next` watches unit test files and stories changes, which is unnecessary.