### PR TITLE
docs: Fix filename for Turbopack traces

### DIFF
--- a/docs/01-app/04-api-reference/08-turbopack.mdx
+++ b/docs/01-app/04-api-reference/08-turbopack.mdx
@@ -80,6 +80,6 @@ These features are currently not supported:
 
 ### Generating Trace Files
 
-Trace files allow the Next.js team to investigate and improve performance metrics and memory usage. To generate a trace file, append `NEXT_TURBOPACK_TRACING=1` to the `next dev --turbopack` command, this will generate a `.next/trace.log` file.
+Trace files allow the Next.js team to investigate and improve performance metrics and memory usage. To generate a trace file, append `NEXT_TURBOPACK_TRACING=1` to the `next dev --turbopack` command, this will generate a `.next/trace-turbopack` file.
 
 When reporting issues related to Turbopack performance and memory usage, please include the trace file in your [GitHub](https://github.com/vercel/next.js) issue.


### PR DESCRIPTION
For https://nextjs.org/docs/app/api-reference/turbopack#generating-trace-files

Closes PACK-3666