### PR TITLE
docs: Update Route Handlers docs for streaming

### DIFF
--- a/docs/01-app/03-building-your-application/01-routing/13-route-handlers.mdx
+++ b/docs/01-app/03-building-your-application/01-routing/13-route-handlers.mdx
@@ -322,31 +322,31 @@ Streaming is commonly used in combination with Large Language Models (LLMs), suc
 
 ```ts filename="app/api/chat/route.ts" switcher
 import { openai } from '@ai-sdk/openai'
-import { StreamingTextResponse, streamText } from 'ai'
+import { streamText } from 'ai'
 
 export async function POST(req: Request) {
   const { messages } = await req.json()
-  const result = await streamText({
-    model: openai('gpt-4-turbo'),
+  const result = streamText({
+    model: openai('gpt-4o'),
     messages,
   })
 
-  return new StreamingTextResponse(result.toAIStream())
+  return result.toDataStreamResponse()
 }
 ```
 
 ```js filename="app/api/chat/route.js" switcher
 import { openai } from '@ai-sdk/openai'
-import { StreamingTextResponse, streamText } from 'ai'
+import { streamText } from 'ai'
 
 export async function POST(req) {
   const { messages } = await req.json()
-  const result = await streamText({
-    model: openai('gpt-4-turbo'),
+  const result = streamText({
+    model: openai('gpt-4o'),
     messages,
   })
 
-  return new StreamingTextResponse(result.toAIStream())
+  return result.toDataStreamResponse()
 }
 ```
 


### PR DESCRIPTION
Updated streaming example with reference to AI SDK 4.0

example: https://sdk.vercel.ai/docs/getting-started/nextjs-app-router#create-a-route-handler
migration guide: https://sdk.vercel.ai/docs/migration-guides/migration-guide-4-0