### PR TITLE
examples: Add new example `GitHub pages with Actions Workflow` for an automated deployment process

### DIFF
--- a/examples/github-pages-with-actions/.github/workflows/nextjs.yml
+++ b/examples/github-pages-with-actions/.github/workflows/nextjs.yml
@@ -1,0 +1,103 @@
+# Sample workflow for building and deploying a Next.js site to GitHub Pages
+name: Deploy Next.js site to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main", "master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect package manager
+        id: detect-package-manager
+        run: |
+          if [ -f "${{ github.workspace }}/yarn.lock" ]; then
+            echo "manager=yarn" >> $GITHUB_OUTPUT
+            echo "command=install" >> $GITHUB_OUTPUT
+            echo "runner=yarn" >> $GITHUB_OUTPUT
+          elif [ -f "${{ github.workspace }}/pnpm-lock.yaml" ]; then
+            echo "manager=pnpm" >> $GITHUB_OUTPUT
+            echo "command=install" >> $GITHUB_OUTPUT
+            echo "runner=pnpm" >> $GITHUB_OUTPUT
+          elif [ -f "${{ github.workspace }}/package.json" ]; then
+            echo "manager=npm" >> $GITHUB_OUTPUT
+            echo "command=ci" >> $GITHUB_OUTPUT
+            echo "runner=npx --no-install" >> $GITHUB_OUTPUT
+          else
+            echo "Unable to determine package manager"
+            exit 1
+          fi
+
+      # Install pnpm if detected
+      - name: Install pnpm
+        if: steps.detect-package-manager.outputs.manager == 'pnpm'
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: ${{ steps.detect-package-manager.outputs.manager }}
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+        with:
+          # Automatically inject basePath in your Next.js configuration file and disable
+          # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
+          static_site_generator: next
+
+      - name: Restore cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml', '**/yarn.lock', '**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml', '**/yarn.lock', '**/package-lock.json') }}-
+
+      - name: Install dependencies
+        run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
+
+      - name: Build with Next.js
+        run: ${{ steps.detect-package-manager.outputs.runner }} next build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/examples/github-pages-with-actions/.gitignore
+++ b/examples/github-pages-with-actions/.gitignore
@@ -1,0 +1,40 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/github-pages-with-actions/README.md
+++ b/examples/github-pages-with-actions/README.md
@@ -1,0 +1,40 @@
+# Deploying to GitHub Pages with GitHub Actions
+
+This example supports deploying a statically exported Next.js application to GitHub Pages eliminating the need to run a script for deployment after making changes. It also omits the need for a separate branch.
+
+The Actions workflow is a modified version of [Next.js starters-workflow](https://github.com/actions/starter-workflows/blob/main/pages/nextjs.yml). It automatically injects basePath in your Next.js configuration file.
+
+It has added support for the following package managers:
+
+- npm
+- yarn
+- pnpm
+
+## How to use
+
+Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init), [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/), or [pnpm](https://pnpm.io) to bootstrap the example:
+
+```bash
+npx create-next-app --example github-pages-with-actions github-pages-with-actions-app
+```
+
+```bash
+yarn create next-app --example github-pages-with-actions github-pages-with-actions-app
+```
+
+```bash
+pnpm create next-app --example github-pages-with-actions github-pages-with-actions-app
+```
+
+### Deploy to GitHub Pages
+
+1.  Create a new public GitHub repository.
+2.  Push the starter code to the `main` branch.
+3.  On GitHub, go to **Settings** > **Pages** > **Build and Deployment**, and choose `GitHub Actions` as the Source.
+4.  Make a change.
+
+The workflow will be triggered each time you make any changes and your site will be deployed to the URL:
+
+```bash
+https://<github-user-name>.github.io/<github-project-name>/
+```

--- a/examples/github-pages-with-actions/README.md
+++ b/examples/github-pages-with-actions/README.md
@@ -1,4 +1,4 @@
-# Deploying to GitHub Pages with GitHub Actions
+# Deploying Next.js Application to GitHub Pages with GitHub Actions
 
 This example supports deploying a statically exported Next.js application to GitHub Pages eliminating the need to run a script for deployment after making changes. It also omits the need for a separate branch.
 

--- a/examples/github-pages-with-actions/app/about/page.tsx
+++ b/examples/github-pages-with-actions/app/about/page.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+export default function Home() {
+  return (
+    <div>
+      <h1>About Page</h1>
+      <div>
+        Back to <Link href="/">Home</Link>
+      </div>
+    </div>
+  );
+}

--- a/examples/github-pages-with-actions/app/layout.tsx
+++ b/examples/github-pages-with-actions/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export const metadata: Metadata = {
+  title: "Next.js on GitHub Pages",
+  description: "A Next.js Static Application on GitHub Pages",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>{children}</body>
+    </html>
+  );
+}

--- a/examples/github-pages-with-actions/app/page.tsx
+++ b/examples/github-pages-with-actions/app/page.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+export default function Home() {
+  return (
+    <div>
+      <h1>Home</h1>
+      <div>
+        Go to <Link href="/about">About</Link> page
+      </div>
+    </div>
+  );
+}

--- a/examples/github-pages-with-actions/package.json
+++ b/examples/github-pages-with-actions/package.json
@@ -1,0 +1,21 @@
+{
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "@types/react": "^19.0.1",
+    "@types/react-dom": "^19.0.2",
+    "eslint": "^9",
+    "eslint-config-next": "latest"
+  }
+}

--- a/examples/github-pages-with-actions/tsconfig.json
+++ b/examples/github-pages-with-actions/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
# GitHub Pages with Actions Example

## What

I've named it **github-pages-with-actions** because a **github-pages** example already existed (which follows a different deployment process)

This example is an automated way to deploy a Next.js application to GitHub Pages using GitHub Actions. It eliminates the need for manually running the deploy script and configuring a separate branch for build outputs. 

Features:
- Automates the build and deployment process using a [modified](https://github.com/Hamdan-Khan/github-pages-with-actions/blob/master/.github/workflows/nextjs.yml) version of [Nextjs.yml workflow](https://github.com/actions/starter-workflows/blob/main/pages/nextjs.yml) originally from [starters-workflow](https://github.com/actions/starter-workflows/) (supported npm and yarn previously, added support for pnpm now).
- Directly uses the output of the build process without creating a separate branch.
- Updating the site automatically whenever a change is made.

## Why

The **github-pages-with-actions** example is an improved version of  [**github-pages**](https://github.com/vercel/next.js/tree/canary/examples/github-pages) example, where:
- A manual script (`npm run deploy`) was needed to be run to generate static files for deployment.
- The generated output was pushed to a separate branch (`gh-pages`)

Whereas this example:
- automates the process by listening for changes that trigger the GitHub Actions workflow.
- GitHub Actions is set as the source for GitHub Pages.

#### Note: This example can not be added as a feature for the previous example. It is a standalone and more automated deployment process just like the one which Vercel provides.

## How

This workflow builds upon the `nextjs.yml` from the GitHub starters-workflows repository, modified to support pnpm.

### Workflow:
- Detects the package manager (`pnpm`, `yarn`, or `npm`) and installs dependencies accordingly. 
- Runs the Next.js `build` and `export` commands to generate static files.
- Injects the `basePath` dynamically to match the repository name during the build process.
- Automatically disables Next.js's image optimization, to make it compatible with GitHub Pages (static nature).
- Uses GitHub Actions to upload static files as an artifact and deploy them directly to GitHub Pages.

### Adding or Updating Examples

- [x]  The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md

- [x]  Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md