### PR TITLE
fix: aria attribute typo for error overlay

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/BuildError.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/BuildError.tsx
@@ -22,8 +22,8 @@ export const BuildError: React.FC<BuildErrorProps> = function BuildError({
     <Overlay fixed>
       <Dialog
         type="error"
-        aria-labelledby="nextjs__container_error_label"
-        aria-describedby="nextjs__container_error_desc"
+        aria-labelledby="nextjs__container_errors_label"
+        aria-describedby="nextjs__container_errors_desc"
         onClose={noop}
       >
         <DialogContent>

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/BuildError.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/BuildError.tsx
@@ -22,8 +22,8 @@ export const BuildError: React.FC<BuildErrorProps> = function BuildError({
     <Overlay fixed>
       <Dialog
         type="error"
-        aria-labelledby="nextjs__container_error_label"
-        aria-describedby="nextjs__container_error_desc"
+        aria-labelledby="nextjs__container_errors_label"
+        aria-describedby="nextjs__container_errors_desc"
         onClose={noop}
       >
         <DialogContent>


### PR DESCRIPTION
### Why?

There's a typo missing `s` in `errors` in the area attribute in `BuildError` component

```diff
- aria-labelledby="nextjs__container_error_label"
+ aria-labelledby="nextjs__container_errors_label"
```