### PR TITLE
fix: reject server action on mpa redirect

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -247,7 +247,7 @@ export function serverActionReducer(
       }
 
       if (!flightData) {
-        resolve(actionResult)
+        reject(actionResult)
 
         // If there is a redirect but no flight data we need to do a mpaNavigation.
         if (redirectLocation) {


### PR DESCRIPTION
Fixes #73536

### Motivation
Call to a redirect in server action 
a) doesn't return a value when url is local
b) returns `undefined` when url is external

Perhaps both cases should not return anything
as any redirect leaves current page anyway.

### Todo
- [X] change don't return mpa redirect in server action
- [ ] run tests locally, check for regressions
- [ ] write test case for new behaviour
