### PR TITLE
docs(fetching-data-and-streaming): add missing types to example

### DIFF
--- a/docs/01-app/01-getting-started/06-data-fetching-and-streaming.mdx
+++ b/docs/01-app/01-getting-started/06-data-fetching-and-streaming.mdx
@@ -136,7 +136,11 @@ Then, in your Client Component, use the `use` hook read the promise:
 'use client'
 import { use } from 'react'
 
-export default function Posts({ posts }) {
+export default function Posts({
+  posts,
+}: {
+  posts: Promise<{ id: string; title: string }[]>
+}) {
   const posts = use(posts)
 
   return (


### PR DESCRIPTION
This PR updates the `use` hook example in the Fetching Data and Streaming section by adding missing TypeScript types for the `posts` prop.