### PR TITLE
Name default Jest project according to used env variables

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ const createJestConfig = nextJest()
 // Any custom config you want to pass to Jest
 /** @type {import('jest').Config} */
 const customJestConfig = {
-  displayName: 'default',
+  displayName: process.env.TURBOPACK ? 'turbopack' : 'default',
   testMatch: ['**/*.test.js', '**/*.test.ts', '**/*.test.jsx', '**/*.test.tsx'],
   setupFilesAfterEnv: ['<rootDir>/jest-setup-after-env.ts'],
   verbose: true,


### PR DESCRIPTION
You can run Turbopack tests both with `--projects` and `TURBOPACK` env variable.
However, only the  `--projects` used the correct display name.

Now specifying `TURBOPACK=1` will correctly label the project with "turbopack":
` PASS   turbopack  test/integration/server-side-dev-errors/test/index.test.js (25.696 s)`