### PR TITLE
Stop sourcemapping function names

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
@@ -80,7 +80,12 @@ export async function batchedTraceSource(
     file: sourceFrame.file,
     lineNumber: sourceFrame.line ?? 0,
     column: sourceFrame.column ?? 0,
-    methodName: sourceFrame.methodName ?? frame.methodName ?? '<unknown>',
+    methodName:
+      // We ignore the sourcemapped name since it won't be the correct name.
+      // The callsite will point to the column of the variable name instead of the
+      // name of the enclosing function.
+      // TODO(NDX-531): Spy on prepareStackTrace to get the enclosing line number for method name mapping.
+      frame.methodName ?? '<unknown>',
     ignored,
     arguments: [],
   }
@@ -222,13 +227,13 @@ async function nativeTraceSource(
 
       const originalStackFrame: IgnorableStackFrame = {
         methodName:
-          originalPosition.name ||
-          // default is not a valid identifier in JS so webpack uses a custom variable when it's an unnamed default export
-          // Resolve it back to `default` for the method name if the source position didn't have the method.
+          // We ignore the sourcemapped name since it won't be the correct name.
+          // The callsite will point to the column of the variable name instead of the
+          // name of the enclosing function.
+          // TODO(NDX-531): Spy on prepareStackTrace to get the enclosing line number for method name mapping.
           frame.methodName
             ?.replace('__WEBPACK_DEFAULT_EXPORT__', 'default')
-            ?.replace('__webpack_exports__.', '') ||
-          '<unknown>',
+            ?.replace('__webpack_exports__.', '') || '<unknown>',
         column: (originalPosition.column ?? 0) + 1,
         file: originalPosition.source?.startsWith('file://')
           ? path.relative(

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-webpack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-webpack.ts
@@ -232,7 +232,10 @@ export async function createOriginalStackFrame({
     lineNumber: sourcePosition.line,
     column: (sourcePosition.column ?? 0) + 1,
     methodName:
-      sourcePosition.name ||
+      // We ignore the sourcemapped name since it won't be the correct name.
+      // The callsite will point to the column of the variable name instead of the
+      // name of the enclosing function.
+      // TODO(NDX-531): Spy on prepareStackTrace to get the enclosing line number for method name mapping.
       // default is not a valid identifier in JS so webpack uses a custom variable when it's an unnamed default export
       // Resolve it back to `default` for the method name if the source position didn't have the method.
       frame.methodName

--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -255,13 +255,13 @@ function getSourcemappedFrameIfPossible(
   }
 
   const originalFrame: IgnoreableStackFrame = {
-    methodName:
-      sourcePosition.name ||
-      // default is not a valid identifier in JS so webpack uses a custom variable when it's an unnamed default export
-      // Resolve it back to `default` for the method name if the source position didn't have the method.
-      frame.methodName
-        ?.replace('__WEBPACK_DEFAULT_EXPORT__', 'default')
-        ?.replace('__webpack_exports__.', ''),
+    // We ignore the sourcemapped name since it won't be the correct name.
+    // The callsite will point to the column of the variable name instead of the
+    // name of the enclosing function.
+    // TODO(NDX-531): Spy on prepareStackTrace to get the enclosing line number for method name mapping.
+    methodName: frame.methodName
+      ?.replace('__WEBPACK_DEFAULT_EXPORT__', 'default')
+      ?.replace('__webpack_exports__.', ''),
     column: sourcePosition.column,
     file: sourcePosition.source,
     lineNumber: sourcePosition.line,

--- a/test/development/acceptance/__snapshots__/ReactRefreshLogBox.test.ts.snap
+++ b/test/development/acceptance/__snapshots__/ReactRefreshLogBox.test.ts.snap
@@ -57,7 +57,7 @@ exports[`ReactRefreshLogBox default module init error not shown 1`] = `
 exports[`ReactRefreshLogBox default should show anonymous frames in stack trace 1`] = `
 "Array.map
 <anonymous> (0:0)
-map
+Page
 pages/index.js (2:13)"
 `;
 

--- a/test/development/acceptance/__snapshots__/error-recovery.test.ts.snap
+++ b/test/development/acceptance/__snapshots__/error-recovery.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ReactRefreshLogBox default syntax > runtime error 1`] = `
-"index.js (5:9) @ Error
+"index.js (5:9) @ eval
 
   3 | setInterval(() => {
   4 |   i++

--- a/test/development/app-dir/capture-console-error-owner-stack/capture-console-error-owner-stack.test.ts
+++ b/test/development/app-dir/capture-console-error-owner-stack/capture-console-error-owner-stack.test.ts
@@ -39,6 +39,7 @@ describe('app-dir - capture-console-error-owner-stack', () => {
 
     const result = await getRedboxResult(browser)
 
+    // TODO(veil): Inconsistent cursor position for the "Page" frame
     if (process.env.TURBOPACK) {
       expect(result).toMatchInlineSnapshot(`
         {
@@ -65,11 +66,11 @@ describe('app-dir - capture-console-error-owner-stack', () => {
         {
           "callStacks": "button
         <anonymous> (0:0)
-        button
+        Page
         app/browser/event/page.js (5:6)",
           "count": 1,
           "description": "trigger an console <error>",
-          "source": "app/browser/event/page.js (7:17) @ error
+          "source": "app/browser/event/page.js (7:17) @ onClick
 
            5 |     <button
            6 |       onClick={() => {
@@ -90,44 +91,23 @@ describe('app-dir - capture-console-error-owner-stack', () => {
     await openRedbox(browser)
 
     const result = await getRedboxResult(browser)
+    expect(result).toMatchInlineSnapshot(`
+       {
+         "callStacks": "",
+         "count": 1,
+         "description": "trigger an console.error in render",
+         "source": "app/browser/render/page.js (4:11) @ Page
 
-    if (process.env.TURBOPACK) {
-      expect(result).toMatchInlineSnapshot(`
-        {
-          "callStacks": "",
-          "count": 1,
-          "description": "trigger an console.error in render",
-          "source": "app/browser/render/page.js (4:11) @ Page
-
-          2 |
-          3 | export default function Page() {
-        > 4 |   console.error('trigger an console.error in render')
-            |           ^
-          5 |   return <p>render</p>
-          6 | }
-          7 |",
-          "title": "Console Error",
-        }
-      `)
-    } else {
-      expect(result).toMatchInlineSnapshot(`
-        {
-          "callStacks": "",
-          "count": 1,
-          "description": "trigger an console.error in render",
-          "source": "app/browser/render/page.js (4:11) @ error
-
-          2 |
-          3 | export default function Page() {
-        > 4 |   console.error('trigger an console.error in render')
-            |           ^
-          5 |   return <p>render</p>
-          6 | }
-          7 |",
-          "title": "Console Error",
-        }
-      `)
-    }
+         2 |
+         3 | export default function Page() {
+       > 4 |   console.error('trigger an console.error in render')
+           |           ^
+         5 |   return <p>render</p>
+         6 | }
+         7 |",
+         "title": "Console Error",
+       }
+    `)
   })
 
   it('should capture browser console error in render and dedupe when multi same errors logged', async () => {
@@ -136,44 +116,23 @@ describe('app-dir - capture-console-error-owner-stack', () => {
     await openRedbox(browser)
 
     const result = await getRedboxResult(browser)
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "callStacks": "",
+        "count": 1,
+        "description": "trigger an console.error in render",
+        "source": "app/browser/render/page.js (4:11) @ Page
 
-    if (process.env.TURBOPACK) {
-      expect(result).toMatchInlineSnapshot(`
-        {
-          "callStacks": "",
-          "count": 1,
-          "description": "trigger an console.error in render",
-          "source": "app/browser/render/page.js (4:11) @ Page
-
-          2 |
-          3 | export default function Page() {
-        > 4 |   console.error('trigger an console.error in render')
-            |           ^
-          5 |   return <p>render</p>
-          6 | }
-          7 |",
-          "title": "Console Error",
-        }
-      `)
-    } else {
-      expect(result).toMatchInlineSnapshot(`
-        {
-          "callStacks": "",
-          "count": 1,
-          "description": "trigger an console.error in render",
-          "source": "app/browser/render/page.js (4:11) @ error
-
-          2 |
-          3 | export default function Page() {
-        > 4 |   console.error('trigger an console.error in render')
-            |           ^
-          5 |   return <p>render</p>
-          6 | }
-          7 |",
-          "title": "Console Error",
-        }
-      `)
-    }
+        2 |
+        3 | export default function Page() {
+      > 4 |   console.error('trigger an console.error in render')
+          |           ^
+        5 |   return <p>render</p>
+        6 | }
+        7 |",
+        "title": "Console Error",
+      }
+    `)
   })
 
   it('should capture server replay string error from console error', async () => {
@@ -182,44 +141,23 @@ describe('app-dir - capture-console-error-owner-stack', () => {
     await openRedbox(browser)
 
     const result = await getRedboxResult(browser)
+    expect(result).toMatchInlineSnapshot(`
+       {
+         "callStacks": "",
+         "count": 1,
+         "description": "ssr console error:client",
+         "source": "app/ssr/page.js (4:11) @ Page
 
-    if (process.env.TURBOPACK) {
-      expect(result).toMatchInlineSnapshot(`
-        {
-          "callStacks": "",
-          "count": 1,
-          "description": "ssr console error:client",
-          "source": "app/ssr/page.js (4:11) @ Page
-
-          2 |
-          3 | export default function Page() {
-        > 4 |   console.error(
-            |           ^
-          5 |     'ssr console error:' + (typeof window === 'undefined' ? 'server' : 'client')
-          6 |   )
-          7 |   return <p>ssr</p>",
-          "title": "Console Error",
-        }
-      `)
-    } else {
-      expect(result).toMatchInlineSnapshot(`
-        {
-          "callStacks": "",
-          "count": 1,
-          "description": "ssr console error:client",
-          "source": "app/ssr/page.js (4:11) @ error
-
-          2 |
-          3 | export default function Page() {
-        > 4 |   console.error(
-            |           ^
-          5 |     'ssr console error:' + (typeof window === 'undefined' ? 'server' : 'client')
-          6 |   )
-          7 |   return <p>ssr</p>",
-          "title": "Console Error",
-        }
-      `)
-    }
+         2 |
+         3 | export default function Page() {
+       > 4 |   console.error(
+           |           ^
+         5 |     'ssr console error:' + (typeof window === 'undefined' ? 'server' : 'client')
+         6 |   )
+         7 |   return <p>ssr</p>",
+         "title": "Console Error",
+       }
+    `)
   })
 
   it('should capture server replay error instance from console error', async () => {
@@ -229,43 +167,23 @@ describe('app-dir - capture-console-error-owner-stack', () => {
 
     const result = await getRedboxResult(browser)
 
-    if (process.env.TURBOPACK) {
-      expect(result).toMatchInlineSnapshot(`
-        {
-          "callStacks": "",
-          "count": 1,
-          "description": "Error: page error",
-          "source": "app/ssr-error-instance/page.js (4:17) @ Page
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "callStacks": "",
+        "count": 1,
+        "description": "Error: page error",
+        "source": "app/ssr-error-instance/page.js (4:17) @ Page
 
-          2 |
-          3 | export default function Page() {
-        > 4 |   console.error(new Error('page error'))
-            |                 ^
-          5 |   return <p>ssr</p>
-          6 | }
-          7 |",
-          "title": "Console Error",
-        }
-      `)
-    } else {
-      expect(result).toMatchInlineSnapshot(`
-        {
-          "callStacks": "",
-          "count": 1,
-          "description": "Error: page error",
-          "source": "app/ssr-error-instance/page.js (4:17) @ Page
-
-          2 |
-          3 | export default function Page() {
-        > 4 |   console.error(new Error('page error'))
-            |                 ^
-          5 |   return <p>ssr</p>
-          6 | }
-          7 |",
-          "title": "Console Error",
-        }
-      `)
-    }
+        2 |
+        3 | export default function Page() {
+      > 4 |   console.error(new Error('page error'))
+          |                 ^
+        5 |   return <p>ssr</p>
+        6 | }
+        7 |",
+        "title": "Console Error",
+      }
+    `)
   })
 
   it('should be able to capture rsc logged error', async () => {

--- a/test/development/app-dir/capture-console-error/capture-console-error.test.ts
+++ b/test/development/app-dir/capture-console-error/capture-console-error.test.ts
@@ -67,21 +67,21 @@ describe('app-dir - capture-console-error', () => {
       `)
     } else {
       expect(result).toMatchInlineSnapshot(`
-        {
-          "callStacks": "",
-          "count": 1,
-          "description": "trigger an console <error>",
-          "source": "app/browser/event/page.js (7:17) @ error
+       {
+         "callStacks": "",
+         "count": 1,
+         "description": "trigger an console <error>",
+         "source": "app/browser/event/page.js (7:17) @ onClick
 
-           5 |     <button
-           6 |       onClick={() => {
-        >  7 |         console.error('trigger an console <%s>', 'error')
-             |                 ^
-           8 |       }}
-           9 |     >
-          10 |       click to error",
-          "title": "Console Error",
-        }
+          5 |     <button
+          6 |       onClick={() => {
+       >  7 |         console.error('trigger an console <%s>', 'error')
+            |                 ^
+          8 |       }}
+          9 |     >
+         10 |       click to error",
+         "title": "Console Error",
+       }
       `)
     }
   })
@@ -113,21 +113,21 @@ describe('app-dir - capture-console-error', () => {
       `)
     } else {
       expect(result).toMatchInlineSnapshot(`
-        {
-          "callStacks": "",
-          "count": 2,
-          "description": "trigger an console.error in render",
-          "source": "app/browser/render/page.js (4:11) @ error
+       {
+         "callStacks": "",
+         "count": 2,
+         "description": "trigger an console.error in render",
+         "source": "app/browser/render/page.js (4:11) @ Page
 
-          2 |
-          3 | export default function Page() {
-        > 4 |   console.error('trigger an console.error in render')
-            |           ^
-          5 |   return <p>render</p>
-          6 | }
-          7 |",
-          "title": "Console Error",
-        }
+         2 |
+         3 | export default function Page() {
+       > 4 |   console.error('trigger an console.error in render')
+           |           ^
+         5 |   return <p>render</p>
+         6 | }
+         7 |",
+         "title": "Console Error",
+       }
       `)
     }
   })
@@ -159,21 +159,21 @@ describe('app-dir - capture-console-error', () => {
       `)
     } else {
       expect(result).toMatchInlineSnapshot(`
-        {
-          "callStacks": "",
-          "count": 2,
-          "description": "trigger an console.error in render",
-          "source": "app/browser/render/page.js (4:11) @ error
+       {
+         "callStacks": "",
+         "count": 2,
+         "description": "trigger an console.error in render",
+         "source": "app/browser/render/page.js (4:11) @ Page
 
-          2 |
-          3 | export default function Page() {
-        > 4 |   console.error('trigger an console.error in render')
-            |           ^
-          5 |   return <p>render</p>
-          6 | }
-          7 |",
-          "title": "Console Error",
-        }
+         2 |
+         3 | export default function Page() {
+       > 4 |   console.error('trigger an console.error in render')
+           |           ^
+         5 |   return <p>render</p>
+         6 | }
+         7 |",
+         "title": "Console Error",
+       }
       `)
     }
   })
@@ -205,21 +205,21 @@ describe('app-dir - capture-console-error', () => {
       `)
     } else {
       expect(result).toMatchInlineSnapshot(`
-        {
-          "callStacks": "",
-          "count": 2,
-          "description": "ssr console error:client",
-          "source": "app/ssr/page.js (4:11) @ error
+       {
+         "callStacks": "",
+         "count": 2,
+         "description": "ssr console error:client",
+         "source": "app/ssr/page.js (4:11) @ Page
 
-          2 |
-          3 | export default function Page() {
-        > 4 |   console.error(
-            |           ^
-          5 |     'ssr console error:' + (typeof window === 'undefined' ? 'server' : 'client')
-          6 |   )
-          7 |   return <p>ssr</p>",
-          "title": "Console Error",
-        }
+         2 |
+         3 | export default function Page() {
+       > 4 |   console.error(
+           |           ^
+         5 |     'ssr console error:' + (typeof window === 'undefined' ? 'server' : 'client')
+         6 |   )
+         7 |   return <p>ssr</p>",
+         "title": "Console Error",
+       }
       `)
     }
   })

--- a/test/development/app-dir/dynamic-error-trace/index.test.ts
+++ b/test/development/app-dir/dynamic-error-trace/index.test.ts
@@ -39,21 +39,8 @@ describe('app dir - dynamic error trace', () => {
 
     const codeframe = await getRedboxSource(browser)
     expect(codeframe).toEqual(
-      process.env.TURBOPACK
-        ? outdent`
+      outdent`
             app/lib.js (4:13) @ Foo
-            
-              2 |
-              3 | export function Foo() {
-            > 4 |   useHeaders()
-                |             ^
-              5 |   return 'foo'
-              6 | }
-              7 |
-          `
-        : // TODO: should be "@ Foo" since that's where we put the codeframe and print the source location
-          outdent`
-            app/lib.js (4:13) @ useHeaders
 
               2 |
               3 | export function Foo() {

--- a/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
+++ b/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
@@ -77,7 +77,7 @@ describe('Dynamic IO Dev Errors', () => {
             '\n    at html (<anonymous>)' +
             '\n    at Root [Server] (<anonymous>)'
           : // TODO(veil): Should be ignore-listed (see https://linear.app/vercel/issue/NDX-464/next-internals-not-ignore-listed-in-terminal-in-webpack#comment-1164a36a)
-            '\n    at tree (..')
+            '\n    at InnerLayoutRouter (..')
     )
 
     const description = await getRedboxDescription(browser)

--- a/test/development/app-dir/owner-stack-invalid-element-type/invalid-element-type.test.ts
+++ b/test/development/app-dir/owner-stack-invalid-element-type/invalid-element-type.test.ts
@@ -41,17 +41,16 @@ const isOwnerStackEnabled =
         `)
       } else {
         expect(stackFramesContent).toMatchInlineSnapshot(`""`)
-        // FIXME: the methodName should be `@ BrowserOnly` instead of `@ Foo`
         expect(source).toMatchInlineSnapshot(`
-          "app/browser/browser-only.js (8:8) @ Foo
+         "app/browser/browser-only.js (8:8) @ BrowserOnly
 
-             6 |   return (
-             7 |     <div>
-          >  8 |       <Foo />
-               |        ^
-             9 |     </div>
-            10 |   )
-            11 | }"
+            6 |   return (
+            7 |     <div>
+         >  8 |       <Foo />
+              |        ^
+            9 |     </div>
+           10 |   )
+           11 | }"
         `)
       }
     })
@@ -78,17 +77,16 @@ const isOwnerStackEnabled =
         `)
       } else {
         expect(stackFramesContent).toMatchInlineSnapshot(`""`)
-        // FIXME: the methodName should be `@ Inner` instead of `@ Foo`
         expect(source).toMatchInlineSnapshot(`
-          "app/rsc/page.js (5:11) @ Foo
+         "app/rsc/page.js (5:11) @ Inner
 
-            3 | // Intermediate component for testing owner stack
-            4 | function Inner() {
-          > 5 |   return <Foo />
-              |           ^
-            6 | }
-            7 |
-            8 | export default function Page() {"
+           3 | // Intermediate component for testing owner stack
+           4 | function Inner() {
+         > 5 |   return <Foo />
+             |           ^
+           6 | }
+           7 |
+           8 | export default function Page() {"
         `)
       }
     })
@@ -115,17 +113,16 @@ const isOwnerStackEnabled =
         `)
       } else {
         expect(stackFramesContent).toMatchInlineSnapshot(`""`)
-        // FIXME: the methodName should be `@ Inner` instead of `@ Foo`
         expect(source).toMatchInlineSnapshot(`
-          "app/ssr/page.js (7:11) @ Foo
+         "app/ssr/page.js (7:11) @ Inner
 
-             5 | // Intermediate component for testing owner stack
-             6 | function Inner() {
-          >  7 |   return <Foo />
-               |           ^
-             8 | }
-             9 |
-            10 | export default function Page() {"
+            5 | // Intermediate component for testing owner stack
+            6 | function Inner() {
+         >  7 |   return <Foo />
+              |           ^
+            8 | }
+            9 |
+           10 | export default function Page() {"
         `)
       }
     })

--- a/test/development/app-dir/owner-stack-invalid-element-type/owner-stack-invalid-element-type.test.ts
+++ b/test/development/app-dir/owner-stack-invalid-element-type/owner-stack-invalid-element-type.test.ts
@@ -41,22 +41,20 @@ const isOwnerStackEnabled =
             11 | }"
         `)
       } else {
-        // FIXME: the owner stack method names should be `Inner > Page`
         expect(stackFramesContent).toMatchInlineSnapshot(`
-          "at BrowserOnly (app/browser/page.js (11:11))
-          at Inner (app/browser/page.js (15:11))"
+         "at Inner (app/browser/page.js (11:11))
+         at Page (app/browser/page.js (15:11))"
         `)
-        // FIXME: the methodName should be `@ BrowserOnly` instead of `@ Foo`
         expect(source).toMatchInlineSnapshot(`
-          "app/browser/browser-only.js (8:8) @ Foo
+         "app/browser/browser-only.js (8:8) @ BrowserOnly
 
-             6 |   return (
-             7 |     <div>
-          >  8 |       <Foo />
-               |        ^
-             9 |     </div>
-            10 |   )
-            11 | }"
+            6 |   return (
+            7 |     <div>
+         >  8 |       <Foo />
+              |        ^
+            9 |     </div>
+           10 |   )
+           11 | }"
         `)
       }
     })
@@ -84,21 +82,19 @@ const isOwnerStackEnabled =
             8 | export default function Page() {"
         `)
       } else {
-        // FIXME: the owner stack method names should be `Page`
         expect(stackFramesContent).toMatchInlineSnapshot(
-          `"at Inner (app/rsc/page.js (11:8))"`
+          `"at Page (app/rsc/page.js (11:8))"`
         )
-        // FIXME: the methodName should be `@ Inner`
         expect(source).toMatchInlineSnapshot(`
-          "app/rsc/page.js (5:11) @ Foo
+         "app/rsc/page.js (5:11) @ Inner
 
-            3 | // Intermediate component for testing owner stack
-            4 | function Inner() {
-          > 5 |   return <Foo />
-              |           ^
-            6 | }
-            7 |
-            8 | export default function Page() {"
+           3 | // Intermediate component for testing owner stack
+           4 | function Inner() {
+         > 5 |   return <Foo />
+             |           ^
+           6 | }
+           7 |
+           8 | export default function Page() {"
         `)
       }
     })
@@ -126,21 +122,19 @@ const isOwnerStackEnabled =
             10 | export default function Page() {"
         `)
       } else {
-        // FIXME: the owner stack method names should be `Page`
         expect(stackFramesContent).toMatchInlineSnapshot(
-          `"at Inner (app/ssr/page.js (13:8))"`
+          `"at Page (app/ssr/page.js (13:8))"`
         )
-        // FIXME: the methodName should be `@ Inner`
         expect(source).toMatchInlineSnapshot(`
-          "app/ssr/page.js (7:11) @ Foo
+         "app/ssr/page.js (7:11) @ Inner
 
-             5 | // Intermediate component for testing owner stack
-             6 | function Inner() {
-          >  7 |   return <Foo />
-               |           ^
-             8 | }
-             9 |
-            10 | export default function Page() {"
+            5 | // Intermediate component for testing owner stack
+            6 | function Inner() {
+         >  7 |   return <Foo />
+              |           ^
+            8 | }
+            9 |
+           10 | export default function Page() {"
         `)
       }
     })

--- a/test/development/app-dir/owner-stack-react-missing-key-prop/owner-stack-react-missing-key-prop.test.ts
+++ b/test/development/app-dir/owner-stack-react-missing-key-prop/owner-stack-react-missing-key-prop.test.ts
@@ -41,14 +41,12 @@ const isOwnerStackEnabled =
             10 |   )"
         `)
       } else {
-        // FIXME: the owner stack method names should be `Page` instead of `map`
         expect(stackFramesContent).toMatchInlineSnapshot(`
           "at span ()
-          at map (app/rsc/page.tsx (6:13))"
+          at Page (app/rsc/page.tsx (6:13))"
         `)
-        // FIXME: the methodName should be `@ <anonymous>` instead of `@ span`
         expect(source).toMatchInlineSnapshot(`
-          "app/rsc/page.tsx (7:10) @ span
+          "app/rsc/page.tsx (7:10) @ eval
 
              5 |     <div>
              6 |       {list.map((item, index) => (
@@ -85,15 +83,13 @@ const isOwnerStackEnabled =
             12 |   )"
         `)
       } else {
-        // FIXME: the owner stack method names should be `Page` instead of `map`
         expect(stackFramesContent).toMatchInlineSnapshot(`
           "at p ()
           at Array.map ()
-          at map (app/ssr/page.tsx (8:13))"
+          at Page (app/ssr/page.tsx (8:13))"
         `)
-        // FIXME: the methodName should be `@ <unknown>` instead of `@ p`
         expect(source).toMatchInlineSnapshot(`
-          "app/ssr/page.tsx (9:10) @ p
+          "app/ssr/page.tsx (9:10) @ eval
 
              7 |     <div>
              8 |       {list.map((item, index) => (

--- a/test/development/app-dir/owner-stack/owner-stack.test.ts
+++ b/test/development/app-dir/owner-stack/owner-stack.test.ts
@@ -45,7 +45,7 @@ async function getStackFramesContent(browser) {
 }
 
 describe('app-dir - owner-stack', () => {
-  const { next } = nextTestSetup({
+  const { isTurbopack, next } = nextTestSetup({
     files: __dirname,
   })
 
@@ -55,17 +55,10 @@ describe('app-dir - owner-stack', () => {
     await assertHasRedbox(browser)
 
     const stackFramesContent = await getStackFramesContent(browser)
-    if (process.env.TURBOPACK) {
-      expect(stackFramesContent).toMatchInlineSnapshot(`
-        "at useErrorHook (app/browser/uncaught/page.js (10:3))
-        at Page (app/browser/uncaught/page.js (14:3))"
+    expect(stackFramesContent).toMatchInlineSnapshot(`
+       "at useErrorHook (app/browser/uncaught/page.js (10:3))
+       at Page (app/browser/uncaught/page.js (14:3))"
       `)
-    } else {
-      expect(stackFramesContent).toMatchInlineSnapshot(`
-        "at useThrowError (app/browser/uncaught/page.js (10:3))
-        at useErrorHook (app/browser/uncaught/page.js (14:3))"
-      `)
-    }
 
     const logs = await browser.log()
     const errorLog = logs.find((log) => {
@@ -126,21 +119,20 @@ describe('app-dir - owner-stack', () => {
     await openRedbox(browser)
 
     const stackFramesContent = await getStackFramesContent(browser)
-
-    if (process.env.TURBOPACK) {
+    if (isTurbopack) {
       expect(stackFramesContent).toMatchInlineSnapshot(`
-        "at useErrorHook (app/browser/caught/page.js (39:3))
-        at Thrower (app/browser/caught/page.js (29:3))
-        at Inner (app/browser/caught/page.js (23:7))
-        at Page (app/browser/caught/page.js (43:10))"
+       "at useErrorHook (app/browser/caught/page.js (39:3))
+       at Thrower (app/browser/caught/page.js (29:3))
+       at Inner (app/browser/caught/page.js (23:7))
+       at Page (app/browser/caught/page.js (43:10))"
       `)
     } else {
       expect(stackFramesContent).toMatchInlineSnapshot(`
-        "at useThrowError (app/browser/caught/page.js (39:3))
-        at useErrorHook (app/browser/caught/page.js (29:3))
-        at Thrower (app/browser/caught/page.js (23:8))
-        at Inner (app/browser/caught/page.js (43:11))"
-      `)
+        "at useErrorHook (app/browser/caught/page.js (39:3))
+        at Thrower (app/browser/caught/page.js (29:3))
+        at Inner (app/browser/caught/page.js (23:8))
+        at Page (app/browser/caught/page.js (43:11))"
+       `)
     }
 
     expect(normalizeStackTrace(errorLog)).toMatchInlineSnapshot(`
@@ -169,17 +161,10 @@ describe('app-dir - owner-stack', () => {
     await assertHasRedbox(browser)
 
     const stackFramesContent = await getStackFramesContent(browser)
-    if (process.env.TURBOPACK) {
-      expect(stackFramesContent).toMatchInlineSnapshot(`
+    expect(stackFramesContent).toMatchInlineSnapshot(`
         "at useErrorHook (app/ssr/page.js (8:3))
         at Page (app/ssr/page.js (12:3))"
       `)
-    } else {
-      expect(stackFramesContent).toMatchInlineSnapshot(`
-        "at useThrowError (app/ssr/page.js (8:3))
-        at useErrorHook (app/ssr/page.js (12:3))"
-      `)
-    }
 
     const logs = await browser.log()
     const errorLog = logs.find((log) => {

--- a/test/development/app-dir/server-navigation-error/server-navigation-error.test.ts
+++ b/test/development/app-dir/server-navigation-error/server-navigation-error.test.ts
@@ -63,14 +63,14 @@ describe('server-navigation-error', () => {
         `)
       } else {
         expect(source).toMatchInlineSnapshot(`
-          "pages/pages/not-found.tsx (4:11) @ notFound
+         "pages/pages/not-found.tsx (4:11) @ Page
 
-            2 |
-            3 | export default function Page() {
-          > 4 |   notFound()
-              |           ^
-            5 | }
-            6 |"
+           2 |
+           3 | export default function Page() {
+         > 4 |   notFound()
+             |           ^
+           5 | }
+           6 |"
         `)
       }
     })
@@ -135,15 +135,15 @@ describe('server-navigation-error', () => {
         `)
       } else {
         expect(source).toMatchInlineSnapshot(`
-          "middleware.ts (6:13) @ notFound
+         "middleware.ts (6:13) @ middleware
 
-            4 | export default function middleware(req: NextRequest) {
-            5 |   if (req.nextUrl.pathname === '/middleware/not-found') {
-          > 6 |     notFound()
-              |             ^
-            7 |   } else if (req.nextUrl.pathname === '/middleware/redirect') {
-            8 |     redirect('/')
-            9 |   }"
+           4 | export default function middleware(req: NextRequest) {
+           5 |   if (req.nextUrl.pathname === '/middleware/not-found') {
+         > 6 |     notFound()
+             |             ^
+           7 |   } else if (req.nextUrl.pathname === '/middleware/redirect') {
+           8 |     redirect('/')
+           9 |   }"
         `)
       }
     })

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -97,7 +97,7 @@ describe('middleware - development errors', () => {
               "\n  2 |       import { NextResponse } from 'next/server'"
           : '\n ⨯ unhandledRejection:  Error: async boom!' +
               '\n    at throwError (middleware.js:4:14)' +
-              '\n    at throwError (middleware.js:7:8)' +
+              '\n    at default (middleware.js:7:8)' +
               "\n  2 |       import { NextResponse } from 'next/server'"
       )
       expect(stripAnsi(next.cliOutput)).toContain(
@@ -154,8 +154,7 @@ describe('middleware - development errors', () => {
               // TODO(veil): Redundant and not clickable
               '\n    at eval (file://webpack-internal:///(middleware)/./middleware.js)' +
               '\n    at eval (middleware.js:4:8)' +
-              // TODO(veil): Redundant
-              '\n    at eval (middleware.js:4:8)' +
+              '\n    at default (middleware.js:4:8)' +
               "\n  2 |       import { NextResponse } from 'next/server'"
       )
       expect(stripAnsi(next.cliOutput)).toContain(
@@ -166,7 +165,7 @@ describe('middleware - development errors', () => {
               '\n    at __TURBOPACK__default__export__ ('
           : "\n ⚠ DynamicCodeEvaluationWarning: Dynamic Code Evaluation (e. g. 'eval', 'new Function') not allowed in Edge Runtime" +
               '\nLearn More: https://nextjs.org/docs/messages/edge-dynamic-code-evaluation' +
-              '\n    at eval (middleware.js:4:8)' +
+              '\n    at default (middleware.js:4:8)' +
               "\n  2 |       import { NextResponse } from 'next/server'"
       )
     })

--- a/test/e2e/app-dir/server-source-maps/server-source-maps-edge.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps-edge.test.ts
@@ -9,7 +9,7 @@ function normalizeCliOutput(output: string) {
 }
 
 describe('app-dir - server source maps edge runtime', () => {
-  const { skipped, next, isNextDev, isTurbopack } = nextTestSetup({
+  const { skipped, next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'fixtures/edge'),
     // Deploy tests don't have access to runtime logs.
     // Manually verify that the runtime logs match.
@@ -27,29 +27,17 @@ describe('app-dir - server source maps edge runtime', () => {
         expect(next.cliOutput.slice(outputIndex)).toContain('Error: Boom')
       })
       expect(normalizeCliOutput(next.cliOutput.slice(outputIndex))).toContain(
-        isTurbopack
-          ? '\nError: Boom' +
-              '\n    at logError (app/rsc-error-log/page.js:2:16)' +
-              '\n    at Page (app/rsc-error-log/page.js:6:2)' +
-              '\n  1 | function logError() {' +
-              "\n> 2 |   console.error(new Error('Boom'))" +
-              '\n    |                ^' +
-              '\n  3 | }' +
-              '\n  4 |' +
-              '\n  5 | export default function Page() { {' +
-              '\n  ' +
-              '\n}'
-          : '\nError: Boom' +
-              '\n    at logError (app/rsc-error-log/page.js:2:16)' +
-              '\n    at logError (app/rsc-error-log/page.js:6:2)' +
-              '\n  1 | function logError() {' +
-              "\n> 2 |   console.error(new Error('Boom'))" +
-              '\n    |                ^' +
-              '\n  3 | }' +
-              '\n  4 |' +
-              '\n  5 | export default function Page() { {' +
-              '\n  ' +
-              '\n}'
+        '\nError: Boom' +
+          '\n    at logError (app/rsc-error-log/page.js:2:16)' +
+          '\n    at Page (app/rsc-error-log/page.js:6:2)' +
+          '\n  1 | function logError() {' +
+          "\n> 2 |   console.error(new Error('Boom'))" +
+          '\n    |                ^' +
+          '\n  3 | }' +
+          '\n  4 |' +
+          '\n  5 | export default function Page() { {' +
+          '\n  ' +
+          '\n}'
       )
     } else {
       // TODO: Test `next build` with `--enable-source-maps`.
@@ -67,30 +55,17 @@ describe('app-dir - server source maps edge runtime', () => {
 
       const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
       expect(cliOutput).toContain(
-        isTurbopack
-          ? '\n ⨯ Error: Boom' +
-              '\n    at throwError (app/ssr-throw/page.js:4:8)' +
-              '\n    at Page (app/ssr-throw/page.js:8:2)' +
-              '\n  2 |' +
-              '\n  3 | function throwError() {' +
-              "\n> 4 |   throw new Error('Boom')" +
-              '\n    |        ^' +
-              '\n  5 | }' +
-              '\n  6 |' +
-              '\n  7 | export default function Page() { {' +
-              "\n  digest: '"
-          : '\n ⨯ Error: Boom' +
-              '\n    at throwError (app/ssr-throw/page.js:4:8)' +
-              // TODO(veil): Method name should be "Page"
-              '\n    at throwError (app/ssr-throw/page.js:8:2)' +
-              '\n  2 |' +
-              '\n  3 | function throwError() {' +
-              "\n> 4 |   throw new Error('Boom')" +
-              '\n    |        ^' +
-              '\n  5 | }' +
-              '\n  6 |' +
-              '\n  7 | export default function Page() { {' +
-              "\n  digest: '"
+        '\n ⨯ Error: Boom' +
+          '\n    at throwError (app/ssr-throw/page.js:4:8)' +
+          '\n    at Page (app/ssr-throw/page.js:8:2)' +
+          '\n  2 |' +
+          '\n  3 | function throwError() {' +
+          "\n> 4 |   throw new Error('Boom')" +
+          '\n    |        ^' +
+          '\n  5 | }' +
+          '\n  6 |' +
+          '\n  7 | export default function Page() { {' +
+          "\n  digest: '"
       )
       expect(cliOutput).toMatch(/digest: '\d+'/)
     } else {
@@ -109,28 +84,16 @@ describe('app-dir - server source maps edge runtime', () => {
 
       const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
       expect(cliOutput).toContain(
-        isTurbopack
-          ? '\n ⨯ Error: Boom' +
-              '\n    at throwError (app/rsc-throw/page.js:2:8)' +
-              '\n    at Page (app/rsc-throw/page.js:6:2)' +
-              '\n  1 | function throwError() {' +
-              "\n> 2 |   throw new Error('Boom')" +
-              '\n    |        ^' +
-              '\n  3 | }' +
-              '\n  4 |' +
-              '\n  5 | export default function Page() { {' +
-              "\n  digest: '"
-          : '\n ⨯ Error: Boom' +
-              '\n    at throwError (app/rsc-throw/page.js:2:8)' +
-              // TODO(veil): Method name should be "Page"
-              '\n    at throwError (app/rsc-throw/page.js:6:2)' +
-              '\n  1 | function throwError() {' +
-              "\n> 2 |   throw new Error('Boom')" +
-              '\n    |        ^' +
-              '\n  3 | }' +
-              '\n  4 |' +
-              '\n  5 | export default function Page() { {' +
-              "\n  digest: '"
+        '\n ⨯ Error: Boom' +
+          '\n    at throwError (app/rsc-throw/page.js:2:8)' +
+          '\n    at Page (app/rsc-throw/page.js:6:2)' +
+          '\n  1 | function throwError() {' +
+          "\n> 2 |   throw new Error('Boom')" +
+          '\n    |        ^' +
+          '\n  3 | }' +
+          '\n  4 |' +
+          '\n  5 | export default function Page() { {' +
+          "\n  digest: '"
       )
       expect(cliOutput).toMatch(/digest: '\d+'/)
     } else {

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -37,10 +37,7 @@ describe('app-dir - server source maps', () => {
       expect(normalizeCliOutput(next.cliOutput.slice(outputIndex))).toContain(
         '\nError: Boom' +
           '\n    at logError (app/rsc-error-log/page.js:4:16)' +
-          (isTurbopack
-            ? '\n    at Page (app/rsc-error-log/page.js:11:2)'
-            : // TODO(veil): Method name should be "Page"
-              '\n    at logError (app/rsc-error-log/page.js:11:2)') +
+          '\n    at Page (app/rsc-error-log/page.js:11:2)' +
           '\n  2 |' +
           '\n  3 | function logError() {' +
           "\n> 4 |   const error = new Error('Boom')" +
@@ -68,8 +65,7 @@ describe('app-dir - server source maps', () => {
           '\n    at logError (app/rsc-error-log-cause/page.js:4:16)' +
           (isTurbopack
             ? '\n    at Page (app/rsc-error-log-cause/page.js:12:2)'
-            : // FIXME: Method name should be "Page"
-              '\n    at logError (app/rsc-error-log-cause/page.js:12:2)') +
+            : '\n    at Page (app/rsc-error-log-cause/page.js:12:2)') +
           '\n  2 |' +
           '\n  3 | function logError(cause) {' +
           "\n> 4 |   const error = new Error('Boom', { cause })" +
@@ -111,8 +107,7 @@ describe('app-dir - server source maps', () => {
               "Module not found: Can't resolve 'internal-pkg'"
             : '\nError: Boom' +
                 '\n    at logError (app/ssr-error-log-ignore-listed/page.js:8:16)' +
-                // TODO(veil): Method name should be "runWithExternalSourceMapped"
-                '\n    at logError (app/ssr-error-log-ignore-listed/page.js:17:10)' +
+                '\n    at runWithExternalSourceMapped (app/ssr-error-log-ignore-listed/page.js:17:10)' +
                 '\n    at runWithExternal (app/ssr-error-log-ignore-listed/page.js:16:32)' +
                 '\n    at runWithInternalSourceMapped (app/ssr-error-log-ignore-listed/page.js:15:18)' +
                 '\n    at runWithInternal (app/ssr-error-log-ignore-listed/page.js:14:28)' +
@@ -146,8 +141,7 @@ describe('app-dir - server source maps', () => {
               "Module not found: Can't resolve 'internal-pkg'"
             : '\nError: Boom' +
                 '\n    at logError (app/rsc-error-log-ignore-listed/page.js:8:16)' +
-                // TODO(veil): Method name should be "runWithExternalSourceMapped"
-                '\n    at logError (app/rsc-error-log-ignore-listed/page.js:19:10)' +
+                '\n    at runWithExternalSourceMapped (app/rsc-error-log-ignore-listed/page.js:19:10)' +
                 '\n    at runWithExternal (app/rsc-error-log-ignore-listed/page.js:18:32)' +
                 '\n    at runWithInternalSourceMapped (app/rsc-error-log-ignore-listed/page.js:17:18)' +
                 '\n    at runWithInternal (app/rsc-error-log-ignore-listed/page.js:16:28)' +
@@ -172,30 +166,17 @@ describe('app-dir - server source maps', () => {
 
       const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
       expect(cliOutput).toContain(
-        isTurbopack
-          ? '\n ⨯ Error: Boom' +
-              '\n    at throwError (app/ssr-throw/Thrower.js:4:8)' +
-              '\n    at Thrower (app/ssr-throw/Thrower.js:8:2)' +
-              '\n  2 |' +
-              '\n  3 | function throwError() {' +
-              "\n> 4 |   throw new Error('Boom')" +
-              '\n    |        ^' +
-              '\n  5 | }' +
-              '\n  6 |' +
-              '\n  7 | export function Thrower() { {' +
-              "\n  digest: '"
-          : '\n ⨯ Error: Boom' +
-              '\n    at throwError (app/ssr-throw/Thrower.js:4:8)' +
-              // TODO(veil): Method name should be "Thrower"
-              '\n    at throwError (app/ssr-throw/Thrower.js:8:2)' +
-              '\n  2 |' +
-              '\n  3 | function throwError() {' +
-              "\n> 4 |   throw new Error('Boom')" +
-              '\n    |        ^' +
-              '\n  5 | }' +
-              '\n  6 |' +
-              '\n  7 | export function Thrower() { {' +
-              "\n  digest: '"
+        '\n ⨯ Error: Boom' +
+          '\n    at throwError (app/ssr-throw/Thrower.js:4:8)' +
+          '\n    at Thrower (app/ssr-throw/Thrower.js:8:2)' +
+          '\n  2 |' +
+          '\n  3 | function throwError() {' +
+          "\n> 4 |   throw new Error('Boom')" +
+          '\n    |        ^' +
+          '\n  5 | }' +
+          '\n  6 |' +
+          '\n  7 | export function Thrower() { {' +
+          "\n  digest: '"
       )
       expect(cliOutput).toMatch(/digest: '\d+'/)
     } else {

--- a/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
+++ b/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
@@ -66,8 +66,7 @@ describe('use-cache-close-over-function', () => {
               '\n  [function fn]' +
               '\n   ^^^^^^^^^^^' +
               '\n    at createCachedFn (app/client/page.tsx:8:2)' +
-              // TODO(veil): Method name should be "Page"
-              '\n    at createCachedFn (app/client/page.tsx:15:27)' +
+              '\n    at Page (app/client/page.tsx:15:27)' +
               '\n   6 |   }' +
               '\n   7 |' +
               '\n>  8 |   return async () => {' +
@@ -120,7 +119,7 @@ describe('use-cache-close-over-function', () => {
               '\n  [function fn]' +
               '\n   ^^^^^^^^^^^' +
               '\n    at createCachedFn (app/server/page.tsx:6:2)' +
-              '\n    at createCachedFn (app/server/page.tsx:12:23)' +
+              '\n    at eval (app/server/page.tsx:12:23)' +
               // TODO(veil): Should be source-mapped.
               '\n    at (rsc)'
       )

--- a/test/integration/edge-runtime-dynamic-code/test/index.test.js
+++ b/test/integration/edge-runtime-dynamic-code/test/index.test.js
@@ -114,8 +114,10 @@ describe.each([
                     // Next.js internal frame. Feel free to adjust.
                     // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
                     '\n    at'
-                : '\n    at eval (../../test/integration/edge-runtime-dynamic-code/lib/utils.js:11:18)' +
-                    '\n    at usingEval (../../test/integration/edge-runtime-dynamic-code/middleware.js:12:53)' +
+                : '\n    at usingEval (../../test/integration/edge-runtime-dynamic-code/lib/utils.js:11:18)' +
+                    '\n    at middleware (../../test/integration/edge-runtime-dynamic-code/middleware.js:12:53)' +
+                    // Next.js internal frame. Feel free to adjust.
+                    // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
                     '\n    at eval (../packages/next/dist'
             )
           } else {
@@ -127,8 +129,8 @@ describe.each([
                     // Next.js internal frame. Feel free to adjust.
                     // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
                     '\n    at'
-                : '\n    at eval (../../test/integration/edge-runtime-dynamic-code/lib/utils.js:11:18)' +
-                    '\n    at usingEval (../../test/integration/edge-runtime-dynamic-code/pages/api/route.js:13:23)' +
+                : '\n    at usingEval (../../test/integration/edge-runtime-dynamic-code/lib/utils.js:11:18)' +
+                    '\n    at handler (../../test/integration/edge-runtime-dynamic-code/pages/api/route.js:13:23)' +
                     '\n   9 | export async function usingEval() {'
             )
           }
@@ -176,7 +178,7 @@ describe.each([
                     // Next.js internal frame. Feel free to adjust.
                     // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
                     '\n    at'
-                : '\n    at WebAssembly (../../test/integration/edge-runtime-dynamic-code/lib/wasm.js:22:23)' +
+                : '\n    at usingWebAssemblyCompile (../../test/integration/edge-runtime-dynamic-code/lib/wasm.js:22:23)' +
                     '\n    at middleware (../../test/integration/edge-runtime-dynamic-code/middleware.js:24:68)' +
                     // Next.js internal frame. Feel free to adjust.
                     // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
@@ -192,7 +194,7 @@ describe.each([
                     // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
                     '\n    at'
                 : '' +
-                    '\n    at WebAssembly (../../test/integration/edge-runtime-dynamic-code/lib/wasm.js:22:23)' +
+                    '\n    at usingWebAssemblyCompile (../../test/integration/edge-runtime-dynamic-code/lib/wasm.js:22:23)' +
                     '\n    at handler (../../test/integration/edge-runtime-dynamic-code/pages/api/route.js:17:42)' +
                     // Next.js internal frame. Feel free to adjust.
                     // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules

--- a/test/integration/server-side-dev-errors/test/index.test.js
+++ b/test/integration/server-side-dev-errors/test/index.test.js
@@ -72,16 +72,15 @@ describe('server-side dev errors', () => {
             '\n    at getStaticProps (../../test/integration/server-side-dev-errors/test/integration/server-side-dev-errors/pages/gsp.js:6:2)' +
             // Next.js internal frame. Feel free to adjust.
             // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-            '\n    at fn'
+            '\n    at <unknown>'
         )
       } else {
         expect(stderrOutput).toStartWith(
           '⨯ ReferenceError: missingVar is not defined' +
-            // TODO(veil): Should be "at getStaticProps"
-            '\n    at missingVar (../../test/integration/server-side-dev-errors/pages/gsp.js:6:2)' +
+            '\n    at getStaticProps (../../test/integration/server-side-dev-errors/pages/gsp.js:6:2)' +
             // Next.js internal frame. Feel free to adjust.
             // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-            '\n    at fn'
+            '\n    at <unknown>'
         )
       }
       expect(stderr).toContain(
@@ -125,16 +124,15 @@ describe('server-side dev errors', () => {
             '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/test/integration/server-side-dev-errors/pages/gssp.js:6:2)' +
             // Next.js internal frame. Feel free to adjust.
             // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-            '\n    at fn'
+            '\n    at <unknown>'
         )
       } else {
         expect(stderrOutput).toStartWith(
           '⨯ ReferenceError: missingVar is not defined' +
-            // TODO(veil): Should be "at getServerSideProps"
-            '\n    at missingVar (../../test/integration/server-side-dev-errors/pages/gssp.js:6:2)' +
+            '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/gssp.js:6:2)' +
             // Next.js internal frame. Feel free to adjust.
             // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-            '\n    at fn'
+            '\n    at <unknown>'
         )
       }
       expect(stderrOutput).toContain(
@@ -178,16 +176,15 @@ describe('server-side dev errors', () => {
             '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/test/integration/server-side-dev-errors/pages/blog/[slug].js:6:2)' +
             // Next.js internal frame. Feel free to adjust.
             // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-            '\n    at fn'
+            '\n    at <unknown>'
         )
       } else {
         expect(stderrOutput).toStartWith(
           '⨯ ReferenceError: missingVar is not defined' +
-            // TODO(veil): Should be "at getServerSideProps"
-            '\n    at missingVar (../../test/integration/server-side-dev-errors/pages/blog/[slug].js:6:2)' +
+            '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/blog/[slug].js:6:2)' +
             // Next.js internal frame. Feel free to adjust.
             // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-            '\n    at fn'
+            '\n    at <unknown>'
         )
       }
       expect(stderrOutput).toContain(
@@ -236,8 +233,7 @@ describe('server-side dev errors', () => {
       } else {
         expect(stderrOutput).toStartWith(
           '⨯ ReferenceError: missingVar is not defined' +
-            // TODO(veil): Should be "at handler"
-            '\n    at missingVar (../../test/integration/server-side-dev-errors/pages/api/hello.js:2:2)' +
+            '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/hello.js:2:2)' +
             // Next.js internal frame. Feel free to adjust.
             // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
             '\n    at async'
@@ -290,8 +286,7 @@ describe('server-side dev errors', () => {
       } else {
         expect(stderrOutput).toContain(
           ' ⨯ ReferenceError: missingVar is not defined' +
-            // TODO(veil): Should be "at handler"
-            '\n    at missingVar (../../test/integration/server-side-dev-errors/pages/api/blog/[slug].js:2:2)' +
+            '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/blog/[slug].js:2:2)' +
             // Next.js internal frame. Feel free to adjust.
             // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
             '\n    at'


### PR DESCRIPTION
Sourcemaps will only give you the name mapping for a specific source position.
However, stack traces will point to the actual callsite not the function declaration.
So we always ask for the name mapping of the variable that we called not the name of the calling function.

We can fix this in v8 by using `callsite.getEnclosingColumnNumber() - 1` but this is more involved since we need to stash the callsites in `Error.prepareStacktrace` for later inspection.

Since all the sourcemapping currently targets dev, we just stop sourcemapping functions names assuming most code is not mangled. That holds at least true for all product code.

Turbopack just used to work since it didn't include name mapping in sourcemaps in dev because it's unnecessary for unmangled code. Webpack always included name mapping even if it was 1:1 so that's why all of the discrepancies were observed in Webpack.