### PR TITLE
test: assert that app exited without signal

### DIFF
--- a/test/production/graceful-shutdown/index.test.ts
+++ b/test/production/graceful-shutdown/index.test.ts
@@ -17,7 +17,7 @@ import { once } from 'events'
 
 const appDir = join(__dirname, './src')
 let appPort
-let app
+let app: Awaited<ReturnType<typeof launchApp>>
 
 function assertDefined<T>(value: T | void): asserts value is T {
   expect(value).toBeDefined()
@@ -143,7 +143,7 @@ function runTests(dev = false) {
       expect(app.exitCode).toBe(null)
 
       // App finally shuts down
-      await appKilledPromise
+      expect(await appKilledPromise).toEqual([0, null])
       expect(app.exitCode).toBe(0)
     })
   } else {
@@ -180,7 +180,7 @@ function runTests(dev = false) {
       expect(responseResolved).toBe(true)
 
       // App finally shuts down
-      await appKilledPromise
+      expect(await appKilledPromise).toEqual([0, null])
       expect(app.exitCode).toBe(0)
     })
 
@@ -215,7 +215,7 @@ function runTests(dev = false) {
         expect(app.exitCode).toBe(null)
 
         // App finally shuts down
-        await appKilledPromise
+        expect(await appKilledPromise).toEqual([0, null])
         expect(app.exitCode).toBe(0)
       })
 
@@ -232,7 +232,7 @@ function runTests(dev = false) {
         ).rejects.toThrow()
 
         // App finally shuts down
-        await appKilledPromise
+        expect(await appKilledPromise).toEqual([0, null])
         expect(app.exitCode).toBe(0)
       })
     })


### PR DESCRIPTION
we've seen these tests flake with this error:
```
    expect(received).toBe(expected) // Object.is equality

    Expected: 0
    Received: null

      234 |         // App finally shuts down
      235 |         await appKilledPromise
    > 236 |         expect(app.exitCode).toBe(0)
          |                              ^
      237 |       })
      238 |     })
      239 |   }

      at Object.toBe (production/graceful-shutdown/index.test.ts:236:
```
this PR doesn't fix that, but it should make it easier to see why the code was `null` -- if signal is nonnull, we'll see what it was.

note: `once(app, 'exit')` returns the arguments passed to the `exit` callback, which are `(code, signal)`