### PR TITLE
Update 15-internationalization.mdx

### DIFF
--- a/docs/01-app/03-building-your-application/01-routing/15-internationalization.mdx
+++ b/docs/01-app/03-building-your-application/01-routing/15-internationalization.mdx
@@ -177,15 +177,15 @@ export async function generateStaticParams() {
   return [{ lang: 'en-US' }, { lang: 'de' }]
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
   params,
 }: Readonly<{
   children: React.ReactNode
-  params: { lang: 'en-US' | 'de' }
+  params: Promise<{ lang: 'en-US' | 'de' }>
 }>) {
   return (
-    <html lang={params.lang}>
+    <html lang={(await params).lang}>
       <body>{children}</body>
     </html>
   )


### PR DESCRIPTION
`params` should be awaited before using its properties

This pull request includes a change to the `docs/01-app/03-building-your-application/01-routing/15-internationalization.mdx` file to handle asynchronous parameters in the `RootLayout` function.

Key change:

* Modified the `RootLayout` function to be asynchronous and handle a `Promise` for the `params` parameter. This ensures that the `lang` attribute is correctly set after resolving the promise.
