### PR TITLE
refactor: remove internal queries, move to request metadata

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2754,12 +2754,12 @@ export default async function build(
                     if (i18n) {
                       defaultMap[`/${i18n.defaultLocale}${page}`] = {
                         page,
-                        query: { __nextFallback: 'true' },
+                        _pagesFallback: true,
                       }
                     } else {
                       defaultMap[page] = {
                         page,
-                        query: { __nextFallback: 'true' },
+                        _pagesFallback: true,
                       }
                     }
                   } else {
@@ -2776,7 +2776,7 @@ export default async function build(
                 routes.forEach((route) => {
                   defaultMap[route.pathname] = {
                     page,
-                    query: { __nextSsgPath: route.encodedPathname },
+                    _ssgPath: route.encodedPathname,
                   }
                 })
               })
@@ -2816,7 +2816,7 @@ export default async function build(
 
                   defaultMap[route.pathname] = {
                     page: originalAppPath,
-                    query: { __nextSsgPath: route.encodedPathname },
+                    _ssgPath: route.encodedPathname,
                     _fallbackRouteParams: route.fallbackRouteParams,
                     _isDynamicError: isDynamicError,
                     _isAppDir: true,
@@ -2835,7 +2835,7 @@ export default async function build(
               } of prospectiveRenders.values()) {
                 defaultMap[page] = {
                   page: originalAppPath,
-                  query: { __nextSsgPath: page },
+                  _ssgPath: page,
                   _fallbackRouteParams: getParamKeys(page),
                   // Prospective renders are only enabled for app pages.
                   _isAppDir: true,
@@ -2865,10 +2865,8 @@ export default async function build(
 
                     defaultMap[outputPath] = {
                       page: defaultMap[page]?.page || page,
-                      query: {
-                        __nextLocale: locale,
-                        __nextFallback: isFallback ? 'true' : undefined,
-                      },
+                      _locale: locale,
+                      _pagesFallback: isFallback,
                     }
                   }
 

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -353,8 +353,8 @@ export async function buildAppStaticPaths({
       waitUntil: afterRunner.context.waitUntil,
       onClose: afterRunner.context.onClose,
       onAfterTaskError: afterRunner.context.onTaskError,
-      buildId,
     },
+    buildId,
   })
 
   const routeParams = await ComponentMod.workAsyncStorage.run(

--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
@@ -85,6 +85,7 @@ export function getRender({
 
   const server = new WebServer({
     dev,
+    buildId,
     conf: config,
     minimalMode: true,
     webServerConfig: {
@@ -93,7 +94,6 @@ export function getRender({
       pagesType,
       interceptionRouteRewrites,
       extendRenderOpts: {
-        buildId,
         runtime: SERVER_RUNTIME.experimentalEdge,
         supportsDynamicResponse: true,
         disableOptimizedLoading: true,

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -317,7 +317,6 @@ async function exportAppImpl(
   // Start the rendering process
   const renderOpts: WorkerRenderOptsPartial = {
     previewProps: prerenderManifest?.preview,
-    buildId,
     nextExport: true,
     assetPrefix: nextConfig.assetPrefix.replace(/\/$/, ''),
     distDir,
@@ -543,6 +542,7 @@ async function exportAppImpl(
     await Promise.all(
       chunks.map((paths) =>
         worker.exportPages({
+          buildId,
           paths,
           exportPathMap,
           parentSpanId: span.getId(),

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -27,6 +27,7 @@ import type { WorkStore } from '../../server/app-render/work-async-storage.exter
 import type { FallbackRouteParams } from '../../server/request/fallback-params'
 import { AfterRunner } from '../../server/after/run-with-after'
 import type { RequestLifecycleOpts } from '../../server/base-server'
+import type { AppSharedContext } from '../../server/app-render/app-render'
 
 export const enum ExportedAppPageFiles {
   HTML = 'HTML',
@@ -44,7 +45,8 @@ export async function prospectiveRenderAppPage(
   pathname: string,
   query: NextParsedUrlQuery,
   fallbackRouteParams: FallbackRouteParams | null,
-  partialRenderOpts: Omit<RenderOpts, keyof RequestLifecycleOpts>
+  partialRenderOpts: Omit<RenderOpts, keyof RequestLifecycleOpts>,
+  sharedContext: AppSharedContext
 ): Promise<undefined> {
   const afterRunner = new AfterRunner()
 
@@ -68,7 +70,8 @@ export async function prospectiveRenderAppPage(
         onAfterTaskError: afterRunner.context.onTaskError,
       },
       undefined,
-      false
+      false,
+      sharedContext
     )
 
     // TODO(after): if we abort a prerender because of an error in an after-callback
@@ -102,7 +105,8 @@ export async function exportAppPage(
   htmlFilepath: string,
   debugOutput: boolean,
   isDynamicError: boolean,
-  fileWriter: FileWriter
+  fileWriter: FileWriter,
+  sharedContext: AppSharedContext
 ): Promise<ExportRouteResult> {
   const afterRunner = new AfterRunner()
 
@@ -130,7 +134,8 @@ export async function exportAppPage(
       fallbackRouteParams,
       renderOpts,
       undefined,
-      false
+      false,
+      sharedContext
     )
 
     const html = result.toUnchunkedString()

--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -87,6 +87,8 @@ export async function exportAppRoute(
       onClose: afterRunner.context.onClose,
       onAfterTaskError: afterRunner.context.onTaskError,
       cacheLifeProfiles,
+    },
+    sharedContext: {
       buildId,
     },
   }

--- a/packages/next/src/export/routes/pages.ts
+++ b/packages/next/src/export/routes/pages.ts
@@ -1,5 +1,9 @@
 import type { ExportRouteResult, FileWriter } from '../types'
-import type { RenderOpts } from '../../server/render'
+import type {
+  PagesRenderContext,
+  PagesSharedContext,
+  RenderOpts,
+} from '../../server/render'
 import type { LoadComponentsReturnType } from '../../server/load-components'
 import type { AmpValidation } from '../types'
 import type { NextParsedUrlQuery } from '../../server/request-meta'
@@ -47,6 +51,8 @@ export async function exportPagesPage(
   pagesDataDir: string,
   buildExport: boolean,
   isDynamic: boolean,
+  sharedContext: PagesSharedContext,
+  renderContext: PagesRenderContext,
   hasOrigQueryValues: boolean,
   renderOpts: RenderOpts,
   components: LoadComponentsReturnType,
@@ -117,7 +123,9 @@ export async function exportPagesPage(
         res,
         page,
         searchAndDynamicParams,
-        renderOpts
+        renderOpts,
+        sharedContext,
+        renderContext
       )
     } catch (err) {
       if (!isBailoutToCSRError(err)) throw err
@@ -173,7 +181,9 @@ export async function exportPagesPage(
           res,
           page,
           { ...searchAndDynamicParams, amp: '1' },
-          renderOpts
+          renderOpts,
+          sharedContext,
+          renderContext
         )
       } catch (err) {
         if (!isBailoutToCSRError(err)) throw err

--- a/packages/next/src/export/types.ts
+++ b/packages/next/src/export/types.ts
@@ -38,6 +38,7 @@ export type FileWriter = (
 type PathMap = ExportPathMap[keyof ExportPathMap]
 
 export interface ExportPagesInput {
+  buildId: string
   paths: string[]
   exportPathMap: ExportPathMap
   parentSpanId: number
@@ -55,6 +56,7 @@ export interface ExportPagesInput {
 }
 
 export interface ExportPageInput {
+  buildId: string
   path: string
   pathMap: PathMap
   distDir: string

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -48,6 +48,8 @@ import {
 import { needsExperimentalReact } from '../lib/needs-experimental-react'
 import type { AppRouteRouteModule } from '../server/route-modules/app-route/module.compiled'
 import { isStaticGenBailoutError } from '../client/components/static-generation-bailout'
+import type { PagesRenderContext, PagesSharedContext } from '../server/render'
+import type { AppSharedContext } from '../server/app-render/app-render'
 
 const envConfig = require('../shared/lib/runtime-config.external')
 
@@ -124,11 +126,8 @@ async function exportPageImpl(
   const ampPath = `${filePath}.amp`
   let renderAmpPath = ampPath
 
-  let updatedPath = query.__nextSsgPath || path
-  delete query.__nextSsgPath
-
-  let locale = query.__nextLocale || input.renderOpts.locale
-  delete query.__nextLocale
+  let updatedPath = pathMap._ssgPath || path
+  let locale = pathMap._locale || input.renderOpts.locale
 
   if (input.renderOpts.locale) {
     const localePathResult = normalizeLocalePath(path, input.renderOpts.locales)
@@ -251,7 +250,7 @@ async function exportPageImpl(
       htmlFilepath,
       fileWriter,
       input.renderOpts.experimental,
-      input.renderOpts.buildId
+      input.buildId
     )
   }
 
@@ -276,6 +275,10 @@ async function exportPageImpl(
 
   // Handle App Pages
   if (isAppDir) {
+    const sharedContext: AppSharedContext = {
+      buildId: input.buildId,
+    }
+
     // If this is a prospective render, don't return any metrics or revalidate
     // timings as we aren't persisting this render (it was only to error).
     if (isProspectiveRender) {
@@ -286,7 +289,8 @@ async function exportPageImpl(
         pathname,
         query,
         fallbackRouteParams,
-        renderOpts
+        renderOpts,
+        sharedContext
       )
     }
 
@@ -302,8 +306,21 @@ async function exportPageImpl(
       htmlFilepath,
       debugOutput,
       isDynamicError,
-      fileWriter
+      fileWriter,
+      sharedContext
     )
+  }
+
+  const sharedContext: PagesSharedContext = {
+    buildId: input.buildId,
+    deploymentId: input.renderOpts.deploymentId,
+    customServer: undefined,
+  }
+
+  const renderContext: PagesRenderContext = {
+    isFallback: pathMap._pagesFallback ?? false,
+    isDraftMode: false,
+    developmentNotFoundSourcePage: undefined,
   }
 
   return exportPagesPage(
@@ -322,6 +339,8 @@ async function exportPageImpl(
     pagesDataDir,
     buildExport,
     isDynamic,
+    sharedContext,
+    renderContext,
     hasOrigQueryValues,
     renderOpts,
     components,
@@ -399,6 +418,7 @@ export async function exportPages(
             debugOutput: options.debugOutput,
             enableExperimentalReact: needsExperimentalReact(nextConfig),
             sriEnabled: Boolean(nextConfig.experimental.sri?.algorithm),
+            buildId: input.buildId,
           }),
           // If exporting the page takes longer than the timeout, reject the promise.
           new Promise((_, reject) => {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -196,7 +196,12 @@ export type GetDynamicParamFromSegment = (
 
 export type GenerateFlight = typeof generateDynamicFlightRenderResult
 
+export type AppSharedContext = {
+  buildId: string
+}
+
 export type AppRenderContext = {
+  sharedContext: AppSharedContext
   workStore: WorkStore
   url: ReturnType<typeof parseRelativeUrl>
   componentMod: AppPageModule
@@ -499,13 +504,13 @@ async function generateDynamicRSCPayload(
     return {
       a: options.actionResult,
       f: flightData,
-      b: ctx.renderOpts.buildId,
+      b: ctx.sharedContext.buildId,
     }
   }
 
   // Otherwise, it's a regular RSC response.
   return {
-    b: ctx.renderOpts.buildId,
+    b: ctx.sharedContext.buildId,
     f: flightData,
     S: workStore.isStaticGeneration,
   }
@@ -812,7 +817,7 @@ async function getRSCPayload(
   return {
     // See the comment above the `Preloads` component (below) for why this is part of the payload
     P: <Preloads preloadCallbacks={preloadCallbacks} />,
-    b: ctx.renderOpts.buildId,
+    b: ctx.sharedContext.buildId,
     p: ctx.assetPrefix,
     c: prepareInitialCanonicalUrl(url),
     i: !!couldBeIntercepted,
@@ -924,7 +929,7 @@ async function getErrorRSCPayload(
     ctx.renderOpts.experimental.isRoutePPREnabled === true
 
   return {
-    b: ctx.renderOpts.buildId,
+    b: ctx.sharedContext.buildId,
     p: ctx.assetPrefix,
     c: prepareInitialCanonicalUrl(url),
     m: undefined,
@@ -1066,7 +1071,8 @@ async function renderToHTMLOrFlightImpl(
   requestEndedState: { ended?: boolean },
   postponedState: PostponedState | null,
   implicitTags: Array<string>,
-  serverComponentsHmrCache: ServerComponentsHmrCache | undefined
+  serverComponentsHmrCache: ServerComponentsHmrCache | undefined,
+  sharedContext: AppSharedContext
 ) {
   const isNotFoundPath = pagePath === '/404'
   if (isNotFoundPath) {
@@ -1233,6 +1239,7 @@ async function renderToHTMLOrFlightImpl(
     isNotFoundPath,
     nonce,
     res,
+    sharedContext,
   }
 
   getTracer().setRootSpanAttribute('next.route', pagePath)
@@ -1477,7 +1484,8 @@ export type AppPageRender = (
   fallbackRouteParams: FallbackRouteParams | null,
   renderOpts: RenderOpts,
   serverComponentsHmrCache: ServerComponentsHmrCache | undefined,
-  isDevWarmup: boolean
+  isDevWarmup: boolean,
+  sharedContext: AppSharedContext
 ) => Promise<RenderResult<AppPageRenderResultMetadata>>
 
 export const renderToHTMLOrFlight: AppPageRender = (
@@ -1488,7 +1496,8 @@ export const renderToHTMLOrFlight: AppPageRender = (
   fallbackRouteParams,
   renderOpts,
   serverComponentsHmrCache,
-  isDevWarmup
+  isDevWarmup,
+  sharedContext
 ) => {
   if (!req.url) {
     throw new Error('Invalid URL')
@@ -1545,6 +1554,7 @@ export const renderToHTMLOrFlight: AppPageRender = (
     requestEndedState,
     // @TODO move to workUnitStore of type Request
     isPrefetchRequest,
+    buildId: sharedContext.buildId,
   })
 
   return workAsyncStorage.run(
@@ -1563,7 +1573,8 @@ export const renderToHTMLOrFlight: AppPageRender = (
     requestEndedState,
     postponedState,
     implicitTags,
-    serverComponentsHmrCache
+    serverComponentsHmrCache,
+    sharedContext
   )
 }
 

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -164,7 +164,6 @@ export interface RenderOptsPartial {
   previewProps: __ApiPreviewProps | undefined
   err?: Error | null
   dev?: boolean
-  buildId: string
   basePath: string
   trailingSlash: boolean
   clientReferenceManifest?: DeepReadonly<ClientReferenceManifest>

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -60,10 +60,14 @@ export type WorkStoreContext = {
     | 'nextExport'
     | 'isDraftMode'
     | 'isDebugDynamicAccesses'
-    | 'buildId'
   > &
     RequestLifecycleOpts &
     Partial<Pick<RenderOpts, 'reactLoadableManifest'>>
+
+  /**
+   * The build ID of the current build.
+   */
+  buildId: string
 }
 
 export function createWorkStore({
@@ -72,6 +76,7 @@ export function createWorkStore({
   renderOpts,
   requestEndedState,
   isPrefetchRequest,
+  buildId,
 }: WorkStoreContext): WorkStore {
   /**
    * Rules of Static & Dynamic HTML:
@@ -116,7 +121,7 @@ export function createWorkStore({
 
     requestEndedState,
     isPrefetchRequest,
-    buildId: renderOpts.buildId,
+    buildId,
     reactLoadableManifest: renderOpts?.reactLoadableManifest || {},
     assetPrefix: renderOpts?.assetPrefix || '',
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -369,6 +369,7 @@ export default abstract class Server<
   protected readonly experimentalTestProxy?: boolean
 
   protected abstract findPageComponents(params: {
+    locale: string | undefined
     page: string
     query: NextParsedUrlQuery
     params: Params
@@ -466,7 +467,6 @@ export default abstract class Server<
       conf,
       dev = false,
       minimalMode = false,
-      customServer = true,
       hostname,
       port,
       experimentalTestProxy,
@@ -558,10 +558,8 @@ export default abstract class Server<
       strictNextHead: this.nextConfig.experimental.strictNextHead ?? true,
       poweredByHeader: this.nextConfig.poweredByHeader,
       canonicalBase: this.nextConfig.amp.canonicalBase || '',
-      buildId: this.buildId,
       generateEtags,
       previewProps: this.getPrerenderManifest().preview,
-      customServer: customServer === true ? true : undefined,
       ampOptimizerConfig: this.nextConfig.experimental.amp?.optimizer,
       basePath: this.nextConfig.basePath,
       images: this.nextConfig.images,
@@ -755,26 +753,26 @@ export default abstract class Server<
         }
 
         // Update the query with the detected locale and default locale.
-        parsedUrl.query.__nextLocale = localePathResult.detectedLocale
-        parsedUrl.query.__nextDefaultLocale = defaultLocale
+        addRequestMeta(req, 'locale', localePathResult.detectedLocale)
+        addRequestMeta(req, 'defaultLocale', defaultLocale)
 
         // If the locale is not detected from the path, we need to mark that
         // it was not inferred from default.
         if (!localePathResult.detectedLocale) {
-          delete parsedUrl.query.__nextInferredLocaleFromDefault
+          removeRequestMeta(req, 'localeInferredFromDefault')
         }
 
         // If no locale was detected and we don't have middleware, we need
         // to render a 404 page.
         if (!localePathResult.detectedLocale && !middleware) {
-          parsedUrl.query.__nextLocale = defaultLocale
+          addRequestMeta(req, 'locale', defaultLocale)
           await this.render404(req, res, parsedUrl)
           return true
         }
       }
 
       parsedUrl.pathname = pathname
-      parsedUrl.query.__nextDataReq = '1'
+      addRequestMeta(req, 'isNextDataReq', true)
 
       return false
     }
@@ -1009,14 +1007,6 @@ export default abstract class Server<
       req.headers['x-forwarded-proto'] ??= isHttps ? 'https' : 'http'
       req.headers['x-forwarded-for'] ??= originalRequest?.socket?.remoteAddress
 
-      // Validate that if i18n isn't configured or the passed parameters are not
-      // valid it should be removed from the query.
-      if (!this.i18nProvider?.validateQuery(parsedUrl.query)) {
-        delete parsedUrl.query.__nextLocale
-        delete parsedUrl.query.__nextDefaultLocale
-        delete parsedUrl.query.__nextInferredLocaleFromDefault
-      }
-
       // This should be done before any normalization of the pathname happens as
       // it captures the initial URL.
       this.attachRequestMeta(req, parsedUrl)
@@ -1030,7 +1020,7 @@ export default abstract class Server<
 
       const defaultLocale =
         domainLocale?.defaultLocale || this.nextConfig.i18n?.defaultLocale
-      parsedUrl.query.__nextDefaultLocale = defaultLocale
+      addRequestMeta(req, 'defaultLocale', defaultLocale)
 
       const url = parseUrlUtil(req.url.replace(/^\/+/, '/'))
       const pathnameInfo = getNextPathnameInfo(url.pathname, {
@@ -1072,7 +1062,7 @@ export default abstract class Server<
           // it's a data request the URL path will be the data URL,
           // basePath is already stripped by this point
           if (this.normalizers.data?.match(urlPathname)) {
-            parsedUrl.query.__nextDataReq = '1'
+            addRequestMeta(req, 'isNextDataReq', true)
           }
           // In minimal mode, if PPR is enabled, then we should check to see if
           // the request should be a resume request.
@@ -1106,14 +1096,14 @@ export default abstract class Server<
           // detected for the request because it will be inferred from the
           // default locale.
           if (localeAnalysisResult) {
-            parsedUrl.query.__nextLocale = localeAnalysisResult.detectedLocale
+            addRequestMeta(req, 'locale', localeAnalysisResult.detectedLocale)
 
             // If the detected locale was inferred from the default locale, we
             // need to modify the metadata on the request to indicate that.
             if (localeAnalysisResult.inferredFromDefault) {
-              parsedUrl.query.__nextInferredLocaleFromDefault = '1'
+              addRequestMeta(req, 'localeInferredFromDefault', true)
             } else {
-              delete parsedUrl.query.__nextInferredLocaleFromDefault
+              removeRequestMeta(req, 'localeInferredFromDefault')
             }
           }
 
@@ -1248,17 +1238,17 @@ export default abstract class Server<
               const routeParams = utils.getParamsFromRouteMatches(
                 req,
                 opts,
-                parsedUrl.query.__nextLocale || ''
+                getRequestMeta(req, 'locale')
               )
 
               // If this returns a locale, it means that the locale was detected
               // from the pathname.
               if (opts.locale) {
-                parsedUrl.query.__nextLocale = opts.locale
+                addRequestMeta(req, 'locale', opts.locale)
 
                 // As the locale was parsed from the pathname, we should mark
                 // that the locale was not inferred as the default.
-                delete parsedUrl.query.__nextInferredLocaleFromDefault
+                removeRequestMeta(req, 'localeInferredFromDefault')
               }
               paramsResult = utils.normalizeDynamicRouteParams(
                 routeParams,
@@ -1322,16 +1312,16 @@ export default abstract class Server<
 
       // If we aren't in minimal mode or there is no locale in the query
       // string, add the locale to the query string.
-      if (!this.minimalMode || !parsedUrl.query.__nextLocale) {
+      if (!this.minimalMode || !getRequestMeta(req, 'locale')) {
         // If the locale is in the pathname, add it to the query string.
         if (pathnameInfo.locale) {
-          parsedUrl.query.__nextLocale = pathnameInfo.locale
+          addRequestMeta(req, 'locale', pathnameInfo.locale)
         }
         // If the default locale is available, add it to the query string and
         // mark it as inferred rather than implicit.
         else if (defaultLocale) {
-          parsedUrl.query.__nextLocale = defaultLocale
-          parsedUrl.query.__nextInferredLocaleFromDefault = '1'
+          addRequestMeta(req, 'locale', defaultLocale)
+          addRequestMeta(req, 'localeInferredFromDefault', true)
         }
       }
 
@@ -1428,7 +1418,7 @@ export default abstract class Server<
         )
 
         if (invokePathnameInfo.locale) {
-          parsedUrl.query.__nextLocale = invokePathnameInfo.locale
+          addRequestMeta(req, 'locale', invokePathnameInfo.locale)
         }
 
         if (parsedUrl.pathname !== parsedMatchedPath.pathname) {
@@ -1441,7 +1431,7 @@ export default abstract class Server<
         )
 
         if (normalizeResult.detectedLocale) {
-          parsedUrl.query.__nextLocale = normalizeResult.detectedLocale
+          addRequestMeta(req, 'locale', normalizeResult.detectedLocale)
         }
         parsedUrl.pathname = normalizeResult.pathname
 
@@ -1805,7 +1795,7 @@ export default abstract class Server<
     }
 
     if (
-      this.renderOpts.customServer &&
+      this.serverOptions.customServer &&
       pathname === '/index' &&
       !(await this.hasPage('/index'))
     ) {
@@ -1821,7 +1811,7 @@ export default abstract class Server<
     if (
       !internalRender &&
       !this.minimalMode &&
-      !query.__nextDataReq &&
+      !getRequestMeta(req, 'isNextDataReq') &&
       (req.url?.match(/^\/_next\//) ||
         (this.hasStaticDir && req.url!.match(/^\/static\//)))
     ) {
@@ -2005,7 +1995,7 @@ export default abstract class Server<
     // Toggle whether or not this is a Data request
     const isNextDataRequest =
       !!(
-        query.__nextDataReq ||
+        getRequestMeta(req, 'isNextDataReq') ||
         (req.headers['x-nextjs-data'] &&
           (this.serverOptions as any).webServerConfig)
       ) &&
@@ -2040,8 +2030,6 @@ export default abstract class Server<
       return null
     }
 
-    delete query.__nextDataReq
-
     // normalize req.url for SSG paths as it is not exposed
     // to getStaticProps and the asPath should not expose /_next/data
     if (
@@ -2053,13 +2041,18 @@ export default abstract class Server<
       req.url = this.stripNextDataPath(req.url)
     }
 
+    const locale = getRequestMeta(req, 'locale')
+    const defaultLocale = isSSG
+      ? this.nextConfig.i18n?.defaultLocale
+      : getRequestMeta(req, 'defaultLocale')
+
     if (
       !!req.headers['x-nextjs-data'] &&
       (!res.statusCode || res.statusCode === 200)
     ) {
       res.setHeader(
         'x-nextjs-matched-path',
-        `${query.__nextLocale ? `/${query.__nextLocale}` : ''}${pathname}`
+        `${locale ? `/${locale}` : ''}${pathname}`
       )
     }
 
@@ -2199,11 +2192,6 @@ export default abstract class Server<
       opts.supportsDynamicResponse = true
     }
 
-    const defaultLocale = isSSG
-      ? this.nextConfig.i18n?.defaultLocale
-      : query.__nextDefaultLocale
-
-    const locale = query.__nextLocale
     const locales = this.nextConfig.i18n?.locales
 
     let previewData: PreviewData
@@ -2352,6 +2340,8 @@ export default abstract class Server<
        */
       postponed: string | undefined
 
+      pagesFallback: boolean | undefined
+
       /**
        * The unknown route params for this render.
        */
@@ -2361,7 +2351,11 @@ export default abstract class Server<
       context: RendererContext
     ) => Promise<ResponseCacheEntry | null>
 
-    const doRender: Renderer = async ({ postponed, fallbackRouteParams }) => {
+    const doRender: Renderer = async ({
+      postponed,
+      pagesFallback = false,
+      fallbackRouteParams,
+    }) => {
       // In development, we always want to generate dynamic HTML.
       let supportsDynamicResponse: boolean =
         // If we're in development, we always support dynamic HTML, unless it's
@@ -2487,7 +2481,9 @@ export default abstract class Server<
               onAfterTaskError: undefined,
               onInstrumentationRequestError:
                 this.renderOpts.onInstrumentationRequestError,
-              buildId: this.renderOpts.buildId,
+            },
+            sharedContext: {
+              buildId: this.buildId,
             },
           }
 
@@ -2595,15 +2591,26 @@ export default abstract class Server<
             // Call the built-in render method on the module.
             try {
               result = await routeModule.render(
-                // TODO: fix this type
-                // @ts-expect-error - preexisting accepted this
-                request,
-                response,
+                request as any,
+                response as any,
                 {
                   page: pathname,
                   params: opts.params,
                   query,
                   renderOpts,
+                  sharedContext: {
+                    buildId: this.buildId,
+                    deploymentId: this.nextConfig.deploymentId,
+                    customServer: this.serverOptions.customServer || undefined,
+                  },
+                  renderContext: {
+                    isFallback: pagesFallback,
+                    isDraftMode: renderOpts.isDraftMode,
+                    developmentNotFoundSourcePage: getRequestMeta(
+                      req,
+                      'developmentNotFoundSourcePage'
+                    ),
+                  },
                 }
               )
             } catch (err) {
@@ -2633,6 +2640,9 @@ export default abstract class Server<
               fallbackRouteParams,
               renderOpts,
               serverComponentsHmrCache: this.getServerComponentsHmrCache(),
+              sharedContext: {
+                buildId: this.buildId,
+              },
             }
 
             // TODO: adapt for putting the RDC inside the postponed data
@@ -2765,7 +2775,7 @@ export default abstract class Server<
           status: isAppPath ? res.statusCode : undefined,
         } satisfies CachedPageValue,
         revalidate: metadata.revalidate,
-        isFallback: query.__nextFallback === 'true',
+        isFallback: pagesFallback,
       }
     }
 
@@ -2910,16 +2920,14 @@ export default abstract class Server<
                 return toResponseCacheEntry(previousFallbackCacheEntry)
               }
 
-              // For the pages router, fallbacks can only be generated on
-              // demand in development, so if we're not in production, and we
-              // aren't a app path, then just add the __nextFallback query
-              // and render.
-              query.__nextFallback = 'true'
-
               // We pass `undefined` and `null` as it doesn't apply to the pages
               // router.
               return doRender({
                 postponed: undefined,
+                // For the pages router, fallbacks can only be generated on
+                // demand in development, so if we're not in production, and we
+                // aren't a app path.
+                pagesFallback: true,
                 fallbackRouteParams: null,
               })
             },
@@ -2948,6 +2956,7 @@ export default abstract class Server<
                 // We pass `undefined` as rendering a fallback isn't resumed
                 // here.
                 postponed: undefined,
+                pagesFallback: undefined,
                 fallbackRouteParams:
                   // If we're in production of we're debugging the fallback
                   // shell then we should postpone when dynamic params are
@@ -3018,6 +3027,7 @@ export default abstract class Server<
       // Perform the render.
       const result = await doRender({
         postponed,
+        pagesFallback: undefined,
         fallbackRouteParams,
       })
       if (!result) return null
@@ -3136,6 +3146,7 @@ export default abstract class Server<
                 // We're an on-demand request, so we don't need to pass in the
                 // fallbackRouteParams.
                 fallbackRouteParams: null,
+                pagesFallback: undefined,
                 postponed: undefined,
               }),
             {
@@ -3311,7 +3322,7 @@ export default abstract class Server<
       }
 
       if (this.renderOpts.dev) {
-        query.__nextNotFoundSrcPage = pathname
+        addRequestMeta(req, 'developmentNotFoundSourcePage', pathname)
       }
       await this.render404(req, res, { pathname, query }, false)
       return null
@@ -3507,6 +3518,7 @@ export default abstract class Server<
       // we've already chained the transformer's readable to the render result.
       doRender({
         postponed: cachedData.postponed,
+        pagesFallback: undefined,
         // This is a resume render, not a fallback render, so we don't need to
         // set this.
         fallbackRouteParams: null,
@@ -3601,6 +3613,7 @@ export default abstract class Server<
     }
 
     const result = await this.findPageComponents({
+      locale: getRequestMeta(ctx.req, 'locale'),
       page,
       query,
       params: ctx.renderOpts.params || {},
@@ -3651,14 +3664,14 @@ export default abstract class Server<
   private async renderToResponseImpl(
     ctx: RequestContext<ServerRequest, ServerResponse>
   ): Promise<ResponsePayload | null> {
-    const { res, query, pathname } = ctx
+    const { req, res, query, pathname } = ctx
     let page = pathname
-    const bubbleNoFallback = !!query._nextBubbleNoFallback
+    const bubbleNoFallback =
+      getRequestMeta(ctx.req, 'bubbleNoFallback') ?? false
     delete query[NEXT_RSC_UNION_QUERY]
-    delete query._nextBubbleNoFallback
 
     const options: MatchOptions = {
-      i18n: this.i18nProvider?.fromQuery(pathname, query),
+      i18n: this.i18nProvider?.fromRequest(req, pathname),
     }
 
     try {
@@ -3735,9 +3748,9 @@ export default abstract class Server<
       // if pages/500 is present we still need to trigger
       // /_error `getInitialProps` to allow reporting error
       if (await this.hasPage('/500')) {
-        ctx.query.__nextCustomErrorRender = '1'
+        addRequestMeta(ctx.req, 'customErrorRender', true)
         await this.renderErrorToResponse(ctx, err)
-        delete ctx.query.__nextCustomErrorRender
+        removeRequestMeta(ctx.req, 'customErrorRender')
       }
 
       const isWrappedError = err instanceof WrappedBuildError
@@ -3764,9 +3777,11 @@ export default abstract class Server<
       !!ctx.req.headers['x-nextjs-data'] &&
       (!res.statusCode || res.statusCode === 200 || res.statusCode === 404)
     ) {
+      const locale = getRequestMeta(req, 'locale')
+
       res.setHeader(
         'x-nextjs-matched-path',
-        `${query.__nextLocale ? `/${query.__nextLocale}` : ''}${pathname}`
+        `${locale ? `/${locale}` : ''}${pathname}`
       )
       res.statusCode = 200
       res.setHeader('content-type', 'application/json')
@@ -3883,6 +3898,7 @@ export default abstract class Server<
         if (this.enabledDirectories.app) {
           // Use the not-found entry in app directory
           result = await this.findPageComponents({
+            locale: getRequestMeta(ctx.req, 'locale'),
             page: UNDERSCORE_NOT_FOUND_ROUTE_ENTRY,
             query,
             params: {},
@@ -3895,6 +3911,7 @@ export default abstract class Server<
 
         if (!result && (await this.hasPage('/404'))) {
           result = await this.findPageComponents({
+            locale: getRequestMeta(ctx.req, 'locale'),
             page: '/404',
             query,
             params: {},
@@ -3909,7 +3926,7 @@ export default abstract class Server<
       let statusPage = `/${res.statusCode}`
 
       if (
-        !ctx.query.__nextCustomErrorRender &&
+        !getRequestMeta(ctx.req, 'customErrorRender') &&
         !result &&
         STATIC_STATUS_PAGES.includes(statusPage)
       ) {
@@ -3917,6 +3934,7 @@ export default abstract class Server<
         // dev overlay is used instead
         if (statusPage !== '/500' || !this.renderOpts.dev) {
           result = await this.findPageComponents({
+            locale: getRequestMeta(ctx.req, 'locale'),
             page: statusPage,
             query,
             params: {},
@@ -3931,6 +3949,7 @@ export default abstract class Server<
 
       if (!result) {
         result = await this.findPageComponents({
+          locale: getRequestMeta(ctx.req, 'locale'),
           page: '/_error',
           query,
           params: {},
@@ -4080,9 +4099,12 @@ export default abstract class Server<
   ): Promise<void> {
     const { pathname, query } = parsedUrl ? parsedUrl : parseUrl(req.url!, true)
 
+    // Ensure the locales are provided on the request meta.
     if (this.nextConfig.i18n) {
-      query.__nextLocale ||= this.nextConfig.i18n.defaultLocale
-      query.__nextDefaultLocale ||= this.nextConfig.i18n.defaultLocale
+      if (!getRequestMeta(req, 'locale')) {
+        addRequestMeta(req, 'locale', this.nextConfig.i18n.defaultLocale)
+      }
+      addRequestMeta(req, 'defaultLocale', this.nextConfig.i18n.defaultLocale)
     }
 
     res.statusCode = 404

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -575,6 +575,28 @@ export type ExportPathMap = {
     query?: NextParsedUrlQuery
 
     /**
+     * When true, this indicates that this is a pages router page that should
+     * be rendered as a fallback.
+     *
+     * @internal
+     */
+    _pagesFallback?: boolean
+
+    /**
+     * The locale that this page should be rendered in.
+     *
+     * @internal
+     */
+    _locale?: string
+
+    /**
+     * The path that was used to generate the page.
+     *
+     * @internal
+     */
+    _ssgPath?: string
+
+    /**
      * The parameters that are currently unknown.
      *
      * @internal

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -774,7 +774,7 @@ export default class DevServer extends Server {
           isrFlushToDisk: this.nextConfig.experimental.isrFlushToDisk,
           maxMemoryCacheSize: this.nextConfig.cacheMaxMemorySize,
           nextConfigOutput: this.nextConfig.output,
-          buildId: this.renderOpts.buildId,
+          buildId: this.buildId,
           authInterrupts: Boolean(this.nextConfig.experimental.authInterrupts),
           sriEnabled: Boolean(this.nextConfig.experimental.sri?.algorithm),
         })
@@ -839,6 +839,7 @@ export default class DevServer extends Server {
   }
 
   protected async findPageComponents({
+    locale,
     page,
     query,
     params,
@@ -847,6 +848,7 @@ export default class DevServer extends Server {
     shouldEnsure,
     url,
   }: {
+    locale: string | undefined
     page: string
     query: NextParsedUrlQuery
     params: Params
@@ -864,7 +866,7 @@ export default class DevServer extends Server {
       throw new WrappedBuildError(compilationErr)
     }
     try {
-      if (shouldEnsure || this.renderOpts.customServer) {
+      if (shouldEnsure || this.serverOptions.customServer) {
         await this.ensurePage({
           page,
           appPaths,
@@ -877,6 +879,7 @@ export default class DevServer extends Server {
       this.nextFontManifest = super.getNextFontManifest()
 
       return await super.findPageComponents({
+        locale,
         page,
         query,
         params,

--- a/packages/next/src/server/internal-utils.ts
+++ b/packages/next/src/server/internal-utils.ts
@@ -2,16 +2,7 @@ import type { NextParsedUrlQuery } from './request-meta'
 
 import { NEXT_RSC_UNION_QUERY } from '../client/components/app-router-headers'
 
-const INTERNAL_QUERY_NAMES = [
-  '__nextFallback',
-  '__nextLocale',
-  '__nextInferredLocaleFromDefault',
-  '__nextDefaultLocale',
-  '__nextIsNotFound',
-  NEXT_RSC_UNION_QUERY,
-] as const
-
-const EDGE_EXTENDED_INTERNAL_QUERY_NAMES = ['__nextDataReq'] as const
+const INTERNAL_QUERY_NAMES = [NEXT_RSC_UNION_QUERY] as const
 
 export function stripInternalQueries(query: NextParsedUrlQuery) {
   for (const name of INTERNAL_QUERY_NAMES) {
@@ -19,21 +10,11 @@ export function stripInternalQueries(query: NextParsedUrlQuery) {
   }
 }
 
-export function stripInternalSearchParams<T extends string | URL>(
-  url: T,
-  isEdge: boolean
-): T {
+export function stripInternalSearchParams<T extends string | URL>(url: T): T {
   const isStringUrl = typeof url === 'string'
   const instance = isStringUrl ? new URL(url) : (url as URL)
-  for (const name of INTERNAL_QUERY_NAMES) {
-    instance.searchParams.delete(name)
-  }
 
-  if (isEdge) {
-    for (const name of EDGE_EXTENDED_INTERNAL_QUERY_NAMES) {
-      instance.searchParams.delete(name)
-    }
-  }
+  instance.searchParams.delete(NEXT_RSC_UNION_QUERY)
 
   return (isStringUrl ? instance.toString() : instance) as T
 }

--- a/packages/next/src/server/lib/i18n-provider.ts
+++ b/packages/next/src/server/lib/i18n-provider.ts
@@ -1,5 +1,5 @@
 import type { DomainLocale, I18NConfig } from '../config-shared'
-import type { NextParsedUrlQuery } from '../request-meta'
+import { getRequestMeta, type NextIncomingMessage } from '../request-meta'
 
 /**
  * The result of matching a locale aware route.
@@ -99,15 +99,15 @@ export class I18NProvider {
    * Pulls the pre-computed locale and inference results from the query
    * object.
    *
+   * @param req the request object
    * @param pathname the pathname that could contain a locale prefix
-   * @param query the query object
    * @returns the locale analysis result
    */
-  public fromQuery(
-    pathname: string,
-    query: NextParsedUrlQuery
+  public fromRequest(
+    req: NextIncomingMessage,
+    pathname: string
   ): LocaleAnalysisResult {
-    const detectedLocale = query.__nextLocale
+    const detectedLocale = getRequestMeta(req, 'locale')
 
     // If a locale was detected on the query, analyze the pathname to ensure
     // that the locale matches.
@@ -130,39 +130,9 @@ export class I18NProvider {
     return {
       pathname,
       detectedLocale,
-      inferredFromDefault: query.__nextInferredLocaleFromDefault === '1',
+      inferredFromDefault:
+        getRequestMeta(req, 'localeInferredFromDefault') ?? false,
     }
-  }
-
-  /**
-   * Validates that the locale is valid.
-   *
-   * @param locale The locale to validate.
-   * @returns `true` if the locale is valid, `false` otherwise.
-   */
-  private validate(locale: string): boolean {
-    return this.lowerCaseLocales.includes(locale.toLowerCase())
-  }
-
-  /**
-   * Validates that the locales in the query object are valid.
-   *
-   * @param query The query object to validate.
-   * @returns `true` if the locale is valid, `false` otherwise.
-   */
-  public validateQuery(query: NextParsedUrlQuery) {
-    if (query.__nextLocale && !this.validate(query.__nextLocale)) {
-      return false
-    }
-
-    if (
-      query.__nextDefaultLocale &&
-      !this.validate(query.__nextDefaultLocale)
-    ) {
-      return false
-    }
-
-    return true
   }
 
   /**

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -246,7 +246,7 @@ export async function initialize(opts: {
       if (
         config.i18n &&
         removePathPrefix(invokePath, config.basePath).startsWith(
-          `/${parsedUrl.query.__nextLocale}/api`
+          `/${getRequestMeta(req, 'locale')}/api`
         )
       ) {
         invokePath = fsChecker.handleLocale(

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -194,9 +194,12 @@ export function getResolveRoutes(
       )
       defaultLocale = domainLocale?.defaultLocale || config.i18n.defaultLocale
 
-      parsedUrl.query.__nextDefaultLocale = defaultLocale
-      parsedUrl.query.__nextLocale =
+      addRequestMeta(req, 'defaultLocale', defaultLocale)
+      addRequestMeta(
+        req,
+        'locale',
         initialLocaleResult.detectedLocale || defaultLocale
+      )
 
       // ensure locale is present for resolving routes
       if (
@@ -217,11 +220,6 @@ export function getResolveRoutes(
           parsedUrl.pathname = maybeAddTrailingSlash(parsedUrl.pathname)
         }
       }
-    } else {
-      // As i18n isn't configured we remove the locale related query params.
-      delete parsedUrl.query.__nextLocale
-      delete parsedUrl.query.__nextDefaultLocale
-      delete parsedUrl.query.__nextInferredLocaleFromDefault
     }
 
     const checkLocaleApi = (pathname: string) => {
@@ -290,7 +288,7 @@ export function getResolveRoutes(
           }
 
           if (pageOutput && curPathname?.startsWith('/_next/data')) {
-            parsedUrl.query.__nextDataReq = '1'
+            addRequestMeta(req, 'isNextDataReq', true)
           }
 
           if (config.useFileSystemPublicRoutes || didRewrite) {
@@ -389,7 +387,7 @@ export function getResolveRoutes(
             let updated = false
             if (normalizers.data.match(normalized)) {
               updated = true
-              parsedUrl.query.__nextDataReq = '1'
+              addRequestMeta(req, 'isNextDataReq', true)
               normalized = normalizers.data.normalize(normalized, true)
             }
 
@@ -400,7 +398,7 @@ export function getResolveRoutes(
               )
 
               if (curLocaleResult.detectedLocale) {
-                parsedUrl.query.__nextLocale = curLocaleResult.detectedLocale
+                addRequestMeta(req, 'locale', curLocaleResult.detectedLocale)
               }
             }
 
@@ -443,7 +441,7 @@ export function getResolveRoutes(
               matchedOutput = output
 
               if (output.locale) {
-                parsedUrl.query.__nextLocale = output.locale
+                addRequestMeta(req, 'locale', output.locale)
               }
               return {
                 parsedUrl,
@@ -629,7 +627,7 @@ export function getResolveRoutes(
                 )
 
                 if (curLocaleResult.detectedLocale) {
-                  parsedUrl.query.__nextLocale = curLocaleResult.detectedLocale
+                  addRequestMeta(req, 'locale', curLocaleResult.detectedLocale)
                 }
               }
             }
@@ -759,7 +757,7 @@ export function getResolveRoutes(
             )
 
             if (curLocaleResult.detectedLocale) {
-              parsedUrl.query.__nextLocale = curLocaleResult.detectedLocale
+              addRequestMeta(req, 'locale', curLocaleResult.detectedLocale)
             }
           }
           didRewrite = true

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -233,7 +233,6 @@ function renderPageTree(
 }
 
 export type RenderOptsPartial = {
-  buildId: string
   canonicalBase: string
   runtimeConfig?: { [key: string]: any }
   assetPrefix?: string
@@ -273,14 +272,11 @@ export type RenderOptsPartial = {
     bodySizeLimit?: SizeLimit
     allowedOrigins?: string[]
   }
-  customServer?: boolean
   crossOrigin?: 'anonymous' | 'use-credentials' | '' | undefined
   images: ImageConfigComplete
   largePageDataBytes?: number
   isOnDemandRevalidate?: boolean
   strictNextHead: boolean
-  isDraftMode?: boolean
-  deploymentId?: string
   isServerAction?: boolean
   isExperimentalCompile?: boolean
   isPrefetch?: boolean
@@ -292,6 +288,47 @@ export type RenderOptsPartial = {
 
 export type RenderOpts = LoadComponentsReturnType<PagesModule> &
   RenderOptsPartial
+
+/**
+ * Shared context used for all page renders.
+ */
+export type PagesSharedContext = {
+  /**
+   * Used to facilitate caching of page bundles, we send it to the client so
+   * that pageloader knows where to load bundles.
+   */
+  buildId: string
+
+  /**
+   * The deployment ID if the user is deploying to a platform that provides one.
+   */
+  deploymentId: string | undefined
+
+  /**
+   * True if the user is using a custom server.
+   */
+  customServer: true | undefined
+}
+
+/**
+ * The context for the given request.
+ */
+export type PagesRenderContext = {
+  /**
+   * Whether this should be rendered as a fallback page.
+   */
+  isFallback: boolean
+
+  /**
+   * Whether this is in draft mode.
+   */
+  isDraftMode: boolean | undefined
+
+  /**
+   * In development, the original source page that returned a 404.
+   */
+  developmentNotFoundSourcePage: string | undefined
+}
 
 /**
  * RenderOptsExtra is being used to split away functionality that's within the
@@ -406,7 +443,9 @@ export async function renderToHTMLImpl(
   pathname: string,
   query: NextParsedUrlQuery,
   renderOpts: Omit<RenderOpts, keyof RenderOptsExtra>,
-  extra: RenderOptsExtra
+  extra: RenderOptsExtra,
+  sharedContext: PagesSharedContext,
+  renderContext: PagesRenderContext
 ): Promise<RenderResult> {
   // Adds support for reading `cookies` in `getServerSideProps` when SSR.
   setLazyProp({ req: req as any }, 'cookies', getCookieParser(req.headers))
@@ -429,9 +468,9 @@ export async function renderToHTMLImpl(
   }
 
   // if deploymentId is provided we append it to all asset requests
-  if (renderOpts.deploymentId) {
+  if (sharedContext.deploymentId) {
     metadata.assetQueryString += `${metadata.assetQueryString ? '&' : '?'}dpl=${
-      renderOpts.deploymentId
+      sharedContext.deploymentId
     }`
   }
 
@@ -468,8 +507,8 @@ export async function renderToHTMLImpl(
     renderOpts.Component
   const OriginComponent = Component
 
-  const isFallback = !!query.__nextFallback
-  const notFoundSrcPage = query.__nextNotFoundSrcPage
+  const isFallback = renderContext.isFallback ?? false
+  const notFoundSrcPage = renderContext.developmentNotFoundSourcePage
 
   // next internal queries should be stripped out
   stripInternalQueries(query)
@@ -1424,8 +1463,6 @@ export async function renderToHTMLImpl(
 
   const {
     assetPrefix,
-    buildId,
-    customServer,
     defaultLocale,
     disableOptimizedLoading,
     domainLocales,
@@ -1438,7 +1475,7 @@ export async function renderToHTMLImpl(
       props, // The result of getInitialProps
       page: pathname, // The rendered page
       query, // querystring parsed / passed by the user
-      buildId, // buildId is used to facilitate caching of page bundles, we send it to the client so that pageloader knows where to load bundles
+      buildId: sharedContext.buildId,
       assetPrefix: assetPrefix === '' ? undefined : assetPrefix, // send assetPrefix to the client side when configured, otherwise don't sent in the resulting HTML
       runtimeConfig, // runtimeConfig if provided, otherwise don't sent in the resulting HTML
       nextExport: nextExport === true ? true : undefined, // If this is a page exported by `next export`
@@ -1452,7 +1489,7 @@ export async function renderToHTMLImpl(
       err: renderOpts.err ? serializeError(dev, renderOpts.err) : undefined, // Error if one happened, otherwise don't sent in the resulting HTML
       gsp: !!getStaticProps ? true : undefined, // whether the page is getStaticProps
       gssp: !!getServerSideProps ? true : undefined, // whether the page is getServerSideProps
-      customServer, // whether the user is using a custom server
+      customServer: sharedContext.customServer,
       gip: hasPageGetInitialProps ? true : undefined, // whether the page has getInitialProps
       appGip: !defaultAppGetInitialProps ? true : undefined, // whether the _app has getInitialProps
       locale,
@@ -1566,7 +1603,9 @@ export type PagesRender = (
   res: ServerResponse,
   pathname: string,
   query: NextParsedUrlQuery,
-  renderOpts: RenderOpts
+  renderOpts: RenderOpts,
+  sharedContext: PagesSharedContext,
+  renderContext: PagesRenderContext
 ) => Promise<RenderResult>
 
 export const renderToHTML: PagesRender = (
@@ -1574,7 +1613,18 @@ export const renderToHTML: PagesRender = (
   res,
   pathname,
   query,
-  renderOpts
+  renderOpts,
+  sharedContext,
+  renderContext
 ) => {
-  return renderToHTMLImpl(req, res, pathname, query, renderOpts, renderOpts)
+  return renderToHTMLImpl(
+    req,
+    res,
+    pathname,
+    query,
+    renderOpts,
+    renderOpts,
+    sharedContext,
+    renderContext
+  )
 }

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -85,6 +85,12 @@ export interface RequestMeta {
   isRSCRequest?: true
 
   /**
+   * True when the request is for the `/_next/data` route using the pages
+   * router.
+   */
+  isNextDataReq?: true
+
+  /**
    * Postponed state to use for resumption. If present it's assumed that the
    * request is for a page that has postponed (there are no guarantees that the
    * page actually has postponed though as it would incur an additional cache
@@ -105,6 +111,11 @@ export interface RequestMeta {
    * The previous revalidate before rendering 404 page for notFound: true
    */
   notFoundRevalidate?: number | false
+
+  /**
+   * In development, the original source page that returned a 404.
+   */
+  developmentNotFoundSourcePage?: string
 
   /**
    * The path we routed to and should be invoked
@@ -140,6 +151,33 @@ export interface RequestMeta {
    * Whether the default route matches were set on the request during routing.
    */
   didSetDefaultRouteMatches?: boolean
+
+  /**
+   * Whether the request is for the custom error page.
+   */
+  customErrorRender?: true
+
+  /**
+   * Whether to bubble up the NoFallbackError to the caller when a 404 is
+   * returned.
+   */
+  bubbleNoFallback?: true
+
+  /**
+   * True when the request had locale information inferred from the default
+   * locale.
+   */
+  localeInferredFromDefault?: true
+
+  /**
+   * The locale that was inferred or explicitly set for the request.
+   */
+  locale?: string
+
+  /**
+   * The default locale that was inferred or explicitly set for the request.
+   */
+  defaultLocale?: string
 }
 
 /**
@@ -213,35 +251,10 @@ export function removeRequestMeta<K extends keyof RequestMeta>(
 }
 
 type NextQueryMetadata = {
-  __nextNotFoundSrcPage?: string
-  __nextDefaultLocale?: string
-  __nextFallback?: 'true'
-
   /**
-   * The locale that was inferred or explicitly set for the request.
-   *
-   * When this property is mutated, it's important to also update the request
-   * metadata for `_nextInferredDefaultLocale` to ensure that the correct
-   * behavior is applied.
+   * The `_rsc` query parameter used for cache busting to ensure that the RSC
+   * requests do not get cached by the browser explicitly.
    */
-  __nextLocale?: string
-
-  /**
-   * `1` when the request did not have a locale in the pathname part of the
-   * URL but the default locale was inferred from either the domain or the
-   * configuration.
-   */
-  __nextInferredLocaleFromDefault?: '1'
-
-  __nextSsgPath?: string
-  _nextBubbleNoFallback?: '1'
-
-  /**
-   * When set to `1`, the request is for the `/_next/data` route using the pages
-   * router.
-   */
-  __nextDataReq?: '1'
-  __nextCustomErrorRender?: '1'
   [NEXT_RSC_UNION_QUERY]?: string
 }
 
@@ -252,28 +265,4 @@ export type NextParsedUrlQuery = ParsedUrlQuery &
 
 export interface NextUrlWithParsedQuery extends UrlWithParsedQuery {
   query: NextParsedUrlQuery
-}
-
-export function getNextInternalQuery(
-  query: NextParsedUrlQuery
-): NextQueryMetadata {
-  const keysToInclude: (keyof NextQueryMetadata)[] = [
-    '__nextDefaultLocale',
-    '__nextFallback',
-    '__nextLocale',
-    '__nextSsgPath',
-    '_nextBubbleNoFallback',
-    '__nextDataReq',
-    '__nextInferredLocaleFromDefault',
-  ]
-  const nextInternalQuery: NextQueryMetadata = {}
-
-  for (const key of keysToInclude) {
-    if (key in query) {
-      // @ts-ignore this can't be typed correctly
-      nextInternalQuery[key] = query[key]
-    }
-  }
-
-  return nextInternalQuery
 }

--- a/packages/next/src/server/route-modules/app-page/module.ts
+++ b/packages/next/src/server/route-modules/app-page/module.ts
@@ -4,7 +4,10 @@ import type { RenderOpts } from '../../app-render/types'
 import type { NextParsedUrlQuery } from '../../request-meta'
 import type { LoaderTree } from '../../lib/app-dir-module'
 
-import { renderToHTMLOrFlight } from '../../app-render/app-render'
+import {
+  renderToHTMLOrFlight,
+  type AppSharedContext,
+} from '../../app-render/app-render'
 import {
   RouteModule,
   type RouteModuleOptions,
@@ -43,6 +46,7 @@ export interface AppPageRouteHandlerContext extends RouteModuleHandleContext {
   fallbackRouteParams: FallbackRouteParams | null
   renderOpts: RenderOpts
   serverComponentsHmrCache?: ServerComponentsHmrCache
+  sharedContext: AppSharedContext
 }
 
 export type AppPageRouteModuleOptions = RouteModuleOptions<
@@ -67,7 +71,8 @@ export class AppPageRouteModule extends RouteModule<
       context.fallbackRouteParams,
       context.renderOpts,
       context.serverComponentsHmrCache,
-      false
+      false,
+      context.sharedContext
     )
   }
 
@@ -84,7 +89,8 @@ export class AppPageRouteModule extends RouteModule<
       context.fallbackRouteParams,
       context.renderOpts,
       context.serverComponentsHmrCache,
-      true
+      true,
+      context.sharedContext
     )
   }
 }

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -96,6 +96,10 @@ export class WrappedNextRouterError {
  */
 export type AppRouteModule = typeof import('../../../build/templates/app-route')
 
+export type AppRouteSharedContext = {
+  buildId: string
+}
+
 /**
  * AppRouteRouteHandlerContext is the context that is passed to the route
  * handler for app routes.
@@ -105,6 +109,7 @@ export interface AppRouteRouteHandlerContext extends RouteModuleHandleContext {
     Pick<RenderOptsPartial, 'onInstrumentationRequestError'> &
     CollectedCacheInfo
   prerenderManifest: DeepReadonly<PrerenderManifest>
+  sharedContext: AppRouteSharedContext
 }
 
 type CollectedCacheInfo = {
@@ -637,6 +642,7 @@ export class AppRouteRouteModule extends RouteModule<
       fallbackRouteParams: null,
       page: this.definition.page,
       renderOpts: context.renderOpts,
+      buildId: context.sharedContext.buildId,
     }
 
     // Add the fetchCache option to the renderOpts.

--- a/packages/next/src/server/route-modules/pages/module.ts
+++ b/packages/next/src/server/route-modules/pages/module.ts
@@ -8,7 +8,11 @@ import type {
 } from '../../../types'
 import type { PagesRouteDefinition } from '../../route-definitions/pages-route-definition'
 import type { NextParsedUrlQuery } from '../../request-meta'
-import type { RenderOpts } from '../../render'
+import type {
+  PagesRenderContext,
+  PagesSharedContext,
+  RenderOpts,
+} from '../../render'
 import type RenderResult from '../../render-result'
 import type { AppType, DocumentType } from '../../../shared/lib/utils'
 
@@ -98,6 +102,18 @@ export interface PagesRouteHandlerContext extends RouteModuleHandleContext {
   query: NextParsedUrlQuery
 
   /**
+   * The shared context used for all page renders.
+   */
+  sharedContext: PagesSharedContext
+
+  /**
+   * The context for the given request.
+   */
+  renderContext: PagesRenderContext
+
+  /**
+   * The arguments for the given request.
+  /**
    * The RenderOpts for the given request which include the specific modules to
    * use for rendering.
    */
@@ -131,7 +147,9 @@ export class PagesRouteModule extends RouteModule<
       {
         App: this.components.App,
         Document: this.components.Document,
-      }
+      },
+      context.sharedContext,
+      context.renderContext
     )
   }
 }

--- a/packages/next/src/server/web-server.ts
+++ b/packages/next/src/server/web-server.ts
@@ -15,9 +15,8 @@ import type { Revalidate, ExpireTime } from './lib/revalidate'
 import { byteLength } from './api-utils/web'
 import BaseServer, { NoFallbackError } from './base-server'
 import { generateETag } from './lib/etag'
-import { addRequestMeta } from './request-meta'
+import { addRequestMeta, getRequestMeta } from './request-meta'
 import WebResponseCache from './response-cache/web'
-import { isAPIRoute } from '../lib/is-api-route'
 import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-slash'
 import { isDynamicRoute } from '../shared/lib/router/utils'
 import {
@@ -37,15 +36,15 @@ import type { ServerOnInstrumentationRequestError } from './app-render/types'
 import { getEdgePreviewProps } from './web/get-edge-preview-props'
 
 interface WebServerOptions extends Options {
+  buildId: string
   webServerConfig: {
     page: string
     pathname: string
     pagesType: PAGE_TYPES
     loadComponent: (page: string) => Promise<LoadComponentsReturnType | null>
-    extendRenderOpts: Partial<BaseServer['renderOpts']> &
-      Pick<BaseServer['renderOpts'], 'buildId'> & {
-        serverActionsManifest?: any
-      }
+    extendRenderOpts: Partial<BaseServer['renderOpts']> & {
+      serverActionsManifest?: any
+    }
     renderToHTML:
       | typeof import('./app-render/app-render').renderToHTMLOrFlight
       | undefined
@@ -102,7 +101,7 @@ export default class NextWebServer extends BaseServer<
   }
 
   protected getBuildId() {
-    return this.serverOptions.webServerConfig.extendRenderOpts.buildId
+    return this.serverOptions.buildId
   }
 
   protected getEnabledDirectories() {
@@ -202,15 +201,11 @@ export default class NextWebServer extends BaseServer<
     if (this.i18nProvider) {
       const { detectedLocale } = await this.i18nProvider.analyze(pathname)
       if (detectedLocale) {
-        parsedUrl.query.__nextLocale = detectedLocale
+        addRequestMeta(req, 'locale', detectedLocale)
       }
     }
 
-    const bubbleNoFallback = !!query._nextBubbleNoFallback
-
-    if (isAPIRoute(pathname)) {
-      delete query._nextBubbleNoFallback
-    }
+    const bubbleNoFallback = getRequestMeta(req, 'bubbleNoFallback')
 
     try {
       await this.render(req, res, pathname, query, parsedUrl, true)
@@ -256,7 +251,10 @@ export default class NextWebServer extends BaseServer<
         runtime: 'experimental-edge',
       }),
       undefined,
-      false
+      false,
+      {
+        buildId: this.serverOptions.buildId,
+      }
     )
   }
 

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -151,7 +151,7 @@ export async function adapter(
   const request = new NextRequestHint({
     page: params.page,
     // Strip internal query parameters off the request.
-    input: stripInternalSearchParams(normalizeUrl, true).toString(),
+    input: stripInternalSearchParams(normalizeUrl).toString(),
     init: {
       body: params.request.body,
       headers: requestHeaders,
@@ -261,7 +261,6 @@ export async function adapter(
                   authInterrupts:
                     !!params.request.nextConfig?.experimental?.authInterrupts,
                 },
-                buildId: buildId ?? '',
                 supportsDynamicResponse: true,
                 waitUntil,
                 onClose: closeController.onClose.bind(closeController),
@@ -271,6 +270,7 @@ export async function adapter(
               isPrefetchRequest: request.headers.has(
                 NEXT_ROUTER_PREFETCH_HEADER
               ),
+              buildId: buildId ?? '',
             })
 
             return await workAsyncStorage.run(workStore, () =>

--- a/packages/next/src/server/web/edge-route-module-wrapper.ts
+++ b/packages/next/src/server/web/edge-route-module-wrapper.ts
@@ -110,8 +110,10 @@ export class EdgeRouteModuleWrapper {
           dynamicIO: !!process.env.__NEXT_DYNAMIC_IO,
           authInterrupts: !!process.env.__NEXT_EXPERIMENTAL_AUTH_INTERRUPTS,
         },
-        buildId: '', // TODO: Populate this properly.
         cacheLifeProfiles: this.nextConfig.experimental.cacheLife,
+      },
+      sharedContext: {
+        buildId: '', // TODO: Populate this properly.
       },
     }
 

--- a/packages/next/src/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/src/shared/lib/router/utils/prepare-destination.ts
@@ -167,10 +167,6 @@ export function prepareDestination(args: {
   query: NextParsedUrlQuery
 }) {
   const query = Object.assign({}, args.query)
-  delete query.__nextLocale
-  delete query.__nextDefaultLocale
-  delete query.__nextDataReq
-  delete query.__nextInferredLocaleFromDefault
   delete query[NEXT_RSC_UNION_QUERY]
 
   let escapedDestination = args.destination


### PR DESCRIPTION
In order to simplify internal state management, this migrates internal use of query parameters over to storing details on the request metadata. Future PR's might be able to pull items off the metadata entirely and use prop drilling and the new `PageRenderContext`, `PageSharedContext`, and app equivalents.