### PR TITLE
Use ErrorOverlayLayout in Errors component

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/ErrorOverlayLayout/ErrorOverlayLayout.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/ErrorOverlayLayout/ErrorOverlayLayout.tsx
@@ -1,29 +1,49 @@
+import type { ReadyRuntimeError } from '../../../helpers/get-error-by-type'
+import type { DebugInfo } from '../../../../../types'
 import type { VersionInfo } from '../../../../../../../../server/dev/parse-version-info'
 import { Dialog, DialogHeader, DialogBody, DialogContent } from '../../Dialog'
 import { Overlay } from '../../Overlay'
+import { ErrorPagination } from '../ErrorPagination/ErrorPagination'
+import { ToolButtonsGroup } from '../../ToolButtonsGroup/ToolButtonsGroup'
 import { VersionStalenessInfo } from '../../VersionStalenessInfo'
 
 type ErrorOverlayLayoutProps = {
+  errorMessage: string | React.ReactNode
   errorType:
     | 'Build Error'
     | 'Runtime Error'
     | 'Console Error'
     | 'Unhandled Runtime Error'
     | 'Missing Required HTML Tag'
-  errorMessage: string | React.ReactNode
-  onClose: () => void
-  isBuildError?: boolean
-  versionInfo?: VersionInfo
   children?: React.ReactNode
+  errorCode?: string
+  error?: Error
+  debugInfo?: DebugInfo
+  isBuildError?: boolean
+  onClose?: () => void
+  // TODO: remove this
+  temporaryHeaderChildren?: React.ReactNode
+  versionInfo?: VersionInfo
+  // TODO: better handle receiving
+  readyErrors?: ReadyRuntimeError[]
+  activeIdx?: number
+  setActiveIndex?: (index: number) => void
 }
 
 export function ErrorOverlayLayout({
-  errorType,
   errorMessage,
-  onClose,
+  errorType,
   children,
-  versionInfo,
+  errorCode,
+  error,
+  debugInfo,
   isBuildError,
+  onClose,
+  temporaryHeaderChildren,
+  versionInfo,
+  readyErrors,
+  activeIdx,
+  setActiveIndex,
 }: ErrorOverlayLayoutProps) {
   return (
     <Overlay fixed={isBuildError}>
@@ -35,12 +55,26 @@ export function ErrorOverlayLayout({
       >
         <DialogContent>
           <DialogHeader className="nextjs-container-errors-header">
-            <h1
-              id="nextjs__container_errors_label"
-              className="nextjs__container_errors_label"
+            {/* TODO: better passing data instead of nullish coalescing */}
+            <ErrorPagination
+              readyErrors={readyErrors ?? []}
+              activeIdx={activeIdx ?? 0}
+              onActiveIndexChange={setActiveIndex ?? (() => {})}
+            />
+            <div
+              className="nextjs__container_errors__error_title"
+              // allow assertion in tests before error rating is implemented
+              data-nextjs-error-code={errorCode}
             >
-              {errorType}
-            </h1>
+              <h1
+                id="nextjs__container_errors_label"
+                className="nextjs__container_errors_label"
+              >
+                {errorType}
+                {/* TODO: Need to relocate this so consider data flow. */}
+              </h1>
+              <ToolButtonsGroup error={error} debugInfo={debugInfo} />
+            </div>
             <VersionStalenessInfo versionInfo={versionInfo} />
             <p
               id="nextjs__container_errors_desc"
@@ -48,6 +82,7 @@ export function ErrorOverlayLayout({
             >
               {errorMessage}
             </p>
+            {temporaryHeaderChildren}
           </DialogHeader>
           <DialogBody className="nextjs-container-errors-body">
             {children}

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/ErrorPagination/ErrorPagination.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/ErrorPagination/ErrorPagination.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { ErrorPagination } from './ErrorPagination'
 import { withShadowPortal } from '../../../storybook/with-shadow-portal'
+import { useState } from 'react'
 
 const meta: Meta<typeof ErrorPagination> = {
   title: 'ErrorPagination',
@@ -37,45 +38,40 @@ const mockErrors = [
 ]
 
 export const SingleError: Story = {
-  args: {
-    activeIdx: 0,
-    previous: () => console.log('Previous clicked'),
-    next: () => console.log('Next clicked'),
-    readyErrors: [mockErrors[0]],
-    minimize: () => console.log('Minimize clicked'),
-    isServerError: false,
+  render: function ErrorPaginationStory() {
+    const [activeIdx, setActiveIdx] = useState(0)
+    return (
+      <ErrorPagination
+        activeIdx={activeIdx}
+        readyErrors={[mockErrors[0]]}
+        onActiveIndexChange={setActiveIdx}
+      />
+    )
   },
 }
 
 export const MultipleErrors: Story = {
-  args: {
-    activeIdx: 1,
-    previous: () => console.log('Previous clicked'),
-    next: () => console.log('Next clicked'),
-    readyErrors: mockErrors,
-    minimize: () => console.log('Minimize clicked'),
-    isServerError: false,
+  render: function ErrorPaginationStory() {
+    const [activeIdx, setActiveIdx] = useState(1)
+    return (
+      <ErrorPagination
+        activeIdx={activeIdx}
+        readyErrors={mockErrors}
+        onActiveIndexChange={setActiveIdx}
+      />
+    )
   },
 }
 
 export const LastError: Story = {
-  args: {
-    activeIdx: 2,
-    previous: () => console.log('Previous clicked'),
-    next: () => console.log('Next clicked'),
-    readyErrors: mockErrors,
-    minimize: () => console.log('Minimize clicked'),
-    isServerError: false,
-  },
-}
-
-export const ServerError: Story = {
-  args: {
-    activeIdx: 0,
-    previous: () => console.log('Previous clicked'),
-    next: () => console.log('Next clicked'),
-    readyErrors: [mockErrors[0]],
-    minimize: () => console.log('Minimize clicked'),
-    isServerError: true,
+  render: function ErrorPaginationStory() {
+    const [activeIdx, setActiveIdx] = useState(2)
+    return (
+      <ErrorPagination
+        activeIdx={activeIdx}
+        readyErrors={mockErrors}
+        onActiveIndexChange={setActiveIdx}
+      />
+    )
   },
 }

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/ToolButtonsGroup/ToolButtonsGroup.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/ToolButtonsGroup/ToolButtonsGroup.tsx
@@ -3,7 +3,7 @@ import { CopyButton } from '../copy-button'
 import { NodejsInspectorCopyButton } from '../nodejs-inspector'
 
 type ToolButtonsGroupProps = {
-  error: Error
+  error: Error | undefined
   debugInfo: DebugInfo | undefined
 }
 
@@ -14,8 +14,8 @@ export function ToolButtonsGroup({ error, debugInfo }: ToolButtonsGroupProps) {
         data-nextjs-data-runtime-error-copy-stack
         actionLabel="Copy error stack"
         successLabel="Copied"
-        content={error.stack || ''}
-        disabled={!error.stack}
+        content={error?.stack || ''}
+        disabled={!error?.stack}
       />
       <NodejsInspectorCopyButton
         devtoolsFrontendUrl={debugInfo?.devtoolsFrontendUrl}


### PR DESCRIPTION
This PR modified the `Errors` (Runtime Error component) to use the shared `ErrorOverlayLayout`.

![CleanShot 2024-12-20 at 12 24 43@2x](https://github.com/user-attachments/assets/a6d5d224-318c-4d6f-ac46-21636961816a)