### PR TITLE
refactor(turbopack-swc-utils): Rewrite IssueCollector to use `ResolvedVc` for emitted issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8420,6 +8420,7 @@ dependencies = [
  "auto-hash-map",
  "concurrent-queue",
  "dashmap 6.1.0",
+ "either",
  "erased-serde",
  "event-listener 2.5.3",
  "futures",
@@ -8829,6 +8830,7 @@ dependencies = [
  "async-trait",
  "auto-hash-map",
  "browserslist-rs",
+ "either",
  "futures",
  "indexmap 2.5.0",
  "lazy_static",
@@ -9177,6 +9179,7 @@ name = "turbopack-swc-utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "either",
  "parking_lot",
  "swc_core",
  "turbo-rcstr",

--- a/turbopack/crates/turbo-tasks/Cargo.toml
+++ b/turbopack/crates/turbo-tasks/Cargo.toml
@@ -22,6 +22,7 @@ async-trait = { workspace = true }
 auto-hash-map = { workspace = true }
 concurrent-queue = { workspace = true }
 dashmap = { workspace = true }
+either = { workspace = true }
 erased-serde = "0.3.20"
 event-listener = "2.5.3"
 futures = { workspace = true }

--- a/turbopack/crates/turbo-tasks/src/marker_trait.rs
+++ b/turbopack/crates/turbo-tasks/src/marker_trait.rs
@@ -66,6 +66,7 @@ macro_rules! impl_auto_marker_trait {
         unsafe impl<T: $trait + ?Sized> $trait for ::std::sync::Mutex<T> {}
         unsafe impl<T: $trait + ?Sized> $trait for ::std::cell::RefCell<T> {}
         unsafe impl<T: ?Sized> $trait for ::std::marker::PhantomData<T> {}
+        unsafe impl<L: $trait, R: $trait> $trait for ::either::Either<L, R> {}
 
         unsafe impl<T: $trait + ?Sized> $trait for $crate::TraitRef<T> {}
         unsafe impl<T> $trait for $crate::ReadRef<T>

--- a/turbopack/crates/turbo-tasks/src/trace.rs
+++ b/turbopack/crates/turbo-tasks/src/trace.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use auto_hash_map::{AutoMap, AutoSet};
+use either::Either;
 use indexmap::{IndexMap, IndexSet};
 use turbo_rcstr::RcStr;
 
@@ -250,6 +251,15 @@ impl<T: TraceRawVcs + ?Sized> TraceRawVcs for &T {
 impl<T: TraceRawVcs + ?Sized> TraceRawVcs for &mut T {
     fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
         (**self).trace_raw_vcs(trace_context);
+    }
+}
+
+impl<L: TraceRawVcs, R: TraceRawVcs> TraceRawVcs for Either<L, R> {
+    fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
+        match self {
+            Either::Left(l) => l.trace_raw_vcs(trace_context),
+            Either::Right(r) => r.trace_raw_vcs(trace_context),
+        }
     }
 }
 

--- a/turbopack/crates/turbopack-core/Cargo.toml
+++ b/turbopack/crates/turbopack-core/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 auto-hash-map = { workspace = true }
 browserslist-rs = { workspace = true }
+either = { workspace = true }
 futures = { workspace = true }
 indexmap = { workspace = true }
 lazy_static = { workspace = true }

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -524,17 +524,7 @@ impl IssueSource {
         start: usize,
         end: usize,
     ) -> Vc<Self> {
-        Self::cell(IssueSource {
-            source,
-            range: match (start == 0, end == 0) {
-                (true, true) => None,
-                (false, false) => Some(SourceRange::ByteOffset(start - 1, end - 1).resolved_cell()),
-                (false, true) => {
-                    Some(SourceRange::ByteOffset(start - 1, start - 1).resolved_cell())
-                }
-                (true, false) => Some(SourceRange::ByteOffset(end - 1, end - 1).resolved_cell()),
-            },
-        })
+        *Self::from_swc_offsets_inline(source, start, end)
     }
 
     #[turbo_tasks::function]
@@ -588,6 +578,24 @@ impl IssueSource {
                 }
             },
             _ => None,
+        })
+    }
+
+    pub fn from_swc_offsets_inline(
+        source: ResolvedVc<Box<dyn Source>>,
+        start: usize,
+        end: usize,
+    ) -> ResolvedVc<Self> {
+        Self::resolved_cell(IssueSource {
+            source,
+            range: match (start == 0, end == 0) {
+                (true, true) => None,
+                (false, false) => Some(SourceRange::ByteOffset(start - 1, end - 1).resolved_cell()),
+                (false, true) => {
+                    Some(SourceRange::ByteOffset(start - 1, start - 1).resolved_cell())
+                }
+                (true, false) => Some(SourceRange::ByteOffset(end - 1, end - 1).resolved_cell()),
+            },
         })
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -86,7 +86,7 @@ impl Chunk for EcmascriptChunk {
         };
 
         // The included chunk items describe the chunk uniquely
-        let chunk_item_key = chunk_item_key();
+        let chunk_item_key = chunk_item_key().to_resolved().await?;
         for &(chunk_item, _) in chunk_items.iter() {
             if let Some((common_path_vc, common_path_ref)) = common_path.as_mut() {
                 let path = chunk_item.asset_ident().path().await?;
@@ -101,7 +101,7 @@ impl Chunk for EcmascriptChunk {
                 }
             }
             assets.push((
-                chunk_item_key.to_resolved().await?,
+                chunk_item_key,
                 chunk_item.content_ident().to_resolved().await?,
             ));
         }

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -262,14 +262,16 @@ async fn parse_file_content(
         source,
         source_map.clone(),
         Some("Ecmascript file had an error".into()),
-    );
+    )
+    .await?;
     let handler = Handler::with_emitter(true, false, Box::new(emitter));
 
     let (emitter, collector_parse) = IssueEmitter::new(
         source,
         source_map.clone(),
         Some("Parsing ecmascript source code failed".into()),
-    );
+    )
+    .await?;
     let parser_handler = Handler::with_emitter(true, false, Box::new(emitter));
     let globals = Arc::new(Globals::new());
     let globals_ref = &globals;

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -409,13 +409,12 @@ pub async fn expand_star_exports(
 }
 
 async fn emit_star_exports_issue(source_ident: Vc<AssetIdent>, message: RcStr) -> Result<()> {
-    AnalyzeIssue::new(
+    AnalyzeIssue::new_with_asset_ident(
         IssueSeverity::Warning.cell(),
-        source_ident,
         Vc::cell("unexpected export *".into()),
         StyledString::Text(message).cell(),
         None,
-        None,
+        source_ident,
     )
     .to_resolved()
     .await?

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -590,7 +590,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
         }
     }
 
-    let (emitter, collector) = IssueEmitter::new(source, source_map.clone(), None);
+    let (emitter, collector) = IssueEmitter::new(source, source_map.clone(), None).await?;
     let handler = Handler::with_emitter(true, false, Box::new(emitter));
 
     let mut var_graph =
@@ -846,13 +846,12 @@ pub(crate) async fn analyse_ecmascript_module_internal(
         .resolved_cell();
         analysis.set_async_module(async_module);
     } else if let Some(span) = top_level_await_span {
-        AnalyzeIssue::new(
+        AnalyzeIssue::new_with_source(
             IssueSeverity::Error.cell(),
-            source.ident(),
             Vc::cell("unexpected top level await".into()),
             StyledString::Text("top level await is only supported in ESM modules.".into()).cell(),
             None,
-            Some(issue_source(*source, span)),
+            issue_source(*source, span),
         )
         .to_resolved()
         .await?

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/references.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/references.rs
@@ -47,7 +47,8 @@ pub async fn module_references(
                 source,
                 source_map.clone(),
                 Some("Parsing webpack bundle failed".into()),
-            );
+            )
+            .await?;
             let handler = Handler::with_emitter(true, false, Box::new(emitter));
             HANDLER.set(&handler, || {
                 program.visit_with(&mut visitor);

--- a/turbopack/crates/turbopack-swc-utils/Cargo.toml
+++ b/turbopack/crates/turbopack-swc-utils/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+either = { workspace = true }
 parking_lot = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }


### PR DESCRIPTION
This is a rather tricky case for the `Vc` -> `ResolvedVc` migration:

- The `Emitter` trait is a synchronous trait provided by swc.
- The `AnalyzeIssue` type needed an `AssetIdent` type that can only be read from `ResolvedVc<Box<dyn Source>>` via a turbo tasks function (returns an unresolved `Vc`).

Changes in this PR:

- When constructing an `AnalyzeIssue` with a source, don't require an identifier, as this appears wasteful/redundant, since it can get the identifier from the source later. Use the `Either` type to represent this. (I probably could've skipped this, but I think it's nice to have anyways)
- Implement common turbo-tasks traits (`TaskInput`, `TraceRawVcs`, `NonLocalValue`, `OperationValue`) for the `Either` type.
- Make the `IssueEmitter` constructor async, and resolve the source's identifier there in case we need it to later to construct an `AnalyzeIssue`.
- Expose a `IssueSource::from_swc_offsets_inline` method for synchronous construction of a `ResolvedVc<IssueSource>`.

Closes PACK-3680