### PR TITLE
chore(turbopack): Ignore no-vc-struct lint in trybuild proc macro tests

### DIFF
--- a/.config/ast-grep/rules/resolved-vc.yml
+++ b/.config/ast-grep/rules/resolved-vc.yml
@@ -40,3 +40,6 @@ rule:
                     kind: attribute
                     regex: '^turbo_tasks::value(\(.*\))?$'
 fix: ResolvedVc<$A>
+
+ignores:
+  - turbopack/crates/turbo-tasks-macros-tests/**/*.rs


### PR DESCRIPTION
These tests exist to see that the compiler generates errors when doing similar things to what the lint is designed to catch.

I'd rather exempt these in the lint than in the trybuild tests, as once we get rid of support for the `local` opt-out in the `turbo_tasks::value` macro, we shouldn't need the lint anymore (it won't be possible to compile code using an unresolved `Vc` in a `VcValueType`), but we still will need these trybuild tests.

Closes PACK-3673