### PR TITLE
chore(turbopack): Remove or improve a few uses of `.to_resolved().await` inside a loop

### DIFF
--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -218,9 +218,14 @@ impl OutputAsset for EcmascriptDevEvaluateChunk {
                 .await?,
         );
 
-        for chunk in &*self.other_chunks.await? {
-            ident.add_modifier(chunk.ident().to_string().to_resolved().await?);
-        }
+        ident.modifiers.extend(
+            self.other_chunks
+                .await?
+                .iter()
+                .map(|chunk| chunk.ident().to_string().to_resolved())
+                .try_join()
+                .await?,
+        );
 
         let ident = AssetIdent::new(Value::new(ident));
         Ok(AssetIdent::from_path(

--- a/turbopack/crates/turbopack-core/src/introspect/utils.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/utils.rs
@@ -92,6 +92,7 @@ pub async fn children_from_module_references(
             }
         }
 
+        let key = key.to_resolved().await?;
         for &module in reference
             .resolve_reference()
             .resolve()
@@ -100,7 +101,7 @@ pub async fn children_from_module_references(
             .await?
             .iter()
         {
-            children.insert((key.to_resolved().await?, IntrospectableModule::new(*module)));
+            children.insert((key, IntrospectableModule::new(*module)));
         }
         for &output_asset in reference
             .resolve_reference()
@@ -108,10 +109,7 @@ pub async fn children_from_module_references(
             .await?
             .iter()
         {
-            children.insert((
-                key.to_resolved().await?,
-                IntrospectableOutputAsset::new(*output_asset),
-            ));
+            children.insert((key, IntrospectableOutputAsset::new(*output_asset)));
         }
     }
     Ok(Vc::cell(children))
@@ -121,12 +119,12 @@ pub async fn children_from_module_references(
 pub async fn children_from_output_assets(
     references: Vc<OutputAssets>,
 ) -> Result<Vc<IntrospectableChildren>> {
-    let key = reference_ty();
+    let key = reference_ty().to_resolved().await?;
     let mut children = FxIndexSet::default();
     let references = references.await?;
     for &reference in &*references {
         children.insert((
-            key.to_resolved().await?,
+            key,
             IntrospectableOutputAsset::new(*ResolvedVc::upcast(reference)),
         ));
     }


### PR DESCRIPTION
- We should generally prefer `try_join` over `to_resolved().await` in a loop as it can provide more parallelism.
- Some of these should just resolve the `Vc` outside the loop.

Closes PACK-3676