### PR TITLE
refactor(turbopack/next-core): Migrate app_page_loader_tree structs to ResolvedVc

### DIFF
--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -169,8 +169,14 @@ impl AppPageLoaderTreeBuilder {
     ) -> Result<()> {
         match item {
             MetadataWithAltItem::Static { path, alt_path } => {
-                self.write_static_metadata_item(app_page, name, item, *path, *alt_path)
-                    .await?;
+                self.write_static_metadata_item(
+                    app_page,
+                    name,
+                    item,
+                    **path,
+                    alt_path.as_deref().copied(),
+                )
+                .await?;
             }
             MetadataWithAltItem::Dynamic { path, .. } => {
                 let i = self.base.unique_number();
@@ -183,7 +189,7 @@ impl AppPageLoaderTreeBuilder {
 
                 let source = dynamic_image_metadata_source(
                     Vc::upcast(self.base.module_asset_context),
-                    *path,
+                    **path,
                     name.into(),
                     app_page.clone(),
                 );

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -32,17 +32,17 @@ pub async fn get_app_metadata_route_source(
     is_multi_dynamic: bool,
 ) -> Result<Vc<Box<dyn Source>>> {
     Ok(match metadata {
-        MetadataItem::Static { path } => static_route_source(mode, path),
+        MetadataItem::Static { path } => static_route_source(mode, *path),
         MetadataItem::Dynamic { path } => {
             let stem = path.file_stem().await?;
             let stem = stem.as_deref().unwrap_or_default();
 
             if stem == "robots" || stem == "manifest" {
-                dynamic_text_route_source(path)
+                dynamic_text_route_source(*path)
             } else if stem == "sitemap" {
-                dynamic_site_map_route_source(mode, path, is_multi_dynamic)
+                dynamic_site_map_route_source(mode, *path, is_multi_dynamic)
             } else {
-                dynamic_image_route_source(path)
+                dynamic_image_route_source(*path)
             }
         }
     })
@@ -60,11 +60,9 @@ pub async fn get_app_metadata_route_entry(
 ) -> Vc<AppEntry> {
     // Read original source's segment config before replacing source into
     // dynamic|static metadata route handler.
-    let original_path = match metadata {
-        MetadataItem::Static { path } | MetadataItem::Dynamic { path } => path,
-    };
+    let original_path = metadata.into_path();
 
-    let source = Vc::upcast(FileSource::new(original_path));
+    let source = Vc::upcast(FileSource::new(*original_path));
     let segment_config = parse_segment_config_from_source(source);
     let is_dynamic_metadata = matches!(metadata, MetadataItem::Dynamic { .. });
     let is_multi_dynamic: bool = if Some(segment_config).is_some() {


### PR DESCRIPTION
A pretty easy/straightforward migration.

Closes PACK-3672