### PR TITLE
docs: next/dynamic in App Router, does not wrap a Suspense boundary

### DIFF
--- a/docs/01-app/03-building-your-application/06-optimizing/07-lazy-loading.mdx
+++ b/docs/01-app/03-building-your-application/06-optimizing/07-lazy-loading.mdx
@@ -18,7 +18,7 @@ By default, Server Components are automatically [code split](https://developer.m
 
 ## `next/dynamic`
 
-`next/dynamic` is an enhancement of [`React.lazy()`](https://react.dev/reference/react/lazy), which allows you to also preload CSS.
+`next/dynamic` is an enhancement of [`React.lazy()`](https://react.dev/reference/react/lazy), which allows you to dynamically render a component with CSS preloading ability.
 
 > **Good to know**: Before Next.js 15, `next/dynamic`:
 >

--- a/docs/01-app/03-building-your-application/06-optimizing/07-lazy-loading.mdx
+++ b/docs/01-app/03-building-your-application/06-optimizing/07-lazy-loading.mdx
@@ -18,7 +18,14 @@ By default, Server Components are automatically [code split](https://developer.m
 
 ## `next/dynamic`
 
-`next/dynamic` is a composite of [`React.lazy()`](https://react.dev/reference/react/lazy) and [Suspense](https://react.dev/reference/react/Suspense). It behaves the same way in the `app` and `pages` directories to allow for incremental migration.
+`next/dynamic` is an enhancement of [`React.lazy()`](https://react.dev/reference/react/lazy), which allows you to also preload CSS.
+
+> **Good to know**: Before Next.js 15, `next/dynamic`:
+>
+> - Was a composite of [`React.lazy()`](https://react.dev/reference/react/lazy) and [Suspense](https://react.dev/reference/react/Suspense)
+> - It behaved the same way in `app` and `pages` directories.
+
+When used within the `app` directory, `next/dynamic` does not wrap your component with a `Suspense` boundary.
 
 ## Examples
 

--- a/docs/01-app/03-building-your-application/06-optimizing/07-lazy-loading.mdx
+++ b/docs/01-app/03-building-your-application/06-optimizing/07-lazy-loading.mdx
@@ -25,7 +25,7 @@ By default, Server Components are automatically [code split](https://developer.m
 > - Was a composite of [`React.lazy()`](https://react.dev/reference/react/lazy) and [Suspense](https://react.dev/reference/react/Suspense)
 > - It behaved the same way in `app` and `pages` directories.
 
-When used within the `app` directory, `next/dynamic` does not wrap your component with a `Suspense` boundary.
+When used within the `app` directory, `next/dynamic` does not wrap your component with a `Suspense` boundary when you didn't specify a `loading` component. When `loading` is specified, it will be used as `fallback` of the `Suspense` boundary
 
 ## Examples
 


### PR DESCRIPTION
### What?

- https://github.com/vercel/next.js/pull/67014

Removed the Suspense boundary for next/dynamic, but the docs still say:

> next/dynamic is a composite of [React.lazy()](https://react.dev/reference/react/lazy) and [Suspense](https://react.dev/reference/react/Suspense). It behaves the same way in the app and pages directories to allow for incremental migration.

### Why?

- https://github.com/vercel/next.js/discussions/74132

### How?

Docs update.

