### PR TITLE
handle `DynamicServerError` wrapped in `cause`

### DIFF
--- a/packages/next/src/lib/helpers/get-error-cause.ts
+++ b/packages/next/src/lib/helpers/get-error-cause.ts
@@ -1,0 +1,21 @@
+/**
+ * This function iterates through the `cause` property of an error object
+ * and it's causes and returns the original cause. *
+ *
+ * External libraries might catch errors, wrap them and re-throw them.
+ * We are interested in the original error thrown by Next.js, and no errors
+ * thrown by Next.js have a `cause` property, so it's safe to recurse into
+ * `err.cause` to get to the original cause.
+ */
+export function getErrorCause(err: unknown): unknown {
+  if (
+    typeof err === 'object' &&
+    err !== null &&
+    'cause' in err &&
+    typeof err.cause === 'object' &&
+    err.cause !== null
+  ) {
+    return getErrorCause(err.cause)
+  }
+  return err
+}

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -183,6 +183,7 @@ import {
   createRenderResumeDataCache,
 } from '../resume-data-cache/resume-data-cache'
 import type { MetadataErrorType } from '../../lib/metadata/resolve-metadata'
+import { getErrorCause } from '../../lib/helpers/get-error-cause'
 
 export type GetDynamicParamFromSegment = (
   // [slug] / [[slug]] / [...slug]
@@ -3721,7 +3722,8 @@ async function prerenderToStream(
         collectedTags: prerenderLegacyStore.tags,
       }
     }
-  } catch (err) {
+  } catch (originalErr) {
+    const err = getErrorCause(originalErr)
     if (
       isStaticGenBailoutError(err) ||
       (typeof err === 'object' &&
@@ -3757,7 +3759,7 @@ async function prerenderToStream(
     // If we errored when we did not have an RSC stream to read from. This is
     // not just a render error, we need to throw early.
     if (reactServerPrerenderResult === null) {
-      throw err
+      throw originalErr
     }
 
     let errorType: MetadataErrorType | 'redirect' | undefined

--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -9,6 +9,7 @@ import { isDynamicServerError } from '../../client/components/hooks-server-conte
 import { isNextRouterError } from '../../client/components/is-next-router-error'
 import { getProperError } from '../../lib/is-error'
 import { createDigestWithErrorCode } from '../../lib/error-telemetry-utils'
+import { getErrorCause } from '../../lib/helpers/get-error-cause'
 
 declare global {
   var __next_log_error__: undefined | ((err: unknown) => void)
@@ -28,6 +29,8 @@ export type DigestedError = Error & { digest: string }
  * reported.
  */
 export function getDigestForWellKnownError(error: unknown): string | undefined {
+  error = getErrorCause(error)
+
   // If we're bailing out to CSR, we don't need to log the error.
   if (isBailoutToCSRError(error)) return error.digest
 


### PR DESCRIPTION
### What?

This PR changes error handling in situations where a `DynamicServerError` is handled, in a way that it looks at the root `cause` of an error to determine how to handle it instead of the thrown error itself.

### Why?

External libraries (e.g. in my case Apollo Client) catch errors thrown by `fetch` and wrap them into their own error types before eventually rethrowing them.

In this case, that means that the `DynamicServerError` becomes an `ApolloError` with a `cause` of `DynamicServerError` - and Next.js currently cannot handle that.

### How?

Since none of the Next.js-internal "signal errors" seem to contain a `cause` on their own, it seemed safe to determine the original cause by just recursively iterating `cause` properties of errors until no more are encountered.

I swapped logic for that into the two code paths where `DynamicServerError` is handled, but there might be more places where such a change makes sense.

### Reproduction:

Removing the `export const dynamic = "force-dynamic";` line in [this example](https://github.com/phryneas/repro_next_dynamic-server-error/blob/main/src/app/page.js#L14) will result in 

> Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
> ApolloError: Dynamic server usage: Route / couldn't be rendered statically because it used revalidate: 0 fetch https://main--hack-the-e-commerce.apollographos.net/graphql /. See more info here: https://nextjs.org/docs/messages/dynamic-server-error
>     at [...]
>     at t.error (/Users/tronic/tmp/repro_dynamic-server-error/.next/server/app/page.js:13:23196)
> Export encountered an error on /page: /, exiting the build.

Swapping a local build of this change in will correctly determine that the page should be built dynamically.

> Route (app)                              Size     First Load JS
> ┌ ƒ /                                    5.77 kB         113 kB
> └ ○ /_not-found                          979 B           108 kB
> + First Load JS shared by all            107 kB
>   ├ chunks/4bd1b696-9ad53b5be643213c.js  52.9 kB
>   ├ chunks/517-1030b149d10896b4.js       52.4 kB
>   └ other shared chunks (total)          1.93 kB