### PR TITLE
used shared worker for lint & typecheck steps

### DIFF
--- a/packages/next/src/build/type-check.ts
+++ b/packages/next/src/build/type-check.ts
@@ -4,7 +4,7 @@ import type { Span } from '../trace'
 
 import path from 'path'
 import * as Log from './output/log'
-import { Worker as JestWorker } from 'next/dist/compiled/jest-worker'
+import { Worker } from '../lib/worker'
 import { verifyAndLint } from '../lib/verifyAndLint'
 import createSpinner from './spinner'
 import { eventTypeCheckCompleted } from '../telemetry/events'
@@ -30,19 +30,17 @@ function verifyTypeScriptSetup(
   hasAppDir: boolean,
   hasPagesDir: boolean
 ) {
-  const typeCheckWorker = new JestWorker(
+  const typeCheckWorker = new Worker(
     require.resolve('../lib/verify-typescript-setup'),
     {
+      exposedMethods: ['verifyTypeScriptSetup'],
       numWorkers: 1,
       enableWorkerThreads,
       maxRetries: 0,
     }
-  ) as JestWorker & {
+  ) as Worker & {
     verifyTypeScriptSetup: typeof import('../lib/verify-typescript-setup').verifyTypeScriptSetup
   }
-
-  typeCheckWorker.getStdout().pipe(process.stdout)
-  typeCheckWorker.getStderr().pipe(process.stderr)
 
   return typeCheckWorker
     .verifyTypeScriptSetup({

--- a/packages/next/src/lib/verifyAndLint.ts
+++ b/packages/next/src/lib/verifyAndLint.ts
@@ -1,5 +1,5 @@
 import { red } from './picocolors'
-import { Worker } from 'next/dist/compiled/jest-worker'
+import { Worker } from './worker'
 import { existsSync } from 'fs'
 import { join } from 'path'
 import { ESLINT_DEFAULT_DIRS } from './constants'
@@ -23,15 +23,13 @@ export async function verifyAndLint(
 
   try {
     lintWorkers = new Worker(require.resolve('./eslint/runLintCheck'), {
+      exposedMethods: ['runLintCheck'],
       numWorkers: 1,
       enableWorkerThreads,
       maxRetries: 0,
     }) as Worker & {
       runLintCheck: typeof import('./eslint/runLintCheck').runLintCheck
     }
-
-    lintWorkers.getStdout().pipe(process.stdout)
-    lintWorkers.getStderr().pipe(process.stderr)
 
     const lintDirs = (configLintDirs ?? ESLINT_DEFAULT_DIRS).reduce(
       (res: string[], d: string) => {


### PR DESCRIPTION
Similar to #73138, this removes the direct usage of `jest-worker` for the linting/typechecking step in favor of the shared worker that has built-in handling for propagating errors to the parent process. This is to ensure that if the worker performing the typechecking/linting receives a SIGKILL signal (which could happen with an OOM error), that the parent process exits appropriately.