### PR TITLE
refactor(turbopack): Rewrite CollectiblesSource callsites to use OperationVc (part 2/3)

### DIFF
--- a/crates/napi/src/next_api/endpoint.rs
+++ b/crates/napi/src/next_api/endpoint.rs
@@ -4,10 +4,15 @@ use anyhow::Result;
 use napi::{bindgen_prelude::External, JsFunction};
 use next_api::{
     paths::ServerPath,
-    route::{Endpoint, WrittenEndpoint},
+    route::{
+        endpoint_server_changed_operation, endpoint_write_to_disk_operation, Endpoint,
+        WrittenEndpoint,
+    },
 };
 use tracing::Instrument;
-use turbo_tasks::{get_effects, Completion, Effects, ReadRef, Vc, VcValueType};
+use turbo_tasks::{
+    get_effects, Completion, Effects, OperationVc, ReadRef, ResolvedVc, Vc, VcValueType,
+};
 use turbopack_core::{
     diagnostics::PlainDiagnostic,
     error::PrettyPrintError,
@@ -99,14 +104,14 @@ impl Deref for ExternalEndpoint {
 // Await the source and return fatal issues if there are any, otherwise
 // propagate any actual error results.
 async fn strongly_consistent_catch_collectables<R: VcValueType + Send>(
-    source: Vc<R>,
+    source: OperationVc<R>,
 ) -> Result<(
     Option<ReadRef<R>>,
     Arc<Vec<ReadRef<PlainIssue>>>,
     Arc<Vec<ReadRef<PlainDiagnostic>>>,
     Arc<Effects>,
 )> {
-    let result = source.strongly_consistent().await;
+    let result = source.connect().strongly_consistent().await;
     let issues = get_issues(source).await?;
     let diagnostics = get_diagnostics(source).await?;
     let effects = Arc::new(get_effects(source).await?);
@@ -130,9 +135,9 @@ struct WrittenEndpointWithIssues {
 
 #[turbo_tasks::function]
 async fn get_written_endpoint_with_issues(
-    endpoint: Vc<Box<dyn Endpoint>>,
+    endpoint: ResolvedVc<Box<dyn Endpoint>>,
 ) -> Result<Vc<WrittenEndpointWithIssues>> {
-    let write_to_disk = endpoint.write_to_disk();
+    let write_to_disk = endpoint_write_to_disk_operation(endpoint);
     let (written, issues, diagnostics, effects) =
         strongly_consistent_catch_collectables(write_to_disk).await?;
     Ok(WrittenEndpointWithIssues {
@@ -236,10 +241,10 @@ impl Eq for EndpointIssuesAndDiags {}
 
 #[turbo_tasks::function]
 async fn subscribe_issues_and_diags(
-    endpoint: Vc<Box<dyn Endpoint>>,
+    endpoint: ResolvedVc<Box<dyn Endpoint>>,
     should_include_issues: bool,
 ) -> Result<Vc<EndpointIssuesAndDiags>> {
-    let changed = endpoint.server_changed();
+    let changed = endpoint_server_changed_operation(endpoint);
 
     if should_include_issues {
         let (changed_value, issues, diagnostics, effects) =
@@ -252,7 +257,7 @@ async fn subscribe_issues_and_diags(
         }
         .cell())
     } else {
-        let changed_value = changed.strongly_consistent().await?;
+        let changed_value = changed.connect().strongly_consistent().await?;
         Ok(EndpointIssuesAndDiags {
             changed: Some(changed_value),
             issues: Arc::new(vec![]),
@@ -276,7 +281,7 @@ pub fn endpoint_client_changed_subscribe(
         move || {
             async move {
                 let changed = endpoint.client_changed();
-                // We don't capture issues and diagonistics here since we don't want to be
+                // We don't capture issues and diagnostics here since we don't want to be
                 // notified when they change
                 changed.strongly_consistent().await?;
                 Ok(())

--- a/crates/napi/src/next_api/utils.rs
+++ b/crates/napi/src/next_api/utils.rs
@@ -10,7 +10,7 @@ use napi::{
 };
 use serde::Serialize;
 use turbo_tasks::{
-    trace::TraceRawVcs, ReadRef, TaskId, TryJoinIterExt, TurboTasks, UpdateInfo, Vc,
+    trace::TraceRawVcs, OperationVc, ReadRef, TaskId, TryJoinIterExt, TurboTasks, UpdateInfo, Vc,
 };
 use turbo_tasks_backend::{default_backing_storage, DefaultBackingStorage};
 use turbo_tasks_fs::FileContent;
@@ -229,7 +229,7 @@ pub fn root_task_dispose(
     Ok(())
 }
 
-pub async fn get_issues<T: Send>(source: Vc<T>) -> Result<Arc<Vec<ReadRef<PlainIssue>>>> {
+pub async fn get_issues<T: Send>(source: OperationVc<T>) -> Result<Arc<Vec<ReadRef<PlainIssue>>>> {
     let issues = source.peek_issues_with_path().await?;
     Ok(Arc::new(issues.get_plain_issues().await?))
 }
@@ -238,7 +238,9 @@ pub async fn get_issues<T: Send>(source: Vc<T>) -> Result<Arc<Vec<ReadRef<PlainI
 /// by the given source and returns it as a
 /// [turbopack_core::diagnostics::PlainDiagnostic]. It does
 /// not consume any Diagnostics held by the source.
-pub async fn get_diagnostics<T: Send>(source: Vc<T>) -> Result<Arc<Vec<ReadRef<PlainDiagnostic>>>> {
+pub async fn get_diagnostics<T: Send>(
+    source: OperationVc<T>,
+) -> Result<Arc<Vec<ReadRef<PlainDiagnostic>>>> {
     let captured_diags = source.peek_diagnostics().await?;
     let mut diags = captured_diags
         .diagnostics

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -66,6 +66,20 @@ pub trait Endpoint {
     fn root_modules(self: Vc<Self>) -> Vc<Modules>;
 }
 
+#[turbo_tasks::function(operation)]
+pub fn endpoint_write_to_disk_operation(
+    endpoint: ResolvedVc<Box<dyn Endpoint>>,
+) -> Vc<WrittenEndpoint> {
+    endpoint.write_to_disk()
+}
+
+#[turbo_tasks::function(operation)]
+pub fn endpoint_server_changed_operation(
+    endpoint: ResolvedVc<Box<dyn Endpoint>>,
+) -> Vc<Completion> {
+    endpoint.server_changed()
+}
+
 #[turbo_tasks::value(shared)]
 #[derive(Debug, Clone)]
 pub enum WrittenEndpoint {


### PR DESCRIPTION
`OperationVc`s should be used with `CollectiblesSource` instead of `Vc`s because collectibles represent a side-effect or implicit extra return value of a function's execution.

Closes PACK-3719