### PR TITLE
[Segment Cache] Support <Link prefetch={true}>

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -279,11 +279,12 @@ function Router({
         ? // Unlike the old implementation, the Segment Cache doesn't store its
           // data in the router reducer state; it writes into a global mutable
           // cache. So we don't need to dispatch an action.
-          (href) =>
+          (href, options) =>
             prefetchWithSegmentCache(
               href,
               actionQueue.state.nextUrl,
-              actionQueue.state.tree
+              actionQueue.state.tree,
+              options?.kind === PrefetchKind.FULL
             )
         : (href, options) => {
             // Use the old prefetch implementation.

--- a/packages/next/src/client/components/segment-cache/prefetch.ts
+++ b/packages/next/src/client/components/segment-cache/prefetch.ts
@@ -7,11 +7,18 @@ import { schedulePrefetchTask } from './scheduler'
  * Entrypoint for prefetching a URL into the Segment Cache.
  * @param href - The URL to prefetch. Typically this will come from a <Link>,
  * or router.prefetch. It must be validated before we attempt to prefetch it.
+ * @param nextUrl - A special header used by the server for interception routes.
+ * Roughly  corresponds to the current URL.
+ * @param treeAtTimeOfPrefetch - The FlightRouterState at the time the prefetch
+ * was requested. This is only used when PPR is disabled.
+ * @param includeDynamicData - Whether to prefetch dynamic data, in addition to
+ * static data. This is used by <Link prefetch={true}>.
  */
 export function prefetch(
   href: string,
   nextUrl: string | null,
-  treeAtTimeOfPrefetch: FlightRouterState
+  treeAtTimeOfPrefetch: FlightRouterState,
+  includeDynamicData: boolean
 ) {
   const url = createPrefetchURL(href)
   if (url === null) {
@@ -19,5 +26,5 @@ export function prefetch(
     return
   }
   const cacheKey = createCacheKey(url.href, nextUrl)
-  schedulePrefetchTask(cacheKey, treeAtTimeOfPrefetch)
+  schedulePrefetchTask(cacheKey, treeAtTimeOfPrefetch, includeDynamicData)
 }

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/mixed-fetch-strategies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/mixed-fetch-strategies/page.tsx
@@ -18,6 +18,17 @@ export default function MixedFetchStrategies() {
           >
             Link to PPR enabled page
           </LinkAccordion>
+          <ul>
+            <li>
+              <LinkAccordion
+                id="ppr-enabled-prefetch-true"
+                prefetch={true}
+                href="/mixed-fetch-strategies/has-loading-boundary/a/b/shared-layout/ppr-enabled"
+              >
+                Same link, but with prefetch=true
+              </LinkAccordion>
+            </li>
+          </ul>
         </li>
         <li>
           <LinkAccordion


### PR DESCRIPTION
This implements support in the Segment Cache for "full" link prefetches, typically initiated by passing `prefetch={true}` to a `<Link>`.

The goal of a full prefetch is to request all the data needed for a navigation, both static and dynamic, so that once the navigation occurs, the router does not need to fetch any additional data. So, a full prefetch implicitly instructs the client cache to treat the response as static, even the dynamic data.

The implementation is largely the same as what we do to support non-PPR-enabled routes — a request tree is sent to the server describing which segments are already cached and which ones need to be rendered. While constructing the request tree, if all the segments are already in the client cache, the request can be skipped entirely. The main difference is that a full prefetch will only reuse a cached segment entry if it does not contain any dynamic holes.