### PR TITLE
refactor(turbopack): Rewrite CollectiblesSource callsites to use OperationVc (part 3/3)

### DIFF
--- a/turbopack/crates/turbo-tasks-testing/tests/collectibles.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/collectibles.rs
@@ -16,15 +16,15 @@ static REGISTRATION: Registration = register!();
 #[tokio::test]
 async fn transitive_emitting() {
     run(&REGISTRATION, || async {
-        let result = my_transitive_emitting_function("".into(), "".into());
-        result.strongly_consistent().await?;
-        let list = result.peek_collectibles::<Box<dyn ValueToString>>();
+        let result_op = my_transitive_emitting_function("".into(), "".into());
+        let result_val = result_op.connect().strongly_consistent().await?;
+        let list = result_op.peek_collectibles::<Box<dyn ValueToString>>();
         assert_eq!(list.len(), 2);
         let mut expected = ["123", "42"].into_iter().collect::<HashSet<_>>();
         for collectible in list {
             assert!(expected.remove(collectible.to_string().await?.as_str()))
         }
-        assert_eq!(result.await?.0, 0);
+        assert_eq!(result_val.0, 0);
         anyhow::Ok(())
     })
     .await
@@ -34,15 +34,15 @@ async fn transitive_emitting() {
 #[tokio::test]
 async fn transitive_emitting_indirect() {
     run(&REGISTRATION, || async {
-        let result = my_transitive_emitting_function("".into(), "".into());
-        let collectibles = my_transitive_emitting_function_collectibles("".into(), "".into());
-        let list = collectibles.strongly_consistent().await?;
+        let result_op = my_transitive_emitting_function("".into(), "".into());
+        let collectibles_op = my_transitive_emitting_function_collectibles("".into(), "".into());
+        let list = collectibles_op.connect().strongly_consistent().await?;
         assert_eq!(list.len(), 2);
         let mut expected = ["123", "42"].into_iter().collect::<HashSet<_>>();
         for collectible in list.iter() {
             assert!(expected.remove(collectible.to_string().await?.as_str()))
         }
-        assert_eq!(result.await?.0, 0);
+        assert_eq!(result_op.connect().await?.0, 0);
         anyhow::Ok(())
     })
     .await
@@ -52,15 +52,15 @@ async fn transitive_emitting_indirect() {
 #[tokio::test]
 async fn multi_emitting() {
     run(&REGISTRATION, || async {
-        let result = my_multi_emitting_function();
-        result.strongly_consistent().await?;
-        let list = result.peek_collectibles::<Box<dyn ValueToString>>();
+        let result_op = my_multi_emitting_function();
+        let result_val = result_op.connect().strongly_consistent().await?;
+        let list = result_op.peek_collectibles::<Box<dyn ValueToString>>();
         assert_eq!(list.len(), 2);
         let mut expected = ["123", "42"].into_iter().collect::<HashSet<_>>();
         for collectible in list {
             assert!(expected.remove(collectible.to_string().await?.as_str()))
         }
-        assert_eq!(result.await?.0, 0);
+        assert_eq!(result_val.0, 0);
         anyhow::Ok(())
     })
     .await
@@ -70,12 +70,13 @@ async fn multi_emitting() {
 #[tokio::test]
 async fn taking_collectibles() {
     run(&REGISTRATION, || async {
-        let result = my_collecting_function();
-        let list = result.take_collectibles::<Box<dyn ValueToString>>();
+        let result_op = my_collecting_function();
+        let result_val = result_op.connect().strongly_consistent().await?;
+        let list = result_op.take_collectibles::<Box<dyn ValueToString>>();
         // my_collecting_function already processed the collectibles so the list should
         // be empty
         assert!(list.is_empty());
-        assert_eq!(result.await?.0, 0);
+        assert_eq!(result_val.0, 0);
         anyhow::Ok(())
     })
     .await
@@ -85,13 +86,13 @@ async fn taking_collectibles() {
 #[tokio::test]
 async fn taking_collectibles_extra_layer() {
     run(&REGISTRATION, || async {
-        let result = my_collecting_function_indirect();
-        result.strongly_consistent().await?;
-        let list = result.take_collectibles::<Box<dyn ValueToString>>();
+        let result_op = my_collecting_function_indirect();
+        let result_val = result_op.connect().strongly_consistent().await?;
+        let list = result_op.take_collectibles::<Box<dyn ValueToString>>();
         // my_collecting_function already processed the collectibles so the list should
         // be empty
         assert!(list.is_empty());
-        assert_eq!(result.await?.0, 0);
+        assert_eq!(result_val.0, 0);
         anyhow::Ok(())
     })
     .await
@@ -101,38 +102,38 @@ async fn taking_collectibles_extra_layer() {
 #[tokio::test]
 async fn taking_collectibles_parallel() {
     run(&REGISTRATION, || async {
-        let result = my_transitive_emitting_function("".into(), "a".into());
-        result.strongly_consistent().await?;
-        let list = result.take_collectibles::<Box<dyn ValueToString>>();
+        let result_op = my_transitive_emitting_function("".into(), "a".into());
+        let result_val = result_op.connect().strongly_consistent().await?;
+        let list = result_op.take_collectibles::<Box<dyn ValueToString>>();
         assert_eq!(list.len(), 2);
-        assert_eq!(result.await?.0, 0);
+        assert_eq!(result_val.0, 0);
 
-        let result = my_transitive_emitting_function("".into(), "b".into());
-        result.strongly_consistent().await?;
-        let list = result.take_collectibles::<Box<dyn ValueToString>>();
+        let result_op = my_transitive_emitting_function("".into(), "b".into());
+        let result_val = result_op.connect().strongly_consistent().await?;
+        let list = result_op.take_collectibles::<Box<dyn ValueToString>>();
         assert_eq!(list.len(), 2);
-        assert_eq!(result.await?.0, 0);
+        assert_eq!(result_val.0, 0);
 
-        let result =
+        let result_op =
             my_transitive_emitting_function_with_child_scope("".into(), "b".into(), "1".into());
-        result.strongly_consistent().await?;
-        let list = result.take_collectibles::<Box<dyn ValueToString>>();
+        let result_val = result_op.connect().strongly_consistent().await?;
+        let list = result_op.take_collectibles::<Box<dyn ValueToString>>();
         assert_eq!(list.len(), 2);
-        assert_eq!(result.await?.0, 0);
+        assert_eq!(result_val.0, 0);
 
-        let result =
+        let result_op =
             my_transitive_emitting_function_with_child_scope("".into(), "b".into(), "2".into());
-        result.strongly_consistent().await?;
-        let list = result.take_collectibles::<Box<dyn ValueToString>>();
+        let result_val = result_op.connect().strongly_consistent().await?;
+        let list = result_op.take_collectibles::<Box<dyn ValueToString>>();
         assert_eq!(list.len(), 2);
-        assert_eq!(result.await?.0, 0);
+        assert_eq!(result_val.0, 0);
 
-        let result =
+        let result_op =
             my_transitive_emitting_function_with_child_scope("".into(), "c".into(), "3".into());
-        result.strongly_consistent().await?;
-        let list = result.take_collectibles::<Box<dyn ValueToString>>();
+        let result_val = result_op.connect().strongly_consistent().await?;
+        let list = result_op.take_collectibles::<Box<dyn ValueToString>>();
         assert_eq!(list.len(), 2);
-        assert_eq!(result.await?.0, 0);
+        assert_eq!(result_val.0, 0);
 
         anyhow::Ok(())
     })
@@ -143,46 +144,53 @@ async fn taking_collectibles_parallel() {
 #[turbo_tasks::value(transparent)]
 struct Collectibles(AutoSet<ResolvedVc<Box<dyn ValueToString>>>);
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation)]
 async fn my_collecting_function() -> Result<Vc<Thing>> {
-    let result = my_transitive_emitting_function("".into(), "".into());
-    result.take_collectibles::<Box<dyn ValueToString>>();
-    Ok(result)
+    let result_op = my_transitive_emitting_function("".into(), "".into());
+    let result_vc = result_op.connect();
+    result_vc.await?;
+    result_op.take_collectibles::<Box<dyn ValueToString>>();
+    Ok(result_vc)
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation)]
 async fn my_collecting_function_indirect() -> Result<Vc<Thing>> {
-    let result = my_collecting_function();
-    result.strongly_consistent().await?;
-    let list = result.peek_collectibles::<Box<dyn ValueToString>>();
+    let result_op = my_collecting_function();
+    let result_vc = result_op.connect();
+    result_vc.strongly_consistent().await?;
+    let list = result_op.peek_collectibles::<Box<dyn ValueToString>>();
     // my_collecting_function already processed the collectibles so the list should
     // be empty
     assert!(list.is_empty());
-    Ok(result)
+    Ok(result_vc)
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation)]
 async fn my_multi_emitting_function() -> Result<Vc<Thing>> {
-    my_transitive_emitting_function("".into(), "a".into()).await?;
-    my_transitive_emitting_function("".into(), "b".into()).await?;
+    my_transitive_emitting_function("".into(), "a".into())
+        .connect()
+        .await?;
+    my_transitive_emitting_function("".into(), "b".into())
+        .connect()
+        .await?;
     my_emitting_function("".into()).await?;
     Ok(Thing::cell(Thing(0)))
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation)]
 async fn my_transitive_emitting_function(key: RcStr, _key2: RcStr) -> Result<Vc<Thing>> {
     my_emitting_function(key).await?;
     Ok(Thing::cell(Thing(0)))
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation)]
 async fn my_transitive_emitting_function_collectibles(
     key: RcStr,
     key2: RcStr,
 ) -> Result<Vc<Collectibles>> {
-    let result = my_transitive_emitting_function(key, key2);
+    let result_op = my_transitive_emitting_function(key, key2);
     Ok(Vc::cell(
-        result
+        result_op
             .peek_collectibles::<Box<dyn ValueToString>>()
             .into_iter()
             .map(|v| v.to_resolved())
@@ -193,17 +201,18 @@ async fn my_transitive_emitting_function_collectibles(
     ))
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation)]
 async fn my_transitive_emitting_function_with_child_scope(
     key: RcStr,
     key2: RcStr,
     _key3: RcStr,
 ) -> Result<Vc<Thing>> {
-    let thing = my_transitive_emitting_function(key, key2);
-    thing.strongly_consistent().await?;
-    let list = thing.peek_collectibles::<Box<dyn ValueToString>>();
+    let thing_op = my_transitive_emitting_function(key, key2);
+    let thing_vc = thing_op.connect();
+    thing_vc.await?;
+    let list = thing_op.peek_collectibles::<Box<dyn ValueToString>>();
     assert_eq!(list.len(), 2);
-    Ok(thing)
+    Ok(thing_vc)
 }
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-testing/tests/dirty_in_progress.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/dirty_in_progress.rs
@@ -71,8 +71,8 @@ impl ValueToString for Collectible {
     }
 }
 
-#[turbo_tasks::function]
-async fn inner_compute(input: Vc<ChangingInput>) -> Result<Vc<u32>> {
+#[turbo_tasks::function(operation)]
+async fn inner_compute(input: ResolvedVc<ChangingInput>) -> Result<Vc<u32>> {
     println!("start inner_compute");
     let value = *input.await?.state.get();
     tokio::time::sleep(Duration::from_millis(200)).await;
@@ -90,10 +90,10 @@ async fn inner_compute(input: Vc<ChangingInput>) -> Result<Vc<u32>> {
 }
 
 #[turbo_tasks::function]
-async fn compute(input: Vc<ChangingInput>) -> Result<Vc<Output>> {
+async fn compute(input: ResolvedVc<ChangingInput>) -> Result<Vc<Output>> {
     println!("start compute");
     let operation = inner_compute(input);
-    let value = *operation.await?;
+    let value = *operation.connect().await?;
     let collectibles = operation.peek_collectibles::<Box<dyn ValueToString>>();
     if collectibles.len() > 1 {
         bail!("expected 0..1 collectible, found {}", collectibles.len());

--- a/turbopack/crates/turbo-tasks-testing/tests/recompute_collectibles.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/recompute_collectibles.rs
@@ -57,9 +57,9 @@ impl ValueToString for Collectible {
     }
 }
 
-#[turbo_tasks::function]
-fn inner_compute(input: Vc<ChangingInput>) -> Vc<u32> {
-    inner_compute2(input, 1000)
+#[turbo_tasks::function(operation)]
+fn inner_compute(input: ResolvedVc<ChangingInput>) -> Vc<u32> {
+    inner_compute2(*input, 1000)
 }
 
 #[turbo_tasks::function]
@@ -79,12 +79,12 @@ async fn inner_compute2(input: Vc<ChangingInput>, innerness: u32) -> Result<Vc<u
 }
 
 #[turbo_tasks::function]
-async fn compute(input: Vc<ChangingInput>, innerness: u32) -> Result<Vc<Output>> {
+async fn compute(input: ResolvedVc<ChangingInput>, innerness: u32) -> Result<Vc<Output>> {
     if innerness > 0 {
-        return Ok(compute(input, innerness - 1));
+        return Ok(compute(*input, innerness - 1));
     }
     let operation = inner_compute(input);
-    let value = *operation.await?;
+    let value = *operation.connect().await?;
     let collectibles = operation.peek_collectibles::<Box<dyn ValueToString>>();
     if collectibles.len() != 1 {
         bail!("expected 1 collectible, found {}", collectibles.len());

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -17,7 +17,6 @@ use std::{
 };
 
 use anyhow::Result;
-use auto_hash_map::AutoSet;
 use serde::{Deserialize, Serialize};
 
 pub use self::{
@@ -35,7 +34,7 @@ use crate::{
     manager::{create_local_cell, try_get_function_meta},
     registry,
     trace::{TraceRawVcs, TraceRawVcsContext},
-    CellId, CollectiblesSource, RawVc, ResolveTypeError, SharedReference, ShrinkToFit,
+    CellId, RawVc, ResolveTypeError, SharedReference, ShrinkToFit,
 };
 
 /// A "Value Cell" (`Vc` for short) is a reference to a memoized computation result stored on the
@@ -584,19 +583,6 @@ where
             node: raw_vc,
             _t: PhantomData,
         }))
-    }
-}
-
-impl<T> CollectiblesSource for Vc<T>
-where
-    T: ?Sized,
-{
-    fn take_collectibles<Vt: VcValueTrait>(self) -> AutoSet<Vc<Vt>> {
-        self.node.take_collectibles()
-    }
-
-    fn peek_collectibles<Vt: VcValueTrait>(self) -> AutoSet<Vc<Vt>> {
-        self.node.peek_collectibles()
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -424,11 +424,6 @@ impl<T> Vc<T>
 where
     T: ?Sized,
 {
-    /// Connects the operation pointed to by this `Vc` to the current task.
-    pub fn connect(vc: Self) {
-        vc.node.connect()
-    }
-
     /// Returns a debug identifier for this `Vc`.
     pub async fn debug_identifier(vc: Self) -> Result<String> {
         let resolved = vc.resolve().await?;

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     apply_effects, debug::ValueDebugFormat, fxindexmap, trace::TraceRawVcs, Completion,
-    NonLocalValue, ResolvedVc, TryJoinIterExt, TurboTasks, Value, Vc,
+    NonLocalValue, OperationVc, ResolvedVc, TryJoinIterExt, TurboTasks, Value, Vc,
 };
 use turbo_tasks_bytes::stream::SingleValue;
 use turbo_tasks_env::CommandLineProcessEnv;
@@ -170,27 +170,28 @@ async fn run(resource: PathBuf, snapshot_mode: IssueSnapshotMode) -> Result<JsRe
 
     let tt = TurboTasks::new(MemoryBackend::default());
     tt.run_once(async move {
-        let emit = run_inner(resource.to_str().unwrap().into(), Value::new(snapshot_mode));
-        let result = emit.strongly_consistent().await?;
-        apply_effects(emit).await?;
+        let emit_op =
+            run_inner_operation(resource.to_str().unwrap().into(), Value::new(snapshot_mode));
+        let result = emit_op.connect().strongly_consistent().await?;
+        apply_effects(emit_op).await?;
 
         Ok(result.clone_value())
     })
     .await
 }
 
-#[turbo_tasks::function]
-async fn run_inner(
+#[turbo_tasks::function(operation)]
+async fn run_inner_operation(
     resource: RcStr,
     snapshot_mode: Value<IssueSnapshotMode>,
 ) -> Result<Vc<JsResult>> {
-    let prepared_test = prepare_test(resource);
-    let run_result = run_test(prepared_test);
+    let prepared_test = prepare_test(resource).to_resolved().await?;
+    let run_result_op = run_test_operation(prepared_test);
     if *snapshot_mode == IssueSnapshotMode::Snapshots {
-        snapshot_issues(prepared_test, run_result).await?;
+        snapshot_issues(*prepared_test, run_result_op).await?;
     }
 
-    Ok(*run_result.await?.js_result)
+    Ok(*run_result_op.connect().await?.js_result)
 }
 
 #[derive(
@@ -264,8 +265,8 @@ async fn prepare_test(resource: RcStr) -> Result<Vc<PreparedTest>> {
     .cell())
 }
 
-#[turbo_tasks::function]
-async fn run_test(prepared_test: Vc<PreparedTest>) -> Result<Vc<RunTestResult>> {
+#[turbo_tasks::function(operation)]
+async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<Vc<RunTestResult>> {
     let PreparedTest {
         path,
         project_path,
@@ -451,10 +452,10 @@ async fn run_test(prepared_test: Vc<PreparedTest>) -> Result<Vc<RunTestResult>> 
 #[turbo_tasks::function]
 async fn snapshot_issues(
     prepared_test: Vc<PreparedTest>,
-    run_result: Vc<RunTestResult>,
+    run_result: OperationVc<RunTestResult>,
 ) -> Result<Vc<()>> {
     let PreparedTest { path, .. } = *prepared_test.await?;
-    let _ = run_result.resolve_strongly_consistent().await;
+    let _ = run_result.connect().resolve_strongly_consistent().await;
 
     let captured_issues = run_result.peek_issues_with_path().await?;
 

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -904,6 +904,14 @@ pub fn emit_with_completion(asset: Vc<Box<dyn OutputAsset>>, output_dir: Vc<File
     let _ = emit_assets_aggregated(asset, output_dir);
 }
 
+#[turbo_tasks::function(operation)]
+pub fn emit_with_completion_operation(
+    asset: ResolvedVc<Box<dyn OutputAsset>>,
+    output_dir: ResolvedVc<FileSystemPath>,
+) -> Vc<()> {
+    emit_with_completion(*asset, *output_dir)
+}
+
 #[turbo_tasks::function]
 fn emit_assets_aggregated(asset: Vc<Box<dyn OutputAsset>>, output_dir: Vc<FileSystemPath>) {
     let aggregated = aggregate(asset);


### PR DESCRIPTION
`OperationVc`s should be used with `CollectiblesSource` instead of `Vc`s because collectibles represent a side-effect or implicit extra return value of a function's execution.

Closes PACK-3720