### PR TITLE
[metadata] Merge the metadata resolve apis into one api

### DIFF
--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -21,10 +21,9 @@ import {
 } from './generate/opengraph'
 import { IconsMetadata } from './generate/icons'
 import {
-  resolveMetadataItems,
-  accumulateMetadata,
-  accumulateViewport,
   type MetadataErrorType,
+  resolveMetadata,
+  resolveViewport,
 } from './resolve-metadata'
 import { MetaFilter } from './generate/meta'
 import type {
@@ -197,17 +196,17 @@ async function getResolvedMetadataImpl(
 ): Promise<React.ReactNode> {
   const errorConvention = errorType === 'redirect' ? undefined : errorType
 
-  const metadataItems = await resolveMetadataItems(
+  const resolvedMetadata = await resolveMetadata(
     tree,
     searchParams,
     errorConvention,
     getDynamicParamFromSegment,
     createServerParamsForMetadata,
-    workStore
+    workStore,
+    metadataContext
   )
-  const elements: Array<React.ReactNode> = createMetadataElements(
-    await accumulateMetadata(metadataItems, metadataContext)
-  )
+  const elements: Array<React.ReactNode> =
+    createMetadataElements(resolvedMetadata)
   return (
     <>
       {elements.map((el, index) => {
@@ -227,17 +226,18 @@ async function getNotFoundMetadataImpl(
   workStore: WorkStore
 ): Promise<React.ReactNode> {
   const notFoundErrorConvention = 'not-found'
-  const notFoundMetadataItems = await resolveMetadataItems(
+  const notFoundResolvedMetadata = await resolveMetadata(
     tree,
     searchParams,
     notFoundErrorConvention,
     getDynamicParamFromSegment,
     createServerParamsForMetadata,
-    workStore
+    workStore,
+    metadataContext
   )
 
   const elements: Array<React.ReactNode> = createMetadataElements(
-    await accumulateMetadata(notFoundMetadataItems, metadataContext)
+    notFoundResolvedMetadata
   )
   return (
     <>
@@ -258,8 +258,7 @@ async function getResolvedViewportImpl(
   errorType?: MetadataErrorType | 'redirect'
 ): Promise<React.ReactNode> {
   const errorConvention = errorType === 'redirect' ? undefined : errorType
-
-  const metadataItems = await resolveMetadataItems(
+  const resolvedViewport = await resolveViewport(
     tree,
     searchParams,
     errorConvention,
@@ -267,9 +266,8 @@ async function getResolvedViewportImpl(
     createServerParamsForMetadata,
     workStore
   )
-  const elements: Array<React.ReactNode> = createViewportElements(
-    await accumulateViewport(metadataItems)
-  )
+  const elements: Array<React.ReactNode> =
+    createViewportElements(resolvedViewport)
   return (
     <>
       {elements.map((el, index) => {
@@ -288,7 +286,7 @@ async function getNotFoundViewportImpl(
   workStore: WorkStore
 ): Promise<React.ReactNode> {
   const notFoundErrorConvention = 'not-found'
-  const notFoundMetadataItems = await resolveMetadataItems(
+  const notFoundResolvedViewport = await resolveViewport(
     tree,
     searchParams,
     notFoundErrorConvention,
@@ -298,7 +296,7 @@ async function getNotFoundViewportImpl(
   )
 
   const elements: Array<React.ReactNode> = createViewportElements(
-    await accumulateViewport(notFoundMetadataItems)
+    notFoundResolvedViewport
   )
   return (
     <>

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -195,7 +195,86 @@ async function getResolvedMetadataImpl(
   errorType?: MetadataErrorType | 'redirect'
 ): Promise<React.ReactNode> {
   const errorConvention = errorType === 'redirect' ? undefined : errorType
+  return renderMetadata(
+    tree,
+    searchParams,
+    getDynamicParamFromSegment,
+    metadataContext,
+    createServerParamsForMetadata,
+    workStore,
+    errorConvention
+  )
+}
 
+const getNotFoundMetadata = cache(getNotFoundMetadataImpl)
+async function getNotFoundMetadataImpl(
+  tree: LoaderTree,
+  searchParams: Promise<ParsedUrlQuery>,
+  getDynamicParamFromSegment: GetDynamicParamFromSegment,
+  metadataContext: MetadataContext,
+  createServerParamsForMetadata: CreateServerParamsForMetadata,
+  workStore: WorkStore
+): Promise<React.ReactNode> {
+  const notFoundErrorConvention = 'not-found'
+  return renderMetadata(
+    tree,
+    searchParams,
+    getDynamicParamFromSegment,
+    metadataContext,
+    createServerParamsForMetadata,
+    workStore,
+    notFoundErrorConvention
+  )
+}
+
+const getResolvedViewport = cache(getResolvedViewportImpl)
+async function getResolvedViewportImpl(
+  tree: LoaderTree,
+  searchParams: Promise<ParsedUrlQuery>,
+  getDynamicParamFromSegment: GetDynamicParamFromSegment,
+  createServerParamsForMetadata: CreateServerParamsForMetadata,
+  workStore: WorkStore,
+  errorType?: MetadataErrorType | 'redirect'
+): Promise<React.ReactNode> {
+  const errorConvention = errorType === 'redirect' ? undefined : errorType
+  return renderViewport(
+    tree,
+    searchParams,
+    getDynamicParamFromSegment,
+    createServerParamsForMetadata,
+    workStore,
+    errorConvention
+  )
+}
+
+const getNotFoundViewport = cache(getNotFoundViewportImpl)
+async function getNotFoundViewportImpl(
+  tree: LoaderTree,
+  searchParams: Promise<ParsedUrlQuery>,
+  getDynamicParamFromSegment: GetDynamicParamFromSegment,
+  createServerParamsForMetadata: CreateServerParamsForMetadata,
+  workStore: WorkStore
+): Promise<React.ReactNode> {
+  const notFoundErrorConvention = 'not-found'
+  return renderViewport(
+    tree,
+    searchParams,
+    getDynamicParamFromSegment,
+    createServerParamsForMetadata,
+    workStore,
+    notFoundErrorConvention
+  )
+}
+
+async function renderMetadata(
+  tree: LoaderTree,
+  searchParams: Promise<ParsedUrlQuery>,
+  getDynamicParamFromSegment: GetDynamicParamFromSegment,
+  metadataContext: MetadataContext,
+  createServerParamsForMetadata: CreateServerParamsForMetadata,
+  workStore: WorkStore,
+  errorConvention?: MetadataErrorType
+) {
   const resolvedMetadata = await resolveMetadata(
     tree,
     searchParams,
@@ -216,80 +295,18 @@ async function getResolvedMetadataImpl(
   )
 }
 
-const getNotFoundMetadata = cache(getNotFoundMetadataImpl)
-async function getNotFoundMetadataImpl(
-  tree: LoaderTree,
-  searchParams: Promise<ParsedUrlQuery>,
-  getDynamicParamFromSegment: GetDynamicParamFromSegment,
-  metadataContext: MetadataContext,
-  createServerParamsForMetadata: CreateServerParamsForMetadata,
-  workStore: WorkStore
-): Promise<React.ReactNode> {
-  const notFoundErrorConvention = 'not-found'
-  const notFoundResolvedMetadata = await resolveMetadata(
-    tree,
-    searchParams,
-    notFoundErrorConvention,
-    getDynamicParamFromSegment,
-    createServerParamsForMetadata,
-    workStore,
-    metadataContext
-  )
-
-  const elements: Array<React.ReactNode> = createMetadataElements(
-    notFoundResolvedMetadata
-  )
-  return (
-    <>
-      {elements.map((el, index) => {
-        return cloneElement(el as React.ReactElement, { key: index })
-      })}
-    </>
-  )
-}
-
-const getResolvedViewport = cache(getResolvedViewportImpl)
-async function getResolvedViewportImpl(
+async function renderViewport(
   tree: LoaderTree,
   searchParams: Promise<ParsedUrlQuery>,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   createServerParamsForMetadata: CreateServerParamsForMetadata,
   workStore: WorkStore,
-  errorType?: MetadataErrorType | 'redirect'
-): Promise<React.ReactNode> {
-  const errorConvention = errorType === 'redirect' ? undefined : errorType
-  const resolvedViewport = await resolveViewport(
-    tree,
-    searchParams,
-    errorConvention,
-    getDynamicParamFromSegment,
-    createServerParamsForMetadata,
-    workStore
-  )
-  const elements: Array<React.ReactNode> =
-    createViewportElements(resolvedViewport)
-  return (
-    <>
-      {elements.map((el, index) => {
-        return cloneElement(el as React.ReactElement, { key: index })
-      })}
-    </>
-  )
-}
-
-const getNotFoundViewport = cache(getNotFoundViewportImpl)
-async function getNotFoundViewportImpl(
-  tree: LoaderTree,
-  searchParams: Promise<ParsedUrlQuery>,
-  getDynamicParamFromSegment: GetDynamicParamFromSegment,
-  createServerParamsForMetadata: CreateServerParamsForMetadata,
-  workStore: WorkStore
-): Promise<React.ReactNode> {
-  const notFoundErrorConvention = 'not-found'
+  errorConvention?: MetadataErrorType
+) {
   const notFoundResolvedViewport = await resolveViewport(
     tree,
     searchParams,
-    notFoundErrorConvention,
+    errorConvention,
     getDynamicParamFromSegment,
     createServerParamsForMetadata,
     workStore

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -918,7 +918,7 @@ export async function resolveMetadata(
     createServerParamsForMetadata,
     workStore
   )
-  return await accumulateMetadata(metadataItems, metadataContext)
+  return accumulateMetadata(metadataItems, metadataContext)
 }
 
 // Exposed API for viewport component, that directly resolve the loader tree and related context as resolved viewport.
@@ -938,5 +938,5 @@ export async function resolveViewport(
     createServerParamsForMetadata,
     workStore
   )
-  return await accumulateViewport(metadataItems)
+  return accumulateViewport(metadataItems)
 }

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -470,9 +470,7 @@ async function collectMetadata({
   }
 }
 
-const cachedResolveMetadataItems = cache(resolveMetadataItems)
-export { cachedResolveMetadataItems as resolveMetadataItems }
-async function resolveMetadataItems(
+const resolveMetadataItems = cache(async function (
   tree: LoaderTree,
   searchParams: Promise<ParsedUrlQuery>,
   errorConvention: MetadataErrorType | undefined,
@@ -496,7 +494,7 @@ async function resolveMetadataItems(
     createServerParamsForMetadata,
     workStore
   )
-}
+})
 
 async function resolveMetadataItemsImpl(
   metadataItems: MetadataItems,

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -901,3 +901,44 @@ export async function accumulateViewport(
   }
   return resolvedViewport
 }
+
+// Exposed API for metadata component, that directly resolve the loader tree and related context as resolved metadata.
+export async function resolveMetadata(
+  tree: LoaderTree,
+  searchParams: Promise<ParsedUrlQuery>,
+  errorConvention: MetadataErrorType | undefined,
+  getDynamicParamFromSegment: GetDynamicParamFromSegment,
+  createServerParamsForMetadata: CreateServerParamsForMetadata,
+  workStore: WorkStore,
+  metadataContext: MetadataContext
+): Promise<ResolvedMetadata> {
+  const metadataItems = await resolveMetadataItems(
+    tree,
+    searchParams,
+    errorConvention,
+    getDynamicParamFromSegment,
+    createServerParamsForMetadata,
+    workStore
+  )
+  return await accumulateMetadata(metadataItems, metadataContext)
+}
+
+// Exposed API for viewport component, that directly resolve the loader tree and related context as resolved viewport.
+export async function resolveViewport(
+  tree: LoaderTree,
+  searchParams: Promise<ParsedUrlQuery>,
+  errorConvention: MetadataErrorType | undefined,
+  getDynamicParamFromSegment: GetDynamicParamFromSegment,
+  createServerParamsForMetadata: CreateServerParamsForMetadata,
+  workStore: WorkStore
+): Promise<ResolvedViewport> {
+  const metadataItems = await resolveMetadataItems(
+    tree,
+    searchParams,
+    errorConvention,
+    getDynamicParamFromSegment,
+    createServerParamsForMetadata,
+    workStore
+  )
+  return await accumulateViewport(metadataItems)
+}


### PR DESCRIPTION
### What

Merge the two steps of resolving metadata or viewport into one, simplifying the usage on the Metadata and Viewport component side, that they only used one API provided by the resolving logic module.