### PR TITLE
Fix missing `await` of `params` when metadata with an image file pt2

### DIFF
--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -250,7 +250,7 @@ impl AppPageLoaderTreeBuilder {
         let metadata_route = &*get_metadata_route_name((*item).into()).await?;
         writeln!(
             self.loader_tree_code,
-            "{s}  url: fillMetadataSegment({}, props.params, {}) + \
+            "{s}  url: fillMetadataSegment({}, await props.params, {}) + \
              `?${{{identifier}.src.split(\"/\").splice(-1)[0]}}`,",
             StringifyJs(&pathname_prefix),
             StringifyJs(metadata_route),


### PR DESCRIPTION
# Fixing a bug
Continuation of #71871 but for another code path.
The function is already marked `async`


## Code that was generated before

```JS
                          openGraph: [
                            async (props) => [
                              {
                                url:
                                  (0,
                                  __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$next$2f$dist$2f$lib$2f$metadata$2f$get$2d$metadata$2d$route$2e$js__$5b$app$2d$rsc$5d$__$28$ecmascript$29$__[
                                    'fillMetadataSegment'
                                  ])(
                                    '//[locale]/page-name',
                                    props.params,
                                    'opengraph-image.jpg'
                                  ) +
                                  `?${__TURBOPACK__imported__module__$5b$project$5d2f$app$2f5b$locale$5d2f$page$2d$name$2f$opengraph$2d$image$2e$jpg$2e$mjs__$7b$__IMAGE__$3d3e$__$225b$project$5d2f$app$2f5b$locale$5d2f$page$2d$name$2f$opengraph$2d$image$2e$jpg__$5b$app$2d$rsc$5d$__$28$static$2922$__$7d$__$5b$app$2d$rsc$5d$__$28$structured__image__object$2c$__ecmascript$2c$__Next$2e$js__server__component$29$__['default'].src.split('/').splice(-1)[0]}`,
								  ...
```

### Stacktrace

```JS
Error: Route "/[locale]/page-name" used `params.locale`. `params` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
    at createParamsAccessError ($REPOROOT\.next\server\chunks\ssr\file:\$REPOROOT\node_modules\next\dist\src\server\request\params.ts:467:10)
    at logDedupedError ($REPOROOT\.next\server\chunks\ssr\file:\$REPOROOT\node_modules\next\dist\src\server\create-deduped-by-callsite-server-error-logger.ts:46:21)
    at syncIODev ($REPOROOT\.next\server\chunks\ssr\file:\$REPOROOT\node_modules\next\dist\src\server\request\params.ts:445:5)
    at Object.get ($REPOROOT\.next\server\chunks\ssr\file:\$REPOROOT\node_modules\next\dist\src\server\request\params.ts:403:11)
    at interpolateDynamicPath ($REPOROOT\.next\server\chunks\ssr\file:\$REPOROOT\node_modules\next\src\server\server-utils.ts:74:25)
    at fillMetadataSegment ($REPOROOT\.next\server\chunks\ssr\file:\$REPOROOT\node_modules\next\src\lib\metadata\get-metadata-route.ts:65:39)
    at tree.children.children.metadata.openGraph ($REPOROOT\.next\server\chunks\ssr\node_modules_next_46559b._.js:78:249)
    at $REPOROOT\.next\server\chunks\ssr\file:\$REPOROOT\node_modules\next\dist\src\lib\metadata\resolve-metadata.ts:383:28
    at Array.map (<anonymous>)
    at collectStaticImagesFiles ($REPOROOT\.next\server\chunks\ssr\file:\$REPOROOT\node_modules\next\dist\src\lib\metadata\resolve-metadata.ts:381:59)
    at resolveStaticMetadata ($REPOROOT\.next\server\chunks\ssr\file:\$REPOROOT\node_modules\next\dist\src\lib\metadata\resolve-metadata.ts:401:5)
    at collectMetadata ($REPOROOT\.next\server\chunks\ssr\file:\$REPOROOT\node_modules\next\dist\src\lib\metadata\resolve-metadata.ts:451:37)
    at process.processTicksAndRejections ($REPOROOT\lib\internal\process\task_queues.js:95:5)
    at async resolveMetadataItemsImpl ($REPOROOT\.next\server\chunks\ssr\file:\$REPOROOT\node_modules\next\dist\src\lib\metadata\resolve-metadata.ts:550:3)
    at async resolveMetadataItemsImpl ($REPOROOT\.next\server\chunks\ssr\file:\$REPOROOT\node_modules\next\dist\src\lib\metadata\resolve-metadata.ts:564:5)
    at async resolveMetadataItemsImpl ($REPOROOT\.next\server\chunks\ssr\node_modules_next_dist_c3ca74._.js:8080:9)
```