### PR TITLE
Fix accessing headers in progressively enhanced form actions

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -657,12 +657,19 @@ export async function handleAction({
             if (typeof action === 'function') {
               // Only warn if it's a server action, otherwise skip for other post requests
               warnBadServerActionRequest()
-              const actionReturnedState = await action()
-              formState = decodeFormState(
+
+              const actionReturnedState = await workUnitAsyncStorage.run(
+                requestStore,
+                action
+              )
+
+              formState = await decodeFormState(
                 actionReturnedState,
                 formData,
                 serverModuleMap
               )
+
+              requestStore.phase = 'render'
             }
 
             // Skip the fetch path
@@ -804,12 +811,19 @@ export async function handleAction({
             if (typeof action === 'function') {
               // Only warn if it's a server action, otherwise skip for other post requests
               warnBadServerActionRequest()
-              const actionReturnedState = await action()
+
+              const actionReturnedState = await workUnitAsyncStorage.run(
+                requestStore,
+                action
+              )
+
               formState = await decodeFormState(
                 actionReturnedState,
                 formData,
                 serverModuleMap
               )
+
+              requestStore.phase = 'render'
             }
 
             // Skip the fetch path

--- a/test/e2e/app-dir/actions/app/header/edge/form/page.tsx
+++ b/test/e2e/app-dir/actions/app/header/edge/form/page.tsx
@@ -1,0 +1,3 @@
+export { default } from '../../node/form/page'
+
+export const runtime = 'edge'

--- a/test/e2e/app-dir/actions/app/header/node/form/page.tsx
+++ b/test/e2e/app-dir/actions/app/header/node/form/page.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useActionState } from 'react'
+import { getCookie, getHeader, setCookie } from '../../actions'
+
+const getReferrer = getHeader.bind(null, 'referer')
+const setTestCookie = setCookie.bind(null, 'test', '42')
+const getTestCookie = getCookie.bind(null, 'test')
+
+export default function Page() {
+  const [referer, getReferrerAction] = useActionState(getReferrer, null)
+
+  const [cookie, getTestCookieAction] = useActionState<ReturnType<
+    typeof getCookie
+  > | null>(getTestCookie, null)
+
+  return (
+    <>
+      <form action={getReferrerAction}>
+        <p id="referer">{referer}</p>
+        <button id="get-referer">Get Referer</button>
+      </form>
+      <form action={getTestCookieAction}>
+        <p id="cookie">{cookie?.value}</p>
+        <button id="set-cookie" formAction={setTestCookie}>
+          Set Cookie
+        </button>
+        <button id="get-cookie">Get Cookie</button>
+      </form>
+    </>
+  )
+}


### PR DESCRIPTION
When scoping the `requestStore` to dynamic renders in #72312, we missed the case when a server action is invoked before hydration is complete.

This leads to an error when a server action tries to read headers, cookies, or anything else that requires the presence of the `requestStore`.

This fixes that for both the Node.js and Edge runtimes. It also appears that progressively enhanced form actions did not work at all before in the Edge runtime due to a missing `await` of `decodeFormState`.

fixes #73992
closes NAR-55