### PR TITLE
refactor(turbo-tasks): Add common traits (TaskInput, NonLocalValue, etc) to `either::Either<L, R>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8420,6 +8420,7 @@ dependencies = [
  "auto-hash-map",
  "concurrent-queue",
  "dashmap 6.1.0",
+ "either",
  "erased-serde",
  "event-listener 2.5.3",
  "futures",

--- a/turbopack/crates/turbo-tasks/Cargo.toml
+++ b/turbopack/crates/turbo-tasks/Cargo.toml
@@ -22,6 +22,7 @@ async-trait = { workspace = true }
 auto-hash-map = { workspace = true }
 concurrent-queue = { workspace = true }
 dashmap = { workspace = true }
+either = { workspace = true }
 erased-serde = "0.3.20"
 event-listener = "2.5.3"
 futures = { workspace = true }

--- a/turbopack/crates/turbo-tasks/src/marker_trait.rs
+++ b/turbopack/crates/turbo-tasks/src/marker_trait.rs
@@ -66,6 +66,7 @@ macro_rules! impl_auto_marker_trait {
         unsafe impl<T: $trait + ?Sized> $trait for ::std::sync::Mutex<T> {}
         unsafe impl<T: $trait + ?Sized> $trait for ::std::cell::RefCell<T> {}
         unsafe impl<T: ?Sized> $trait for ::std::marker::PhantomData<T> {}
+        unsafe impl<L: $trait, R: $trait> $trait for ::either::Either<L, R> {}
 
         unsafe impl<T: $trait + ?Sized> $trait for $crate::TraitRef<T> {}
         unsafe impl<T> $trait for $crate::ReadRef<T>

--- a/turbopack/crates/turbo-tasks/src/trace.rs
+++ b/turbopack/crates/turbo-tasks/src/trace.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use auto_hash_map::{AutoMap, AutoSet};
+use either::Either;
 use indexmap::{IndexMap, IndexSet};
 use turbo_rcstr::RcStr;
 
@@ -250,6 +251,15 @@ impl<T: TraceRawVcs + ?Sized> TraceRawVcs for &T {
 impl<T: TraceRawVcs + ?Sized> TraceRawVcs for &mut T {
     fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
         (**self).trace_raw_vcs(trace_context);
+    }
+}
+
+impl<L: TraceRawVcs, R: TraceRawVcs> TraceRawVcs for Either<L, R> {
+    fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
+        match self {
+            Either::Left(l) => l.trace_raw_vcs(trace_context),
+            Either::Right(r) => r.trace_raw_vcs(trace_context),
+        }
     }
 }
 


### PR DESCRIPTION
I ended up abandoning https://github.com/vercel/next.js/pull/74108, but the `Either` trait implementations in there seemed nice-to-have, so I'm publishing them here instead.

Closes PACK-3691