### PR TITLE
refactor(next-core): Remove local annotations from structs in next-core/src/app_structure.rs

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -800,7 +800,7 @@ enum AppPageEndpointType {
     Rsc,
 }
 
-#[derive(Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Debug, TraceRawVcs)]
+#[derive(Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Debug, TraceRawVcs, NonLocalValue)]
 enum AppEndpointType {
     Page {
         ty: AppPageEndpointType,
@@ -815,7 +815,7 @@ enum AppEndpointType {
     },
 }
 
-#[turbo_tasks::value(local)]
+#[turbo_tasks::value]
 struct AppEndpoint {
     ty: AppEndpointType,
     app_project: ResolvedVc<AppProject>,


### PR DESCRIPTION
These only need trivial modifications to implement `NonLocalValue`.

Closes PACK-3682