### PR TITLE
Add web-worker to server-external-packages.json

### DIFF
--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -60,6 +60,7 @@
   "ts-morph",
   "typescript",
   "vscode-oniguruma",
+  "web-worker",
   "webpack",
   "websocket",
   "zeromq"


### PR DESCRIPTION
### What?

Adds the `web-worker` package to `server-external-packages.json`.

### Why?

`web-worker` is a popular package ([1.1k GitHub stars](https://github.com/developit/web-worker), [910k weekly downloads](https://www.npmjs.com/package/web-worker) on npm).

Unfortunately, bundling it causes it to break on the server side, causing mysterious hangs when trying to start worker threads. Since this library is used as a dependency by other libraries which require worker threads, debugging the issue can be hard. Adding the library to `serverExternalPackages` in the Next config resolves the issue.