### PR TITLE
docs: pin react version to 18 in Next.js 14 upgrade guide

### DIFF
--- a/docs/01-app/03-building-your-application/11-upgrading/04-version-14.mdx
+++ b/docs/01-app/03-building-your-application/11-upgrading/04-version-14.mdx
@@ -10,19 +10,19 @@ description: Upgrade your Next.js Application from Version 13 to 14.
 To update to Next.js version 14, run the following command using your preferred package manager:
 
 ```bash filename="Terminal"
-npm i next@next-14 react@latest react-dom@latest && npm i eslint-config-next@next-14 -D
+npm i next@next-14 react@18 react-dom@18 && npm i eslint-config-next@next-14 -D
 ```
 
 ```bash filename="Terminal"
-yarn add next@next-14 react@latest react-dom@latest && yarn add eslint-config-next@next-14 -D
+yarn add next@next-14 react@18 react-dom@18 && yarn add eslint-config-next@next-14 -D
 ```
 
 ```bash filename="Terminal"
-pnpm i next@next-14 react@latest react-dom@latest && pnpm i eslint-config-next@next-14 -D
+pnpm i next@next-14 react@18 react-dom@18 && pnpm i eslint-config-next@next-14 -D
 ```
 
 ```bash filename="Terminal"
-bun add next@next-14 react@latest react-dom@latest && bun add eslint-config-next@next-14 -D
+bun add next@next-14 react@18 react-dom@18 && bun add eslint-config-next@next-14 -D
 ```
 
 > **Good to know:** If you are using TypeScript, ensure you also upgrade `@types/react` and `@types/react-dom` to their latest versions.


### PR DESCRIPTION
### Improving Documentation

I was just upgrading from Next.js v13 to v14 following this guide:
https://nextjs.org/docs/app/building-your-application/upgrading/version-14

npm installation throws the below error:

```sh
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: blog@0.0.8
npm error Found: react@19.0.0
npm error node_modules/react
npm error   react@"19.0.0" from the root project
npm error
npm error Could not resolve dependency:
npm error peer react@"^18.2.0" from next@14.2.21
npm error node_modules/next
npm error   next@"14.2.21" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
```

The react version for Next.js v14 should be pinned to react@18.