### PR TITLE
update sitemap.mdx example paths to align with generate-sitemaps.mdx

### DIFF
--- a/docs/01-app/04-api-reference/03-file-conventions/01-metadata/sitemap.mdx
+++ b/docs/01-app/04-api-reference/03-file-conventions/01-metadata/sitemap.mdx
@@ -389,7 +389,7 @@ export default async function sitemap({ id }) {
 }
 ```
 
-Your generated sitemaps will be available at `/.../sitemap/[id]`. For example, `/product/sitemap/1.xml`.
+Your generated sitemaps will be available at `/.../sitemap.xml/[id]`. For example, `/product/sitemap.xml/1`.
 
 See the [`generateSitemaps` API reference](/docs/app/api-reference/functions/generate-sitemaps) for more information.
 


### PR DESCRIPTION
Updates the example paths provided in `sitemap.mdx` to the correct paths, as detailed in `generate-sitemaps.mdx`, currently the example paths shown in `sitemap.mdx` under creating multiple sitemaps are incorrect. 