### PR TITLE
Allow parallel route slot names in kebab-case

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -445,7 +445,7 @@ async function createTreeCodeFromPath(
     return {
       treeCode: `{
         ${Object.entries(props)
-          .map(([key, value]) => `${key}: ${value}`)
+          .map(([key, value]) => `${JSON.stringify(key)}: ${value}`)
           .join(',\n')}
       }`,
     }

--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
@@ -177,7 +177,9 @@ export interface LayoutProps {
   children?: React.ReactNode
 ${
   options.slots
-    ? options.slots.map((slot) => `  ${slot}: React.ReactNode`).join('\n')
+    ? options.slots
+        .map((slot) => `  ${JSON.stringify(slot)}: React.ReactNode`)
+        .join('\n')
     : ''
 }
   params?: Promise<SegmentParams>

--- a/test/e2e/app-dir/parallel-routes-kebab-case-slot/app/@slot-name/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-kebab-case-slot/app/@slot-name/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return '@slot-name rendered'
+}

--- a/test/e2e/app-dir/parallel-routes-kebab-case-slot/app/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-kebab-case-slot/app/layout.tsx
@@ -1,0 +1,16 @@
+export default function Layout({
+  children,
+  ...parallelRoutes
+}: {
+  children: React.ReactNode
+  'slot-name': React.ReactNode
+}) {
+  return (
+    <html>
+      <body>
+        {children}
+        {parallelRoutes['slot-name']}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-kebab-case-slot/app/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-kebab-case-slot/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div id="children-slot">@children rendered</div>
+}

--- a/test/e2e/app-dir/parallel-routes-kebab-case-slot/next.config.js
+++ b/test/e2e/app-dir/parallel-routes-kebab-case-slot/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/parallel-routes-kebab-case-slot/parallel-routes-kebab-case-slot.test.ts
+++ b/test/e2e/app-dir/parallel-routes-kebab-case-slot/parallel-routes-kebab-case-slot.test.ts
@@ -1,0 +1,18 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('parallel-routes-kebab-case-slot', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('Should render the parallel route if the slot name is not a valid JavaScript variable name', async () => {
+    const browser = await next.browser('/')
+    // both the page slot (children) and the parallel slot should be rendered at the root layout
+    expect(await browser.elementByCss('body').text()).toContain(
+      '@children rendered'
+    )
+    expect(await browser.elementByCss('body').text()).toContain(
+      '@slot-name rendered'
+    )
+  })
+})


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

Closes NEXT-
Fixes #

-->

### What?

This PR adds support for parallel route slot names written with kebab-case. So instead of `@deleteModal`, we can have `@delete-modal`.

### Why?

There are projects that prefer to use exclusively kebab-case for file/folder names due to various reasons, such as to prevent issues related to how different operating systems handle file system casing.

However, currently, parallel route slot names must be a valid JavaScript variable name. This PR aims to relax this requirement.

### How?

```diff
- .map(([key, value]) => `${key}: ${value}`)
+ .map(([key, value]) => `${JSON.stringify(key)}: ${value}`)
```

This alone is not enough to support parallel route slot names like `@!@#$%^&*()`, but should be well enough to support more normal file name conventions. (Even slot names with a space are supported.)

### Notes

It might be a cool idea to automatically transform kebab-case slot names to camelCase, sort of like how Nuxt does transforming for component names. If this sounds good to you, let me know and I will try to implement that.

```
app/
  @slot-name/
    ...
  layout.tsx <- { children: React.ReactNode, slotName: React.ReactNode }
```

This PR supersedes #67151 after fixing merge conflicts.