### PR TITLE
docs: fix typo in self-host after() details

### DIFF
--- a/docs/01-app/03-building-your-application/10-deploying/index.mdx
+++ b/docs/01-app/03-building-your-application/10-deploying/index.mdx
@@ -322,7 +322,7 @@ When `after` is called, Next.js will access `waitUntil` like this:
 ```jsx
 const RequestContext = globalThis[Symbol.for('@next/request-context')]
 const contextValue = RequestContext?.get()
-const waitUntil = context?.waitUntil
+const waitUntil = contextValue?.waitUntil
 ```
 
 Which means that `globalThis[Symbol.for('@next/request-context')]` is expected to contain an object like this:


### PR DESCRIPTION
fix typo
