### PR TITLE
ci: use consistent playwright-chromium version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1739,8 +1739,8 @@ importers:
         specifier: ^2.0.5
         version: 2.0.5
       playwright-chromium:
-        specifier: ^1.39.0
-        version: 1.41.2
+        specifier: 1.48.0
+        version: 1.48.0
       split2:
         specifier: ^4.2.0
         version: 4.2.0
@@ -12505,11 +12505,6 @@ packages:
 
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
-
-  playwright-chromium@1.41.2:
-    resolution: {integrity: sha512-1XoW4aGGRbS2BJLldtLcv2QW3deMv8myE5iCtfGRPq99BWqmBLJvJTgY/SyfBCoklwQvl91zUWYWHjCAuvKGkw==}
-    engines: {node: '>=16'}
-    hasBin: true
 
   playwright-chromium@1.48.0:
     resolution: {integrity: sha512-jPFKhB4+zGEcAwc+h1mTLa8L08Rb+FwGKFqd/o7mWSGyxAtwBu5R4QxSG/a8KcHbewOj4DLBUVVK2N/uKrYmiQ==}
@@ -30146,10 +30141,6 @@ snapshots:
       find-up: 3.0.0
 
   platform@1.3.6: {}
-
-  playwright-chromium@1.41.2:
-    dependencies:
-      playwright-core: 1.41.2
 
   playwright-chromium@1.48.0:
     dependencies:

--- a/turbopack/packages/devlow-bench/package.json
+++ b/turbopack/packages/devlow-bench/package.json
@@ -48,7 +48,7 @@
     "minimist": "^1.2.8",
     "picocolors": "1.0.1",
     "pidusage-tree": "^2.0.5",
-    "playwright-chromium": "^1.39.0",
+    "playwright-chromium": "1.48.0",
     "split2": "^4.2.0",
     "tree-kill": "^1.2.2"
   }


### PR DESCRIPTION
Fixes failing devlow jobs. 

x-ref: https://github.com/vercel/next.js/actions/runs/12458537348/job/34774816138