### PR TITLE
Fixed typo in documentation

### DIFF
--- a/docs/01-app/03-building-your-application/11-upgrading/06-from-create-react-app.mdx
+++ b/docs/01-app/03-building-your-application/11-upgrading/06-from-create-react-app.mdx
@@ -64,7 +64,7 @@ Create a `next.config.mjs` at the root of your project. This file will hold your
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export', // Outputs a Single-Page Application (SPA).
-  distDir: './build', // Changes the build output directory to `./dist`.
+  distDir: './build', // Changes the build output directory to `./build`.
 }
 
 export default nextConfig


### PR DESCRIPTION
There is a bug in the documentation.  The code sample sets the `distDir `to `'./build'`, but the comment says `'./dist'`.
