### PR TITLE
Fix `use server` diagnostics for type exports

### DIFF
--- a/packages/next/src/server/typescript/rules/server-boundary.ts
+++ b/packages/next/src/server/typescript/rules/server-boundary.ts
@@ -67,7 +67,7 @@ const serverBoundary = {
     if (!node.isTypeOnly && exportClause && ts.isNamedExports(exportClause)) {
       for (const e of exportClause.elements) {
         if (e.isTypeOnly) {
-          continue;
+          continue
         }
         if (!isFunctionReturningPromise(e, typeChecker, ts)) {
           diagnostics.push({

--- a/packages/next/src/server/typescript/rules/server-boundary.ts
+++ b/packages/next/src/server/typescript/rules/server-boundary.ts
@@ -64,8 +64,11 @@ const serverBoundary = {
     const diagnostics: tsModule.Diagnostic[] = []
 
     const exportClause = node.exportClause
-    if (exportClause && ts.isNamedExports(exportClause)) {
+    if (!node.isTypeOnly && exportClause && ts.isNamedExports(exportClause)) {
       for (const e of exportClause.elements) {
+        if (e.isTypeOnly) {
+          continue;
+        }
         if (!isFunctionReturningPromise(e, typeChecker, ts)) {
           diagnostics.push({
             file: source,


### PR DESCRIPTION
### What?

NextJS should not throw `The "use server" file can only export async functions.` for type exports.

### Why?

Because type exports are just a compile time abstraction.