### PR TITLE
refactor: error boundary rendering in app-render

### DIFF
--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -209,12 +209,6 @@ async function createComponentTreeInternal({
           injectedJS: injectedJSWithCurrentLayout,
         })
       : []
-  const forbiddenElement = Forbidden ? (
-    <>
-      {forbiddenStyles}
-      <Forbidden />
-    </>
-  ) : undefined
 
   const [Unauthorized, unauthorizedStyles] =
     authInterrupts && unauthorized
@@ -226,6 +220,21 @@ async function createComponentTreeInternal({
           injectedJS: injectedJSWithCurrentLayout,
         })
       : []
+
+  const notFoundElement = NotFound ? (
+    <>
+      {notFoundStyles}
+      <NotFound />
+    </>
+  ) : undefined
+
+  const forbiddenElement = Forbidden ? (
+    <>
+      {forbiddenStyles}
+      <Forbidden />
+    </>
+  ) : undefined
+
   const unauthorizedElement = Unauthorized ? (
     <>
       {unauthorizedStyles}
@@ -411,13 +420,9 @@ async function createComponentTreeInternal({
         const isChildrenRouteKey = parallelRouteKey === 'children'
         const parallelRoute = parallelRoutes[parallelRouteKey]
 
-        const notFoundComponent =
-          NotFound && isChildrenRouteKey ? (
-            <>
-              {notFoundStyles}
-              <NotFound />
-            </>
-          ) : undefined
+        const notFoundComponent = isChildrenRouteKey
+          ? notFoundElement
+          : undefined
 
         const forbiddenComponent = isChildrenRouteKey
           ? forbiddenElement
@@ -709,56 +714,30 @@ async function createComponentTreeInternal({
         // but it's not ideal, as it needlessly invokes the `NotFound` component and renders the `RootLayout` twice.
         // We should instead look into handling the fallback behavior differently in development mode so that it doesn't
         // rely on the `NotFound` behavior.
-        if (NotFound) {
-          const notFoundParallelRouteProps = {
-            children: (
-              <>
-                {notFoundStyles}
-                <NotFound />
-              </>
-            ),
-          }
-          notfoundClientSegment = (
-            <>
-              {layerAssets}
-              <ClientSegmentRoot
-                Component={SegmentComponent}
-                slots={notFoundParallelRouteProps}
-                params={currentParams}
-              />
-            </>
-          )
-        }
-        if (Forbidden) {
-          const forbiddenParallelRouteProps = {
-            children: forbiddenElement,
-          }
-          forbiddenClientSegment = (
-            <>
-              {layerAssets}
-              <ClientSegmentRoot
-                Component={SegmentComponent}
-                slots={forbiddenParallelRouteProps}
-                params={currentParams}
-              />
-            </>
-          )
-        }
-        if (Unauthorized) {
-          const unauthorizedParallelRouteProps = {
-            children: unauthorizedElement,
-          }
-          unauthorizedClientSegment = (
-            <>
-              {layerAssets}
-              <ClientSegmentRoot
-                Component={SegmentComponent}
-                slots={unauthorizedParallelRouteProps}
-                params={currentParams}
-              />
-            </>
-          )
-        }
+        notfoundClientSegment = createErrorBoundaryClientSegmentRoot({
+          ErrorBoundaryComponent: NotFound,
+          errorElement: notFoundElement,
+          ClientSegmentRoot,
+          layerAssets,
+          SegmentComponent,
+          currentParams,
+        })
+        forbiddenClientSegment = createErrorBoundaryClientSegmentRoot({
+          ErrorBoundaryComponent: Forbidden,
+          errorElement: forbiddenElement,
+          ClientSegmentRoot,
+          layerAssets,
+          SegmentComponent,
+          currentParams,
+        })
+        unauthorizedClientSegment = createErrorBoundaryClientSegmentRoot({
+          ErrorBoundaryComponent: Unauthorized,
+          errorElement: unauthorizedElement,
+          ClientSegmentRoot,
+          layerAssets,
+          SegmentComponent,
+          currentParams,
+        })
         if (
           notfoundClientSegment ||
           forbiddenClientSegment ||
@@ -861,3 +840,36 @@ async function MetadataOutlet({
   return null
 }
 MetadataOutlet.displayName = OUTLET_BOUNDARY_NAME
+
+function createErrorBoundaryClientSegmentRoot({
+  ErrorBoundaryComponent,
+  errorElement,
+  ClientSegmentRoot,
+  layerAssets,
+  SegmentComponent,
+  currentParams,
+}: {
+  ErrorBoundaryComponent: React.ComponentType<any> | undefined
+  errorElement: React.ReactNode
+  ClientSegmentRoot: React.ComponentType<any>
+  layerAssets: React.ReactNode
+  SegmentComponent: React.ComponentType<any>
+  currentParams: Params
+}) {
+  if (ErrorBoundaryComponent) {
+    const notFoundParallelRouteProps = {
+      children: errorElement,
+    }
+    return (
+      <>
+        {layerAssets}
+        <ClientSegmentRoot
+          Component={SegmentComponent}
+          slots={notFoundParallelRouteProps}
+          params={currentParams}
+        />
+      </>
+    )
+  }
+  return null
+}


### PR DESCRIPTION
### What

While moving the metadata along to the page component, we also need to render the metadata into the error boundary when page is not displayed but the error boundary fallback itself. Noticed some places can be simplified and encapsulated as shared functions. This will make it easier to inject the rendered metadata there later. 

* Organize the initial creation of error components
* Create another helper for rendering client segement root of all error boundaries


This PR is not strictly in the metadata dependency PR paths, so I filed a separate PR to refactor the app-render