### PR TITLE
[metadata] Move metadata rendering adjacent to page component

### DIFF
--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -700,8 +700,10 @@ function createPendingCacheNode(
     rsc: createDeferredRsc() as React.ReactNode,
     head: isLeafSegment
       ? [
+          // TODO: change head back to ReactNode when metadata
+          // is stably rendered in body
           createDeferredRsc() as React.ReactNode,
-          createDeferredRsc() as React.ReactNode,
+          null,
         ]
       : [null, null],
   }
@@ -805,12 +807,11 @@ function finishPendingCacheNode(
   // a pending promise that needs to be resolved with the dynamic head from
   // the server.
   const head = cacheNode.head
-  // Handle head[0] - viewport and head[1] - metadata
+  // TODO: change head back to ReactNode when metadata
+  // is stably rendered in body
+  // Handle head[0] - viewport
   if (isDeferredRsc(head[0])) {
     head[0].resolve(dynamicHead[0])
-  }
-  if (isDeferredRsc(head[1])) {
-    head[1].resolve(dynamicHead[1])
   }
 }
 

--- a/packages/next/src/lib/metadata/generate/basic.tsx
+++ b/packages/next/src/lib/metadata/generate/basic.tsx
@@ -31,6 +31,7 @@ function resolveViewportLayout(viewport: Viewport) {
 
 export function ViewportMeta({ viewport }: { viewport: ResolvedViewport }) {
   return MetaFilter([
+    <meta charSet="utf-8" />,
     Meta({ name: 'viewport', content: resolveViewportLayout(viewport) }),
     ...(viewport.themeColor
       ? viewport.themeColor.map((themeColor) =>
@@ -51,7 +52,6 @@ export function BasicMeta({ metadata }: { metadata: ResolvedMetadata }) {
     : undefined
 
   return MetaFilter([
-    <meta charSet="utf-8" />,
     metadata.title !== null && metadata.title.absolute ? (
       <title>{metadata.title.absolute}</title>
     ) : null,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -481,10 +481,7 @@ async function generateDynamicRSCPayload(
             {/* Adding requestId as react key to make metadata remount for each render */}
             <ViewportTree key={requestId} />
           </React.Fragment>,
-          <React.Fragment key={flightDataPathMetadataKey}>
-            {/* Adding requestId as react key to make metadata remount for each render */}
-            <MetadataTree key={requestId} />
-          </React.Fragment>,
+          null,
         ],
         injectedCSS: new Set(),
         injectedJS: new Set(),
@@ -493,6 +490,14 @@ async function generateDynamicRSCPayload(
         getViewportReady,
         getMetadataReady,
         preloadCallbacks,
+        MetadataTree: () => {
+          return (
+            <React.Fragment key={flightDataPathMetadataKey}>
+              {/* Adding requestId as react key to make metadata remount for each render */}
+              <MetadataTree key={requestId} />
+            </React.Fragment>
+          )
+        },
       })
     ).map((path) => path.slice(1)) // remove the '' (root) segment
   }
@@ -779,6 +784,7 @@ async function getRSCPayload(
     missingSlots,
     preloadCallbacks,
     authInterrupts: ctx.renderOpts.experimental.authInterrupts,
+    MetadataTree,
   })
 
   // When the `vary` response header is present with `Next-URL`, that means there's a chance
@@ -788,12 +794,13 @@ async function getRSCPayload(
   const couldBeIntercepted =
     typeof varyHeader === 'string' && varyHeader.includes(NEXT_URL)
 
-  const initialHeadMetadata = (
-    <React.Fragment key={flightDataPathMetadataKey}>
-      {/* Adding requestId as react key to make metadata remount for each render */}
-      <MetadataTree key={ctx.requestId} />
-    </React.Fragment>
-  )
+  const initialHeadMetadata = null
+  //  (
+  //   <React.Fragment key={flightDataPathMetadataKey}>
+  //     {/* Adding requestId as react key to make metadata remount for each render */}
+  //     <MetadataTree key={ctx.requestId} />
+  //   </React.Fragment>
+  // )
 
   const initialHeadViewport = (
     <React.Fragment key={flightDataPathViewportKey}>
@@ -886,12 +893,13 @@ async function getErrorRSCPayload(
     ViewportBoundary,
   })
 
-  const initialHeadMetadata = (
-    <React.Fragment key={flightDataPathMetadataKey}>
-      {/* Adding requestId as react key to make metadata remount for each render */}
-      <MetadataTree key={requestId} />
-    </React.Fragment>
-  )
+  const initialHeadMetadata = null
+  // (
+  //   <React.Fragment key={flightDataPathMetadataKey}>
+  //     {/* Adding requestId as react key to make metadata remount for each render */}
+  //     <MetadataTree key={requestId} />
+  //   </React.Fragment>
+  // )
   const initialHeadViewport = (
     <React.Fragment key={flightDataPathViewportKey}>
       <NonIndex ctx={ctx} />
@@ -914,8 +922,13 @@ async function getErrorRSCPayload(
   const initialSeedData: CacheNodeSeedData = [
     initialTree[0],
     <html id="__next_error__">
-      <head></head>
-      <body></body>
+      <head>
+        <React.Fragment key={flightDataPathMetadataKey}>
+          {/* Adding requestId as react key to make metadata remount for each render */}
+          <MetadataTree key={requestId} />
+        </React.Fragment>
+      </head>
+      <body />
     </html>,
     {},
     null,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -777,8 +777,8 @@ async function getRSCPayload(
   function MetadataComponent() {
     return (
       <React.Fragment key={flightDataPathMetadataKey}>
-        {/* Adding requestId as react key to make metadata remount for each render */}
-        <MetadataTree key={ctx.requestId} />
+        {/* Not add requestId as react key to ensure segment prefetch could result consistently if nothing changed */}
+        <MetadataTree />
       </React.Fragment>
     )
   }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -718,6 +718,7 @@ async function getRSCPayload(
   ctx: AppRenderContext,
   is404: boolean
 ): Promise<InitialRSCPayload & { P: React.ReactNode }> {
+  console.log('getRSCPayload')
   const injectedCSS = new Set<string>()
   const injectedJS = new Set<string>()
   const injectedFontPreloadTags = new Set<string>()
@@ -794,13 +795,13 @@ async function getRSCPayload(
   const couldBeIntercepted =
     typeof varyHeader === 'string' && varyHeader.includes(NEXT_URL)
 
-  const initialHeadMetadata = null
-  //  (
-  //   <React.Fragment key={flightDataPathMetadataKey}>
-  //     {/* Adding requestId as react key to make metadata remount for each render */}
-  //     <MetadataTree key={ctx.requestId} />
-  //   </React.Fragment>
-  // )
+  const initialHeadMetadata = 
+   (
+    <React.Fragment key={flightDataPathMetadataKey}>
+      {/* Adding requestId as react key to make metadata remount for each render */}
+      <MetadataTree key={ctx.requestId} />
+    </React.Fragment>
+  )
 
   const initialHeadViewport = (
     <React.Fragment key={flightDataPathViewportKey}>
@@ -860,6 +861,7 @@ async function getErrorRSCPayload(
   ctx: AppRenderContext,
   errorType: MetadataErrorType | 'redirect' | undefined
 ) {
+  console.log('getErrorRSCPayload')
   const {
     getDynamicParamFromSegment,
     query,
@@ -900,6 +902,7 @@ async function getErrorRSCPayload(
   //     <MetadataTree key={requestId} />
   //   </React.Fragment>
   // )
+  
   const initialHeadViewport = (
     <React.Fragment key={flightDataPathViewportKey}>
       <NonIndex ctx={ctx} />
@@ -923,10 +926,6 @@ async function getErrorRSCPayload(
     initialTree[0],
     <html id="__next_error__">
       <head>
-        <React.Fragment key={flightDataPathMetadataKey}>
-          {/* Adding requestId as react key to make metadata remount for each render */}
-          <MetadataTree key={requestId} />
-        </React.Fragment>
       </head>
       <body />
     </html>,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -467,6 +467,16 @@ async function generateDynamicRSCPayload(
         MetadataBoundary,
         ViewportBoundary,
       })
+
+    const MetadataComponent = () => {
+      return (
+        <React.Fragment key={flightDataPathMetadataKey}>
+          {/* Adding requestId as react key to make metadata remount for each render */}
+          <MetadataTree key={requestId} />
+        </React.Fragment>
+      )
+    }
+
     flightData = (
       await walkTreeWithFlightRouterState({
         ctx,
@@ -490,14 +500,7 @@ async function generateDynamicRSCPayload(
         getViewportReady,
         getMetadataReady,
         preloadCallbacks,
-        MetadataComponent: () => {
-          return (
-            <React.Fragment key={flightDataPathMetadataKey}>
-              {/* Adding requestId as react key to make metadata remount for each render */}
-              <MetadataTree key={requestId} />
-            </React.Fragment>
-          )
-        },
+        MetadataComponent,
       })
     ).map((path) => path.slice(1)) // remove the '' (root) segment
   }
@@ -771,6 +774,15 @@ async function getRSCPayload(
 
   const preloadCallbacks: PreloadCallbacks = []
 
+  function MetadataComponent() {
+    return (
+      <React.Fragment key={flightDataPathMetadataKey}>
+        {/* Adding requestId as react key to make metadata remount for each render */}
+        <MetadataTree key={ctx.requestId} />
+      </React.Fragment>
+    )
+  }
+
   const seedData = await createComponentTree({
     ctx,
     loaderTree: tree,
@@ -784,12 +796,7 @@ async function getRSCPayload(
     missingSlots,
     preloadCallbacks,
     authInterrupts: ctx.renderOpts.experimental.authInterrupts,
-    MetadataComponent: () => (
-      <React.Fragment key={flightDataPathMetadataKey}>
-        {/* Adding requestId as react key to make metadata remount for each render */}
-        <MetadataTree key={ctx.requestId} />
-      </React.Fragment>
-    ),
+    MetadataComponent,
   })
 
   // When the `vary` response header is present with `Next-URL`, that means there's a chance
@@ -919,10 +926,8 @@ async function getErrorRSCPayload(
   const seedData: CacheNodeSeedData = [
     initialTree[0],
     <>
-      {/* Place metadata in root and let React Float manages to reposition it properly */}
-      {initialHeadMetadata}
       <html id="__next_error__">
-        <head />
+        <head>{initialHeadMetadata}</head>
         <body />
       </html>
     </>,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -490,7 +490,7 @@ async function generateDynamicRSCPayload(
         getViewportReady,
         getMetadataReady,
         preloadCallbacks,
-        MetadataTree: () => {
+        MetadataComponent: () => {
           return (
             <React.Fragment key={flightDataPathMetadataKey}>
               {/* Adding requestId as react key to make metadata remount for each render */}
@@ -718,7 +718,6 @@ async function getRSCPayload(
   ctx: AppRenderContext,
   is404: boolean
 ): Promise<InitialRSCPayload & { P: React.ReactNode }> {
-  console.log('getRSCPayload')
   const injectedCSS = new Set<string>()
   const injectedJS = new Set<string>()
   const injectedFontPreloadTags = new Set<string>()
@@ -785,7 +784,7 @@ async function getRSCPayload(
     missingSlots,
     preloadCallbacks,
     authInterrupts: ctx.renderOpts.experimental.authInterrupts,
-    MetadataTree,
+    MetadataComponent: MetadataTree,
   })
 
   // When the `vary` response header is present with `Next-URL`, that means there's a chance
@@ -795,13 +794,13 @@ async function getRSCPayload(
   const couldBeIntercepted =
     typeof varyHeader === 'string' && varyHeader.includes(NEXT_URL)
 
-  const initialHeadMetadata = 
-   (
-    <React.Fragment key={flightDataPathMetadataKey}>
-      {/* Adding requestId as react key to make metadata remount for each render */}
-      <MetadataTree key={ctx.requestId} />
-    </React.Fragment>
-  )
+  const initialHeadMetadata = null
+  //  (
+  //   <React.Fragment key={flightDataPathMetadataKey}>
+  //     {/* Adding requestId as react key to make metadata remount for each render */}
+  //     <MetadataTree key={ctx.requestId} />
+  //   </React.Fragment>
+  // )
 
   const initialHeadViewport = (
     <React.Fragment key={flightDataPathViewportKey}>
@@ -950,7 +949,7 @@ async function getErrorRSCPayload(
       [
         initialTree,
         initialSeedData,
-        [initialHeadViewport, initialHeadMetadata],
+        [initialHeadViewport, null],
         isPossiblyPartialHead,
       ] as FlightDataPath,
     ],

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -925,12 +925,10 @@ async function getErrorRSCPayload(
   // so we create a not found page with AppRouter
   const seedData: CacheNodeSeedData = [
     initialTree[0],
-    <>
-      <html id="__next_error__">
-        <head>{initialHeadMetadata}</head>
-        <body />
-      </html>
-    </>,
+    <html id="__next_error__">
+      <head>{initialHeadMetadata}</head>
+      <body />
+    </html>,
     {},
     null,
     false,

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -225,27 +225,6 @@ async function createComponentTreeInternal({
         })
       : []
 
-  const notFoundElement = NotFound ? (
-    <>
-      {notFoundStyles}
-      <NotFound />
-    </>
-  ) : undefined
-
-  const forbiddenElement = Forbidden ? (
-    <>
-      {forbiddenStyles}
-      <Forbidden />
-    </>
-  ) : undefined
-
-  const unauthorizedElement = Unauthorized ? (
-    <>
-      {unauthorizedStyles}
-      <Unauthorized />
-    </>
-  ) : undefined
-
   let dynamic = layoutOrPageMod?.dynamic
 
   if (nextConfigOutput === 'export') {
@@ -417,7 +396,31 @@ async function createComponentTreeInternal({
   // as it's used as a placeholder for navigation.
   const metadata =
     actualSegment !== DEFAULT_SEGMENT_KEY ? <MetadataComponent /> : undefined
-  //
+
+  const notFoundElement = NotFound ? (
+    <>
+      {metadata}
+      {notFoundStyles}
+      <NotFound />
+    </>
+  ) : undefined
+
+  const forbiddenElement = Forbidden ? (
+    <>
+      {metadata}
+      {forbiddenStyles}
+      <Forbidden />
+    </>
+  ) : undefined
+
+  const unauthorizedElement = Unauthorized ? (
+    <>
+      {metadata}
+      {unauthorizedStyles}
+      <Unauthorized />
+    </>
+  ) : undefined
+
   // TODO: Combine this `map` traversal with the loop below that turns the array
   // into an object.
   const parallelRouteMap = await Promise.all(
@@ -428,26 +431,17 @@ async function createComponentTreeInternal({
         const isChildrenRouteKey = parallelRouteKey === 'children'
         const parallelRoute = parallelRoutes[parallelRouteKey]
 
-        const notFoundComponent = isChildrenRouteKey ? (
-          <>
-            {metadata}
-            {notFoundElement}
-          </>
-        ) : undefined
+        const notFoundComponent = isChildrenRouteKey
+          ? notFoundElement
+          : undefined
 
-        const forbiddenComponent = isChildrenRouteKey ? (
-          <>
-            {metadata}
-            {forbiddenElement}
-          </>
-        ) : undefined
+        const forbiddenComponent = isChildrenRouteKey
+          ? forbiddenElement
+          : undefined
 
-        const unauthorizedComponent = isChildrenRouteKey ? (
-          <>
-            {metadata}
-            {unauthorizedElement}
-          </>
-        ) : undefined
+        const unauthorizedComponent = isChildrenRouteKey
+          ? unauthorizedElement
+          : undefined
 
         // if we're prefetching and that there's a Loading component, we bail out
         // otherwise we keep rendering for the prefetch.
@@ -740,7 +734,6 @@ async function createComponentTreeInternal({
           layerAssets,
           SegmentComponent,
           currentParams,
-          metadata,
         })
         forbiddenClientSegment = createErrorBoundaryClientSegmentRoot({
           ErrorBoundaryComponent: Forbidden,
@@ -749,7 +742,6 @@ async function createComponentTreeInternal({
           layerAssets,
           SegmentComponent,
           currentParams,
-          metadata,
         })
         unauthorizedClientSegment = createErrorBoundaryClientSegmentRoot({
           ErrorBoundaryComponent: Unauthorized,
@@ -758,7 +750,6 @@ async function createComponentTreeInternal({
           layerAssets,
           SegmentComponent,
           currentParams,
-          metadata,
         })
         if (
           notfoundClientSegment ||
@@ -779,7 +770,6 @@ async function createComponentTreeInternal({
         } else {
           segmentNode = (
             <React.Fragment key={cacheNodeKey}>
-              {metadata}
               {layerAssets}
               {clientSegment}
             </React.Fragment>
@@ -788,7 +778,6 @@ async function createComponentTreeInternal({
       } else {
         segmentNode = (
           <React.Fragment key={cacheNodeKey}>
-            {metadata}
             {layerAssets}
             {clientSegment}
           </React.Fragment>
@@ -873,7 +862,6 @@ function createErrorBoundaryClientSegmentRoot({
   layerAssets,
   SegmentComponent,
   currentParams,
-  metadata,
 }: {
   ErrorBoundaryComponent: React.ComponentType<any> | undefined
   errorElement: React.ReactNode
@@ -881,16 +869,10 @@ function createErrorBoundaryClientSegmentRoot({
   layerAssets: React.ReactNode
   SegmentComponent: React.ComponentType<any>
   currentParams: Params
-  metadata: React.ReactNode
 }) {
   if (ErrorBoundaryComponent) {
     const notFoundParallelRouteProps = {
-      children: (
-        <>
-          {metadata}
-          {errorElement}
-        </>
-      ),
+      children: errorElement,
     }
     return (
       <>

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -35,7 +35,7 @@ export function createComponentTree(props: {
   missingSlots?: Set<string>
   preloadCallbacks: PreloadCallbacks
   authInterrupts: boolean
-  MetadataTree: React.ComponentType<{}>
+  MetadataComponent: React.ComponentType<{}>
 }): Promise<CacheNodeSeedData> {
   return getTracer().trace(
     NextNodeServerSpan.createComponentTree,
@@ -71,7 +71,7 @@ async function createComponentTreeInternal({
   missingSlots,
   preloadCallbacks,
   authInterrupts,
-  MetadataTree,
+  MetadataComponent,
 }: {
   loaderTree: LoaderTree
   parentParams: Params
@@ -85,7 +85,7 @@ async function createComponentTreeInternal({
   missingSlots?: Set<string>
   preloadCallbacks: PreloadCallbacks
   authInterrupts: boolean
-  MetadataTree: React.ComponentType<{}>
+  MetadataComponent: React.ComponentType<{}>
 }): Promise<CacheNodeSeedData> {
   const {
     renderOpts: { nextConfigOutput, experimental },
@@ -508,7 +508,7 @@ async function createComponentTreeInternal({
             missingSlots,
             preloadCallbacks,
             authInterrupts,
-            MetadataTree,
+            MetadataComponent: MetadataComponent,
           })
 
           childCacheNodeSeedData = seedData
@@ -603,7 +603,7 @@ async function createComponentTreeInternal({
   }
 
   const isClientComponent = isClientReference(layoutOrPageMod)
-  const metadata = <MetadataTree />
+  const metadata = <MetadataComponent />
 
   if (
     process.env.NODE_ENV === 'development' &&
@@ -662,7 +662,7 @@ async function createComponentTreeInternal({
     return [
       actualSegment,
       <React.Fragment key={cacheNodeKey}>
-        {metadata}
+        {/* {metadata} */}
         {pageElement}
         {layerAssets}
         <OutletBoundary>

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -35,6 +35,7 @@ export function createComponentTree(props: {
   missingSlots?: Set<string>
   preloadCallbacks: PreloadCallbacks
   authInterrupts: boolean
+  MetadataTree: React.ComponentType<{}>
 }): Promise<CacheNodeSeedData> {
   return getTracer().trace(
     NextNodeServerSpan.createComponentTree,
@@ -70,6 +71,7 @@ async function createComponentTreeInternal({
   missingSlots,
   preloadCallbacks,
   authInterrupts,
+  MetadataTree,
 }: {
   loaderTree: LoaderTree
   parentParams: Params
@@ -83,6 +85,7 @@ async function createComponentTreeInternal({
   missingSlots?: Set<string>
   preloadCallbacks: PreloadCallbacks
   authInterrupts: boolean
+  MetadataTree: React.ComponentType<{}>
 }): Promise<CacheNodeSeedData> {
   const {
     renderOpts: { nextConfigOutput, experimental },
@@ -504,7 +507,8 @@ async function createComponentTreeInternal({
             ctx,
             missingSlots,
             preloadCallbacks,
-            authInterrupts: authInterrupts,
+            authInterrupts,
+            MetadataTree,
           })
 
           childCacheNodeSeedData = seedData
@@ -657,6 +661,7 @@ async function createComponentTreeInternal({
     return [
       actualSegment,
       <React.Fragment key={cacheNodeKey}>
+        <MetadataTree />
         {pageElement}
         {layerAssets}
         <OutletBoundary>

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -603,6 +603,7 @@ async function createComponentTreeInternal({
   }
 
   const isClientComponent = isClientReference(layoutOrPageMod)
+  const metadata = <MetadataTree />
 
   if (
     process.env.NODE_ENV === 'development' &&
@@ -661,7 +662,7 @@ async function createComponentTreeInternal({
     return [
       actualSegment,
       <React.Fragment key={cacheNodeKey}>
-        <MetadataTree />
+        {metadata}
         {pageElement}
         {layerAssets}
         <OutletBoundary>

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -40,6 +40,7 @@ export async function walkTreeWithFlightRouterState({
   getMetadataReady,
   ctx,
   preloadCallbacks,
+  MetadataTree,
 }: {
   loaderTreeToFilter: LoaderTree
   parentParams: { [key: string]: string | string[] }
@@ -54,6 +55,7 @@ export async function walkTreeWithFlightRouterState({
   getViewportReady: () => Promise<void>
   ctx: AppRenderContext
   preloadCallbacks: PreloadCallbacks
+  MetadataTree: React.ComponentType<{}>
 }): Promise<FlightDataPath[]> {
   const {
     renderOpts: { nextFontManifest, experimental },
@@ -202,6 +204,7 @@ export async function walkTreeWithFlightRouterState({
         getMetadataReady,
         preloadCallbacks,
         authInterrupts: experimental.authInterrupts,
+        MetadataTree,
       }
     )
 
@@ -261,6 +264,7 @@ export async function walkTreeWithFlightRouterState({
       getViewportReady,
       getMetadataReady,
       preloadCallbacks,
+      MetadataTree,
     })
 
     for (const subPath of subPaths) {

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -204,7 +204,7 @@ export async function walkTreeWithFlightRouterState({
         getMetadataReady,
         preloadCallbacks,
         authInterrupts: experimental.authInterrupts,
-        MetadataComponent: MetadataComponent,
+        MetadataComponent,
       }
     )
 
@@ -264,7 +264,7 @@ export async function walkTreeWithFlightRouterState({
       getViewportReady,
       getMetadataReady,
       preloadCallbacks,
-      MetadataComponent: MetadataComponent,
+      MetadataComponent,
     })
 
     for (const subPath of subPaths) {

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -40,7 +40,7 @@ export async function walkTreeWithFlightRouterState({
   getMetadataReady,
   ctx,
   preloadCallbacks,
-  MetadataTree,
+  MetadataComponent,
 }: {
   loaderTreeToFilter: LoaderTree
   parentParams: { [key: string]: string | string[] }
@@ -55,7 +55,7 @@ export async function walkTreeWithFlightRouterState({
   getViewportReady: () => Promise<void>
   ctx: AppRenderContext
   preloadCallbacks: PreloadCallbacks
-  MetadataTree: React.ComponentType<{}>
+  MetadataComponent: React.ComponentType<{}>
 }): Promise<FlightDataPath[]> {
   const {
     renderOpts: { nextFontManifest, experimental },
@@ -204,7 +204,7 @@ export async function walkTreeWithFlightRouterState({
         getMetadataReady,
         preloadCallbacks,
         authInterrupts: experimental.authInterrupts,
-        MetadataTree,
+        MetadataComponent: MetadataComponent,
       }
     )
 
@@ -264,7 +264,7 @@ export async function walkTreeWithFlightRouterState({
       getViewportReady,
       getMetadataReady,
       preloadCallbacks,
-      MetadataTree,
+      MetadataComponent: MetadataComponent,
     })
 
     for (const subPath of subPaths) {

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -439,6 +439,7 @@ describe('Error overlay for hydration errors in App router', () => {
                        <RedirectBoundary>
                          <RedirectErrorBoundary router={{...}}>
                            <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                             <__next_metadata_boundary__>
                              <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
                                <Page params={Promise} searchParams={Promise}>
      >                           <table>
@@ -894,18 +895,19 @@ describe('Error overlay for hydration errors in App router', () => {
            <RedirectBoundary>
              <RedirectErrorBoundary router={{...}}>
                <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
-                 <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
-                   <Page params={Promise} searchParams={Promise}>
-                     <div>
+                 <__next_metadata_boundary__>
+                   <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                     <Page params={Promise} searchParams={Promise}>
                        <div>
                          <div>
                            <div>
-                             <Mismatch>
-                               <p>
-                                 <span>
-                                   ...
-       +                            client
-       -                            server"
+                             <div>
+                               <Mismatch>
+                                 <p>
+                                   <span>
+                                     ...
+       +                              client
+       -                              server"
       `)
     } else {
       expect(fullPseudoHtml).toMatchInlineSnapshot(`
@@ -914,18 +916,19 @@ describe('Error overlay for hydration errors in App router', () => {
            <RedirectBoundary>
              <RedirectErrorBoundary router={{...}}>
                <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
-                 <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
-                   <Page params={Promise} searchParams={Promise}>
-                     <div>
+                 <__next_metadata_boundary__>
+                   <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                     <Page params={Promise} searchParams={Promise}>
                        <div>
                          <div>
                            <div>
-                             <Mismatch>
-                               <p>
-                                 <span>
-                                   ...
-       +                            client
-       -                            server"
+                             <div>
+                               <Mismatch>
+                                 <p>
+                                   <span>
+                                     ...
+       +                              client
+       -                              server"
       `)
     }
   })


### PR DESCRIPTION
### What

This work prepares for streaming metadata by moving metadata from the top-level head component into the body, rendering it just before and adjacent to the page component. In the future, we’ll wrap it with a suspense boundary, depending on whether the request's user agent supports streaming rendering.

### Minor Changes

* Move `charset` into viewport at early top as according to spec: `<meta> elements which declare a character encoding must be located entirely within the first 1024 bytes of the document.`
* Replace the previous `metadata` data in the `HeadData` to null. It will be changed back to single `ReactNode` later in #74299


