### PR TITLE
fix: remove manifest retries in production builds

### DIFF
--- a/packages/next/src/server/load-components.ts
+++ b/packages/next/src/server/load-components.ts
@@ -176,7 +176,7 @@ async function loadComponentsImpl<N = any>({
   // that can occur while app and pages are compiling at the same time, and the
   // build-manifest is still being written to disk while an app path is
   // attempting to load.
-  const manifestLoadAttempts = isDev ? 3 : 1
+  const manifestLoadAttempts = isDev ? 3 : 0
 
   let reactLoadableManifestPath
   if (!process.env.TURBOPACK) {


### PR DESCRIPTION
- Next.js might retry reading a manifest it needs for rendering the page in dev because the compiler might not have outputted that particular manifest to the disk
- this behaviour is not really needed in production because the manifests has to be outputted beforehand 
- however in particular cases, Next.js might try to read a non-existent path, leading to wasteful retries
- this PR just removes that single retry because there's no reason to have it
- this PR does not fix the underlying bug that might cause Next.js to read that path, but we'll be fixing this in a separate PR

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
