### PR TITLE
chore(github): update comments stale period

### DIFF
--- a/.github/comments/invalid-reproduction.md
+++ b/.github/comments/invalid-reproduction.md
@@ -16,7 +16,7 @@ Ensure the link is pointing to a codebase that is accessible (e.g. not a private
 
 ### What happens if I don't provide a sufficient minimal reproduction?
 
-Issues with the `please add a complete reproduction` label that receives no meaningful activity (e.g. new comments with a reproduction link) are automatically closed and locked after 30 days.
+Issues with the `please add a complete reproduction` label that receives no meaningful activity (e.g. new comments with a reproduction link) are automatically closed and locked after **2** days.
 
 If your issue has _not_ been resolved in that time and it has been closed/locked, please open a new issue with the required reproduction.
 

--- a/.github/comments/simplify-reproduction.md
+++ b/.github/comments/simplify-reproduction.md
@@ -21,7 +21,7 @@ If you cannot create a clean reproduction, another way you can help the maintain
 
 ### What happens if I don't provide a sufficient minimal reproduction?
 
-Issues with the `please simplify reproduction` label that receive no meaningful activity (e.g. new comments with a simplified reproduction link) are automatically closed and locked after 30 days.
+Issues with the `please simplify reproduction` label that receive no meaningful activity (e.g. new comments with a simplified reproduction link) are automatically closed and locked after **14** days.
 
 If your issue has _not_ been resolved in that time and it has been closed/locked, please open a new issue with the required reproduction.
 

--- a/.github/comments/verify-canary.md
+++ b/.github/comments/verify-canary.md
@@ -18,7 +18,7 @@ Next.js does not backport bug fixes to older versions of Next.js. Instead, we ar
 
 ### What happens if I don't verify against the canary version of Next.js?
 
-An issue with the `please verify canary` that receives no meaningful activity (e.g. new comments that acknowledge verification against `canary`) will be automatically closed and locked after 30 days.
+An issue with the `please verify canary` that receives no meaningful activity (e.g. new comments that acknowledge verification against `canary`) will be automatically closed and locked after **14** days.
 
 If your issue has not been resolved in that time and it has been closed/locked, please open a new issue, with the required reproduction, using `next@canary`.
 


### PR DESCRIPTION
## Why?

Since we updated the stale waiting period in https://github.com/vercel/next.js/pull/73709, we need to update these comments as well.