### PR TITLE
fix(turbopack): error while compile module sass, filename mismatched with loc

### DIFF
--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -268,6 +268,7 @@ export declare function projectUpdateInfoSubscribe(
 export interface StackFrame {
   isServer: boolean
   isInternal?: boolean
+  originalFile?: string
   file: string
   line?: number
   column?: number

--- a/test/development/module-sass-error/app/global.module.scss
+++ b/test/development/module-sass-error/app/global.module.scss
@@ -1,0 +1,15 @@
+.wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background-color: #f0f0f0;
+
+  &.children {
+    :global {
+      .inner {
+        background-color: #f00;
+      }
+    }
+  }
+}

--- a/test/development/module-sass-error/app/layout.js
+++ b/test/development/module-sass-error/app/layout.js
@@ -1,0 +1,5 @@
+'use client'
+
+export default function Layout({ children }) {
+  return <>{children}</>
+}

--- a/test/development/module-sass-error/app/sass-error/page.js
+++ b/test/development/module-sass-error/app/sass-error/page.js
@@ -1,0 +1,11 @@
+'use client'
+
+import styles from '../global.module.scss'
+
+export default function Page() {
+  return (
+    <>
+      <div className={styles.wrapper}></div>
+    </>
+  )
+}

--- a/test/development/module-sass-error/index.test.ts
+++ b/test/development/module-sass-error/index.test.ts
@@ -1,0 +1,41 @@
+import { nextTestSetup } from 'e2e-utils'
+import { assertHasRedbox, getRedboxSource } from 'next-test-utils'
+
+describe('app dir - css', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    dependencies: {
+      sass: 'latest',
+    },
+  })
+
+  if (skipped) {
+    return
+  }
+
+  describe('module sass support', () => {
+    describe('error handling', () => {
+      it('should use original source points for module sass errors', async () => {
+        const browser = await next.browser('/sass-error')
+
+        await assertHasRedbox(browser)
+        const source = await getRedboxSource(browser)
+
+        expect(source).toMatchInlineSnapshot(`
+            "./app/global.module.scss:10:7
+            Parsing css source code failed
+               8 |   &.children {
+               9 |     :global {
+            > 10 |       .inner {
+                 |       ^
+              11 |         background-color: #f00;
+              12 |       }
+              13 |     }
+
+            Ambiguous CSS module class not supported at [project]/app/global.module.scss.module.css:0:122"
+          `)
+      })
+    })
+  })
+})

--- a/test/development/sass-error/index.test.ts
+++ b/test/development/sass-error/index.test.ts
@@ -26,7 +26,7 @@ describe('app dir - css', () => {
 
           // css-loader does not report an error for this case
           expect(source).toMatchInlineSnapshot(`
-            "./app/global.scss.css:45:1
+            "./app/global.scss:45:1
             Parsing css source code failed
               43 | }
               44 |

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -401,8 +401,8 @@ async fn process_content(
 
                 // We need to collect here because we need to avoid holding the lock while calling
                 // `.await` in the loop.
-                let warngins = warnings.read().unwrap().iter().cloned().collect::<Vec<_>>();
-                for err in warngins.iter() {
+                let warnings = warnings.read().unwrap().iter().cloned().collect::<Vec<_>>();
+                for err in warnings.iter() {
                     match err.kind {
                         lightningcss::error::ParserError::UnexpectedToken(_)
                         | lightningcss::error::ParserError::UnexpectedImportRule
@@ -424,7 +424,7 @@ async fn process_content(
                             };
 
                             ParsingIssue {
-                                file: fs_path_vc,
+                                file: origin.origin_path().to_resolved().await?,
                                 msg: ResolvedVc::cell(err.to_string().into()),
                                 source,
                             }


### PR DESCRIPTION
### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

AS-IS
```
./app/global.module.scss.module.css:10:7
Parsing css source code failed
       8 |   &.children {
       9 |     :global {
    > 10 |       .inner {
         |       ^
      11 |         background-color: #f00;
      12 |       }
      13 |     }
    
Ambiguous CSS module class not supported at [project]/app/global.module.scss.module.css:0:122
```

TO-BE
```
./app/global.module.scss:10:7
Parsing css source code failed
       8 |   &.children {
       9 |     :global {
    > 10 |       .inner {
         |       ^
      11 |         background-color: #f00;
      12 |       }
      13 |     }
    
    Ambiguous CSS module class not supported at [project]/app/global.module.scss.module.css:0:122
```


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

loc of error locates origin file(`global.module.scss`), but the filename is already renamed module css file.

### How?

I replaced reported `FileSystemPath` to new `FileSystemPath` without extension.
for the sass files, origin file path already renamed in rules from `maybe_add_sass_loader`.
But i'm not sure it's right way to fix the problem.