### PR TITLE
Document image optimization's fallback to JPEG

### DIFF
--- a/docs/01-app/04-api-reference/02-components/image.mdx
+++ b/docs/01-app/04-api-reference/02-components/image.mdx
@@ -685,7 +685,7 @@ module.exports = {
 
 The default [Image Optimization API](#loader) will automatically detect the browser's supported image formats via the request's `Accept` header in order to determine the best output format.
 
-If the `Accept` header matches more than one of the configured formats, the first match in the array is used. Therefore, the array order matters. If there is no match (or the source image is [animated](#animated-images)), the Image Optimization API will fallback to the original image's format.
+If the `Accept` header matches more than one of the configured formats, the first match in the array is used. Therefore, the array order matters. If there is no match (or the source image is [animated](#animated-images)), the Image Optimization API will fallback to the original image's format. If the original format of the fallback image is `webp` or `avif` and the `Accept` header does not match, the Optimization API will downlevel the image to JPEG.
 
 If no configuration is provided, the default below is used.
 


### PR DESCRIPTION
### What?

Documents the behavior added in https://github.com/vercel/next.js/pull/35190 for the Image Optimization API's behavior when the source image is webp or AVIF and the browser does not support the image.

### Why?

I want to migrate my project to store our files as AVIF. I was worried by Next.js's documentation suggesting that it would still serve the "original source file" even if the browser does not support AVIF. It wasn't until finding https://github.com/vercel/next.js/pull/35190 that I realized it's safe for me to store the image as AVIF.