### PR TITLE
Fix Accessing element.ref was removed in React 19

### DIFF
--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -1,4 +1,4 @@
-'use client'-
+'use client'
 
 import React, { createContext, useContext, useOptimistic, useRef } from 'react'
 import type { UrlObject } from 'url'
@@ -312,23 +312,22 @@ function getReactElementRef(
   element: React.ReactElement<{ ref?: React.Ref<unknown> }>
 ): React.Ref<any> | undefined {
   // React <=18 in DEV
-  let getter = Object.getOwnPropertyDescriptor(element.props, 'ref')?.get;
-  let mayWarn = getter && 'isReactWarning' in getter && getter.isReactWarning;
+  let getter = Object.getOwnPropertyDescriptor(element.props, 'ref')?.get
+  let mayWarn = getter && 'isReactWarning' in getter && getter.isReactWarning
   if (mayWarn) {
-    return (element as any).ref;
+    return (element as any).ref
   }
 
   // React 19 in DEV
-  getter = Object.getOwnPropertyDescriptor(element, 'ref')?.get;
-  mayWarn = getter && 'isReactWarning' in getter && getter.isReactWarning;
+  getter = Object.getOwnPropertyDescriptor(element, 'ref')?.get
+  mayWarn = getter && 'isReactWarning' in getter && getter.isReactWarning
   if (mayWarn) {
-    return element.props.ref;
+    return element.props.ref
   }
 
   // Not DEV
-  return element.props.ref || (element as any).ref;
+  return element.props.ref || (element as any).ref
 }
-
 
 /**
  * A React component that extends the HTML `<a>` element to provide

--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -1,4 +1,4 @@
-'use client'
+'use client'-
 
 import React, { createContext, useContext, useOptimistic, useRef } from 'react'
 import type { UrlObject } from 'url'
@@ -300,6 +300,37 @@ function formatStringOrUrl(urlObjOrString: UrlObject | string): string {
 }
 
 /**
+ * Returns the ref of a React element handling differences between React 19 and older versions.
+ * It will throw runtime error if the element is not a valid React element.
+ *
+ * The source is a copy and paste of https://github.com/radix-ui/primitives/blob/6e75e117977c9e6ffa939e6951a707f16ba0f95e/packages/react/presence/src/presence.tsx#L173
+ * It's also duplicated in the Pages Router source.
+ * @param element React.ReactElement
+ * @returns React.Ref<any> | undefined
+ */
+function getReactElementRef(
+  element: React.ReactElement<{ ref?: React.Ref<unknown> }>
+): React.Ref<any> | undefined {
+  // React <=18 in DEV
+  let getter = Object.getOwnPropertyDescriptor(element.props, 'ref')?.get;
+  let mayWarn = getter && 'isReactWarning' in getter && getter.isReactWarning;
+  if (mayWarn) {
+    return (element as any).ref;
+  }
+
+  // React 19 in DEV
+  getter = Object.getOwnPropertyDescriptor(element, 'ref')?.get;
+  mayWarn = getter && 'isReactWarning' in getter && getter.isReactWarning;
+  if (mayWarn) {
+    return element.props.ref;
+  }
+
+  // Not DEV
+  return element.props.ref || (element as any).ref;
+}
+
+
+/**
  * A React component that extends the HTML `<a>` element to provide
  * [prefetching](https://nextjs.org/docs/app/building-your-application/routing/linking-and-navigating#2-prefetching)
  * and client-side navigation. This is the primary way to navigate between routes in Next.js.
@@ -546,7 +577,7 @@ export default function LinkComponent(
   }
 
   const childRef: any = legacyBehavior
-    ? child && typeof child === 'object' && child.ref
+    ? getReactElementRef(child)
     : forwardedRef
 
   // Use a callback ref to attach an IntersectionObserver to the anchor tag on

--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -1,4 +1,4 @@
-'use client'
+'use client'-
 
 import type {
   NextRouter,
@@ -281,6 +281,36 @@ function formatStringOrUrl(urlObjOrString: UrlObject | string): string {
 }
 
 /**
+ * Returns the ref of a React element handling differences between React 19 and older versions.
+ * It will throw runtime error if the element is not a valid React element.
+ *
+ * The source is a copy and paste of https://github.com/radix-ui/primitives/blob/6e75e117977c9e6ffa939e6951a707f16ba0f95e/packages/react/presence/src/presence.tsx#L173
+ * It's also duplicated in the App Router source.
+ * @param element React.ReactElement
+ * @returns React.Ref<any> | undefined
+ */
+function getReactElementRef(
+  element: React.ReactElement<{ ref?: React.Ref<unknown> }>
+): React.Ref<any> | undefined {
+  // React <=18 in DEV
+  let getter = Object.getOwnPropertyDescriptor(element.props, 'ref')?.get;
+  let mayWarn = getter && 'isReactWarning' in getter && getter.isReactWarning;
+  if (mayWarn) {
+    return (element as any).ref;
+  }
+
+  // React 19 in DEV
+  getter = Object.getOwnPropertyDescriptor(element, 'ref')?.get;
+  mayWarn = getter && 'isReactWarning' in getter && getter.isReactWarning;
+  if (mayWarn) {
+    return element.props.ref;
+  }
+
+  // Not DEV
+  return element.props.ref || (element as any).ref;
+}
+
+/**
  * A React component that extends the HTML `<a>` element to provide [prefetching](https://nextjs.org/docs/app/building-your-application/routing/linking-and-navigating#2-prefetching)
  * and client-side navigation between routes.
  *
@@ -500,7 +530,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
     }
 
     const childRef: any = legacyBehavior
-      ? child && typeof child === 'object' && child.ref
+      ? getReactElementRef(child)
       : forwardedRef
 
     const [setIntersectionRef, isVisible, resetVisible] = useIntersection({

--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -1,4 +1,4 @@
-'use client'-
+'use client'
 
 import type {
   NextRouter,
@@ -293,21 +293,21 @@ function getReactElementRef(
   element: React.ReactElement<{ ref?: React.Ref<unknown> }>
 ): React.Ref<any> | undefined {
   // React <=18 in DEV
-  let getter = Object.getOwnPropertyDescriptor(element.props, 'ref')?.get;
-  let mayWarn = getter && 'isReactWarning' in getter && getter.isReactWarning;
+  let getter = Object.getOwnPropertyDescriptor(element.props, 'ref')?.get
+  let mayWarn = getter && 'isReactWarning' in getter && getter.isReactWarning
   if (mayWarn) {
-    return (element as any).ref;
+    return (element as any).ref
   }
 
   // React 19 in DEV
-  getter = Object.getOwnPropertyDescriptor(element, 'ref')?.get;
-  mayWarn = getter && 'isReactWarning' in getter && getter.isReactWarning;
+  getter = Object.getOwnPropertyDescriptor(element, 'ref')?.get
+  mayWarn = getter && 'isReactWarning' in getter && getter.isReactWarning
   if (mayWarn) {
-    return element.props.ref;
+    return element.props.ref
   }
 
   // Not DEV
-  return element.props.ref || (element as any).ref;
+  return element.props.ref || (element as any).ref
 }
 
 /**


### PR DESCRIPTION
See https://codesandbox.io/p/devbox/muddy-http-h3r423?file=%2Fpages%2Findex.tsx%3A12%2C5&workspaceId=ws_JTzKEPRDQXMzzhKd3x4aSM as a reproduction of the problem

```jsx
import NextLink from "next/link";

const ref = { current: null };

export default function Index() {
  return (
    <div>
      <NextLink href="/bar" legacyBehavior>
        <a ref={ref}>Link fail</a>
      </NextLink>
    </div>
  );
}
```

<img width="663" alt="SCR-20241227-tphm" src="https://github.com/user-attachments/assets/ff673fc0-6c8a-4de2-8ce9-a692bb148405" />

---

Context https://github.com/vercel/next.js/issues/72873#issuecomment-2539708741 doesn't look accurate. However, going to https://github.com/mui/material-ui/tree/master/examples/material-ui-nextjs-pages-router and opening the /about page is enough to reproduce the problem. 

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
