### PR TITLE
docs: remove catch-all for opengraph-image

### DIFF
--- a/docs/01-app/04-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/01-app/04-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
@@ -239,7 +239,6 @@ export default function Image({ params }) {
 | `app/shop/opengraph-image.js`              | `/shop`     | `undefined`               |
 | `app/shop/[slug]/opengraph-image.js`       | `/shop/1`   | `{ slug: '1' }`           |
 | `app/shop/[tag]/[item]/opengraph-image.js` | `/shop/1/2` | `{ tag: '1', item: '2' }` |
-| `app/shop/[...slug]/opengraph-image.js`    | `/shop/1/2` | `{ slug: ['1', '2'] }`    |
 
 ### Returns
 


### PR DESCRIPTION
x-ref: https://github.com/vercel/next.js/issues/49630