### PR TITLE
docs: add missing `use client` directive and `to`

### DIFF
--- a/docs/01-app/01-getting-started/06-data-fetching-and-streaming.mdx
+++ b/docs/01-app/01-getting-started/06-data-fetching-and-streaming.mdx
@@ -130,7 +130,7 @@ export default function Page() {
 }
 ```
 
-Then, in your Client Component, use the `use` hook read the promise:
+Then, in your Client Component, use the `use` hook to read the promise:
 
 ```tsx filename="app/ui/posts.tsx" switcher
 'use client'

--- a/docs/01-app/04-api-reference/02-components/link.mdx
+++ b/docs/01-app/04-api-reference/02-components/link.mdx
@@ -718,6 +718,8 @@ export default NavLink
 ```
 
 ```jsx filename="components/nav-link.js" switcher
+'use client'
+
 import Link from 'next/link'
 import styled from 'styled-components'
 

--- a/docs/01-app/04-api-reference/02-components/link.mdx
+++ b/docs/01-app/04-api-reference/02-components/link.mdx
@@ -696,6 +696,8 @@ If the child of `Link` is a custom component that wraps an `<a>` tag, you must a
 </PagesOnly>
 
 ```tsx filename="components/nav-link.tsx" switcher
+'use client'
+
 import Link from 'next/link'
 import styled from 'styled-components'
 


### PR DESCRIPTION
Hi, Team!

1. Fixed the missing `to` in the sentence.
2. Added the missing `use client` directive (since this is a client component using styled-components).