### PR TITLE
fix: Check if path segments includes `node_modules` explicitly

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-swc-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-swc-loader.ts
@@ -45,7 +45,7 @@ const maybeExclude = (
   const shouldBeBundled = isResourceInPackages(excludePath, transpilePackages)
   if (shouldBeBundled) return false
 
-  return excludePath.includes('node_modules')
+  return excludePath.split(path.sep).includes('node_modules')
 }
 
 export interface SWCLoaderOptions {


### PR DESCRIPTION
### What?

And edge case, as reported by https://github.com/vercel/next.js/issues/74404, where when the `root` dir name, contains the string `node_modules`, then Webpack errors are observed. 

For example:

```console
 ⨯ ./app/layout.tsx
Module parse failed: Unexpected token (1:12)
> import type { FC, PropsWithChildren } from "react";
| 
| const RootLayout: FC<PropsWithChildren> = ({
```

### Why?

Although this is an edge case, it has been observed in user land, as per #74404 

### How?

Check if the `node_modules` is a path segment. Either of these works:

```js
  return excludePath.split(path.sep).includes('node_modules')
  return excludePath.includes(path.sep + 'node_modules' + path.sep)
  return excludePath.includes('/node_modules/')
```

Or even a regexp match. I am just not sure about winOS and their path separators... and whether the path at this point is already normalised to `/`.

Fixes #74404