### PR TITLE
docs: fix 404 from public directory

### DIFF
--- a/docs/01-app/03-building-your-application/01-routing/15-internationalization.mdx
+++ b/docs/01-app/03-building-your-application/01-routing/15-internationalization.mdx
@@ -59,8 +59,8 @@ export function middleware(request) {
 
 export const config = {
   matcher: [
-    // Skip all internal paths (_next)
-    '/((?!_next).*)',
+    // Only match paths that don't have file extensions and aren't _next
+    '/((?!api|_next|.*\\..*$).*)',
     // Optional: only run on root (/) URL
     // '/'
   ],


### PR DESCRIPTION
### What?

Images under the `/public` folder returns 404.

### Why?

Images under the `/public` folder returns 404.

### How?

Only match paths that don't have file extensions and aren't _next.