### PR TITLE
docs: add note to custom server page about instrumentation

### DIFF
--- a/docs/01-app/03-building-your-application/07-configuring/10-custom-server.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/10-custom-server.mdx
@@ -10,6 +10,7 @@ Next.js includes its own server with `next start` by default. If you have an exi
 > **Good to know**:
 >
 > - Before deciding to use a custom server, keep in mind that it should only be used when the integrated router of Next.js can't meet your app requirements. A custom server will remove important performance optimizations, like **[Automatic Static Optimization](/docs/pages/building-your-application/rendering/automatic-static-optimization).**
+> - If you need to perform some work when the server starts (like initializing monitoring or performing some other side effect), consider whether Next.js's [instrumentation support](/docs/app/building-your-application/optimizing/instrumentation) can handle your use case instead.
 > - A custom server **cannot** be deployed on [Vercel](https://vercel.com/frameworks/nextjs).
 > - When using standalone output mode, it does not trace custom server files. This mode outputs a separate minimal `server.js` file, instead. These cannot be used together.
 


### PR DESCRIPTION
I've been using Next for years but missed that this feature was added (and already stable!).