### PR TITLE
docs: remove non-existent renderType from onRequestError example

### DIFF
--- a/docs/01-app/04-api-reference/03-file-conventions/instrumentation.mdx
+++ b/docs/01-app/04-api-reference/03-file-conventions/instrumentation.mdx
@@ -99,7 +99,6 @@ export function onRequestError(
       | 'react-server-components-payload'
       | 'server-rendering'
     revalidateReason: 'on-demand' | 'stale' | undefined // undefined is a normal request without revalidation
-    renderType: 'dynamic' | 'dynamic-resume' // 'dynamic-resume' for PPR
   }
 ): void | Promise<void>
 ```


### PR DESCRIPTION
Happy New Year! Wishing you and your team all the best in the year ahead.

The `renderType` property is mentioned for the onRequestError function in the example. 
However, it is not defined in the [RequestErrorContext type](https://github.com/vercel/next.js/blob/35acd7e1faae66feddeffe6362fae9fb5a5b1281/packages/next/src/server/instrumentation/types.ts#L1-L11) nor used in the Next.js source code. 
(Perhaps this property is planned for future implementation?)

This PR removes the property from the example to align the documentation with the current implementation.

If renderType is intended for future use, please kindly disregard this PR.