### PR TITLE
docs: align app router examples with file naming conventions

### DIFF
--- a/docs/01-app/03-building-your-application/07-configuring/03-environment-variables.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/03-environment-variables.mdx
@@ -157,7 +157,9 @@ This will tell Next.js to replace all references to `process.env.NEXT_PUBLIC_ANA
 
 > **Note**: After being built, your app will no longer respond to changes to these environment variables. For instance, if you use a Heroku pipeline to promote slugs built in one environment to another environment, or if you build and deploy a single Docker image to multiple environments, all `NEXT_PUBLIC_` variables will be frozen with the value evaluated at build time, so these values need to be set appropriately when the project is built. If you need access to runtime environment values, you'll have to setup your own API to provide them to the client (either on demand or during initialization).
 
-```js filename="pages/index.js"
+<AppOnly>
+
+```jsx filename="app/page.js"
 import setupAnalyticsService from '../lib/my-analytics-service'
 
 // 'NEXT_PUBLIC_ANALYTICS_ID' can be used here as it's prefixed by 'NEXT_PUBLIC_'.
@@ -170,6 +172,26 @@ function HomePage() {
 
 export default HomePage
 ```
+
+</AppOnly>
+
+<PagesOnly>
+
+```jsx filename="pages/index.js"
+import setupAnalyticsService from '../lib/my-analytics-service'
+
+// 'NEXT_PUBLIC_ANALYTICS_ID' can be used here as it's prefixed by 'NEXT_PUBLIC_'.
+// It will be transformed at build time to `setupAnalyticsService('abcdefghijk')`.
+setupAnalyticsService(process.env.NEXT_PUBLIC_ANALYTICS_ID)
+
+function HomePage() {
+  return <h1>Hello World</h1>
+}
+
+export default HomePage
+```
+
+</PagesOnly>
 
 Note that dynamic lookups will _not_ be inlined, such as:
 


### PR DESCRIPTION
Hi Team,

Currently both App router and Pages router examples use `pages/index.js`, which does not align with the file convention for App Router. I've updated the examples to ensure clarity:

- App Router now uses app/page.js only.
- Pages Router retains pages/index.js.