### PR TITLE
docs: clarify server action behavior with middleware

### DIFF
--- a/docs/01-app/03-building-your-application/02-data-fetching/03-server-actions-and-mutations.mdx
+++ b/docs/01-app/03-building-your-application/02-data-fetching/03-server-actions-and-mutations.mdx
@@ -122,6 +122,7 @@ Runtime type-checking will still ensure you don't accidentally pass a function t
 - Server Actions are not limited to `<form>` and can be invoked from event handlers, `useEffect`, third-party libraries, and other form elements like `<button>`.
 - Server Actions integrate with the Next.js [caching and revalidation](/docs/app/building-your-application/caching) architecture. When an action is invoked, Next.js can return both the updated UI and new data in a single server roundtrip.
 - Behind the scenes, actions use the `POST` method, and only this HTTP method can invoke them.
+- Calls to Server Actions also invoke [Middleware](/docs/app/building-your-application/routing/middleware), if a middleware is defined. In this case, the `request` argument passed to the middleware is a `POST` request to the action.
 - The arguments and return value of Server Actions must be serializable by React. See the React docs for a list of [serializable arguments and values](https://react.dev/reference/react/use-server#serializable-parameters-and-return-values).
 - Server Actions are functions. This means they can be reused anywhere in your application.
 - Server Actions inherit the [runtime](/docs/app/building-your-application/rendering/edge-and-nodejs-runtimes) from the page or layout they are used on.


### PR DESCRIPTION
I added a line to the ["Server Actions and Mutations" page](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations#behavior) to clarify that calling Server Actions triggers middleware execution as well.