### PR TITLE
fix:sign-up search parameter could be message but also error or success in with-supabase example

### DIFF
--- a/examples/with-supabase/app/(auth-pages)/sign-up/page.tsx
+++ b/examples/with-supabase/app/(auth-pages)/sign-up/page.tsx
@@ -10,7 +10,7 @@ export default async function Signup(props: {
   searchParams: Promise<Message>;
 }) {
   const searchParams = await props.searchParams;
-  if ("message" in searchParams) {
+  if (searchParams) {
     return (
       <div className="w-full flex-1 flex items-center h-screen sm:max-w-md justify-center gap-2 p-4">
         <FormMessage message={searchParams} />


### PR DESCRIPTION
In the Supabase auth example, the code for the sign-up process looks as follows:

```
export default async function Signup(props: {
  searchParams: Promise<Message>;
}) {
  const searchParams = await props.searchParams;
  if ('message' in searchParams) {
    return (
      <div className="flex h-screen w-full flex-1 items-center justify-center gap-2 p-4 sm:max-w-md">
        <FormMessage message={searchParams} />
      </div>
    );
  }
  ...
```

However, the `Message` type is defined as follows in the same example:

```
export type Message =
  | { success: string }
  | { error: string }
  | { message: string };
```

This means the feedback from Supabase can include not only a general message, but also success or error messages. Therefore, the implementation should be adjusted to handle all three cases—success, error, and message—and display the appropriate feedback accordingly.
