### PR TITLE
refactor(turbopack/next-api): Make VcArc use OperationVc

### DIFF
--- a/crates/napi/src/next_api/utils.rs
+++ b/crates/napi/src/next_api/utils.rs
@@ -175,13 +175,12 @@ pub fn create_turbo_tasks(
 #[derive(Clone)]
 pub struct VcArc<T> {
     turbo_tasks: NextTurboTasks,
-    /// The Vc. Must be resolved, otherwise you are referencing an inactive
-    /// operation.
-    vc: T,
+    /// The Vc. Must be unresolved, otherwise you are referencing an inactive operation.
+    vc: OperationVc<T>,
 }
 
 impl<T> VcArc<T> {
-    pub fn new(turbo_tasks: NextTurboTasks, vc: T) -> Self {
+    pub fn new(turbo_tasks: NextTurboTasks, vc: OperationVc<T>) -> Self {
         Self { turbo_tasks, vc }
     }
 
@@ -191,7 +190,7 @@ impl<T> VcArc<T> {
 }
 
 impl<T> Deref for VcArc<T> {
-    type Target = T;
+    type Target = OperationVc<T>;
 
     fn deref(&self) -> &Self::Target {
         &self.vc

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -804,8 +804,8 @@ pub fn app_entry_point_to_route(
             pages
                 .into_iter()
                 .map(|page| AppPageRoute {
-                    original_name: page.to_string(),
-                    html_endpoint: Vc::upcast(
+                    original_name: RcStr::from(page.to_string()),
+                    html_endpoint: ResolvedVc::upcast(
                         AppEndpoint {
                             ty: AppEndpointType::Page {
                                 ty: AppPageEndpointType::Html,
@@ -814,9 +814,9 @@ pub fn app_entry_point_to_route(
                             app_project,
                             page: page.clone(),
                         }
-                        .cell(),
+                        .resolved_cell(),
                     ),
-                    rsc_endpoint: Vc::upcast(
+                    rsc_endpoint: ResolvedVc::upcast(
                         AppEndpoint {
                             ty: AppEndpointType::Page {
                                 ty: AppPageEndpointType::Rsc,
@@ -825,7 +825,7 @@ pub fn app_entry_point_to_route(
                             app_project,
                             page,
                         }
-                        .cell(),
+                        .resolved_cell(),
                     ),
                 })
                 .collect(),
@@ -835,7 +835,7 @@ pub fn app_entry_point_to_route(
             path,
             root_layouts,
         } => Route::AppRoute {
-            original_name: page.to_string(),
+            original_name: page.to_string().into(),
             endpoint: ResolvedVc::upcast(
                 AppEndpoint {
                     ty: AppEndpointType::Route { path, root_layouts },
@@ -846,7 +846,7 @@ pub fn app_entry_point_to_route(
             ),
         },
         AppEntrypoint::AppMetadata { page, metadata } => Route::AppRoute {
-            original_name: page.to_string(),
+            original_name: page.to_string().into(),
             endpoint: ResolvedVc::upcast(
                 AppEndpoint {
                     ty: AppEndpointType::Metadata { metadata },

--- a/crates/next-api/src/entrypoints.rs
+++ b/crates/next-api/src/entrypoints.rs
@@ -6,7 +6,7 @@ use crate::{
     route::{Endpoint, Route},
 };
 
-#[turbo_tasks::value(shared, local)]
+#[turbo_tasks::value(shared)]
 pub struct Entrypoints {
     pub routes: FxIndexMap<RcStr, Route>,
     pub middleware: Option<Middleware>,

--- a/crates/next-api/src/global_module_id_strategy.rs
+++ b/crates/next-api/src/global_module_id_strategy.rs
@@ -31,14 +31,12 @@ impl GlobalModuleIdStrategyBuilder {
         preprocessed_module_ids.push(preprocess_module_ids(*entrypoints.pages_document_endpoint));
 
         if let Some(middleware) = &entrypoints.middleware {
-            preprocessed_module_ids.push(preprocess_module_ids(middleware.endpoint));
+            preprocessed_module_ids.push(preprocess_module_ids(*middleware.endpoint));
         }
 
         if let Some(instrumentation) = &entrypoints.instrumentation {
-            let node_js = instrumentation.node_js;
-            let edge = instrumentation.edge;
-            preprocessed_module_ids.push(preprocess_module_ids(node_js));
-            preprocessed_module_ids.push(preprocess_module_ids(edge));
+            preprocessed_module_ids.push(preprocess_module_ids(*instrumentation.node_js));
+            preprocessed_module_ids.push(preprocess_module_ids(*instrumentation.edge));
         }
 
         for (_, route) in entrypoints.routes.iter() {
@@ -56,9 +54,9 @@ impl GlobalModuleIdStrategyBuilder {
                 Route::AppPage(page_routes) => {
                     for page_route in page_routes {
                         preprocessed_module_ids
-                            .push(preprocess_module_ids(page_route.html_endpoint));
+                            .push(preprocess_module_ids(*page_route.html_endpoint));
                         preprocessed_module_ids
-                            .push(preprocess_module_ids(page_route.rsc_endpoint));
+                            .push(preprocess_module_ids(*page_route.rsc_endpoint));
                     }
                 }
                 Route::AppRoute {

--- a/crates/next-api/src/lib.rs
+++ b/crates/next-api/src/lib.rs
@@ -15,6 +15,7 @@ mod loadable_manifest;
 mod middleware;
 mod module_graph;
 mod nft_json;
+pub mod operation;
 mod pages;
 pub mod paths;
 pub mod project;

--- a/crates/next-api/src/operation.rs
+++ b/crates/next-api/src/operation.rs
@@ -32,10 +32,6 @@ pub struct EntrypointsOperation {
 }
 
 /// HACK: Wraps an `OperationVc<Entrypoints>` inside of a second `OperationVc`.
-///
-/// When `CollectiblesSource::take_collectibles` happens, it in-place *mutates* the `OperationVc`,
-/// which isn't what we want in `entrypoints_without_diagnostics_operation`. Instead we want a *new*
-/// `OperationVc` without diagnostics. This creates that new `OperationVc` to be mutated.
 #[turbo_tasks::function(operation)]
 fn entrypoints_wrapper(entrypoints: OperationVc<Entrypoints>) -> Vc<Entrypoints> {
     entrypoints.connect()

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -211,10 +211,6 @@ impl PagesProject {
             add_dir_to_routes(&mut routes, *pages, make_page_route).await?;
         }
 
-        for route in routes.values_mut() {
-            route.resolve().await?;
-        }
-
         Ok(Vc::cell(routes))
     }
 

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -236,18 +236,18 @@ pub struct DefineEnv {
     pub nodejs: Vec<(RcStr, RcStr)>,
 }
 
-#[derive(Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, ValueDebugFormat)]
+#[derive(Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, ValueDebugFormat, NonLocalValue)]
 pub struct Middleware {
-    pub endpoint: Vc<Box<dyn Endpoint>>,
+    pub endpoint: ResolvedVc<Box<dyn Endpoint>>,
 }
 
-#[derive(Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, ValueDebugFormat)]
+#[derive(Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, ValueDebugFormat, NonLocalValue)]
 pub struct Instrumentation {
-    pub node_js: Vc<Box<dyn Endpoint>>,
-    pub edge: Vc<Box<dyn Endpoint>>,
+    pub node_js: ResolvedVc<Box<dyn Endpoint>>,
+    pub edge: ResolvedVc<Box<dyn Endpoint>>,
 }
 
-#[turbo_tasks::value(local)]
+#[turbo_tasks::value]
 pub struct ProjectContainer {
     name: RcStr,
     options_state: State<Option<ProjectOptions>>,
@@ -754,12 +754,12 @@ impl Project {
         endpoints.push(entrypoints.pages_document_endpoint);
 
         if let Some(middleware) = &entrypoints.middleware {
-            endpoints.push(middleware.endpoint.to_resolved().await?);
+            endpoints.push(middleware.endpoint);
         }
 
         if let Some(instrumentation) = &entrypoints.instrumentation {
-            endpoints.push(instrumentation.node_js.to_resolved().await?);
-            endpoints.push(instrumentation.edge.to_resolved().await?);
+            endpoints.push(instrumentation.node_js);
+            endpoints.push(instrumentation.edge);
         }
 
         for (_, route) in entrypoints.routes.iter() {
@@ -780,7 +780,7 @@ impl Project {
                         rsc_endpoint: _,
                     } in page_routes
                     {
-                        endpoints.push(html_endpoint.to_resolved().await?);
+                        endpoints.push(*html_endpoint);
                     }
                 }
                 Route::AppRoute {
@@ -1136,7 +1136,7 @@ impl Project {
         let middleware = self.find_middleware();
         let middleware = if let FindContextFileResult::Found(..) = *middleware.await? {
             Some(Middleware {
-                endpoint: self.middleware_endpoint(),
+                endpoint: self.middleware_endpoint().to_resolved().await?,
             })
         } else {
             None
@@ -1145,8 +1145,8 @@ impl Project {
         let instrumentation = self.find_instrumentation();
         let instrumentation = if let FindContextFileResult::Found(..) = *instrumentation.await? {
             Some(Instrumentation {
-                node_js: self.instrumentation_endpoint(false),
-                edge: self.instrumentation_endpoint(true),
+                node_js: self.instrumentation_endpoint(false).to_resolved().await?,
+                edge: self.instrumentation_endpoint(true).to_resolved().await?,
             })
         } else {
             None

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -1,34 +1,31 @@
-use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    debug::ValueDebugFormat, trace::TraceRawVcs, Completion, FxIndexMap, ResolvedVc, Vc,
+    debug::ValueDebugFormat, trace::TraceRawVcs, Completion, FxIndexMap, NonLocalValue,
+    OperationVc, ResolvedVc, Vc,
 };
 use turbopack_core::{module::Modules, module_graph::ModuleGraph};
 
 use crate::paths::ServerPath;
 
-#[derive(TraceRawVcs, Serialize, Deserialize, PartialEq, Eq, ValueDebugFormat, Clone, Debug)]
+#[derive(
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    ValueDebugFormat,
+    Clone,
+    Debug,
+    NonLocalValue,
+)]
 pub struct AppPageRoute {
-    pub original_name: String,
-    pub html_endpoint: Vc<Box<dyn Endpoint>>,
-    pub rsc_endpoint: Vc<Box<dyn Endpoint>>,
+    pub original_name: RcStr,
+    pub html_endpoint: ResolvedVc<Box<dyn Endpoint>>,
+    pub rsc_endpoint: ResolvedVc<Box<dyn Endpoint>>,
 }
 
-impl AppPageRoute {
-    async fn resolve(&mut self) -> Result<()> {
-        let Self {
-            html_endpoint,
-            rsc_endpoint,
-            ..
-        } = self;
-        *html_endpoint = html_endpoint.resolve().await?;
-        *rsc_endpoint = rsc_endpoint.resolve().await?;
-        Ok(())
-    }
-}
-
-#[turbo_tasks::value(shared, local)]
+#[turbo_tasks::value(shared)]
 #[derive(Clone, Debug)]
 pub enum Route {
     Page {
@@ -40,22 +37,10 @@ pub enum Route {
     },
     AppPage(Vec<AppPageRoute>),
     AppRoute {
-        original_name: String,
+        original_name: RcStr,
         endpoint: ResolvedVc<Box<dyn Endpoint>>,
     },
     Conflict,
-}
-
-impl Route {
-    pub async fn resolve(&mut self) -> Result<()> {
-        if let Route::AppPage(routes) = self {
-            for route in routes {
-                route.resolve().await?;
-            }
-        }
-
-        Ok(())
-    }
 }
 
 #[turbo_tasks::value_trait(local)]
@@ -77,16 +62,16 @@ pub struct Endpoints(Vec<ResolvedVc<Box<dyn Endpoint>>>);
 
 #[turbo_tasks::function(operation)]
 pub fn endpoint_write_to_disk_operation(
-    endpoint: ResolvedVc<Box<dyn Endpoint>>,
+    endpoint: OperationVc<Box<dyn Endpoint>>,
 ) -> Vc<WrittenEndpoint> {
-    endpoint.write_to_disk()
+    endpoint.connect().write_to_disk()
 }
 
 #[turbo_tasks::function(operation)]
 pub fn endpoint_server_changed_operation(
-    endpoint: ResolvedVc<Box<dyn Endpoint>>,
+    endpoint: OperationVc<Box<dyn Endpoint>>,
 ) -> Vc<Completion> {
-    endpoint.server_changed()
+    endpoint.connect().server_changed()
 }
 
 #[turbo_tasks::value(shared)]
@@ -106,5 +91,5 @@ pub enum WrittenEndpoint {
 
 /// The routes as map from pathname to route. (pathname includes the leading
 /// slash)
-#[turbo_tasks::value(transparent, local)]
+#[turbo_tasks::value(transparent)]
 pub struct Routes(FxIndexMap<RcStr, Route>);


### PR DESCRIPTION
`VcArc` represents values passed through napi to next.js and back. Because these values exit the scope of turbo-tasks, similar to how `State` works, they must be operations, so that they're recomputed/"kept alive" when read.

These changes were extracted from @sokra's original `OperationVc` work (mostly preserved here: https://github.com/vercel/next.js/pull/72776), though adapted significantly for the removal of the `OperationVc::new()` constructor.

Closes PACK-3753