### PR TITLE
perf(rcstr): Support inline string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8385,6 +8385,7 @@ version = "0.1.0"
 name = "turbo-rcstr"
 version = "0.1.0"
 dependencies = [
+ "new_debug_unreachable",
  "serde",
  "triomphe 0.1.12",
  "turbo-tasks-hash",

--- a/turbopack/crates/turbo-rcstr/Cargo.toml
+++ b/turbopack/crates/turbo-rcstr/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 triomphe = { workspace = true }
 turbo-tasks-hash = { workspace = true }
 serde = { workspace = true }
+new_debug_unreachable = "1.0.6"
 
 [lints]
 workspace = true

--- a/turbopack/crates/turbo-rcstr/Cargo.toml
+++ b/turbopack/crates/turbo-rcstr/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 
+[features]
+atom_size_64=[]
+atom_size_128=[]
+
 [dependencies]
 triomphe = { workspace = true }
 turbo-tasks-hash = { workspace = true }

--- a/turbopack/crates/turbo-rcstr/src/dynamic.rs
+++ b/turbopack/crates/turbo-rcstr/src/dynamic.rs
@@ -1,0 +1,76 @@
+use std::{
+    borrow::Cow,
+    hash::{Hash, Hasher},
+    ptr::NonNull,
+};
+
+use triomphe::Arc;
+
+use crate::{
+    tagged_value::{TaggedValue, MAX_INLINE_LEN},
+    RcStr, INLINE_TAG_INIT, LEN_OFFSET, TAG_MASK,
+};
+
+#[derive(Debug)]
+pub(crate) struct Entry {
+    pub string: Arc<str>,
+}
+
+impl Entry {
+    pub unsafe fn cast(ptr: TaggedValue) -> *const Entry {
+        ptr.get_ptr().cast()
+    }
+
+    pub unsafe fn deref_from<'i>(ptr: TaggedValue) -> &'i Entry {
+        &*Self::cast(ptr)
+    }
+
+    pub unsafe fn restore_arc(v: TaggedValue) -> Arc<Entry> {
+        let ptr = v.get_ptr() as *const Entry;
+        Arc::from_raw(ptr)
+    }
+}
+
+impl PartialEq for Entry {
+    fn eq(&self, other: &Self) -> bool {
+        self.string == other.string
+    }
+}
+
+impl Eq for Entry {}
+
+impl Hash for Entry {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.string.hash(state);
+    }
+}
+
+/// This can create any kind of [Atom], although this lives in the `dynamic`
+/// module.
+pub(crate) fn new_atom(text: Cow<str>) -> RcStr {
+    let len = text.len();
+
+    if len < MAX_INLINE_LEN {
+        // INLINE_TAG ensures this is never zero
+        let tag = INLINE_TAG_INIT | ((len as u8) << LEN_OFFSET);
+        let mut unsafe_data = TaggedValue::new_tag(tag);
+        unsafe {
+            unsafe_data.data_mut()[..len].copy_from_slice(text.as_bytes());
+        }
+        return RcStr { unsafe_data };
+    }
+
+    let entry = Arc::new(Entry {
+        string: text.into(),
+    });
+    let entry = Arc::into_raw(entry);
+
+    let ptr: NonNull<Entry> = unsafe {
+        // Safety: Arc::into_raw returns a non-null pointer
+        NonNull::new_unchecked(entry as *mut Entry)
+    };
+    debug_assert!(0 == ptr.as_ptr() as u8 & TAG_MASK);
+    RcStr {
+        unsafe_data: TaggedValue::new_ptr(ptr),
+    }
+}

--- a/turbopack/crates/turbo-rcstr/src/dynamic.rs
+++ b/turbopack/crates/turbo-rcstr/src/dynamic.rs
@@ -1,8 +1,4 @@
-use std::{
-    borrow::Cow,
-    hash::{Hash, Hasher},
-    ptr::NonNull,
-};
+use std::ptr::NonNull;
 
 use triomphe::Arc;
 
@@ -11,63 +7,40 @@ use crate::{
     RcStr, INLINE_TAG_INIT, LEN_OFFSET, TAG_MASK,
 };
 
-#[derive(Debug)]
-pub(crate) struct Dynamic {
-    pub string: Arc<str>,
+pub unsafe fn cast(ptr: TaggedValue) -> *const String {
+    ptr.get_ptr().cast()
 }
 
-impl Dynamic {
-    pub unsafe fn cast(ptr: TaggedValue) -> *const Dynamic {
-        ptr.get_ptr().cast()
-    }
-
-    pub unsafe fn deref_from<'i>(ptr: TaggedValue) -> &'i Dynamic {
-        &*Self::cast(ptr)
-    }
-
-    pub unsafe fn restore_arc(v: TaggedValue) -> Arc<Dynamic> {
-        let ptr = v.get_ptr() as *const Dynamic;
-        Arc::from_raw(ptr)
-    }
+pub unsafe fn deref_from<'i>(ptr: TaggedValue) -> &'i String {
+    &*cast(ptr)
 }
 
-impl PartialEq for Dynamic {
-    fn eq(&self, other: &Self) -> bool {
-        self.string == other.string
-    }
-}
-
-impl Eq for Dynamic {}
-
-impl Hash for Dynamic {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.string.hash(state);
-    }
+pub unsafe fn restore_arc(v: TaggedValue) -> Arc<String> {
+    let ptr = v.get_ptr() as *const String;
+    Arc::from_raw(ptr)
 }
 
 /// This can create any kind of [Atom], although this lives in the `dynamic`
 /// module.
-pub(crate) fn new_atom(text: Cow<str>) -> RcStr {
-    let len = text.len();
+pub(crate) fn new_atom<T: AsRef<str> + Into<String>>(text: T) -> RcStr {
+    let len = text.as_ref().len();
 
     if len < MAX_INLINE_LEN {
         // INLINE_TAG ensures this is never zero
         let tag = INLINE_TAG_INIT | ((len as u8) << LEN_OFFSET);
         let mut unsafe_data = TaggedValue::new_tag(tag);
         unsafe {
-            unsafe_data.data_mut()[..len].copy_from_slice(text.as_bytes());
+            unsafe_data.data_mut()[..len].copy_from_slice(text.as_ref().as_bytes());
         }
         return RcStr { unsafe_data };
     }
 
-    let entry = Arc::new(Dynamic {
-        string: text.into_owned().into(),
-    });
+    let entry = Arc::new(text.into());
     let entry = Arc::into_raw(entry);
 
-    let ptr: NonNull<Dynamic> = unsafe {
+    let ptr: NonNull<String> = unsafe {
         // Safety: Arc::into_raw returns a non-null pointer
-        NonNull::new_unchecked(entry as *mut Dynamic)
+        NonNull::new_unchecked(entry as *mut String)
     };
     debug_assert!(0 == ptr.as_ptr() as u8 & TAG_MASK);
     RcStr {

--- a/turbopack/crates/turbo-rcstr/src/dynamic.rs
+++ b/turbopack/crates/turbo-rcstr/src/dynamic.rs
@@ -12,34 +12,34 @@ use crate::{
 };
 
 #[derive(Debug)]
-pub(crate) struct Entry {
+pub(crate) struct Dynamic {
     pub string: Arc<str>,
 }
 
-impl Entry {
-    pub unsafe fn cast(ptr: TaggedValue) -> *const Entry {
+impl Dynamic {
+    pub unsafe fn cast(ptr: TaggedValue) -> *const Dynamic {
         ptr.get_ptr().cast()
     }
 
-    pub unsafe fn deref_from<'i>(ptr: TaggedValue) -> &'i Entry {
+    pub unsafe fn deref_from<'i>(ptr: TaggedValue) -> &'i Dynamic {
         &*Self::cast(ptr)
     }
 
-    pub unsafe fn restore_arc(v: TaggedValue) -> Arc<Entry> {
-        let ptr = v.get_ptr() as *const Entry;
+    pub unsafe fn restore_arc(v: TaggedValue) -> Arc<Dynamic> {
+        let ptr = v.get_ptr() as *const Dynamic;
         Arc::from_raw(ptr)
     }
 }
 
-impl PartialEq for Entry {
+impl PartialEq for Dynamic {
     fn eq(&self, other: &Self) -> bool {
         self.string == other.string
     }
 }
 
-impl Eq for Entry {}
+impl Eq for Dynamic {}
 
-impl Hash for Entry {
+impl Hash for Dynamic {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.string.hash(state);
     }
@@ -60,14 +60,14 @@ pub(crate) fn new_atom(text: Cow<str>) -> RcStr {
         return RcStr { unsafe_data };
     }
 
-    let entry = Arc::new(Entry {
+    let entry = Arc::new(Dynamic {
         string: text.into_owned().into(),
     });
     let entry = Arc::into_raw(entry);
 
-    let ptr: NonNull<Entry> = unsafe {
+    let ptr: NonNull<Dynamic> = unsafe {
         // Safety: Arc::into_raw returns a non-null pointer
-        NonNull::new_unchecked(entry as *mut Entry)
+        NonNull::new_unchecked(entry as *mut Dynamic)
     };
     debug_assert!(0 == ptr.as_ptr() as u8 & TAG_MASK);
     RcStr {

--- a/turbopack/crates/turbo-rcstr/src/dynamic.rs
+++ b/turbopack/crates/turbo-rcstr/src/dynamic.rs
@@ -15,6 +15,7 @@ pub unsafe fn deref_from<'i>(ptr: TaggedValue) -> &'i String {
     &*cast(ptr)
 }
 
+/// Caller should call `forget` (or `clone`) on the returned `Arc`
 pub unsafe fn restore_arc(v: TaggedValue) -> Arc<String> {
     let ptr = v.get_ptr() as *const String;
     Arc::from_raw(ptr)

--- a/turbopack/crates/turbo-rcstr/src/dynamic.rs
+++ b/turbopack/crates/turbo-rcstr/src/dynamic.rs
@@ -47,7 +47,9 @@ impl Hash for Entry {
 
 /// This can create any kind of [Atom], although this lives in the `dynamic`
 /// module.
-pub(crate) fn new_atom<S: Into<Arc<str>>>(len: usize, text: S) -> RcStr {
+pub(crate) fn new_atom(text: Cow<str>) -> RcStr {
+    let len = text.len();
+
     if len < MAX_INLINE_LEN {
         // INLINE_TAG ensures this is never zero
         let tag = INLINE_TAG_INIT | ((len as u8) << LEN_OFFSET);
@@ -59,7 +61,7 @@ pub(crate) fn new_atom<S: Into<Arc<str>>>(len: usize, text: S) -> RcStr {
     }
 
     let entry = Arc::new(Entry {
-        string: text.into(),
+        string: text.into_owned().into(),
     });
     let entry = Arc::into_raw(entry);
 

--- a/turbopack/crates/turbo-rcstr/src/dynamic.rs
+++ b/turbopack/crates/turbo-rcstr/src/dynamic.rs
@@ -47,9 +47,7 @@ impl Hash for Entry {
 
 /// This can create any kind of [Atom], although this lives in the `dynamic`
 /// module.
-pub(crate) fn new_atom(text: Cow<str>) -> RcStr {
-    let len = text.len();
-
+pub(crate) fn new_atom<S: Into<Arc<str>>>(len: usize, text: S) -> RcStr {
     if len < MAX_INLINE_LEN {
         // INLINE_TAG ensures this is never zero
         let tag = INLINE_TAG_INIT | ((len as u8) << LEN_OFFSET);

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -98,7 +98,7 @@ impl RcStr {
             DYNAMIC_TAG => {
                 let arc = unsafe { dynamic::restore_arc(self.unsafe_data) };
 
-                match Arc::try_unwrap(arc) {
+                match Arc::try_unwrap(arc.clone()) {
                     Ok(v) => v,
                     Err(arc) => {
                         let s = arc.to_string();

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -100,7 +100,11 @@ impl RcStr {
 
                 match Arc::try_unwrap(arc) {
                     Ok(v) => v,
-                    Err(arc) => arc.to_string(),
+                    Err(arc) => {
+                        let s = arc.to_string();
+                        forget(arc);
+                        s
+                    }
                 }
             }
             INLINE_TAG => self.as_str().to_string(),

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -15,7 +15,7 @@ use triomphe::Arc;
 use turbo_tasks_hash::{DeterministicHash, DeterministicHasher};
 
 use crate::{
-    dynamic::{new_atom, Entry},
+    dynamic::{new_atom, Dynamic},
     tagged_value::TaggedValue,
 };
 
@@ -83,7 +83,7 @@ impl RcStr {
     #[inline(never)]
     pub fn as_str(&self) -> &str {
         match self.tag() {
-            DYNAMIC_TAG => &unsafe { Entry::deref_from(self.unsafe_data) }.string,
+            DYNAMIC_TAG => &unsafe { Dynamic::deref_from(self.unsafe_data) }.string,
             INLINE_TAG => {
                 let len = (self.unsafe_data.tag() & LEN_MASK) >> LEN_OFFSET;
                 let src = self.unsafe_data.data();
@@ -113,7 +113,7 @@ impl RcStr {
     pub(crate) fn from_alias(alias: TaggedValue) -> Self {
         if alias.tag() & TAG_MASK == DYNAMIC_TAG {
             unsafe {
-                let arc = Entry::restore_arc(alias);
+                let arc = Dynamic::restore_arc(alias);
                 forget(arc.clone());
                 forget(arc);
             }

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -80,12 +80,6 @@ impl RcStr {
         self.unsafe_data.tag() & TAG_MASK
     }
 
-    /// Return true if this is a dynamic Atom.
-    #[inline(always)]
-    fn is_dynamic(&self) -> bool {
-        self.tag() == DYNAMIC_TAG
-    }
-
     #[inline(never)]
     pub fn as_str(&self) -> &str {
         match self.tag() {
@@ -263,7 +257,7 @@ impl Eq for RcStr {}
 
 impl PartialOrd for RcStr {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.as_str().partial_cmp(other.as_str())
+        Some(self.cmp(other))
     }
 }
 

--- a/turbopack/crates/turbo-rcstr/src/tagged_value.rs
+++ b/turbopack/crates/turbo-rcstr/src/tagged_value.rs
@@ -1,0 +1,148 @@
+#![allow(clippy::missing_transmute_annotations)]
+
+use std::{num::NonZeroU8, os::raw::c_void, ptr::NonNull, slice};
+
+#[cfg(feature = "atom_size_128")]
+type RawTaggedValue = u128;
+#[cfg(any(
+    target_pointer_width = "32",
+    target_pointer_width = "16",
+    feature = "atom_size_64"
+))]
+type RawTaggedValue = u64;
+#[cfg(not(any(
+    target_pointer_width = "32",
+    target_pointer_width = "16",
+    feature = "atom_size_64",
+    feature = "atom_size_128"
+)))]
+type RawTaggedValue = usize;
+
+#[cfg(feature = "atom_size_128")]
+type RawTaggedNonZeroValue = std::num::NonZeroU128;
+#[cfg(any(
+    target_pointer_width = "32",
+    target_pointer_width = "16",
+    feature = "atom_size_64"
+))]
+type RawTaggedNonZeroValue = std::num::NonZeroU64;
+#[cfg(not(any(
+    target_pointer_width = "32",
+    target_pointer_width = "16",
+    feature = "atom_size_64",
+    feature = "atom_size_128"
+)))]
+type RawTaggedNonZeroValue = std::ptr::NonNull<()>;
+
+pub(crate) const MAX_INLINE_LEN: usize = std::mem::size_of::<TaggedValue>() - 1;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub(crate) struct TaggedValue {
+    value: RawTaggedNonZeroValue,
+}
+
+impl TaggedValue {
+    #[inline(always)]
+    pub fn new_ptr<T>(value: NonNull<T>) -> Self {
+        #[cfg(any(
+            target_pointer_width = "32",
+            target_pointer_width = "16",
+            feature = "atom_size_64",
+            feature = "atom_size_128"
+        ))]
+        unsafe {
+            let value: std::num::NonZeroUsize = std::mem::transmute(value);
+            Self {
+                value: RawTaggedNonZeroValue::new_unchecked(value.get() as _),
+            }
+        }
+
+        #[cfg(not(any(
+            target_pointer_width = "32",
+            target_pointer_width = "16",
+            feature = "atom_size_64",
+            feature = "atom_size_128"
+        )))]
+        {
+            Self {
+                value: value.cast(),
+            }
+        }
+    }
+
+    #[inline(always)]
+    pub fn new_tag(value: NonZeroU8) -> Self {
+        let value = value.get() as RawTaggedValue;
+        Self {
+            value: unsafe { std::mem::transmute(value) },
+        }
+    }
+
+    #[inline(always)]
+    pub fn hash(&self) -> u64 {
+        self.get_value() as _
+    }
+
+    #[inline(always)]
+    pub fn get_ptr(&self) -> *const c_void {
+        #[cfg(any(
+            target_pointer_width = "32",
+            target_pointer_width = "16",
+            feature = "atom_size_64",
+            feature = "atom_size_128"
+        ))]
+        {
+            self.value.get() as usize as _
+        }
+        #[cfg(not(any(
+            target_pointer_width = "32",
+            target_pointer_width = "16",
+            feature = "atom_size_64",
+            feature = "atom_size_128"
+        )))]
+        unsafe {
+            std::mem::transmute(Some(self.value))
+        }
+    }
+
+    #[inline(always)]
+    fn get_value(&self) -> RawTaggedValue {
+        unsafe { std::mem::transmute(Some(self.value)) }
+    }
+
+    #[inline(always)]
+    pub fn tag(&self) -> u8 {
+        (self.get_value() & 0xff) as u8
+    }
+
+    pub fn data(&self) -> &[u8] {
+        let x: *const _ = &self.value;
+        let mut data = x as *const u8;
+        // All except the lowest byte, which is first in little-endian, last in
+        // big-endian.
+        if cfg!(target_endian = "little") {
+            unsafe {
+                data = data.offset(1);
+            }
+        }
+        let len = std::mem::size_of::<TaggedValue>() - 1;
+        unsafe { slice::from_raw_parts(data, len) }
+    }
+
+    /// The `TaggedValue` is a non-zero number or pointer, so caution must be
+    /// used when setting the untagged slice part of this value. If tag is
+    /// zero and the slice is zeroed out, using this `TaggedValue` will be
+    /// UB!
+    pub unsafe fn data_mut(&mut self) -> &mut [u8] {
+        let x: *mut _ = &mut self.value;
+        let mut data = x as *mut u8;
+        // All except the lowest byte, which is first in little-endian, last in
+        // big-endian.
+        if cfg!(target_endian = "little") {
+            data = data.offset(1);
+        }
+        let len = std::mem::size_of::<TaggedValue>() - 1;
+        slice::from_raw_parts_mut(data, len)
+    }
+}

--- a/turbopack/crates/turbo-rcstr/src/tagged_value.rs
+++ b/turbopack/crates/turbo-rcstr/src/tagged_value.rs
@@ -80,11 +80,6 @@ impl TaggedValue {
     }
 
     #[inline(always)]
-    pub fn hash(&self) -> u64 {
-        self.get_value() as _
-    }
-
-    #[inline(always)]
     pub fn get_ptr(&self) -> *const c_void {
         #[cfg(any(
             target_pointer_width = "32",


### PR DESCRIPTION
### What?

Support inline string for `RcStr`. Most of the code is copied from https://github.com/dudykr/ddbase/tree/67c7cec871073f5c8c93d030d40fb8226170797f/crates/hstr/src (I own the code)

### Why?

To see at the perf difference.

#### Command: `ddt profile instruments run -t Memory -- $(which node) $(which pnpm) build-turbopack`

 - Old:
 
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/e9946dcf-7509-42ed-8648-6f6589de6313" />

 - New:


<img width="1840" alt="image" src="https://github.com/user-attachments/assets/08ea782e-9c66-4537-94a3-9f63956aa11a" />

### How?



Closes PACK-3692