### PR TITLE
tests: Add image preloading unit tests.

### DIFF
--- a/test/unit/next-image-new.test.ts
+++ b/test/unit/next-image-new.test.ts
@@ -97,4 +97,36 @@ describe('Image rendering', () => {
     expect($2('noscript').length).toBe(0)
     expect($3('noscript').length).toBe(0)
   })
+
+  it('should preload images when priority true', async () => {
+    const element1 = React.createElement(Image, {
+      alt: 'test',
+      src: '/test.png',
+      width: 100,
+      height: 100,
+      priority: true,
+    })
+    const element2 = React.createElement(Image, {
+      alt: 'test',
+      src: '/test.png',
+      width: 100,
+      height: 100,
+      priority: false,
+      loading: 'eager',
+    })
+    const element3 = React.createElement(Image, {
+      alt: 'test',
+      src: '/test.png',
+      width: 100,
+      height: 100,
+      priority: false,
+      loading: 'lazy',
+    })
+    const $1 = cheerio.load(ReactDOMServer.renderToString(element1))
+    const $2 = cheerio.load(ReactDOMServer.renderToString(element2))
+    const $3 = cheerio.load(ReactDOMServer.renderToString(element3))
+    expect($1('link[rel=preload]').length).toBe(1)
+    expect($2('link[rel=preload]').length).toBe(0)
+    expect($3('link[rel=preload]').length).toBe(0)
+  })
 })


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

-->

### What?
This adds unit tests to the image component to tests if the preload links are correctly added.

### Why?
In #74234 I outlined that the preloading behavior of the image component does not match the expected behavior described in the docs.
One of the tests, the scenario with the wrong behavior, fails, which proves that the image component is not working as expected. 

### How?
This adds 3 unit tests:
1. Image component with `priority: true`, for this scenario a preload link is expected
2. Image component with `priority: false` and `loading: eager`, for this scenario a preload link is NOT expected, this scenario fails, as Next.js adds a preload link.
3. Image component with `priority: false` and `loading: lazy`, for this scenario a preload link is NOT expected.

Closes NEXT-
Fixes #74234 - Doesnt actually fix the issue, but introduces unit tests that prove the bug.



