### PR TITLE
chore(examples): update React in reproduction templates to stable 19

### DIFF
--- a/examples/reproduction-template-pages/.gitignore
+++ b/examples/reproduction-template-pages/.gitignore
@@ -28,9 +28,10 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
-# local env files
-.env*.local
+# env files (can opt-in for committing if needed)
+.env*
 
 # vercel
 .vercel

--- a/examples/reproduction-template-pages/next.config.js
+++ b/examples/reproduction-template-pages/next.config.js
@@ -1,6 +1,0 @@
-/** @type {import("next").NextConfig} */
-const nextConfig = {
-  reactStrictMode: true,
-};
-
-module.exports = nextConfig;

--- a/examples/reproduction-template-pages/next.config.ts
+++ b/examples/reproduction-template-pages/next.config.ts
@@ -1,0 +1,8 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  /* config options here */
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/examples/reproduction-template-pages/package.json
+++ b/examples/reproduction-template-pages/package.json
@@ -7,12 +7,12 @@
   },
   "dependencies": {
     "next": "canary",
-    "react": "19.0.0-beta-04b058868c-20240508",
-    "react-dom": "19.0.0-beta-04b058868c-20240508"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@types/node": "20.4.5",
-    "@types/react": "18.2.18",
-    "typescript": "5.1.3"
+    "@types/node": "^22",
+    "@types/react": "^19",
+    "typescript": "^5"
   }
 }

--- a/examples/reproduction-template-pages/tsconfig.json
+++ b/examples/reproduction-template-pages/tsconfig.json
@@ -1,20 +1,27 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
-    "forceConsistentCasingInFileNames": true,
+    "strict": true,
     "noEmit": true,
-    "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/examples/reproduction-template/.gitignore
+++ b/examples/reproduction-template/.gitignore
@@ -2,7 +2,7 @@
 
 # dependencies
 /node_modules
-/.pnp0
+/.pnp
 .pnp.*
 .yarn/*
 !.yarn/patches
@@ -28,9 +28,10 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
-# local env files
-.env*.local
+# env files (can opt-in for committing if needed)
+.env*
 
 # vercel
 .vercel

--- a/examples/reproduction-template/app/layout.tsx
+++ b/examples/reproduction-template/app/layout.tsx
@@ -1,7 +1,10 @@
-export default function RootLayout({ children }) {
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
   return (
-    <html>
-      <head />
+    <html lang="en">
       <body>{children}</body>
     </html>
   );

--- a/examples/reproduction-template/next.config.mjs
+++ b/examples/reproduction-template/next.config.mjs
@@ -1,8 +1,0 @@
-/**
- * @type {import('next').NextConfig}
- */
-const nextConfig = {
-  reactStrictMode: true,
-};
-
-export default nextConfig;

--- a/examples/reproduction-template/next.config.ts
+++ b/examples/reproduction-template/next.config.ts
@@ -1,0 +1,8 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  /* config options here */
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/examples/reproduction-template/package.json
+++ b/examples/reproduction-template/package.json
@@ -11,9 +11,8 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@types/node": "20.12.12",
-    "@types/react": "18.3.3",
-    "@types/react-dom": "18.3.0",
-    "typescript": "5.3.3"
+    "@types/node": "^22",
+    "@types/react": "^19",
+    "typescript": "^5"
   }
 }

--- a/examples/reproduction-template/tsconfig.json
+++ b/examples/reproduction-template/tsconfig.json
@@ -1,24 +1,26 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
-    "forceConsistentCasingInFileNames": true,
+    "strict": true,
     "noEmit": true,
-    "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
+    "incremental": true,
     "plugins": [
       {
         "name": "next"
       }
-    ]
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Why?

- Update React in reproduction example templates to stable v19
- Switch `.ts` for `next.config`
- Fixes https://github.com/vercel/next.js/issues/74422