### PR TITLE
Fix image preloading behavior.

### DIFF
--- a/packages/next/src/shared/lib/get-img-props.ts
+++ b/packages/next/src/shared/lib/get-img-props.ts
@@ -254,7 +254,7 @@ export function getImgProps(
     onLoadingComplete,
     placeholder = 'empty',
     blurDataURL,
-    fetchPriority,
+    fetchPriority = 'low',
     decoding = 'async',
     layout,
     objectFit,
@@ -687,7 +687,7 @@ export function getImgProps(
   const props: ImgProps = {
     ...rest,
     loading: isLazy ? 'lazy' : loading,
-    fetchPriority,
+    fetchPriority: priority ? 'high' : fetchPriority,
     width: widthInt,
     height: heightInt,
     decoding,

--- a/test/unit/next-image-new.test.ts
+++ b/test/unit/next-image-new.test.ts
@@ -97,4 +97,36 @@ describe('Image rendering', () => {
     expect($2('noscript').length).toBe(0)
     expect($3('noscript').length).toBe(0)
   })
+
+  it('should preload images when priority true', async () => {
+    const element1 = React.createElement(Image, {
+      alt: 'test',
+      src: '/test.png',
+      width: 100,
+      height: 100,
+      priority: true,
+    })
+    const element2 = React.createElement(Image, {
+      alt: 'test',
+      src: '/test.png',
+      width: 100,
+      height: 100,
+      priority: false,
+      loading: 'eager',
+    })
+    const element3 = React.createElement(Image, {
+      alt: 'test',
+      src: '/test.png',
+      width: 100,
+      height: 100,
+      priority: false,
+      loading: 'lazy',
+    })
+    const $1 = cheerio.load(ReactDOMServer.renderToString(element1))
+    const $2 = cheerio.load(ReactDOMServer.renderToString(element2))
+    const $3 = cheerio.load(ReactDOMServer.renderToString(element3))
+    expect($1('link[rel=preload]').length).toBe(1)
+    expect($2('link[rel=preload]').length).toBe(0)
+    expect($3('link[rel=preload]').length).toBe(0)
+  })
 })

--- a/test/unit/next-image-new.test.ts
+++ b/test/unit/next-image-new.test.ts
@@ -25,6 +25,7 @@ describe('Image rendering', () => {
       width: '100',
       height: '100',
       decoding: 'async',
+      fetchpriority: 'low',
       'data-nimg': '1',
       style: 'color:transparent',
       srcset:
@@ -98,7 +99,7 @@ describe('Image rendering', () => {
     expect($3('noscript').length).toBe(0)
   })
 
-  it('should preload images when priority true', async () => {
+  it('should preload images when priority=true', async () => {
     const element1 = React.createElement(Image, {
       alt: 'test',
       src: '/test.png',


### PR DESCRIPTION
### What?
Updates the preloading behavior to not create preload links for eager loaded images with `priority` set to `false`.

### Why?
The current behavior is incorrect and does not match the documenation. Currently images get preloaded even if they have `priority` set to `false`. This PR fixes that.

### How?
The `fetchPriority` is now set to `low` as default. If the image has `priority` set to `true` then the `fetchPriority` is set to `high`.
Explicity setting `fetchPriority` to `low` ensures that react does not preload the image.

Fixes #74234