### PR TITLE
refactor(turbopack): Use ResolvedVc for chunk graph related types

### DIFF
--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -390,7 +390,7 @@ impl ChunkingContext for BrowserChunkingContext {
 
     #[turbo_tasks::function]
     async fn chunk_group(
-        self: Vc<Self>,
+        self: ResolvedVc<Self>,
         ident: Vc<AssetIdent>,
         module: ResolvedVc<Box<dyn ChunkableModule>>,
         availability_info: Value<AvailabilityInfo>,
@@ -403,7 +403,7 @@ impl ChunkingContext for BrowserChunkingContext {
                 chunks,
                 availability_info,
             } = make_chunk_group(
-                Vc::upcast(self),
+                ResolvedVc::upcast(self),
                 [ResolvedVc::upcast(module)],
                 input_availability_info,
             )
@@ -454,7 +454,7 @@ impl ChunkingContext for BrowserChunkingContext {
 
     #[turbo_tasks::function]
     async fn evaluated_chunk_group(
-        self: Vc<Self>,
+        self: ResolvedVc<Self>,
         ident: Vc<AssetIdent>,
         evaluatable_assets: Vc<EvaluatableAssets>,
         availability_info: Value<AvailabilityInfo>,
@@ -476,7 +476,7 @@ impl ChunkingContext for BrowserChunkingContext {
             let MakeChunkGroupResult {
                 chunks,
                 availability_info,
-            } = make_chunk_group(Vc::upcast(self), entries, availability_info).await?;
+            } = make_chunk_group(ResolvedVc::upcast(self), entries, availability_info).await?;
 
             let mut assets: Vec<ResolvedVc<Box<dyn OutputAsset>>> = chunks
                 .iter()

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content_entry.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content_entry.rs
@@ -59,7 +59,11 @@ impl EcmascriptDevChunkContentEntries {
                 async move {
                     Ok((
                         chunk_item.id().await?,
-                        EcmascriptDevChunkContentEntry::new(chunk_item, async_module_info).await?,
+                        EcmascriptDevChunkContentEntry::new(
+                            *chunk_item,
+                            async_module_info.map(|info| *info),
+                        )
+                        .await?,
                     ))
                 }
                 .instrument(info_span!(

--- a/turbopack/crates/turbopack-core/src/chunk/availability_info.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/availability_info.rs
@@ -17,14 +17,14 @@ pub enum AvailabilityInfo {
 }
 
 impl AvailabilityInfo {
-    pub fn available_chunk_items(&self) -> Option<Vc<AvailableChunkItems>> {
+    pub fn available_chunk_items(&self) -> Option<ResolvedVc<AvailableChunkItems>> {
         match self {
             Self::Untracked => None,
             Self::Root => None,
             Self::Complete {
                 available_chunk_items,
                 ..
-            } => Some(**available_chunk_items),
+            } => Some(*available_chunk_items),
         }
     }
 

--- a/turbopack/crates/turbopack-core/src/chunk/chunking.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking.rs
@@ -53,7 +53,9 @@ pub async fn make_chunks(
         .await?
         .iter()
         .map(|&(chunk_item, async_info)| async move {
-            let chunk_item_info = chunk_item_info(chunking_context, chunk_item, async_info).await?;
+            let chunk_item_info =
+                chunk_item_info(chunking_context, *chunk_item, async_info.map(|info| *info))
+                    .await?;
             Ok((chunk_item, async_info, chunk_item_info))
         })
         .try_join()
@@ -118,8 +120,8 @@ pub async fn make_chunks(
 }
 
 type ChunkItemWithInfo = (
-    Vc<Box<dyn ChunkItem>>,
-    Option<Vc<AsyncModuleInfo>>,
+    ResolvedVc<Box<dyn ChunkItem>>,
+    Option<ResolvedVc<AsyncModuleInfo>>,
     usize,
     ReadRef<RcStr>,
 );

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
@@ -34,11 +34,12 @@ impl AsyncLoaderChunkItem {
         let module = self.module.await?;
         if let Some(chunk_items) = module.availability_info.available_chunk_items() {
             if chunk_items
+                .await?
                 .get(
                     module
                         .inner
                         .as_chunk_item(*ResolvedVc::upcast(self.chunking_context))
-                        .resolve()
+                        .to_resolved()
                         .await?,
                 )
                 .await?

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{TryJoinIterExt, ValueDefault, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueDefault, ValueToString, Vc};
 use turbopack_core::{
     chunk::{
         round_chunk_item_size, AsyncModuleInfo, Chunk, ChunkItem, ChunkItemWithAsyncModuleInfo,
@@ -45,9 +45,9 @@ impl ChunkType for EcmascriptChunkType {
         let content = EcmascriptChunkContent {
             chunk_items: chunk_items
                 .iter()
-                .map(|(chunk_item, async_info)| async move {
+                .map(|&(chunk_item, async_info)| async move {
                     let Some(chunk_item) =
-                        Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkItem>>(*chunk_item)
+                        ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkItem>>(chunk_item)
                             .await?
                     else {
                         bail!(
@@ -55,7 +55,7 @@ impl ChunkType for EcmascriptChunkType {
                              ecmascript"
                         );
                     };
-                    Ok((chunk_item, *async_info))
+                    Ok((chunk_item, async_info))
                 })
                 .try_join()
                 .await?,

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/content.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/content.rs
@@ -1,14 +1,14 @@
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::ResolvedVc;
 use turbopack_core::{chunk::AsyncModuleInfo, output::OutputAsset};
 
 use super::item::EcmascriptChunkItem;
 
 type EcmascriptChunkItemWithAsyncInfo = (
-    Vc<Box<dyn EcmascriptChunkItem>>,
-    Option<Vc<AsyncModuleInfo>>,
+    ResolvedVc<Box<dyn EcmascriptChunkItem>>,
+    Option<ResolvedVc<AsyncModuleInfo>>,
 );
 
-#[turbo_tasks::value(shared, local)]
+#[turbo_tasks::value(shared)]
 pub struct EcmascriptChunkContent {
     pub chunk_items: Vec<EcmascriptChunkItemWithAsyncInfo>,
     pub referenced_output_assets: Vec<ResolvedVc<Box<dyn OutputAsset>>>,

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -145,9 +145,8 @@ impl Chunk for EcmascriptChunk {
         Ok(ChunkItems(
             chunk_items
                 .iter()
-                .map(|(item, _)| async move { Ok(ResolvedVc::upcast(item.to_resolved().await?)) })
-                .try_join()
-                .await?,
+                .map(|&(item, _)| ResolvedVc::upcast(item))
+                .collect(),
         )
         .cell())
     }

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -66,10 +66,11 @@ impl ManifestAsyncModule {
         let this = self.await?;
         if let Some(chunk_items) = this.availability_info.available_chunk_items() {
             if chunk_items
+                .await?
                 .get(
                     this.inner
                         .as_chunk_item(*ResolvedVc::upcast(this.chunking_context))
-                        .resolve()
+                        .to_resolved()
                         .await?,
                 )
                 .await?

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -293,7 +293,7 @@ impl ChunkingContext for NodeJsChunkingContext {
 
     #[turbo_tasks::function]
     async fn chunk_group(
-        self: Vc<Self>,
+        self: ResolvedVc<Self>,
         _ident: Vc<AssetIdent>,
         module: ResolvedVc<Box<dyn ChunkableModule>>,
         availability_info: Value<AvailabilityInfo>,
@@ -307,7 +307,7 @@ impl ChunkingContext for NodeJsChunkingContext {
                 chunks,
                 availability_info,
             } = make_chunk_group(
-                Vc::upcast(self),
+                ResolvedVc::upcast(self),
                 [ResolvedVc::upcast(module)],
                 availability_info.into_value(),
             )
@@ -334,7 +334,7 @@ impl ChunkingContext for NodeJsChunkingContext {
     /// * exports the result of evaluating the given module as a CommonJS default export.
     #[turbo_tasks::function]
     pub async fn entry_chunk_group(
-        self: Vc<Self>,
+        self: ResolvedVc<Self>,
         path: Vc<FileSystemPath>,
         module: ResolvedVc<Box<dyn Module>>,
         evaluatable_assets: Vc<EvaluatableAssets>,
@@ -347,7 +347,7 @@ impl ChunkingContext for NodeJsChunkingContext {
             chunks,
             availability_info,
         } = make_chunk_group(
-            Vc::upcast(self),
+            ResolvedVc::upcast(self),
             once(module).chain(
                 evaluatable_assets
                     .await?
@@ -378,7 +378,7 @@ impl ChunkingContext for NodeJsChunkingContext {
         let asset = ResolvedVc::upcast(
             EcmascriptBuildNodeEntryChunk::new(
                 path,
-                self,
+                *self,
                 Vc::cell(other_chunks),
                 evaluatable_assets,
                 *module,

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -55,7 +55,7 @@ pub(super) async fn chunk_items(
         .map(|&(chunk_item, async_module_info)| async move {
             Ok((
                 chunk_item.id().await?,
-                chunk_item.code(async_module_info).await?,
+                chunk_item.code(async_module_info.map(|info| *info)).await?,
             ))
         })
         .try_join()

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -210,7 +210,7 @@ impl ChunkItem for ModuleChunkItem {
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<OutputAssets>> {
         let loader_references = self.module.loader().references().await?;
-        references_to_output_assets(loader_references.iter().map(|r| **r).collect::<_>()).await
+        references_to_output_assets(&*loader_references).await
     }
 
     #[turbo_tasks::function]


### PR DESCRIPTION
Allows a few more `turbo_tasks::value`s to implement `NonLocalValue`, making them safe for use with local tasks.

Closes PACK-3689