### PR TITLE
refactor(turbopack-ecmascript) Use ResolvedVc in EsmExport type

### DIFF
--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -94,10 +94,14 @@ impl ChunkableModule for NextDynamicEntryModule {
 impl EcmascriptChunkPlaceable for NextDynamicEntryModule {
     #[turbo_tasks::function]
     async fn get_exports(&self) -> Result<Vc<EcmascriptExports>> {
-        let module_reference = Vc::upcast(SingleChunkableModuleReference::new(
-            Vc::upcast(*self.module),
-            dynamic_ref_description(),
-        ));
+        let module_reference = ResolvedVc::upcast(
+            SingleChunkableModuleReference::new(
+                Vc::upcast(*self.module),
+                dynamic_ref_description(),
+            )
+            .to_resolved()
+            .await?,
+        );
 
         let mut exports = BTreeMap::new();
         exports.insert(
@@ -108,7 +112,7 @@ impl EcmascriptChunkPlaceable for NextDynamicEntryModule {
         Ok(EcmascriptExports::EsmExports(
             EsmExports {
                 exports,
-                star_exports: vec![module_reference.to_resolved().await?],
+                star_exports: vec![module_reference],
             }
             .resolved_cell(),
         )

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -114,9 +114,11 @@ impl ChunkableModule for NextServerComponentModule {
 impl EcmascriptChunkPlaceable for NextServerComponentModule {
     #[turbo_tasks::function]
     async fn get_exports(&self) -> Result<Vc<EcmascriptExports>> {
-        let module_reference = Vc::upcast(NextServerComponentModuleReference::new(Vc::upcast(
-            *self.module,
-        )));
+        let module_reference = ResolvedVc::upcast(
+            NextServerComponentModuleReference::new(Vc::upcast(*self.module))
+                .to_resolved()
+                .await?,
+        );
 
         let mut exports = BTreeMap::new();
         exports.insert(
@@ -127,7 +129,7 @@ impl EcmascriptChunkPlaceable for NextServerComponentModule {
         Ok(EcmascriptExports::EsmExports(
             EsmExports {
                 exports,
-                star_exports: vec![module_reference.to_resolved().await?],
+                star_exports: vec![module_reference],
             }
             .resolved_cell(),
         )

--- a/crates/next-core/src/next_server_utility/server_utility_module.rs
+++ b/crates/next-core/src/next_server_utility/server_utility_module.rs
@@ -92,9 +92,11 @@ impl ChunkableModule for NextServerUtilityModule {
 impl EcmascriptChunkPlaceable for NextServerUtilityModule {
     #[turbo_tasks::function]
     async fn get_exports(&self) -> Result<Vc<EcmascriptExports>> {
-        let module_reference = Vc::upcast(NextServerUtilityModuleReference::new(Vc::upcast(
-            *self.module,
-        )));
+        let module_reference = ResolvedVc::upcast(
+            NextServerUtilityModuleReference::new(Vc::upcast(*self.module))
+                .to_resolved()
+                .await?,
+        );
 
         let mut exports = BTreeMap::new();
         exports.insert(
@@ -105,7 +107,7 @@ impl EcmascriptChunkPlaceable for NextServerUtilityModule {
         Ok(EcmascriptExports::EsmExports(
             EsmExports {
                 exports,
-                star_exports: vec![module_reference.to_resolved().await?],
+                star_exports: vec![module_reference],
             }
             .resolved_cell(),
         )

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -186,10 +186,14 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
                             exports.insert(
                                 name.clone(),
                                 EsmExport::ImportedBinding(
-                                    Vc::upcast(EcmascriptModulePartReference::new_part(
-                                        *self.module,
-                                        ModulePart::locals(),
-                                    )),
+                                    ResolvedVc::upcast(
+                                        EcmascriptModulePartReference::new_part(
+                                            *self.module,
+                                            ModulePart::locals(),
+                                        )
+                                        .to_resolved()
+                                        .await?,
+                                    ),
                                     name,
                                     *mutable,
                                 ),
@@ -229,10 +233,14 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
                     exports.insert(
                         "default".into(),
                         EsmExport::ImportedBinding(
-                            Vc::upcast(EcmascriptModulePartReference::new_part(
-                                *self.module,
-                                ModulePart::exports(),
-                            )),
+                            ResolvedVc::upcast(
+                                EcmascriptModulePartReference::new_part(
+                                    *self.module,
+                                    ModulePart::exports(),
+                                )
+                                .to_resolved()
+                                .await?,
+                            ),
                             "default".into(),
                             false,
                         ),
@@ -252,7 +260,11 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
                 exports.insert(
                     export.await?.clone_value(),
                     EsmExport::ImportedBinding(
-                        Vc::upcast(EcmascriptModulePartReference::new(*self.module)),
+                        ResolvedVc::upcast(
+                            EcmascriptModulePartReference::new(*self.module)
+                                .to_resolved()
+                                .await?,
+                        ),
                         original_export.clone_value(),
                         false,
                     ),
@@ -261,9 +273,11 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
             ModulePart::RenamedNamespace { export } => {
                 exports.insert(
                     export.await?.clone_value(),
-                    EsmExport::ImportedNamespace(Vc::upcast(EcmascriptModulePartReference::new(
-                        *self.module,
-                    ))),
+                    EsmExport::ImportedNamespace(ResolvedVc::upcast(
+                        EcmascriptModulePartReference::new(*self.module)
+                            .to_resolved()
+                            .await?,
+                    )),
                 );
             }
             ModulePart::Evaluation => {
@@ -276,8 +290,8 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
             exports,
             star_exports,
         }
-        .cell();
-        Ok(EcmascriptExports::EsmExports(exports.to_resolved().await?).cell())
+        .resolved_cell();
+        Ok(EcmascriptExports::EsmExports(exports).cell())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -93,8 +93,8 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleLocalsModule {
             exports,
             star_exports: vec![],
         }
-        .cell();
-        Ok(EcmascriptExports::EsmExports(exports.to_resolved().await?).cell())
+        .resolved_cell();
+        Ok(EcmascriptExports::EsmExports(exports).cell())
     }
 
     #[turbo_tasks::function]


### PR DESCRIPTION
This removes the `local` opt-out from `EsmExports`.

Closes PACK-3693