### PR TITLE
Attempt to load WASM by package name before downloading

### DIFF
--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1007,11 +1007,11 @@ async function loadWasm(importPath = '') {
 
       if (importPath) {
         // the import path must be exact when not in node_modules
-        pkgPath = path.join(importPath, pkg, 'wasm.js')
+        pkgPath = pathToFileURL(
+          path.join(importPath, pkg, 'wasm.js')
+        ).toString()
       }
-      let bindings: RawWasmBindings = await import(
-        pathToFileURL(pkgPath).toString()
-      )
+      let bindings: RawWasmBindings = await import(pkgPath)
       if (pkg === '@next/swc-wasm-web') {
         bindings = await bindings.default!()
       }


### PR DESCRIPTION
Prior to this, the import would be `file:///@next/swc-wasm-web`, which would never actually resolve, even if the package was installed.