### PR TITLE
test: add missing await for hydration test

### DIFF
--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -786,7 +786,7 @@ describe('Error overlay for hydration errors in App router', () => {
     const { session, browser } = sandbox
     await session.openRedbox()
 
-    retry(async () => {
+    await retry(async () => {
       expect(await getRedboxTotalErrorCount(browser)).toBe(4)
     })
 

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -624,7 +624,9 @@ describe('Error overlay for hydration errors in App router', () => {
     const { session, browser } = sandbox
     await session.openRedbox()
 
-    expect(await getRedboxTotalErrorCount(browser)).toBe(2)
+    await retry(async () => {
+      expect(await getRedboxTotalErrorCount(browser)).toBe(2)
+    })
 
     const description = await session.getRedboxDescription()
     expect(description).toContain(


### PR DESCRIPTION
The `retry()` call needs to be awaited, where the callback keeps get invoked while new errors are being added to the error queue.

x-ref: https://github.com/vercel/next.js/actions/runs/12629855744/job/35188630034?pr=74262
x-ref: https://github.com/vercel/next.js/actions/runs/12630087365/job/35189250327?pr=74542