### PR TITLE
fix: add prerender abort errors to unstable rethrow

### DIFF
--- a/packages/next/src/client/components/unstable-rethrow.ts
+++ b/packages/next/src/client/components/unstable-rethrow.ts
@@ -1,4 +1,5 @@
 import { isDynamicUsageError } from '../../export/helpers/is-dynamic-usage-error'
+import { isHangingPromiseRejectionError } from '../../server/dynamic-rendering-utils'
 import { isPostpone } from '../../server/lib/router-utils/is-postpone'
 import { isBailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
 import { isNextRouterError } from './is-next-router-error'
@@ -15,7 +16,8 @@ export function unstable_rethrow(error: unknown): void {
     isNextRouterError(error) ||
     isBailoutToCSRError(error) ||
     isDynamicUsageError(error) ||
-    isPostpone(error)
+    isPostpone(error) ||
+    isHangingPromiseRejectionError(error)
   ) {
     throw error
   }

--- a/packages/next/src/server/dynamic-rendering-utils.ts
+++ b/packages/next/src/server/dynamic-rendering-utils.ts
@@ -1,3 +1,25 @@
+export function isHangingPromiseRejectionError(
+  err: unknown
+): err is HangingPromiseRejectionError {
+  if (typeof err !== 'object' || err === null || !('digest' in err)) {
+    return false
+  }
+
+  return err.digest === HANGING_PROMISE_REJECTION
+}
+
+const HANGING_PROMISE_REJECTION = 'HANGING_PROMISE_REJECTION'
+
+class HangingPromiseRejectionError extends Error {
+  public readonly digest = HANGING_PROMISE_REJECTION
+
+  constructor(public readonly expression: string) {
+    super(
+      `During prerendering, ${expression} rejects when the prerender is complete. Typically these errors are handled by React but if you move ${expression} to a different context by using \`setTimeout\`, \`after\`, or similar functions you may observe this error and you should handle it in that context.`
+    )
+  }
+}
+
 /**
  * This function constructs a promise that will never resolve. This is primarily
  * useful for dynamicIO where we use promise resolution timing to determine which
@@ -13,11 +35,7 @@ export function makeHangingPromise<T>(
     signal.addEventListener(
       'abort',
       () => {
-        reject(
-          new Error(
-            `During prerendering, ${expression} rejects when the prerender is complete. Typically these errors are handled by React but if you move ${expression} to a different context by using \`setTimeout\`, \`after\`, or similar functions you may observe this error and you should handle it in that context.`
-          )
-        )
+        reject(new HangingPromiseRejectionError(expression))
       },
       { once: true }
     )


### PR DESCRIPTION
Prerender errors triggered during development should be rethrown by the `unstable_rethrow` api.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
