### PR TITLE
add types for `__next_app__` module loading functions

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -21,8 +21,8 @@ export { tree, pages }
 export { default as GlobalError } from 'VAR_MODULE_GLOBAL_ERROR' with { 'turbopack-transition': 'next-server-utility' }
 
 // These are injected by the loader afterwards.
-declare const __next_app_require__: any
-declare const __next_app_load_chunk__: any
+declare const __next_app_require__: (id: string | number) => unknown
+declare const __next_app_load_chunk__: (id: string | number) => Promise<unknown>
 
 // INJECT:__next_app_require__
 // INJECT:__next_app_load_chunk__

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -912,12 +912,14 @@ export async function handleAction({
         }
       }
 
-      const actionHandler = (
-        await ComponentMod.__next_app__.require(actionModId)
-      )[
-        // `actionId` must exist if we got here, as otherwise we would have thrown an error above
-        actionId!
-      ]
+      const actionMod = (await ComponentMod.__next_app__.require(
+        actionModId
+      )) as Record<string, (...args: unknown[]) => Promise<unknown>>
+      const actionHandler =
+        actionMod[
+          // `actionId` must exist if we got here, as otherwise we would have thrown an error above
+          actionId!
+        ]
 
       const returnVal = await workUnitAsyncStorage.run(requestStore, () =>
         actionHandler.apply(null, boundActionArguments)

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1189,12 +1189,13 @@ async function renderToHTMLOrFlightImpl(
     // cache reads we wrap the loadChunk in this tracking. This allows us
     // to treat chunk loading with similar semantics as cache reads to avoid
     // async loading chunks from causing a prerender to abort too early.
-    // @ts-ignore
-    globalThis.__next_chunk_load__ = (...args: Array<any>) => {
+    const __next_chunk_load__: typeof instrumented.loadChunk = (...args) => {
       const loadingChunk = instrumented.loadChunk(...args)
       trackChunkLoading(loadingChunk)
       return loadingChunk
     }
+    // @ts-expect-error
+    globalThis.__next_chunk_load__ = __next_chunk_load__
   }
 
   if (process.env.NODE_ENV === 'development') {

--- a/packages/next/src/server/client-component-renderer-logger.ts
+++ b/packages/next/src/server/client-component-renderer-logger.ts
@@ -1,15 +1,19 @@
+import type { AppPageModule } from './route-modules/app-page/module'
+
 // Combined load times for loading client components
 let clientComponentLoadStart = 0
 let clientComponentLoadTimes = 0
 let clientComponentLoadCount = 0
 
-export function wrapClientComponentLoader(ComponentMod: any) {
+export function wrapClientComponentLoader(
+  ComponentMod: AppPageModule
+): AppPageModule['__next_app__'] {
   if (!('performance' in globalThis)) {
     return ComponentMod.__next_app__
   }
 
   return {
-    require: (...args: any[]) => {
+    require: (...args) => {
       const startTime = performance.now()
 
       if (clientComponentLoadStart === 0) {
@@ -23,7 +27,7 @@ export function wrapClientComponentLoader(ComponentMod: any) {
         clientComponentLoadTimes += performance.now() - startTime
       }
     },
-    loadChunk: (...args: any[]) => {
+    loadChunk: (...args) => {
       const startTime = performance.now()
       try {
         return ComponentMod.__next_app__.loadChunk(...args)

--- a/packages/next/src/server/client-component-renderer-logger.ts
+++ b/packages/next/src/server/client-component-renderer-logger.ts
@@ -29,11 +29,13 @@ export function wrapClientComponentLoader(
     },
     loadChunk: (...args) => {
       const startTime = performance.now()
-      try {
-        return ComponentMod.__next_app__.loadChunk(...args)
-      } finally {
+      const result = ComponentMod.__next_app__.loadChunk(...args)
+      // Avoid wrapping `loadChunk`'s result in an extra promise in case something like React depends on its identity.
+      // We only need to know when it's settled.
+      result.finally(() => {
         clientComponentLoadTimes += performance.now() - startTime
-      }
+      })
+      return result
     },
   }
 }


### PR DESCRIPTION
`__next_app__.require` and `__next_app__.loadChunk` were typed as `any` for no good reason. i made them more strict + adjusted callsites as needed.

also contains a drive-by fix for `wrapClientComponentLoader` -- it was using a `try ... finally` without awaiting, so it wasn't measuring anything (because `loadChunk`, being async, would always return immediately)