### PR TITLE
fix: add aria-hidden to error overlay voting icons

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/error-overlay-layout/error-overlay-layout.test.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/error-overlay-layout/error-overlay-layout.test.tsx
@@ -60,6 +60,25 @@ describe('ErrorOverlayLayout Component', () => {
       )
     ).toBeInTheDocument()
   })
+  test('voting buttons have aria-hidden icons', () => {
+    renderTestComponent()
+
+    const helpfulButton = screen.getByRole('button', {
+      name: 'Mark as helpful',
+    })
+    const notHelpfulButton = screen.getByRole('button', {
+      name: 'Mark as not helpful',
+    })
+
+    expect(helpfulButton.querySelector('svg')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    )
+    expect(notHelpfulButton.querySelector('svg')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    )
+  })
 
   test('sends feedback when clicking helpful button', async () => {
     renderTestComponent()

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/icons/thumbs/thumbs-down.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/icons/thumbs/thumbs-down.tsx
@@ -1,4 +1,6 @@
-export function ThumbsDown() {
+import type { ComponentProps } from 'react'
+
+export function ThumbsDown(props: ComponentProps<'svg'>) {
   return (
     <svg
       width="16"
@@ -7,6 +9,7 @@ export function ThumbsDown() {
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       className="thumbs-down-icon"
+      {...props}
     >
       <path
         fillRule="evenodd"

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/icons/thumbs/thumbs-up.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/icons/thumbs/thumbs-up.tsx
@@ -1,4 +1,6 @@
-export function ThumbsUp() {
+import type { ComponentProps } from 'react'
+
+export function ThumbsUp(props: ComponentProps<'svg'>) {
   return (
     <svg
       width="16"
@@ -7,6 +9,7 @@ export function ThumbsUp() {
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       className="thumbs-up-icon"
+      {...props}
     >
       <g id="thumb-up-16">
         <path


### PR DESCRIPTION
## What?
Added accessibility improvements to the error overlay voting buttons by making their icons properly hidden from screen readers.

## Why?
To enhance accessibility for users relying on screen readers by preventing redundant icon announcements while maintaining the clear button labels "Mark as helpful" and "Mark as not helpful".

## How?
- Added `ComponentProps<'svg'>` type to ThumbsUp and ThumbsDown components to allow passing SVG attributes
- Spread props to SVG elements to enable aria attributes
- Added test coverage to ensure icons have `aria-hidden="true"`
