### PR TITLE
Backport: Use provided waitUntil for pending revalidates (#74164)

### DIFF
--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -10,6 +10,7 @@ import type { LoadingModuleData } from '../../shared/lib/app-router-context.shar
 import type { DeepReadonly } from '../../shared/lib/deep-readonly'
 
 import s from 'next/dist/compiled/superstruct'
+import type { WaitUntil } from '../lib/builtin-request-context'
 
 export type DynamicParamTypes =
   | 'catchall'
@@ -170,6 +171,8 @@ export interface RenderOptsPartial {
    */
   isDebugPPRSkeleton?: boolean
   isStaticGeneration?: boolean
+
+  builtInWaitUntil?: WaitUntil
 }
 
 export type RenderOpts = LoadComponentsReturnType<AppPageModule> &

--- a/packages/next/src/server/async-storage/static-generation-async-storage-wrapper.ts
+++ b/packages/next/src/server/async-storage/static-generation-async-storage-wrapper.ts
@@ -42,6 +42,7 @@ export type StaticGenerationContext = {
     | 'nextExport'
     | 'isDraftMode'
     | 'isDebugPPRSkeleton'
+    | 'builtInWaitUntil'
   >
 }
 

--- a/packages/next/src/server/lib/builtin-request-context.ts
+++ b/packages/next/src/server/lib/builtin-request-context.ts
@@ -1,0 +1,41 @@
+import { createAsyncLocalStorage } from '../../client/components/async-local-storage'
+
+export function getBuiltinRequestContext():
+  | BuiltinRequestContextValue
+  | undefined {
+  const _globalThis = globalThis as GlobalThisWithRequestContext
+  const ctx = _globalThis[NEXT_REQUEST_CONTEXT_SYMBOL]
+  return ctx?.get()
+}
+
+const NEXT_REQUEST_CONTEXT_SYMBOL = Symbol.for('@next/request-context')
+
+type GlobalThisWithRequestContext = typeof globalThis & {
+  [NEXT_REQUEST_CONTEXT_SYMBOL]?: BuiltinRequestContext
+}
+
+/** A request context provided by the platform. */
+export type BuiltinRequestContext = {
+  get(): BuiltinRequestContextValue | undefined
+}
+
+export type RunnableBuiltinRequestContext = BuiltinRequestContext & {
+  run<T>(value: BuiltinRequestContextValue, callback: () => T): T
+}
+
+export type BuiltinRequestContextValue = {
+  waitUntil?: WaitUntil
+}
+export type WaitUntil = (promise: Promise<any>) => void
+
+/** "@next/request-context" has a different signature from AsyncLocalStorage,
+ * matching [AsyncContext.Variable](https://github.com/tc39/proposal-async-context).
+ * We don't need a full AsyncContext adapter here, just having `.get()` is enough
+ */
+export function createLocalRequestContext(): RunnableBuiltinRequestContext {
+  const storage = createAsyncLocalStorage<BuiltinRequestContextValue>()
+  return {
+    get: () => storage.getStore(),
+    run: (value, callback) => storage.run(value, callback),
+  }
+}

--- a/test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts
+++ b/test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts
@@ -1,4 +1,4 @@
-import { findPort, waitFor } from 'next-test-utils'
+import { findPort, retry, waitFor } from 'next-test-utils'
 import http from 'http'
 import { outdent } from 'outdent'
 import { isNextDev, isNextStart, nextTestSetup } from 'e2e-utils'
@@ -104,12 +104,10 @@ describe('app-fetch-deduping', () => {
 
         expect(invocation(next.cliOutput)).toBe(1)
 
-        // wait for the revalidation to finish
-        await waitFor(revalidate * 1000 + 1000)
-
-        await next.render('/test')
-
-        expect(invocation(next.cliOutput)).toBe(2)
+        await retry(async () => {
+          await next.render('/test')
+          expect(invocation(next.cliOutput)).toBe(2)
+        }, 10_000)
       })
     })
   } else {

--- a/test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts
+++ b/test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts
@@ -1,4 +1,4 @@
-import { findPort, retry, waitFor } from 'next-test-utils'
+import { findPort, retry } from 'next-test-utils'
 import http from 'http'
 import { outdent } from 'outdent'
 import { isNextDev, isNextStart, nextTestSetup } from 'e2e-utils'


### PR DESCRIPTION
This backports https://github.com/vercel/next.js/pull/74164 to leverage built-in waitUntil if available instead of using the approach that keeps the stream open until the waitUntil promise resolves. 

x-ref: [slack thread](https://vercel.slack.com/archives/C02K2HCH5V4/p1736211642221149?thread_ts=1734707275.666089&cid=C02K2HCH5V4)