### PR TITLE
[Turbopack] fix shadow-rs build caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3067,9 +3067,9 @@ dependencies = [
 
 [[package]]
 name = "is_debug"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d198e9919d9822d5f7083ba8530e04de87841eaf21ead9af8f2304efd57c89"
+checksum = "e8ea828c9d6638a5bd3d8b14e37502b4d56cae910ccf8a5b7f51c7a0eb1d0508"
 
 [[package]]
 name = "isahc"
@@ -5935,9 +5935,9 @@ dependencies = [
 
 [[package]]
 name = "shadow-rs"
-version = "0.35.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2311e39772c00391875f40e34d43efef247b23930143a70ca5fbec9505937420"
+checksum = "974eb8222c62a8588bc0f02794dd1ba5b60b3ec88b58e050729d0907ed6af610"
 dependencies = [
  "const_format",
  "is_debug",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ serde_path_to_error = "0.1.9"
 serde_qs = "0.11.0"
 serde_with = "2.3.2"
 serde_yaml = "0.9.17"
-shadow-rs = { version = "0.35.0", default-features = false, features = [
+shadow-rs = { version = "0.37.0", default-features = false, features = [
   "tzdb",
 ] }
 smallvec = { version = "1.13.1", features = [

--- a/crates/napi/build.rs
+++ b/crates/napi/build.rs
@@ -1,10 +1,19 @@
+use std::fs;
+
 extern crate napi_build;
 
 fn main() {
     // Generates, stores build-time information as static values.
     // There are some places relying on correct values for this (i.e telemetry),
     // So failing build if this fails.
-    shadow_rs::new().expect("Should able to generate build time information");
+    shadow_rs::ShadowBuilder::builder()
+        .build()
+        .expect("Should able to generate build time information");
+
+    let git_head = fs::read_to_string("../../.git/HEAD").unwrap_or_default();
+    if !git_head.is_empty() && !git_head.starts_with("ref: ") {
+        println!("cargo:warning=git version {}", git_head);
+    }
 
     #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
     napi_build::setup();

--- a/crates/next-api/build.rs
+++ b/crates/next-api/build.rs
@@ -4,7 +4,10 @@ fn main() {
     // Generates, stores build-time information as static values.
     // There are some places relying on correct values for this (i.e telemetry),
     // So failing build if this fails.
-    shadow_rs::new().expect("Should able to generate build time information");
+    shadow_rs::ShadowBuilder::builder()
+        .build_pattern(shadow_rs::BuildPattern::Lazy)
+        .build()
+        .expect("Should able to generate build time information");
 
     generate_register();
 }


### PR DESCRIPTION
### What?

updates shadow-rs dependency, which fixes the build.rs caching problem: https://github.com/baoyachi/shadow-rs/pull/195/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R40

Also prints the git version during the build

Closes PACK-3685