### PR TITLE
Turbopack dev: Remove client to server websocket ping event

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/helpers/use-websocket.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/helpers/use-websocket.ts
@@ -96,6 +96,12 @@ export function useWebsocketPing(
   const { tree } = useContext(GlobalLayoutRouterContext)
 
   useEffect(() => {
+    // Never send pings when using Turbopack as it's not used.
+    // Pings were originally used to keep track of active routes in on-demand-entries with webpack.
+    if (process.env.TURBOPACK) {
+      return
+    }
+
     // Taken from on-demand-entries-client.js
     const interval = setInterval(() => {
       sendMessage(

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/use-websocket.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/use-websocket.ts
@@ -96,6 +96,12 @@ export function useWebsocketPing(
   const { tree } = useContext(GlobalLayoutRouterContext)
 
   useEffect(() => {
+    // Never send pings when using Turbopack as it's not used.
+    // Pings were originally used to keep track of active routes in on-demand-entries with webpack.
+    if (process.env.TURBOPACK) {
+      return
+    }
+
     // Taken from on-demand-entries-client.js
     const interval = setInterval(() => {
       sendMessage(

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -727,9 +727,6 @@ export async function createHotReloaderTurbopack(
 
           // Next.js messages
           switch (parsedData.event) {
-            case 'ping':
-              // Ping doesn't need additional handling in Turbopack.
-              break
             case 'span-end': {
               hotReloaderSpan.manualTraceChild(
                 parsedData.spanName,


### PR DESCRIPTION
## What?

Skips the websocket ping for Turbopack. Currently the ping is only used by the webpack integration to keep track of "active" entrypoints that are still being viewed. Entrypoints that are no longer viewed will be disposed from the webpack compiler.

With Turbopack this mechanism is not used and it keeps the entrypoints around. Removing the ping makes the websocket events easier to monitor and read while debugging.


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
