### PR TITLE
backport: force module format for virtual client-proxy (#74162)

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
+++ b/packages/next-swc/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
@@ -67,11 +67,13 @@ impl EcmascriptClientReferenceProxyModule {
     #[turbo_tasks::function]
     async fn proxy_module(&self) -> Result<Vc<EcmascriptModuleAsset>> {
         let mut code = CodeBuilder::default();
+        let is_esm: bool;
 
         let server_module_path = &*self.server_module_ident.path().to_string().await?;
 
         // Adapted from https://github.com/facebook/react/blob/c5b9375767e2c4102d7e5559d383523736f1c902/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js#L323-L354
         if let EcmascriptExports::EsmExports(exports) = &*self.client_module.get_exports().await? {
+            is_esm = true;
             let exports = exports.expand_exports().await?;
 
             if !exports.dynamic_exports.is_empty() {
@@ -127,6 +129,7 @@ impl EcmascriptClientReferenceProxyModule {
                 }
             }
         } else {
+            is_esm = false;
             writedoc!(
                 code,
                 r#"
@@ -143,7 +146,13 @@ impl EcmascriptClientReferenceProxyModule {
             AssetContent::file(File::from(code.source_code().clone()).into());
 
         let proxy_source = VirtualSource::new(
-            self.server_module_ident.path().join("proxy.js".to_string()),
+            self.server_module_ident.path().join(
+                // Depending on the original format, we call the file `proxy.mjs` or `proxy.cjs`.
+                // This is because we're placing the virtual module next to the original code, so
+                // its parsing will be affected by `type` fields in package.json --
+                // a bare `proxy.js` may end up being unexpectedly parsed as the wrong format.
+                format!("proxy.{}", if is_esm { "mjs" } else { "cjs" }),
+            ),
             proxy_module_content,
         );
 

--- a/test/e2e/app-dir/client-module-with-package-type/app/import-cjs/page.tsx
+++ b/test/e2e/app-dir/client-module-with-package-type/app/import-cjs/page.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react'
+
+import EsmFromCjs from 'lib-cjs'
+
+export default function Page() {
+  return (
+    <p>
+      lib-cjs: <EsmFromCjs />
+    </p>
+  )
+}

--- a/test/e2e/app-dir/client-module-with-package-type/app/import-esm/page.tsx
+++ b/test/e2e/app-dir/client-module-with-package-type/app/import-esm/page.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react'
+
+import EsmFromEsm from 'lib-esm'
+
+export default function Page() {
+  return (
+    <p>
+      lib-esm: <EsmFromEsm />
+    </p>
+  )
+}

--- a/test/e2e/app-dir/client-module-with-package-type/app/layout.tsx
+++ b/test/e2e/app-dir/client-module-with-package-type/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/client-module-with-package-type/app/require-cjs/page.tsx
+++ b/test/e2e/app-dir/client-module-with-package-type/app/require-cjs/page.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react'
+
+const CjsFromCjs = require('lib-cjs')
+
+export default function Page() {
+  return (
+    <p>
+      lib-cjs: <CjsFromCjs />
+    </p>
+  )
+}

--- a/test/e2e/app-dir/client-module-with-package-type/app/require-esm/page.tsx
+++ b/test/e2e/app-dir/client-module-with-package-type/app/require-esm/page.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react'
+
+const CjsFromEsm = require('lib-esm')
+
+export default function Page() {
+  return (
+    <p>
+      lib-esm: <CjsFromEsm />
+    </p>
+  )
+}

--- a/test/e2e/app-dir/client-module-with-package-type/index.test.ts
+++ b/test/e2e/app-dir/client-module-with-package-type/index.test.ts
@@ -1,0 +1,31 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('esm-client-module-without-exports', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  describe('"type": "commonjs" in package.json', () => {
+    it('should render without errors: import cjs', async () => {
+      const $ = await next.render$('/import-cjs')
+      expect($('p').text()).toContain('lib-cjs: esm')
+    })
+
+    it('should render without errors: require cjs', async () => {
+      const $ = await next.render$('/require-cjs')
+      expect($('p').text()).toContain('lib-cjs: cjs')
+    })
+  })
+
+  describe('"type": "module" in package.json', () => {
+    it('should render without errors: import esm', async () => {
+      const $ = await next.render$('/import-esm')
+      expect($('p').text()).toContain('lib-esm: esm')
+    })
+
+    it('should render without errors: require esm', async () => {
+      const $ = await next.render$('/require-esm')
+      expect($('p').text()).toContain('lib-esm: cjs')
+    })
+  })
+})

--- a/test/e2e/app-dir/client-module-with-package-type/next.config.js
+++ b/test/e2e/app-dir/client-module-with-package-type/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/client-module-with-package-type/node_modules/lib-cjs/index.js
+++ b/test/e2e/app-dir/client-module-with-package-type/node_modules/lib-cjs/index.js
@@ -1,0 +1,3 @@
+'use client'
+console.log('lib-cjs :: cjs')
+module.exports = () => 'cjs'

--- a/test/e2e/app-dir/client-module-with-package-type/node_modules/lib-cjs/index.mjs
+++ b/test/e2e/app-dir/client-module-with-package-type/node_modules/lib-cjs/index.mjs
@@ -1,0 +1,3 @@
+'use client'
+console.log('lib-cjs :: esm')
+export default () => 'esm'

--- a/test/e2e/app-dir/client-module-with-package-type/node_modules/lib-cjs/package.json
+++ b/test/e2e/app-dir/client-module-with-package-type/node_modules/lib-cjs/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "lib-cjs",
+  "type": "commonjs",
+  "exports": {
+    ".": {
+      "import": "./index.mjs",
+      "default": "./index.js"
+    }
+  }
+}

--- a/test/e2e/app-dir/client-module-with-package-type/node_modules/lib-esm/index.cjs
+++ b/test/e2e/app-dir/client-module-with-package-type/node_modules/lib-esm/index.cjs
@@ -1,0 +1,3 @@
+'use client'
+console.log('lib-esm :: cjs')
+module.exports = () => 'cjs'

--- a/test/e2e/app-dir/client-module-with-package-type/node_modules/lib-esm/index.js
+++ b/test/e2e/app-dir/client-module-with-package-type/node_modules/lib-esm/index.js
@@ -1,0 +1,3 @@
+'use client'
+console.log('lib-esm :: esm')
+export default () => 'esm'

--- a/test/e2e/app-dir/client-module-with-package-type/node_modules/lib-esm/package.json
+++ b/test/e2e/app-dir/client-module-with-package-type/node_modules/lib-esm/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "lib-esm",
+  "type": "module",
+  "exports": {
+    ".": {
+      "require": "./index.cjs",
+      "default": "./index.js"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #74062 (`jotai` ran into this error [when they added `"type": "commonjs"` to their
package.json](https://github.com/pmndrs/jotai/discussions/2579#discussioncomment-9812492))

> this is a bug in the transform we do when a `'use client'` directive
is encountered. I think what's happening is that we're creating a virtual file that uses ESM import/export syntax, but it's called proxy.js (not proxy.mjs), so the `"type": "commonjs" `makes turbopack "correctly" upset at the ESM syntax.
https://github.com/vercel/next.js/issues/74062#issuecomment-2555922867

The (slightly kludgy) solution is to use `proxy.mjs` or `proxy.cjs` to force the module format, bypassing the issue where `proxy.js` changes meaning depending on `package.json#type`.