### PR TITLE
misc: add `.stories.tsx` to vscode file nesting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -68,8 +68,8 @@
   // Enable file nesting for unit test files.
   "explorer.fileNesting.enabled": true,
   "explorer.fileNesting.patterns": {
-    "*.ts": "$(capture).test.ts, $(capture).test.tsx",
-    "*.tsx": "$(capture).test.ts, $(capture).test.tsx"
+    "*.ts": "$(capture).test.ts, $(capture).test.tsx, $(capture).stories.tsx",
+    "*.tsx": "$(capture).test.ts, $(capture).test.tsx, $(capture).stories.tsx"
   },
   // Compile rust-analyzer in a separate directory to avoid conflicts with the main project.
   "rust-analyzer.cargo.targetDir": true,


### PR DESCRIPTION
This PR allows `.stories.tsx` files to be viewed as nested when they share the same filename with `.ts` and `.tsx`, similar to the `.test.` files.

https://github.com/user-attachments/assets/8e280369-984d-4d33-b91a-392b3c18b5d9

