### PR TITLE
restore deleted comment in next-app-loader

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -754,6 +754,7 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
       tree: treeCodeResult.treeCode,
       pages: treeCodeResult.pages,
       __next_app_require__: '__webpack_require__',
+      // all modules are in the entry chunk, so we never actually need to load chunks in webpack
       __next_app_load_chunk__: '() => Promise.resolve()',
     }
   )


### PR DESCRIPTION
this comment is a useful explanation, but was accidentally lost in #52846, when a bunch of loader stuff was unified between webpack and turbopack

see: https://github.com/vercel/next.js/pull/52846/files#diff-173d1bc6424869c0d3c43f8fba124186427d03e5bd056587f141886a0075b1d3L699-L700