### PR TITLE
[metadata] initial support of streaming metadata

### DIFF
--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -359,6 +359,7 @@ async function exportAppImpl(
       clientSegmentCache: nextConfig.experimental.clientSegmentCache ?? false,
       inlineCss: nextConfig.experimental.inlineCss ?? false,
       authInterrupts: !!nextConfig.experimental.authInterrupts,
+      streamingMetadata: !!nextConfig.experimental.streamingMetadata,
     },
     reactMaxHeadersLength: nextConfig.reactMaxHeadersLength,
   }

--- a/packages/next/src/lib/metadata/async-metadata.tsx
+++ b/packages/next/src/lib/metadata/async-metadata.tsx
@@ -7,18 +7,22 @@ import { useServerInsertedHTML } from '../../client/components/navigation'
 // and
 function ServerInsertMetadata({ promise }: { promise: Promise<any> }) {
   let metadataToFlush: React.ReactNode = null
+  // Only inserted once to avoid multi insertion on re-renders
+  let inserted = false
 
   promise.then((resolvedMetadata) => {
     metadataToFlush = resolvedMetadata
   })
 
   useServerInsertedHTML(() => {
-    if (metadataToFlush) {
+    if (metadataToFlush && !inserted) {
       const flushing = metadataToFlush
       metadataToFlush = null
       return flushing
     }
   })
+
+  inserted = true
 
   return null
 }

--- a/packages/next/src/lib/metadata/async-metadata.tsx
+++ b/packages/next/src/lib/metadata/async-metadata.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { use } from 'react'
+import { useServerInsertedHTML } from '../../client/components/navigation'
+
+// This is a SSR-only version that will wait the promise of metadata to resolve
+// and
+function ServerInsertMetadata({ promise }: { promise: Promise<any> }) {
+  let metadataToFlush: React.ReactNode = null
+
+  promise.then((resolvedMetadata) => {
+    metadataToFlush = resolvedMetadata
+  })
+
+  useServerInsertedHTML(() => {
+    if (metadataToFlush) {
+      const flushing = metadataToFlush
+      metadataToFlush = null
+      return flushing
+    }
+  })
+
+  return null
+}
+
+function BrowserResolvedMetadata({ promise }: { promise: Promise<any> }) {
+  return use(promise)
+}
+
+export function AsyncMetadata({ promise }: { promise: Promise<any> }) {
+  return (
+    <>
+      {typeof window === 'undefined' ? (
+        <ServerInsertMetadata promise={promise} />
+      ) : (
+        <BrowserResolvedMetadata promise={promise} />
+      )}
+    </>
+  )
+}

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -146,7 +146,7 @@ export function createMetadataComponents({
 
   async function resolveFinalMetadata() {
     try {
-      return metadata()
+      return await metadata()
     } catch (error) {
       if (!errorType && isHTTPAccessFallbackError(error)) {
         try {

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -150,7 +150,7 @@ export function createMetadataComponents({
     } catch (error) {
       if (!errorType && isHTTPAccessFallbackError(error)) {
         try {
-          return getNotFoundMetadata(
+          return await getNotFoundMetadata(
             tree,
             searchParams,
             getDynamicParamFromSegment,

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -37,6 +37,7 @@ import {
   METADATA_BOUNDARY_NAME,
   VIEWPORT_BOUNDARY_NAME,
 } from './metadata-constants'
+import { AsyncMetadata } from './async-metadata'
 
 // Use a promise to share the status of the metadata resolving,
 // returning two components `MetadataTree` and `MetadataOutlet`
@@ -55,6 +56,7 @@ export function createMetadataComponents({
   workStore,
   MetadataBoundary,
   ViewportBoundary,
+  serveStreamingMetadata,
 }: {
   tree: LoaderTree
   searchParams: Promise<ParsedUrlQuery>
@@ -66,6 +68,7 @@ export function createMetadataComponents({
   workStore: WorkStore
   MetadataBoundary: (props: { children: React.ReactNode }) => React.ReactNode
   ViewportBoundary: (props: { children: React.ReactNode }) => React.ReactNode
+  serveStreamingMetadata: boolean
 }): {
   MetadataTree: React.ComponentType
   ViewportTree: React.ComponentType
@@ -141,7 +144,7 @@ export function createMetadataComponents({
     )
   }
 
-  async function Metadata() {
+  async function resolveFinalMetadata() {
     try {
       return await metadata()
     } catch (error) {
@@ -164,10 +167,21 @@ export function createMetadataComponents({
       return null
     }
   }
+  async function Metadata() {
+    if (serveStreamingMetadata) {
+      return <AsyncMetadata promise={resolveFinalMetadata()} />
+    }
+    return await resolveFinalMetadata()
+  }
+
   Metadata.displayName = METADATA_BOUNDARY_NAME
 
   async function getMetadataReady(): Promise<void> {
-    await metadata()
+    // Only warm up metadata() call when it's blocking metadata,
+    // otherwise it will be fully managed by AsyncMetadata component.
+    if (!serveStreamingMetadata) {
+      await metadata()
+    }
     return undefined
   }
 

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -97,7 +97,7 @@ export function createMetadataComponents({
     )
   }
 
-  async function viewport() {
+  function viewport() {
     return getResolvedViewport(
       tree,
       searchParams,
@@ -132,7 +132,7 @@ export function createMetadataComponents({
   }
   Viewport.displayName = VIEWPORT_BOUNDARY_NAME
 
-  async function metadata() {
+  function metadata() {
     return getResolvedMetadata(
       tree,
       searchParams,
@@ -146,11 +146,11 @@ export function createMetadataComponents({
 
   async function resolveFinalMetadata() {
     try {
-      return await metadata()
+      return metadata()
     } catch (error) {
       if (!errorType && isHTTPAccessFallbackError(error)) {
         try {
-          return await getNotFoundMetadata(
+          return getNotFoundMetadata(
             tree,
             searchParams,
             getDynamicParamFromSegment,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -314,6 +314,20 @@ function createNotFoundLoaderTree(loaderTree: LoaderTree): LoaderTree {
   ]
 }
 
+function createSuspenseyMetadata(
+  Metadata: React.ComponentType<{}>,
+  serveStreamingMetadata: boolean
+): React.ComponentType<{}> {
+  return () =>
+    serveStreamingMetadata ? (
+      <React.Suspense fallback={null}>
+        <Metadata />
+      </React.Suspense>
+    ) : (
+      <Metadata />
+    )
+}
+
 /**
  * Returns a function that parses the dynamic segment and return the associated value.
  */
@@ -469,14 +483,14 @@ async function generateDynamicRSCPayload(
         serveStreamingMetadata: !!ctx.renderOpts.serveStreamingMetadata,
       })
 
-    const MetadataComponent = () => {
+    const MetadataComponent = createSuspenseyMetadata(() => {
       return (
         <React.Fragment key={flightDataPathMetadataKey}>
           {/* Adding requestId as react key to make metadata remount for each render */}
           <MetadataTree key={requestId} />
         </React.Fragment>
       )
-    }
+    }, !!ctx.renderOpts.serveStreamingMetadata)
 
     flightData = (
       await walkTreeWithFlightRouterState({
@@ -776,14 +790,14 @@ async function getRSCPayload(
 
   const preloadCallbacks: PreloadCallbacks = []
 
-  function MetadataComponent() {
+  const MetadataComponent = createSuspenseyMetadata(() => {
     return (
       <React.Fragment key={flightDataPathMetadataKey}>
         {/* Not add requestId as react key to ensure segment prefetch could result consistently if nothing changed */}
         <MetadataTree />
       </React.Fragment>
     )
-  }
+  }, !!ctx.renderOpts.serveStreamingMetadata)
 
   const seedData = await createComponentTree({
     ctx,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -499,15 +499,14 @@ async function generateDynamicRSCPayload(
         parentParams: {},
         flightRouterState,
         // For flight, render metadata inside leaf page
-        rscHead: [
+        rscHead: (
           <React.Fragment key={flightDataPathViewportKey}>
             {/* noindex needs to be blocking */}
             <NonIndex ctx={ctx} />
             {/* Adding requestId as react key to make metadata remount for each render */}
             <ViewportTree key={requestId} />
-          </React.Fragment>,
-          null,
-        ],
+          </React.Fragment>
+        ),
         injectedCSS: new Set(),
         injectedJS: new Set(),
         injectedFontPreloadTags: new Set(),

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -466,6 +466,7 @@ async function generateDynamicRSCPayload(
         workStore,
         MetadataBoundary,
         ViewportBoundary,
+        serveStreamingMetadata: !!ctx.renderOpts.serveStreamingMetadata,
       })
 
     const MetadataComponent = () => {
@@ -770,6 +771,7 @@ async function getRSCPayload(
       workStore,
       MetadataBoundary,
       ViewportBoundary,
+      serveStreamingMetadata: !!ctx.renderOpts.serveStreamingMetadata,
     })
 
   const preloadCallbacks: PreloadCallbacks = []
@@ -895,6 +897,7 @@ async function getErrorRSCPayload(
     workStore,
     MetadataBoundary,
     ViewportBoundary,
+    serveStreamingMetadata: !!ctx.renderOpts.serveStreamingMetadata,
   })
 
   const initialHeadMetadata = (

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -913,11 +913,14 @@ async function getErrorRSCPayload(
     serveStreamingMetadata: !!ctx.renderOpts.serveStreamingMetadata,
   })
 
-  const initialHeadMetadata = (
-    <React.Fragment key={flightDataPathMetadataKey}>
-      {/* Adding requestId as react key to make metadata remount for each render */}
-      <MetadataTree key={requestId} />
-    </React.Fragment>
+  const ErrorMetadataComponent = createSuspenseyMetadata(
+    () => (
+      <React.Fragment key={flightDataPathMetadataKey}>
+        {/* Adding requestId as react key to make metadata remount for each render */}
+        <MetadataTree key={requestId} />
+      </React.Fragment>
+    ),
+    !!ctx.renderOpts.serveStreamingMetadata
   )
 
   const initialHeadViewport = (
@@ -942,7 +945,9 @@ async function getErrorRSCPayload(
   const seedData: CacheNodeSeedData = [
     initialTree[0],
     <html id="__next_error__">
-      <head>{initialHeadMetadata}</head>
+      <head>
+        <ErrorMetadataComponent />
+      </head>
       <body />
     </html>,
     {},

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -177,7 +177,7 @@ export interface RenderOptsPartial {
   assetPrefix?: string
   crossOrigin?: '' | 'anonymous' | 'use-credentials' | undefined
   nextFontManifest?: DeepReadonly<NextFontManifest>
-  isBot?: boolean
+  serveStreamingMetadata?: boolean
   incrementalCache?: import('../lib/incremental-cache').IncrementalCache
   cacheLifeProfiles?: {
     [profile: string]: import('../use-cache/cache-life').CacheLife
@@ -215,6 +215,7 @@ export interface RenderOptsPartial {
     clientSegmentCache: boolean
     inlineCss: boolean
     authInterrupts: boolean
+    streamingMetadata: boolean
   }
   postponed?: string
 

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -440,6 +440,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         serverComponentsHmrCache: z.boolean().optional(),
         authInterrupts: z.boolean().optional(),
         newDevOverlay: z.boolean().optional(),
+        streamingMetadata: z.boolean().optional(),
       })
       .optional(),
     exportPathMap: z

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -570,7 +570,7 @@ export interface ExperimentalConfig {
 
   /**
    * @experimental This is temporary and will be **removed** in the short future.
-   * Enables the streaming metadata by default or not.
+   * When enabled will cause async metadata calls to stream rather than block the render.
    */
   streamingMetadata?: boolean
 }
@@ -1197,6 +1197,7 @@ export const defaultConfig: NextConfig = {
     dynamicIO: false,
     inlineCss: false,
     newDevOverlay: false,
+    streamingMetadata: false,
   },
   bundlePagesRouterDependencies: false,
 }

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -567,6 +567,12 @@ export interface ExperimentalConfig {
    * Enables the new dev overlay.
    */
   newDevOverlay?: boolean
+
+  /**
+   * @experimental This is temporary and will be **removed** in the short future.
+   * Enables the streaming metadata by default or not.
+   */
+  streamingMetadata?: boolean
 }
 
 export type ExportPathMap = {

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -569,7 +569,6 @@ export interface ExperimentalConfig {
   newDevOverlay?: boolean
 
   /**
-   * @experimental This is temporary and will be **removed** in the short future.
    * When enabled will cause async metadata calls to stream rather than block the render.
    */
   streamingMetadata?: boolean

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -265,7 +265,7 @@ export type RenderOptsPartial = {
   domainLocales?: readonly DomainLocale[]
   disableOptimizedLoading?: boolean
   supportsDynamicResponse: boolean
-  isBot?: boolean
+  serveStreamingMetadata?: boolean
   runtime?: ServerRuntime
   serverComponents?: boolean
   serverActions?: {

--- a/packages/next/src/shared/lib/router/utils/is-bot.ts
+++ b/packages/next/src/shared/lib/router/utils/is-bot.ts
@@ -1,5 +1,5 @@
 // Bot crawler that will spin up a headless browser and execute JS
-const HEADLESS_BOT_UA_RE =
+const HEADLESS_BROWSER_BOT_UA_RE =
   /Googlebot|Google-PageRenderer|AdsBot-Google|googleweblight|Storebot-Google/i
 
 // This regex contains the bots that we need to do a blocking render for and can't safely stream the response
@@ -7,14 +7,14 @@ const HEADLESS_BOT_UA_RE =
 const HTML_LIMITED_BOT_UA_RE =
   /Mediapartners-Google|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview/i
 
-function isHeadlessBrowserBot(userAgent: string) {
-  return HEADLESS_BOT_UA_RE.test(userAgent)
+function isHeadlessBrowserBotUA(userAgent: string) {
+  return HEADLESS_BROWSER_BOT_UA_RE.test(userAgent)
 }
 
-function isHtmlLimitedBot(userAgent: string) {
+export function isHtmlLimitedBotUA(userAgent: string) {
   return HTML_LIMITED_BOT_UA_RE.test(userAgent)
 }
 
 export function isBot(userAgent: string): boolean {
-  return isHeadlessBrowserBot(userAgent) || isHtmlLimitedBot(userAgent)
+  return isHeadlessBrowserBotUA(userAgent) || isHtmlLimitedBotUA(userAgent)
 }

--- a/test/e2e/app-dir/metadata-streaming/app/layout.tsx
+++ b/test/e2e/app-dir/metadata-streaming/app/layout.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <div>
+          <Link href="/slow" id="to-slow">
+            {`to /slow`}
+          </Link>
+          <br />
+          <Link href="/" id="to-home">
+            {`to /`}
+          </Link>
+        </div>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/metadata-streaming/app/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming/app/page.tsx
@@ -8,3 +8,5 @@ export async function generateMetadata() {
     title: 'index page',
   }
 }
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/app-dir/metadata-streaming/app/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming/app/page.tsx
@@ -1,0 +1,10 @@
+export default function Page() {
+  return <p>index</p>
+}
+
+export async function generateMetadata() {
+  await new Promise((resolve) => setTimeout(resolve, 3 * 1000))
+  return {
+    title: 'index page',
+  }
+}

--- a/test/e2e/app-dir/metadata-streaming/app/slow/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming/app/slow/page.tsx
@@ -3,7 +3,7 @@ export default function Page() {
 }
 
 export async function generateMetadata() {
-  await new Promise((resolve) => setTimeout(resolve, 3 * 1000))
+  await new Promise((resolve) => setTimeout(resolve, 1 * 1000))
   return {
     title: 'slow page',
     description: 'slow page description',
@@ -17,3 +17,5 @@ export async function generateMetadata() {
     robots: 'index, follow',
   }
 }
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/app-dir/metadata-streaming/app/slow/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming/app/slow/page.tsx
@@ -1,0 +1,19 @@
+export default function Page() {
+  return <p>slow</p>
+}
+
+export async function generateMetadata() {
+  await new Promise((resolve) => setTimeout(resolve, 3 * 1000))
+  return {
+    title: 'slow page',
+    description: 'slow page description',
+    generator: 'next.js',
+    applicationName: 'test',
+    referrer: 'origin-when-cross-origin',
+    keywords: ['next.js', 'react', 'javascript'],
+    authors: [{ name: 'huozhi' }],
+    creator: 'huozhi',
+    publisher: 'vercel',
+    robots: 'index, follow',
+  }
+}

--- a/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
+++ b/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
@@ -1,0 +1,32 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('metadata-streaming', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
+  it('should work using cheerio', async () => {
+    const $ = await next.render$('/')
+    expect($('p').text()).toBe('hello world')
+  })
+
+  // Recommended for tests that need a full browser
+  it('should work using browser', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('p').text()).toBe('hello world')
+  })
+
+  // In case you need the full HTML. Can also use $.html() with cheerio.
+  it('should work with html', async () => {
+    const html = await next.render('/')
+    expect(html).toContain('hello world')
+  })
+
+  // In case you need to test the response object
+  it('should work with fetch', async () => {
+    const res = await next.fetch('/')
+    const html = await res.text()
+    expect(html).toContain('hello world')
+  })
+})

--- a/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
+++ b/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
@@ -31,7 +31,7 @@ describe('metadata-streaming', () => {
     // navigate from / to /slow, the metadata should be empty first, e.g. no title.
     // then the metadata should be loaded after few seconds.
     const browser = await next.browser('/')
-    await browser.eval(`document.getElementById('to-slow').click()`)
+    await browser.elementByCss('#to-slow').click()
 
     await retry(async () => {
       expect(await browser.elementByCss('title').text()).toBe('slow page')

--- a/test/e2e/app-dir/metadata-streaming/next.config.js
+++ b/test/e2e/app-dir/metadata-streaming/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    streamingMetadata: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
### What

This PR enables the experimental support for streaming metadata with a temporary experimental flag, by default is not enabled yet as there're still some holes need to be filled.

### Major Changes

We're wrapping a Suspense boundary with a empty fallback for metadata that can be streamed, which will be rendered as suspensey component during the first render, which allows the metadata resolving and rendering to be separate from the page rendering. Since we have few refactors before where we moved

Then to insert metadata into page properly, we introduced a `async-metadata` component to deal with it. When it's doing SSR, we just wait for the promise to resolve, and insert the metadata if it's early resolved. The insertion is made through `useServerInsertedHTML` and only insert once to avoid duplicate metadata emission into body due to suspense resolved in streaming.

There's also a rule that we only serving streaming metadata when the bots are not HTML limited bots (which couldn't execute JS or handle streams) and the streaming metadata experimental flag needs to be enabled.

### Follow Up

The PPR side support is not fully finished yet, we'll surface the PPR rendering improves later with other optimizations.

Closes NDX-539