### PR TITLE
SingleModuleGraph: yield edge weights during traversal

### DIFF
--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -174,9 +174,9 @@ impl NextDynamicGraph {
 
             // module -> the client reference entry (if any)
             let mut state_map = HashMap::new();
-            graph.traverse_edges_from_entry(entry, |(parent_node, node)| {
+            graph.traverse_edges_from_entry(entry, |parent_info, node| {
                 let module = node.module;
-                let Some(parent_node) = parent_node else {
+                let Some((parent_node, _)) = parent_info else {
                     state_map.insert(module, VisitState::Entry);
                     return GraphTraversalAction::Continue;
                 };
@@ -362,9 +362,9 @@ impl ClientReferencesGraph {
                 entry,
                 // state_map is `module -> Option< the current so parent server component >`
                 &mut HashMap::new(),
-                |(parent_node, node), state_map| {
+                |parent_info, node, state_map| {
                     let module = node.module;
-                    let Some(parent_node) = parent_node else {
+                    let Some((parent_node, _)) = parent_info else {
                         state_map.insert(module, None);
                         return GraphTraversalAction::Continue;
                     };
@@ -390,8 +390,8 @@ impl ClientReferencesGraph {
                         _ => GraphTraversalAction::Continue,
                     }
                 },
-                |(parent_node, node), state_map| {
-                    let Some(parent_node) = parent_node else {
+                |parent_info, node, state_map| {
+                    let Some((parent_node, _)) = parent_info else {
                         return;
                     };
                     let parent_module = parent_node.module;

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use petgraph::{
-    graph::{DiGraph, NodeIndex},
+    graph::{DiGraph, EdgeIndex, NodeIndex},
     visit::{Dfs, VisitMap, Visitable},
 };
 use serde::{Deserialize, Serialize};
@@ -212,11 +212,18 @@ impl SingleModuleGraph {
     /// target.
     ///
     /// This means that target nodes can be revisited (once per incoming edge).
+    ///
+    /// * `entry` - The entry module to start the traversal from
+    /// * `visitor` - Called before visiting the children of a node.
+    ///    - Receives (originating &SingleModuleGraphNode, edge &ChunkingType), target
+    ///      &SingleModuleGraphNode, state &S
+    ///    - Can return [GraphTraversalAction]s to control the traversal
     pub fn traverse_edges_from_entry<'a>(
         &'a self,
         entry: ResolvedVc<Box<dyn Module>>,
         mut visitor: impl FnMut(
-            (Option<&'a SingleModuleGraphNode>, &'a SingleModuleGraphNode),
+            Option<(&'a SingleModuleGraphNode, &'a ChunkingType)>,
+            &'a SingleModuleGraphNode,
         ) -> GraphTraversalAction,
     ) -> Result<()> {
         let graph = &self.graph;
@@ -226,14 +233,24 @@ impl SingleModuleGraph {
         let mut discovered = graph.visit_map();
         let entry_weight = graph.node_weight(entry_node).unwrap();
         entry_weight.emit_issues();
-        visitor((None, entry_weight));
+        visitor(None, entry_weight);
 
         while let Some(node) = stack.pop() {
             let node_weight = graph.node_weight(node).unwrap();
             if discovered.visit(node) {
-                for succ in graph.neighbors(node).collect::<Vec<_>>() {
+                let neighbors = {
+                    let mut neighbors = vec![];
+                    let mut walker = graph.neighbors(node).detach();
+                    while let Some((edge, succ)) = walker.next(graph) {
+                        neighbors.push((edge, succ));
+                    }
+                    neighbors
+                };
+
+                for (edge, succ) in neighbors {
                     let succ_weight = graph.node_weight(succ).unwrap();
-                    let action = visitor((Some(node_weight), succ_weight));
+                    let edge_weight = graph.edge_weight(edge).unwrap();
+                    let action = visitor(Some((node_weight, edge_weight)), succ_weight);
                     if !discovered.is_visited(&succ) && action == GraphTraversalAction::Continue {
                         stack.push(succ);
                     }
@@ -251,16 +268,29 @@ impl SingleModuleGraph {
     ///
     /// Target nodes can be revisited (once per incoming edge).
     /// Edges are traversed in normal order, so should correspond to reference order.
+    ///
+    /// * `entry` - The entry module to start the traversal from
+    /// * `state` - The state to be passed to the visitors
+    /// * `visit_preorder` - Called before visiting the children of a node.
+    ///    - Receives: (originating &SingleModuleGraphNode, edge &ChunkingType), target
+    ///      &SingleModuleGraphNode, state &S
+    ///    - Can return [GraphTraversalAction]s to control the traversal
+    /// * `visit_postorder` - Called after visiting the children of a node. Return
+    ///    - Receives: (originating &SingleModuleGraphNode, edge &ChunkingType), target
+    ///      &SingleModuleGraphNode, state &S
+    ///    - Can return [GraphTraversalAction]s to control the traversal
     pub fn traverse_edges_from_entry_topological<'a, S>(
         &'a self,
         entry: ResolvedVc<Box<dyn Module>>,
         state: &mut S,
         mut visit_preorder: impl FnMut(
-            (Option<&'a SingleModuleGraphNode>, &'a SingleModuleGraphNode),
+            Option<(&'a SingleModuleGraphNode, &'a ChunkingType)>,
+            &'a SingleModuleGraphNode,
             &mut S,
         ) -> GraphTraversalAction,
         mut visit_postorder: impl FnMut(
-            (Option<&'a SingleModuleGraphNode>, &'a SingleModuleGraphNode),
+            Option<(&'a SingleModuleGraphNode, &'a ChunkingType)>,
+            &'a SingleModuleGraphNode,
             &mut S,
         ),
     ) -> Result<()> {
@@ -272,39 +302,47 @@ impl SingleModuleGraph {
             ExpandAndVisit,
         }
 
-        let mut stack: Vec<(ReverseTopologicalPass, Option<NodeIndex>, NodeIndex)> =
-            vec![(ReverseTopologicalPass::ExpandAndVisit, None, entry_node)];
+        #[allow(clippy::type_complexity)] // This is a temporary internal structure
+        let mut stack: Vec<(
+            ReverseTopologicalPass,
+            Option<(NodeIndex, EdgeIndex)>,
+            NodeIndex,
+        )> = vec![(ReverseTopologicalPass::ExpandAndVisit, None, entry_node)];
         let mut expanded = HashSet::new();
         while let Some((pass, parent, current)) = stack.pop() {
             match pass {
                 ReverseTopologicalPass::Visit => {
                     visit_postorder(
-                        (
-                            parent.map(|parent| graph.node_weight(parent).unwrap()),
-                            graph.node_weight(current).unwrap(),
-                        ),
+                        parent.map(|parent| {
+                            (
+                                graph.node_weight(parent.0).unwrap(),
+                                graph.edge_weight(parent.1).unwrap(),
+                            )
+                        }),
+                        graph.node_weight(current).unwrap(),
                         state,
                     );
                 }
                 ReverseTopologicalPass::ExpandAndVisit => {
                     let action = visit_preorder(
-                        (
-                            parent.map(|parent| graph.node_weight(parent).unwrap()),
-                            graph.node_weight(current).unwrap(),
-                        ),
+                        parent.map(|parent| {
+                            (
+                                graph.node_weight(parent.0).unwrap(),
+                                graph.edge_weight(parent.1).unwrap(),
+                            )
+                        }),
+                        graph.node_weight(current).unwrap(),
                         state,
                     );
                     stack.push((ReverseTopologicalPass::Visit, parent, current));
                     if expanded.insert(current) && action == GraphTraversalAction::Continue {
-                        stack.extend(
-                            graph
-                                .neighbors(current)
-                                // .collect::<Vec<_>>()
-                                // .rev()
-                                .map(|child| {
-                                    (ReverseTopologicalPass::ExpandAndVisit, Some(current), child)
-                                }),
-                        );
+                        stack.extend(iter_neighbors(graph, current).map(|(edge, child)| {
+                            (
+                                ReverseTopologicalPass::ExpandAndVisit,
+                                Some((current, edge)),
+                                child,
+                            )
+                        }));
                     }
                 }
             }
@@ -532,4 +570,12 @@ impl Visit<SingleModuleGraphBuilderNode> for SingleModuleGraphBuilder {
             }
         }
     }
+}
+
+fn iter_neighbors<N, E>(
+    graph: &DiGraph<N, E>,
+    node: NodeIndex,
+) -> impl Iterator<Item = (EdgeIndex, NodeIndex)> + '_ {
+    let mut walker = graph.neighbors(node).detach();
+    std::iter::from_fn(move || walker.next(graph))
 }


### PR DESCRIPTION
This adds the edge weight (the `ChunkingType`) of the edge during `traverse_edges_from_entry` and `traverse_edges_from_entry_topological`, rather than only providing only the originating node.

Test Plan: Added a log to verify edge types were provided to these visitors.


Closes PACK-3704