### PR TITLE
fix fetch lock not being consistently released

### DIFF
--- a/test/e2e/app-dir/app-fetch-deduping-errors/app-fetch-deduping-errors.test.ts
+++ b/test/e2e/app-dir/app-fetch-deduping-errors/app-fetch-deduping-errors.test.ts
@@ -1,0 +1,13 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('app-fetch-errors', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should still successfully render when a fetch request that acquires a cache lock errors', async () => {
+    const browser = await next.browser('/1')
+
+    expect(await browser.elementByCss('body').text()).toBe('Hello World 1')
+  })
+})

--- a/test/e2e/app-dir/app-fetch-deduping-errors/app/[id]/page.tsx
+++ b/test/e2e/app-dir/app-fetch-deduping-errors/app/[id]/page.tsx
@@ -1,0 +1,45 @@
+'use server'
+
+import { Metadata } from 'next'
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}): Promise<Metadata> {
+  const { id } = await params
+
+  try {
+    // this fetch request will error
+    await fetch('http://localhost:8000', {
+      cache: 'force-cache',
+      next: { tags: ['id'] },
+    })
+  } catch (err) {
+    console.log(err)
+  }
+
+  return {
+    title: id,
+  }
+}
+
+export default async function Error({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+
+  try {
+    // this fetch request will error
+    await fetch('http://localhost:8000', {
+      cache: 'force-cache',
+      next: { tags: ['id'] },
+    })
+  } catch (err) {
+    console.log(err)
+  }
+
+  return <div>Hello World {id}</div>
+}

--- a/test/e2e/app-dir/app-fetch-deduping-errors/app/layout.tsx
+++ b/test/e2e/app-dir/app-fetch-deduping-errors/app/layout.tsx
@@ -1,0 +1,10 @@
+export default function Layout({ children }) {
+  return (
+    <html lang="en">
+      <head>
+        <title>my static site</title>
+      </head>
+      <body>{children}</body>
+    </html>
+  )
+}


### PR DESCRIPTION
When we acquire a lock on a fetch, and the fetch errors, we weren't resolving the lock. This meant a subsequent request would stall waiting to acquire a lock and prevent the page from rendering. 

An example of this is a fetch with force-cache in `generateMetadata` and another in the RSC where both requests encounter a fetch error. 

Fixes #74613