### PR TITLE
docs(images): update distinction between priority and fetchPriority

### DIFF
--- a/docs/01-app/03-building-your-application/06-optimizing/01-images.mdx
+++ b/docs/01-app/03-building-your-application/06-optimizing/01-images.mdx
@@ -167,7 +167,7 @@ You can define a loader per-image with the [`loader` prop](/docs/app/api-referen
 
 ## Priority
 
-You should add the `priority` property to the image that will be the [Largest Contentful Paint (LCP) element](https://web.dev/lcp/#what-elements-are-considered) for each page. Doing so allows Next.js to specially prioritize the image for loading (e.g. through preload tags or priority hints), leading to a meaningful boost in LCP.
+You should add the `priority` property to the image that will be the [Largest Contentful Paint (LCP) element](https://web.dev/lcp/#what-elements-are-considered) for each page. Doing so allows Next.js to specially prioritize the image for loading using the [preload](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preload) attribute, leading to a meaningful boost in LCP.
 
 The LCP element is typically the largest image or text block visible within the viewport of the page. When you run `next dev`, you'll see a console warning if the LCP element is an `<Image>` without the `priority` property.
 

--- a/docs/01-app/03-building-your-application/06-optimizing/01-images.mdx
+++ b/docs/01-app/03-building-your-application/06-optimizing/01-images.mdx
@@ -167,7 +167,7 @@ You can define a loader per-image with the [`loader` prop](/docs/app/api-referen
 
 ## Priority
 
-You should add the `priority` property to the image that will be the [Largest Contentful Paint (LCP) element](https://web.dev/lcp/#what-elements-are-considered) for each page. Doing so allows Next.js to specially prioritize the image for loading using the [preload](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preload) attribute, leading to a meaningful boost in LCP.
+You should add the `priority` property to the image that will be the [Largest Contentful Paint (LCP) element](https://web.dev/lcp/#what-elements-are-considered) for each page. Doing so allows Next.js to [preload](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preload) the image, leading to a meaningful boost in LCP.
 
 The LCP element is typically the largest image or text block visible within the viewport of the page. When you run `next dev`, you'll see a console warning if the LCP element is an `<Image>` without the `priority` property.
 

--- a/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
@@ -264,14 +264,6 @@ For example, you can have a dynamic route segment which loads MDX components fro
   height="849"
 />
 
-<Image
-  alt="Route segments for dynamic MDX components"
-  srcLight="/docs/light/mdx-files.png"
-  srcDark="/docs/dark/mdx-files.png"
-  width="1600"
-  height="849"
-/>
-
 [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) can be used to prerender the provided routes. By marking `dynamicParams` as `false`, accessing a route not defined in `generateStaticParams` will 404.
 
 ```tsx filename="app/blog/[slug]/page.tsx" switcher

--- a/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
@@ -264,6 +264,14 @@ For example, you can have a dynamic route segment which loads MDX components fro
   height="849"
 />
 
+<Image
+  alt="Route segments for dynamic MDX components"
+  srcLight="/docs/light/mdx-files.png"
+  srcDark="/docs/dark/mdx-files.png"
+  width="1600"
+  height="849"
+/>
+
 [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) can be used to prerender the provided routes. By marking `dynamicParams` as `false`, accessing a route not defined in `generateStaticParams` will 404.
 
 ```tsx filename="app/blog/[slug]/page.tsx" switcher

--- a/docs/01-app/04-api-reference/02-components/image.mdx
+++ b/docs/01-app/04-api-reference/02-components/image.mdx
@@ -267,8 +267,8 @@ If the [`qualities`](#qualities) configuration is defined in `next.config.js`, t
 priority={false} // {false} | {true}
 ```
 
-When true, the image will be considered high priority and
-[preload](https://web.dev/preload-responsive-images/). Lazy loading is automatically disabled for images using `priority`. If the [`loading`](#loading) property is also used and set to `lazy`, the `priority` property can't be used. The [`loading`](#loading) property is only meant for advanced use cases. Remove `loading` when `priority` is needed.
+When true, Next.js will prioritize the image for loading using the
+[preload](https://web.dev/preload-responsive-images/) attribute. Lazy loading is automatically disabled for images using `priority`. If the [`loading`](#loading) property is also used and set to `lazy`, the `priority` property can't be used. The [`loading`](#loading) property is only meant for advanced use cases. Remove `loading` when `priority` is needed.
 
 You should use the `priority` property on any image detected as the [Largest Contentful Paint (LCP)](https://nextjs.org/learn/seo/web-performance/lcp) element. It may be appropriate to have multiple priority images, as different images may be the LCP element for different viewport sizes.
 

--- a/docs/01-app/04-api-reference/02-components/image.mdx
+++ b/docs/01-app/04-api-reference/02-components/image.mdx
@@ -267,8 +267,8 @@ If the [`qualities`](#qualities) configuration is defined in `next.config.js`, t
 priority={false} // {false} | {true}
 ```
 
-When true, Next.js will prioritize the image for loading using the
-[preload](https://web.dev/preload-responsive-images/) attribute. Lazy loading is automatically disabled for images using `priority`. If the [`loading`](#loading) property is also used and set to `lazy`, the `priority` property can't be used. The [`loading`](#loading) property is only meant for advanced use cases. Remove `loading` when `priority` is needed.
+When true, Next.js will
+[preload](https://web.dev/preload-responsive-images/) the image. Lazy loading is automatically disabled for images using `priority`. If the [`loading`](#loading) property is also used and set to `lazy`, the `priority` property can't be used. The [`loading`](#loading) property is only meant for advanced use cases. Remove `loading` when `priority` is needed.
 
 You should use the `priority` property on any image detected as the [Largest Contentful Paint (LCP)](https://nextjs.org/learn/seo/web-performance/lcp) element. It may be appropriate to have multiple priority images, as different images may be the LCP element for different viewport sizes.
 


### PR DESCRIPTION
## Why?

This [PR](https://github.com/vercel/next.js/pull/67351) de-coupled functionality between the Next.js-provided `priority` property and the native `<img>`-provided `fetchPriority` property.

We need to update the documentation to reflect this.