### PR TITLE
[Turbopack] lower indexing threshold

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -119,7 +119,7 @@ impl PersistanceState {
     }
 }
 
-const INDEX_THRESHOLD: usize = 1024;
+const INDEX_THRESHOLD: usize = 128;
 
 type IndexedMap<T> = AutoMap<
     <<T as KeyValuePair>::Key as Indexed>::Index,


### PR DESCRIPTION
### What?

This improves the performance. In cases where nodes have 500-1000 entries of one kind, this slows down iteration of the others.

This change improves this worse case.

Closes PACK-3690