### PR TITLE
Remove unused dependencyFactory plugin code

### DIFF
--- a/packages/next/src/build/webpack/plugins/app-build-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/app-build-manifest-plugin.ts
@@ -25,20 +25,6 @@ export class AppBuildManifestPlugin {
   }
 
   public apply(compiler: any) {
-    compiler.hooks.compilation.tap(
-      PLUGIN_NAME,
-      (compilation: any, { normalModuleFactory }: any) => {
-        compilation.dependencyFactories.set(
-          webpack.dependencies.ModuleDependency,
-          normalModuleFactory
-        )
-        compilation.dependencyTemplates.set(
-          webpack.dependencies.ModuleDependency,
-          new webpack.dependencies.NullDependency.Template()
-        )
-      }
-    )
-
     compiler.hooks.make.tap(PLUGIN_NAME, (compilation: any) => {
       compilation.hooks.processAssets.tap(
         {

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -179,20 +179,6 @@ export class FlightClientEntryPlugin {
   }
 
   apply(compiler: webpack.Compiler) {
-    compiler.hooks.compilation.tap(
-      PLUGIN_NAME,
-      (compilation, { normalModuleFactory }) => {
-        compilation.dependencyFactories.set(
-          webpack.dependencies.ModuleDependency,
-          normalModuleFactory
-        )
-        compilation.dependencyTemplates.set(
-          webpack.dependencies.ModuleDependency,
-          new webpack.dependencies.NullDependency.Template()
-        )
-      }
-    )
-
     compiler.hooks.finishMake.tapPromise(PLUGIN_NAME, (compilation) =>
       this.createClientEntries(compiler, compilation)
     )

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -224,28 +224,17 @@ export class ClientReferenceManifestPlugin {
   }
 
   apply(compiler: webpack.Compiler) {
-    compiler.hooks.compilation.tap(
-      PLUGIN_NAME,
-      (compilation, { normalModuleFactory }) => {
-        compilation.dependencyFactories.set(
-          webpack.dependencies.ModuleDependency,
-          normalModuleFactory
-        )
-        compilation.dependencyTemplates.set(
-          webpack.dependencies.ModuleDependency,
-          new webpack.dependencies.NullDependency.Template()
-        )
-        compilation.hooks.processAssets.tap(
-          {
-            name: PLUGIN_NAME,
-            // Have to be in the optimize stage to run after updating the CSS
-            // asset hash via extract mini css plugin.
-            stage: webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH,
-          },
-          (assets) => this.createAsset(assets, compilation, compiler.context)
-        )
-      }
-    )
+    compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+      compilation.hooks.processAssets.tap(
+        {
+          name: PLUGIN_NAME,
+          // Have to be in the optimize stage to run after updating the CSS
+          // asset hash via extract mini css plugin.
+          stage: webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH,
+        },
+        (assets) => this.createAsset(assets, compilation, compiler.context)
+      )
+    })
   }
 
   createAsset(


### PR DESCRIPTION
These internal APIs should not be necessary so removing them to avoid confusion/un-necessary APIs from being used. 

x-ref: [slack thread](https://vercel.slack.com/archives/C0861RLN3AP/p1736181537629329?thread_ts=1736180335.833419&cid=C0861RLN3AP)

