### PR TITLE
build(scripts/pack-next): Add support for compressing debuginfo with zlib

### DIFF
--- a/scripts/pack-next.cjs
+++ b/scripts/pack-next.cjs
@@ -101,14 +101,16 @@ async function main() {
         await packWithTar(packagePath, NEXT_SWC_TARBALL)
         break
       case 'objcopy-zstd':
+      case 'objcopy-zlib':
         if (process.platform !== 'linux') {
-          throw new Error('objcopy-zstd is only supported on Linux')
+          throw new Error('objcopy-{zstd,zlib} is only supported on Linux')
         }
+        const format = PACK_NEXT_COMPRESS == 'objcopy-zstd' ? 'zstd' : 'zlib'
         await Promise.all(
           (await nextSwcBinaries()).map((bin) =>
             execAsyncWithOutput(
               'Compressing debug symbols in next-swc native binary',
-              ['objcopy', '--compress-debug-sections=zstd', '--', bin]
+              ['objcopy', `--compress-debug-sections=${format}`, '--', bin]
             )
           )
         )
@@ -119,7 +121,8 @@ async function main() {
         break
       default:
         throw new Error(
-          "PACK_NEXT_COMPRESS must be one of 'strip', 'objcopy-zstd', or 'none'"
+          "PACK_NEXT_COMPRESS must be one of 'strip', 'objcopy-zstd', " +
+            "'objcopy-zlib', or 'none'"
         )
     }
   }


### PR DESCRIPTION
On Linux we must either compress or strip debuginfo, otherwise the debug tarball will be >2GiB, and pnpm (it's actually a node/libuv bug) has issues with files larger than 2GiB.

As far as I can tell Rust can generate line numbers for backtraces with zlib-compressed debuginfo, but not with newer zstd-compressed debuginfo.

Closes PACK-3696