### PR TITLE
Use prefer offline flag for CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -26,6 +26,7 @@ env:
   DD_ENV: 'ci'
   TEST_TIMINGS_TOKEN: ${{ secrets.TEST_TIMINGS_TOKEN }}
   NEXT_TEST_JOB: 1
+  NEXT_TEST_PREFER_OFFLINE: 1
 
 jobs:
   optimize-ci:

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -85,6 +85,7 @@ env:
   NEXT_TEST_JOB: 1
   VERCEL_TEST_TOKEN: ${{ secrets.VERCEL_TEST_TOKEN }}
   VERCEL_TEST_TEAM: vtest314-next-e2e-tests
+  NEXT_TEST_PREFER_OFFLINE: 1
 
 jobs:
   build:


### PR DESCRIPTION
Aims to speed up CI by avoiding checking npm registry un-necessarily for every test run since we mostly hard code our test package versions when the version matters. 