### PR TITLE
Remove PPR feature check from Segment Cache client

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -275,30 +275,29 @@ function Router({
     const routerInstance: AppRouterInstance = {
       back: () => window.history.back(),
       forward: () => window.history.forward(),
-      prefetch:
-        process.env.__NEXT_PPR && process.env.__NEXT_CLIENT_SEGMENT_CACHE
-          ? // Unlike the old implementation, the Segment Cache doesn't store its
-            // data in the router reducer state; it writes into a global mutable
-            // cache. So we don't need to dispatch an action.
-            (href) =>
-              prefetchWithSegmentCache(
-                href,
-                actionQueue.state.nextUrl,
-                actionQueue.state.tree
-              )
-          : (href, options) => {
-              // Use the old prefetch implementation.
-              const url = createPrefetchURL(href)
-              if (url !== null) {
-                startTransition(() => {
-                  dispatch({
-                    type: ACTION_PREFETCH,
-                    url,
-                    kind: options?.kind ?? PrefetchKind.FULL,
-                  })
+      prefetch: process.env.__NEXT_CLIENT_SEGMENT_CACHE
+        ? // Unlike the old implementation, the Segment Cache doesn't store its
+          // data in the router reducer state; it writes into a global mutable
+          // cache. So we don't need to dispatch an action.
+          (href) =>
+            prefetchWithSegmentCache(
+              href,
+              actionQueue.state.nextUrl,
+              actionQueue.state.tree
+            )
+        : (href, options) => {
+            // Use the old prefetch implementation.
+            const url = createPrefetchURL(href)
+            if (url !== null) {
+              startTransition(() => {
+                dispatch({
+                  type: ACTION_PREFETCH,
+                  url,
+                  kind: options?.kind ?? PrefetchKind.FULL,
                 })
-              }
-            },
+              })
+            }
+          },
       replace: (href, options = {}) => {
         startTransition(() => {
           navigate(href, 'replace', options.scroll ?? true)

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -173,7 +173,7 @@ export function navigateReducer(
     return handleExternalUrl(state, mutable, href, pendingPush)
   }
 
-  if (process.env.__NEXT_PPR && process.env.__NEXT_CLIENT_SEGMENT_CACHE) {
+  if (process.env.__NEXT_CLIENT_SEGMENT_CACHE) {
     // (Very Early Experimental Feature) Segment Cache
     //
     // Bypass the normal prefetch cache and use the new per-segment cache

--- a/packages/next/src/client/components/router-reducer/reducers/prefetch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/prefetch-reducer.ts
@@ -11,10 +11,9 @@ import {
 
 export const prefetchQueue = new PromiseQueue(5)
 
-export const prefetchReducer =
-  process.env.__NEXT_PPR && process.env.__NEXT_CLIENT_SEGMENT_CACHE
-    ? identityReducerWhenSegmentCacheIsEnabled
-    : prefetchReducerImpl
+export const prefetchReducer = process.env.__NEXT_CLIENT_SEGMENT_CACHE
+  ? identityReducerWhenSegmentCacheIsEnabled
+  : prefetchReducerImpl
 
 function identityReducerWhenSegmentCacheIsEnabled<T>(state: T): T {
   // Unlike the old implementation, the Segment Cache doesn't store its data in


### PR DESCRIPTION
Follow-up to #73960. We should no longer check if PPR is enabled when determining whether to use the Segment Cache or the old client cache.