### PR TITLE
[Segment Cache] Cancel prefetch on viewport exit

### DIFF
--- a/test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
+++ b/test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
@@ -47,15 +47,11 @@ describe('segment cache (basic tests)', () => {
           `"<div><div data-streaming-text-static="Static in nav">Static in nav</div><div data-streaming-text-dynamic="Dynamic in nav">Dynamic in nav</div></div>"`
         )
       },
-      // When the outer act scope exits, the blocked prefetches are allowed
-      // to continue.
-      // TODO: As an optimization, in the case where a fully static page is
-      // returned during a dynamic response, we should populate the prefetch
-      // cache with the static data. Then we wouldn't have to prefetch it again
-      // here, because it would already be cached. Only works for fully static
-      // pages because in a partial response we don't know which parts are
-      // static versus dynamic.
-      { includes: 'Static in nav' }
+      // Although the blocked prefetches are allowed to continue when we exit
+      // the outer `act` scope, they were canceled when we navigated to the new
+      // page. So there should be no additional requests in the outer
+      // `act` scope.
+      'no-requests'
     )
   })
 


### PR DESCRIPTION
We use an IntersectionObserver to prefetch links when they enter the viewport. This updates the behavior to cancel the prefetch if the link exits the viewport before it completes.

This can greatly reduce the amount of data transfer caused by prefetching, however, the impact of this change will depend on the user's network conditions. The faster the network conditions, the more likely the link will have already been prefetched by the time the link exits the screen.

We'll need a different strategy for limiting prefetch data transfer in fast network conditions, perhaps by tracking and throttling the overall bitrate.