### PR TITLE
[Segment Cache] Prioritize hovered links

### DIFF
--- a/packages/next/src/client/components/segment-cache/prefetch.ts
+++ b/packages/next/src/client/components/segment-cache/prefetch.ts
@@ -1,7 +1,7 @@
 import type { FlightRouterState } from '../../../server/app-render/types'
 import { createPrefetchURL } from '../../components/app-router'
 import { createCacheKey } from './cache-key'
-import { schedulePrefetchTask } from './scheduler'
+import { schedulePrefetchTask, PrefetchPriority } from './scheduler'
 
 /**
  * Entrypoint for prefetching a URL into the Segment Cache.
@@ -26,5 +26,10 @@ export function prefetch(
     return
   }
   const cacheKey = createCacheKey(url.href, nextUrl)
-  schedulePrefetchTask(cacheKey, treeAtTimeOfPrefetch, includeDynamicData)
+  schedulePrefetchTask(
+    cacheKey,
+    treeAtTimeOfPrefetch,
+    includeDynamicData,
+    PrefetchPriority.Default
+  )
 }


### PR DESCRIPTION
This adds a new internal priority level to the prefetch queue for links that are hovered or touched. The idea is that if a user hovers over a link, they're much more likely to click on it.

The elevated priority is added on mouseenter/touchstart. It is _not_ removed on mouseleave/touchend, because even though the user left the link without navigating to it, the link is still more likely to be navigated to than a link that was never hovered at all.

Because the prefetch queue is last-in-first-out, the highest priority link is whichever link was most recently hovered.