### PR TITLE
fix unnecessary missing slots warnings

### DIFF
--- a/packages/next/src/client/components/http-access-fallback/error-boundary.tsx
+++ b/packages/next/src/client/components/http-access-fallback/error-boundary.tsx
@@ -57,6 +57,7 @@ class HTTPAccessFallbackErrorBoundary extends React.Component<
     if (
       process.env.NODE_ENV === 'development' &&
       this.props.missingSlots &&
+      this.props.missingSlots.size > 0 &&
       // A missing children slot is the typical not-found case, so no need to warn
       !this.props.missingSlots.has('children')
     ) {
@@ -64,14 +65,12 @@ class HTTPAccessFallbackErrorBoundary extends React.Component<
         'No default component was found for a parallel route rendered on this page. Falling back to nearest NotFound boundary.\n' +
         'Learn more: https://nextjs.org/docs/app/building-your-application/routing/parallel-routes#defaultjs\n\n'
 
-      if (this.props.missingSlots.size > 0) {
-        const formattedSlots = Array.from(this.props.missingSlots)
-          .sort((a, b) => a.localeCompare(b))
-          .map((slot) => `@${slot}`)
-          .join(', ')
+      const formattedSlots = Array.from(this.props.missingSlots)
+        .sort((a, b) => a.localeCompare(b))
+        .map((slot) => `@${slot}`)
+        .join(', ')
 
-        warningMessage += 'Missing slots: ' + formattedSlots
-      }
+      warningMessage += 'Missing slots: ' + formattedSlots
 
       warnOnce(warningMessage)
     }

--- a/test/e2e/app-dir/parallel-route-not-found/app/@bar/has-both-slots/not-found-error/page.tsx
+++ b/test/e2e/app-dir/parallel-route-not-found/app/@bar/has-both-slots/not-found-error/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>@bar slot</div>
+}

--- a/test/e2e/app-dir/parallel-route-not-found/app/@foo/has-both-slots/not-found-error/page.tsx
+++ b/test/e2e/app-dir/parallel-route-not-found/app/@foo/has-both-slots/not-found-error/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>@bar slot</div>
+}

--- a/test/e2e/app-dir/parallel-route-not-found/app/has-both-slots/not-found-error/page.tsx
+++ b/test/e2e/app-dir/parallel-route-not-found/app/has-both-slots/not-found-error/page.tsx
@@ -1,0 +1,5 @@
+import { notFound } from 'next/navigation'
+
+export default function NotFoundError() {
+  notFound()
+}

--- a/test/e2e/app-dir/parallel-route-not-found/parallel-route-not-found.test.ts
+++ b/test/e2e/app-dir/parallel-route-not-found/parallel-route-not-found.test.ts
@@ -43,6 +43,18 @@ describe('parallel-route-not-found', () => {
     }
   })
 
+  it('should not include any parallel route warnings for a deliberate notFound()', async () => {
+    const browser = await next.browser('/has-both-slots/not-found-error')
+    const logs = await browser.log()
+
+    expect(await browser.elementByCss('body').text()).toContain(
+      'This page could not be found'
+    )
+
+    const warnings = logs.filter((log) => log.source === 'warning')
+    expect(warnings.length).toBe(0)
+  })
+
   it('should render the page & slots if all parallel routes are found', async () => {
     const browser = await next.browser('/has-both-slots')
     const logs = await browser.log()


### PR DESCRIPTION
This is meant to provide a warning when a `notFound` page is triggered by an unmatched parallel route, but was erroneously triggering for deliberate `notFound()` cases as well. This adjusts the warning to only occur when `missingSlots` has items in the set which will only be the case when a missing non-children slot triggers the `notFound()`

Fixes #74642