### PR TITLE
test: assert the logs has updated after revaluate js value

### DIFF
--- a/test/development/acceptance-app/ReactRefreshRequire.test.ts
+++ b/test/development/acceptance-app/ReactRefreshRequire.test.ts
@@ -42,6 +42,8 @@ describe('ReactRefreshRequire app', () => {
     // We only edited Bar, and it accepted.
     // So we expect it to re-run alone.
     await session.evaluate(() => ((window as any).log = []))
+    expect(await session.evaluate(() => (window as any).log)).toEqual([])
+
     await session.patch(
       './bar.js',
       `window.log.push('init BarV2'); export default function Bar() { return null; };`
@@ -53,6 +55,8 @@ describe('ReactRefreshRequire app', () => {
     // We only edited Bar, and it accepted.
     // So we expect it to re-run alone.
     await session.evaluate(() => ((window as any).log = []))
+    expect(await session.evaluate(() => (window as any).log)).toEqual([])
+
     await session.patch(
       './bar.js',
       `window.log.push('init BarV3'); export default function Bar() { return null; };`


### PR DESCRIPTION
### What

Constantly seeing this is failed with turbopack, seems like the logs was not reset to the empty array value properly. We add an assertion here to ensure it's updated

```
pnpm test-dev-turbo test/development/acceptance-app/ReactRefreshRequire.test.ts (turbopack)

ReactRefreshRequire app > re-runs accepted modules
Expand output
● ReactRefreshRequire app › re-runs accepted modules

expect(received).toEqual(expected) // deep equality

- Expected  - 0
+ Received  + 2

  Array [
+   "init FooV1",
+   "init FooV1",
    "init BarV2",
  ]

  47 |       `window.log.push('init BarV2'); export default function Bar() { return null; };`
  48 |     )
> 49 |     expect(await session.evaluate(() => (window as any).log)).toEqual([
     |                                                               ^
  50 |       'init BarV2',
  51 |     ])
  52 |

  at Object.toEqual (development/acceptance-app/ReactRefreshRequire.test.ts:49:63)
```