### PR TITLE
Recommend styled-components VSCode extension to get CSS autocomplete in Dev Overlay

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -23,6 +23,9 @@
     "ms-vscode.vscode-js-profile-flame",
 
     // MDX Authoring
-    "unifiedjs.vscode-mdx"
+    "unifiedjs.vscode-mdx",
+
+    // CSS Authoring (mainly Dev Overlay)
+    "styled-components.vscode-styled-components"
   ]
 }


### PR DESCRIPTION
![CleanShot 2025-01-09 at 11 55 10](https://github.com/user-attachments/assets/14a00e34-1b11-40bb-9d17-6e5d299d29f9)

Also considered just adding the TypeScript plugin but those have this config pitfall where you need to select the correct TS version. The extension also adds syntax highlighting which the TS language plugin doesn't I believe.