### PR TITLE
Show numerical values for configured experimental features

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1270,6 +1270,7 @@ export default async function loadConfig(
 
 export type ConfiguredExperimentalFeature =
   | { name: keyof ExperimentalConfig; type: 'boolean'; value: boolean }
+  | { name: keyof ExperimentalConfig; type: 'number'; value: number }
   | { name: keyof ExperimentalConfig; type: 'other' }
 
 export function getConfiguredExperimentalFeatures(
@@ -1296,7 +1297,9 @@ export function getConfiguredExperimentalFeatures(
         configuredExperimentalFeatures.push(
           typeof value === 'boolean'
             ? { name, type: 'boolean', value }
-            : { name, type: 'other' }
+            : typeof value === 'number'
+              ? { name, type: 'number', value }
+              : { name, type: 'other' }
         )
       }
     }

--- a/packages/next/src/server/lib/app-info-log.ts
+++ b/packages/next/src/server/lib/app-info-log.ts
@@ -47,7 +47,9 @@ export function logStartInfo({
             : bold('⨯')
           : '·'
 
-      Log.bootstrap(`  ${symbol} ${exp.name}`)
+      const suffix = exp.type === 'number' ? `: ${exp.value}` : ''
+
+      Log.bootstrap(`  ${symbol} ${exp.name}${suffix}`)
     }
     /* indicate if there are more than the maximum shown no. flags */
     if (experimentalFeatures.length > maxExperimentalFeatures) {

--- a/test/integration/config-experimental-warning/next.config.js
+++ b/test/integration/config-experimental-warning/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  experimental: {
+    staticGenerationRetryCount: 2,
+    staticGenerationMaxConcurrency: 4,
+  },
+}

--- a/test/integration/config-experimental-warning/test/index.test.js
+++ b/test/integration/config-experimental-warning/test/index.test.js
@@ -129,6 +129,20 @@ describe('Config Experimental Warning', () => {
     expect(stdout).toMatch(' ⨯ prerenderEarlyExit')
   })
 
+  it('should show the configured value for numerical features', async () => {
+    configFile.write(`
+      module.exports = {
+        experimental: {
+          cpus: 2
+        }
+      }
+    `)
+
+    const stdout = await collectStdoutFromDev(appDir)
+    expect(stdout).toMatch(experimentalHeader)
+    expect(stdout).toMatch(' · cpus: 2')
+  })
+
   it('should show warning with config from object with experimental and multiple keys', async () => {
     configFile.write(`
       module.exports = {
@@ -184,7 +198,7 @@ describe('Config Experimental Warning', () => {
       `)
         const stdout = await collectStdoutFromBuild(appDir)
         expect(stdout).toMatch(experimentalHeader)
-        expect(stdout).toMatch(' · cpus')
+        expect(stdout).toMatch(' · cpus: 2')
         expect(stdout).toMatch(' ✓ workerThreads')
         expect(stdout).toMatch(' ✓ scrollRestoration')
         expect(stdout).toMatch(' ⨯ prerenderEarlyExit')


### PR DESCRIPTION
Based on #74691 we can now also show numerical values for configured experimental features:

<img width="393" alt="numbers" src="https://github.com/user-attachments/assets/77309353-1319-4806-89e2-0ba1841e341a" />
