### PR TITLE
test: consolidate hmr test for turbopack

### DIFF
--- a/test/development/acceptance-app/ReactRefreshRequire.test.ts
+++ b/test/development/acceptance-app/ReactRefreshRequire.test.ts
@@ -42,8 +42,6 @@ describe('ReactRefreshRequire app', () => {
     // We only edited Bar, and it accepted.
     // So we expect it to re-run alone.
     await session.evaluate(() => ((window as any).log = []))
-    expect(await session.evaluate(() => (window as any).log)).toEqual([])
-
     await session.patch(
       './bar.js',
       `window.log.push('init BarV2'); export default function Bar() { return null; };`
@@ -55,8 +53,6 @@ describe('ReactRefreshRequire app', () => {
     // We only edited Bar, and it accepted.
     // So we expect it to re-run alone.
     await session.evaluate(() => ((window as any).log = []))
-    expect(await session.evaluate(() => (window as any).log)).toEqual([])
-
     await session.patch(
       './bar.js',
       `window.log.push('init BarV3'); export default function Bar() { return null; };`

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -1661,13 +1661,13 @@
       "ReactRefreshRequire app provides fresh value for ES6 named import in parents",
       "ReactRefreshRequire app provides fresh value for exports.* in parents",
       "ReactRefreshRequire app provides fresh value for module.exports in parents",
-      "ReactRefreshRequire app re-runs accepted modules",
       "ReactRefreshRequire app runs dependencies before dependents",
       "ReactRefreshRequire app stops update propagation after module-level errors"
     ],
     "failed": [],
     "pending": [
-      "ReactRefreshRequire app propagates a module that stops accepting in next version"
+      "ReactRefreshRequire app propagates a module that stops accepting in next version",
+      "ReactRefreshRequire app re-runs accepted modules"
     ],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
* revert https://github.com/vercel/next.js/pull/74686 as it should already being skipped
* add flaky test to turbopack dev manifest

There's an issue that the skipped tests in manifest are still get executed. This PR only adds them into the manifest. The CI issue will be addressed separately