### PR TITLE
refactor(turbopack-dev-server): Use ResolvedVc/NonLocalValue in RewriteType, remove all "local" opt-outs from structs

### DIFF
--- a/turbopack/crates/turbopack-dev-server/src/source/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/mod.rs
@@ -475,33 +475,31 @@ impl ContentSource for NoContentSource {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue)]
 pub enum RewriteType {
     Location {
-        /// The new path and query used to lookup content. This _does not_ need
-        /// to be the original path or query.
+        /// The new path and query used to lookup content. This _does not_ need to be the original
+        /// path or query.
         path_and_query: RcStr,
     },
     ContentSource {
-        /// [Vc<Box<dyn ContentSource>>]s from which to restart the lookup
-        /// process. This _does not_ need to be the original content
-        /// source.
-        source: Vc<Box<dyn ContentSource>>,
+        /// [`ContentSource`]s from which to restart the lookup process. This _does not_ need to be
+        /// the original content source.
+        source: ResolvedVc<Box<dyn ContentSource>>,
         /// The new path and query used to lookup content. This _does not_ need
         /// to be the original path or query.
         path_and_query: RcStr,
     },
     Sources {
-        /// [GetContentSourceContent]s from which to restart the lookup
-        /// process. This _does not_ need to be the original content
-        /// source.
-        sources: Vc<GetContentSourceContents>,
+        /// [`GetContentSourceContent`]s from which to restart the lookup process. This _does not_
+        /// need to be the original content source.
+        sources: ResolvedVc<GetContentSourceContents>,
     },
 }
 
 /// A rewrite returned from a [ContentSource]. This tells the dev server to
 /// update its parsed url, path, and queries with this new information.
-#[turbo_tasks::value(shared, local)]
+#[turbo_tasks::value(shared)]
 #[derive(Debug)]
 pub struct Rewrite {
     pub ty: RewriteType,
@@ -531,7 +529,7 @@ impl RewriteBuilder {
     }
 
     pub fn new_source_with_path_and_query(
-        source: Vc<Box<dyn ContentSource>>,
+        source: ResolvedVc<Box<dyn ContentSource>>,
         path_and_query: RcStr,
     ) -> Self {
         Self {
@@ -546,7 +544,7 @@ impl RewriteBuilder {
         }
     }
 
-    pub fn new_sources(sources: Vc<GetContentSourceContents>) -> Self {
+    pub fn new_sources(sources: ResolvedVc<GetContentSourceContents>) -> Self {
         Self {
             rewrite: Rewrite {
                 ty: RewriteType::Sources { sources },

--- a/turbopack/crates/turbopack-dev-server/src/source/resolve.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/resolve.rs
@@ -22,7 +22,7 @@ use super::{
 /// The result of [`resolve_source_request`]. Similar to a
 /// `ContentSourceContent`, but without the `Rewrite` variant as this is taken
 /// care in the function.
-#[turbo_tasks::value(serialization = "none", local)]
+#[turbo_tasks::value(serialization = "none")]
 pub enum ResolveSourceRequestResult {
     NotFound,
     Static(ResolvedVc<StaticContent>, ResolvedVc<HeaderList>),
@@ -102,7 +102,7 @@ pub async fn resolve_source_request(
                             RewriteType::Sources {
                                 sources: new_sources,
                             } => {
-                                sources = *new_sources;
+                                sources = **new_sources;
                                 continue 'sources;
                             }
                         }

--- a/turbopack/crates/turbopack-dev-server/src/source/wrapping_source.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/wrapping_source.rs
@@ -63,7 +63,7 @@ impl GetContentSourceContent for WrappedGetContentSourceContent {
                             "Rewrites for WrappedGetContentSourceContent are not implemented yet"
                         ),
                         RewriteType::Sources { sources } => RewriteType::Sources {
-                            sources: Vc::cell(
+                            sources: ResolvedVc::cell(
                                 sources
                                     .await?
                                     .iter()


### PR DESCRIPTION


Closes PACK-3712