### PR TITLE
test: add feature of overriding files

### DIFF
--- a/test/development/app-dir/owner-stack-invalid-element-type/invalid-element-type.test.ts
+++ b/test/development/app-dir/owner-stack-invalid-element-type/invalid-element-type.test.ts
@@ -8,9 +8,7 @@ import {
 } from 'next-test-utils'
 
 // TODO: When owner stack is enabled by default, remove the condition and only keep one test
-const isOwnerStackEnabled =
-  process.env.TEST_OWNER_STACK !== 'false' ||
-  process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+const isOwnerStackEnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
 
 ;(isOwnerStackEnabled ? describe.skip : describe)(
   'app-dir - invalid-element-type',

--- a/test/development/app-dir/owner-stack-react-missing-key-prop/owner-stack-react-missing-key-prop.test.ts
+++ b/test/development/app-dir/owner-stack-react-missing-key-prop/owner-stack-react-missing-key-prop.test.ts
@@ -6,9 +6,7 @@ import {
 } from 'next-test-utils'
 
 // TODO: When owner stack is enabled by default, remove the condition and only keep one test
-const isOwnerStackEnabled =
-  process.env.TEST_OWNER_STACK !== 'false' ||
-  process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+const isOwnerStackEnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
 
 ;(isOwnerStackEnabled ? describe : describe.skip)(
   'app-dir - owner-stack-react-missing-key-prop',

--- a/test/development/app-dir/owner-stack-react-missing-key-prop/react-missing-key-prop.test.ts
+++ b/test/development/app-dir/owner-stack-react-missing-key-prop/react-missing-key-prop.test.ts
@@ -63,29 +63,29 @@ async function getStackFramesContent(browser) {
       if (process.env.TURBOPACK) {
         expect(stackFramesContent).toMatchInlineSnapshot(`""`)
         expect(source).toMatchInlineSnapshot(`
-        "app/rsc/page.tsx (5:5) @ Page
+         "app/rsc/page.tsx (5:6) @ Page
 
-          3 | export default function Page() {
-          4 |   return (
-        > 5 |     <div>
-            |     ^
-          6 |       {list.map((item, index) => (
-          7 |         <span>{item}</span>
-          8 |       ))}"
-      `)
+           3 | export default function Page() {
+           4 |   return (
+         > 5 |     <div>
+             |      ^
+           6 |       {list.map((item, index) => (
+           7 |         <span>{item}</span>
+           8 |       ))}"
+        `)
       } else {
         expect(stackFramesContent).toMatchInlineSnapshot(`""`)
         expect(source).toMatchInlineSnapshot(`
-        "app/rsc/page.tsx (5:6) @ Page
+                 "app/rsc/page.tsx (5:6) @ Page
 
-          3 | export default function Page() {
-          4 |   return (
-        > 5 |     <div>
-            |      ^
-          6 |       {list.map((item, index) => (
-          7 |         <span>{item}</span>
-          8 |       ))}"
-      `)
+                   3 | export default function Page() {
+                   4 |   return (
+                 > 5 |     <div>
+                     |      ^
+                   6 |       {list.map((item, index) => (
+                   7 |         <span>{item}</span>
+                   8 |       ))}"
+              `)
       }
     })
 
@@ -98,29 +98,29 @@ async function getStackFramesContent(browser) {
       if (process.env.TURBOPACK) {
         expect(stackFramesContent).toMatchInlineSnapshot(`""`)
         expect(source).toMatchInlineSnapshot(`
-        "app/ssr/page.tsx (7:5) @ Page
+                 "app/ssr/page.tsx (7:5) @ Page
 
-           5 | export default function Page() {
-           6 |   return (
-        >  7 |     <div>
-             |     ^
-           8 |       {list.map((item, index) => (
-           9 |         <p>{item}</p>
-          10 |       ))}"
-      `)
+                    5 | export default function Page() {
+                    6 |   return (
+                 >  7 |     <div>
+                      |     ^
+                    8 |       {list.map((item, index) => (
+                    9 |         <p>{item}</p>
+                   10 |       ))}"
+              `)
       } else {
         expect(stackFramesContent).toMatchInlineSnapshot(`""`)
         expect(source).toMatchInlineSnapshot(`
-        "app/ssr/page.tsx (7:6) @ Page
+                 "app/ssr/page.tsx (7:6) @ Page
 
-           5 | export default function Page() {
-           6 |   return (
-        >  7 |     <div>
-             |      ^
-           8 |       {list.map((item, index) => (
-           9 |         <p>{item}</p>
-          10 |       ))}"
-      `)
+                    5 | export default function Page() {
+                    6 |   return (
+                 >  7 |     <div>
+                      |      ^
+                    8 |       {list.map((item, index) => (
+                    9 |         <p>{item}</p>
+                   10 |       ))}"
+              `)
       }
     })
   }

--- a/test/development/app-dir/owner-stack-react-missing-key-prop/react-missing-key-prop.test.ts
+++ b/test/development/app-dir/owner-stack-react-missing-key-prop/react-missing-key-prop.test.ts
@@ -2,9 +2,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { getRedboxSource, openRedbox } from 'next-test-utils'
 
 // TODO: When owner stack is enabled by default, remove the condition and only keep one test
-const isOwnerStackEnabled =
-  process.env.TEST_OWNER_STACK !== 'false' ||
-  process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+const isOwnerStackEnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
 
 async function getStackFramesContent(browser) {
   const stackFrameElements = await browser.elementsByCss(
@@ -33,29 +31,26 @@ async function getStackFramesContent(browser) {
   return stackFramesContent
 }
 
+// Without owner stack, the source is not available
 ;(isOwnerStackEnabled ? describe.skip : describe)(
   'app-dir - react-missing-key-prop',
   () => {
     const { next } = nextTestSetup({
       files: __dirname,
-    })
+      overrideFiles: {
+        'next.config.js': `
+        /**
+         * @type {import('next').NextConfig}
+         */
+        const nextConfig = {
+          experimental: {
+            reactOwnerStack: false,
+          },
+        }
 
-    let nextConfig: string = ''
-    beforeAll(async () => {
-      await next.stop()
-      await next.patchFile('next.config.js', (content: string) => {
-        nextConfig = content
-        return content.replace(
-          `reactOwnerStack: true`,
-          `reactOwnerStack: false`
-        )
-      })
-      await next.start()
-    })
-    afterAll(async () => {
-      await next.stop()
-      // Restore original next.config.js
-      await next.patchFile('next.config.js', nextConfig)
+        module.exports = nextConfig
+        `,
+      },
     })
 
     it('should catch invalid element from on rsc component', async () => {
@@ -80,9 +75,8 @@ async function getStackFramesContent(browser) {
       `)
       } else {
         expect(stackFramesContent).toMatchInlineSnapshot(`""`)
-        // FIXME: the methodName should be `@ Page` instead of `@ div`
         expect(source).toMatchInlineSnapshot(`
-        "app/rsc/page.tsx (5:6) @ div
+        "app/rsc/page.tsx (5:6) @ Page
 
           3 | export default function Page() {
           4 |   return (
@@ -116,9 +110,8 @@ async function getStackFramesContent(browser) {
       `)
       } else {
         expect(stackFramesContent).toMatchInlineSnapshot(`""`)
-        // FIXME: the methodName should be `@ Page` instead of `@ div`
         expect(source).toMatchInlineSnapshot(`
-        "app/ssr/page.tsx (7:6) @ div
+        "app/ssr/page.tsx (7:6) @ Page
 
            5 | export default function Page() {
            6 |   return (


### PR DESCRIPTION
### What

* For testing, we add a `overrideFiles` to `nextTestSetup` to override the local files to easily create vary test cases. This was a small improvement for testing util I planned before. (Closes NDX-323). So you can have 2 test files for one test fixture, and override the file with `overridingFiles`. Same usage as `files`.
* Update the bad test condition where it was accidentally get skipped. Also fix the bad snapshot

###. Example

For instance, if you want to use the same app fixture but different next config, just override the config. You don't have to stop the nextjs instance and modify then restart. Time saver.

```js
const { next } = nextTestSetup({
      files: __dirname,
      overrideFiles: {
        'next.config.js': `
        /**
         * @type {import('next').NextConfig}
         */
        const nextConfig = {
          experimental: {
            reactOwnerStack: false,
          },
        }
        module.exports = nextConfig
        `,
      },
     // ...
```      