### PR TITLE
docs: update chakra ui link

### DIFF
--- a/docs/01-app/01-getting-started/05-css-and-styling.mdx
+++ b/docs/01-app/01-getting-started/05-css-and-styling.mdx
@@ -262,7 +262,7 @@ export default nextConfig
 The following libraries are supported in **Client Components** in the `app` directory (alphabetical):
 
 - [`ant-design`](https://ant.design/docs/react/use-with-next#using-app-router)
-- [`chakra-ui`](https://chakra-ui.com/getting-started/nextjs-app-guide)
+- [`chakra-ui`](https://chakra-ui.com/docs/get-started/frameworks/next-app)
 - [`@fluentui/react-components`](https://react.fluentui.dev/?path=/docs/concepts-developer-server-side-rendering-next-js-appdir-setup--page)
 - [`kuma-ui`](https://kuma-ui.com)
 - [`@mui/material`](https://mui.com/material-ui/guides/next-js-app-router/)


### PR DESCRIPTION
Updating a link as the current one is broken