### PR TITLE
chore(github): switch back to STALE_TOKEN

### DIFF
--- a/.github/workflows/issue_stale.yml
+++ b/.github/workflows/issue_stale.yml
@@ -14,7 +14,7 @@ jobs:
         id: stale-no-repro
         name: 'Close stale issues with no reproduction'
         with:
-          repo-token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          repo-token: ${{ secrets.STALE_TOKEN }}
           any-of-labels: 'please add a complete reproduction'
           close-issue-message: 'This issue has been automatically closed due to 2 days of inactivity and the absence of a complete reproduction. If you believe this was done in error, please leave a comment. If you are experiencing a similar issue, consider opening a new issue with a complete reproduction. Thank you.'
           days-before-issue-close: 1
@@ -27,7 +27,7 @@ jobs:
         id: stale-simple-repro
         name: 'Close issues with no simple repro'
         with:
-          repo-token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          repo-token: ${{ secrets.STALE_TOKEN }}
           any-of-labels: 'please simplify reproduction'
           close-issue-message: 'This issue has been automatically closed due to 14 days of inactivity and the absence of a simple reproduction for investigation. If you believe this was done in error, please leave a comment. If you are experiencing a similar issue, consider opening a new issue with a simple reproduction. Thank you.'
           days-before-issue-close: 1
@@ -40,7 +40,7 @@ jobs:
         id: stale-no-canary
         name: 'Close issues not verified on canary'
         with:
-          repo-token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          repo-token: ${{ secrets.STALE_TOKEN }}
           any-of-labels: 'please verify canary'
           close-issue-message: 'This issue has been automatically closed due to 14 days of inactivity and the absence of testing against next@canary. If you believe this was done in error, please leave a comment. If you are experiencing a similar issue, consider opening a new issue with a reproduction. Thank you.'
           days-before-issue-close: 1


### PR DESCRIPTION
## Why?

We have regenerated the token with necessary permission as `STALE_TOKEN`.