### PR TITLE
Improve memory usage of the new backend

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/indexed.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/indexed.rs
@@ -1,4 +1,0 @@
-pub trait Indexed {
-    type Index: Clone + PartialEq + Eq + std::hash::Hash;
-    fn index(&self) -> Self::Index;
-}

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -151,7 +151,7 @@ struct TurboTasksBackendInner<B: BackingStorage> {
 
     persisted_storage_data_log: Option<PersistedStorageLog>,
     persisted_storage_meta_log: Option<PersistedStorageLog>,
-    storage: Storage<TaskId, CachedDataItem>,
+    storage: Storage,
 
     /// Number of executing operations + Highest bit is set when snapshot is
     /// requested. When that bit is set, operations should pause until the

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1391,6 +1391,14 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         drop(removed_data);
 
+        let mut task = ctx.task(task_id, TaskDataCategory::All);
+        task.shrink_to_fit(CachedDataItemType::CellData);
+        task.shrink_to_fit(CachedDataItemType::CellTypeMaxIndex);
+        task.shrink_to_fit(CachedDataItemType::CellDependency);
+        task.shrink_to_fit(CachedDataItemType::OutputDependency);
+        task.shrink_to_fit(CachedDataItemType::CollectiblesDependency);
+        drop(task);
+
         false
     }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -50,8 +50,8 @@ use crate::{
     backing_storage::BackingStorage,
     data::{
         ActiveType, AggregationNumber, CachedDataItem, CachedDataItemIndex, CachedDataItemKey,
-        CachedDataItemValue, CachedDataUpdate, CellRef, CollectibleRef, CollectiblesRef,
-        DirtyState, InProgressCellState, InProgressState, OutputValue, RootState,
+        CachedDataItemValue, CachedDataItemValueRef, CachedDataUpdate, CellRef, CollectibleRef,
+        CollectiblesRef, DirtyState, InProgressCellState, InProgressState, OutputValue, RootState,
     },
     utils::{bi_map::BiMap, chunked_vec::ChunkedVec, ptr_eq_arc::PtrEqArc, sharded::Sharded},
 };
@@ -1257,7 +1257,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             task.remove(&CachedDataItemKey::CellTypeMaxIndex { cell_type });
         }
 
-        let mut removed_data = Vec::new();
+        let mut removed_data: Vec<CachedDataItem> = Vec::new();
         let mut old_edges = Vec::new();
 
         // Remove no longer existing cells and notify in progress cells
@@ -1336,7 +1336,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 match (key, value) {
                     (
                         &CachedDataItemKey::InProgressCell { cell },
-                        CachedDataItemValue::InProgressCell { value },
+                        CachedDataItemValueRef::InProgressCell { value },
                     ) if cell_counters
                         .get(&cell.type_id)
                         .is_none_or(|start_index| cell.index >= *start_index) =>
@@ -1356,8 +1356,8 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                     }
                     (
                         &CachedDataItemKey::OutdatedCollectible { collectible },
-                        &CachedDataItemValue::OutdatedCollectible { value },
-                    ) => old_edges.push(OutdatedEdge::Collectible(collectible, value)),
+                        CachedDataItemValueRef::OutdatedCollectible { value },
+                    ) => old_edges.push(OutdatedEdge::Collectible(collectible, *value)),
                     (&CachedDataItemKey::OutdatedCellDependency { target }, _) => {
                         old_edges.push(OutdatedEdge::CellDependency(target));
                     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -375,6 +375,7 @@ pub trait TaskGuard: Debug {
         &self,
         ty: CachedDataItemType,
     ) -> impl Iterator<Item = (CachedDataItemKey, CachedDataItemValueRef<'_>)>;
+    fn shrink_to_fit(&mut self, ty: CachedDataItemType);
     fn extract_if<'l, F>(
         &'l mut self,
         ty: CachedDataItemType,
@@ -606,6 +607,10 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
         ty: CachedDataItemType,
     ) -> impl Iterator<Item = (CachedDataItemKey, CachedDataItemValueRef<'_>)> {
         self.task.iter(ty)
+    }
+
+    fn shrink_to_fit(&mut self, ty: CachedDataItemType) {
+        self.task.shrink_to_fit(ty)
     }
 
     fn extract_if<'l, F>(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -389,7 +389,7 @@ pub trait TaskGuard: Debug {
 
 struct TaskGuardImpl<'a, B: BackingStorage> {
     task_id: TaskId,
-    task: StorageWriteGuard<'a, TaskId, CachedDataItem>,
+    task: StorageWriteGuard<'a>,
     backend: &'a TurboTasksBackendInner<B>,
     #[cfg(debug_assertions)]
     category: TaskDataCategory,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -473,10 +473,9 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
             self.task
                 .insert(CachedDataItem::from_key_and_value(key, value))
         } else if value.is_persistent() {
-            let old = self.task.insert(CachedDataItem::from_key_and_value(
-                key.clone(),
-                value.clone(),
-            ));
+            let old = self
+                .task
+                .insert(CachedDataItem::from_key_and_value(key, value.clone()));
             self.task.persistance_state_mut().add_persisting_item();
             self.backend
                 .persisted_storage_log(key.category())
@@ -490,7 +489,7 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
                 );
             old
         } else {
-            let item = CachedDataItem::from_key_and_value(key.clone(), value);
+            let item = CachedDataItem::from_key_and_value(key, value);
             if let Some(old) = self.task.insert(item) {
                 if old.is_persistent() {
                     self.task.persistance_state_mut().add_persisting_item();
@@ -569,14 +568,13 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
                 && key.is_persistent()
                 && value.is_persistent()
             {
-                let key = key.clone();
                 self.task.persistance_state_mut().add_persisting_item();
                 self.backend
                     .persisted_storage_log(key.category())
                     .unwrap()
                     .push(
                         self.task_id,
-                        key,
+                        *key,
                         value.is_persistent().then(|| value.clone()),
                         None,
                     );

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
@@ -41,8 +41,8 @@ impl UpdateCellOperation {
         let dependent = get_many!(
             task,
             CellDependent { cell: dependent_cell, task }
-            if *dependent_cell == cell
-            => *task
+            if dependent_cell == cell
+            => task
         );
 
         drop(task);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
@@ -104,11 +104,11 @@ impl UpdateOutputOperation {
 
         let dependent_tasks = ctx
             .should_track_dependencies()
-            .then(|| get_many!(task, OutputDependent { task } => *task))
+            .then(|| get_many!(task, OutputDependent { task } => task))
             .unwrap_or_default();
         let children = ctx
             .should_track_children()
-            .then(|| get_many!(task, Child { task } => *task))
+            .then(|| get_many!(task, Child { task } => task))
             .unwrap_or_default();
 
         let mut queue = AggregationUpdateQueue::new();

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
@@ -13,10 +13,7 @@ use crate::{
         storage::{get, get_many},
         TaskDataCategory,
     },
-    data::{
-        CachedDataItem, CachedDataItemKey, CachedDataItemValue, CellRef, InProgressState,
-        OutputValue,
-    },
+    data::{CachedDataItem, CachedDataItemKey, CellRef, InProgressState, OutputValue},
 };
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -50,13 +47,10 @@ impl UpdateOutputOperation {
             return;
         }
         let old_error = task.remove(&CachedDataItemKey::Error {});
-        let current_output = task.get(&CachedDataItemKey::Output {});
+        let current_output = get!(task, Output);
         let output_value = match output {
             Ok(Ok(RawVc::TaskOutput(output_task_id))) => {
-                if let Some(CachedDataItemValue::Output {
-                    value: OutputValue::Output(current_task_id),
-                }) = current_output
-                {
+                if let Some(OutputValue::Output(current_task_id)) = current_output {
                     if *current_task_id == output_task_id {
                         return;
                     }
@@ -64,13 +58,10 @@ impl UpdateOutputOperation {
                 OutputValue::Output(output_task_id)
             }
             Ok(Ok(RawVc::TaskCell(output_task_id, cell))) => {
-                if let Some(CachedDataItemValue::Output {
-                    value:
-                        OutputValue::Cell(CellRef {
-                            task: current_task_id,
-                            cell: current_cell,
-                        }),
-                }) = current_output
+                if let Some(OutputValue::Cell(CellRef {
+                    task: current_task_id,
+                    cell: current_cell,
+                })) = current_output
                 {
                     if *current_task_id == output_task_id && *current_cell == cell {
                         return;

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -295,7 +295,7 @@ impl Storage {
         key1: TaskId,
         key2: TaskId,
     ) -> (StorageWriteGuard<'_>, StorageWriteGuard<'_>) {
-        let (a, b) = get_multiple_mut(&self.map, key1, key2, || InnerStorage::new());
+        let (a, b) = get_multiple_mut(&self.map, key1, key2, InnerStorage::new);
         (
             StorageWriteGuard { inner: a },
             StorageWriteGuard { inner: b },

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -251,7 +251,14 @@ where
     }
 
     pub fn remove(&mut self, key: &T::Key) -> Option<T::Value> {
-        self.get_map_mut(key).and_then(|m| m.remove(key))
+        self.get_map_mut(key).and_then(|m| {
+            if let Some(result) = m.remove(key) {
+                m.shrink_amortized();
+                Some(result)
+            } else {
+                None
+            }
+        })
     }
 
     pub fn get(&self, key: &T::Key) -> Option<&T::Value> {
@@ -339,6 +346,7 @@ where
                 *value = v;
             } else {
                 map.remove(key);
+                map.shrink_amortized();
             }
         } else if let Some(v) = update(None) {
             map.insert(key.clone(), v);

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -8,7 +8,7 @@ use turbo_tasks::{
     CellId, KeyValuePair, SessionId, TaskId, TraitTypeId, TypedSharedReference, ValueTypeId,
 };
 
-use crate::backend::{indexed::Indexed, TaskDataCategory};
+use crate::backend::TaskDataCategory;
 
 // this traits are needed for the transient variants of `CachedDataItem`
 // transient variants are never cloned or compared
@@ -623,100 +623,6 @@ pub mod allow_mut_access {
     pub const AggregateRoot: () = ();
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum CachedDataItemIndex {
-    Children,
-    Collectibles,
-    Follower,
-    Upper,
-    AggregatedDirtyContainer,
-    AggregatedCollectible,
-    CellData,
-    CellTypeMaxIndex,
-    CellDependent,
-    OutputDependent,
-    CollectiblesDependent,
-    Dependencies,
-    InProgressCell,
-}
-
-#[allow(non_upper_case_globals, dead_code)]
-pub mod indicies {
-    use super::CachedDataItemIndex;
-
-    pub const Child: CachedDataItemIndex = CachedDataItemIndex::Children;
-    pub const OutdatedChild: CachedDataItemIndex = CachedDataItemIndex::Children;
-    pub const Collectible: CachedDataItemIndex = CachedDataItemIndex::Collectibles;
-    pub const OutdatedCollectible: CachedDataItemIndex = CachedDataItemIndex::Collectibles;
-    pub const Follower: CachedDataItemIndex = CachedDataItemIndex::Follower;
-    pub const Upper: CachedDataItemIndex = CachedDataItemIndex::Upper;
-    pub const AggregatedDirtyContainer: CachedDataItemIndex =
-        CachedDataItemIndex::AggregatedDirtyContainer;
-    pub const AggregatedCollectible: CachedDataItemIndex =
-        CachedDataItemIndex::AggregatedCollectible;
-    pub const CellData: CachedDataItemIndex = CachedDataItemIndex::CellData;
-    pub const CellTypeMaxIndex: CachedDataItemIndex = CachedDataItemIndex::CellTypeMaxIndex;
-    pub const CellDependent: CachedDataItemIndex = CachedDataItemIndex::CellDependent;
-    pub const OutputDependent: CachedDataItemIndex = CachedDataItemIndex::OutputDependent;
-    pub const CollectiblesDependent: CachedDataItemIndex =
-        CachedDataItemIndex::CollectiblesDependent;
-    pub const OutputDependency: CachedDataItemIndex = CachedDataItemIndex::Dependencies;
-    pub const CellDependency: CachedDataItemIndex = CachedDataItemIndex::Dependencies;
-    pub const CollectibleDependency: CachedDataItemIndex = CachedDataItemIndex::Dependencies;
-    pub const OutdatedOutputDependency: CachedDataItemIndex = CachedDataItemIndex::Dependencies;
-    pub const OutdatedCellDependency: CachedDataItemIndex = CachedDataItemIndex::Dependencies;
-    pub const OutdatedCollectiblesDependency: CachedDataItemIndex =
-        CachedDataItemIndex::Dependencies;
-    pub const OutdatedCollectibleDependency: CachedDataItemIndex =
-        CachedDataItemIndex::Dependencies;
-    pub const InProgressCell: CachedDataItemIndex = CachedDataItemIndex::InProgressCell;
-}
-
-impl Indexed for CachedDataItemKey {
-    type Index = Option<CachedDataItemIndex>;
-
-    fn index(&self) -> Option<CachedDataItemIndex> {
-        match self {
-            CachedDataItemKey::Child { .. } => Some(CachedDataItemIndex::Children),
-            CachedDataItemKey::OutdatedChild { .. } => Some(CachedDataItemIndex::Children),
-            CachedDataItemKey::Collectible { .. } => Some(CachedDataItemIndex::Collectibles),
-            CachedDataItemKey::OutdatedCollectible { .. } => {
-                Some(CachedDataItemIndex::Collectibles)
-            }
-            CachedDataItemKey::Follower { .. } => Some(CachedDataItemIndex::Follower),
-            CachedDataItemKey::Upper { .. } => Some(CachedDataItemIndex::Upper),
-            CachedDataItemKey::AggregatedDirtyContainer { .. } => {
-                Some(CachedDataItemIndex::AggregatedDirtyContainer)
-            }
-            CachedDataItemKey::AggregatedCollectible { .. } => {
-                Some(CachedDataItemIndex::AggregatedCollectible)
-            }
-            CachedDataItemKey::CellData { .. } => Some(CachedDataItemIndex::CellData),
-            CachedDataItemKey::CellTypeMaxIndex { .. } => {
-                Some(CachedDataItemIndex::CellTypeMaxIndex)
-            }
-            CachedDataItemKey::CellDependent { .. } => Some(CachedDataItemIndex::CellDependent),
-            CachedDataItemKey::OutputDependent { .. } => Some(CachedDataItemIndex::OutputDependent),
-            CachedDataItemKey::OutputDependency { .. } => Some(CachedDataItemIndex::Dependencies),
-            CachedDataItemKey::CellDependency { .. } => Some(CachedDataItemIndex::Dependencies),
-            CachedDataItemKey::CollectiblesDependency { .. } => {
-                Some(CachedDataItemIndex::Dependencies)
-            }
-            CachedDataItemKey::OutdatedOutputDependency { .. } => {
-                Some(CachedDataItemIndex::Dependencies)
-            }
-            CachedDataItemKey::OutdatedCellDependency { .. } => {
-                Some(CachedDataItemIndex::Dependencies)
-            }
-            CachedDataItemKey::OutdatedCollectiblesDependency { .. } => {
-                Some(CachedDataItemIndex::Dependencies)
-            }
-            CachedDataItemKey::InProgressCell { .. } => Some(CachedDataItemIndex::InProgressCell),
-            _ => None,
-        }
-    }
-}
-
 impl CachedDataItemValue {
     pub fn is_persistent(&self) -> bool {
         match self {
@@ -750,6 +656,7 @@ mod tests {
         assert_eq!(std::mem::size_of::<super::CachedDataItem>(), 40);
         assert_eq!(std::mem::size_of::<super::CachedDataItemKey>(), 20);
         assert_eq!(std::mem::size_of::<super::CachedDataItemValue>(), 32);
+        assert_eq!(std::mem::size_of::<super::CachedDataItemStorage>(), 48);
         assert_eq!(std::mem::size_of::<super::CachedDataUpdate>(), 48);
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -742,3 +742,14 @@ pub enum CachedDataUpdate {
     /// An item was replaced. This is step 2 and tells about the new value.
     Replace2 { value: CachedDataItemValue },
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_sizes() {
+        assert_eq!(std::mem::size_of::<super::CachedDataItem>(), 40);
+        assert_eq!(std::mem::size_of::<super::CachedDataItemKey>(), 20);
+        assert_eq!(std::mem::size_of::<super::CachedDataItemValue>(), 32);
+        assert_eq!(std::mem::size_of::<super::CachedDataUpdate>(), 48);
+    }
+}

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -812,7 +812,8 @@ struct SerializeLikeCachedDataItem<'l>(&'l CachedDataItemKey, &'l CachedDataItem
 
 impl Serialize for SerializeLikeCachedDataItem<'_> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let item = CachedDataItem::from_key_and_value(self.0.clone(), self.1.clone());
+        // TODO add CachedDataItemRef to avoid cloning
+        let item = CachedDataItem::from_key_and_value(*self.0, self.1.clone());
         item.serialize(serializer)
     }
 }

--- a/turbopack/crates/turbo-tasks-macros/src/derive/key_value_pair_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/key_value_pair_macro.rs
@@ -130,15 +130,13 @@ pub fn derive_key_value_pair(input: TokenStream) -> TokenStream {
             Reserved,
         }
 
-        #[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
+        #[derive(Debug, Copy, Clone, PartialEq, Eq)]
         #vis enum #value_ref_name<'l> {
             #(
                 #variant_names {
                     #value_ref_decl
                 },
             )*
-            #[default]
-            Reserved,
         }
     }
     .into()

--- a/turbopack/crates/turbo-tasks-macros/src/derive/key_value_pair_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/key_value_pair_macro.rs
@@ -7,9 +7,13 @@ pub fn derive_key_value_pair(input: TokenStream) -> TokenStream {
 
     let ident = &input.ident;
     let vis = &input.vis;
+    let type_name = Ident::new(&format!("{}Type", input.ident), input.ident.span());
     let key_name = Ident::new(&format!("{}Key", input.ident), input.ident.span());
     let value_name = Ident::new(&format!("{}Value", input.ident), input.ident.span());
     let value_ref_name = Ident::new(&format!("{}ValueRef", input.ident), input.ident.span());
+    let value_ref_mut_name = Ident::new(&format!("{}ValueRefMut", input.ident), input.ident.span());
+    let iter_name = Ident::new(&format!("{}Iter", input.ident), input.ident.span());
+    let storage_name = Ident::new(&format!("{}Storage", input.ident), input.ident.span());
 
     let variant_names = input
         .variants
@@ -60,13 +64,273 @@ pub fn derive_key_value_pair(input: TokenStream) -> TokenStream {
     let value_clone_fields = clone_fields(&value_fields);
 
     let value_ref_decl = ref_field_declarations(&value_fields);
+    let value_ref_mut_decl = mut_ref_field_declarations(&value_fields);
     let value_ref_fields = ref_fields(&value_fields);
+
+    let storage = key_fields
+        .iter()
+        .zip(value_fields.iter()).zip(variant_names.iter())
+        .map(|((key_fields, value_fields), variant_name)| {
+            let value_types = value_fields
+                .iter()
+                .map(|field| {
+                    let ty = &field.ty;
+                    quote! {
+                        #ty
+                    }
+                })
+                .collect::<Vec<_>>();
+            let key_types = key_fields
+                .iter()
+                .map(|field| {
+                    let ty = &field.ty;
+                    quote! {
+                        #ty
+                    }
+                })
+                .collect::<Vec<_>>();
+            let value_fields = value_fields
+                .iter()
+                .map(|field| {
+                    let ident = field.ident.as_ref().unwrap();
+                    quote! {
+                        #ident
+                    }
+                })
+                .collect::<Vec<_>>();
+            let key_fields = key_fields
+                .iter()
+                .map(|field| {
+                    let ident = field.ident.as_ref().unwrap();
+                    quote! {
+                        #ident
+                    }
+                })
+                .collect::<Vec<_>>();
+            match (key_types.len(), value_types.len()) {
+                (0, 1) => {
+                    StorageDecl {
+                        decl: quote! {
+                            storage: Option<#(#value_types)*>,
+                        },
+                        add: quote! {
+                            (#storage_name::#variant_name { storage }, #ident::#variant_name { #(#value_fields)* }) => {
+                                if storage.is_none() {
+                                    *storage = Some(#(#value_fields)*);
+                                    true
+                                } else {
+                                    false
+                                }
+                            }
+                        },
+                        insert: quote! {
+                            (#storage_name::#variant_name { storage }, #ident::#variant_name { #(#value_fields)* }) => {
+                                std::mem::replace(storage, Some(#(#value_fields)*))
+                                    .map(|#(#value_fields)*| #value_name::#variant_name { #(#value_fields)* })
+                            }
+                        },
+                        remove: quote! {
+                            (#storage_name::#variant_name { storage }, #key_name::#variant_name {}) => {
+                                storage.take()
+                                    .map(|#(#value_fields)*| #value_name::#variant_name { #(#value_fields)* })
+                            }
+                        },
+                        contains_key: quote! {
+                            (#storage_name::#variant_name { storage }, #key_name::#variant_name {}) => {
+                                storage.is_some()
+                            }
+                        },
+                        get: quote! {
+                            (#storage_name::#variant_name { storage }, #key_name::#variant_name {}) => {
+                                storage.as_ref()
+                                    .map(|#(#value_fields)*| #value_ref_name::#variant_name { #(#value_fields)* })
+                            }
+                        },
+                        get_mut: quote! {
+                            (#storage_name::#variant_name { storage }, #key_name::#variant_name {}) => {
+                                storage.as_mut()
+                                    .map(|#(#value_fields)*| #value_ref_mut_name::#variant_name { #(#value_fields)* })
+                            }
+                        },
+                        iter: quote! {
+                            #storage_name::#variant_name { storage } => {
+                                #iter_name::#variant_name(storage.iter())
+                            }
+                        },
+                        iterator: quote! {
+                            std::option::Iter<'l, #(#value_types)*>
+                        },
+                        iterator_next: quote! {
+                            iter.next().map(|#(#value_fields)*| (#key_name::#variant_name {}, #value_ref_name::#variant_name { #(#value_fields)* }))
+                        },
+                    }
+                }
+                (1, 1) => {
+                    StorageDecl {
+                        decl: quote! {
+                            storage: auto_hash_map::AutoMap<#(#key_types)*, #(#value_types)*, std::hash::BuildHasherDefault<rustc_hash::FxHasher>, 1>,
+                        },
+                        add: quote! {
+                            (#storage_name::#variant_name { storage }, #ident::#variant_name { #(#key_fields)*, #(#value_fields)* }) => {
+                                match storage.entry(#(#key_fields)*) {
+                                    auto_hash_map::map::Entry::Occupied(_) => false,
+                                    auto_hash_map::map::Entry::Vacant(e) => {
+                                        e.insert(#(#value_fields)*);
+                                        true
+                                    }
+                                }
+                            }
+                        },
+                        insert: quote! {
+                            (#storage_name::#variant_name { storage }, #ident::#variant_name { #(#key_fields)*, #(#value_fields)* }) => {
+                                storage.insert(#(#key_fields)*, #(#value_fields)*)
+                                    .map(|#(#value_fields)*| #value_name::#variant_name { #(#value_fields)* })
+                            }
+                        },
+                        remove: quote! {
+                            (#storage_name::#variant_name { storage }, #key_name::#variant_name { #(#key_fields)* }) => {
+                                let result = storage.remove(#(#key_fields)*)
+                                    .map(|#(#value_fields)*| #value_name::#variant_name { #(#value_fields)* });
+                                if result.is_some() {
+                                    storage.shrink_amortized();
+                                }
+                                result
+                            }
+                        },
+                        contains_key: quote! {
+                            (#storage_name::#variant_name { storage }, #key_name::#variant_name { #(#key_fields)* }) => {
+                                storage.contains_key(#(#key_fields)*)
+                            }
+                        },
+                        get: quote! {
+                            (#storage_name::#variant_name { storage }, #key_name::#variant_name { #(#key_fields)* }) => {
+                                storage.get(#(#key_fields)*)
+                                    .map(|#(#value_fields)*| #value_ref_name::#variant_name { #(#value_fields)* })
+                            }
+                        },
+                        get_mut: quote! {
+                            (#storage_name::#variant_name { storage }, #key_name::#variant_name { #(#key_fields)* }) => {
+                                storage.get_mut(#(#key_fields)*)
+                                    .map(|#(#value_fields)*| #value_ref_mut_name::#variant_name { #(#value_fields)* })
+                            }
+                        },
+                        iter: quote! {
+                            #storage_name::#variant_name { storage } => {
+                                #iter_name::#variant_name(storage.iter())
+                            }
+                        },
+                        iterator: quote! {
+                            auto_hash_map::map::Iter<'l, #(#key_types)*, #(#value_types)*>
+                        },
+                        iterator_next: quote! {
+                            iter.next()
+                            .map(|(#(#key_fields)*, #(#value_fields)*)| (#key_name::#variant_name { #(#key_fields: *#key_fields)* }, #value_ref_name::#variant_name { #(#value_fields)* }))
+                        },
+                    }
+                }
+                (_, 1) => {
+                    StorageDecl {
+                        decl: quote! {
+                            storage: auto_hash_map::AutoMap<(#(#key_types),*), #(#value_types)*, std::hash::BuildHasherDefault<rustc_hash::FxHasher>, 1>,
+                        },
+                        add: quote! {
+                            (#storage_name::#variant_name { storage }, #ident::#variant_name { #(#key_fields),*, #(#value_fields)* }) => {
+                                match storage.entry((#(#key_fields),*)) {
+                                    auto_hash_map::map::Entry::Occupied(_) => false,
+                                    auto_hash_map::map::Entry::Vacant(e) => {
+                                        e.insert(#(#value_fields)*);
+                                        true
+                                    }
+                                }
+                            }
+                        },
+                        insert: quote! {
+                            (#storage_name::#variant_name { storage }, #ident::#variant_name { #(#key_fields),*, #(#value_fields)* }) => {
+                                storage.insert((#(#key_fields),*), #(#value_fields)*)
+                                    .map(|#(#value_fields)*| #value_name::#variant_name { #(#value_fields)* })
+                            }
+                        },
+                        remove: quote! {
+                            (#storage_name::#variant_name { storage }, &#key_name::#variant_name { #(#key_fields),* }) => {
+                                let result = storage.remove(&(#(#key_fields),*))
+                                    .map(|#(#value_fields)*| #value_name::#variant_name { #(#value_fields)* });
+                                if result.is_some() {
+                                    storage.shrink_amortized();
+                                }
+                                result
+                            }
+                        },
+                        contains_key: quote! {
+                            (#storage_name::#variant_name { storage }, &#key_name::#variant_name { #(#key_fields),* }) => {
+                                storage.contains_key(&(#(#key_fields),*))
+                            }
+                        },
+                        get: quote! {
+                            (#storage_name::#variant_name { storage }, &#key_name::#variant_name { #(#key_fields),* }) => {
+                                storage.get(&(#(#key_fields),*))
+                                    .map(|#(#value_fields)*| #value_ref_name::#variant_name { #(#value_fields)* })
+                            }
+                        },
+                        get_mut: quote! {
+                            (#storage_name::#variant_name { storage }, &#key_name::#variant_name { #(#key_fields),* }) => {
+                                storage.get_mut(&(#(#key_fields),*))
+                                    .map(|#(#value_fields)*| #value_ref_mut_name::#variant_name { #(#value_fields)* })
+                            }
+                        },
+                        iter: quote! {
+                            #storage_name::#variant_name { storage } => {
+                                #iter_name::#variant_name(storage.iter())
+                            }
+                        },
+                        iterator: quote! {
+                            auto_hash_map::map::Iter<'l, (#(#key_types),*), #(#value_types)*>
+                        },
+                        iterator_next: quote! {
+                            iter.next()
+                                .map(|((#(#key_fields),*), #(#value_fields)*)| (#key_name::#variant_name { #(#key_fields: *#key_fields),* }, #value_ref_name::#variant_name { #(#value_fields)* }))
+                        },
+                    }
+                }
+                _ => unreachable!()
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let storage_decl = storage.iter().map(|decl| &decl.decl).collect::<Vec<_>>();
+    let storage_add = storage.iter().map(|decl| &decl.add).collect::<Vec<_>>();
+    let storage_insert = storage.iter().map(|decl| &decl.insert).collect::<Vec<_>>();
+    let storage_remove = storage.iter().map(|decl| &decl.remove).collect::<Vec<_>>();
+    let storage_contains_key = storage
+        .iter()
+        .map(|decl| &decl.contains_key)
+        .collect::<Vec<_>>();
+    let storage_get = storage.iter().map(|decl| &decl.get).collect::<Vec<_>>();
+    let storage_get_mut = storage.iter().map(|decl| &decl.get_mut).collect::<Vec<_>>();
+    let storage_iter = storage.iter().map(|decl| &decl.iter).collect::<Vec<_>>();
+    let storage_iterator = storage
+        .iter()
+        .map(|decl| &decl.iterator)
+        .collect::<Vec<_>>();
+    let storage_iterator_next = storage
+        .iter()
+        .map(|decl| &decl.iterator_next)
+        .collect::<Vec<_>>();
 
     quote! {
         impl turbo_tasks::KeyValuePair for #ident {
+            type Type = #type_name;
             type Key = #key_name;
             type Value = #value_name;
             type ValueRef<'l> = #value_ref_name<'l> where Self: 'l;
+            type ValueRefMut<'l> = #value_ref_mut_name<'l> where Self: 'l;
+
+            fn ty(&self) -> #type_name {
+                match self {
+                    #(
+                        #ident::#variant_names { .. } => #type_name::#variant_names,
+                    )*
+                }
+            }
 
             fn key(&self) -> #key_name {
                 match self {
@@ -92,6 +356,14 @@ pub fn derive_key_value_pair(input: TokenStream) -> TokenStream {
                 }
             }
 
+            fn value_mut(&mut self) -> #value_ref_mut_name<'_> {
+                match self {
+                    #(
+                        #ident::#variant_names { #value_pat .. } => #value_ref_mut_name::#variant_names { #value_ref_fields },
+                    )*
+                }
+            }
+
             fn from_key_and_value(key: #key_name, value: #value_name) -> Self {
                 match (key, value) {
                     #(
@@ -110,7 +382,14 @@ pub fn derive_key_value_pair(input: TokenStream) -> TokenStream {
             }
         }
 
-        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+        #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+        #vis enum #type_name {
+            #(
+                #variant_names,
+            )*
+        }
+
+        #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         #vis enum #key_name {
             #(
                 #variant_names {
@@ -137,6 +416,153 @@ pub fn derive_key_value_pair(input: TokenStream) -> TokenStream {
                     #value_ref_decl
                 },
             )*
+        }
+
+        #[derive(Debug, PartialEq, Eq)]
+        #vis enum #value_ref_mut_name<'l> {
+            #(
+                #variant_names {
+                    #value_ref_mut_decl
+                },
+            )*
+        }
+
+        impl #key_name {
+            pub fn ty(&self) -> #type_name {
+                match self {
+                    #(
+                        #key_name::#variant_names { .. } => #type_name::#variant_names,
+                    )*
+                }
+            }
+        }
+
+        impl #value_name {
+            pub fn as_ref(&self) -> #value_ref_name<'_> {
+                match self {
+                    #(
+                        #value_name::#variant_names { #value_pat .. } => #value_ref_name::#variant_names { #value_ref_fields },
+                    )*
+                    #value_name::Reserved => unreachable!(),
+                }
+            }
+
+            pub fn as_mut(&mut self) -> #value_ref_mut_name<'_> {
+                match self {
+                    #(
+                        #value_name::#variant_names { #value_pat .. } => #value_ref_mut_name::#variant_names { #value_ref_fields },
+                    )*
+                    #value_name::Reserved => unreachable!(),
+                }
+            }
+        }
+
+        #vis enum #storage_name {
+            #(
+                #variant_names {
+                    #storage_decl
+                },
+            )*
+        }
+
+        impl #storage_name {
+            pub fn new(ty: #type_name) -> Self {
+                match ty {
+                    #(
+                        #type_name::#variant_names => #storage_name::#variant_names { storage: Default::default() },
+                    )*
+                }
+            }
+
+            pub fn ty(&self) -> #type_name {
+                match self {
+                    #(
+                        #storage_name::#variant_names { .. } => #type_name::#variant_names,
+                    )*
+                }
+            }
+
+            pub fn add(&mut self, item: #ident) -> bool {
+                match (self, item) {
+                    #(
+                        #storage_add
+                    )*
+                    _ => unreachable!(),
+                }
+            }
+
+            pub fn insert(&mut self, item: #ident) -> Option<#value_name> {
+                match (self, item) {
+                    #(
+                        #storage_insert
+                    )*
+                    _ => unreachable!(),
+                }
+            }
+
+            pub fn remove(&mut self, key: &#key_name) -> Option<#value_name> {
+                match (self, key) {
+                    #(
+                        #storage_remove
+                    )*
+                    _ => unreachable!(),
+                }
+            }
+
+            pub fn contains_key(&self, key: &#key_name) -> bool {
+                match (self, key) {
+                    #(
+                        #storage_contains_key
+                    )*
+                    _ => unreachable!(),
+                }
+            }
+
+            pub fn get(&self, key: &#key_name) -> Option<#value_ref_name> {
+                match (self, key) {
+                    #(
+                        #storage_get
+                    )*
+                    _ => unreachable!(),
+                }
+            }
+
+            pub fn get_mut(&mut self, key: &#key_name) -> Option<#value_ref_mut_name> {
+                match (self, key) {
+                    #(
+                        #storage_get_mut
+                    )*
+                    _ => unreachable!(),
+                }
+            }
+
+            pub fn iter(&self) -> #iter_name {
+                match self {
+                    #(
+                        #storage_iter
+                    )*
+                }
+            }
+        }
+
+        #vis enum #iter_name<'l> {
+            #(
+                #variant_names(#storage_iterator),
+            )*
+        }
+
+        impl<'l> Iterator for #iter_name<'l> {
+            type Item = (#key_name, #value_ref_name<'l>);
+
+            fn next(&mut self) -> Option<Self::Item> {
+                match self {
+                    #(
+                        #iter_name::#variant_names(iter) => {
+                            #storage_iterator_next
+                        }
+                    )*
+                }
+            }
         }
     }
     .into()
@@ -249,4 +675,41 @@ fn ref_field_declarations(fields: &[Vec<&syn::Field>]) -> Vec<proc_macro2::Token
             }
         })
         .collect::<Vec<_>>()
+}
+
+fn mut_ref_field_declarations(fields: &[Vec<&syn::Field>]) -> Vec<proc_macro2::TokenStream> {
+    fields
+        .iter()
+        .map(|fields| {
+            let fields = fields
+                .iter()
+                .map(|field| {
+                    let ty = &field.ty;
+                    let ident = field.ident.as_ref().unwrap();
+                    let attrs = &field.attrs;
+                    quote! {
+                        #(#attrs)*
+                        #ident: &'l mut #ty
+                    }
+                })
+                .collect::<Vec<_>>();
+            quote! {
+                #(#fields),*
+            }
+        })
+        .collect::<Vec<_>>()
+}
+
+struct StorageDecl {
+    decl: proc_macro2::TokenStream,
+    add: proc_macro2::TokenStream,
+    insert: proc_macro2::TokenStream,
+    remove: proc_macro2::TokenStream,
+    contains_key: proc_macro2::TokenStream,
+    get: proc_macro2::TokenStream,
+    get_mut: proc_macro2::TokenStream,
+    iter: proc_macro2::TokenStream,
+
+    iterator: proc_macro2::TokenStream,
+    iterator_next: proc_macro2::TokenStream,
 }

--- a/turbopack/crates/turbo-tasks/src/key_value_pair.rs
+++ b/turbopack/crates/turbo-tasks/src/key_value_pair.rs
@@ -1,14 +1,20 @@
 use std::fmt::Debug;
 
 pub trait KeyValuePair {
+    type Type: Debug + Copy + Clone + PartialEq + Eq + std::hash::Hash;
     type Key: Debug + Clone + PartialEq + Eq + std::hash::Hash;
     type Value: Debug + Clone + Default + PartialEq + Eq;
     type ValueRef<'l>: Debug + Copy + Clone + PartialEq + Eq + 'l
     where
         Self: 'l;
+    type ValueRefMut<'l>: Debug + PartialEq + Eq + 'l
+    where
+        Self: 'l;
+    fn ty(&self) -> Self::Type;
     fn key(&self) -> Self::Key;
     fn value(&self) -> Self::Value;
     fn value_ref(&self) -> Self::ValueRef<'_>;
+    fn value_mut(&mut self) -> Self::ValueRefMut<'_>;
     fn from_key_and_value(key: Self::Key, value: Self::Value) -> Self;
     fn into_key_and_value(self) -> (Self::Key, Self::Value);
 }

--- a/turbopack/crates/turbo-tasks/src/key_value_pair.rs
+++ b/turbopack/crates/turbo-tasks/src/key_value_pair.rs
@@ -3,8 +3,12 @@ use std::fmt::Debug;
 pub trait KeyValuePair {
     type Key: Debug + Clone + PartialEq + Eq + std::hash::Hash;
     type Value: Debug + Clone + Default + PartialEq + Eq;
+    type ValueRef<'l>: Debug + Copy + Clone + PartialEq + Eq + 'l
+    where
+        Self: 'l;
     fn key(&self) -> Self::Key;
     fn value(&self) -> Self::Value;
+    fn value_ref(&self) -> Self::ValueRef<'_>;
     fn from_key_and_value(key: Self::Key, value: Self::Value) -> Self;
     fn into_key_and_value(self) -> (Self::Key, Self::Value);
 }


### PR DESCRIPTION
### What?

Improves memory usage by changing the way data is stored in the new backend. Instead of keeping a map `enum CachedDataItemKey` -> `enum CachedDataItemValue`, it uses a Vec `enum CachedDataItemStorage` which keeps a single storage for every `enum CachedDataItemType`. The storage is strongly types and e. g. stores a map `TaskId` -> `()`, which makes it more memory efficient while still not wasting memory for unused types.

It also calls `shrink_to_fit` after task completion and `shrink_amortized` after removing items, to reduce the unnecessary capacity.


Closes PACK-3703