### PR TITLE
Fix small bug in getting started docs

### DIFF
--- a/docs/01-app/01-getting-started/06-data-fetching-and-streaming.mdx
+++ b/docs/01-app/01-getting-started/06-data-fetching-and-streaming.mdx
@@ -141,11 +141,11 @@ export default function Posts({
 }: {
   posts: Promise<{ id: string; title: string }[]>
 }) {
-  const posts = use(posts)
+  const allPosts = use(posts)
 
   return (
     <ul>
-      {posts.map((post) => (
+      {allPosts.map((post) => (
         <li key={post.id}>{post.title}</li>
       ))}
     </ul>


### PR DESCRIPTION
This will fix a small bug in one of the examples in the Getting Started docs. The examples declares a variable that's already declared in the props which would result in an error when running this.