### PR TITLE
Ensure metadata doesn't break scroll-to-top on navigation

### DIFF
--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -215,6 +215,14 @@ class InnerScrollAndFocusHandler extends React.Component<ScrollAndFocusHandlerPr
       // Verify if the element is a HTMLElement and if we want to consider it for scroll behavior.
       // If the element is skipped, try to select the next sibling and try again.
       while (!(domNode instanceof HTMLElement) || shouldSkipElement(domNode)) {
+        if (process.env.NODE_ENV !== 'production') {
+          if (domNode.parentElement?.localName === 'head') {
+            console.error(
+              'Tried to scroll to a head element. This is a bug in Next.js.'
+            )
+          }
+        }
+
         // No siblings found that match the criteria are found, so handle scroll higher up in the tree instead.
         if (domNode.nextElementSibling === null) {
           return

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -399,25 +399,25 @@ async function createComponentTreeInternal({
 
   const notFoundElement = NotFound ? (
     <>
+      <NotFound />
       {metadata}
       {notFoundStyles}
-      <NotFound />
     </>
   ) : undefined
 
   const forbiddenElement = Forbidden ? (
     <>
+      <Forbidden />
       {metadata}
       {forbiddenStyles}
-      <Forbidden />
     </>
   ) : undefined
 
   const unauthorizedElement = Unauthorized ? (
     <>
+      <Unauthorized />
       {metadata}
       {unauthorizedStyles}
-      <Unauthorized />
     </>
   ) : undefined
 
@@ -669,8 +669,13 @@ async function createComponentTreeInternal({
     return [
       actualSegment,
       <React.Fragment key={cacheNodeKey}>
-        {metadata}
         {pageElement}
+        {/*
+         * The order here matters since a parent might call findDOMNode().
+         * findDOMNode() will return the first child if multiple children are rendered.
+         * But React will hoist metadata into <head> which breaks scroll handling.
+         */}
+        {metadata}
         {layerAssets}
         <OutletBoundary>
           <MetadataOutlet ready={getViewportReady} />
@@ -805,12 +810,12 @@ async function createComponentTreeInternal({
             notFound={
               NotFound ? (
                 <>
-                  {metadata}
                   {layerAssets}
                   <SegmentComponent params={params}>
                     {notFoundStyles}
                     <NotFound />
                   </SegmentComponent>
+                  {metadata}
                 </>
               ) : undefined
             }

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -374,7 +374,9 @@ describe('Error overlay for hydration errors in App router', () => {
     const { session, browser } = sandbox
     await session.openRedbox()
 
-    expect(await getRedboxTotalErrorCount(browser)).toBe(2)
+    await retry(async () => {
+      expect(await getRedboxTotalErrorCount(browser)).toBe(2)
+    })
 
     // FIXME: Should also have "text nodes cannot be a child of tr"
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
@@ -439,7 +441,6 @@ describe('Error overlay for hydration errors in App router', () => {
                        <RedirectBoundary>
                          <RedirectErrorBoundary router={{...}}>
                            <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
-                             <__next_metadata_boundary__>
                              <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
                                <Page params={Promise} searchParams={Promise}>
      >                           <table>
@@ -567,7 +568,9 @@ describe('Error overlay for hydration errors in App router', () => {
     const { session, browser } = sandbox
     await session.openRedbox()
 
-    expect(await getRedboxTotalErrorCount(browser)).toBe(2)
+    await retry(async () => {
+      expect(await getRedboxTotalErrorCount(browser)).toBe(2)
+    })
 
     const description = await session.getRedboxDescription()
     expect(description).toContain(
@@ -665,7 +668,9 @@ describe('Error overlay for hydration errors in App router', () => {
     const { session, browser } = sandbox
     await session.openRedbox()
 
-    expect(await getRedboxTotalErrorCount(browser)).toBe(2)
+    await retry(async () => {
+      expect(await getRedboxTotalErrorCount(browser)).toBe(2)
+    })
 
     const description = await session.getRedboxDescription()
     expect(description).toEqual(outdent`
@@ -718,7 +723,9 @@ describe('Error overlay for hydration errors in App router', () => {
     const { session, browser } = sandbox
     await session.openRedbox()
 
-    expect(await getRedboxTotalErrorCount(browser)).toBe(2)
+    await retry(async () => {
+      expect(await getRedboxTotalErrorCount(browser)).toBe(2)
+    })
 
     const description = await session.getRedboxDescription()
     expect(description).toContain(
@@ -895,19 +902,18 @@ describe('Error overlay for hydration errors in App router', () => {
            <RedirectBoundary>
              <RedirectErrorBoundary router={{...}}>
                <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
-                 <__next_metadata_boundary__>
-                   <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
-                     <Page params={Promise} searchParams={Promise}>
+                 <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                   <Page params={Promise} searchParams={Promise}>
+                     <div>
                        <div>
                          <div>
                            <div>
-                             <div>
-                               <Mismatch>
-                                 <p>
-                                   <span>
-                                     ...
-       +                              client
-       -                              server"
+                             <Mismatch>
+                               <p>
+                                 <span>
+                                   ...
+       +                            client
+       -                            server"
       `)
     } else {
       expect(fullPseudoHtml).toMatchInlineSnapshot(`
@@ -916,19 +922,18 @@ describe('Error overlay for hydration errors in App router', () => {
            <RedirectBoundary>
              <RedirectErrorBoundary router={{...}}>
                <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
-                 <__next_metadata_boundary__>
-                   <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
-                     <Page params={Promise} searchParams={Promise}>
+                 <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                   <Page params={Promise} searchParams={Promise}>
+                     <div>
                        <div>
                          <div>
                            <div>
-                             <div>
-                               <Mismatch>
-                                 <p>
-                                   <span>
-                                     ...
-       +                              client
-       -                              server"
+                             <Mismatch>
+                               <p>
+                                 <span>
+                                   ...
+       +                            client
+       -                            server"
       `)
     }
   })

--- a/test/e2e/app-dir/router-autoscroll/app/new-metadata/page.tsx
+++ b/test/e2e/app-dir/router-autoscroll/app/new-metadata/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  keywords: ['new-metadata'],
+}
+export default function Page() {
+  return (
+    <>
+      {
+        // Repeat 500 elements
+        Array.from({ length: 500 }, (_, i) => (
+          <div key={i}>{i}</div>
+        ))
+      }
+    </>
+  )
+}

--- a/test/e2e/app-dir/router-autoscroll/app/page.tsx
+++ b/test/e2e/app-dir/router-autoscroll/app/page.tsx
@@ -31,6 +31,10 @@ export default function Page() {
           To sticky first element
         </Link>
       </div>
+
+      <div>
+        <Link href="/new-metadata">To new metadata</Link>
+      </div>
     </>
   )
 }

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1553,8 +1553,9 @@ export async function assertNoConsoleErrors(browser: BrowserInterface) {
       log.source === 'warning' ||
       (log.source === 'error' &&
         // These are expected when we visit 404 pages.
-        log.message !==
-          'Failed to load resource: the server responded with a status of 404 (Not Found)')
+        !log.message.startsWith(
+          'Failed to load resource: the server responded with a status of 404'
+        ))
     )
   })
 


### PR DESCRIPTION
`findDOMNode()` returns the DOM element of the first child. However, this is not what we want  in `InnerScrollAndFocusHandler` if metadata is the first child since React will have hoisted those into `<head>` by the time e.g. `componentDidMount` runs (or any other after mutation phase handlers). The fix is to ensure the relevant element comes before metadata in the tree. This shouldn't break rendering prio since these nodes are still siblings and we have sibling pre-warming now.

The alternative would be to move the handling of `InnerScrollAndFocusHandler` handler into `create-component-tree` to ensure it's wrapped around the designated element. But that might result in missing to add `InnerScrollAndFocusHandler` which you probably don't think about when working on `create-component-tree`.

Added a dev-only warning to `ScrollAndFocus` if `findDOMNode(this)` returns an element that renders in `<head>`. Might be better to throw in our tests. Usually not a good idea to have different flow between test and prod but better chances it is flushed out in tests. There were many more tests that hit this warning without failing the test: https://github.com/vercel/next.js/pull/74751

Closes https://linear.app/vercel/issue/NDX-651