### PR TITLE
[not for merge] Flush out tests where scroll-to-top broke due to metadata hoisting

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -621,5 +621,6 @@
   "620": "A required parameter (%s) was not provided as %s received %s in getStaticPaths for %s",
   "621": "Required root params (%s) were not provided in generateStaticParams for %s, please provide at least one value for each.",
   "622": "A required root parameter (%s) was not provided in generateStaticParams for %s, please provide at least one value.",
-  "623": "Invalid quality prop (%s) on \\`next/image\\` does not match \\`images.qualities\\` configured in your \\`next.config.js\\`\\nSee more info: https://nextjs.org/docs/messages/next-image-unconfigured-qualities"
+  "623": "Invalid quality prop (%s) on \\`next/image\\` does not match \\`images.qualities\\` configured in your \\`next.config.js\\`\\nSee more info: https://nextjs.org/docs/messages/next-image-unconfigured-qualities",
+  "624": "Tried to scroll to a head element. This is a bug in Next.js"
 }

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -215,6 +215,11 @@ class InnerScrollAndFocusHandler extends React.Component<ScrollAndFocusHandlerPr
       // Verify if the element is a HTMLElement and if we want to consider it for scroll behavior.
       // If the element is skipped, try to select the next sibling and try again.
       while (!(domNode instanceof HTMLElement) || shouldSkipElement(domNode)) {
+        if (domNode.parentElement?.localName === 'head') {
+          throw new Error(
+            'Tried to scroll to a head element. This is a bug in Next.js'
+          )
+        }
         // No siblings found that match the criteria are found, so handle scroll higher up in the tree instead.
         if (domNode.nextElementSibling === null) {
           return


### PR DESCRIPTION
Flushing out what https://github.com/vercel/next.js/pull/74748 fixed.

Will land in https://github.com/vercel/next.js/pull/74748 as a warning.