### PR TITLE
fix: always show indicator in app router

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/app/ReactDevOverlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/app/ReactDevOverlay.tsx
@@ -40,7 +40,6 @@ export default class ReactDevOverlay extends React.PureComponent<
     const { isReactError } = this.state
 
     const hasBuildError = state.buildError != null
-    const hasRuntimeErrors = Boolean(state.errors.length)
     const hasStaticIndicator = state.staticIndicator
     const debugInfo = state.debugInfo
 
@@ -69,21 +68,15 @@ export default class ReactDevOverlay extends React.PureComponent<
               versionInfo={state.versionInfo}
             />
           ) : (
-            <>
-              {hasRuntimeErrors ? (
-                <Errors
-                  isTurbopackEnabled={!!process.env.TURBOPACK}
-                  isAppDir={true}
-                  initialDisplayState={
-                    isReactError ? 'fullscreen' : 'minimized'
-                  }
-                  errors={state.errors}
-                  versionInfo={state.versionInfo}
-                  hasStaticIndicator={hasStaticIndicator}
-                  debugInfo={debugInfo}
-                />
-              ) : null}
-            </>
+            <Errors
+              isTurbopackEnabled={!!process.env.TURBOPACK}
+              isAppDir={true}
+              initialDisplayState={isReactError ? 'fullscreen' : 'minimized'}
+              errors={state.errors}
+              versionInfo={state.versionInfo}
+              hasStaticIndicator={hasStaticIndicator}
+              debugInfo={debugInfo}
+            />
           )}
         </ShadowPortal>
       </>


### PR DESCRIPTION
When there are no errors, we show `Errors` component with `minimized` status, which means that it should only render the indicator on the bottom left corner of the screen. E2E tests for the new DevOverlay will be added later.