### PR TITLE
misc: add `.cursorignore`

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,23 @@
+# Add directories or file patterns to ignore during indexing (e.g. foo/ or *.csv)
+.config/
+.github/
+.husky/
+.vscode/
+bench/
+crates/**/tests/
+docs/
+errors/
+examples/
+packages/create-next-app/templates/
+packages/next/src/compiled/
+packages/next-codemod/bin/__testfixtures__/
+packages/next-codemod/transforms/__testfixtures__/
+packages/next-codemod/transforms/__tests__/
+scripts/
+test/
+turbopack/**/tests/
+
+**/*.test.*
+**/*.md
+**/*.toml
+**/*.txt

--- a/.cursorignore
+++ b/.cursorignore
@@ -15,9 +15,13 @@ packages/next-codemod/transforms/__testfixtures__/
 packages/next-codemod/transforms/__tests__/
 scripts/
 test/
+turbo/
 turbopack/**/tests/
 
 **/*.test.*
 **/*.md
 **/*.toml
 **/*.txt
+**/*.yaml
+**/*.yml
+.*


### PR DESCRIPTION
This PR added a `.cursorignore` file to ignore **27,500 files** for Cursor to index.

```.gitignore
# The reverse pattern did not work.
*
!packages/**
```

### Before

![CleanShot 2025-01-11 at 03 47 56](https://github.com/user-attachments/assets/21ebf15b-301f-4238-b500-1e21529130cf)

### After

![CleanShot 2025-01-11 at 03 58 50](https://github.com/user-attachments/assets/f3842039-c6e5-43e0-924b-ac1c24ebd281)
