### PR TITLE
chore(github): ignore PRs in for stale issue bot

### DIFF
--- a/.github/workflows/issue_stale.yml
+++ b/.github/workflows/issue_stale.yml
@@ -18,6 +18,8 @@ jobs:
           ascending: true
           days-before-issue-stale: 730 # issues with no activity in over two years
           days-before-issue-close: 7
+          days-before-pr-close: -1
+          days-before-pr-stale: -1
           remove-issue-stale-when-updated: true
           stale-issue-label: 'stale'
           stale-issue-message: 'This issue has been automatically marked as stale due to two years of inactivity. It will be closed in 7 days unless there’s further input. If you believe this issue is still relevant, please leave a comment or provide updated details. Thank you.'


### PR DESCRIPTION
## Why?

We have to explicitly give a `-1` for `days-before-pr-close` and `days-before-pr-stale` in order to ignore sifting through PRs.

- https://github.com/vercel/next.js/actions/runs/12716117689/job/35449724177#step:2:376