### PR TITLE
[Turbopack] connect children in a batch when task is about to finish

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1277,10 +1277,13 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         drop(task);
 
-        // Remove outdated edges first, before removing in_progress+dirty flag.
-        // We need to make sure all outdated edges are removed before the task can potentially be
-        // scheduled and executed again
-        CleanupOldEdgesOperation::run(task_id, old_edges, queue, &mut ctx);
+        {
+            let _span = tracing::trace_span!("CleanupOldEdgesOperation").entered();
+            // Remove outdated edges first, before removing in_progress+dirty flag.
+            // We need to make sure all outdated edges are removed before the task can potentially
+            // be scheduled and executed again
+            CleanupOldEdgesOperation::run(task_id, old_edges, queue, &mut ctx);
+        }
 
         // When restoring from persistent caching the following might not be executed (since we can
         // suspend in `CleanupOldEdgesOperation`), but that's ok as the task is still dirty and

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1162,6 +1162,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             task.add_new(CachedDataItem::InProgress {
                 value: InProgressState::Scheduled { done_event },
             });
+            drop(task);
 
             // All `new_children` are currently hold active with an active count and we need to undo
             // that.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1134,6 +1134,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         stateful: bool,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) -> bool {
+        let _span = tracing::trace_span!("task execution completed").entered();
         let mut ctx = self.execute_context(turbo_tasks);
         let mut task = ctx.task(task_id, TaskDataCategory::All);
         let Some(in_progress) = get_mut!(task, InProgress) else {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1214,9 +1214,15 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 }
             }
 
-            let active_count =
-                get!(task, Activeness).map_or(0, |activeness| activeness.active_counter);
-            connect_children(task_id, &mut task, new_children, &mut queue, active_count);
+            let has_active_count =
+                get!(task, Activeness).map_or(false, |activeness| activeness.active_counter > 0);
+            connect_children(
+                task_id,
+                &mut task,
+                new_children,
+                &mut queue,
+                has_active_count,
+            );
         }
 
         // Remove no longer existing cells and notify in progress cells

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -425,9 +425,6 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         }
 
         if self.should_track_children() && matches!(consistency, ReadConsistency::Strong) {
-            if let Some(value) = check_in_progress(self, &task, reader) {
-                return value;
-            }
             // Ensure it's an root node
             loop {
                 let aggregation_number = get_aggregation_number(&task);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -1177,17 +1177,18 @@ impl AggregationUpdateQueue {
                 ctx.schedule(task_id);
             }
         }
-        if is_aggregating_node(get_aggregation_number(&task)) {
+        let aggregation_number = get_aggregation_number(&task);
+        if is_aggregating_node(aggregation_number) {
             // if it has `Activeness` we can skip visiting the nested nodes since
             // this would already be scheduled by the `Activeness`
-            if !task.has_key(&CachedDataItemKey::Activeness {}) {
+            let is_active_until_clean =
+                get!(task, Activeness).is_some_and(|a| a.active_until_clean);
+            if !is_active_until_clean {
                 let dirty_containers: Vec<_> = get_many!(task, AggregatedDirtyContainer { task } count if count.get(session_id) > 0 => task);
                 if !dirty_containers.is_empty() || dirty {
-                    let mut activeness_state = ActivenessState::new(task_id);
+                    let activeness_state =
+                        get_mut_or_insert_with!(task, Activeness, || ActivenessState::new(task_id));
                     activeness_state.set_active_until_clean();
-                    task.insert(CachedDataItem::Activeness {
-                        value: activeness_state,
-                    });
                     drop(task);
 
                     self.extend_find_and_schedule_dirty(dirty_containers);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -54,8 +54,12 @@ pub enum OutdatedEdge {
 }
 
 impl CleanupOldEdgesOperation {
-    pub fn run(task_id: TaskId, outdated: Vec<OutdatedEdge>, ctx: &mut impl ExecuteContext) {
-        let queue = AggregationUpdateQueue::new();
+    pub fn run(
+        task_id: TaskId,
+        outdated: Vec<OutdatedEdge>,
+        queue: AggregationUpdateQueue,
+        ctx: &mut impl ExecuteContext,
+    ) {
         CleanupOldEdgesOperation::RemoveEdges {
             task_id,
             outdated,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -102,8 +102,10 @@ impl Operation for CleanupOldEdgesOperation {
                                     });
                                 } else {
                                     let upper_ids = get_uppers(&task);
-                                    if get!(task, Activeness).is_some_and(|a| a.active_counter > 0)
-                                    {
+                                    let has_active_count = get!(task, Activeness)
+                                        .is_some_and(|a| a.active_counter > 0);
+                                    drop(task);
+                                    if has_active_count {
                                         // TODO combine both operations to avoid the clone
                                         queue.push(AggregationUpdateJob::DecreaseActiveCounts {
                                             task_ids: children.clone(),

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -52,6 +52,15 @@ impl ConnectChildOperation {
 
         let mut queue = AggregationUpdateQueue::new();
 
+        // Handle the transient to persistent boundary by making the persistent task a root task
+        if parent_task_id.is_transient() && !child_task_id.is_transient() {
+            queue.push(AggregationUpdateJob::UpdateAggregationNumber {
+                task_id: child_task_id,
+                base_aggregation_number: u32::MAX,
+                distance: None,
+            });
+        }
+
         queue.push(AggregationUpdateJob::IncreaseActiveCount {
             task: child_task_id,
         });

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -65,8 +65,6 @@ impl ConnectChildOperation {
             task: child_task_id,
         });
 
-        #[cfg(feature = "trace_aggregation_update")]
-        let _span = tracing::trace_span!("connect_child").entered();
         ConnectChildOperation::UpdateAggregation {
             aggregation_update: queue,
         }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -1,24 +1,17 @@
-use std::{cmp::max, num::NonZeroU32};
-
 use serde::{Deserialize, Serialize};
 use turbo_tasks::TaskId;
 
 use crate::{
     backend::{
+        get_mut,
         operation::{
-            aggregation_update::{
-                get_uppers, is_aggregating_node, AggregationUpdateJob, AggregationUpdateQueue,
-                LEAF_NUMBER,
-            },
-            is_root_node, ExecuteContext, Operation, TaskGuard,
+            aggregation_update::{AggregationUpdateJob, AggregationUpdateQueue},
+            ExecuteContext, Operation, TaskGuard,
         },
-        storage::{count, get},
         TaskDataCategory,
     },
-    data::{CachedDataItem, CachedDataItemKey},
+    data::{CachedDataItem, CachedDataItemKey, InProgressState},
 };
-
-const AGGREGATION_NUMBER_BUFFER_SPACE: u32 = 3;
 
 #[derive(Serialize, Deserialize, Clone, Default)]
 #[allow(clippy::large_enum_variant)]
@@ -44,112 +37,31 @@ impl ConnectChildOperation {
             }
             return;
         }
-        let mut parent_task = ctx.task(parent_task_id, TaskDataCategory::All);
+        let mut parent_task = ctx.task(parent_task_id, TaskDataCategory::Meta);
+        let Some(InProgressState::InProgress { new_children, .. }) =
+            get_mut!(parent_task, InProgress)
+        else {
+            panic!("Task is not in progress while calling another task");
+        };
+
         // Quick skip if the child was already connected before
-        if parent_task
-            .remove(&CachedDataItemKey::OutdatedChild {
-                task: child_task_id,
-            })
-            .is_some()
-        {
+        if !new_children.insert(child_task_id) {
             return;
         }
-        if parent_task.add(CachedDataItem::Child {
+        drop(parent_task);
+
+        let mut queue = AggregationUpdateQueue::new();
+
+        queue.push(AggregationUpdateJob::IncreaseActiveCount {
             task: child_task_id,
-            value: (),
-        }) {
-            let mut queue = AggregationUpdateQueue::new();
+        });
 
-            if get!(parent_task, Activeness).is_some_and(|a| a.active_counter > 0) {
-                queue.push(AggregationUpdateJob::IncreaseActiveCount {
-                    task: child_task_id,
-                })
-            }
-
-            // Get the children count
-            let children_count = count!(parent_task, Child);
-
-            // Compute future parent aggregation number based on the number of children
-            let current_parent_aggregation = get!(parent_task, AggregationNumber)
-                .copied()
-                .unwrap_or_default();
-            let (parent_aggregation, future_parent_aggregation) =
-                if is_root_node(current_parent_aggregation.base) {
-                    (u32::MAX, u32::MAX)
-                } else {
-                    let target_distance = children_count.ilog2() * 2;
-                    if target_distance > current_parent_aggregation.distance {
-                        queue.push(AggregationUpdateJob::UpdateAggregationNumber {
-                            task_id: parent_task_id,
-                            base_aggregation_number: 0,
-                            distance: NonZeroU32::new(target_distance),
-                        })
-                    }
-                    (
-                        current_parent_aggregation.effective,
-                        current_parent_aggregation.base.saturating_add(max(
-                            target_distance,
-                            current_parent_aggregation.distance,
-                        )),
-                    )
-                };
-
-            // Update child aggregation number based on parent aggregation number
-            let aggregating_node = is_aggregating_node(parent_aggregation);
-            if parent_task_id.is_transient() && !child_task_id.is_transient() {
-                queue.push(AggregationUpdateJob::UpdateAggregationNumber {
-                    task_id: child_task_id,
-                    base_aggregation_number: u32::MAX,
-                    distance: None,
-                });
-            } else if !aggregating_node {
-                let base_aggregation_number =
-                    future_parent_aggregation.saturating_add(AGGREGATION_NUMBER_BUFFER_SPACE);
-                queue.push(AggregationUpdateJob::UpdateAggregationNumber {
-                    task_id: child_task_id,
-                    base_aggregation_number: if is_aggregating_node(
-                        base_aggregation_number.saturating_add(AGGREGATION_NUMBER_BUFFER_SPACE - 1),
-                    ) {
-                        LEAF_NUMBER
-                    } else {
-                        base_aggregation_number
-                    },
-                    distance: None,
-                });
-            }
-            if aggregating_node {
-                queue.push(AggregationUpdateJob::InnerOfUpperHasNewFollower {
-                    upper_id: parent_task_id,
-                    new_follower_id: child_task_id,
-                });
-            } else {
-                let upper_ids = get_uppers(&parent_task);
-                queue.push(AggregationUpdateJob::InnerOfUppersHasNewFollower {
-                    upper_ids,
-                    new_follower_id: child_task_id,
-                });
-            }
-            drop(parent_task);
-
-            {
-                let mut task = ctx.task(child_task_id, TaskDataCategory::Meta);
-                if !task.has_key(&CachedDataItemKey::Output {}) {
-                    let description = ctx.get_task_desc_fn(child_task_id);
-                    let should_schedule = task.add(CachedDataItem::new_scheduled(description));
-                    drop(task);
-                    if should_schedule {
-                        ctx.schedule(child_task_id);
-                    }
-                }
-            }
-
-            #[cfg(feature = "trace_aggregation_update")]
-            let _span = tracing::trace_span!("connect_child").entered();
-            ConnectChildOperation::UpdateAggregation {
-                aggregation_update: queue,
-            }
-            .execute(&mut ctx);
+        #[cfg(feature = "trace_aggregation_update")]
+        let _span = tracing::trace_span!("connect_child").entered();
+        ConnectChildOperation::UpdateAggregation {
+            aggregation_update: queue,
         }
+        .execute(&mut ctx);
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -37,7 +37,7 @@ impl ConnectChildOperation {
             }
             return;
         }
-        let mut parent_task = ctx.task(parent_task_id, TaskDataCategory::Meta);
+        let mut parent_task = ctx.task(parent_task_id, TaskDataCategory::All);
         let Some(InProgressState::InProgress(box InProgressStateInner { new_children, .. })) =
             get_mut!(parent_task, InProgress)
         else {
@@ -46,6 +46,12 @@ impl ConnectChildOperation {
 
         // Quick skip if the child was already connected before
         if !new_children.insert(child_task_id) {
+            return;
+        }
+        if parent_task.has_key(&CachedDataItemKey::Child {
+            task: child_task_id,
+        }) {
+            // It is already connected, we can skip the rest
             return;
         }
         drop(parent_task);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -10,7 +10,7 @@ use crate::{
         },
         TaskDataCategory,
     },
-    data::{CachedDataItem, CachedDataItemKey, InProgressState},
+    data::{CachedDataItem, CachedDataItemKey, InProgressState, InProgressStateInner},
 };
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -38,7 +38,7 @@ impl ConnectChildOperation {
             return;
         }
         let mut parent_task = ctx.task(parent_task_id, TaskDataCategory::Meta);
-        let Some(InProgressState::InProgress { new_children, .. }) =
+        let Some(InProgressState::InProgress(box InProgressStateInner { new_children, .. })) =
             get_mut!(parent_task, InProgress)
         else {
             panic!("Task is not in progress while calling another task");

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
@@ -19,7 +19,7 @@ const AGGREGATION_NUMBER_BUFFER_SPACE: u32 = 3;
 pub fn connect_children(
     parent_task_id: TaskId,
     parent_task: &mut impl TaskGuard,
-    mut new_children: FxHashSet<TaskId>,
+    new_children: FxHashSet<TaskId>,
     queue: &mut AggregationUpdateQueue,
     active_count: i32,
 ) {
@@ -77,22 +77,6 @@ pub fn connect_children(
 
     let aggregating_node = is_aggregating_node(parent_aggregation);
     let upper_ids = (!aggregating_node).then(|| get_uppers(&*parent_task));
-
-    // Handle the transient to persistent boundary by making the persistent task a root task
-    if parent_task_id.is_transient() || !aggregating_node {
-        new_children.retain(|&child_task_id| {
-            if parent_task_id.is_transient() && !child_task_id.is_transient() {
-                queue.push(AggregationUpdateJob::UpdateAggregationNumber {
-                    task_id: child_task_id,
-                    base_aggregation_number: u32::MAX,
-                    distance: None,
-                });
-                false
-            } else {
-                true
-            }
-        });
-    }
 
     if let Some(upper_ids) = upper_ids {
         if !upper_ids.is_empty() {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
@@ -1,0 +1,66 @@
+use rustc_hash::FxHashSet;
+use turbo_tasks::TaskId;
+
+use crate::{
+    backend::operation::{
+        get_aggregation_number, get_uppers, is_aggregating_node, AggregationUpdateJob,
+        AggregationUpdateQueue, TaskGuard,
+    },
+    data::CachedDataItem,
+};
+
+pub fn connect_children(
+    parent_task_id: TaskId,
+    parent_task: &mut impl TaskGuard,
+    mut new_children: FxHashSet<TaskId>,
+    queue: &mut AggregationUpdateQueue,
+    active_count: i32,
+) {
+    for &new_child in new_children.iter() {
+        parent_task.add_new(CachedDataItem::Child {
+            task: new_child,
+            value: (),
+        });
+    }
+
+    let new_follower_ids: Vec<_> = new_children.iter().copied().collect();
+
+    let aggregating_node = is_aggregating_node(get_aggregation_number(parent_task));
+    let upper_ids = (!aggregating_node).then(|| get_uppers(&*parent_task));
+
+    // Handle the transient to persistent boundary by making the persistent task a root task
+    if parent_task_id.is_transient() || !aggregating_node {
+        new_children.retain(|&child_task_id| {
+            if parent_task_id.is_transient() && !child_task_id.is_transient() {
+                queue.push(AggregationUpdateJob::UpdateAggregationNumber {
+                    task_id: child_task_id,
+                    base_aggregation_number: u32::MAX,
+                    distance: None,
+                });
+                false
+            } else {
+                true
+            }
+        });
+    }
+
+    if let Some(upper_ids) = upper_ids {
+        if !upper_ids.is_empty() {
+            queue.push(AggregationUpdateJob::InnerOfUppersHasNewFollowers {
+                upper_ids,
+                new_follower_ids: new_follower_ids.clone(),
+            });
+        }
+    } else {
+        queue.push(AggregationUpdateJob::InnerOfUpperHasNewFollowers {
+            upper_id: parent_task_id,
+            new_follower_ids: new_follower_ids.clone(),
+        });
+    }
+
+    if active_count == 0 {
+        queue.push(AggregationUpdateJob::DecreaseActiveCounts {
+            task_ids: new_follower_ids,
+        })
+    }
+}

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
@@ -1,13 +1,20 @@
+use std::{cmp::max, num::NonZeroU32};
+
 use rustc_hash::FxHashSet;
 use turbo_tasks::TaskId;
 
 use crate::{
-    backend::operation::{
-        get_aggregation_number, get_uppers, is_aggregating_node, AggregationUpdateJob,
-        AggregationUpdateQueue, TaskGuard,
+    backend::{
+        get,
+        operation::{
+            get_uppers, is_aggregating_node, is_root_node, AggregationUpdateJob,
+            AggregationUpdateQueue, TaskGuard,
+        },
     },
     data::CachedDataItem,
 };
+
+const AGGREGATION_NUMBER_BUFFER_SPACE: u32 = 3;
 
 pub fn connect_children(
     parent_task_id: TaskId,
@@ -16,6 +23,49 @@ pub fn connect_children(
     queue: &mut AggregationUpdateQueue,
     active_count: i32,
 ) {
+    if new_children.is_empty() {
+        return;
+    }
+    let children_count = new_children.len();
+
+    // Compute future parent aggregation number based on the number of children
+    let current_parent_aggregation = get!(parent_task, AggregationNumber)
+        .copied()
+        .unwrap_or_default();
+    let (parent_aggregation, future_parent_aggregation) =
+        if is_root_node(current_parent_aggregation.base) {
+            (u32::MAX, u32::MAX)
+        } else {
+            let target_distance = children_count.ilog2() * 2;
+            if target_distance > current_parent_aggregation.distance {
+                queue.push(AggregationUpdateJob::UpdateAggregationNumber {
+                    task_id: parent_task_id,
+                    base_aggregation_number: 0,
+                    distance: NonZeroU32::new(target_distance),
+                })
+            }
+            (
+                current_parent_aggregation.effective,
+                current_parent_aggregation
+                    .base
+                    .saturating_add(max(target_distance, current_parent_aggregation.distance)),
+            )
+        };
+
+    // When the parent is a leaf node, we need to increase the aggregation number of the children to
+    // be counting from the parent's aggregation number.
+    if !is_aggregating_node(future_parent_aggregation) {
+        let child_base_aggregation_number =
+            future_parent_aggregation + AGGREGATION_NUMBER_BUFFER_SPACE;
+        for &new_child in new_children.iter() {
+            queue.push(AggregationUpdateJob::UpdateAggregationNumber {
+                task_id: new_child,
+                base_aggregation_number: child_base_aggregation_number,
+                distance: None,
+            });
+        }
+    };
+
     for &new_child in new_children.iter() {
         parent_task.add_new(CachedDataItem::Child {
             task: new_child,
@@ -25,7 +75,7 @@ pub fn connect_children(
 
     let new_follower_ids: Vec<_> = new_children.iter().copied().collect();
 
-    let aggregating_node = is_aggregating_node(get_aggregation_number(parent_task));
+    let aggregating_node = is_aggregating_node(parent_aggregation);
     let upper_ids = (!aggregating_node).then(|| get_uppers(&*parent_task));
 
     // Handle the transient to persistent boundary by making the persistent task a root task

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
@@ -22,7 +22,7 @@ pub fn connect_children(
     parent_task: &mut impl TaskGuard,
     new_children: FxHashSet<TaskId>,
     queue: &mut AggregationUpdateQueue,
-    active_count: i32,
+    has_active_count: bool,
 ) {
     if new_children.is_empty() {
         return;
@@ -89,14 +89,16 @@ pub fn connect_children(
                 .into(),
             );
         }
+        if !has_active_count {
+            queue.push(AggregationUpdateJob::DecreaseActiveCounts {
+                task_ids: new_follower_ids,
+            })
+        }
     } else {
         queue.push(AggregationUpdateJob::InnerOfUpperHasNewFollowers {
             upper_id: parent_task_id,
             new_follower_ids: new_follower_ids.clone(),
         });
-    }
-
-    if active_count == 0 {
         queue.push(AggregationUpdateJob::DecreaseActiveCounts {
             task_ids: new_follower_ids,
         })

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
@@ -13,7 +13,10 @@ use crate::{
         storage::{get, get_mut},
         TaskDataCategory,
     },
-    data::{CachedDataItem, CachedDataItemKey, CachedDataItemValue, DirtyState, InProgressState},
+    data::{
+        CachedDataItem, CachedDataItemKey, CachedDataItemValue, DirtyState, InProgressState,
+        InProgressStateInner,
+    },
 };
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -196,7 +199,9 @@ pub fn make_task_dirty_internal(
     ctx: &impl ExecuteContext,
 ) {
     if make_stale {
-        if let Some(InProgressState::InProgress { stale, .. }) = get_mut!(task, InProgress) {
+        if let Some(InProgressState::InProgress(box InProgressStateInner { stale, .. })) =
+            get_mut!(task, InProgress)
+        {
             if !*stale {
                 #[cfg(feature = "trace_task_dirty")]
                 let _span = tracing::trace_span!(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -1,6 +1,7 @@
 mod aggregation_update;
 mod cleanup_old_edges;
 mod connect_child;
+mod connect_children;
 mod invalidate;
 mod update_cell;
 mod update_collectible;
@@ -746,9 +747,11 @@ impl_operation!(AggregationUpdate aggregation_update::AggregationUpdateQueue);
 pub use self::invalidate::TaskDirtyCause;
 pub use self::{
     aggregation_update::{
-        get_aggregation_number, is_root_node, AggregatedDataUpdate, AggregationUpdateJob,
+        get_aggregation_number, get_uppers, is_aggregating_node, is_root_node,
+        AggregatedDataUpdate, AggregationUpdateJob,
     },
     cleanup_old_edges::OutdatedEdge,
+    connect_children::connect_children,
     update_cell::UpdateCellOperation,
     update_collectible::UpdateCollectibleOperation,
 };

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
@@ -15,7 +15,10 @@ use crate::{
         storage::{get, get_many},
         TaskDataCategory,
     },
-    data::{CachedDataItem, CachedDataItemKey, CellRef, InProgressState, OutputValue},
+    data::{
+        CachedDataItem, CachedDataItemKey, CellRef, InProgressState, InProgressStateInner,
+        OutputValue,
+    },
 };
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -45,11 +48,11 @@ impl UpdateOutputOperation {
         mut ctx: impl ExecuteContext,
     ) {
         let mut task = ctx.task(task_id, TaskDataCategory::Meta);
-        let Some(InProgressState::InProgress {
+        let Some(InProgressState::InProgress(box InProgressStateInner {
             stale,
             new_children,
             ..
-        }) = get!(task, InProgress)
+        })) = get!(task, InProgress)
         else {
             panic!("Task is not in progress while updating the output");
         };

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -588,7 +588,7 @@ macro_rules! get_mut {
         use $crate::backend::operation::TaskGuard;
         if let Some($crate::data::CachedDataItemValueRefMut::$key {
             value,
-        }) = $task.get_mut(&$crate::data::CachedDataItemKey::$key $input).as_mut() {
+        }) = $task.get_mut(&$crate::data::CachedDataItemKey::$key $input) {
             let () = $crate::data::allow_mut_access::$key;
             Some(value)
         } else {

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -304,21 +304,22 @@ pub enum RootType {
 }
 
 #[derive(Debug)]
+pub struct InProgressStateInner {
+    pub stale: bool,
+    #[allow(dead_code)]
+    pub once_task: bool,
+    pub session_dependent: bool,
+    pub marked_as_completed: bool,
+    pub done_event: Event,
+    /// Children that should be connected to the task and have their active_count decremented
+    /// once the task completes.
+    pub new_children: FxHashSet<TaskId>,
+}
+
+#[derive(Debug)]
 pub enum InProgressState {
-    Scheduled {
-        done_event: Event,
-    },
-    InProgress {
-        stale: bool,
-        #[allow(dead_code)]
-        once_task: bool,
-        session_dependent: bool,
-        marked_as_completed: bool,
-        done_event: Event,
-        /// Children that should be connected to the task and have their active_count decremented
-        /// once the task completes.
-        new_children: FxHashSet<TaskId>,
-    },
+    Scheduled { done_event: Event },
+    InProgress(Box<InProgressStateInner>),
 }
 
 transient_traits!(InProgressState);

--- a/turbopack/crates/turbo-tasks-testing/tests/basic.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/basic.rs
@@ -21,6 +21,12 @@ async fn basic() {
         let output3 = func_persistent(output1);
         assert_eq!(output3.await?.value, 123);
 
+        let output4 = nested_func_without_args_waiting();
+        assert_eq!(output4.await?.value, 123);
+
+        let output5 = nested_func_without_args_non_waiting();
+        assert_eq!(output5.await?.value, 123);
+
         anyhow::Ok(())
     })
     .await
@@ -28,6 +34,7 @@ async fn basic() {
 }
 
 #[turbo_tasks::value]
+#[derive(Clone, Debug)]
 struct Value {
     value: u32,
 }
@@ -51,4 +58,17 @@ async fn func_without_args() -> Result<Vc<Value>> {
     println!("func_without_args");
     let value = 123;
     Ok(Value { value }.cell())
+}
+
+#[turbo_tasks::function]
+async fn nested_func_without_args_waiting() -> Result<Vc<Value>> {
+    println!("nested_func_without_args_waiting");
+    let value = func_without_args().await?.clone_value();
+    Ok(value.cell())
+}
+
+#[turbo_tasks::function]
+async fn nested_func_without_args_non_waiting() -> Result<Vc<Value>> {
+    println!("nested_func_without_args_non_waiting");
+    Ok(func_without_args())
 }

--- a/turbopack/crates/turbo-tasks-testing/tests/emptied_cells.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/emptied_cells.rs
@@ -51,12 +51,14 @@ struct ChangingInput {
 
 #[turbo_tasks::function]
 async fn compute(input: Vc<ChangingInput>) -> Result<Vc<u32>> {
+    println!("compute()");
     let value = *inner_compute(input).await?;
     Ok(Vc::cell(value))
 }
 
 #[turbo_tasks::function]
 async fn inner_compute(input: Vc<ChangingInput>) -> Result<Vc<u32>> {
+    println!("inner_compute()");
     let state_value = *input.await?.state.get();
     let mut last = None;
     for i in 0..=state_value {
@@ -67,6 +69,7 @@ async fn inner_compute(input: Vc<ChangingInput>) -> Result<Vc<u32>> {
 
 #[turbo_tasks::function]
 async fn compute2(input: Vc<u32>) -> Result<Vc<u32>> {
+    println!("compute2()");
     let value = *input.await?;
     Ok(Vc::cell(value))
 }

--- a/turbopack/crates/turbo-tasks/src/event.rs
+++ b/turbopack/crates/turbo-tasks/src/event.rs
@@ -154,7 +154,7 @@ pub struct EventListener {
     note: Arc<dyn Fn() -> String + Sync + Send>,
     // Timeout need to stay pinned while polling and also while it's dropped.
     // So it's important to put it into a pinned Box to be able to take it out of the Option.
-    future: Option<Pin<Box<Timeout<event_listener::EventListener>>>>,
+    future: Option<std::pin::Pin<Box<Timeout<event_listener::EventListener>>>>,
     duration: Duration,
 }
 
@@ -200,7 +200,7 @@ impl Future for EventListener {
                         self.duration,
                         // SAFETY: We can move the inner future since it's an EventListener and
                         // that is Unpin.
-                        unsafe { Pin::into_inner_unchecked(future) }.into_inner(),
+                        unsafe { std::pin::Pin::into_inner_unchecked(future) }.into_inner(),
                     )));
                 }
             }


### PR DESCRIPTION
### What?

Connects all (new) children once the task is finished instead of each task when it's called.

To keep tasks active while the parent is in progress, but not finished, it uses the new active counter.

Closes PACK-3850