### PR TITLE
Always display version indicator

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -631,9 +631,7 @@ export async function createHotReloaderTurbopack(
     getNextErrorFeedbackMiddleware(opts.telemetry),
   ]
 
-  const versionInfoPromise = getVersionInfo(
-    isTestMode || opts.telemetry.isEnabled
-  )
+  const versionInfoPromise = getVersionInfo()
 
   let devtoolsFrontendUrl: string | undefined
   const nodeDebugType = getNodeDebugType()

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -86,11 +86,6 @@ import { getNodeDebugType } from '../lib/utils'
 import { getNextErrorFeedbackMiddleware } from '../../client/components/react-dev-overlay/server/get-next-error-feedback-middleware'
 
 const MILLISECONDS_IN_NANOSECOND = BigInt(1_000_000)
-const isTestMode = !!(
-  process.env.NEXT_TEST_MODE ||
-  process.env.__NEXT_TEST_MODE ||
-  process.env.DEBUG
-)
 
 function diff(a: Set<any>, b: Set<any>) {
   return new Set([...a].filter((v) => !b.has(v)))
@@ -196,12 +191,8 @@ function erroredPages(compilation: webpack.Compilation) {
   return failedPages
 }
 
-export async function getVersionInfo(enabled: boolean): Promise<VersionInfo> {
+export async function getVersionInfo(): Promise<VersionInfo> {
   let installed = '0.0.0'
-
-  if (!enabled) {
-    return { installed, staleness: 'unknown' }
-  }
 
   try {
     installed = require('next/package.json').version
@@ -751,10 +742,10 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
     })
   }
 
-  private async tracedGetVersionInfo(span: Span, enabled: boolean) {
+  private async tracedGetVersionInfo(span: Span) {
     const versionInfoSpan = span.traceChild('get-version-info')
     return versionInfoSpan.traceAsyncFn<VersionInfo>(async () =>
-      getVersionInfo(enabled)
+      getVersionInfo()
     )
   }
 
@@ -762,10 +753,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
     const startSpan = this.hotReloaderSpan.traceChild('start')
     startSpan.stop() // Stop immediately to create an artificial parent span
 
-    this.versionInfo = await this.tracedGetVersionInfo(
-      startSpan,
-      isTestMode || this.telemetry.isEnabled
-    )
+    this.versionInfo = await this.tracedGetVersionInfo(startSpan)
 
     const nodeDebugType = getNodeDebugType()
     if (nodeDebugType && !this.devtoolsFrontendUrl) {


### PR DESCRIPTION
### What

Remove the condition to check when version indicator can be displayed as it doesn't have to be coupled with test mode or telemetry 