### PR TITLE
feat: added rewrite headers after user-supplied rewrites

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -163,6 +163,8 @@ import {
   NEXT_ROUTER_STATE_TREE_HEADER,
   NEXT_DID_POSTPONE_HEADER,
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+  NEXT_REWRITTEN_PATH_HEADER,
+  NEXT_REWRITTEN_QUERY_HEADER,
 } from '../client/components/app-router-headers'
 import { webpackBuild } from './webpack-build'
 import { NextBuildContext, type MappedPages } from './build-context'
@@ -403,6 +405,10 @@ export type RoutesManifest = {
     prefetchHeader: typeof NEXT_ROUTER_PREFETCH_HEADER
     suffix: typeof RSC_SUFFIX
     prefetchSuffix: typeof RSC_PREFETCH_SUFFIX
+  }
+  rewriteHeaders: {
+    pathHeader: typeof NEXT_REWRITTEN_PATH_HEADER
+    queryHeader: typeof NEXT_REWRITTEN_QUERY_HEADER
   }
   skipMiddlewareUrlNormalize?: boolean
   caseSensitive?: boolean
@@ -1260,6 +1266,10 @@ export default async function build(
               contentTypeHeader: RSC_CONTENT_TYPE_HEADER,
               suffix: RSC_SUFFIX,
               prefetchSuffix: RSC_PREFETCH_SUFFIX,
+            },
+            rewriteHeaders: {
+              pathHeader: NEXT_REWRITTEN_PATH_HEADER,
+              queryHeader: NEXT_REWRITTEN_QUERY_HEADER,
             },
             skipMiddlewareUrlNormalize: config.skipMiddlewareUrlNormalize,
             ppr: isAppPPREnabled

--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -27,4 +27,6 @@ export const NEXT_RSC_UNION_QUERY = '_rsc' as const
 
 export const NEXT_ROUTER_STALE_TIME_HEADER = 'x-nextjs-stale-time' as const
 export const NEXT_DID_POSTPONE_HEADER = 'x-nextjs-postponed' as const
+export const NEXT_REWRITTEN_PATH_HEADER = 'x-nextjs-rewritten-path' as const
+export const NEXT_REWRITTEN_QUERY_HEADER = 'x-nextjs-rewritten-query' as const
 export const NEXT_IS_PRERENDER_HEADER = 'x-nextjs-prerender' as const

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1430,9 +1430,7 @@ export default abstract class Server<
         parsedUrl.pathname = normalizeResult.pathname
 
         for (const key of Object.keys(parsedUrl.query)) {
-          if (!key.startsWith('__next') && !key.startsWith('_next')) {
-            delete parsedUrl.query[key]
-          }
+          delete parsedUrl.query[key]
         }
         const invokeQuery = getRequestMeta(req, 'invokeQuery')
 

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -40,6 +40,7 @@ import {
   NEXT_REWRITTEN_PATH_HEADER,
   NEXT_REWRITTEN_QUERY_HEADER,
   NEXT_ROUTER_STATE_TREE_HEADER,
+  RSC_HEADER,
 } from '../../../client/components/app-router-headers'
 import { getSelectedParams } from '../../../client/components/router-reducer/compute-changed-path'
 import { isInterceptionRouteRewrite } from '../../../lib/generate-interception-routes-rewrites'
@@ -621,23 +622,26 @@ export function getResolveRoutes(
                 }
               }
 
-              // We set the rewritten path and query headers on the response now
-              // that we know that the it's not an external rewrite.
-              if (
-                parsedDestination.pathname &&
-                parsedUrl.pathname !== parsedDestination.pathname
-              ) {
-                res.setHeader(
-                  NEXT_REWRITTEN_PATH_HEADER,
-                  parsedDestination.pathname
-                )
-              }
-              if (parsedDestination.search) {
-                res.setHeader(
-                  NEXT_REWRITTEN_QUERY_HEADER,
-                  // remove the leading ? from the search
-                  parsedDestination.search.slice(1)
-                )
+              // Set the rewrite headers only if this is a RSC request.
+              if (req.headers[RSC_HEADER.toLowerCase()] === '1') {
+                // We set the rewritten path and query headers on the response now
+                // that we know that the it's not an external rewrite.
+                if (
+                  parsedDestination.pathname &&
+                  parsedUrl.pathname !== parsedDestination.pathname
+                ) {
+                  res.setHeader(
+                    NEXT_REWRITTEN_PATH_HEADER,
+                    parsedDestination.pathname
+                  )
+                }
+                if (parsedDestination.search) {
+                  res.setHeader(
+                    NEXT_REWRITTEN_QUERY_HEADER,
+                    // remove the leading ? from the search
+                    parsedDestination.search.slice(1)
+                  )
+                }
               }
 
               // Assign the parsed destination to parsedUrl so that the next
@@ -780,17 +784,20 @@ export function getResolveRoutes(
             }
           }
 
-          // We set the rewritten path and query headers on the response now
-          // that we know that the it's not an external rewrite.
-          if (parsedUrl.pathname !== destinationPathname) {
-            res.setHeader(NEXT_REWRITTEN_PATH_HEADER, destinationPathname)
-          }
-          if (destinationSearch) {
-            res.setHeader(
-              NEXT_REWRITTEN_QUERY_HEADER,
-              // remove the leading ? from the search
-              destinationSearch.slice(1)
-            )
+          // Set the rewrite headers only if this is a RSC request.
+          if (req.headers[RSC_HEADER.toLowerCase()] === '1') {
+            // We set the rewritten path and query headers on the response now
+            // that we know that the it's not an external rewrite.
+            if (parsedUrl.pathname !== destinationPathname) {
+              res.setHeader(NEXT_REWRITTEN_PATH_HEADER, destinationPathname)
+            }
+            if (destinationSearch) {
+              res.setHeader(
+                NEXT_REWRITTEN_QUERY_HEADER,
+                // remove the leading ? from the search
+                destinationSearch.slice(1)
+              )
+            }
           }
 
           if (config.i18n) {

--- a/test/e2e/app-dir/rewrite-headers/app/hello/[name]/page.jsx
+++ b/test/e2e/app-dir/rewrite-headers/app/hello/[name]/page.jsx
@@ -1,0 +1,8 @@
+export default async function Page(props) {
+  const { name } = await props.params
+  return <div>Hello {name}</div>
+}
+
+export async function generateStaticParams() {
+  return [{ name: 'world' }, { name: 'wyatt' }, { name: 'admin' }]
+}

--- a/test/e2e/app-dir/rewrite-headers/app/layout.jsx
+++ b/test/e2e/app-dir/rewrite-headers/app/layout.jsx
@@ -1,0 +1,11 @@
+import { Suspense } from 'react'
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>
+        <Suspense>{children}</Suspense>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/rewrite-headers/app/other/page.jsx
+++ b/test/e2e/app-dir/rewrite-headers/app/other/page.jsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Other Page</div>
+}

--- a/test/e2e/app-dir/rewrite-headers/app/page.jsx
+++ b/test/e2e/app-dir/rewrite-headers/app/page.jsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>Hello World</div>
+}

--- a/test/e2e/app-dir/rewrite-headers/middleware.js
+++ b/test/e2e/app-dir/rewrite-headers/middleware.js
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server'
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico, sitemap.xml, robots.txt (metadata files)
+     */
+    '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
+  ],
+}
+
+export default function middleware(req) {
+  const url = new URL(req.url)
+
+  if (url.pathname === '/hello/wyatt') {
+    return NextResponse.rewrite(new URL('/hello/admin?key=value', url))
+  }
+
+  if (url.pathname === '/hello/bob') {
+    return NextResponse.rewrite(new URL('/hello/bobby', url))
+  }
+
+  if (url.pathname === '/hello/john') {
+    return NextResponse.rewrite(new URL('/hello/john?key=value', url))
+  }
+
+  if (url.pathname === '/hello/vercel') {
+    return NextResponse.rewrite('https://www.vercel.com')
+  }
+
+  return NextResponse.next()
+}

--- a/test/e2e/app-dir/rewrite-headers/next.config.js
+++ b/test/e2e/app-dir/rewrite-headers/next.config.js
@@ -1,0 +1,23 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  rewrites: async () => {
+    return [
+      {
+        source: '/hello/sam',
+        destination: '/hello/samantha',
+      },
+      {
+        source: '/hello/other',
+        destination: '/other',
+      },
+      {
+        source: '/hello/fred',
+        destination: '/other?key=value',
+      },
+      {
+        source: '/hello/(.*)/google',
+        destination: 'https://www.google.$1/',
+      },
+    ]
+  },
+}

--- a/test/e2e/app-dir/rewrite-headers/rewrite-headers.test.ts
+++ b/test/e2e/app-dir/rewrite-headers/rewrite-headers.test.ts
@@ -78,8 +78,8 @@ const cases: {
     name: 'middleware rewrite HTML',
     pathname: '/hello/wyatt',
     expected: {
-      'x-nextjs-rewritten-path': '/hello/admin',
-      'x-nextjs-rewritten-query': 'key=value',
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': null,
     },
   },
   {
@@ -110,7 +110,7 @@ const cases: {
     name: 'middleware rewrite dynamic HTML',
     pathname: '/hello/bob',
     expected: {
-      'x-nextjs-rewritten-path': '/hello/bobby',
+      'x-nextjs-rewritten-path': null,
       'x-nextjs-rewritten-query': null,
     },
   },
@@ -203,7 +203,7 @@ const cases: {
     name: 'next.config.js rewrites HTML',
     pathname: '/hello/sam',
     expected: {
-      'x-nextjs-rewritten-path': '/hello/samantha',
+      'x-nextjs-rewritten-path': null,
       'x-nextjs-rewritten-query': null,
     },
   },
@@ -234,7 +234,7 @@ const cases: {
     name: 'next.config.js rewrites static HTML',
     pathname: '/hello/other',
     expected: {
-      'x-nextjs-rewritten-path': '/other',
+      'x-nextjs-rewritten-path': null,
       'x-nextjs-rewritten-query': null,
     },
   },
@@ -274,7 +274,7 @@ const cases: {
     pathname: '/hello/john',
     expected: {
       'x-nextjs-rewritten-path': null,
-      'x-nextjs-rewritten-query': 'key=value',
+      'x-nextjs-rewritten-query': null,
     },
   },
   {
@@ -335,8 +335,8 @@ const cases: {
     name: 'next.config.js rewrites with query HTML',
     pathname: '/hello/fred',
     expected: {
-      'x-nextjs-rewritten-path': '/other',
-      'x-nextjs-rewritten-query': 'key=value',
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': null,
     },
   },
   {

--- a/test/e2e/app-dir/rewrite-headers/rewrite-headers.test.ts
+++ b/test/e2e/app-dir/rewrite-headers/rewrite-headers.test.ts
@@ -1,0 +1,410 @@
+import { nextTestSetup } from 'e2e-utils'
+
+const targets = ['x-nextjs-rewritten-path', 'x-nextjs-rewritten-query'] as const
+
+type Target = (typeof targets)[number]
+
+const cases: {
+  name: string
+  pathname: string
+  only?: boolean
+  debug?: true
+  headers?: Record<string, string>
+  expected: Record<Target, string | null>
+}[] = [
+  {
+    name: 'static HTML',
+    pathname: '/',
+    expected: {
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'static RSC',
+    pathname: '/',
+    headers: {
+      RSC: '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'static Prefetch RSC',
+    pathname: '/',
+    headers: {
+      RSC: '1',
+      'Next-Router-Prefetch': '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'prerender HTML',
+    pathname: '/hello/world',
+    expected: {
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'prerendered RSC',
+    pathname: '/hello/world',
+    headers: {
+      RSC: '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'prerendered Prefetch RSC',
+    pathname: '/hello/world',
+    headers: {
+      RSC: '1',
+      'Next-Router-Prefetch': '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'middleware rewrite HTML',
+    pathname: '/hello/wyatt',
+    expected: {
+      'x-nextjs-rewritten-path': '/hello/admin',
+      'x-nextjs-rewritten-query': 'key=value',
+    },
+  },
+  {
+    name: 'middleware rewrite RSC',
+    pathname: '/hello/wyatt',
+    headers: {
+      RSC: '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': '/hello/admin',
+      'x-nextjs-rewritten-query': 'key=value',
+    },
+  },
+  {
+    name: 'middleware rewrite Prefetch RSC',
+    pathname: '/hello/wyatt',
+    headers: {
+      RSC: '1',
+      'Next-Router-Prefetch': '1',
+    },
+    // only: true,
+    expected: {
+      'x-nextjs-rewritten-path': '/hello/admin',
+      'x-nextjs-rewritten-query': 'key=value',
+    },
+  },
+  {
+    name: 'middleware rewrite dynamic HTML',
+    pathname: '/hello/bob',
+    expected: {
+      'x-nextjs-rewritten-path': '/hello/bobby',
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'middleware rewrite dynamic RSC',
+    pathname: '/hello/bob',
+    headers: {
+      RSC: '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': '/hello/bobby',
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'middleware rewrite dynamic Prefetch RSC',
+    pathname: '/hello/bob',
+    headers: {
+      RSC: '1',
+      'Next-Router-Prefetch': '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': '/hello/bobby',
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'dynamic HTML',
+    pathname: '/hello/mary',
+    expected: {
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'dynamic RSC',
+    pathname: '/hello/mary',
+    headers: {
+      RSC: '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'dynamic Prefetch RSC',
+    pathname: '/hello/mary',
+    headers: {
+      RSC: '1',
+      'Next-Router-Prefetch': '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'dynamic HTML with query',
+    pathname: '/hello/mary?key=value',
+    expected: {
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'dynamic RSC with query',
+    pathname: '/hello/mary?key=value',
+    headers: {
+      RSC: '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'dynamic Prefetch RSC with query',
+    pathname: '/hello/mary?key=value',
+    headers: {
+      RSC: '1',
+      'Next-Router-Prefetch': '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'next.config.js rewrites HTML',
+    pathname: '/hello/sam',
+    expected: {
+      'x-nextjs-rewritten-path': '/hello/samantha',
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'next.config.js rewrites RSC',
+    pathname: '/hello/sam',
+    headers: {
+      RSC: '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': '/hello/samantha',
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'next.config.js rewrites Prefetch RSC',
+    pathname: '/hello/sam',
+    headers: {
+      RSC: '1',
+      'Next-Router-Prefetch': '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': '/hello/samantha',
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'next.config.js rewrites static HTML',
+    pathname: '/hello/other',
+    expected: {
+      'x-nextjs-rewritten-path': '/other',
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'next.config.js rewrites static RSC',
+    pathname: '/hello/other',
+    headers: {
+      RSC: '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': '/other',
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'next.config.js rewrites static Prefetch RSC',
+    pathname: '/hello/other',
+    headers: {
+      RSC: '1',
+      'Next-Router-Prefetch': '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': '/other',
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'next.config.js rewrites external URL',
+    pathname: '/hello/google',
+    expected: {
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'middleware rewrite query HTML',
+    pathname: '/hello/john',
+    expected: {
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': 'key=value',
+    },
+  },
+  {
+    name: 'middleware rewrite query RSC',
+    pathname: '/hello/john',
+    headers: {
+      RSC: '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': 'key=value',
+    },
+  },
+  {
+    name: 'middleware rewrite query Prefetch RSC',
+    pathname: '/hello/john',
+    headers: {
+      RSC: '1',
+      'Next-Router-Prefetch': '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': 'key=value',
+    },
+  },
+  {
+    name: 'middleware rewrite external HTML',
+    pathname: '/hello/vercel',
+    expected: {
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'middleware rewrite external RSC',
+    pathname: '/hello/vercel',
+    headers: {
+      RSC: '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'middleware rewrite external Prefetch RSC',
+    pathname: '/hello/vercel',
+    headers: {
+      RSC: '1',
+      'Next-Router-Prefetch': '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'next.config.js rewrites with query HTML',
+    pathname: '/hello/fred',
+    expected: {
+      'x-nextjs-rewritten-path': '/other',
+      'x-nextjs-rewritten-query': 'key=value',
+    },
+  },
+  {
+    name: 'next.config.js rewrites with query RSC',
+    pathname: '/hello/fred',
+    headers: {
+      RSC: '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': '/other',
+      'x-nextjs-rewritten-query': 'key=value',
+    },
+  },
+  {
+    name: 'next.config.js rewrites with query Prefetch RSC',
+    pathname: '/hello/fred',
+    headers: {
+      RSC: '1',
+      'Next-Router-Prefetch': '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': '/other',
+      'x-nextjs-rewritten-query': 'key=value',
+    },
+  },
+]
+
+describe('rewrite-headers', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    // TODO: re-enable once changes in infrastructure are merged
+    skipDeployment: true,
+  })
+
+  describe.each(cases)(
+    '$name ($pathname)',
+    ({ pathname, headers = {}, expected }) => {
+      let response
+      beforeAll(async () => {
+        response = await next.fetch(pathname, { headers })
+        if (response.status !== 200) {
+          throw new Error(
+            `Expected status 200, got ${response.status} for ${pathname}`
+          )
+        }
+      })
+
+      it('should have the expected headers', () => {
+        const headers = Object.fromEntries(response.headers.entries())
+
+        // This is so that the following check works. If we expect that the
+        // header is null, but it's not present, we need to set it to null.
+        Object.entries(expected).forEach(([key, value]) => {
+          if (value === null && !headers[key]) {
+            headers[key] = null
+          }
+        })
+
+        // Remove any headers that we're not testing for to simplify the test
+        // output.
+        Object.keys(headers).forEach((key) => {
+          if (!targets.includes(key as Target)) {
+            delete headers[key]
+          }
+        })
+
+        expect(headers).toEqual(expected)
+      })
+    }
+  )
+})

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -2097,6 +2097,10 @@ const runTests = (isDev = false) => {
             source: '/has-header-4',
           },
         ],
+        rewriteHeaders: {
+          pathHeader: 'x-nextjs-rewritten-path',
+          queryHeader: 'x-nextjs-rewritten-query',
+        },
         rewrites: {
           beforeFiles: [
             {

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -1509,6 +1509,10 @@ function runTests({ dev }) {
             },
           },
         ],
+        rewriteHeaders: {
+          pathHeader: 'x-nextjs-rewritten-path',
+          queryHeader: 'x-nextjs-rewritten-query',
+        },
         rsc: {
           header: 'RSC',
           contentTypeHeader: 'text/x-component',


### PR DESCRIPTION
Next.js's client router needs to know the pathname and query that the request was rewritten to in order to facilitate reuse of static RSC payloads generated from fallbacks. This takes the form of additional headers being sent back on the response that includes the correct rewritten pathname that later the client can take into account when generating the client route key.