### PR TITLE
docs update: Remove public access modifier from resetRequestCache method in CacheHandler class, it's not available in js file (only in typescript)

### DIFF
--- a/docs/01-app/03-building-your-application/10-deploying/index.mdx
+++ b/docs/01-app/03-building-your-application/10-deploying/index.mdx
@@ -228,7 +228,7 @@ module.exports = class CacheHandler {
 
   // If you want to have temporary in memory cache for a single request that is reset
   // before the next request you can leverage this method
-  public resetRequestCache() {}
+  resetRequestCache() {}
 }
 ```
 


### PR DESCRIPTION
### What?

During development I noticed that example of custom CacheHandler contains expression that works only in TypeScript but the file is declared as JS.

### Why?

To improve documentation DX, so other developers won't be surprised that code they copied from official docs is not correct semantically.

### How?

Added small fix removing public accessor
