### PR TITLE
fix: add parser metadata for eslint 9 cache

### DIFF
--- a/packages/eslint-config-next/parser.js
+++ b/packages/eslint-config-next/parser.js
@@ -2,7 +2,7 @@ const {
   parse,
   parseForESLint,
 } = require('next/dist/compiled/babel/eslint-parser')
-const { version } = require('./package.json');
+const { version } = require('./package.json')
 
 module.exports = {
   parse,

--- a/packages/eslint-config-next/parser.js
+++ b/packages/eslint-config-next/parser.js
@@ -2,8 +2,13 @@ const {
   parse,
   parseForESLint,
 } = require('next/dist/compiled/babel/eslint-parser')
+const { version } = require('./package.json');
 
 module.exports = {
   parse,
   parseForESLint,
+  meta: {
+    name: 'eslint-config-next/parser',
+    version,
+  },
 }


### PR DESCRIPTION
When using `eslint-config-next` on eslint 9.x with a flat config (as per next.js [docs](https://nextjs.org/docs/app/api-reference/config/eslint#specifying-a-root-directory-within-a-monorepo)) and with the `--cache` flag - eslint would fail:

```
> ./node_modules/.bin/eslint --cache

Oops! Something went wrong! :(

ESLint: 9.17.0

TypeError: Cannot serialize key "parse" in parser: Function values are not supported.
    at languageOptionsToJSON (.../next-eslint-issue/node_modules/eslint/lib/config/config.js:113:23)
    at languageOptionsToJSON (.../next-eslint-issue/node_modules/eslint/lib/config/config.js:107:35)
    at Config.toJSON (.../next-eslint-issue/node_modules/eslint/lib/config/config.js:260:30)
    at stringify (.../next-eslint-issue/node_modules/json-stable-stringify-without-jsonify/index.js:25:25)
    at module.exports (.../next-eslint-issue/node_modules/json-stable-stringify-without-jsonify/index.js:68:7)
    at hashOfConfigFor (.../next-eslint-issue/node_modules/eslint/lib/cli-engine/lint-result-cache.js:50:75)
    at LintResultCache.getCachedLintResults (.../next-eslint-issue/node_modules/eslint/lib/cli-engine/lint-result-cache.js:116:30)
    at .../next-eslint-issue/node_modules/eslint/lib/eslint/eslint.js:783:41
    at async Promise.all (index 0)
    at async ESLint.lintFiles (.../next-eslint-issue/node_modules/eslint/lib/eslint/eslint.js:759:25)
```

(see a minimal repro here: https://github.com/CvX/next-eslint-issue)

This happens because eslint is unable to serialize the `parser` object in the config. Adding metadata fixes that.

The issue was originally reported over at eslint repo in: https://github.com/eslint/eslint/issues/19322

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
