### PR TITLE
Docs: Fix the misstatement in full route cache invalidation section

### DIFF
--- a/docs/01-app/03-building-your-application/04-caching/index.mdx
+++ b/docs/01-app/03-building-your-application/04-caching/index.mdx
@@ -299,7 +299,7 @@ By default, the Full Route Cache is persistent. This means that the render outpu
 
 There are two ways you can invalidate the Full Route Cache:
 
-- **[Revalidating Data](/docs/app/building-your-application/caching#revalidating)**: Revalidating the [Data Cache](#data-cache), will in turn invalidate the Router Cache by re-rendering components on the server and caching the new render output.
+- **[Revalidating Data](/docs/app/building-your-application/caching#revalidating)**: Revalidating the [Data Cache](#data-cache), will in turn invalidate the Full Route Cache by re-rendering components on the server and caching the new render output.
 - **Redeploying**: Unlike the Data Cache, which persists across deployments, the Full Route Cache is cleared on new deployments.
 
 ### Opting out


### PR DESCRIPTION
Fixed the misstatement in the [invalidation section](https://nextjs.org/docs/app/building-your-application/caching#invalidation) of Full Route Cache.

Revalidating the Data Cache should affect the Full Route Cache instead of the client-side Router Cache.