### PR TITLE
Docs: Clarify unsupported composition pattern

### DIFF
--- a/docs/01-app/03-building-your-application/03-rendering/03-composition-patterns.mdx
+++ b/docs/01-app/03-building-your-application/03-rendering/03-composition-patterns.mdx
@@ -471,6 +471,8 @@ export default function ClientComponent({ children }) {
 }
 ```
 
+By default, components in Next.js are Server Components. This means you can theoretically import a _Server Component_ (or a component not explicitly marked as a Client Component) into a Client Component **if it doesn’t use any server-specific constructs**. However, since, "use client" defines a network boundary, any component imported into a [Client Component](/docs/app/building-your-application/rendering/client-components) will be considered part of client bundle.
+
 ### Supported Pattern: Passing Server Components to Client Components as Props
 
 The following pattern is supported. You can pass Server Components as a prop to a Client Component.


### PR DESCRIPTION
## Motivation
The unsupported composition pattern mentions that you cannot import a Server Component into a Client Component which is not particularly true. A component is a Server Component by default, so if it doesn't use any server-specific stuff, it can be imported client component without any errors becoming a part of the client bundle.

## Fix
Added a few sentences under the example to clarify this point.