### PR TITLE
Add next-globe-gen as another option for i18n package to docs page

### DIFF
--- a/docs/01-app/03-building-your-application/01-routing/15-internationalization.mdx
+++ b/docs/01-app/03-building-your-application/01-routing/15-internationalization.mdx
@@ -209,6 +209,7 @@ export default async function RootLayout({ children, params }) {
 ## Resources
 
 - [Minimal i18n routing and translations](https://github.com/vercel/next.js/tree/canary/examples/i18n-routing)
+- [`next-globe-gen`](https://next-globe-gen.dev)
 - [`next-intl`](https://next-intl.dev)
 - [`next-international`](https://github.com/QuiiBz/next-international)
 - [`next-i18n-router`](https://github.com/i18nexus/next-i18n-router)


### PR DESCRIPTION
[NextGlobeGen](https://next-globe-gen.dev/) is a TypeSafe internationalization package for Next.js App Router. It has really easy setup and extremely smooth DX. It also supports static rendering and output export mode out of the box which other packages do not. It would be a great addition to the external resources for Next.js App Router internationalization.
