### PR TITLE
[not for merge] Add fixture highlighting slot layout remount under `test/e2e/app-dir/hello-world`

### DIFF
--- a/test/e2e/app-dir/hello-world/app/@audience/layout.js
+++ b/test/e2e/app-dir/hello-world/app/@audience/layout.js
@@ -1,0 +1,27 @@
+'use client'
+import * as React from 'react'
+import Link from 'next/link'
+
+export default function AudienceLayout({ children }) {
+  React.useEffect(() => {
+    console.log('mount')
+  }, [])
+
+  return (
+    <fieldset>
+      <legend>app/@audience/layout</legend>
+      <ul>
+        <li>
+          <Link href="/">home</Link>
+        </li>
+        <li>
+          <Link href="/one">one</Link>
+        </li>
+        <li>
+          <Link href="/two">two</Link>
+        </li>
+      </ul>
+      {children}
+    </fieldset>
+  )
+}

--- a/test/e2e/app-dir/hello-world/app/@audience/one/page.js
+++ b/test/e2e/app-dir/hello-world/app/@audience/one/page.js
@@ -1,0 +1,7 @@
+export default function AudienceOnePage() {
+  return (
+    <fieldset>
+      <legend>app/@audience/one/page</legend>
+    </fieldset>
+  )
+}

--- a/test/e2e/app-dir/hello-world/app/@audience/page.js
+++ b/test/e2e/app-dir/hello-world/app/@audience/page.js
@@ -1,0 +1,7 @@
+export default function AudiencePage() {
+  return (
+    <fieldset>
+      <legend>app/@audience/page</legend>
+    </fieldset>
+  )
+}

--- a/test/e2e/app-dir/hello-world/app/@audience/two/page.js
+++ b/test/e2e/app-dir/hello-world/app/@audience/two/page.js
@@ -1,0 +1,7 @@
+export default function AudienceTwoPage() {
+  return (
+    <fieldset>
+      <legend>app/@audience/two/page</legend>
+    </fieldset>
+  )
+}

--- a/test/e2e/app-dir/hello-world/app/default.js
+++ b/test/e2e/app-dir/hello-world/app/default.js
@@ -1,7 +1,7 @@
 export default function Page() {
   return (
     <fieldset>
-      <legend>app/page</legend>
+      <legend>app/default</legend>
     </fieldset>
   )
 }

--- a/test/e2e/app-dir/hello-world/app/global.css
+++ b/test/e2e/app-dir/hello-world/app/global.css
@@ -1,0 +1,16 @@
+:focus-visible {
+  outline-color: red;
+}
+
+@keyframes highlight {
+  from {
+    background-color: green;
+  }
+  to {
+    background-color: white;
+  }
+}
+
+legend {
+  animation: highlight 1s ease-in-out 1;
+}

--- a/test/e2e/app-dir/hello-world/app/layout.tsx
+++ b/test/e2e/app-dir/hello-world/app/layout.tsx
@@ -1,7 +1,21 @@
-export default function Root({ children }: { children: React.ReactNode }) {
+'use client'
+import './global.css'
+export default function Root({
+  children,
+  audience,
+}: {
+  children: React.ReactNode
+  audience: React.ReactNode
+}) {
   return (
     <html>
-      <body>{children}</body>
+      <body>
+        <fieldset>
+          <legend>app/layout</legend>
+          {children}
+          {audience}
+        </fieldset>
+      </body>
     </html>
   )
 }


### PR DESCRIPTION
`pnpm test dev test/e2e/app-dir/hello-world` and then click between "home" and "one"

Not sure if intended. If so we hopefully have a test checking that we remount a slotted layout. Otherwise I convert this into one.


https://github.com/user-attachments/assets/493acc30-e953-48c1-900f-6e75f9dc720c

