### PR TITLE
docs: unstable_cache clarify usage

### DIFF
--- a/docs/01-app/04-api-reference/04-functions/unstable_cache.mdx
+++ b/docs/01-app/04-api-reference/04-functions/unstable_cache.mdx
@@ -1,10 +1,9 @@
 ---
 title: unstable_cache
 description: API Reference for the unstable_cache function.
-version: legacy
 ---
 
-In version 15, we recommend using the [`use cache`](/docs/app/api-reference/directives/use-cache) directive instead.
+> **Note:** This API will be replaced by [`use cache`](/docs/app/api-reference/directives/use-cache) when it reaches stability.
 
 `unstable_cache` allows you to cache the results of expensive operations, like database queries, and reuse them across multiple requests.
 


### PR DESCRIPTION
It can still be used now, until `"use cache"` is ready.