### PR TITLE
fix(74660): cacheLife with revalidate < 1 causes error in production …

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -20,7 +20,7 @@
   "19": "can't decode empty hex",
   "20": "The provided export path '%s' doesn't match the '%s' page.\\nRead more: https://nextjs.org/docs/messages/export-path-mismatch",
   "21": "Image with src \"%s\" cannot end with a space or control character. Use src.trimEnd() to remove it or encodeURIComponent(src) to keep it.",
-  "22": "Invalid revalidate configuration provided: %s < 1",
+  "22": "Invalid revalidate configuration provided: %s < 0",
   "23": "The \"modules.namedExport\" option requires the \"modules.exportLocalsConvention\" option to be \"camelCaseOnly\"",
   "24": "Invalid flags should be run as node detached-flush dev ./path-to/project",
   "25": "NodeModuleLoader is not supported in edge runtime.",

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -3260,9 +3260,9 @@ export default abstract class Server<
 
       // If the cache entry has a revalidate value that's a number, use it.
       else if (typeof cacheEntry.revalidate === 'number') {
-        if (cacheEntry.revalidate < 1) {
+        if (cacheEntry.revalidate < 0) {
           throw new Error(
-            `Invalid revalidate configuration provided: ${cacheEntry.revalidate} < 1`
+            `Invalid revalidate configuration provided: ${cacheEntry.revalidate} < 0`
           )
         }
 


### PR DESCRIPTION
### Fixing a bug

### What?
Change the behavior of `cacheEntry.revalidate`.

### Why?
It failed if the number is < 1. But it seems unexpected, it works fine in development.
A value < `1`, like `0.5` works like expected.

### How?
Update to handle all number above 0.

Closes https://github.com/vercel/next.js/issues/74660
Fixes #74660
