### PR TITLE
docs: mark app router dynamic example as client component

### DIFF
--- a/docs/01-app/03-building-your-application/06-optimizing/07-lazy-loading.mdx
+++ b/docs/01-app/03-building-your-application/06-optimizing/07-lazy-loading.mdx
@@ -127,6 +127,8 @@ export default function Page() {
 ### Adding a custom loading component
 
 ```jsx filename="app/page.js"
+'use client'
+
 import dynamic from 'next/dynamic'
 
 const WithCustomLoading = dynamic(


### PR DESCRIPTION
Update the example of `next/dynamic` usage in app router with "use client" directive, as most of time we use it for client side bundle splitting

[slack-ref](https://vercel.slack.com/archives/C02CDC2ALJH/p1736595720229759)