### PR TITLE
examples: fix `with-zones` repository name in the deploy link

### DIFF
--- a/examples/with-zones/README.md
+++ b/examples/with-zones/README.md
@@ -67,7 +67,7 @@ The `blog` app should be up and running in [http://localhost:4000/blog](http://l
 
 Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example) or preview live with [StackBlitz](https://stackblitz.com/github/vercel/next.js/tree/canary/examples/with-zones)
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/next.js/tree/canary/examples/with-youtube-embed&project-name=with-youtube-embed&repository-name=with-youtube-embed)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/next.js/tree/canary/examples/with-zones&project-name=with-zones&repository-name=with-zones)
 
 ### Deploy Your Local Project
 


### PR DESCRIPTION
## Summary

At #73546, I missed the deploy link of [`with-zones` example README.md](https://github.com/vercel/next.js/blob/canary/examples/with-zones/README.md).
This PR fix it.

CC: @samcx 

### Adding or Updating Examples

- [x] The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- [x] Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md