### PR TITLE
docs: fix typos in 08-mutating-data.mdx

### DIFF
--- a/docs/01-app/01-getting-started/08-mutating-data.mdx
+++ b/docs/01-app/01-getting-started/08-mutating-data.mdx
@@ -38,7 +38,7 @@ export async function deletePost(formData) {}
 Server Functions can be inlined in Server Components by adding the `"use server"` directive to the top of the function body:
 
 ```tsx filename="app/page.tsx" switcher
-export async default function Page() {
+export default function Page() {
   // Server Action
   async function createPost() {
     'use server'
@@ -66,7 +66,7 @@ export default function Page() {
 
 It's not possible to define Server Functions in Client Components. However, you can invoke them in Client Components by importing them from a file that has the `"use server"` directive at the top of it:
 
-```tsx filename="app/actions.ts" switcher
+```ts filename="app/actions.ts" switcher
 'use server'
 
 export async function createPost() {}
@@ -139,7 +139,7 @@ export function Form() {
 }
 ```
 
-```tsx filename="app/actions.ts" switcher
+```ts filename="app/actions.ts" switcher
 'use server'
 
 export async function createPost(formData: FormData) {
@@ -151,7 +151,7 @@ export async function createPost(formData: FormData) {
 }
 ```
 
-```jsx filename="app/actions.js" switcher
+```js filename="app/actions.js" switcher
 'use server'
 
 export async function createPost(formData) {
@@ -189,6 +189,9 @@ export default function LikeButton({ initialLikes }: { initialLikes: number }) {
       >
         Like
       </button>
+    </>
+  )
+}
 ```
 
 ```jsx filename="app/like-button.js" switcher


### PR DESCRIPTION
## Summary

I update the [08-mutating-data.mdx](https://github.com/vercel/next.js/blob/canary/docs/01-app/01-getting-started/08-mutating-data.mdx) at below points.

1. Delete unnecessary `async` word
2. Fix some code block extension
3. Add the missing brackets

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide