### PR TITLE
chore: fix local development warnings inside next monorepo

### DIFF
--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -317,15 +317,21 @@ export async function writeConfigurationDefaults(
   if (process.env.NEXT_PRIVATE_LOCAL_DEV && userTsConfig.exclude) {
     const tsGlob = '**/*.test.ts'
     const tsxGlob = '**/*.test.tsx'
+    let hasUpdates = false
     if (!userTsConfig.exclude.includes(tsGlob)) {
       userTsConfig.exclude.push(tsGlob)
+      hasUpdates = true
     }
     if (!userTsConfig.exclude.includes(tsxGlob)) {
       userTsConfig.exclude.push(tsxGlob)
+      hasUpdates = true
     }
-    requiredActions.push(
-      'Local development only: Excluded test files from coverage'
-    )
+
+    if (hasUpdates) {
+      requiredActions.push(
+        'Local development only: Excluded test files from coverage'
+      )
+    }
   }
 
   if (suggestedActions.length < 1 && requiredActions.length < 1) {


### PR DESCRIPTION
### What

Follow up of #74647, do not enque warnings otherwise it's showing a message of updating `tsconfig.json` inside nextjs monorepo when you do `pnpm next <app path>`

```
   We detected TypeScript in your project and reconfigured your tsconfig.json file for you. Strict-mode is set to false by default.
```

This is because when there's action we'll always log this.