### PR TITLE
fix(example): add missing await keyword within the with-supabase template

### DIFF
--- a/examples/with-supabase/components/tutorial/fetch-data-steps.tsx
+++ b/examples/with-supabase/components/tutorial/fetch-data-steps.tsx
@@ -16,7 +16,7 @@ values
 const server = `import { createClient } from '@/utils/supabase/server'
 
 export default async function Page() {
-  const supabase = createClient()
+  const supabase = await createClient()
   const { data: notes } = await supabase.from('notes').select()
 
   return <pre>{JSON.stringify(notes, null, 2)}</pre>


### PR DESCRIPTION

### What?
There's a missing `await` keyword.
### Why?
It led to an error boundary bug when starting the development server.
### How?
This PR will add the missing keyword.