### PR TITLE
docs: remove duplicate 'to' in data-fetching-and-streaming.mdx

### DIFF
--- a/docs/01-app/01-getting-started/06-data-fetching-and-streaming.mdx
+++ b/docs/01-app/01-getting-started/06-data-fetching-and-streaming.mdx
@@ -10,7 +10,7 @@ related:
     - app/api-reference/file-conventions/loading
 ---
 
-This page will walk you through how you can fetch data in [Server Components](#server-components) and [Client Components](#client-components). As well as how to to [stream](#streaming) content that depends on data.
+This page will walk you through how you can fetch data in [Server Components](#server-components) and [Client Components](#client-components). As well as how to [stream](#streaming) content that depends on data.
 
 ## Fetching data
 


### PR DESCRIPTION
Fix redundant 'to' in sentence