### PR TITLE
Turbopack: capture all references in module graph

### DIFF
--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -35,7 +35,10 @@ pub async fn map_client_references(
         .await?
         .iter_nodes()
         .map(|node| async move {
-            let module = node.module;
+            let Some(module) = node.module() else {
+                return Ok(None);
+            };
+
             if let Some(client_reference_module) =
                 ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(module).await?
             {

--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -35,9 +35,7 @@ pub async fn map_client_references(
         .await?
         .iter_nodes()
         .map(|node| async move {
-            let Some(module) = node.module() else {
-                return Ok(None);
-            };
+            let module = node.module;
 
             if let Some(client_reference_module) =
                 ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(module).await?

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -34,7 +34,7 @@ use turbopack_core::{
         ChunkingContext, ModuleId,
     },
     module::Module,
-    module_graph::{SingleModuleGraph, SingleModuleGraphNode},
+    module_graph::{SingleModuleGraph, SingleModuleGraphModuleNode, SingleModuleGraphNode},
     output::OutputAssets,
 };
 

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -121,7 +121,10 @@ pub async fn map_next_dynamic(graph: Vc<SingleModuleGraph>) -> Result<Vc<Dynamic
         .await?
         .iter_nodes()
         .map(|node| async move {
-            let SingleModuleGraphNode::Module { module, layer, .. } = node else {
+            let SingleModuleGraphNode::Module(SingleModuleGraphModuleNode {
+                module, layer, ..
+            }) = node
+            else {
                 return Ok(None);
             };
 

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -34,7 +34,7 @@ use turbopack_core::{
         ChunkingContext, ModuleId,
     },
     module::Module,
-    module_graph::SingleModuleGraph,
+    module_graph::{SingleModuleGraph, SingleModuleGraphNode},
     output::OutputAssets,
 };
 
@@ -121,14 +121,17 @@ pub async fn map_next_dynamic(graph: Vc<SingleModuleGraph>) -> Result<Vc<Dynamic
         .await?
         .iter_nodes()
         .map(|node| async move {
-            let module = node.module;
-            let layer = node.layer.as_ref();
+            let SingleModuleGraphNode::Module { module, layer, .. } = node else {
+                return Ok(None);
+            };
+
+            let layer = layer.as_ref();
             if layer.is_some_and(|layer| &**layer == "app-client" || &**layer == "client") {
                 if let Some(dynamic_entry_module) =
-                    ResolvedVc::try_downcast_type::<NextDynamicEntryModule>(module).await?
+                    ResolvedVc::try_downcast_type::<NextDynamicEntryModule>(*module).await?
                 {
                     return Ok(Some((
-                        module,
+                        *module,
                         DynamicImportEntriesMapType::DynamicEntry(dynamic_entry_module),
                     )));
                 }
@@ -136,10 +139,10 @@ pub async fn map_next_dynamic(graph: Vc<SingleModuleGraph>) -> Result<Vc<Dynamic
             // TODO add this check once these modules have the correct layer
             // if layer.is_some_and(|layer| &**layer == "app-rsc") {
             if let Some(client_reference_module) =
-                ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(module).await?
+                ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(*module).await?
             {
                 return Ok(Some((
-                    module,
+                    *module,
                     DynamicImportEntriesMapType::ClientReference(client_reference_module),
                 )));
             }

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -34,7 +34,7 @@ use turbopack_core::{
         ChunkingContext, ModuleId,
     },
     module::Module,
-    module_graph::{SingleModuleGraph, SingleModuleGraphModuleNode, SingleModuleGraphNode},
+    module_graph::{SingleModuleGraph, SingleModuleGraphModuleNode},
     output::OutputAssets,
 };
 
@@ -121,15 +121,12 @@ pub async fn map_next_dynamic(graph: Vc<SingleModuleGraph>) -> Result<Vc<Dynamic
         .await?
         .iter_nodes()
         .map(|node| async move {
-            let SingleModuleGraphNode::Module(SingleModuleGraphModuleNode {
-                module, layer, ..
-            }) = node
-            else {
-                return Ok(None);
-            };
+            let SingleModuleGraphModuleNode { module, layer, .. } = node;
 
-            let layer = layer.as_ref();
-            if layer.is_some_and(|layer| &**layer == "app-client" || &**layer == "client") {
+            if layer
+                .as_ref()
+                .is_some_and(|layer| &**layer == "app-client" || &**layer == "client")
+            {
                 if let Some(dynamic_entry_module) =
                     ResolvedVc::try_downcast_type::<NextDynamicEntryModule>(*module).await?
                 {

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -350,11 +350,6 @@ impl ClientReferencesGraph {
                 &mut HashMap::new(),
                 |parent_info, node, state_map| {
                     let module = node.module;
-                    let Some((parent_node, _)) = parent_info else {
-                        state_map.insert(module, None);
-                        return GraphTraversalAction::Continue;
-                    };
-                    let module = node.module;
                     let module_type = data.get(&module);
 
                     let current_server_component = if let Some(
@@ -362,8 +357,11 @@ impl ClientReferencesGraph {
                     ) = module_type
                     {
                         Some(*module)
-                    } else {
+                    } else if let Some((parent_node, _)) = parent_info {
                         *state_map.get(&parent_node.module).unwrap()
+                    } else {
+                        // a root node
+                        None
                     };
 
                     state_map.insert(module, current_server_component);

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -40,16 +40,16 @@ async fn get_module_graph_for_endpoint(
 
     let mut graphs = vec![];
 
-    let mut visited_modules = if !server_utils.is_empty() {
+    let mut visited_modules = VisitedModules::empty();
+
+    if !server_utils.is_empty() {
         let graph = SingleModuleGraph::new_with_entries_visited(
             server_utils.iter().map(|m| **m).collect(),
-            Vc::cell(Default::default()),
+            visited_modules,
         );
         graphs.push(graph);
-        VisitedModules::from_graph(graph)
-    } else {
-        VisitedModules::empty()
-    };
+        visited_modules = VisitedModules::from_graph(graph)
+    }
 
     for module in server_component_entries.iter() {
         let graph = SingleModuleGraph::new_with_entries_visited(

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -18,7 +18,7 @@ use turbopack_core::{
     context::AssetContext,
     issue::Issue,
     module::Module,
-    module_graph::{GraphTraversalAction, SingleModuleGraph, SingleModuleGraphs, VisitedModules},
+    module_graph::{GraphTraversalAction, ModuleGraph, SingleModuleGraph, VisitedModules},
 };
 
 use crate::{
@@ -32,7 +32,7 @@ use crate::{
 #[turbo_tasks::function]
 async fn get_module_graph_for_endpoint(
     entry: ResolvedVc<Box<dyn Module>>,
-) -> Result<Vc<SingleModuleGraphs>> {
+) -> Result<Vc<ModuleGraph>> {
     let ServerEntries {
         server_utils,
         server_component_entries,
@@ -70,7 +70,7 @@ async fn get_module_graph_for_endpoint(
     let graph = SingleModuleGraph::new_with_entries_visited(*entry, vec![*entry], visited_modules);
     graphs.push(graph);
 
-    Ok(SingleModuleGraphs::from_graphs(graphs))
+    Ok(ModuleGraph::from_graphs(graphs))
 }
 
 #[turbo_tasks::value]
@@ -572,7 +572,7 @@ async fn get_reduced_graphs_for_endpoint_inner_operation(
         ),
         NextMode::Build => (
             false,
-            SingleModuleGraphs::from_single_graph(
+            ModuleGraph::from_single_graph(
                 async move {
                     get_global_module_graph(*project)
                         .resolve_strongly_consistent()

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -30,7 +30,7 @@ use turbopack_core::{
     context::AssetContext,
     file_source::FileSource,
     module::Module,
-    module_graph::SingleModuleGraph,
+    module_graph::{SingleModuleGraph, SingleModuleGraphNode},
     output::OutputAsset,
     reference_type::{EcmaScriptModulesReferenceSubType, ReferenceType},
     resolve::ModulePart,
@@ -399,8 +399,12 @@ pub async fn map_server_actions(graph: Vc<SingleModuleGraph>) -> Result<Vc<AllMo
         .iter_nodes()
         .map(|node| {
             async move {
+                let SingleModuleGraphNode::Module { module, layer, .. } = node else {
+                    return Ok(None);
+                };
+
                 // TODO: compare module contexts instead?
-                let layer = match &node.layer {
+                let layer = match &layer {
                     Some(layer) if &**layer == "app-rsc" || &**layer == "app-edge-rsc" => {
                         ActionLayer::Rsc
                     }
@@ -410,9 +414,9 @@ pub async fn map_server_actions(graph: Vc<SingleModuleGraph>) -> Result<Vc<AllMo
                 };
                 // TODO the old implementation did parse_actions(to_rsc_context(module))
                 // is that really necessary?
-                Ok(parse_actions(*node.module)
+                Ok(parse_actions(**module)
                     .await?
-                    .map(|action_map| (node.module, (layer, action_map))))
+                    .map(|action_map| (*module, (layer, action_map))))
             }
         })
         .try_flat_join()

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -30,7 +30,7 @@ use turbopack_core::{
     context::AssetContext,
     file_source::FileSource,
     module::Module,
-    module_graph::{SingleModuleGraph, SingleModuleGraphNode},
+    module_graph::{SingleModuleGraph, SingleModuleGraphModuleNode, SingleModuleGraphNode},
     output::OutputAsset,
     reference_type::{EcmaScriptModulesReferenceSubType, ReferenceType},
     resolve::ModulePart,
@@ -399,7 +399,12 @@ pub async fn map_server_actions(graph: Vc<SingleModuleGraph>) -> Result<Vc<AllMo
         .iter_nodes()
         .map(|node| {
             async move {
-                let SingleModuleGraphNode::Module { module, layer, .. } = node else {
+                let SingleModuleGraphNode::Module(SingleModuleGraphModuleNode {
+                    module,
+                    layer,
+                    ..
+                }) = node
+                else {
                     return Ok(None);
                 };
 

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -30,7 +30,7 @@ use turbopack_core::{
     context::AssetContext,
     file_source::FileSource,
     module::Module,
-    module_graph::{SingleModuleGraph, SingleModuleGraphModuleNode, SingleModuleGraphNode},
+    module_graph::{SingleModuleGraph, SingleModuleGraphModuleNode},
     output::OutputAsset,
     reference_type::{EcmaScriptModulesReferenceSubType, ReferenceType},
     resolve::ModulePart,
@@ -399,14 +399,7 @@ pub async fn map_server_actions(graph: Vc<SingleModuleGraph>) -> Result<Vc<AllMo
         .iter_nodes()
         .map(|node| {
             async move {
-                let SingleModuleGraphNode::Module(SingleModuleGraphModuleNode {
-                    module,
-                    layer,
-                    ..
-                }) = node
-                else {
-                    return Ok(None);
-                };
+                let SingleModuleGraphModuleNode { module, layer, .. } = node;
 
                 // TODO: compare module contexts instead?
                 let layer = match &layer {

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -925,8 +925,7 @@ impl Visit<SingleModuleGraphBuilderNode> for SingleModuleGraphBuilder<'_> {
             SingleModuleGraphBuilderNode::VisitedModule { .. }
             | SingleModuleGraphBuilderNode::Issues(_) => unreachable!(),
         };
-        // TODO make `Self::EdgesFuture + 'this` somehow
-        let visited_modules = self.visited_modules.clone();
+        let visited_modules = self.visited_modules;
         async move {
             Ok(match (module, chunkable_ref_target) {
                 (Some(module), None) => {

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -889,7 +889,7 @@ struct SingleModuleGraphBuilderEdge {
 const COMMON_CHUNKING_TYPE: ChunkingType = ChunkingType::ParallelInheritAsync;
 
 struct SingleModuleGraphBuilder<'a> {
-    visited_modules: &'a HashMap<ResolvedVc<Box<dyn Module>>, GraphNodeIndex>,
+    visited_modules: &'a FxIndexMap<ResolvedVc<Box<dyn Module>>, GraphNodeIndex>,
 }
 impl Visit<SingleModuleGraphBuilderNode> for SingleModuleGraphBuilder<'_> {
     type Edge = SingleModuleGraphBuilderEdge;

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -136,9 +136,11 @@ impl SingleModuleGraph {
             .await?;
 
         let children_nodes_iter = AdjacencyMap::new()
+            .skip_duplicates()
             .visit(root_edges, SingleModuleGraphBuilder { visited_modules })
             .await
-            .completed()?;
+            .completed()?
+            .into_inner();
 
         let mut modules: HashMap<ResolvedVc<Box<dyn Module>>, NodeIndex<u32>> = HashMap::new();
         {

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -626,7 +626,7 @@ impl ModuleGraph {
     ///    - Receives: (originating &SingleModuleGraphNode, edge &ChunkingType), target
     ///      &SingleModuleGraphNode, state &S
     ///    - Can return [GraphTraversalAction]s to control the traversal
-    pub async fn traverse_edges_from_entry_topological<'a, S>(
+    pub async fn traverse_edges_from_entries_topological<'a, S>(
         &self,
         entries: impl IntoIterator<Item = &'a ResolvedVc<Box<dyn Module>>>,
         state: &mut S,

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -659,7 +659,6 @@ impl SingleModuleGraphs {
         let mut expanded = HashSet::new();
         while let Some((pass, parent, current)) = stack.pop() {
             let parent_arg = parent.map(|(parent_node, parent_edge)| {
-                let graph = &graphs[parent_node.graph_idx].graph;
                 (
                     get_node!(graphs, parent_node),
                     graphs[parent_node.graph_idx]

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -260,12 +260,15 @@ impl SingleModuleGraph {
             .context("Couldn't find entry module in graph")
     }
 
-    /// Iterate over all nodes in the graph (potentially in the whole app!).
-    pub fn iter_nodes(&self) -> impl Iterator<Item = &'_ SingleModuleGraphNode> + '_ {
-        self.graph.node_weights()
+    /// Iterate over all nodes in the graph
+    pub fn iter_nodes(&self) -> impl Iterator<Item = &'_ SingleModuleGraphModuleNode> + '_ {
+        self.graph.node_weights().filter_map(|n| match n {
+            SingleModuleGraphNode::Module(node) => Some(node),
+            SingleModuleGraphNode::VisitedModule { .. } => None,
+        })
     }
 
-    /// Enumerate over all nodes in the graph (potentially in the whole app!).
+    /// Enumerate all nodes in the graph
     pub fn enumerate_nodes(
         &self,
     ) -> impl Iterator<Item = (NodeIndex, &'_ SingleModuleGraphNode)> + '_ {


### PR DESCRIPTION
Everything should be in place now to have the module petgraph be 100% accurate even if its split across multiple graphs (i.e. in dev or because of the actions).

Nothing uses this yet, in the future we should measure if there's a perf impact of running next/dynamic, client references, server actions  on the whole graph as opposed to only on the change layout segments (which is what currently happens).

- [x] clean up/ensure that there are always all needed `entries` in the graph struct

Closes PACK-3733