### PR TITLE
[DevTools] Add `CMD + .` keyboard shortcut to show/hide

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -622,5 +622,6 @@
   "621": "Required root params (%s) were not provided in generateStaticParams for %s, please provide at least one value for each.",
   "622": "A required root parameter (%s) was not provided in generateStaticParams for %s, please provide at least one value.",
   "623": "Invalid quality prop (%s) on \\`next/image\\` does not match \\`images.qualities\\` configured in your \\`next.config.js\\`\\nSee more info: https://nextjs.org/docs/messages/next-image-unconfigured-qualities",
-  "624": "Internal Next.js Error: createMutableActionQueue was called more than once"
+  "624": "Internal Next.js Error: createMutableActionQueue was called more than once",
+  "625": "Invalid modifier: %s"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -622,6 +622,5 @@
   "621": "Required root params (%s) were not provided in generateStaticParams for %s, please provide at least one value for each.",
   "622": "A required root parameter (%s) was not provided in generateStaticParams for %s, please provide at least one value.",
   "623": "Invalid quality prop (%s) on \\`next/image\\` does not match \\`images.qualities\\` configured in your \\`next.config.js\\`\\nSee more info: https://nextjs.org/docs/messages/next-image-unconfigured-qualities",
-  "624": "Internal Next.js Error: createMutableActionQueue was called more than once",
-  "625": "Invalid modifier: %s"
+  "624": "Internal Next.js Error: createMutableActionQueue was called more than once"
 }

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -87,10 +87,7 @@ const DevToolsPopover = ({
 
               <IndicatorRow
                 label="Hide Dev Tools"
-                value={
-                  // TODO: replace with cmd+.for mac, ctrl+. for windows & implement hiding + unhiding logic
-                  null
-                }
+                value={<DevToolsShortcutGroup />}
                 onClick={hide}
               />
               <IndicatorRow
@@ -146,4 +143,21 @@ const IssueCount = ({ count }: { count: number }) => {
       </span>
     </span>
   )
+}
+
+function DevToolsShortcutGroup() {
+  return (
+    <span data-nextjs-dev-tools-shortcut-group>
+      <CmdIcon />
+      <DotIcon />
+    </span>
+  )
+}
+
+function CmdIcon() {
+  return <span data-nextjs-dev-tools-icon>⌘</span>
+}
+
+function DotIcon() {
+  return <span data-nextjs-dev-tools-icon>.</span>
 }

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -146,9 +146,19 @@ const IssueCount = ({ count }: { count: number }) => {
 }
 
 function DevToolsShortcutGroup() {
+  const isMac =
+    // Feature detect for `navigator.userAgentData` which is experimental:
+    // https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/platform
+    'userAgentData' in navigator
+      ? (navigator.userAgentData as any).platform === 'macOS'
+      : // This is the least-bad option to detect the modifier key when using `navigator.platform`:
+        // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform#examples
+        navigator.platform.indexOf('Mac') === 0 ||
+        navigator.platform === 'iPhone'
+
   return (
     <span data-nextjs-dev-tools-shortcut-group>
-      <CmdIcon />
+      {isMac ? <CmdIcon /> : <CtrlIcon />}
       <DotIcon />
     </span>
   )
@@ -156,6 +166,10 @@ function DevToolsShortcutGroup() {
 
 function CmdIcon() {
   return <span data-nextjs-dev-tools-icon>⌘</span>
+}
+
+function CtrlIcon() {
+  return <span data-nextjs-dev-tools-icon>ctrl</span>
 }
 
 function DotIcon() {

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -169,7 +169,11 @@ function CmdIcon() {
 }
 
 function CtrlIcon() {
-  return <span data-nextjs-dev-tools-icon>ctrl</span>
+  return (
+    <span data-nextjs-dev-tools-icon data-nextjs-dev-tools-ctrl-icon>
+      ctrl
+    </span>
+  )
 }
 
 function DotIcon() {

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/dev-tools-indicator/styles.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/dev-tools-indicator/styles.ts
@@ -141,4 +141,31 @@ export const styles = css`
     padding: var(--size-1_5);
     background: var(--color-background-100);
   }
+
+  [data-nextjs-dev-tools-shortcut-group] {
+    display: flex;
+    align-items: flex-start;
+    gap: 4px;
+  }
+
+  [data-nextjs-dev-tools-icon] {
+    display: flex;
+    width: var(--size-5);
+    height: var(--size-5);
+    padding: var(--size-1) var(--size-1_5);
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: var(--size-2);
+    border-radius: var(--rounded-md);
+    border: 1px solid var(--color-gray-alpha-400);
+    background: var(--color-background-100);
+
+    color: var(--color-gray-1000);
+    text-align: center;
+    font-size: var(--size-font-small);
+    font-style: normal;
+    font-weight: 400;
+    line-height: var(--size-4);
+  }
 `

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/dev-tools-indicator/styles.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/dev-tools-indicator/styles.ts
@@ -145,27 +145,29 @@ export const styles = css`
   [data-nextjs-dev-tools-shortcut-group] {
     display: flex;
     align-items: flex-start;
-    gap: 4px;
+    gap: var(--size-1);
   }
 
   [data-nextjs-dev-tools-icon] {
     display: flex;
-    width: var(--size-5);
+    min-width: var(--size-5);
     height: var(--size-5);
     padding: var(--size-1) var(--size-1_5);
-    flex-direction: column;
     justify-content: center;
     align-items: center;
-    gap: var(--size-2);
     border-radius: var(--rounded-md);
     border: 1px solid var(--color-gray-alpha-400);
     background: var(--color-background-100);
 
     color: var(--color-gray-1000);
     text-align: center;
-    font-size: var(--size-font-small);
+    font-size: var(--size-font-smaller);
     font-style: normal;
     font-weight: 400;
     line-height: var(--size-4);
+  }
+
+  [data-nextjs-dev-tools-ctrl-icon] {
+    width: 100%;
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/Errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/Errors.tsx
@@ -206,7 +206,7 @@ export function Errors({
   useKeyboardShortcut({
     key: '.',
     modifiers: [MODIFIERS.CTRL_CMD],
-    cb: () => {
+    callback: () => {
       setDisplayState((prev) => (prev === 'hidden' ? 'minimized' : 'hidden'))
     },
   })

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/Errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/Errors.tsx
@@ -26,6 +26,8 @@ import {
 import { extractNextErrorCode } from '../../../../../../lib/error-telemetry-utils'
 import { DevToolsIndicator } from '../components/Errors/dev-tools-indicator/dev-tools-indicator'
 import { ErrorOverlayLayout } from '../components/Errors/error-overlay-layout/error-overlay-layout'
+import { useKeyboardShortcut } from '../hooks/use-keyboard-shortcut'
+import { MODIFIERS } from '../hooks/use-keyboard-shortcut'
 
 export type SupportedErrorEvent = {
   id: number
@@ -199,6 +201,15 @@ export function Errors({
 
   const hide = useCallback(() => setDisplayState('hidden'), [])
   const fullscreen = useCallback(() => setDisplayState('fullscreen'), [])
+
+  // Register `(cmd|ctrl) + .` to show/hide the error indicator.
+  useKeyboardShortcut({
+    key: '.',
+    modifiers: [MODIFIERS.CTRL_CMD],
+    cb: () => {
+      setDisplayState((prev) => (prev === 'hidden' ? 'minimized' : 'hidden'))
+    },
+  })
 
   if (displayState === 'hidden') {
     return null

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/hooks/use-keyboard-shortcut.test.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/hooks/use-keyboard-shortcut.test.ts
@@ -24,7 +24,7 @@ describe('useKeyboardShortcut', () => {
     const { unmount } = renderHook(() =>
       useKeyboardShortcut({
         key: 'k',
-        cb: callback,
+        callback,
         modifiers: [MODIFIERS.CTRL_CMD],
       })
     )
@@ -44,7 +44,7 @@ describe('useKeyboardShortcut', () => {
     renderHook(() =>
       useKeyboardShortcut({
         key: 'k',
-        cb: callback,
+        callback,
         modifiers: [MODIFIERS.CTRL_CMD],
       })
     )
@@ -65,7 +65,7 @@ describe('useKeyboardShortcut', () => {
     renderHook(() =>
       useKeyboardShortcut({
         key: 'k',
-        cb: callback,
+        callback,
         modifiers: [MODIFIERS.CTRL_CMD, MODIFIERS.SHIFT],
       })
     )
@@ -95,7 +95,7 @@ describe('useKeyboardShortcut', () => {
     renderHook(() =>
       useKeyboardShortcut({
         key: 'k',
-        cb: callback,
+        callback,
         modifiers: [MODIFIERS.CTRL_CMD],
       })
     )
@@ -115,7 +115,7 @@ describe('useKeyboardShortcut', () => {
     renderHook(() =>
       useKeyboardShortcut({
         key: 'k',
-        cb: callback,
+        callback,
         modifiers: [MODIFIERS.CTRL_CMD],
       })
     )

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/hooks/use-keyboard-shortcut.test.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/hooks/use-keyboard-shortcut.test.ts
@@ -29,10 +29,11 @@ describe('useKeyboardShortcut', () => {
       })
     )
 
-    expect(addEventListenerSpy).toHaveBeenCalledWith(
-      'keydown',
-      expect.any(Function)
-    )
+    // When used `expect.any(Function)`, received:
+    // error TS21228: [ban-function-calls] Constructing functions from strings can lead to XSS.
+    const eventListener = addEventListenerSpy.mock.calls[0][1]
+    expect(typeof eventListener).toBe('function')
+    expect(addEventListenerSpy).toHaveBeenCalledWith('keydown', eventListener)
 
     unmount()
     expect(removeEventListenerSpy).toHaveBeenCalled()

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/hooks/use-keyboard-shortcut.test.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/hooks/use-keyboard-shortcut.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/no-extraneous-dependencies */
+import { renderHook } from '@testing-library/react'
+import { useKeyboardShortcut } from './use-keyboard-shortcut'
+import { MODIFIERS } from './use-keyboard-shortcut'
+
+describe('useKeyboardShortcut', () => {
+  let addEventListenerSpy: jest.SpyInstance
+  let removeEventListenerSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    addEventListenerSpy = jest.spyOn(window, 'addEventListener')
+    removeEventListenerSpy = jest.spyOn(window, 'removeEventListener')
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should add and remove event listener', () => {
+    const callback = jest.fn()
+    const { unmount } = renderHook(() =>
+      useKeyboardShortcut({
+        key: 'k',
+        cb: callback,
+        modifiers: [MODIFIERS.CTRL_CMD],
+      })
+    )
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      'keydown',
+      expect.any(Function)
+    )
+
+    unmount()
+    expect(removeEventListenerSpy).toHaveBeenCalled()
+  })
+
+  it('should trigger callback when correct key and modifier are pressed', () => {
+    const callback = jest.fn()
+    renderHook(() =>
+      useKeyboardShortcut({
+        key: 'k',
+        cb: callback,
+        modifiers: [MODIFIERS.CTRL_CMD],
+      })
+    )
+
+    // Simulate keydown event with Cmd/Ctrl + K
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'k',
+        metaKey: true,
+      })
+    )
+
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('should work with multiple modifiers', () => {
+    const callback = jest.fn()
+    renderHook(() =>
+      useKeyboardShortcut({
+        key: 'k',
+        cb: callback,
+        modifiers: [MODIFIERS.CTRL_CMD, MODIFIERS.SHIFT],
+      })
+    )
+
+    // Should not trigger with just Cmd/Ctrl
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'k',
+        metaKey: true,
+      })
+    )
+    expect(callback).not.toHaveBeenCalled()
+
+    // Should trigger with Cmd/Ctrl + Shift
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'k',
+        metaKey: true,
+        shiftKey: true,
+      })
+    )
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('should be case insensitive', () => {
+    const callback = jest.fn()
+    renderHook(() =>
+      useKeyboardShortcut({
+        key: 'k',
+        cb: callback,
+        modifiers: [MODIFIERS.CTRL_CMD],
+      })
+    )
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'K', // uppercase
+        metaKey: true,
+      })
+    )
+
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('should prevent default event behavior', () => {
+    const callback = jest.fn()
+    renderHook(() =>
+      useKeyboardShortcut({
+        key: 'k',
+        cb: callback,
+        modifiers: [MODIFIERS.CTRL_CMD],
+      })
+    )
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'k',
+      metaKey: true,
+    })
+    const preventDefaultSpy = jest.spyOn(event, 'preventDefault')
+
+    window.dispatchEvent(event)
+
+    expect(preventDefaultSpy).toHaveBeenCalled()
+  })
+})

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/hooks/use-keyboard-shortcut.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/hooks/use-keyboard-shortcut.ts
@@ -8,13 +8,13 @@ export const MODIFIERS = {
 
 type KeyboardShortcutProps = {
   key: string
-  cb: () => void
+  callback: () => void
   modifiers: (typeof MODIFIERS)[keyof typeof MODIFIERS][]
 }
 
 export function useKeyboardShortcut({
   key,
-  cb,
+  callback,
   modifiers,
 }: KeyboardShortcutProps) {
   useEffect(() => {
@@ -34,11 +34,11 @@ export function useKeyboardShortcut({
 
       if (modifiersPressed && e.key.toLowerCase() === key.toLowerCase()) {
         e.preventDefault()
-        cb()
+        callback()
       }
     }
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [key, cb, modifiers])
+  }, [key, callback, modifiers])
 }

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/hooks/use-keyboard-shortcut.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/hooks/use-keyboard-shortcut.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react'
+
+export const MODIFIERS = {
+  CTRL_CMD: 'CTRL_CMD',
+  ALT: 'ALT',
+  SHIFT: 'SHIFT',
+} as const
+
+type KeyboardShortcutProps = {
+  key: string
+  cb: () => void
+  modifiers: (typeof MODIFIERS)[keyof typeof MODIFIERS][]
+}
+
+export function useKeyboardShortcut({
+  key,
+  cb,
+  modifiers,
+}: KeyboardShortcutProps) {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const modifiersPressed = modifiers.every((modifier) => {
+        switch (modifier) {
+          case MODIFIERS.CTRL_CMD:
+            return e.metaKey || e.ctrlKey
+          case MODIFIERS.ALT:
+            return e.altKey
+          case MODIFIERS.SHIFT:
+            return e.shiftKey
+          default:
+            throw new Error(`Invalid modifier: ${modifier}`)
+        }
+      })
+
+      if (modifiersPressed && e.key.toLowerCase() === key.toLowerCase()) {
+        e.preventDefault()
+        cb()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [key, cb, modifiers])
+}

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/hooks/use-keyboard-shortcut.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/hooks/use-keyboard-shortcut.ts
@@ -28,7 +28,7 @@ export function useKeyboardShortcut({
           case MODIFIERS.SHIFT:
             return e.shiftKey
           default:
-            throw new Error(`Invalid modifier: ${modifier}`)
+            return false
         }
       })
 


### PR DESCRIPTION
This PR added a `cmd + .` keyboard shortcut for the DevTools Indicator.

### Mac Light

https://github.com/user-attachments/assets/5d99098a-3983-460b-ad9c-1d4f7c24220d

### Mac Dark

https://github.com/user-attachments/assets/de71b668-c79a-4962-a105-fc4b2cbd9a64

### Windows Light

https://github.com/user-attachments/assets/6f615f27-2871-41a3-aa39-7592237e63ad

### Windows Dark

https://github.com/user-attachments/assets/d5997095-5161-4d1f-a69c-54e74f032821

Closes NDX-568