### PR TITLE
Polish error feedback row

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/error-overlay-footer/error-feedback/error-feedback.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/error-overlay-footer/error-feedback/error-feedback.tsx
@@ -71,8 +71,8 @@ export function ErrorFeedback({ errorCode }: ErrorFeedbackProps) {
 export const styles = css`
   .error-feedback {
     display: flex;
-    align-items: center;
     gap: var(--size-gap);
+    white-space: nowrap;
   }
 
   .error-feedback-thanks {

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/error-overlay-footer/error-overlay-footer.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/error-overlay-footer/error-overlay-footer.tsx
@@ -3,8 +3,8 @@ import { styles as feedbackStyles } from './error-feedback/error-feedback'
 import { noop as css } from '../../../helpers/noop-template'
 
 export type ErrorOverlayFooterProps = {
-  errorCode: string
-  footerMessage?: string
+  errorCode: string | undefined
+  footerMessage: string | undefined
 }
 
 export function ErrorOverlayFooter({
@@ -13,8 +13,10 @@ export function ErrorOverlayFooter({
 }: ErrorOverlayFooterProps) {
   return (
     <footer className="error-overlay-footer">
-      <p className="error-overlay-footer-message">{footerMessage}</p>
-      <ErrorFeedback errorCode={errorCode} />
+      {footerMessage ? (
+        <p className="error-overlay-footer-message">{footerMessage}</p>
+      ) : null}
+      {errorCode ? <ErrorFeedback errorCode={errorCode} /> : null}
     </footer>
   )
 }
@@ -22,8 +24,10 @@ export function ErrorOverlayFooter({
 export const styles = css`
   .error-overlay-footer {
     display: flex;
-    align-items: center;
+    flex-direction: row;
     justify-content: space-between;
+
+    gap: var(--size-gap);
     padding: var(--size-3);
     background: var(--color-background-200);
     border-top: 1px solid var(--color-gray-400);

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/error-overlay-layout/error-overlay-layout.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/error-overlay-layout/error-overlay-layout.stories.tsx
@@ -22,7 +22,11 @@ export const Default: Story = {
       installed: '15.0.0',
       staleness: 'fresh',
     },
-    children: "Module not found: Cannot find module './missing-module'",
+    children: (
+      <div style={{ margin: '1rem' }}>
+        Module not found: Cannot find module './missing-module'
+      </div>
+    ),
   },
 }
 
@@ -30,5 +34,27 @@ export const Turbopack: Story = {
   args: {
     ...Default.args,
     isTurbopack: true,
+  },
+}
+
+export const NoErrorCode: Story = {
+  args: {
+    ...Default.args,
+    errorCode: undefined,
+  },
+}
+
+export const WithLongFooterMessage: Story = {
+  args: {
+    ...Default.args,
+    footerMessage:
+      'This is a very long footer message that demonstrates how the footer handles lengthy text. It could contain important information about the error or additional context for debugging.',
+  },
+}
+
+export const WithShortFooterMessage: Story = {
+  args: {
+    ...Default.args,
+    footerMessage: 'A brief error description.',
   },
 }

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/error-overlay-layout/error-overlay-layout.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/error-overlay-layout/error-overlay-layout.tsx
@@ -95,10 +95,9 @@ export function ErrorOverlayLayout({
           <ErrorOverlayDialogBody>{children}</ErrorOverlayDialogBody>
 
           <DialogFooter>
-            {/* TODO: errorCode should not be undefined whatsoever */}
             <ErrorOverlayFooter
               footerMessage={footerMessage}
-              errorCode={errorCode!}
+              errorCode={errorCode}
             />
             <ErrorOverlayBottomStacks
               errorsCount={readyErrors?.length ?? 0}


### PR DESCRIPTION
### Updates

1. **Hide "Was it helpful" component for errors without codes**  
   Errors without specific codes (e.g., from third-party libraries) will no longer display the "Was it helpful" component.  

2. **Improved footer styling**  
   Enhanced layout for long footer messages to improve readability and consistency.  

| **Before**                                                                 | **After**                                                                  |
|----------------------------------------------------------------------------|----------------------------------------------------------------------------|
| ![Before](https://github.com/user-attachments/assets/3f72ba33-8eee-4815-ac33-0f91c42b2747) | ![After](https://github.com/user-attachments/assets/e493c6b4-3d2e-46e0-815d-e694bbe6b333) |
