### PR TITLE
[DevOverlay] use buttons for interactive indicator row options

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -163,11 +163,12 @@ const IndicatorRow = ({
   value: React.ReactNode
   onClick?: () => void
 }) => {
+  const Wrapper = onClick ? 'button' : 'div'
   return (
-    <div data-nextjs-dev-tools-row data-clickable={!!onClick} onClick={onClick}>
+    <Wrapper data-nextjs-dev-tools-row onClick={onClick}>
       <span data-nextjs-dev-tools-row-label>{label}</span>
       <span data-nextjs-dev-tools-row-value>{value}</span>
-    </div>
+    </Wrapper>
   )
 }
 

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/dev-tools-indicator/styles.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/dev-tools-indicator/styles.ts
@@ -77,10 +77,6 @@ export const styles = css`
     border-radius: var(--rounded-md);
   }
 
-  [data-nextjs-dev-tools-row][data-clickable='true'] {
-    cursor: pointer;
-  }
-
   [data-nextjs-dev-tools-row]:hover {
     background-color: var(--color-gray-100);
   }


### PR DESCRIPTION
Removes the need for custom CSS to style these and also enables keyboard interactivity. 