### PR TITLE
docs: remove duplicate `scroll` section from link.mdx

### DIFF
--- a/docs/01-app/04-api-reference/02-components/link.mdx
+++ b/docs/01-app/04-api-reference/02-components/link.mdx
@@ -370,34 +370,6 @@ An `<a>` element is no longer required as a child of `<Link>`. Add the `legacyBe
 
 Forces `Link` to send the `href` property to its child. Defaults to `false`. See the [passing a functional component](#nesting-a-functional-component) example for more information.
 
-### `scroll`
-
-Scroll to the top of the page after a navigation. Defaults to `true`.
-
-```tsx filename="pages/index.tsx" switcher
-import Link from 'next/link'
-
-export default function Home() {
-  return (
-    <Link href="/dashboard" scroll={false}>
-      Dashboard
-    </Link>
-  )
-}
-```
-
-```jsx filename="pages/index.js" switcher
-import Link from 'next/link'
-
-export default function Home() {
-  return (
-    <Link href="/dashboard" scroll={false}>
-      Dashboard
-    </Link>
-  )
-}
-```
-
 ### `shallow`
 
 Update the path of the current page without rerunning [`getStaticProps`](/docs/pages/building-your-application/data-fetching/get-static-props), [`getServerSideProps`](/docs/pages/building-your-application/data-fetching/get-server-side-props) or [`getInitialProps`](/docs/pages/api-reference/functions/get-initial-props). Defaults to `false`.


### PR DESCRIPTION
## What is the documentation issue?

<details><summary>#74861 description</summary>
<p>

There are two `scroll` sections in the pages reference for the [`Link` documentation](https://nextjs.org/docs/pages/api-reference/components/link), with different descriptions, namely https://nextjs.org/docs/pages/api-reference/components/link#scroll and https://nextjs.org/docs/pages/api-reference/components/link#scroll-1

</p>
</details> 

## Why?

A new scroll section was created at #53804.
However, this commit forgot to remove an old scroll section.

## How do you solve it?

Remove an old scroll section.

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

Fixes #74861