### PR TITLE
[DevOverlay] Gather Feedback per Error

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/error-overlay-footer/error-feedback/error-feedback.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/Errors/error-overlay-footer/error-feedback/error-feedback.tsx
@@ -7,13 +7,18 @@ interface ErrorFeedbackProps {
   errorCode: string
 }
 export function ErrorFeedback({ errorCode }: ErrorFeedbackProps) {
-  const [voted, setVoted] = useState<boolean | null>(null)
-  const hasVoted = voted !== null
+  const [votedMap, setVotedMap] = useState<Record<string, boolean>>({})
+  const voted = votedMap[errorCode]
+  const hasVoted = voted !== undefined
 
   const handleFeedback = useCallback(
     async (wasHelpful: boolean) => {
       // Optimistically set feedback state without loading/error states to keep implementation simple
-      setVoted(wasHelpful)
+      setVotedMap((prev) => ({
+        ...prev,
+        [errorCode]: wasHelpful,
+      }))
+
       try {
         const response = await fetch(
           `${process.env.__NEXT_ROUTER_BASEPATH || ''}/__nextjs_error_feedback?${new URLSearchParams(
@@ -36,35 +41,33 @@ export function ErrorFeedback({ errorCode }: ErrorFeedbackProps) {
   )
 
   return (
-    <>
-      <div className="error-feedback" role="region" aria-label="Error feedback">
-        {hasVoted ? (
-          <p className="error-feedback-thanks" role="status" aria-live="polite">
-            Thanks for your feedback!
-          </p>
-        ) : (
-          <>
-            <p>Was this helpful?</p>
-            <button
-              aria-label="Mark as helpful"
-              onClick={() => handleFeedback(true)}
-              className={`feedback-button ${voted === true ? 'voted' : ''}`}
-              type="button"
-            >
-              <ThumbsUp aria-hidden="true" />
-            </button>
-            <button
-              aria-label="Mark as not helpful"
-              onClick={() => handleFeedback(false)}
-              className={`feedback-button ${voted === false ? 'voted' : ''}`}
-              type="button"
-            >
-              <ThumbsDown aria-hidden="true" />
-            </button>
-          </>
-        )}
-      </div>
-    </>
+    <div className="error-feedback" role="region" aria-label="Error feedback">
+      {hasVoted ? (
+        <p className="error-feedback-thanks" role="status" aria-live="polite">
+          Thanks for your feedback!
+        </p>
+      ) : (
+        <>
+          <p>Was this helpful?</p>
+          <button
+            aria-label="Mark as helpful"
+            onClick={() => handleFeedback(true)}
+            className={`feedback-button ${voted === true ? 'voted' : ''}`}
+            type="button"
+          >
+            <ThumbsUp aria-hidden="true" />
+          </button>
+          <button
+            aria-label="Mark as not helpful"
+            onClick={() => handleFeedback(false)}
+            className={`feedback-button ${voted === false ? 'voted' : ''}`}
+            type="button"
+          >
+            <ThumbsDown aria-hidden="true" />
+          </button>
+        </>
+      )}
+    </div>
   )
 }
 

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/Errors.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/Errors.stories.tsx
@@ -22,7 +22,9 @@ export const Default: Story = {
         id: 1,
         event: {
           type: ACTION_UNHANDLED_ERROR,
-          reason: new Error('First error message'),
+          reason: Object.assign(new Error('First error message'), {
+            __NEXT_ERROR_CODE: 'E001',
+          }),
           componentStackFrames: [
             {
               file: 'app/page.tsx',
@@ -47,7 +49,9 @@ export const Default: Story = {
         id: 2,
         event: {
           type: ACTION_UNHANDLED_ERROR,
-          reason: new Error('Second error message'),
+          reason: Object.assign(new Error('Second error message'), {
+            __NEXT_ERROR_CODE: 'E002',
+          }),
           frames: [],
         },
       },
@@ -55,7 +59,9 @@ export const Default: Story = {
         id: 3,
         event: {
           type: ACTION_UNHANDLED_ERROR,
-          reason: new Error('Third error message'),
+          reason: Object.assign(new Error('Third error message'), {
+            __NEXT_ERROR_CODE: 'E003',
+          }),
           frames: [],
         },
       },
@@ -63,7 +69,9 @@ export const Default: Story = {
         id: 4,
         event: {
           type: ACTION_UNHANDLED_ERROR,
-          reason: new Error('Fourth error message'),
+          reason: Object.assign(new Error('Fourth error message'), {
+            __NEXT_ERROR_CODE: 'E004',
+          }),
           frames: [],
         },
       },


### PR DESCRIPTION
Gather feedback per error, not the whole overlay. Added map to store `errorCode` value as key and boolean for `voted`.

### Before

https://github.com/user-attachments/assets/f2b3a2b3-23e5-4639-84f3-680832e5c651

### After

https://github.com/user-attachments/assets/1a2c55dd-c297-4bcc-a65f-bc192dad7015

Closes NDX-621