### PR TITLE
Ensure client reference manifest is traced for global not found page

### DIFF
--- a/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -249,12 +249,13 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
               entrypoint.name
             ]?.replace(this.appDir, '')
 
+          const entryIsStaticMetadataRoute =
+            appDirRelativeEntryPath &&
+            isStaticMetadataRoute(appDirRelativeEntryPath)
+
           // Include the client reference manifest in the trace, but not for
           // static metadata routes, for which we don't generate those.
-          if (
-            appDirRelativeEntryPath &&
-            !isStaticMetadataRoute(appDirRelativeEntryPath)
-          ) {
+          if (!entryIsStaticMetadataRoute) {
             entryFiles.add(
               nodePath.join(
                 outputPath,

--- a/test/e2e/app-dir/prefetching-not-found/prefetching-not-found.test.ts
+++ b/test/e2e/app-dir/prefetching-not-found/prefetching-not-found.test.ts
@@ -24,8 +24,10 @@ describe('prefetching-not-found', () => {
       expect(await browser.elementByCss('h1').text()).toBe('Home Page')
     })
 
-    // assert the same behavior, but starting at the not found page. This is to ensure that when we seed the prefetch cache,
-    // we don't have any cache collisions that would cause the not-found page to remain rendered when following a link to the home page
+    // Assert the same behavior, but starting at the not found page. This is to
+    // ensure that when we seed the prefetch cache, we don't have any cache
+    // collisions that would cause the not-found page to remain rendered when
+    // following a link to the home page.
     browser = await next.browser('/fake-link')
     expect(await browser.elementByCss('body').text()).toContain(
       'This page could not be found.'


### PR DESCRIPTION
Follow-up fix for #74876. Not all app dir entries have an `absolutePagePath` in their module build info, e.g. the global not found page does not have one. But we still need to include the client reference manifest in the trace for those entries.

[x-ref](https://vercel.com/vtest314-next-e2e-tests/vtest314-e2e-tests/EngjzrvvzQ4GQra6tnGCy98PR6yd/logs?startDate=1736936280&endDate=1736938140&selectedLogId=fl27k-1736937944551-421fa6816369)