### PR TITLE
[Turbopack] fix unemit collectible

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -203,6 +203,14 @@ impl AggregatedDataUpdate {
             for collectible in collectibles {
                 collectibles_update.push((collectible, 1));
             }
+            collectibles_update.extend(iter_many!(
+                task,
+                Collectible {
+                    collectible
+                } count => {
+                    (collectible, *count)
+                }
+            ));
         }
         if let Some(dirty) = get!(task, Dirty) {
             dirty_container_count.update_with_dirty_state(dirty);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_collectible.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_collectible.rs
@@ -5,8 +5,8 @@ use turbo_tasks::TaskId;
 use crate::{
     backend::{
         operation::{
-            AggregatedDataUpdate, AggregationUpdateJob, AggregationUpdateQueue, ExecuteContext,
-            Operation,
+            get_aggregation_number, is_root_node, AggregatedDataUpdate, AggregationUpdateJob,
+            AggregationUpdateQueue, ExecuteContext, Operation,
         },
         storage::{get, update_count},
         TaskDataCategory,
@@ -27,8 +27,34 @@ impl UpdateCollectibleOperation {
             // Collectibles are not supported without children tracking
             return;
         }
-        let mut queue = AggregationUpdateQueue::new();
         let mut task = ctx.task(task_id, TaskDataCategory::All);
+        if count < 0 {
+            // Ensure it's an root node
+            loop {
+                let aggregation_number = get_aggregation_number(&task);
+                if is_root_node(aggregation_number) {
+                    break;
+                }
+                drop(task);
+                {
+                    let _span = tracing::trace_span!(
+                        "make root node for removing collectible",
+                        %task_id
+                    )
+                    .entered();
+                    AggregationUpdateQueue::run(
+                        AggregationUpdateJob::UpdateAggregationNumber {
+                            task_id,
+                            base_aggregation_number: u32::MAX,
+                            distance: None,
+                        },
+                        &mut ctx,
+                    );
+                }
+                task = ctx.task(task_id, TaskDataCategory::All);
+            }
+        }
+        let mut queue = AggregationUpdateQueue::new();
         let outdated = get!(task, OutdatedCollectible { collectible }).copied();
         if let Some(outdated) = outdated {
             if count > 0 && outdated > 0 {


### PR DESCRIPTION
### What?

tasks with negative collectible count need to be root tasks so they eliminate the count correctly. Otherwise the child we want to override the collectibles from could be attached multiple times in the graph duplicating the collectible.

Closes PACK-3735