### PR TITLE
fix: static indicator for new overlay decoupled from appIsrStatus

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
@@ -335,7 +335,10 @@ function processMessage(
 
   switch (obj.action) {
     case HMR_ACTIONS_SENT_TO_BROWSER.APP_ISR_MANIFEST: {
-      if (process.env.__NEXT_APP_ISR_INDICATOR) {
+      if (
+        process.env.__NEXT_APP_ISR_INDICATOR ||
+        process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY
+      ) {
         if (appIsrManifestRef) {
           appIsrManifestRef.current = obj.data
 
@@ -344,18 +347,22 @@ function processMessage(
           // as we'll receive the updated manifest before usePathname
           // triggers for new value
           if ((pathnameRef.current as string) in obj.data) {
-            // the indicator can be hidden for an hour.
-            // check if it's still hidden
-            const indicatorHiddenAt = Number(
-              localStorage?.getItem('__NEXT_DISMISS_PRERENDER_INDICATOR')
-            )
+            if (process.env.__NEXT_APP_ISR_INDICATOR) {
+              // the indicator can be hidden for an hour.
+              // check if it's still hidden
+              const indicatorHiddenAt = Number(
+                localStorage?.getItem('__NEXT_DISMISS_PRERENDER_INDICATOR')
+              )
 
-            const isHidden =
-              indicatorHiddenAt &&
-              !isNaN(indicatorHiddenAt) &&
-              Date.now() < indicatorHiddenAt
+              const isHidden =
+                indicatorHiddenAt &&
+                !isNaN(indicatorHiddenAt) &&
+                Date.now() < indicatorHiddenAt
 
-            if (!isHidden) {
+              if (!isHidden) {
+                dispatcher.onStaticIndicator(true)
+              }
+            } else if (process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY) {
               dispatcher.onStaticIndicator(true)
             }
           } else {
@@ -625,7 +632,10 @@ export default function HotReload({
   const appIsrManifestRef = useRef<Record<string, false | number>>({})
   const pathnameRef = useRef(pathname)
 
-  if (process.env.__NEXT_APP_ISR_INDICATOR) {
+  if (
+    process.env.__NEXT_APP_ISR_INDICATOR ||
+    process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY
+  ) {
     // this conditional is only for dead-code elimination which
     // isn't a runtime conditional only build-time so ignore hooks rule
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -637,16 +647,20 @@ export default function HotReload({
       if (appIsrManifest) {
         if (pathname && pathname in appIsrManifest) {
           try {
-            const indicatorHiddenAt = Number(
-              localStorage?.getItem('__NEXT_DISMISS_PRERENDER_INDICATOR')
-            )
+            if (process.env.__NEXT_APP_ISR_INDICATOR) {
+              const indicatorHiddenAt = Number(
+                localStorage?.getItem('__NEXT_DISMISS_PRERENDER_INDICATOR')
+              )
 
-            const isHidden =
-              indicatorHiddenAt &&
-              !isNaN(indicatorHiddenAt) &&
-              Date.now() < indicatorHiddenAt
+              const isHidden =
+                indicatorHiddenAt &&
+                !isNaN(indicatorHiddenAt) &&
+                Date.now() < indicatorHiddenAt
 
-            if (!isHidden) {
+              if (!isHidden) {
+                dispatcher.onStaticIndicator(true)
+              }
+            } else if (process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY) {
               dispatcher.onStaticIndicator(true)
             }
           } catch (reason) {


### PR DESCRIPTION
The prerender indicator was controlled by https://nextjs.org/docs/app/api-reference/config/next-config-js/devIndicators#appisrstatus-static-indicator.

With the new dev overlay, the route type should work regardless of `NextConfig#devIndicators#appIsrStatus`, so this PR ensures the status wiring is enabled even when `appIsrStatus` is disabled.

Note: Will follow up with a test soon.

![CleanShot 2025-01-15 at 10.19.29@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/rKSEEwxbNzdFs9t0yyxN/d01aff4d-e787-4e46-9c8c-fb4e5cab9767.png)

