### PR TITLE
[Turbopack] refactor to pass ModuleGraph to chunk_group

### DIFF
--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -109,6 +109,8 @@ impl InstrumentationEndpoint {
 
         let module = self.core_modules().await?.edge_entry_module;
 
+        let module_graph = this.project.module_graph(*module);
+
         let mut evaluatable_assets = get_server_runtime_entries(
             Value::new(ServerContextType::Instrumentation {
                 app_dir: this.app_dir,
@@ -137,6 +139,7 @@ impl InstrumentationEndpoint {
         let edge_files = edge_chunking_context.evaluated_chunk_group_assets(
             module.ident(),
             Vc::cell(evaluatable_assets),
+            module_graph,
             Value::new(AvailabilityInfo::Root),
         );
 
@@ -150,6 +153,7 @@ impl InstrumentationEndpoint {
         let chunking_context = this.project.server_chunking_context(false);
 
         let userland_module = self.core_modules().await?.userland_module;
+        let module_graph = this.project.module_graph(*userland_module);
 
         let Some(module) = ResolvedVc::try_downcast(userland_module).await? else {
             bail!("Entry module must be evaluatable");
@@ -170,6 +174,7 @@ impl InstrumentationEndpoint {
                     this.project.next_mode(),
                 )
                 .resolve_entries(*this.asset_context),
+                module_graph,
                 OutputAssets::empty(),
                 Value::new(AvailabilityInfo::Root),
             )

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -109,11 +109,15 @@ impl MiddlewareEndpoint {
             .context("Entry module must be evaluatable")?;
         evaluatable_assets.push(evaluatable.to_resolved().await?);
 
+        let evaluatable_assets = Vc::cell(evaluatable_assets);
+        let module_graph = self.project.module_graph_for_entries(evaluatable_assets);
+
         let edge_chunking_context = self.project.edge_chunking_context(false);
 
         let edge_files = edge_chunking_context.evaluated_chunk_group_assets(
             module.ident(),
-            Vc::cell(evaluatable_assets),
+            evaluatable_assets,
+            module_graph,
             Value::new(AvailabilityInfo::Root),
         );
 

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -199,10 +199,7 @@ impl ServerActionsGraph {
     ) -> Result<Vc<AllActions>> {
         let span = tracing::info_span!("collect server actions for endpoint");
         async move {
-            let data: &HashMap<
-                ResolvedVc<Box<dyn Module>>,
-                (ActionLayer, ResolvedVc<crate::server_actions::ActionMap>),
-            > = &*self.data.await?;
+            let data = &*self.data.await?;
             let data = if self.is_single_page {
                 // The graph contains the page (= `entry`) only, no need to filter.
                 Cow::Borrowed(data)

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -2,7 +2,6 @@ use std::{borrow::Cow, collections::HashMap};
 
 use anyhow::Result;
 use next_core::{
-    mode::NextMode,
     next_client_reference::{
         find_server_entries, ClientReference, ClientReferenceGraphResult, ClientReferenceType,
         ServerEntries, VisitedClientReferenceGraphNodes,
@@ -18,58 +17,14 @@ use turbopack_core::{
     context::AssetContext,
     issue::Issue,
     module::Module,
-    module_graph::{GraphTraversalAction, ModuleGraph, SingleModuleGraph, VisitedModules},
+    module_graph::{GraphTraversalAction, ModuleGraph, SingleModuleGraph},
 };
 
 use crate::{
     client_references::{map_client_references, ClientReferenceMapType, ClientReferencesSet},
     dynamic_imports::{map_next_dynamic, DynamicImportEntries, DynamicImportEntriesMapType},
-    project::Project,
     server_actions::{map_server_actions, to_rsc_context, AllActions, AllModuleActions},
 };
-
-/// Implements layout segment optimization to compute a graph "chain" for each layout segment
-#[turbo_tasks::function]
-async fn get_module_graph_for_endpoint(
-    entry: ResolvedVc<Box<dyn Module>>,
-) -> Result<Vc<ModuleGraph>> {
-    let ServerEntries {
-        server_utils,
-        server_component_entries,
-    } = &*find_server_entries(*entry).await?;
-
-    let mut graphs = vec![];
-
-    let mut visited_modules = VisitedModules::empty();
-
-    if !server_utils.is_empty() {
-        let graph = SingleModuleGraph::new_with_entries_visited(
-            server_utils.iter().map(|m| **m).collect(),
-            visited_modules,
-        );
-        graphs.push(graph);
-        visited_modules = VisitedModules::from_graph(graph)
-    }
-
-    for module in server_component_entries.iter() {
-        let graph = SingleModuleGraph::new_with_entries_visited(
-            vec![Vc::upcast(**module)],
-            visited_modules,
-        );
-        graphs.push(graph);
-        let is_layout = module.server_path().file_stem().await?.as_deref() == Some("layout");
-        if is_layout {
-            // Only propagate the visited_modules of the parent layout(s), not across siblings such
-            // as loading.js and page.js.
-            visited_modules = visited_modules.concatenate(graph);
-        }
-    }
-
-    let graph = SingleModuleGraph::new_with_entries_visited(vec![*entry], visited_modules);
-    graphs.push(graph);
-
-    Ok(ModuleGraph::from_graphs(graphs))
-}
 
 #[turbo_tasks::value]
 pub struct NextDynamicGraph {
@@ -244,7 +199,10 @@ impl ServerActionsGraph {
     ) -> Result<Vc<AllActions>> {
         let span = tracing::info_span!("collect server actions for endpoint");
         async move {
-            let data = &*self.data.await?;
+            let data: &HashMap<
+                ResolvedVc<Box<dyn Module>>,
+                (ActionLayer, ResolvedVc<crate::server_actions::ActionMap>),
+            > = &*self.data.await?;
             let data = if self.is_single_page {
                 // The graph contains the page (= `entry`) only, no need to filter.
                 Cow::Borrowed(data)
@@ -559,42 +517,14 @@ impl ReducedGraphs {
     }
 }
 
-// This is a performance optimization. This function is a root aggregation function that aggregates
-// over the whole subgraph.
-#[turbo_tasks::function]
-async fn get_global_module_graph(project: ResolvedVc<Project>) -> Vc<SingleModuleGraph> {
-    SingleModuleGraph::new_with_entries(project.get_all_entries())
-}
-
 #[turbo_tasks::function(operation)]
 async fn get_reduced_graphs_for_endpoint_inner_operation(
-    project: ResolvedVc<Project>,
-    entry: ResolvedVc<Box<dyn Module>>,
+    module_graph: ResolvedVc<ModuleGraph>,
+    is_single_page: bool,
 ) -> Result<Vc<ReducedGraphs>> {
-    let (is_single_page, graph) = match &*project.next_mode().await? {
-        NextMode::Development => (
-            true,
-            async move { get_module_graph_for_endpoint(*entry).await }
-                .instrument(tracing::info_span!("module graph for endpoint"))
-                .await?,
-        ),
-        NextMode::Build => (
-            false,
-            ModuleGraph::from_single_graph(
-                async move {
-                    get_global_module_graph(*project)
-                        .resolve_strongly_consistent()
-                        .await
-                }
-                .instrument(tracing::info_span!("module graph for app"))
-                .await?,
-            )
-            .await?,
-        ),
-    };
-
+    let module_graph = module_graph.await?;
     let next_dynamic = async {
-        graph
+        module_graph
             .graphs
             .iter()
             .map(|graph| NextDynamicGraph::new_with_entries(**graph, is_single_page).to_resolved())
@@ -605,7 +535,7 @@ async fn get_reduced_graphs_for_endpoint_inner_operation(
     .await?;
 
     let server_actions = async {
-        graph
+        module_graph
             .graphs
             .iter()
             .map(|graph| {
@@ -618,7 +548,7 @@ async fn get_reduced_graphs_for_endpoint_inner_operation(
     .await?;
 
     let client_references = async {
-        graph
+        module_graph
             .graphs
             .iter()
             .map(|graph| {
@@ -643,14 +573,14 @@ async fn get_reduced_graphs_for_endpoint_inner_operation(
 /// references, etc).
 #[turbo_tasks::function]
 pub async fn get_reduced_graphs_for_endpoint(
-    project: ResolvedVc<Project>,
-    entry: ResolvedVc<Box<dyn Module>>,
+    module_graph: ResolvedVc<ModuleGraph>,
+    is_single_page: bool,
 ) -> Result<Vc<ReducedGraphs>> {
     // TODO get rid of this function once everything inside of
     // `get_reduced_graphs_for_endpoint_inner` calls `take_collectibles()` when needed
-    let result_op = get_reduced_graphs_for_endpoint_inner_operation(project, entry);
+    let result_op = get_reduced_graphs_for_endpoint_inner_operation(module_graph, is_single_page);
     let result_vc = result_op.connect();
-    if project.next_mode().await?.is_production() {
+    if !is_single_page {
         result_vc.strongly_consistent().await?;
         let _issues = result_op.take_collectibles::<Box<dyn Issue>>();
     }

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -30,7 +30,7 @@ use turbopack_core::{
     context::AssetContext,
     file_source::FileSource,
     module::Module,
-    module_graph::{SingleModuleGraph, SingleModuleGraphModuleNode},
+    module_graph::{ModuleGraph, SingleModuleGraph, SingleModuleGraphModuleNode},
     output::OutputAsset,
     reference_type::{EcmaScriptModulesReferenceSubType, ReferenceType},
     resolve::ModulePart,
@@ -63,6 +63,7 @@ pub(crate) async fn create_server_actions_manifest(
     page_name: RcStr,
     runtime: NextRuntime,
     rsc_asset_context: Vc<Box<dyn AssetContext>>,
+    module_graph: Vc<ModuleGraph>,
     chunking_context: Vc<Box<dyn ChunkingContext>>,
 ) -> Result<Vc<ServerActionsManifest>> {
     let loader =
@@ -73,7 +74,7 @@ pub(crate) async fn create_server_actions_manifest(
         .to_resolved()
         .await?;
 
-    let chunk_item = loader.as_chunk_item(Vc::upcast(chunking_context));
+    let chunk_item = loader.as_chunk_item(module_graph, Vc::upcast(chunking_context));
     let manifest = build_manifest(node_root, page_name, runtime, actions, chunk_item).await?;
     Ok(ServerActionsManifest {
         loader: evaluable,

--- a/crates/next-core/src/next_app/app_client_shared_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_shared_chunks.rs
@@ -5,6 +5,7 @@ use turbopack_core::{
         availability_info::AvailabilityInfo, ChunkGroupResult, ChunkingContext, EvaluatableAssets,
     },
     ident::AssetIdent,
+    module_graph::ModuleGraph,
     output::OutputAssets,
 };
 
@@ -12,6 +13,7 @@ use turbopack_core::{
 pub async fn get_app_client_shared_chunk_group(
     ident: Vc<AssetIdent>,
     app_client_runtime_entries: Vc<EvaluatableAssets>,
+    module_graph: Vc<ModuleGraph>,
     client_chunking_context: Vc<Box<dyn ChunkingContext>>,
 ) -> Result<Vc<ChunkGroupResult>> {
     if app_client_runtime_entries.await?.is_empty() {
@@ -26,6 +28,7 @@ pub async fn get_app_client_shared_chunk_group(
     let app_client_shared_chunk_grou = client_chunking_context.evaluated_chunk_group(
         ident,
         app_client_runtime_entries,
+        module_graph,
         Value::new(AvailabilityInfo::Root),
     );
 

--- a/crates/next-core/src/next_app/include_modules_module.rs
+++ b/crates/next-core/src/next_app/include_modules_module.rs
@@ -7,6 +7,7 @@ use turbopack_core::{
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkableModuleReference, ChunkingContext},
     ident::AssetIdent,
     module::Module,
+    module_graph::ModuleGraph,
     reference::{ModuleReference, ModuleReferences},
     resolve::ModuleResolveResult,
 };
@@ -81,6 +82,7 @@ impl ChunkableModule for IncludeModulesModule {
     #[turbo_tasks::function]
     fn as_chunk_item(
         self: ResolvedVc<Self>,
+        _module_graph: Vc<ModuleGraph>,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn ChunkItem>> {
         Vc::upcast(

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
@@ -14,6 +14,7 @@ use turbopack_core::{
     context::AssetContext,
     ident::AssetIdent,
     module::Module,
+    module_graph::ModuleGraph,
     reference::ModuleReferences,
     reference_type::ReferenceType,
     virtual_source::VirtualSource,
@@ -236,9 +237,12 @@ impl ChunkableModule for EcmascriptClientReferenceProxyModule {
     #[turbo_tasks::function]
     async fn as_chunk_item(
         self: ResolvedVc<Self>,
+        module_graph: Vc<ModuleGraph>,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn ChunkItem>>> {
-        let item = self.proxy_module().as_chunk_item(*chunking_context);
+        let item = self
+            .proxy_module()
+            .as_chunk_item(module_graph, *chunking_context);
         let ecmascript_item = Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkItem>>(item)
             .await?
             .context("EcmascriptModuleAsset must implement EcmascriptChunkItem")?

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -19,6 +19,7 @@ use turbopack_core::{
     context::AssetContext,
     ident::AssetIdent,
     issue::{IssueExt, IssueSeverity},
+    module_graph::ModuleGraph,
     reference_type::{InnerAssets, ReferenceType},
     resolve::{
         options::{ImportMapResult, ImportMappingReplacement, ReplacedImportMapping},
@@ -694,12 +695,14 @@ async fn get_mock_stylesheet(
         .module();
 
     let root = mock_fs.root();
+    let module_graph = ModuleGraph::from_module(mocked_response_asset);
     let val = evaluate(
         mocked_response_asset,
         root,
         *env,
         AssetIdent::from_path(loader_path),
         asset_context,
+        module_graph,
         *chunking_context,
         None,
         vec![],

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -1,6 +1,6 @@
 //! Type definitions for the Next.js manifest formats.
 
-pub(crate) mod client_reference_manifest;
+pub mod client_reference_manifest;
 
 use std::collections::HashMap;
 

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -10,6 +10,7 @@ use turbopack_core::{
     chunk::{ChunkItem, ChunkItemExt, ChunkType, ChunkableModule, ChunkingContext},
     ident::AssetIdent,
     module::{Module, Modules},
+    module_graph::ModuleGraph,
     reference::ModuleReferences,
 };
 use turbopack_ecmascript::{
@@ -98,10 +99,12 @@ impl ChunkableModule for NextServerComponentModule {
     #[turbo_tasks::function]
     fn as_chunk_item(
         self: ResolvedVc<Self>,
+        module_graph: ResolvedVc<ModuleGraph>,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
         Vc::upcast(
             NextServerComponentChunkItem {
+                module_graph,
                 chunking_context,
                 inner: self,
             }
@@ -139,6 +142,7 @@ impl EcmascriptChunkPlaceable for NextServerComponentModule {
 
 #[turbo_tasks::value]
 struct NextServerComponentChunkItem {
+    module_graph: ResolvedVc<ModuleGraph>,
     chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     inner: ResolvedVc<NextServerComponentModule>,
 }
@@ -156,7 +160,7 @@ impl EcmascriptChunkItem for NextServerComponentChunkItem {
 
         let module_id = inner
             .module
-            .as_chunk_item(Vc::upcast(*self.chunking_context))
+            .as_chunk_item(*self.module_graph, Vc::upcast(*self.chunking_context))
             .id()
             .await?;
         Ok(EcmascriptChunkItemContent {

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -14,6 +14,7 @@ use turbopack_core::{
     environment::Environment,
     ident::AssetIdent,
     module::Module,
+    module_graph::ModuleGraph,
     output::{OutputAsset, OutputAssets},
 };
 use turbopack_ecmascript::{
@@ -222,12 +223,15 @@ impl BrowserChunkingContext {
         ident: Vc<AssetIdent>,
         other_chunks: Vc<OutputAssets>,
         evaluatable_assets: Vc<EvaluatableAssets>,
+        // TODO(sokra) remove this argument and pass chunk items instead
+        module_graph: Vc<ModuleGraph>,
     ) -> Vc<Box<dyn OutputAsset>> {
         Vc::upcast(EcmascriptDevEvaluateChunk::new(
             self,
             ident,
             other_chunks,
             evaluatable_assets,
+            module_graph,
         ))
     }
 
@@ -393,6 +397,7 @@ impl ChunkingContext for BrowserChunkingContext {
         self: ResolvedVc<Self>,
         ident: Vc<AssetIdent>,
         module: ResolvedVc<Box<dyn ChunkableModule>>,
+        module_graph: Vc<ModuleGraph>,
         availability_info: Value<AvailabilityInfo>,
     ) -> Result<Vc<ChunkGroupResult>> {
         let span = tracing::info_span!("chunking", ident = ident.to_string().await?.to_string());
@@ -403,8 +408,9 @@ impl ChunkingContext for BrowserChunkingContext {
                 chunks,
                 availability_info,
             } = make_chunk_group(
-                ResolvedVc::upcast(self),
                 [ResolvedVc::upcast(module)],
+                module_graph,
+                ResolvedVc::upcast(self),
                 input_availability_info,
             )
             .await?;
@@ -455,6 +461,7 @@ impl ChunkingContext for BrowserChunkingContext {
         self: ResolvedVc<Self>,
         ident: Vc<AssetIdent>,
         evaluatable_assets: Vc<EvaluatableAssets>,
+        module_graph: Vc<ModuleGraph>,
         availability_info: Value<AvailabilityInfo>,
     ) -> Result<Vc<ChunkGroupResult>> {
         let span = {
@@ -474,7 +481,13 @@ impl ChunkingContext for BrowserChunkingContext {
             let MakeChunkGroupResult {
                 chunks,
                 availability_info,
-            } = make_chunk_group(ResolvedVc::upcast(self), entries, availability_info).await?;
+            } = make_chunk_group(
+                entries,
+                module_graph,
+                ResolvedVc::upcast(self),
+                availability_info,
+            )
+            .await?;
 
             let mut assets: Vec<ResolvedVc<Box<dyn OutputAsset>>> = chunks
                 .iter()
@@ -498,7 +511,7 @@ impl ChunkingContext for BrowserChunkingContext {
             }
 
             assets.push(
-                self.generate_evaluate_chunk(ident, other_assets, evaluatable_assets)
+                self.generate_evaluate_chunk(ident, other_assets, evaluatable_assets, module_graph)
                     .to_resolved()
                     .await?,
             );
@@ -519,6 +532,7 @@ impl ChunkingContext for BrowserChunkingContext {
         _path: Vc<FileSystemPath>,
         _module: Vc<Box<dyn Module>>,
         _evaluatable_assets: Vc<EvaluatableAssets>,
+        _module_graph: Vc<ModuleGraph>,
         _extra_chunks: Vc<OutputAssets>,
         _availability_info: Value<AvailabilityInfo>,
     ) -> Result<Vc<EntryChunkGroupResult>> {
@@ -534,18 +548,20 @@ impl ChunkingContext for BrowserChunkingContext {
     async fn async_loader_chunk_item(
         self: Vc<Self>,
         module: Vc<Box<dyn ChunkableModule>>,
+        module_graph: Vc<ModuleGraph>,
         availability_info: Value<AvailabilityInfo>,
     ) -> Result<Vc<Box<dyn ChunkItem>>> {
         Ok(if self.await?.manifest_chunks {
             let manifest_asset =
-                ManifestAsyncModule::new(module, Vc::upcast(self), availability_info);
+                ManifestAsyncModule::new(module, module_graph, Vc::upcast(self), availability_info);
             Vc::upcast(ManifestLoaderChunkItem::new(
                 manifest_asset,
+                module_graph,
                 Vc::upcast(self),
             ))
         } else {
             let module = AsyncLoaderModule::new(module, Vc::upcast(self), availability_info);
-            Vc::upcast(module.as_chunk_item(Vc::upcast(self)))
+            Vc::upcast(module.as_chunk_item(module_graph, Vc::upcast(self)))
         })
     }
 

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -25,6 +25,7 @@ use turbopack_core::{
     ident::AssetIdent,
     issue::{handle_issues, IssueReporter, IssueSeverity},
     module::Module,
+    module_graph::ModuleGraph,
     output::{OutputAsset, OutputAssets},
     reference::all_assets_from_entries,
     reference_type::{EntryReferenceSubType, ReferenceType},
@@ -307,6 +308,8 @@ async fn build_internal(
         .try_join()
         .await?;
 
+    let module_graph = ModuleGraph::from_modules(Vc::cell(entries.clone()));
+
     let entry_chunk_groups = entries
         .into_iter()
         .map(|entry_module| async move {
@@ -333,6 +336,7 @@ async fn build_internal(
                                             .with_extension("entry.js".into()),
                                     ),
                                     EvaluatableAssets::one(*ResolvedVc::upcast(ecmascript)),
+                                    module_graph,
                                     Value::new(AvailabilityInfo::Root),
                                 )
                                 .await?
@@ -355,6 +359,7 @@ async fn build_internal(
                                         .with_extension("entry.js".into()),
                                     *ResolvedVc::upcast(ecmascript),
                                     EvaluatableAssets::one(*ResolvedVc::upcast(ecmascript)),
+                                    module_graph,
                                     OutputAssets::empty(),
                                     Value::new(AvailabilityInfo::Root),
                                 )

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -11,6 +11,7 @@ use crate::{
     environment::Environment,
     ident::AssetIdent,
     module::Module,
+    module_graph::ModuleGraph,
     output::{OutputAsset, OutputAssets},
 };
 
@@ -114,6 +115,7 @@ pub trait ChunkingContext {
     fn async_loader_chunk_item(
         &self,
         module: Vc<Box<dyn ChunkableModule>>,
+        module_graph: Vc<ModuleGraph>,
         availability_info: Value<AvailabilityInfo>,
     ) -> Vc<Box<dyn ChunkItem>>;
     fn async_loader_chunk_item_id(&self, module: Vc<Box<dyn ChunkableModule>>) -> Vc<ModuleId>;
@@ -122,6 +124,7 @@ pub trait ChunkingContext {
         self: Vc<Self>,
         ident: Vc<AssetIdent>,
         module: Vc<Box<dyn ChunkableModule>>,
+        module_graph: Vc<ModuleGraph>,
         availability_info: Value<AvailabilityInfo>,
     ) -> Vc<ChunkGroupResult>;
 
@@ -129,6 +132,7 @@ pub trait ChunkingContext {
         self: Vc<Self>,
         ident: Vc<AssetIdent>,
         evaluatable_assets: Vc<EvaluatableAssets>,
+        module_graph: Vc<ModuleGraph>,
         availability_info: Value<AvailabilityInfo>,
     ) -> Vc<ChunkGroupResult>;
 
@@ -141,6 +145,7 @@ pub trait ChunkingContext {
         path: Vc<FileSystemPath>,
         module: Vc<Box<dyn Module>>,
         evaluatable_assets: Vc<EvaluatableAssets>,
+        module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
         availability_info: Value<AvailabilityInfo>,
     ) -> Result<Vc<EntryChunkGroupResult>>;
@@ -159,6 +164,7 @@ pub trait ChunkingContextExt {
     fn root_chunk_group(
         self: Vc<Self>,
         module: Vc<Box<dyn ChunkableModule>>,
+        module_graph: Vc<ModuleGraph>,
     ) -> Vc<ChunkGroupResult>
     where
         Self: Send;
@@ -166,6 +172,7 @@ pub trait ChunkingContextExt {
     fn root_chunk_group_assets(
         self: Vc<Self>,
         module: Vc<Box<dyn ChunkableModule>>,
+        module_graph: Vc<ModuleGraph>,
     ) -> Vc<OutputAssets>
     where
         Self: Send;
@@ -174,6 +181,7 @@ pub trait ChunkingContextExt {
         self: Vc<Self>,
         ident: Vc<AssetIdent>,
         evaluatable_assets: Vc<EvaluatableAssets>,
+        module_graph: Vc<ModuleGraph>,
         availability_info: Value<AvailabilityInfo>,
     ) -> Vc<OutputAssets>
     where
@@ -184,6 +192,7 @@ pub trait ChunkingContextExt {
         path: Vc<FileSystemPath>,
         module: Vc<Box<dyn Module>>,
         evaluatable_assets: Vc<EvaluatableAssets>,
+        module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
         availability_info: Value<AvailabilityInfo>,
     ) -> Vc<Box<dyn OutputAsset>>
@@ -194,6 +203,7 @@ pub trait ChunkingContextExt {
         self: Vc<Self>,
         path: Vc<FileSystemPath>,
         module: Vc<Box<dyn Module>>,
+        module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
         evaluatable_assets: Vc<EvaluatableAssets>,
     ) -> Vc<EntryChunkGroupResult>
@@ -204,6 +214,7 @@ pub trait ChunkingContextExt {
         self: Vc<Self>,
         path: Vc<FileSystemPath>,
         module: Vc<Box<dyn Module>>,
+        module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
         evaluatable_assets: Vc<EvaluatableAssets>,
     ) -> Vc<Box<dyn OutputAsset>>
@@ -213,6 +224,7 @@ pub trait ChunkingContextExt {
     fn chunk_group_assets(
         self: Vc<Self>,
         module: Vc<Box<dyn ChunkableModule>>,
+        module_graph: Vc<ModuleGraph>,
         availability_info: Value<AvailabilityInfo>,
     ) -> Vc<OutputAssets>
     where
@@ -223,27 +235,36 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
     fn root_chunk_group(
         self: Vc<Self>,
         module: Vc<Box<dyn ChunkableModule>>,
+        module_graph: Vc<ModuleGraph>,
     ) -> Vc<ChunkGroupResult> {
-        self.chunk_group(module.ident(), module, Value::new(AvailabilityInfo::Root))
+        self.chunk_group(
+            module.ident(),
+            module,
+            module_graph,
+            Value::new(AvailabilityInfo::Root),
+        )
     }
 
     fn root_chunk_group_assets(
         self: Vc<Self>,
         module: Vc<Box<dyn ChunkableModule>>,
+        module_graph: Vc<ModuleGraph>,
     ) -> Vc<OutputAssets> {
-        root_chunk_group_assets(Vc::upcast(self), module)
+        root_chunk_group_assets(Vc::upcast(self), module, module_graph)
     }
 
     fn evaluated_chunk_group_assets(
         self: Vc<Self>,
         ident: Vc<AssetIdent>,
         evaluatable_assets: Vc<EvaluatableAssets>,
+        module_graph: Vc<ModuleGraph>,
         availability_info: Value<AvailabilityInfo>,
     ) -> Vc<OutputAssets> {
         evaluated_chunk_group_assets(
             Vc::upcast(self),
             ident,
             evaluatable_assets,
+            module_graph,
             availability_info,
         )
     }
@@ -253,6 +274,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
         path: Vc<FileSystemPath>,
         module: Vc<Box<dyn Module>>,
         evaluatable_assets: Vc<EvaluatableAssets>,
+        module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
         availability_info: Value<AvailabilityInfo>,
     ) -> Vc<Box<dyn OutputAsset>> {
@@ -261,6 +283,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
             Vc::upcast(self),
             module,
             evaluatable_assets,
+            module_graph,
             extra_chunks,
             availability_info,
         )
@@ -270,6 +293,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
         self: Vc<Self>,
         path: Vc<FileSystemPath>,
         module: Vc<Box<dyn Module>>,
+        module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
         evaluatable_assets: Vc<EvaluatableAssets>,
     ) -> Vc<EntryChunkGroupResult> {
@@ -277,6 +301,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
             path,
             module,
             evaluatable_assets,
+            module_graph,
             extra_chunks,
             Value::new(AvailabilityInfo::Root),
         )
@@ -286,6 +311,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
         self: Vc<Self>,
         path: Vc<FileSystemPath>,
         module: Vc<Box<dyn Module>>,
+        module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
         evaluatable_assets: Vc<EvaluatableAssets>,
     ) -> Vc<Box<dyn OutputAsset>> {
@@ -294,6 +320,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
             Vc::upcast(self),
             module,
             evaluatable_assets,
+            module_graph,
             extra_chunks,
             Value::new(AvailabilityInfo::Root),
         )
@@ -302,9 +329,10 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
     fn chunk_group_assets(
         self: Vc<Self>,
         module: Vc<Box<dyn ChunkableModule>>,
+        module_graph: Vc<ModuleGraph>,
         availability_info: Value<AvailabilityInfo>,
     ) -> Vc<OutputAssets> {
-        chunk_group_assets(Vc::upcast(self), module, availability_info)
+        chunk_group_assets(Vc::upcast(self), module, module_graph, availability_info)
     }
 }
 
@@ -312,8 +340,12 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
 async fn root_chunk_group_assets(
     chunking_context: Vc<Box<dyn ChunkingContext>>,
     module: Vc<Box<dyn ChunkableModule>>,
+    module_graph: Vc<ModuleGraph>,
 ) -> Result<Vc<OutputAssets>> {
-    Ok(*chunking_context.root_chunk_group(module).await?.assets)
+    Ok(*chunking_context
+        .root_chunk_group(module, module_graph)
+        .await?
+        .assets)
 }
 
 #[turbo_tasks::function]
@@ -321,10 +353,11 @@ async fn evaluated_chunk_group_assets(
     chunking_context: Vc<Box<dyn ChunkingContext>>,
     ident: Vc<AssetIdent>,
     evaluatable_assets: Vc<EvaluatableAssets>,
+    module_graph: Vc<ModuleGraph>,
     availability_info: Value<AvailabilityInfo>,
 ) -> Result<Vc<OutputAssets>> {
     Ok(*chunking_context
-        .evaluated_chunk_group(ident, evaluatable_assets, availability_info)
+        .evaluated_chunk_group(ident, evaluatable_assets, module_graph, availability_info)
         .await?
         .assets)
 }
@@ -335,6 +368,7 @@ async fn entry_chunk_group_asset(
     chunking_context: Vc<Box<dyn ChunkingContext>>,
     module: Vc<Box<dyn Module>>,
     evaluatable_assets: Vc<EvaluatableAssets>,
+    module_graph: Vc<ModuleGraph>,
     extra_chunks: Vc<OutputAssets>,
     availability_info: Value<AvailabilityInfo>,
 ) -> Result<Vc<Box<dyn OutputAsset>>> {
@@ -343,6 +377,7 @@ async fn entry_chunk_group_asset(
             path,
             module,
             evaluatable_assets,
+            module_graph,
             extra_chunks,
             availability_info,
         )
@@ -354,10 +389,11 @@ async fn entry_chunk_group_asset(
 async fn chunk_group_assets(
     chunking_context: Vc<Box<dyn ChunkingContext>>,
     module: Vc<Box<dyn ChunkableModule>>,
+    module_graph: Vc<ModuleGraph>,
     availability_info: Value<AvailabilityInfo>,
 ) -> Result<Vc<OutputAssets>> {
     Ok(*chunking_context
-        .chunk_group(module.ident(), module, availability_info)
+        .chunk_group(module.ident(), module, module_graph, availability_info)
         .await?
         .assets)
 }

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -41,8 +41,8 @@ pub use self::{
     evaluate::{EvaluatableAsset, EvaluatableAssetExt, EvaluatableAssets},
 };
 use crate::{
-    asset::Asset, ident::AssetIdent, module::Module, output::OutputAssets,
-    reference::ModuleReference,
+    asset::Asset, ident::AssetIdent, module::Module, module_graph::ModuleGraph,
+    output::OutputAssets, reference::ModuleReference,
 };
 
 /// A module id, which can be a number or string
@@ -89,6 +89,7 @@ pub struct ModuleIds(Vec<ResolvedVc<ModuleId>>);
 pub trait ChunkableModule: Module + Asset {
     fn as_chunk_item(
         self: Vc<Self>,
+        module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn ChunkItem>>;
 }

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -520,12 +520,23 @@ impl ModuleGraph {
     pub fn from_graphs(graphs: Vec<ResolvedVc<SingleModuleGraph>>) -> Vc<Self> {
         Self { graphs }.cell()
     }
+
     #[turbo_tasks::function]
     pub fn from_single_graph(graph: ResolvedVc<SingleModuleGraph>) -> Vc<Self> {
         Self {
             graphs: vec![graph],
         }
         .cell()
+    }
+
+    #[turbo_tasks::function]
+    pub fn from_module(module: ResolvedVc<Box<dyn Module>>) -> Vc<Self> {
+        Self::from_single_graph(SingleModuleGraph::new_with_entries(Vc::cell(vec![module])))
+    }
+
+    #[turbo_tasks::function]
+    pub fn from_modules(modules: Vc<Modules>) -> Vc<Self> {
+        Self::from_single_graph(SingleModuleGraph::new_with_entries(modules))
     }
 }
 

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -15,6 +15,7 @@ use turbopack_core::{
     },
     ident::AssetIdent,
     module::Module,
+    module_graph::ModuleGraph,
     output::{OutputAsset, OutputAssets},
     version::{Version, VersionedContent},
 };
@@ -24,6 +25,7 @@ use turbopack_core::{
 )]
 pub struct DevHtmlEntry {
     pub chunkable_module: ResolvedVc<Box<dyn ChunkableModule>>,
+    pub module_graph: ResolvedVc<ModuleGraph>,
     pub chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     pub runtime_entries: Option<ResolvedVc<EvaluatableAssets>>,
 }
@@ -139,6 +141,7 @@ impl DevHtmlAsset {
                 let &DevHtmlEntry {
                     chunkable_module,
                     chunking_context,
+                    module_graph,
                     runtime_entries,
                 } = entry;
 
@@ -156,10 +159,14 @@ impl DevHtmlAsset {
                     chunking_context.evaluated_chunk_group_assets(
                         chunkable_module.ident(),
                         *runtime_entries,
+                        *module_graph,
                         Value::new(AvailabilityInfo::Root),
                     )
                 } else {
-                    chunking_context.root_chunk_group_assets(*ResolvedVc::upcast(chunkable_module))
+                    chunking_context.root_chunk_group_assets(
+                        *ResolvedVc::upcast(chunkable_module),
+                        *module_graph,
+                    )
                 };
 
                 assets.await

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
@@ -6,6 +6,7 @@ use turbopack_core::{
     chunk::{availability_info::AvailabilityInfo, ChunkableModule, ChunkingContext},
     ident::AssetIdent,
     module::Module,
+    module_graph::ModuleGraph,
     reference::{ModuleReferences, SingleModuleReference},
 };
 
@@ -84,11 +85,13 @@ impl ChunkableModule for AsyncLoaderModule {
     #[turbo_tasks::function]
     async fn as_chunk_item(
         self: ResolvedVc<Self>,
+        module_graph: ResolvedVc<ModuleGraph>,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
         Vc::upcast(
             AsyncLoaderChunkItem {
                 chunking_context,
+                module_graph,
                 module: self,
             }
             .cell(),

--- a/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
@@ -6,7 +6,10 @@ use swc_core::ecma::{
 };
 use turbo_rcstr::RcStr;
 use turbo_tasks::{debug::ValueDebugFormat, trace::TraceRawVcs, NonLocalValue, ResolvedVc, Vc};
-use turbopack_core::chunk::{AsyncModuleInfo, ChunkingContext};
+use turbopack_core::{
+    chunk::{AsyncModuleInfo, ChunkingContext},
+    module_graph::ModuleGraph,
+};
 
 /// impl of code generation inferred from a ModuleReference.
 /// This is rust only and can't be implemented by non-rust plugins.
@@ -94,6 +97,7 @@ pub trait VisitorFactory: Send + Sync {
 pub trait CodeGenerateable {
     fn code_generation(
         self: Vc<Self>,
+        module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Vc<CodeGeneration>;
 }
@@ -102,6 +106,7 @@ pub trait CodeGenerateable {
 pub trait CodeGenerateableWithAsyncModuleInfo {
     fn code_generation(
         self: Vc<Self>,
+        module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Vc<CodeGeneration>;

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -8,6 +8,7 @@ use turbopack_core::{
     },
     ident::AssetIdent,
     module::Module,
+    module_graph::ModuleGraph,
     output::OutputAssets,
     reference::{ModuleReferences, SingleOutputAssetReference},
 };
@@ -34,6 +35,7 @@ fn modifier() -> Vc<RcStr> {
 #[turbo_tasks::value(shared)]
 pub struct ManifestAsyncModule {
     pub inner: ResolvedVc<Box<dyn ChunkableModule>>,
+    pub module_graph: ResolvedVc<ModuleGraph>,
     pub chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     pub availability_info: AvailabilityInfo,
 }
@@ -43,11 +45,13 @@ impl ManifestAsyncModule {
     #[turbo_tasks::function]
     pub async fn new(
         module: ResolvedVc<Box<dyn ChunkableModule>>,
+        module_graph: ResolvedVc<ModuleGraph>,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
         availability_info: Value<AvailabilityInfo>,
     ) -> Vc<Self> {
         Self::cell(ManifestAsyncModule {
             inner: module,
+            module_graph,
             chunking_context,
             availability_info: availability_info.into_value(),
         })
@@ -57,6 +61,7 @@ impl ManifestAsyncModule {
     pub(super) fn chunks(&self) -> Vc<OutputAssets> {
         self.chunking_context.chunk_group_assets(
             *ResolvedVc::upcast(self.inner),
+            *self.module_graph,
             Value::new(self.availability_info),
         )
     }
@@ -69,9 +74,11 @@ impl ManifestAsyncModule {
                 return Ok(Vc::cell(vec![]));
             }
         }
-        Ok(this
-            .chunking_context
-            .chunk_group_assets(Vc::upcast(self), Value::new(this.availability_info)))
+        Ok(this.chunking_context.chunk_group_assets(
+            Vc::upcast(self),
+            *this.module_graph,
+            Value::new(this.availability_info),
+        ))
     }
 
     #[turbo_tasks::function]
@@ -140,6 +147,7 @@ impl ChunkableModule for ManifestAsyncModule {
     #[turbo_tasks::function]
     async fn as_chunk_item(
         self: ResolvedVc<Self>,
+        _module_graph: Vc<ModuleGraph>,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
         Vc::upcast(

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -18,6 +18,7 @@ use turbo_tasks::{
 use turbopack_core::{
     chunk::{ChunkableModuleReference, ChunkingContext},
     issue::IssueSource,
+    module_graph::ModuleGraph,
     reference::ModuleReference,
     resolve::{origin::ResolveOrigin, parse::Request, ModuleResolveResult},
 };
@@ -158,6 +159,7 @@ impl CodeGenerateable for AmdDefineWithDependenciesCodeGen {
     #[turbo_tasks::function]
     async fn code_generation(
         &self,
+        module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let mut visitors = Vec::new();
@@ -174,6 +176,7 @@ impl CodeGenerateable for AmdDefineWithDependenciesCodeGen {
                         pattern_mapping: PatternMapping::resolve_request(
                             **request,
                             *self.origin,
+                            module_graph,
                             Vc::upcast(chunking_context),
                             cjs_resolve(
                                 *self.origin,

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -9,6 +9,7 @@ use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
 use turbopack_core::{
     chunk::{ChunkableModuleReference, ChunkingContext},
     issue::IssueSource,
+    module_graph::ModuleGraph,
     reference::ModuleReference,
     resolve::{origin::ResolveOrigin, parse::Request, ModuleResolveResult},
 };
@@ -135,11 +136,13 @@ impl CodeGenerateable for CjsRequireAssetReference {
     #[turbo_tasks::function]
     async fn code_generation(
         &self,
+        module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let pm = PatternMapping::resolve_request(
             *self.request,
             *self.origin,
+            module_graph,
             Vc::upcast(chunking_context),
             cjs_resolve(
                 *self.origin,
@@ -242,11 +245,13 @@ impl CodeGenerateable for CjsRequireResolveAssetReference {
     #[turbo_tasks::function]
     async fn code_generation(
         &self,
+        module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let pm = PatternMapping::resolve_request(
             *self.request,
             *self.origin,
+            module_graph,
             Vc::upcast(chunking_context),
             cjs_resolve(
                 *self.origin,
@@ -303,7 +308,8 @@ impl CodeGenerateable for CjsRequireCacheAccess {
     #[turbo_tasks::function]
     async fn code_generation(
         &self,
-        _context: Vc<Box<dyn ChunkingContext>>,
+        _module_graph: Vc<ModuleGraph>,
+        _chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let mut visitors = Vec::new();
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/constant_condition.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/constant_condition.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use swc_core::quote;
 use turbo_tasks::{ResolvedVc, Value, Vc};
-use turbopack_core::chunk::ChunkingContext;
+use turbopack_core::{chunk::ChunkingContext, module_graph::ModuleGraph};
 
 use super::AstPath;
 use crate::{
@@ -39,7 +39,8 @@ impl CodeGenerateable for ConstantCondition {
     #[turbo_tasks::function]
     async fn code_generation(
         &self,
-        _context: Vc<Box<dyn ChunkingContext>>,
+        _module_graph: Vc<ModuleGraph>,
+        _chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let value = self.value;
         let visitors = [

--- a/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
 use swc_core::quote;
 use turbo_tasks::{ResolvedVc, Value, Vc};
-use turbopack_core::{chunk::ChunkingContext, compile_time_info::CompileTimeDefineValue};
+use turbopack_core::{
+    chunk::ChunkingContext, compile_time_info::CompileTimeDefineValue, module_graph::ModuleGraph,
+};
 
 use super::AstPath;
 use crate::{
@@ -31,7 +33,8 @@ impl CodeGenerateable for ConstantValue {
     #[turbo_tasks::function]
     async fn code_generation(
         &self,
-        _context: Vc<Box<dyn ChunkingContext>>,
+        _module_graph: Vc<ModuleGraph>,
+        _chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let value = self.value.clone();
         let path = &self.path.await?;

--- a/turbopack/crates/turbopack-ecmascript/src/references/dynamic_expression.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/dynamic_expression.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use swc_core::quote;
 use turbo_tasks::{debug::ValueDebugFormat, trace::TraceRawVcs, NonLocalValue, ResolvedVc, Vc};
-use turbopack_core::chunk::ChunkingContext;
+use turbopack_core::{chunk::ChunkingContext, module_graph::ModuleGraph};
 
 use super::AstPath;
 use crate::{
@@ -46,7 +46,8 @@ impl CodeGenerateable for DynamicExpression {
     #[turbo_tasks::function]
     async fn code_generation(
         &self,
-        _context: Vc<Box<dyn ChunkingContext>>,
+        _module_graph: Vc<ModuleGraph>,
+        _chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let path = &self.path.await?;
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -18,6 +18,7 @@ use turbopack_core::{
         OptionStyledString, StyledString,
     },
     module::Module,
+    module_graph::ModuleGraph,
     reference::ModuleReference,
     reference_type::{EcmaScriptModulesReferenceSubType, ImportWithType},
     resolve::{
@@ -251,6 +252,7 @@ impl CodeGenerateable for EsmAssetReference {
     #[turbo_tasks::function]
     async fn code_generation(
         self: Vc<Self>,
+        module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let this = &*self.await?;
@@ -283,7 +285,7 @@ impl CodeGenerateable for EsmAssetReference {
                     }
                     ReferencedAsset::Some(asset) => {
                         let id = asset
-                            .as_chunk_item(Vc::upcast(chunking_context))
+                            .as_chunk_item(module_graph, Vc::upcast(chunking_context))
                             .id()
                             .await?;
                         Some((

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
@@ -15,7 +15,7 @@ use swc_core::{
 };
 use turbo_rcstr::RcStr;
 use turbo_tasks::{trace::TraceRawVcs, NonLocalValue, ResolvedVc, TaskInput, Vc};
-use turbopack_core::chunk::ChunkingContext;
+use turbopack_core::{chunk::ChunkingContext, module_graph::ModuleGraph};
 
 use super::EsmAssetReference;
 use crate::{
@@ -155,7 +155,8 @@ impl CodeGenerateable for EsmBindings {
     #[turbo_tasks::function]
     async fn code_generation(
         &self,
-        _context: Vc<Box<dyn ChunkingContext>>,
+        _module_graph: Vc<ModuleGraph>,
+        _chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let mut visitors = Vec::new();
         let bindings = self.bindings.clone();

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -10,6 +10,7 @@ use turbopack_core::{
     chunk::{ChunkableModuleReference, ChunkingContext, ChunkingType, ChunkingTypeOption},
     environment::ChunkLoading,
     issue::IssueSource,
+    module_graph::ModuleGraph,
     reference::ModuleReference,
     reference_type::EcmaScriptModulesReferenceSubType,
     resolve::{
@@ -111,11 +112,13 @@ impl CodeGenerateable for EsmAsyncAssetReference {
     #[turbo_tasks::function]
     async fn code_generation(
         &self,
+        module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let pm = PatternMapping::resolve_request(
             *self.request,
             *self.origin,
+            module_graph,
             Vc::upcast(chunking_context),
             esm_resolve(
                 self.get_origin().resolve().await?,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -25,6 +25,7 @@ use turbopack_core::{
     ident::AssetIdent,
     issue::{analyze::AnalyzeIssue, IssueExt, IssueSeverity, StyledString},
     module::Module,
+    module_graph::ModuleGraph,
     reference::ModuleReference,
 };
 
@@ -495,7 +496,8 @@ impl CodeGenerateable for EsmExports {
     #[turbo_tasks::function]
     async fn code_generation(
         self: Vc<Self>,
-        _context: Vc<Box<dyn ChunkingContext>>,
+        _module_graph: Vc<ModuleGraph>,
+        _chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let expanded = self.expand_exports().await?;
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
@@ -8,7 +8,7 @@ use swc_core::{
 };
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
-use turbopack_core::chunk::ChunkingContext;
+use turbopack_core::{chunk::ChunkingContext, module_graph::ModuleGraph};
 
 use crate::{
     code_gen::{CodeGenerateable, CodeGeneration},
@@ -40,6 +40,7 @@ impl CodeGenerateable for ImportMetaBinding {
     #[turbo_tasks::function]
     async fn code_generation(
         &self,
+        _module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let rel_path = chunking_context
@@ -99,7 +100,8 @@ impl CodeGenerateable for ImportMetaRef {
     #[turbo_tasks::function]
     async fn code_generation(
         &self,
-        _context: Vc<Box<dyn ChunkingContext>>,
+        _module_graph: Vc<ModuleGraph>,
+        _chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let ast_path = &self.ast_path.await?;
         let visitor = create_visitor!(ast_path, visit_mut_expr(expr: &mut Expr) {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
@@ -7,6 +7,7 @@ use turbopack_core::{
         ChunkItemExt, ChunkableModule, ChunkableModuleReference, ChunkingContext,
         ChunkingTypeOption,
     },
+    module_graph::ModuleGraph,
     reference::ModuleReference,
     resolve::ModuleResolveResult,
 };
@@ -65,13 +66,14 @@ impl CodeGenerateable for EsmModuleIdAssetReference {
     #[turbo_tasks::function]
     async fn code_generation(
         &self,
+        module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let mut visitors = Vec::new();
 
         if let ReferencedAsset::Some(asset) = &*self.inner.get_referenced_asset().await? {
             let id = asset
-                .as_chunk_item(Vc::upcast(chunking_context))
+                .as_chunk_item(module_graph, Vc::upcast(chunking_context))
                 .id()
                 .await?;
             let id = module_id_to_lit(&id);

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_item.rs
@@ -10,7 +10,7 @@ use swc_core::{
     quote,
 };
 use turbo_tasks::{ResolvedVc, Vc};
-use turbopack_core::chunk::ChunkingContext;
+use turbopack_core::{chunk::ChunkingContext, module_graph::ModuleGraph};
 
 use crate::{
     code_gen::{CodeGenerateable, CodeGeneration},
@@ -40,7 +40,8 @@ impl CodeGenerateable for EsmModuleItem {
     #[turbo_tasks::function]
     async fn code_generation(
         &self,
-        _context: Vc<Box<dyn ChunkingContext>>,
+        _module_graph: Vc<ModuleGraph>,
+        _chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let mut visitors = Vec::new();
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -12,6 +12,7 @@ use turbopack_core::{
     },
     environment::Rendering,
     issue::IssueSource,
+    module_graph::ModuleGraph,
     reference::ModuleReference,
     reference_type::{ReferenceType, UrlReferenceSubType},
     resolve::{
@@ -141,6 +142,7 @@ impl CodeGenerateable for UrlAssetReference {
     #[turbo_tasks::function]
     async fn code_generation(
         self: Vc<Self>,
+        module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let this = self.await?;
@@ -163,7 +165,7 @@ impl CodeGenerateable for UrlAssetReference {
                         // We rewrite the first `new URL()` arguments to be a require() of the chunk
                         // item, which exports the static asset path to the linked file.
                         let id = asset
-                            .as_chunk_item(Vc::upcast(chunking_context))
+                            .as_chunk_item(module_graph, Vc::upcast(chunking_context))
                             .id()
                             .await?;
 
@@ -229,7 +231,7 @@ impl CodeGenerateable for UrlAssetReference {
                         // We rewrite the first `new URL()` arguments to be a require() of the
                         // chunk item, which returns the asset path as its exports.
                         let id = asset
-                            .as_chunk_item(Vc::upcast(chunking_context))
+                            .as_chunk_item(module_graph, Vc::upcast(chunking_context))
                             .id()
                             .await?;
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -10,6 +10,7 @@ use turbopack_core::{
     chunk::{AsyncModuleInfo, ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     ident::AssetIdent,
     module::Module,
+    module_graph::ModuleGraph,
     reference::{ModuleReference, ModuleReferences},
 };
 
@@ -154,6 +155,7 @@ impl ChunkableModule for CachedExternalModule {
     #[turbo_tasks::function]
     fn as_chunk_item(
         self: ResolvedVc<Self>,
+        _module_graph: Vc<ModuleGraph>,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn ChunkItem>> {
         Vc::upcast(

--- a/turbopack/crates/turbopack-ecmascript/src/references/ident.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/ident.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use swc_core::{ecma::ast::Expr, quote};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
-use turbopack_core::chunk::ChunkingContext;
+use turbopack_core::{chunk::ChunkingContext, module_graph::ModuleGraph};
 
 use super::AstPath;
 use crate::{
@@ -32,7 +32,8 @@ impl CodeGenerateable for IdentReplacement {
     #[turbo_tasks::function]
     async fn code_generation(
         &self,
-        _context: Vc<Box<dyn ChunkingContext>>,
+        _module_graph: Vc<ModuleGraph>,
+        _chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let value = self.value.clone();
         let path = &self.path.await?;

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -21,6 +21,7 @@ use turbopack_core::{
         code_gen::CodeGenerationIssue, module::emit_unknown_module_type_error, IssueExt,
         IssueSeverity, StyledString,
     },
+    module_graph::ModuleGraph,
     resolve::{
         origin::ResolveOrigin, parse::Request, ExternalType, ModuleResolveResult,
         ModuleResolveResultItem,
@@ -299,6 +300,7 @@ impl PatternMapping {
 
 async fn to_single_pattern_mapping(
     origin: Vc<Box<dyn ResolveOrigin>>,
+    module_graph: Vc<ModuleGraph>,
     chunking_context: Vc<Box<dyn ChunkingContext>>,
     resolve_item: &ModuleResolveResultItem,
     resolve_type: ResolveType,
@@ -353,7 +355,7 @@ async fn to_single_pattern_mapping(
                 ));
             }
             ResolveType::ChunkItem => {
-                let chunk_item = chunkable.as_chunk_item(chunking_context);
+                let chunk_item = chunkable.as_chunk_item(module_graph, chunking_context);
                 return Ok(SinglePatternMapping::Module(
                     chunk_item.id().await?.clone_value(),
                 ));
@@ -383,6 +385,7 @@ impl PatternMapping {
     pub async fn resolve_request(
         request: Vc<Request>,
         origin: Vc<Box<dyn ResolveOrigin>>,
+        module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
         resolve_result: Vc<ModuleResolveResult>,
         resolve_type: Value<ResolveType>,
@@ -396,9 +399,14 @@ impl PatternMapping {
             .cell()),
             1 => {
                 let resolve_item = result.primary.first().unwrap().1;
-                let single_pattern_mapping =
-                    to_single_pattern_mapping(origin, chunking_context, resolve_item, resolve_type)
-                        .await?;
+                let single_pattern_mapping = to_single_pattern_mapping(
+                    origin,
+                    module_graph,
+                    chunking_context,
+                    resolve_item,
+                    resolve_type,
+                )
+                .await?;
                 Ok(PatternMapping::Single(single_pattern_mapping).cell())
             }
             _ => {
@@ -411,9 +419,14 @@ impl PatternMapping {
                         set.insert(request).then(|| (request.to_string(), v))
                     })
                     .map(|(k, v)| async move {
-                        let single_pattern_mapping =
-                            to_single_pattern_mapping(origin, chunking_context, v, resolve_type)
-                                .await?;
+                        let single_pattern_mapping = to_single_pattern_mapping(
+                            origin,
+                            module_graph,
+                            chunking_context,
+                            v,
+                            resolve_type,
+                        )
+                        .await?;
                         Ok((k, single_pattern_mapping))
                     })
                     .try_join()

--- a/turbopack/crates/turbopack-ecmascript/src/references/unreachable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/unreachable.rs
@@ -17,7 +17,7 @@ use swc_core::{
     quote,
 };
 use turbo_tasks::{ResolvedVc, Vc};
-use turbopack_core::chunk::ChunkingContext;
+use turbopack_core::{chunk::ChunkingContext, module_graph::ModuleGraph};
 
 use crate::{
     code_gen::{CodeGenerateable, CodeGeneration},
@@ -43,7 +43,8 @@ impl CodeGenerateable for Unreachable {
     #[turbo_tasks::function]
     async fn code_generation(
         &self,
-        _context: Vc<Box<dyn ChunkingContext>>,
+        _module_graph: Vc<ModuleGraph>,
+        _chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let range = self.range.await?;
         let visitors = match &*range {

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -10,6 +10,7 @@ use turbopack_core::{
     chunk::{ChunkableModule, ChunkableModuleReference, ChunkingContext},
     issue::{code_gen::CodeGenerationIssue, IssueExt, IssueSeverity, IssueSource, StyledString},
     module::Module,
+    module_graph::ModuleGraph,
     reference::ModuleReference,
     reference_type::{ReferenceType, WorkerReferenceSubType},
     resolve::{origin::ResolveOrigin, parse::Request, url_resolve, ModuleResolveResult},
@@ -119,6 +120,7 @@ impl CodeGenerateable for WorkerAssetReference {
     #[turbo_tasks::function]
     async fn code_generation(
         &self,
+        _module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let Some(loader) = self.worker_loader_module().await? else {

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -8,6 +8,7 @@ use turbopack_core::{
     chunk::{ChunkableModule, ChunkingContext, EvaluatableAsset},
     ident::AssetIdent,
     module::Module,
+    module_graph::ModuleGraph,
     reference::ModuleReferences,
     resolve::ModulePart,
 };
@@ -334,11 +335,13 @@ impl ChunkableModule for EcmascriptModuleFacadeModule {
     #[turbo_tasks::function]
     fn as_chunk_item(
         self: ResolvedVc<Self>,
+        module_graph: ResolvedVc<ModuleGraph>,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
         Vc::upcast(
             EcmascriptModuleFacadeChunkItem {
                 module: self,
+                module_graph,
                 chunking_context,
             }
             .cell(),

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
@@ -4,6 +4,7 @@ use turbopack_core::{
     chunk::{AsyncModuleInfo, ChunkItem, ChunkType, ChunkingContext},
     ident::AssetIdent,
     module::Module,
+    module_graph::ModuleGraph,
 };
 
 use super::module::EcmascriptModuleLocalsModule;
@@ -19,6 +20,7 @@ use crate::{
 #[turbo_tasks::value(shared)]
 pub struct EcmascriptModuleLocalsChunkItem {
     pub(super) module: ResolvedVc<EcmascriptModuleLocalsModule>,
+    pub(super) module_graph: ResolvedVc<ModuleGraph>,
     pub(super) chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
 }
 
@@ -36,6 +38,7 @@ impl EcmascriptChunkItem for EcmascriptModuleLocalsChunkItem {
     ) -> Result<Vc<EcmascriptChunkItemContent>> {
         let module = self.module.await?;
         let chunking_context = self.chunking_context;
+        let module_graph = self.module_graph;
         let exports = self.module.get_exports();
         let original_module = module.module;
         let parsed = original_module.parse().resolve().await?;
@@ -51,6 +54,7 @@ impl EcmascriptChunkItem for EcmascriptModuleLocalsChunkItem {
             parsed,
             self.module.ident(),
             module_type_result.module_type,
+            *module_graph,
             *chunking_context,
             *analyze_result.local_references,
             *analyze_result.code_generation,

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -8,6 +8,7 @@ use turbopack_core::{
     chunk::{ChunkableModule, ChunkingContext},
     ident::AssetIdent,
     module::Module,
+    module_graph::ModuleGraph,
     reference::ModuleReferences,
     resolve::ModulePart,
 };
@@ -125,11 +126,13 @@ impl ChunkableModule for EcmascriptModuleLocalsModule {
     #[turbo_tasks::function]
     fn as_chunk_item(
         self: ResolvedVc<Self>,
+        module_graph: ResolvedVc<ModuleGraph>,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
         Vc::upcast(
             EcmascriptModuleLocalsChunkItem {
                 module: self,
+                module_graph,
                 chunking_context,
             }
             .cell(),

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
@@ -8,6 +8,7 @@ use turbopack_core::{
         ChunkingTypeOption,
     },
     module::Module,
+    module_graph::ModuleGraph,
     reference::ModuleReference,
     resolve::{ModulePart, ModuleResolveResult},
 };
@@ -112,6 +113,7 @@ impl CodeGenerateable for EcmascriptModulePartReference {
     #[turbo_tasks::function]
     async fn code_generation(
         self: Vc<Self>,
+        module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
         let referenced_asset = ReferencedAsset::from_resolve_result(self.resolve_reference());
@@ -125,7 +127,7 @@ impl CodeGenerateable for EcmascriptModulePartReference {
             bail!("part module reference should have an module reference");
         };
         let id = module
-            .as_chunk_item(Vc::upcast(chunking_context))
+            .as_chunk_item(module_graph, Vc::upcast(chunking_context))
             .id()
             .await?;
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -8,6 +8,7 @@ use turbopack_core::{
     context::AssetContext,
     ident::AssetIdent,
     module::Module,
+    module_graph::ModuleGraph,
     reference::{ModuleReference, ModuleReferences, SingleModuleReference},
     resolve::{origin::ResolveOrigin, ModulePart},
 };
@@ -72,11 +73,12 @@ impl EcmascriptAnalyzable for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     fn module_content(
         &self,
+        module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Vc<EcmascriptModuleContent> {
         self.full_module
-            .module_content(chunking_context, async_module_info)
+            .module_content(module_graph, chunking_context, async_module_info)
     }
 }
 
@@ -378,11 +380,13 @@ impl ChunkableModule for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     fn as_chunk_item(
         self: ResolvedVc<Self>,
+        module_graph: ResolvedVc<ModuleGraph>,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
         Vc::upcast(
             EcmascriptModulePartChunkItem {
                 module: self,
+                module_graph,
                 chunking_context,
             }
             .cell(),

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
@@ -5,6 +5,7 @@ use turbopack_core::{
     chunk::{AsyncModuleInfo, ChunkItem, ChunkType, ChunkingContext},
     ident::AssetIdent,
     module::Module,
+    module_graph::ModuleGraph,
 };
 
 use super::{asset::EcmascriptModulePartAsset, part_of_module, split_module};
@@ -26,6 +27,7 @@ use crate::{
 #[turbo_tasks::value(shared)]
 pub struct EcmascriptModulePartChunkItem {
     pub(super) module: ResolvedVc<EcmascriptModulePartAsset>,
+    pub(super) module_graph: ResolvedVc<ModuleGraph>,
     pub(super) chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
 }
 
@@ -55,6 +57,7 @@ impl EcmascriptChunkItem for EcmascriptModulePartChunkItem {
             parsed,
             module.full_module.ident(),
             module_type_result.module_type,
+            *self.module_graph,
             *self.chunking_context,
             *analyze.references,
             *analyze.code_generation,

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effect_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effect_module.rs
@@ -7,6 +7,7 @@ use turbopack_core::{
     chunk::{ChunkableModule, ChunkingContext, EvaluatableAsset},
     ident::AssetIdent,
     module::Module,
+    module_graph::ModuleGraph,
     reference::{ModuleReferences, SingleChunkableModuleReference},
     resolve::ModulePart,
 };
@@ -132,12 +133,13 @@ impl ChunkableModule for SideEffectsModule {
     #[turbo_tasks::function]
     async fn as_chunk_item(
         self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
+        _module_graph: ResolvedVc<ModuleGraph>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
         Ok(Vc::upcast(
             SideEffectsModuleChunkItem {
                 module: self.to_resolved().await?,
-                chunking_context: chunking_context.to_resolved().await?,
+                chunking_context,
             }
             .cell(),
         ))

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -9,6 +9,7 @@ use turbopack_core::{
     },
     ident::AssetIdent,
     module::Module,
+    module_graph::ModuleGraph,
     output::OutputAssets,
 };
 
@@ -24,6 +25,7 @@ use crate::{
 #[turbo_tasks::value(shared)]
 pub struct WorkerLoaderChunkItem {
     pub module: ResolvedVc<WorkerLoaderModule>,
+    pub module_graph: ResolvedVc<ModuleGraph>,
     pub chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
 }
 
@@ -54,6 +56,7 @@ impl WorkerLoaderChunkItem {
             )
             .with_modifier(worker_modifier()),
             EvaluatableAssets::empty().with_entry(*evaluatable),
+            *self.module_graph,
             Value::new(AvailabilityInfo::Root),
         ))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -9,6 +9,7 @@ use turbopack_core::{
     },
     ident::AssetIdent,
     module::Module,
+    module_graph::ModuleGraph,
     reference::{ModuleReference, ModuleReferences},
     resolve::ModuleResolveResult,
 };
@@ -70,12 +71,14 @@ impl ChunkableModule for WorkerLoaderModule {
     #[turbo_tasks::function]
     fn as_chunk_item(
         self: ResolvedVc<Self>,
+        module_graph: ResolvedVc<ModuleGraph>,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
         Vc::upcast(
             WorkerLoaderChunkItem {
-                chunking_context,
                 module: self,
+                module_graph,
+                chunking_context,
             }
             .cell(),
         )

--- a/turbopack/crates/turbopack-json/src/lib.rs
+++ b/turbopack/crates/turbopack-json/src/lib.rs
@@ -20,6 +20,7 @@ use turbopack_core::{
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     ident::AssetIdent,
     module::Module,
+    module_graph::ModuleGraph,
     source::Source,
 };
 use turbopack_ecmascript::chunk::{
@@ -66,6 +67,7 @@ impl ChunkableModule for JsonModuleAsset {
     #[turbo_tasks::function]
     fn as_chunk_item(
         self: ResolvedVc<Self>,
+        _module_graph: Vc<ModuleGraph>,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
         Vc::upcast(JsonChunkItem::cell(JsonChunkItem {

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -20,6 +20,7 @@ use turbopack_core::{
     changed::content_changed,
     chunk::{ChunkingContext, ChunkingContextExt, EvaluatableAssets},
     module::Module,
+    module_graph::ModuleGraph,
     output::{OutputAsset, OutputAssets, OutputAssetsSet},
     source_map::GenerateSourceMap,
     virtual_output::VirtualOutputAsset,
@@ -267,6 +268,7 @@ pub fn get_intermediate_asset(
     Vc::upcast(chunking_context.root_entry_chunk_group_asset(
         chunking_context.chunk_path(main_entry.ident(), ".js".into()),
         main_entry,
+        ModuleGraph::from_module(main_entry),
         OutputAssets::empty(),
         other_entries,
     ))

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -19,6 +19,7 @@ use turbopack_core::{
     issue::{
         Issue, IssueDescriptionExt, IssueSeverity, IssueStage, OptionStyledString, StyledString,
     },
+    module_graph::ModuleGraph,
     reference_type::{EntryReferenceSubType, InnerAssets, ReferenceType},
     resolve::{find_context_file_or_package_key, options::ImportMapping, FindContextFileResult},
     source::Source,
@@ -530,12 +531,17 @@ impl PostCssTransformedAsset {
             "".into()
         };
 
+        let module_graph = ModuleGraph::from_module(*postcss_executor)
+            .to_resolved()
+            .await?;
+
         let config_value = evaluate_webpack_loader(WebpackLoaderContext {
             module_asset: postcss_executor,
             cwd: *project_path,
             env: *env,
             context_ident_for_issue: self.source.ident().to_resolved().await?,
             asset_context: evaluate_context,
+            module_graph,
             chunking_context: *chunking_context,
             resolve_options_context: None,
             args: vec![

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -25,6 +25,7 @@ use turbopack_core::{
     ident::AssetIdent,
     issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
     module::Module,
+    module_graph::ModuleGraph,
     reference_type::{InnerAssets, ReferenceType},
     resolve::{
         options::{ConditionValue, ResolveInPackage, ResolveIntoPackage, ResolveOptions},
@@ -222,6 +223,11 @@ impl WebpackLoadersProcessedAsset {
             .module()
             .to_resolved()
             .await?;
+
+        let module_graph = ModuleGraph::from_module(*webpack_loaders_executor)
+            .to_resolved()
+            .await?;
+
         let resource_fs_path = this.source.ident().path();
         let resource_fs_path_ref = resource_fs_path.await?;
         let Some(resource_path) = project_path
@@ -241,6 +247,7 @@ impl WebpackLoadersProcessedAsset {
             env,
             context_ident_for_issue: this.source.ident().to_resolved().await?,
             asset_context: evaluate_context,
+            module_graph,
             chunking_context,
             resolve_options_context: Some(transform.resolve_options_context),
             args: vec![
@@ -397,6 +404,7 @@ pub struct WebpackLoaderContext {
     pub env: ResolvedVc<Box<dyn ProcessEnv>>,
     pub context_ident_for_issue: ResolvedVc<AssetIdent>,
     pub asset_context: ResolvedVc<Box<dyn AssetContext>>,
+    pub module_graph: ResolvedVc<ModuleGraph>,
     pub chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     pub resolve_options_context: Option<ResolvedVc<ResolveOptionsContext>>,
     pub args: Vec<ResolvedVc<JsonValue>>,
@@ -420,6 +428,7 @@ impl EvaluateContext for WebpackLoaderContext {
             *self.cwd,
             *self.env,
             *self.asset_context,
+            *self.module_graph,
             *self.chunking_context,
             None,
             *self.additional_invalidation,

--- a/turbopack/crates/turbopack-static/src/lib.rs
+++ b/turbopack/crates/turbopack-static/src/lib.rs
@@ -24,6 +24,7 @@ use turbopack_core::{
     context::AssetContext,
     ident::AssetIdent,
     module::Module,
+    module_graph::ModuleGraph,
     output::{OutputAsset, OutputAssets},
     source::Source,
 };
@@ -96,6 +97,7 @@ impl ChunkableModule for StaticModuleAsset {
     #[turbo_tasks::function]
     async fn as_chunk_item(
         self: ResolvedVc<Self>,
+        _module_graph: Vc<ModuleGraph>,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
         Ok(Vc::upcast(ModuleChunkItem::cell(ModuleChunkItem {

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -35,6 +35,7 @@ use turbopack_core::{
     environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
     file_source::FileSource,
     issue::{Issue, IssueDescriptionExt},
+    module_graph::ModuleGraph,
     reference_type::{InnerAssets, ReferenceType},
     resolve::{
         options::{ImportMap, ImportMapping},
@@ -408,12 +409,15 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
         )
         .module();
 
+    let module_graph = ModuleGraph::from_module(jest_entry_asset);
+
     let res = evaluate(
         jest_entry_asset,
         *path,
         Vc::upcast(CommandLineProcessEnv::new()),
         test_source.ident(),
         asset_context,
+        module_graph,
         Vc::upcast(chunking_context),
         None,
         vec![],

--- a/turbopack/crates/turbopack-wasm/src/raw.rs
+++ b/turbopack/crates/turbopack-wasm/src/raw.rs
@@ -7,6 +7,7 @@ use turbopack_core::{
     context::AssetContext,
     ident::AssetIdent,
     module::Module,
+    module_graph::ModuleGraph,
     output::{OutputAsset, OutputAssets},
     source::Source,
 };
@@ -76,6 +77,7 @@ impl ChunkableModule for RawWebAssemblyModuleAsset {
     #[turbo_tasks::function]
     async fn as_chunk_item(
         self: ResolvedVc<Self>,
+        _module_graph: Vc<ModuleGraph>,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
         Ok(Vc::upcast(


### PR DESCRIPTION
### What?

Creates the correct ModuleGraphs and passes them everywhere needed.

Preparation for production chunking where it needs the full module graph.


Closes PACK-3734