### PR TITLE
Track dynamic IO feature usage

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2675,6 +2675,10 @@ export default async function build(
 
       const features: EventBuildFeatureUsage[] = [
         {
+          featureName: 'experimental/dynamicIO',
+          invocationCount: config.experimental.dynamicIO ? 1 : 0,
+        },
+        {
           featureName: 'experimental/optimizeCss',
           invocationCount: config.experimental.optimizeCss ? 1 : 0,
         },

--- a/packages/next/src/telemetry/events/build.ts
+++ b/packages/next/src/telemetry/events/build.ts
@@ -153,6 +153,7 @@ export type EventBuildFeatureUsage = {
     | 'next/font/google'
     | 'next/font/local'
     | 'experimental/nextScriptWorkers'
+    | 'experimental/dynamicIO'
     | 'experimental/optimizeCss'
     | 'experimental/ppr'
     | 'swcLoader'

--- a/test/integration/telemetry/next.config.dynamic-io
+++ b/test/integration/telemetry/next.config.dynamic-io
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    dynamicIO: true
+  }
+}

--- a/test/integration/telemetry/test/config.test.js
+++ b/test/integration/telemetry/test/config.test.js
@@ -368,6 +368,32 @@ describe('config telemetry', () => {
         }
       )
 
+      it('emits telemetry for usage of `experimental/dynamicIO`', async () => {
+        await fs.rename(
+          path.join(appDir, 'next.config.dynamic-io'),
+          path.join(appDir, 'next.config.js')
+        )
+
+        const { stderr } = await nextBuild(appDir, [], {
+          stderr: true,
+          env: { NEXT_TELEMETRY_DEBUG: 1 },
+        })
+
+        await fs.rename(
+          path.join(appDir, 'next.config.js'),
+          path.join(appDir, 'next.config.dynamic-io')
+        )
+
+        const events = findAllTelemetryEvents(
+          stderr,
+          'NEXT_BUILD_FEATURE_USAGE'
+        )
+        expect(events).toContainEqual({
+          featureName: 'experimental/dynamicIO',
+          invocationCount: 1,
+        })
+      })
+
       it('emits telemetry for usage of `optimizeCss`', async () => {
         await fs.rename(
           path.join(appDir, 'next.config.optimize-css'),


### PR DESCRIPTION
Extend https://nextjs.org/telemetry to cover usages of dynamic IO

Closes NDX-673