### PR TITLE
Fixed link to stale-while-revalidate article

### DIFF
--- a/docs/01-app/03-building-your-application/04-caching/index.mdx
+++ b/docs/01-app/03-building-your-application/04-caching/index.mdx
@@ -185,7 +185,7 @@ Alternatively, you can use [Route Segment Config options](#segment-config-option
   - Once the data is fetched successfully, Next.js will update the Data Cache with the fresh data.
   - If the background revalidation fails, the previous data will be kept unaltered.
 
-This is similar to [**stale-while-revalidate**](https://web.dev/stale-while-revalidate/) behavior.
+This is similar to [**stale-while-revalidate**](https://web.dev/articles/stale-while-revalidate) behavior.
 
 #### On-demand Revalidation
 


### PR DESCRIPTION
It feels like the old article now leads to less informative case-study.