### PR TITLE
Emit build error if `'use action'` directive is used

### DIFF
--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -2649,6 +2649,12 @@ impl DirectiveVisitor<'_> {
                         directive: value.to_string(),
                         expected_directive: "use server".to_string(),
                     });
+                } else if value == "use action" {
+                    emit_error(ServerActionsErrorKind::MisspelledDirective {
+                        span: *span,
+                        directive: value.to_string(),
+                        expected_directive: "use server".to_string(),
+                    });
                 } else
                 // `use cache` or `use cache: foo`
                 if value == "use cache" || value.starts_with("use cache: ") {

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/27/input.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/27/input.js
@@ -1,0 +1,3 @@
+'use action'
+
+export async function foo() {}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/27/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/27/output.js
@@ -1,0 +1,2 @@
+'use action';
+export async function foo() {}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/27/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/27/output.stderr
@@ -1,0 +1,6 @@
+  x Did you mean "use server"? "use action" is not a supported directive name."
+  | 
+   ,-[input.js:1:1]
+ 1 | 'use action'
+   : ^^^^^^^^^^^^
+   `----


### PR DESCRIPTION
When accidentally writing `'use action'` instead of `'use server'`, we are now emitting a build error.