### PR TITLE
perf(turbopack): Use fxhash for ES analyzer

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -1,9 +1,9 @@
 use std::{
-    collections::HashMap,
     iter,
     mem::{replace, take},
 };
 
+use rustc_hash::FxHashMap;
 use swc_core::{
     atoms::Atom,
     common::{comments::Comments, pass::AstNodePath, Mark, Span, Spanned, SyntaxContext, GLOBALS},
@@ -242,9 +242,9 @@ impl Effect {
 
 #[derive(Debug)]
 pub struct VarGraph {
-    pub values: HashMap<Id, JsValue>,
+    pub values: FxHashMap<Id, JsValue>,
     /// Map FreeVar names to their Id to facilitate lookups into [values]
-    pub free_var_ids: HashMap<Atom, Id>,
+    pub free_var_ids: FxHashMap<Atom, Id>,
 
     pub effects: Vec<Effect>,
 }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
@@ -1,10 +1,11 @@
 use std::{
-    collections::{hash_map::Entry, HashMap, HashSet},
+    collections::{hash_map::Entry, HashSet},
     future::Future,
     mem::take,
 };
 
 use anyhow::Result;
+use rustc_hash::FxHashMap;
 use swc_core::ecma::ast::Id;
 
 use super::{graph::VarGraph, JsValue};
@@ -14,7 +15,7 @@ pub async fn link<'a, B, RB, F, RF>(
     mut val: JsValue,
     early_visitor: &B,
     visitor: &F,
-    fun_args_values: HashMap<u32, Vec<JsValue>>,
+    fun_args_values: FxHashMap<u32, Vec<JsValue>>,
 ) -> Result<JsValue>
 where
     RB: 'a + Future<Output = Result<(JsValue, bool)>> + Send,
@@ -36,7 +37,7 @@ pub(crate) async fn link_internal_iterative<'a, B, RB, F, RF>(
     val: JsValue,
     early_visitor: &'a B,
     visitor: &'a F,
-    mut fun_args_values: HashMap<u32, Vec<JsValue>>,
+    mut fun_args_values: FxHashMap<u32, Vec<JsValue>>,
 ) -> Result<JsValue>
 where
     RB: 'a + Future<Output = Result<(JsValue, bool)>> + Send,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -32,6 +32,7 @@ use num_traits::Zero;
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use regex::Regex;
+use rustc_hash::FxHashMap;
 use sourcemap::decode_data_url;
 use swc_core::{
     atoms::JsWord,
@@ -346,7 +347,7 @@ struct AnalysisState<'a> {
     var_graph: &'a VarGraph,
     /// This is the current state of known values of function
     /// arguments.
-    fun_args_values: Mutex<HashMap<u32, Vec<JsValue>>>,
+    fun_args_values: Mutex<FxHashMap<u32, Vec<JsValue>>>,
     // There can be many references to import.meta, but only the first should hoist
     // the object allocation.
     first_import_meta: bool,
@@ -860,7 +861,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
         origin,
         compile_time_info,
         var_graph: &var_graph,
-        fun_args_values: Mutex::new(HashMap::<u32, Vec<JsValue>>::new()),
+        fun_args_values: Mutex::new(FxHashMap::<u32, Vec<JsValue>>::default()),
         first_import_meta: true,
         tree_shaking_mode: options.tree_shaking_mode,
         import_externals: options.import_externals,


### PR DESCRIPTION
### What?

Use fxhash instead of SipHash (the default hasher of rustic)

### Why?

### How?

Closes NEXT-
Fixes #



Closes PACK-3740