### PR TITLE
perf(turbopack): Reduce size of `ConstantValue`

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -171,7 +171,7 @@ pub enum ConstantValue {
     True,
     False,
     Null,
-    BigInt(BigInt),
+    BigInt(Box<BigInt>),
     Regex(Atom, Atom),
 }
 
@@ -253,7 +253,7 @@ impl From<Lit> for ConstantValue {
             }
             Lit::Null(_) => ConstantValue::Null,
             Lit::Num(v) => ConstantValue::Num(ConstantNumber(v.value)),
-            Lit::BigInt(v) => ConstantValue::BigInt(*v.value),
+            Lit::BigInt(v) => ConstantValue::BigInt(v.value),
             Lit::Regex(v) => ConstantValue::Regex(v.exp, v.flags),
             Lit::JSXText(v) => ConstantValue::Str(ConstantString::Atom(v.value)),
         }
@@ -523,6 +523,12 @@ impl From<Atom> for JsValue {
 
 impl From<BigInt> for JsValue {
     fn from(v: BigInt) -> Self {
+        Self::from(Box::new(v))
+    }
+}
+
+impl From<Box<BigInt>> for JsValue {
+    fn from(v: Box<BigInt>) -> Self {
         ConstantValue::BigInt(v).into()
     }
 }


### PR DESCRIPTION
### What?

Box the `BigInt` variant of `ConstantValue`.

### Why?

The `BigInt` variant is rarely instantiated so it's fine to penalize it to reduce the memory usage of the `ConstantValue` type, which is frequently created.

### How?


Closes PACK-3743