### PR TITLE
refactor(turbopack): Merge `Atom` and `JsWord` variant of `ConstantString`

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -99,7 +99,6 @@ impl Eq for ConstantNumber {}
 
 #[derive(Debug, Clone)]
 pub enum ConstantString {
-    Word(JsWord),
     Atom(Atom),
     RcStr(RcStr),
 }
@@ -107,7 +106,6 @@ pub enum ConstantString {
 impl ConstantString {
     pub fn as_str(&self) -> &str {
         match self {
-            Self::Word(s) => s,
             Self::Atom(s) => s,
             Self::RcStr(s) => s,
         }
@@ -146,7 +144,7 @@ impl From<Atom> for ConstantString {
 
 impl From<&'static str> for ConstantString {
     fn from(v: &'static str) -> Self {
-        ConstantString::Word(v.into())
+        ConstantString::Atom(v.into())
     }
 }
 
@@ -236,14 +234,14 @@ impl From<bool> for ConstantValue {
 
 impl From<&'_ str> for ConstantValue {
     fn from(v: &str) -> Self {
-        ConstantValue::Str(ConstantString::Word(v.into()))
+        ConstantValue::Str(ConstantString::Atom(v.into()))
     }
 }
 
 impl From<Lit> for ConstantValue {
     fn from(v: Lit) -> Self {
         match v {
-            Lit::Str(v) => ConstantValue::Str(ConstantString::Word(v.value)),
+            Lit::Str(v) => ConstantValue::Str(ConstantString::Atom(v.value)),
             Lit::Bool(v) => {
                 if v.value {
                     ConstantValue::True
@@ -511,7 +509,7 @@ pub enum JsValue {
 
 impl From<&'_ str> for JsValue {
     fn from(v: &str) -> Self {
-        ConstantValue::Str(ConstantString::Word(v.into())).into()
+        ConstantValue::Str(ConstantString::Atom(v.into())).into()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -3381,7 +3381,7 @@ fn is_invoking_node_process_eval(args: &[JsValue]) -> bool {
                 {
                     // Is `-e` one of the arguments passed to the program?
                     if items.iter().any(|e| {
-                        if let JsValue::Constant(JsConstantValue::Str(ConstantString::Word(arg))) =
+                        if let JsValue::Constant(JsConstantValue::Str(ConstantString::Atom(arg))) =
                             e
                         {
                             arg == "-e"

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/1/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/1/graph.snapshot
@@ -52,7 +52,7 @@
                         ),
                         Constant(
                             Str(
-                                Word(
+                                Atom(
                                     ".js",
                                 ),
                             ),
@@ -70,14 +70,14 @@
             values: [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "hello",
                         ),
                     ),
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "world",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array-map/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array-map/graph-effects.snapshot
@@ -5,14 +5,14 @@
             items: [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "../lib/a.js",
                         ),
                     ),
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "../lib/b.js",
                         ),
                     ),
@@ -72,14 +72,14 @@
             items: [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "../lib/a.js",
                         ),
                     ),
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "../lib/b.js",
                         ),
                     ),
@@ -245,14 +245,14 @@
             items: [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "../lib/a.js",
                         ),
                     ),
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "../lib/b.js",
                         ),
                     ),
@@ -312,14 +312,14 @@
             items: [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "../lib/a.js",
                         ),
                     ),
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "../lib/b.js",
                         ),
                     ),
@@ -485,14 +485,14 @@
             items: [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "../lib/a.js",
                         ),
                     ),
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "../lib/b.js",
                         ),
                     ),
@@ -552,14 +552,14 @@
             items: [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "../lib/a.js",
                         ),
                     ),
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "../lib/b.js",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array-map/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array-map/graph.snapshot
@@ -66,14 +66,14 @@
             items: [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "../lib/a.js",
                         ),
                     ),
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "../lib/b.js",
                         ),
                     ),
@@ -91,14 +91,14 @@
                 items: [
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "../lib/a.js",
                             ),
                         ),
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "../lib/b.js",
                             ),
                         ),
@@ -132,14 +132,14 @@
                 items: [
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "../lib/a.js",
                             ),
                         ),
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "../lib/b.js",
                             ),
                         ),
@@ -173,14 +173,14 @@
                 items: [
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "../lib/a.js",
                             ),
                         ),
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "../lib/b.js",
                             ),
                         ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array/graph-effects.snapshot
@@ -12,7 +12,7 @@
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "foo",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array/graph.snapshot
@@ -13,7 +13,7 @@
         "b",
         Constant(
             Str(
-                Word(
+                Atom(
                     "foo",
                 ),
             ),
@@ -35,7 +35,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "foo",
                             ),
                         ),
@@ -72,7 +72,7 @@
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "foo",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/assign/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/assign/graph.snapshot
@@ -6,7 +6,7 @@
             values: [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "",
                         ),
                     ),
@@ -22,7 +22,7 @@
                         ),
                         Constant(
                             Str(
-                                Word(
+                                Atom(
                                     "x",
                                 ),
                             ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/conditional-import/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/conditional-import/graph-effects.snapshot
@@ -158,7 +158,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "a",
                         ),
                     ),
@@ -450,7 +450,7 @@
             StrictEqual,
             Constant(
                 Str(
-                    Word(
+                    Atom(
                         "edge",
                     ),
                 ),
@@ -639,7 +639,7 @@
                         StrictEqual,
                         Constant(
                             Str(
-                                Word(
+                                Atom(
                                     "edge",
                                 ),
                             ),
@@ -647,14 +647,14 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "next/dist/compiled/@vercel/og/index.edge.js",
                             ),
                         ),
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "next/dist/compiled/@vercel/og/index.node.js",
                             ),
                         ),
@@ -711,7 +711,7 @@
                             Value(
                                 Constant(
                                     Str(
-                                        Word(
+                                        Atom(
                                             "a",
                                         ),
                                     ),
@@ -797,7 +797,7 @@
                             Value(
                                 Constant(
                                     Str(
-                                        Word(
+                                        Atom(
                                             "b",
                                         ),
                                     ),
@@ -1244,7 +1244,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "c",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/conditional-import/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/conditional-import/graph.snapshot
@@ -9,7 +9,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "a",
                         ),
                     ),
@@ -42,7 +42,7 @@
                     [
                         Constant(
                             Str(
-                                Word(
+                                Atom(
                                     "a",
                                 ),
                             ),
@@ -57,7 +57,7 @@
                     [
                         Constant(
                             Str(
-                                Word(
+                                Atom(
                                     "b",
                                 ),
                             ),
@@ -106,7 +106,7 @@
                         StrictEqual,
                         Constant(
                             Str(
-                                Word(
+                                Atom(
                                     "edge",
                                 ),
                             ),
@@ -114,14 +114,14 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "next/dist/compiled/@vercel/og/index.edge.js",
                             ),
                         ),
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "next/dist/compiled/@vercel/og/index.node.js",
                             ),
                         ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/declarations/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/declarations/graph.snapshot
@@ -69,7 +69,7 @@
         "d",
         Constant(
             Str(
-                Word(
+                Atom(
                     "hello",
                 ),
             ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild-reduced/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild-reduced/graph-effects.snapshot
@@ -89,7 +89,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "path",
                         ),
                     ),
@@ -178,7 +178,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "path",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild-reduced/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild-reduced/graph.snapshot
@@ -102,7 +102,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "esbuild-windows-arm64",
                             ),
                         ),
@@ -118,7 +118,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "esbuild-windows-32",
                             ),
                         ),
@@ -134,7 +134,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "esbuild-windows-64",
                             ),
                         ),
@@ -154,7 +154,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "path",
                         ),
                     ),
@@ -172,7 +172,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "path",
                         ),
                     ),
@@ -298,7 +298,7 @@
                 },
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "esbuild.exe",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph-effects.snapshot
@@ -691,7 +691,7 @@
                             StrictNotEqual,
                             Constant(
                                 Str(
-                                    Word(
+                                    Atom(
                                         "main.js",
                                     ),
                                 ),
@@ -723,7 +723,7 @@
                             StrictNotEqual,
                             Constant(
                                 Str(
-                                    Word(
+                                    Atom(
                                         "lib",
                                     ),
                                 ),
@@ -1328,7 +1328,7 @@
                             Value(
                                 Constant(
                                     Str(
-                                        Word(
+                                        Atom(
                                             "..",
                                         ),
                                     ),
@@ -1337,7 +1337,7 @@
                             Value(
                                 Constant(
                                     Str(
-                                        Word(
+                                        Atom(
                                             "bin",
                                         ),
                                     ),
@@ -1346,7 +1346,7 @@
                             Value(
                                 Constant(
                                     Str(
-                                        Word(
+                                        Atom(
                                             "esbuild",
                                         ),
                                     ),
@@ -1872,7 +1872,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "--ping",
                         ),
                     ),
@@ -1961,7 +1961,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "path",
                         ),
                     ),
@@ -2050,7 +2050,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "path",
                         ),
                     ),
@@ -2139,7 +2139,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "os",
                         ),
                     ),
@@ -4532,7 +4532,7 @@
                             Value(
                                 Constant(
                                     Str(
-                                        Word(
+                                        Atom(
                                             "pnpapi",
                                         ),
                                     ),
@@ -4882,7 +4882,7 @@
                                             Value(
                                                 Constant(
                                                     Str(
-                                                        Word(
+                                                        Atom(
                                                             "esbuild",
                                                         ),
                                                     ),
@@ -4993,7 +4993,7 @@
                                                     [
                                                         Constant(
                                                             Str(
-                                                                Word(
+                                                                Atom(
                                                                     "esbuild",
                                                                 ),
                                                             ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph.snapshot
@@ -12,7 +12,7 @@
                         items: [
                             Constant(
                                 Str(
-                                    Word(
+                                    Atom(
                                         "node",
                                     ),
                                 ),
@@ -41,21 +41,21 @@
                                             ),
                                             Constant(
                                                 Str(
-                                                    Word(
+                                                    Atom(
                                                         "..",
                                                     ),
                                                 ),
                                             ),
                                             Constant(
                                                 Str(
-                                                    Word(
+                                                    Atom(
                                                         "bin",
                                                     ),
                                                 ),
                                             ),
                                             Constant(
                                                 Str(
-                                                    Word(
+                                                    Atom(
                                                         "esbuild",
                                                     ),
                                                 ),
@@ -368,7 +368,7 @@
                     [
                         Constant(
                             Str(
-                                Word(
+                                Atom(
                                     "esbuild",
                                 ),
                             ),
@@ -436,7 +436,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "esbuild-android-arm64",
                             ),
                         ),
@@ -452,7 +452,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "esbuild-darwin-arm64",
                             ),
                         ),
@@ -468,7 +468,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "esbuild-darwin-64",
                             ),
                         ),
@@ -484,7 +484,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "esbuild-freebsd-arm64",
                             ),
                         ),
@@ -500,7 +500,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "esbuild-freebsd-64",
                             ),
                         ),
@@ -516,7 +516,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "esbuild-linux-arm",
                             ),
                         ),
@@ -532,7 +532,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "esbuild-linux-arm64",
                             ),
                         ),
@@ -548,7 +548,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "esbuild-linux-32",
                             ),
                         ),
@@ -564,7 +564,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "esbuild-linux-mips64le",
                             ),
                         ),
@@ -580,7 +580,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "esbuild-linux-ppc64le",
                             ),
                         ),
@@ -596,7 +596,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "esbuild-linux-s390x",
                             ),
                         ),
@@ -612,7 +612,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "esbuild-linux-64",
                             ),
                         ),
@@ -628,7 +628,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "esbuild-netbsd-64",
                             ),
                         ),
@@ -644,7 +644,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "esbuild-openbsd-64",
                             ),
                         ),
@@ -660,7 +660,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "esbuild-sunos-64",
                             ),
                         ),
@@ -685,7 +685,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "esbuild-windows-arm64",
                             ),
                         ),
@@ -701,7 +701,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "esbuild-windows-32",
                             ),
                         ),
@@ -717,7 +717,7 @@
                     ),
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "esbuild-windows-64",
                             ),
                         ),
@@ -737,7 +737,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "os",
                         ),
                     ),
@@ -755,7 +755,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "path",
                         ),
                     ),
@@ -773,7 +773,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "path",
                         ),
                     ),
@@ -986,14 +986,14 @@
                 },
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "esbuild.exe",
                         ),
                     ),
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "bin/esbuild",
                         ),
                     ),
@@ -1052,7 +1052,7 @@
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "--ping",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array-2/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array-2/graph-effects.snapshot
@@ -10,7 +10,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "1",
                         ),
                     ),
@@ -19,7 +19,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "2",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array-2/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array-2/graph.snapshot
@@ -62,14 +62,14 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "1",
                         ),
                     ),
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "2",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array/graph-effects.snapshot
@@ -10,7 +10,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "1",
                         ),
                     ),
@@ -19,7 +19,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "2",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array/graph.snapshot
@@ -62,14 +62,14 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "1",
                         ),
                     ),
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "2",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/free-vars/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/free-vars/graph-effects.snapshot
@@ -113,7 +113,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "Hello World",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/free-vars/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/free-vars/graph.snapshot
@@ -16,7 +16,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "Hello World",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/iife-2/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/iife-2/graph-effects.snapshot
@@ -897,7 +897,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "####",
                         ),
                     ),
@@ -1874,7 +1874,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/iife/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/iife/graph-effects.snapshot
@@ -51,7 +51,7 @@
                             Value(
                                 Constant(
                                     Str(
-                                        Word(
+                                        Atom(
                                             "test",
                                         ),
                                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph-effects.snapshot
@@ -85,7 +85,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "crypt",
                         ),
                     ),
@@ -167,7 +167,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "charenc",
                         ),
                     ),
@@ -338,7 +338,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "charenc",
                         ),
                     ),
@@ -503,7 +503,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "is-buffer",
                         ),
                     ),
@@ -585,7 +585,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "charenc",
                         ),
                     ),
@@ -756,7 +756,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "charenc",
                         ),
                     ),
@@ -1211,7 +1211,7 @@
                                     StrictEqual,
                                     Constant(
                                         Str(
-                                            Word(
+                                            Atom(
                                                 "binary",
                                             ),
                                         ),
@@ -29023,7 +29023,7 @@
                                     [
                                         Constant(
                                             Str(
-                                                Word(
+                                                Atom(
                                                     "Illegal argument ",
                                                 ),
                                             ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph.snapshot
@@ -2854,7 +2854,7 @@
                 [
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "charenc",
                             ),
                         ),
@@ -4127,7 +4127,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "crypt",
                         ),
                     ),
@@ -5478,7 +5478,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "is-buffer",
                         ),
                     ),
@@ -5865,7 +5865,7 @@
                 [
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "charenc",
                             ),
                         ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/mongoose-reduced/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/mongoose-reduced/graph-effects.snapshot
@@ -152,7 +152,7 @@
                         ),
                         Constant(
                             Str(
-                                Word(
+                                Atom(
                                     "/connection",
                                 ),
                             ),
@@ -252,7 +252,7 @@
                         ),
                         Constant(
                             Str(
-                                Word(
+                                Atom(
                                     "/collection",
                                 ),
                             ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/mongoose-reduced/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/mongoose-reduced/graph.snapshot
@@ -18,7 +18,7 @@
                         ),
                         Constant(
                             Str(
-                                Word(
+                                Atom(
                                     "/collection",
                                 ),
                             ),
@@ -47,7 +47,7 @@
                         ),
                         Constant(
                             Str(
-                                Word(
+                                Atom(
                                     "/connection",
                                 ),
                             ),
@@ -78,7 +78,7 @@
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "./drivers/node-mongodb-native",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph-effects.snapshot
@@ -10,7 +10,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "a",
                         ),
                     ),
@@ -657,7 +657,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "b",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph.snapshot
@@ -74,7 +74,7 @@
                 [
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "b",
                             ),
                         ),
@@ -213,7 +213,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "a",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/new-url/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/new-url/graph-effects.snapshot
@@ -156,7 +156,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "./worker.ts",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/new-url/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/new-url/graph.snapshot
@@ -9,7 +9,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "./worker.ts",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/object/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/object/graph-effects.snapshot
@@ -52,7 +52,7 @@
         ),
         prop: Constant(
             Str(
-                Word(
+                Atom(
                     "a",
                 ),
             ),
@@ -140,7 +140,7 @@
         ),
         prop: Constant(
             Str(
-                Word(
+                Atom(
                     "b",
                 ),
             ),
@@ -228,7 +228,7 @@
         ),
         prop: Constant(
             Str(
-                Word(
+                Atom(
                     "c",
                 ),
             ),
@@ -316,7 +316,7 @@
         ),
         prop: Constant(
             Str(
-                Word(
+                Atom(
                     "d",
                 ),
             ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/object/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/object/graph.snapshot
@@ -49,7 +49,7 @@
             ),
             Constant(
                 Str(
-                    Word(
+                    Atom(
                         "a",
                     ),
                 ),
@@ -182,7 +182,7 @@
             ),
             Constant(
                 Str(
-                    Word(
+                    Atom(
                         "b",
                     ),
                 ),
@@ -315,7 +315,7 @@
             ),
             Constant(
                 Str(
-                    Word(
+                    Atom(
                         "c",
                     ),
                 ),
@@ -353,7 +353,7 @@
             ),
             Constant(
                 Str(
-                    Word(
+                    Atom(
                         "c",
                     ),
                 ),
@@ -448,7 +448,7 @@
             ),
             Constant(
                 Str(
-                    Word(
+                    Atom(
                         "d",
                     ),
                 ),
@@ -571,7 +571,7 @@
                 KeyValue(
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "c",
                             ),
                         ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2236/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2236/graph-effects.snapshot
@@ -114,7 +114,7 @@
             StrictEqual,
             Constant(
                 Str(
-                    Word(
+                    Atom(
                         "undefined",
                     ),
                 ),
@@ -183,7 +183,7 @@
                             Value(
                                 Constant(
                                     Str(
-                                        Word(
+                                        Atom(
                                             "ioredis",
                                         ),
                                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2236/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2236/graph.snapshot
@@ -14,7 +14,7 @@
                 StrictEqual,
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "undefined",
                         ),
                     ),
@@ -28,7 +28,7 @@
                 [
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "ioredis",
                             ),
                         ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2521/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2521/graph-effects.snapshot
@@ -50,7 +50,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "./libvips",
                         ),
                     ),
@@ -225,7 +225,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "runtimePlatform:",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2521/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2521/graph.snapshot
@@ -66,7 +66,7 @@
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "../src/build/Release/sharp-wasm32.node",
                         ),
                     ),
@@ -98,7 +98,7 @@
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "@img/sharp-wasm32/sharp.node",
                         ),
                     ),
@@ -132,7 +132,7 @@
                 [
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "./libvips",
                             ),
                         ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2682/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2682/graph-effects.snapshot
@@ -370,7 +370,7 @@
             StrictEqual,
             Constant(
                 Str(
-                    Word(
+                    Atom(
                         "true",
                     ),
                 ),
@@ -660,7 +660,7 @@
                                 StrictEqual,
                                 Constant(
                                     Str(
-                                        Word(
+                                        Atom(
                                             "true",
                                         ),
                                     ),
@@ -688,7 +688,7 @@
                                     StrictEqual,
                                     Constant(
                                         Str(
-                                            Word(
+                                            Atom(
                                                 "true",
                                             ),
                                         ),
@@ -696,14 +696,14 @@
                                 ),
                                 Constant(
                                     Str(
-                                        Word(
+                                        Atom(
                                             "true",
                                         ),
                                     ),
                                 ),
                                 Constant(
                                     Str(
-                                        Word(
+                                        Atom(
                                             "false",
                                         ),
                                     ),
@@ -831,7 +831,7 @@
                             ),
                             Constant(
                                 Str(
-                                    Word(
+                                    Atom(
                                         "false",
                                     ),
                                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2682/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2682/graph.snapshot
@@ -39,7 +39,7 @@
                                     StrictEqual,
                                     Constant(
                                         Str(
-                                            Word(
+                                            Atom(
                                                 "true",
                                             ),
                                         ),
@@ -67,7 +67,7 @@
                                         StrictEqual,
                                         Constant(
                                             Str(
-                                                Word(
+                                                Atom(
                                                     "true",
                                                 ),
                                             ),
@@ -75,14 +75,14 @@
                                     ),
                                     Constant(
                                         Str(
-                                            Word(
+                                            Atom(
                                                 "true",
                                             ),
                                         ),
                                     ),
                                     Constant(
                                         Str(
-                                            Word(
+                                            Atom(
                                                 "false",
                                             ),
                                         ),
@@ -129,7 +129,7 @@
                             ),
                             Constant(
                                 Str(
-                                    Word(
+                                    Atom(
                                         "false",
                                     ),
                                 ),
@@ -162,7 +162,7 @@
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "true",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/path-join/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/path-join/graph-effects.snapshot
@@ -50,7 +50,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "foo",
                         ),
                     ),
@@ -139,7 +139,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "path",
                         ),
                     ),
@@ -248,7 +248,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "foo",
                         ),
                     ),
@@ -257,7 +257,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "bar",
                         ),
                     ),
@@ -366,7 +366,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "foo/",
                         ),
                     ),
@@ -375,7 +375,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "bar",
                         ),
                     ),
@@ -484,7 +484,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "foo",
                         ),
                     ),
@@ -493,7 +493,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "/bar",
                         ),
                     ),
@@ -602,7 +602,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "foo/",
                         ),
                     ),
@@ -611,7 +611,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "/bar",
                         ),
                     ),
@@ -765,7 +765,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "foo",
                         ),
                     ),
@@ -774,7 +774,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "bar",
                         ),
                     ),
@@ -783,7 +783,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "..",
                         ),
                     ),
@@ -792,7 +792,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "baz",
                         ),
                     ),
@@ -806,7 +806,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "..",
                         ),
                     ),
@@ -815,7 +815,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "foo",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/path-join/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/path-join/graph.snapshot
@@ -9,7 +9,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "foo",
                         ),
                     ),
@@ -27,7 +27,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "path",
                         ),
                     ),
@@ -55,14 +55,14 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "foo",
                         ),
                     ),
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "bar",
                         ),
                     ),
@@ -90,14 +90,14 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "foo/",
                         ),
                     ),
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "bar",
                         ),
                     ),
@@ -125,14 +125,14 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "foo",
                         ),
                     ),
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "/bar",
                         ),
                     ),
@@ -160,14 +160,14 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "foo/",
                         ),
                     ),
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "/bar",
                         ),
                     ),
@@ -195,28 +195,28 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "foo",
                         ),
                     ),
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "bar",
                         ),
                     ),
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "..",
                         ),
                     ),
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "baz",
                         ),
                     ),
@@ -226,14 +226,14 @@
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "..",
                         ),
                     ),
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "foo",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/process-and-os/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/process-and-os/graph-effects.snapshot
@@ -50,7 +50,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "os",
                         ),
                     ),
@@ -139,7 +139,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "process",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/process-and-os/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/process-and-os/graph.snapshot
@@ -11,7 +11,7 @@
                 [
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "os",
                             ),
                         ),
@@ -467,7 +467,7 @@
                 [
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "os",
                             ),
                         ),
@@ -501,7 +501,7 @@
                 [
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "os",
                             ),
                         ),
@@ -529,7 +529,7 @@
                 [
                     Constant(
                         Str(
-                            Word(
+                            Atom(
                                 "process",
                             ),
                         ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/require-context/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/require-context/graph-effects.snapshot
@@ -113,7 +113,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "./test",
                         ),
                     ),
@@ -283,7 +283,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "./a",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/require-context/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/require-context/graph.snapshot
@@ -19,7 +19,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "./a",
                         ),
                     ),
@@ -44,7 +44,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "./test",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/try/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/try/graph-effects.snapshot
@@ -59,7 +59,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "packages/not-found",
                         ),
                     ),
@@ -169,7 +169,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "packages/found",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/try/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/try/graph.snapshot
@@ -39,7 +39,7 @@
                     [
                         Constant(
                             Str(
-                                Word(
+                                Atom(
                                     "packages/not-found",
                                 ),
                             ),
@@ -54,7 +54,7 @@
                     [
                         Constant(
                             Str(
-                                Word(
+                                Atom(
                                     "packages/found",
                                 ),
                             ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/turbopack-ignore/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/turbopack-ignore/graph-effects.snapshot
@@ -7,7 +7,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "w_i",
                         ),
                     ),
@@ -102,7 +102,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "w_i_f",
                         ),
                     ),
@@ -151,7 +151,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "t_i",
                         ),
                     ),
@@ -246,7 +246,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "t_i_f",
                         ),
                     ),
@@ -341,7 +341,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "w_r_t",
                         ),
                     ),
@@ -436,7 +436,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "w_r_f",
                         ),
                     ),
@@ -531,7 +531,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "t_r_t",
                         ),
                     ),
@@ -626,7 +626,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "t_r_f",
                         ),
                     ),
@@ -724,7 +724,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "exported_t_r",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/turbopack-ignore/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/turbopack-ignore/graph.snapshot
@@ -9,7 +9,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "exported_t_r",
                         ),
                     ),
@@ -27,7 +27,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "t_i",
                         ),
                     ),
@@ -48,7 +48,7 @@
                     [
                         Constant(
                             Str(
-                                Word(
+                                Atom(
                                     "w_i_f",
                                 ),
                             ),
@@ -63,7 +63,7 @@
                     [
                         Constant(
                             Str(
-                                Word(
+                                Atom(
                                     "t_i_f",
                                 ),
                             ),
@@ -78,7 +78,7 @@
                     [
                         Constant(
                             Str(
-                                Word(
+                                Atom(
                                     "t_r_t",
                                 ),
                             ),
@@ -93,7 +93,7 @@
                     [
                         Constant(
                             Str(
-                                Word(
+                                Atom(
                                     "t_r_f",
                                 ),
                             ),
@@ -114,7 +114,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "w_i",
                         ),
                     ),
@@ -135,7 +135,7 @@
                     [
                         Constant(
                             Str(
-                                Word(
+                                Atom(
                                     "w_r_t",
                                 ),
                             ),
@@ -150,7 +150,7 @@
                     [
                         Constant(
                             Str(
-                                Word(
+                                Atom(
                                     "w_r_f",
                                 ),
                             ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/graph-effects.snapshot
@@ -887,7 +887,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "fs/promises",
                         ),
                     ),
@@ -1189,7 +1189,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "./hello.txt",
                         ),
                     ),
@@ -1198,7 +1198,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "utf-8",
                         ),
                     ),
@@ -2086,7 +2086,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "../../webpack-api-runtime.js",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/graph.snapshot
@@ -99,7 +99,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "../../webpack-api-runtime.js",
                         ),
                     ),
@@ -159,14 +159,14 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "./hello.txt",
                         ),
                     ),
                 ),
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "utf-8",
                         ),
                     ),
@@ -191,7 +191,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "fs/promises",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/worker/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/worker/graph-effects.snapshot
@@ -156,7 +156,7 @@
             Value(
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "./worker.ts",
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/worker/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/worker/graph.snapshot
@@ -9,7 +9,7 @@
             [
                 Constant(
                     Str(
-                        Word(
+                        Atom(
                             "./worker.ts",
                         ),
                     ),


### PR DESCRIPTION
### What?

Merge two variants as those are exactly the same.

### Why?

`JsWord` is an alias of `Atom`.

Closes PACK-3745