### PR TITLE
rest errors queue after passing to handler

### DIFF
--- a/packages/next/src/client/components/errors/use-error-handler.ts
+++ b/packages/next/src/client/components/errors/use-error-handler.ts
@@ -69,8 +69,9 @@ export function useErrorHandler(
         1
       )
 
-      errorQueue.splice(0, errorQueue.length)
-      rejectionQueue.splice(0, rejectionQueue.length)
+      // Reset error queues.
+      errorQueue.splice(0, 0)
+      rejectionQueue.splice(0, 0)
     }
   }, [handleOnUnhandledError, handleOnUnhandledRejection])
 }

--- a/packages/next/src/client/components/errors/use-error-handler.ts
+++ b/packages/next/src/client/components/errors/use-error-handler.ts
@@ -68,6 +68,9 @@ export function useErrorHandler(
         rejectionHandlers.indexOf(handleOnUnhandledRejection),
         1
       )
+
+      errorQueue.splice(0, errorQueue.length)
+      rejectionQueue.splice(0, rejectionQueue.length)
     }
   }, [handleOnUnhandledError, handleOnUnhandledRejection])
 }


### PR DESCRIPTION
### What

Reset error queues in effects clean up phase as they're already passed to the handler during execution, which means the errors are present on the dialog. To prevent they're being processed again we just clean up the error queue. This is an preparation for #74983
