### PR TITLE
feature(error): capture ssr error in overlay during dev

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -26,6 +26,7 @@ import { createInitialRouterState } from './components/router-reducer/create-ini
 import { MissingSlotContext } from '../shared/lib/app-router-context.shared-runtime'
 import { setAppBuildId } from './app-build-id'
 import { shouldRenderRootLevelErrorOverlay } from './lib/is-error-thrown-while-rendering-rsc'
+import { handleClientError } from './components/errors/use-error-handler'
 
 /// <reference types="react-dom/experimental" />
 
@@ -267,6 +268,19 @@ export function hydrate() {
     }
 
     ReactDOMClient.createRoot(appElement, reactRootOptions).render(element)
+
+    const ssrErrorTemplateTag = document.querySelector(
+      'template[data-next-error-message]'
+    )
+    if (ssrErrorTemplateTag) {
+      const message: string = ssrErrorTemplateTag.getAttribute(
+        'data-next-error-message'
+      )!
+      const stack = ssrErrorTemplateTag.getAttribute('data-next-error-stack')
+      const error = new Error(message)
+      error.stack = stack || ''
+      handleClientError(error, [])
+    }
   } else {
     React.startTransition(() => {
       ReactDOMClient.hydrateRoot(appElement, reactEl, {

--- a/test/development/app-dir/ssr-only-error/app/layout.tsx
+++ b/test/development/app-dir/ssr-only-error/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/ssr-only-error/app/page.tsx
+++ b/test/development/app-dir/ssr-only-error/app/page.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+export default function Page() {
+  if (typeof window === 'undefined') {
+    throw new Error('SSR only error')
+  }
+  return <p>hello world</p>
+}

--- a/test/development/app-dir/ssr-only-error/next.config.js
+++ b/test/development/app-dir/ssr-only-error/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/development/app-dir/ssr-only-error/ssr-only-error.test.ts
+++ b/test/development/app-dir/ssr-only-error/ssr-only-error.test.ts
@@ -1,0 +1,43 @@
+import { nextTestSetup } from 'e2e-utils'
+import {
+  getRedboxDescription,
+  getRedboxSource,
+  hasErrorToast,
+  openRedbox,
+} from 'next-test-utils'
+
+describe('ssr-only-error', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should show ssr only error in error overlay', async () => {
+    const browser = await next.browser('/')
+
+    // Ensure it's not like server error that is shown by default
+    await hasErrorToast(browser)
+
+    await openRedbox(browser)
+
+    const description = await getRedboxDescription(browser)
+    const source = await getRedboxSource(browser)
+
+    expect({
+      description,
+      source,
+    }).toMatchInlineSnapshot(`
+     {
+       "description": "Error: SSR only error",
+       "source": "app/page.tsx (5:11) @ Page
+
+       3 | export default function Page() {
+       4 |   if (typeof window === 'undefined') {
+     > 5 |     throw new Error('SSR only error')
+         |           ^
+       6 |   }
+       7 |   return <p>hello world</p>
+       8 | }",
+     }
+    `)
+  })
+})


### PR DESCRIPTION
### What

When there's an SSR only error occured but browser client is all good, for example:

```js
// page.js
'use client'

export default function Page() {
  if (typeof window === 'undefined') {
    throw new Error('SSR only error')
  }
  return <p>hello world</p>
}
```

In this case, we did logged the error in the terminal but the errors are not presented to users. So we developed a way that, when we find a SSR error, excluding the RSC one, we'll wrap it up as a hidden `template` tag in error html body and send to client during development. On client we can consume that serialized error from `template` attributes and report to dev overlay. It will be in an uninterruptive way that users can still see it, but not block on viewing the client rendered page.


Closes NDX-670 