### PR TITLE
test: temporarily disable after deploy test

### DIFF
--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -56,7 +56,8 @@
       "test/e2e/socket-io/index.test.js",
       "test/e2e/middleware-matcher/index.test.ts",
       "test/e2e/next-script/index.test.ts",
-      "test/production/standalone-mode/**/*"
+      "test/production/standalone-mode/**/*",
+      "test/e2e/app-dir/next-after-app-deploy/index.test.ts"
     ]
   }
 }


### PR DESCRIPTION
this test currently fails in deploy mode for internal reasons that'll be resolved in the coming days, and it's just causing a lot of noise because it fails on every commit. we can reenable it next week