### PR TITLE
refactor: updated route regexp handling to simplify

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -430,7 +430,9 @@ export type RoutesManifest = {
 }
 
 function pageToRoute(page: string) {
-  const routeRegex = getNamedRouteRegex(page, true)
+  const routeRegex = getNamedRouteRegex(page, {
+    prefixRouteKeys: true,
+  })
   return {
     page,
     regex: normalizeRouteRegex(routeRegex.re.source),
@@ -3221,7 +3223,9 @@ export default async function build(
                     : undefined,
                   experimentalBypassFor: bypassFor,
                   routeRegex: normalizeRouteRegex(
-                    getNamedRouteRegex(route.pathname, false).re.source
+                    getNamedRouteRegex(route.pathname, {
+                      prefixRouteKeys: false,
+                    }).re.source
                   ),
                   dataRoute,
                   fallback,
@@ -3235,22 +3239,21 @@ export default async function build(
                   dataRouteRegex: !dataRoute
                     ? null
                     : normalizeRouteRegex(
-                        getNamedRouteRegex(
-                          dataRoute.replace(/\.rsc$/, ''),
-                          false
-                        ).re.source.replace(/\(\?:\\\/\)\?\$$/, '\\.rsc$')
+                        getNamedRouteRegex(dataRoute, {
+                          prefixRouteKeys: false,
+                          includeExtraParts: true,
+                          excludeOptionalTrailingSlash: true,
+                        }).re.source
                       ),
                   prefetchDataRoute,
                   prefetchDataRouteRegex: !prefetchDataRoute
                     ? undefined
                     : normalizeRouteRegex(
-                        getNamedRouteRegex(
-                          prefetchDataRoute.replace(/\.prefetch\.rsc$/, ''),
-                          false
-                        ).re.source.replace(
-                          /\(\?:\\\/\)\?\$$/,
-                          '\\.prefetch\\.rsc$'
-                        )
+                        getNamedRouteRegex(prefetchDataRoute, {
+                          prefixRouteKeys: false,
+                          includeExtraParts: true,
+                          excludeOptionalTrailingSlash: true,
+                        }).re.source
                       ),
                   allowHeader: ALLOWED_HEADERS,
                 }
@@ -3648,7 +3651,9 @@ export default async function build(
 
           prerenderManifest.dynamicRoutes[tbdRoute] = {
             routeRegex: normalizeRouteRegex(
-              getNamedRouteRegex(tbdRoute, false).re.source
+              getNamedRouteRegex(tbdRoute, {
+                prefixRouteKeys: false,
+              }).re.source
             ),
             experimentalPPR: undefined,
             renderingMode: undefined,
@@ -3662,10 +3667,11 @@ export default async function build(
             fallbackSourceRoute: undefined,
             fallbackRootParams: undefined,
             dataRouteRegex: normalizeRouteRegex(
-              getNamedRouteRegex(
-                dataRoute.replace(/\.json$/, ''),
-                false
-              ).re.source.replace(/\(\?:\\\/\)\?\$$/, '\\.json$')
+              getNamedRouteRegex(dataRoute, {
+                prefixRouteKeys: true,
+                includeExtraParts: true,
+                excludeOptionalTrailingSlash: true,
+              }).re.source
             ),
             // Pages does not have a prefetch data route.
             prefetchDataRoute: undefined,

--- a/packages/next/src/lib/metadata/get-metadata-route.ts
+++ b/packages/next/src/lib/metadata/get-metadata-route.ts
@@ -61,7 +61,9 @@ export function fillMetadataSegment(
   lastSegment: string
 ) {
   const pathname = normalizeAppPath(segment)
-  const routeRegex = getNamedRouteRegex(pathname, false)
+  const routeRegex = getNamedRouteRegex(pathname, {
+    prefixRouteKeys: false,
+  })
   const route = interpolateDynamicPath(pathname, params, routeRegex)
   const { name, ext } = path.parse(lastSegment)
   const pagePath = path.posix.join(segment, name)

--- a/packages/next/src/server/lib/router-utils/build-data-route.test.ts
+++ b/packages/next/src/server/lib/router-utils/build-data-route.test.ts
@@ -1,0 +1,29 @@
+import { buildDataRoute } from './build-data-route'
+
+describe('buildDataRoute', () => {
+  it('should build a dynamic data route', () => {
+    const dataRoute = buildDataRoute('/[...slug]', '123')
+    expect(dataRoute).toMatchInlineSnapshot(`
+     {
+       "dataRouteRegex": "^/_next/data/123/(.+?)\\.json$",
+       "namedDataRouteRegex": "^/_next/data/123/(?<nxtPslug>.+?)\\.json$",
+       "page": "/[...slug]",
+       "routeKeys": {
+         "nxtPslug": "nxtPslug",
+       },
+     }
+    `)
+  })
+
+  it('should build a static data route', () => {
+    const dataRoute = buildDataRoute('/about', '123')
+    expect(dataRoute).toMatchInlineSnapshot(`
+     {
+       "dataRouteRegex": "^/_next/data/123/about\\.json$",
+       "namedDataRouteRegex": undefined,
+       "page": "/about",
+       "routeKeys": undefined,
+     }
+    `)
+  })
+})

--- a/packages/next/src/server/lib/router-utils/build-data-route.ts
+++ b/packages/next/src/server/lib/router-utils/build-data-route.ts
@@ -14,18 +14,14 @@ export function buildDataRoute(page: string, buildId: string) {
   let routeKeys: { [named: string]: string } | undefined
 
   if (isDynamicRoute(page)) {
-    const routeRegex = getNamedRouteRegex(
-      dataRoute.replace(/\.json$/, ''),
-      true
-    )
+    const routeRegex = getNamedRouteRegex(dataRoute, {
+      prefixRouteKeys: true,
+      includeExtraParts: true,
+      excludeOptionalTrailingSlash: true,
+    })
 
-    dataRouteRegex = normalizeRouteRegex(
-      routeRegex.re.source.replace(/\(\?:\\\/\)\?\$$/, `\\.json$`)
-    )
-    namedDataRouteRegex = routeRegex.namedRegex!.replace(
-      /\(\?:\/\)\?\$$/,
-      `\\.json$`
-    )
+    dataRouteRegex = normalizeRouteRegex(routeRegex.re.source)
+    namedDataRouteRegex = routeRegex.namedRegex
     routeKeys = routeRegex.routeKeys
   } else {
     dataRouteRegex = normalizeRouteRegex(

--- a/packages/next/src/server/server-utils.ts
+++ b/packages/next/src/server/server-utils.ts
@@ -196,7 +196,9 @@ export function getUtils({
   let defaultRouteMatches: ParsedUrlQuery | undefined
 
   if (pageIsDynamic) {
-    defaultRouteRegex = getNamedRouteRegex(page, false)
+    defaultRouteRegex = getNamedRouteRegex(page, {
+      prefixRouteKeys: false,
+    })
     dynamicRouteMatcher = getRouteMatcher(defaultRouteRegex)
     defaultRouteMatches = dynamicRouteMatcher(page) as ParsedUrlQuery
   }

--- a/packages/next/src/server/web-server.ts
+++ b/packages/next/src/server/web-server.ts
@@ -165,7 +165,9 @@ export default class NextWebServer extends BaseServer<
       pathname = normalizedPage
 
       if (isDynamicRoute(pathname)) {
-        const routeRegex = getNamedRouteRegex(pathname, false)
+        const routeRegex = getNamedRouteRegex(pathname, {
+          prefixRouteKeys: false,
+        })
         const dynamicRouteMatcher = getRouteMatcher(routeRegex)
         const defaultRouteMatches = dynamicRouteMatcher(
           pathname

--- a/packages/next/src/shared/lib/page-path/normalize-page-path.test.ts
+++ b/packages/next/src/shared/lib/page-path/normalize-page-path.test.ts
@@ -1,0 +1,23 @@
+import { normalizePagePath } from './normalize-page-path'
+
+describe('normalizePagePath', () => {
+  it('should normalize the page path', () => {
+    expect(normalizePagePath('/')).toBe('/index')
+  })
+
+  it('should normalize the page path with a dynamic route', () => {
+    expect(normalizePagePath('/[locale]')).toBe('/[locale]')
+  })
+
+  it('should normalize the page path with a dynamic route and a trailing slash', () => {
+    expect(normalizePagePath('/[locale]/')).toBe('/[locale]/')
+  })
+
+  it('should normalize the page with a leading index', () => {
+    expect(normalizePagePath('/index')).toBe('/index/index')
+  })
+
+  it('should normalize the page with a leading index and suffix', () => {
+    expect(normalizePagePath('/index/foo')).toBe('/index/index/foo')
+  })
+})

--- a/packages/next/src/shared/lib/router/utils/route-regex.test.ts
+++ b/packages/next/src/shared/lib/router/utils/route-regex.test.ts
@@ -3,7 +3,9 @@ import { parseParameter } from './route-regex'
 
 describe('getNamedRouteRegex', () => {
   it('should handle interception markers adjacent to dynamic path segments', () => {
-    const regex = getNamedRouteRegex('/photos/(.)[author]/[id]', true)
+    const regex = getNamedRouteRegex('/photos/(.)[author]/[id]', {
+      prefixRouteKeys: true,
+    })
 
     expect(regex.routeKeys).toEqual({
       nxtIauthor: 'nxtIauthor',
@@ -26,19 +28,28 @@ describe('getNamedRouteRegex', () => {
   })
 
   it('should match named routes correctly when interception markers are adjacent to dynamic segments', () => {
-    let regex = getNamedRouteRegex('/(.)[author]/[id]', true)
+    let regex = getNamedRouteRegex('/(.)[author]/[id]', {
+      prefixRouteKeys: true,
+    })
     let namedRegexp = new RegExp(regex.namedRegex)
     expect(namedRegexp.test('/[author]/[id]')).toBe(false)
     expect(namedRegexp.test('/(.)[author]/[id]')).toBe(true)
 
-    regex = getNamedRouteRegex('/(..)(..)[author]/[id]', true)
+    regex = getNamedRouteRegex('/(..)(..)[author]/[id]', {
+      prefixRouteKeys: true,
+    })
+    expect(regex.namedRegex).toMatchInlineSnapshot(
+      `"^/\\(\\.\\.\\)\\(\\.\\.\\)(?<nxtIauthor>[^/]+?)/(?<nxtPid>[^/]+?)(?:/)?$"`
+    )
     namedRegexp = new RegExp(regex.namedRegex)
     expect(namedRegexp.test('/[author]/[id]')).toBe(false)
     expect(namedRegexp.test('/(..)(..)[author]/[id]')).toBe(true)
   })
 
   it('should handle multi-level interception markers', () => {
-    const regex = getNamedRouteRegex('/photos/(..)(..)[author]/[id]', true)
+    const regex = getNamedRouteRegex('/photos/(..)(..)[author]/[id]', {
+      prefixRouteKeys: true,
+    })
 
     expect(regex.routeKeys).toEqual({
       nxtIauthor: 'nxtIauthor',
@@ -60,8 +71,30 @@ describe('getNamedRouteRegex', () => {
     expect(regex.re.test('/photos/(..)(..)next/123')).toBe(true)
   })
 
+  it('should not remove extra parts beside the param segments', () => {
+    const { re, namedRegex, routeKeys } = getNamedRouteRegex(
+      '/[locale]/about.segments/[...segmentPath].segment.rsc',
+      {
+        prefixRouteKeys: true,
+        includeExtraParts: true,
+      }
+    )
+    expect(routeKeys).toEqual({
+      nxtPlocale: 'nxtPlocale',
+      nxtPsegmentPath: 'nxtPsegmentPath',
+    })
+    expect(namedRegex).toMatchInlineSnapshot(
+      `"^/(?<nxtPlocale>[^/]+?)/about\\.segments/(?<nxtPsegmentPath>.+?)\\.segment\\.rsc(?:/)?$"`
+    )
+    expect(re.source).toMatchInlineSnapshot(
+      `"^\\/([^/]+?)\\/about\\.segments\\/(.+?)\\.segment\\.rsc(?:\\/)?$"`
+    )
+  })
+
   it('should handle interception markers not adjacent to dynamic path segments', () => {
-    const regex = getNamedRouteRegex('/photos/(.)author/[id]', true)
+    const regex = getNamedRouteRegex('/photos/(.)author/[id]', {
+      prefixRouteKeys: true,
+    })
 
     expect(regex.routeKeys).toEqual({
       nxtPid: 'nxtPid',
@@ -79,7 +112,9 @@ describe('getNamedRouteRegex', () => {
   })
 
   it('should handle optional dynamic path segments', () => {
-    const regex = getNamedRouteRegex('/photos/[[id]]', true)
+    const regex = getNamedRouteRegex('/photos/[[id]]', {
+      prefixRouteKeys: true,
+    })
 
     expect(regex.routeKeys).toEqual({
       nxtPid: 'nxtPid',
@@ -93,7 +128,9 @@ describe('getNamedRouteRegex', () => {
   })
 
   it('should handle optional catch-all dynamic path segments', () => {
-    const regex = getNamedRouteRegex('/photos/[[...id]]', true)
+    const regex = getNamedRouteRegex('/photos/[[...id]]', {
+      prefixRouteKeys: true,
+    })
 
     expect(regex.routeKeys).toEqual({
       nxtPid: 'nxtPid',


### PR DESCRIPTION
Previously we had to do a lot of custom RegExp source mangling in order to preserve extra bits (like the `.rsc` or `.json` suffixes) on dynamic route parameter segments. This updates the handling to simply includes those in situations where it's desired.

Unit tests have been created to verify the new behaviour, no additional e2e tests should need to be adjusted.