### PR TITLE
Re-enable app-dir logging test

### DIFF
--- a/test/e2e/app-dir/logging/fetch-logging.test.ts
+++ b/test/e2e/app-dir/logging/fetch-logging.test.ts
@@ -84,9 +84,7 @@ describe('app-dir - fetch logging', () => {
   })
 })
 
-// TODO: this test has been quite flaky, so we are skipping it for now
-// will rewrite it later
-describe.skip('app-dir - logging', () => {
+describe('app-dir - logging', () => {
   const { next, isNextDev } = nextTestSetup({
     skipDeployment: true,
     files: __dirname,


### PR DESCRIPTION
It was disabled to test flakiness but have not had time to continue the investigation. Hence, we are re-enabling it to prevent regression.