### PR TITLE
Add `next-custom-transforms` tests to verify source maps

### DIFF
--- a/crates/next-custom-transforms/tests/fixture.rs
+++ b/crates/next-custom-transforms/tests/fixture.rs
@@ -916,6 +916,36 @@ fn test_edge_assert(input: PathBuf) {
     );
 }
 
+#[fixture("tests/fixture/source-maps/**/input.js")]
+fn test_source_maps(input: PathBuf) {
+    let output = input.parent().unwrap().join("output.js");
+    test_fixture(
+        syntax(),
+        &|_tr| {
+            (
+                resolver(Mark::new(), Mark::new(), false),
+                server_actions(
+                    &FileName::Real("/app/item.js".into()),
+                    server_actions::Config {
+                        is_react_server_layer: true,
+                        dynamic_io_enabled: true,
+                        hash_salt: "".into(),
+                        cache_kinds: FxHashSet::from_iter([]),
+                    },
+                    _tr.comments.as_ref().clone(),
+                ),
+            )
+        },
+        &input,
+        &output,
+        FixtureTestConfig {
+            module: Some(true),
+            sourcemap: true,
+            ..Default::default()
+        },
+    );
+}
+
 fn lint_to_fold<R>(r: R) -> impl Pass
 where
     R: Visit,

--- a/crates/next-custom-transforms/tests/fixture/source-maps/use-cache/1/input.js
+++ b/crates/next-custom-transforms/tests/fixture/source-maps/use-cache/1/input.js
@@ -1,0 +1,9 @@
+'use cache'
+
+const foo = async () => {
+  'use cache'
+}
+
+export async function bar() {
+  return foo()
+}

--- a/crates/next-custom-transforms/tests/fixture/source-maps/use-cache/1/output.js
+++ b/crates/next-custom-transforms/tests/fixture/source-maps/use-cache/1/output.js
@@ -1,0 +1,17 @@
+/* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0","80951c375b4a6a6e89d67b743ec5808127cfde405d":"$$RSC_SERVER_CACHE_1"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function() {});
+Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+    "value": "foo",
+    "writable": false
+});
+const foo = /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
+export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", 0, /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ async function bar() {
+    return foo();
+});
+Object.defineProperty($$RSC_SERVER_CACHE_1, "name", {
+    "value": "bar",
+    "writable": false
+});
+export var bar = registerServerReference($$RSC_SERVER_CACHE_1, "80951c375b4a6a6e89d67b743ec5808127cfde405d", null);

--- a/crates/next-custom-transforms/tests/fixture/source-maps/use-cache/1/output.map
+++ b/crates/next-custom-transforms/tests/fixture/source-maps/use-cache/1/output.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["input.js"],"sourcesContent":["'use cache'\n\nconst foo = async () => {\n  'use cache'\n}\n\nexport async function bar() {\n  return foo()\n}\n"],"names":[],"mappings":";;;0HAIA;;;;;AAFA,MAAM,MAAM,uCACC,GADD;wGAIL,uCACO,GADP,eAAe;IACpB,OAAO;AACT;;;;;AAFA,WAAsB,MAAf"}


### PR DESCRIPTION
This test suite allows us to quickly verify that the spans that are defined in the SWC transforms yield correct source maps. The `output.js` and `output.js.map` files can be used to visualize the source mapping, e.g. at https://evanw.github.io/source-map-visualization/.

For now I'm adding a single fixture for `'use cache'` with this PR.