### PR TITLE
chore(github): use Issue Types

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -1,6 +1,6 @@
 name: Report an issue
 description: Report a Next.js issue.
-labels: ['bug']
+type: Bug
 body:
   - type: markdown
     attributes:
@@ -64,7 +64,7 @@ body:
           Yarn: 1.22.22
           pnpm: 9.10.0
         Relevant Packages:
-          next: 15.0.0-canary.148 
+          next: 15.0.0-canary.148
           eslint-config-next: 15.0.0-canary.148
           react: 19.0.0-rc-3dfd5d9e-20240910
           react-dom: 19.0.0-rc-3dfd5d9e-20240910

--- a/.github/ISSUE_TEMPLATE/2.example_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/2.example_bug_report.yml
@@ -1,6 +1,6 @@
 name: Report an issue with an example
 description: Report an issue with one of our Next.js examples.
-labels: ['examples']
+type: Examples
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/4.docs_report.yml
+++ b/.github/ISSUE_TEMPLATE/4.docs_report.yml
@@ -1,8 +1,7 @@
 name: 'Report a documentation issue'
 description: Report an issue with the Next.js documentation.
 title: 'Docs: '
-labels:
-  - 'Documentation'
+type: Documentation
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Why?

Start using [**Issue Types**](https://github.com/orgs/community/discussions/139933) over **labels** for "labeling" which issue template was used.