### PR TITLE
Track `use cache` usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4525,6 +4525,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "dashmap 6.1.0",
  "easy-error",
  "either",
  "fxhash",
@@ -4561,6 +4562,7 @@ dependencies = [
  "anyhow",
  "backtrace",
  "console-subscriber",
+ "dashmap 6.1.0",
  "dhat",
  "fxhash",
  "getrandom",

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -73,6 +73,7 @@ tracing-chrome = "0.5.0"
 url = { workspace = true }
 urlencoding = { workspace = true }
 once_cell = { workspace = true }
+dashmap = "6.1.0"
 
 swc_core = { workspace = true, features = [
     "base_concurrent",

--- a/crates/napi/src/transform.rs
+++ b/crates/napi/src/transform.rs
@@ -88,8 +88,7 @@ impl Task for TransformTask {
     fn compute(&mut self) -> napi::Result<Self::Output> {
         GLOBALS.set(&Default::default(), || {
             let eliminated_packages: Rc<RefCell<fxhash::FxHashSet<String>>> = Default::default();
-            let use_cache_telemetry_tracker: Rc<RefCell<DashMap<String, usize>>> =
-                Default::default();
+            let use_cache_telemetry_tracker: Rc<DashMap<String, usize>> = Default::default();
 
             let res = catch_unwind(AssertUnwindSafe(|| {
                 try_with_handler(
@@ -170,7 +169,7 @@ impl Task for TransformTask {
                         (
                             o,
                             eliminated_packages.replace(Default::default()),
-                            use_cache_telemetry_tracker.replace(Default::default()),
+                            (*use_cache_telemetry_tracker).clone(),
                         )
                     })
                     .convert_err(),

--- a/crates/next-core/src/next_shared/transforms/server_actions.rs
+++ b/crates/next-core/src/next_shared/transforms/server_actions.rs
@@ -1,5 +1,3 @@
-use std::sync::{atomic::AtomicUsize, Arc};
-
 use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::server_actions::{server_actions, Config};
@@ -63,7 +61,7 @@ impl CustomTransformer for NextServerActions {
                 cache_kinds: self.cache_kinds.await?.clone_value(),
             },
             ctx.comments.clone(),
-            Arc::new(AtomicUsize::new(0)),
+            Default::default(),
         );
         program.mutate(actions);
         Ok(())

--- a/crates/next-core/src/next_shared/transforms/server_actions.rs
+++ b/crates/next-core/src/next_shared/transforms/server_actions.rs
@@ -1,3 +1,5 @@
+use std::sync::{atomic::AtomicUsize, Arc};
+
 use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::server_actions::{server_actions, Config};
@@ -61,8 +63,8 @@ impl CustomTransformer for NextServerActions {
                 cache_kinds: self.cache_kinds.await?.clone_value(),
             },
             ctx.comments.clone(),
+            Arc::new(AtomicUsize::new(0)),
         );
-
         program.mutate(actions);
         Ok(())
     }

--- a/crates/next-custom-transforms/Cargo.toml
+++ b/crates/next-custom-transforms/Cargo.toml
@@ -30,6 +30,7 @@ sha1 = "0.10.1"
 tracing = { version = "0.1.37" }
 anyhow = { workspace = true }
 lazy_static = { workspace = true }
+dashmap = "6.1.0"
 
 swc_core = { workspace = true, features = [
   "base",

--- a/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/crates/next-custom-transforms/src/chain_transforms.rs
@@ -1,4 +1,9 @@
-use std::{cell::RefCell, path::PathBuf, rc::Rc, sync::Arc};
+use std::{
+    cell::RefCell,
+    path::PathBuf,
+    rc::Rc,
+    sync::{atomic::AtomicUsize, Arc},
+};
 
 use either::Either;
 use fxhash::FxHashSet;
@@ -125,6 +130,7 @@ pub fn custom_before_pass<'a, C>(
     comments: C,
     eliminated_packages: Rc<RefCell<FxHashSet<String>>>,
     unresolved_mark: Mark,
+    use_cache_directive_count: Arc<AtomicUsize>,
 ) -> impl Pass + 'a
 where
     C: Clone + Comments + 'a,
@@ -303,6 +309,7 @@ where
                     &file.name,
                     config.clone(),
                     comments.clone(),
+                    use_cache_directive_count,
                 )),
                 None => Either::Right(noop_pass()),
             },

--- a/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/crates/next-custom-transforms/src/chain_transforms.rs
@@ -126,7 +126,7 @@ pub fn custom_before_pass<'a, C>(
     comments: C,
     eliminated_packages: Rc<RefCell<FxHashSet<String>>>,
     unresolved_mark: Mark,
-    use_cache_telemetry_tracker: Rc<RefCell<DashMap<String, usize>>>,
+    use_cache_telemetry_tracker: Rc<DashMap<String, usize>>,
 ) -> impl Pass + 'a
 where
     C: Clone + Comments + 'a,

--- a/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/crates/next-custom-transforms/src/chain_transforms.rs
@@ -1,10 +1,6 @@
-use std::{
-    cell::RefCell,
-    path::PathBuf,
-    rc::Rc,
-    sync::{atomic::AtomicUsize, Arc},
-};
+use std::{cell::RefCell, path::PathBuf, rc::Rc, sync::Arc};
 
+use dashmap::DashMap;
 use either::Either;
 use fxhash::FxHashSet;
 use modularize_imports;
@@ -130,7 +126,7 @@ pub fn custom_before_pass<'a, C>(
     comments: C,
     eliminated_packages: Rc<RefCell<FxHashSet<String>>>,
     unresolved_mark: Mark,
-    use_cache_directive_count: Arc<AtomicUsize>,
+    use_cache_telemetry_tracker: Rc<RefCell<DashMap<String, usize>>>,
 ) -> impl Pass + 'a
 where
     C: Clone + Comments + 'a,
@@ -309,7 +305,7 @@ where
                     &file.name,
                     config.clone(),
                     comments.clone(),
-                    use_cache_directive_count,
+                    use_cache_telemetry_tracker,
                 )),
                 None => Either::Right(noop_pass()),
             },

--- a/crates/next-custom-transforms/tests/errors.rs
+++ b/crates/next-custom-transforms/tests/errors.rs
@@ -1,8 +1,4 @@
-use std::{
-    iter::FromIterator,
-    path::PathBuf,
-    sync::{atomic::AtomicUsize, Arc},
-};
+use std::{iter::FromIterator, path::PathBuf};
 
 use next_custom_transforms::transforms::{
     disallow_re_export_all_in_page::disallow_re_export_all_in_page,
@@ -195,7 +191,7 @@ fn react_server_actions_server_errors(input: PathBuf) {
                         cache_kinds: FxHashSet::default(),
                     },
                     tr.comments.as_ref().clone(),
-                    Arc::new(AtomicUsize::new(0)),
+                    Default::default(),
                 ),
             )
         },
@@ -236,7 +232,7 @@ fn react_server_actions_client_errors(input: PathBuf) {
                         cache_kinds: FxHashSet::default(),
                     },
                     tr.comments.as_ref().clone(),
-                    Arc::new(AtomicUsize::new(0)),
+                    Default::default(),
                 ),
             )
         },
@@ -295,7 +291,7 @@ fn use_cache_not_allowed(input: PathBuf) {
                         cache_kinds: FxHashSet::from_iter(["x".into()]),
                     },
                     tr.comments.as_ref().clone(),
-                    Arc::new(AtomicUsize::new(0)),
+                    Default::default(),
                 ),
             )
         },

--- a/crates/next-custom-transforms/tests/errors.rs
+++ b/crates/next-custom-transforms/tests/errors.rs
@@ -1,4 +1,8 @@
-use std::{iter::FromIterator, path::PathBuf};
+use std::{
+    iter::FromIterator,
+    path::PathBuf,
+    sync::{atomic::AtomicUsize, Arc},
+};
 
 use next_custom_transforms::transforms::{
     disallow_re_export_all_in_page::disallow_re_export_all_in_page,
@@ -191,6 +195,7 @@ fn react_server_actions_server_errors(input: PathBuf) {
                         cache_kinds: FxHashSet::default(),
                     },
                     tr.comments.as_ref().clone(),
+                    Arc::new(AtomicUsize::new(0)),
                 ),
             )
         },
@@ -231,6 +236,7 @@ fn react_server_actions_client_errors(input: PathBuf) {
                         cache_kinds: FxHashSet::default(),
                     },
                     tr.comments.as_ref().clone(),
+                    Arc::new(AtomicUsize::new(0)),
                 ),
             )
         },
@@ -289,6 +295,7 @@ fn use_cache_not_allowed(input: PathBuf) {
                         cache_kinds: FxHashSet::from_iter(["x".into()]),
                     },
                     tr.comments.as_ref().clone(),
+                    Arc::new(AtomicUsize::new(0)),
                 ),
             )
         },

--- a/crates/next-custom-transforms/tests/fixture.rs
+++ b/crates/next-custom-transforms/tests/fixture.rs
@@ -2,7 +2,6 @@ use std::{
     env::current_dir,
     iter::FromIterator,
     path::{Path, PathBuf},
-    sync::{atomic::AtomicUsize, Arc},
 };
 
 use next_custom_transforms::transforms::{
@@ -573,7 +572,7 @@ fn server_actions_server_fixture(input: PathBuf) {
                         cache_kinds: FxHashSet::from_iter(["x".into()]),
                     },
                     _tr.comments.as_ref().clone(),
-                    Arc::new(AtomicUsize::new(0)),
+                    Default::default(),
                 ),
             )
         },
@@ -607,7 +606,7 @@ fn next_font_with_directive_fixture(input: PathBuf) {
                         cache_kinds: FxHashSet::default(),
                     },
                     _tr.comments.as_ref().clone(),
-                    Arc::new(AtomicUsize::new(0)),
+                    Default::default(),
                 ),
             )
         },
@@ -634,7 +633,7 @@ fn server_actions_client_fixture(input: PathBuf) {
                         cache_kinds: FxHashSet::default(),
                     },
                     _tr.comments.as_ref().clone(),
-                    Arc::new(AtomicUsize::new(0)),
+                    Default::default(),
                 ),
             )
         },
@@ -937,7 +936,7 @@ fn test_source_maps(input: PathBuf) {
                         cache_kinds: FxHashSet::from_iter([]),
                     },
                     _tr.comments.as_ref().clone(),
-                    Arc::new(AtomicUsize::new(0)),
+                    Default::default(),
                 ),
             )
         },

--- a/crates/next-custom-transforms/tests/fixture.rs
+++ b/crates/next-custom-transforms/tests/fixture.rs
@@ -2,6 +2,7 @@ use std::{
     env::current_dir,
     iter::FromIterator,
     path::{Path, PathBuf},
+    sync::{atomic::AtomicUsize, Arc},
 };
 
 use next_custom_transforms::transforms::{
@@ -572,6 +573,7 @@ fn server_actions_server_fixture(input: PathBuf) {
                         cache_kinds: FxHashSet::from_iter(["x".into()]),
                     },
                     _tr.comments.as_ref().clone(),
+                    Arc::new(AtomicUsize::new(0)),
                 ),
             )
         },
@@ -605,6 +607,7 @@ fn next_font_with_directive_fixture(input: PathBuf) {
                         cache_kinds: FxHashSet::default(),
                     },
                     _tr.comments.as_ref().clone(),
+                    Arc::new(AtomicUsize::new(0)),
                 ),
             )
         },
@@ -631,6 +634,7 @@ fn server_actions_client_fixture(input: PathBuf) {
                         cache_kinds: FxHashSet::default(),
                     },
                     _tr.comments.as_ref().clone(),
+                    Arc::new(AtomicUsize::new(0)),
                 ),
             )
         },
@@ -933,6 +937,7 @@ fn test_source_maps(input: PathBuf) {
                         cache_kinds: FxHashSet::from_iter([]),
                     },
                     _tr.comments.as_ref().clone(),
+                    Arc::new(AtomicUsize::new(0)),
                 ),
             )
         },

--- a/crates/next-custom-transforms/tests/full.rs
+++ b/crates/next-custom-transforms/tests/full.rs
@@ -1,7 +1,4 @@
-use std::{
-    path::{Path, PathBuf},
-    sync::{atomic::AtomicUsize, Arc},
-};
+use std::path::{Path, PathBuf};
 
 use next_custom_transforms::chain_transforms::{custom_before_pass, TransformOptions};
 use serde::de::DeserializeOwned;
@@ -105,7 +102,7 @@ fn test(input: &Path, minify: bool) {
                         comments.clone(),
                         Default::default(),
                         unresolved_mark,
-                        Arc::new(AtomicUsize::new(0)),
+                        Default::default(),
                     )
                 },
                 |_| noop_pass(),

--- a/crates/next-custom-transforms/tests/full.rs
+++ b/crates/next-custom-transforms/tests/full.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::{atomic::AtomicUsize, Arc},
+};
 
 use next_custom_transforms::chain_transforms::{custom_before_pass, TransformOptions};
 use serde::de::DeserializeOwned;
@@ -102,6 +105,7 @@ fn test(input: &Path, minify: bool) {
                         comments.clone(),
                         Default::default(),
                         unresolved_mark,
+                        Arc::new(AtomicUsize::new(0)),
                     )
                 },
                 |_| noop_pass(),

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1,4 +1,4 @@
-use std::sync::{atomic::AtomicUsize, Arc};
+use std::sync::Arc;
 
 use anyhow::{Context, Error};
 use js_sys::JsString;
@@ -107,7 +107,7 @@ pub fn transform_sync(s: JsValue, opts: JsValue) -> Result<JsValue, JsValue> {
                                     comments.clone(),
                                     Default::default(),
                                     unresolved_mark,
-                                    Arc::new(AtomicUsize::new(0)),
+                                    Default::default(),
                                 )
                             },
                             |_| noop_pass(),

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{atomic::AtomicUsize, Arc};
 
 use anyhow::{Context, Error};
 use js_sys::JsString;
@@ -107,6 +107,7 @@ pub fn transform_sync(s: JsValue, opts: JsValue) -> Result<JsValue, JsValue> {
                                     comments.clone(),
                                     Default::default(),
                                     unresolved_mark,
+                                    Arc::new(AtomicUsize::new(0)),
                                 )
                             },
                             |_| noop_pass(),

--- a/packages/next/src/build/build-context.ts
+++ b/packages/next/src/build/build-context.ts
@@ -4,7 +4,7 @@ import type { __ApiPreviewProps } from '../server/api-utils'
 import type { NextConfigComplete } from '../server/config-shared'
 import type { Span } from '../trace'
 import type getBaseWebpackConfig from './webpack-config'
-import type { TelemetryPluginState } from './webpack/plugins/telemetry-plugin'
+import type { TelemetryPluginState } from './webpack/plugins/telemetry-plugin/telemetry-plugin'
 import type { Telemetry } from '../telemetry/storage'
 
 // A layer for storing data that is used by plugins to communicate with each

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -3637,6 +3637,17 @@ export default async function build(
             NextBuildContext.telemetryState.packagesUsedInServerSideProps
           )
         )
+        const useCacheCount = NextBuildContext.telemetryState.useCacheCount
+        if (useCacheCount > 0) {
+          telemetry.record(
+            eventBuildFeatureUsage([
+              {
+                featureName: 'useCache',
+                invocationCount: useCacheCount,
+              },
+            ])
+          )
+        }
       }
 
       if (ssgPages.size > 0 || appDir) {

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -217,6 +217,7 @@ import {
 } from '../server/lib/utils'
 import { InvariantError } from '../shared/lib/invariant-error'
 import { HTML_LIMITED_BOT_UA_RE_STRING } from '../shared/lib/router/utils/is-bot'
+import type { UseCacheTrackerKey } from './webpack/plugins/telemetry-plugin/use-cache-tracker-utils'
 
 type Fallback = null | boolean | string
 
@@ -3637,13 +3638,14 @@ export default async function build(
             NextBuildContext.telemetryState.packagesUsedInServerSideProps
           )
         )
-        const useCacheCount = NextBuildContext.telemetryState.useCacheCount
-        if (useCacheCount > 0) {
+        const useCacheTracker = NextBuildContext.telemetryState.useCacheTracker
+
+        for (const [key, value] of Object.entries(useCacheTracker)) {
           telemetry.record(
             eventBuildFeatureUsage([
               {
-                featureName: 'useCache',
-                invocationCount: useCacheCount,
+                featureName: key as UseCacheTrackerKey,
+                invocationCount: value,
               },
             ])
           )

--- a/packages/next/src/build/webpack-build/impl.ts
+++ b/packages/next/src/build/webpack-build/impl.ts
@@ -17,7 +17,7 @@ import type { NextError } from '../../lib/is-error'
 import {
   TelemetryPlugin,
   type TelemetryPluginState,
-} from '../webpack/plugins/telemetry-plugin'
+} from '../webpack/plugins/telemetry-plugin/telemetry-plugin'
 import {
   NextBuildContext,
   resumePluginState,
@@ -353,7 +353,7 @@ export async function webpackBuildImpl(
         usages: telemetryPlugin?.usages() || [],
         packagesUsedInServerSideProps:
           telemetryPlugin?.packagesUsedInServerSideProps() || [],
-        useCacheCount: telemetryPlugin?.useCacheCount() || 0,
+        useCacheTracker: telemetryPlugin?.getUseCacheTracker() || {},
       },
     }
   }

--- a/packages/next/src/build/webpack-build/impl.ts
+++ b/packages/next/src/build/webpack-build/impl.ts
@@ -353,6 +353,7 @@ export async function webpackBuildImpl(
         usages: telemetryPlugin?.usages() || [],
         packagesUsedInServerSideProps:
           telemetryPlugin?.packagesUsedInServerSideProps() || [],
+        useCacheCount: telemetryPlugin?.useCacheCount() || 0,
       },
     }
   }

--- a/packages/next/src/build/webpack-build/index.ts
+++ b/packages/next/src/build/webpack-build/index.ts
@@ -82,7 +82,12 @@ async function webpackBuildWithWorker(
     prunedBuildContext.pluginState = pluginState
 
     if (curResult.telemetryState) {
-      NextBuildContext.telemetryState = curResult.telemetryState
+      NextBuildContext.telemetryState = {
+        ...curResult.telemetryState,
+        useCacheCount:
+          (NextBuildContext.telemetryState?.useCacheCount || 0) +
+          curResult.telemetryState.useCacheCount,
+      }
     }
 
     combinedResult.duration += curResult.duration

--- a/packages/next/src/build/webpack-build/index.ts
+++ b/packages/next/src/build/webpack-build/index.ts
@@ -10,6 +10,7 @@ import {
   formatNodeOptions,
   getParsedNodeOptionsWithoutInspect,
 } from '../../server/lib/utils'
+import { mergeUseCacheTrackers } from '../webpack/plugins/telemetry-plugin/use-cache-tracker-utils'
 
 const debug = origDebug('next:build:webpack-build')
 
@@ -84,9 +85,10 @@ async function webpackBuildWithWorker(
     if (curResult.telemetryState) {
       NextBuildContext.telemetryState = {
         ...curResult.telemetryState,
-        useCacheCount:
-          (NextBuildContext.telemetryState?.useCacheCount || 0) +
-          curResult.telemetryState.useCacheCount,
+        useCacheTracker: mergeUseCacheTrackers(
+          NextBuildContext.telemetryState?.useCacheTracker,
+          curResult.telemetryState.useCacheTracker
+        ),
       }
     }
 

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -52,7 +52,7 @@ import { NextTypesPlugin } from './webpack/plugins/next-types-plugin'
 import type {
   Feature,
   SWC_TARGET_TRIPLE,
-} from './webpack/plugins/telemetry-plugin'
+} from './webpack/plugins/telemetry-plugin/telemetry-plugin'
 import type { Span } from '../trace'
 import type { MiddlewareMatcher } from './analysis/get-page-static-info'
 import loadJsConfig, {
@@ -1907,7 +1907,9 @@ export default async function getBaseWebpackConfig(
         new CssChunkingPlugin(config.experimental.cssChunking === 'strict'),
       !dev &&
         isClient &&
-        new (require('./webpack/plugins/telemetry-plugin').TelemetryPlugin)(
+        new (
+          require('./webpack/plugins/telemetry-plugin/telemetry-plugin') as typeof import('./webpack/plugins/telemetry-plugin/telemetry-plugin')
+        ).TelemetryPlugin(
           new Map(
             [
               ['swcLoader', useSWCLoader],
@@ -1939,9 +1941,9 @@ export default async function getBaseWebpackConfig(
         ),
       !dev &&
         !isClient &&
-        new (require('./webpack/plugins/telemetry-plugin').TelemetryPlugin)(
-          new Map()
-        ),
+        new (
+          require('./webpack/plugins/telemetry-plugin/telemetry-plugin') as typeof import('./webpack/plugins/telemetry-plugin/telemetry-plugin')
+        ).TelemetryPlugin(new Map()),
     ].filter(Boolean as any as ExcludesFalse),
   }
 

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1940,7 +1940,7 @@ export default async function getBaseWebpackConfig(
           )
         ),
       !dev &&
-        !isClient &&
+        isNodeServer &&
         new (
           require('./webpack/plugins/telemetry-plugin/telemetry-plugin') as typeof import('./webpack/plugins/telemetry-plugin/telemetry-plugin')
         ).TelemetryPlugin(new Map()),

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1937,6 +1937,11 @@ export default async function getBaseWebpackConfig(
             ].filter<[Feature, boolean]>(Boolean as any)
           )
         ),
+      !dev &&
+        !isClient &&
+        new (require('./webpack/plugins/telemetry-plugin').TelemetryPlugin)(
+          new Map()
+        ),
     ].filter(Boolean as any as ExcludesFalse),
   }
 

--- a/packages/next/src/build/webpack/loaders/next-swc-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-swc-loader.ts
@@ -33,6 +33,12 @@ import { getLoaderSWCOptions } from '../../swc/options'
 import path, { isAbsolute } from 'path'
 import { babelIncludeRegexes } from '../../webpack-config'
 import { isResourceInPackages } from '../../handle-externals'
+import type { TelemetryLoaderContext } from '../plugins/telemetry-plugin/telemetry-plugin'
+import {
+  updateTelemetryLoaderCtxFromTransformOutput,
+  type SwcTransformTelemetryOutput,
+} from '../plugins/telemetry-plugin/update-telemetry-loader-context-from-swc'
+import type { LoaderContext } from 'webpack'
 
 const maybeExclude = (
   excludePath: string,
@@ -72,7 +78,7 @@ const FORCE_TRANSPILE_CONDITIONS =
   /(next\/font|next\/dynamic|use server|use client)/
 
 async function loaderTransform(
-  this: any,
+  this: LoaderContext<SWCLoaderOptions> & TelemetryLoaderContext,
   source?: string,
   inputSourceMap?: any
 ) {
@@ -115,7 +121,7 @@ async function loaderTransform(
     bundleLayer,
     esm,
   } = loaderOptions
-  const isPageFile = filename.startsWith(pagesDir)
+  const isPageFile = pagesDir ? filename.startsWith(pagesDir) : false
   const relativeFilePathFromRoot = path.relative(rootDir, filename)
 
   const swcOptions = getLoaderSWCOptions({
@@ -179,19 +185,17 @@ async function loaderTransform(
       this.mode === 'development'
   }
 
-  return transform(source as any, programmaticOptions).then((output) => {
-    if (output.eliminatedPackages && this.eliminatedPackages) {
-      for (const pkg of JSON.parse(output.eliminatedPackages)) {
-        this.eliminatedPackages.add(pkg)
-      }
+  return transform(source as any, programmaticOptions).then(
+    (
+      output: {
+        code: string
+        map?: string
+      } & SwcTransformTelemetryOutput
+    ) => {
+      updateTelemetryLoaderCtxFromTransformOutput(this, output)
+      return [output.code, output.map ? JSON.parse(output.map) : undefined]
     }
-
-    if (output.useCacheCount > 0 && this.useCacheCountRef) {
-      this.useCacheCountRef.current += output.useCacheCount
-    }
-
-    return [output.code, output.map ? JSON.parse(output.map) : undefined]
-  })
+  )
 }
 
 const EXCLUDED_PATHS =

--- a/packages/next/src/build/webpack/loaders/next-swc-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-swc-loader.ts
@@ -185,6 +185,11 @@ async function loaderTransform(
         this.eliminatedPackages.add(pkg)
       }
     }
+
+    if (output.useCacheCount > 0 && this.useCacheCountRef) {
+      this.useCacheCountRef.current += output.useCacheCount
+    }
+
     return [output.code, output.map ? JSON.parse(output.map) : undefined]
   })
 }

--- a/packages/next/src/build/webpack/plugins/telemetry-plugin/update-telemetry-loader-context-from-swc.ts
+++ b/packages/next/src/build/webpack/plugins/telemetry-plugin/update-telemetry-loader-context-from-swc.ts
@@ -1,0 +1,29 @@
+import type { TelemetryLoaderContext } from './telemetry-plugin'
+export type SwcTransformTelemetryOutput = {
+  eliminatedPackages?: string
+  useCacheTelemetryTracker?: string
+}
+
+export function updateTelemetryLoaderCtxFromTransformOutput(
+  ctx: TelemetryLoaderContext,
+  output: SwcTransformTelemetryOutput
+) {
+  if (output.eliminatedPackages && ctx.eliminatedPackages) {
+    for (const pkg of JSON.parse(output.eliminatedPackages)) {
+      ctx.eliminatedPackages.add(pkg)
+    }
+  }
+
+  if (output.useCacheTelemetryTracker && ctx.useCacheTracker) {
+    for (const [key, value] of JSON.parse(output.useCacheTelemetryTracker)) {
+      const prefixedKey = `useCache/${key}` as const
+      const numericValue = Number(value)
+      if (!isNaN(numericValue)) {
+        ctx.useCacheTracker.set(
+          prefixedKey,
+          (ctx.useCacheTracker.get(prefixedKey) || 0) + numericValue
+        )
+      }
+    }
+  }
+}

--- a/packages/next/src/build/webpack/plugins/telemetry-plugin/use-cache-tracker-utils.ts
+++ b/packages/next/src/build/webpack/plugins/telemetry-plugin/use-cache-tracker-utils.ts
@@ -1,0 +1,34 @@
+export type UseCacheTrackerKey = `useCache/${string}`
+
+export const createUseCacheTracker = () => new Map<UseCacheTrackerKey, number>()
+
+/**
+ * Example usage:
+ *
+ * const tracker1 = { 'useCache/file1': 1, 'useCache/file2': 2 };
+ * const tracker2 = { 'useCache/file2': 3, 'useCache/file3': 4 };
+ * const merged = mergeUseCacheTrackers(tracker1, tracker2);
+ *
+ * // Result: { 'useCache/file1': 1, 'useCache/file2': 5, 'useCache/file3': 4 }
+ */
+export const mergeUseCacheTrackers = (
+  tracker1: Record<UseCacheTrackerKey, number> | undefined,
+  tracker2: Record<UseCacheTrackerKey, number> | undefined
+): Record<UseCacheTrackerKey, number> => {
+  const mergedTracker: Record<UseCacheTrackerKey, number> = { ...tracker1 }
+
+  if (tracker2) {
+    for (const key in tracker2) {
+      if (Object.prototype.hasOwnProperty.call(tracker2, key)) {
+        const typedKey = key as UseCacheTrackerKey
+        if (mergedTracker[typedKey] !== undefined) {
+          mergedTracker[typedKey] += tracker2[typedKey]
+        } else {
+          mergedTracker[typedKey] = tracker2[typedKey]
+        }
+      }
+    }
+  }
+
+  return mergedTracker
+}

--- a/packages/next/src/telemetry/events/build.ts
+++ b/packages/next/src/telemetry/events/build.ts
@@ -173,6 +173,7 @@ export type EventBuildFeatureUsage = {
     | 'skipTrailingSlashRedirect'
     | 'modularizeImports'
     | 'esmExternals'
+    | 'useCache'
   invocationCount: number
 }
 export function eventBuildFeatureUsage(

--- a/packages/next/src/telemetry/events/build.ts
+++ b/packages/next/src/telemetry/events/build.ts
@@ -1,5 +1,6 @@
-import type { TelemetryPlugin } from '../../build/webpack/plugins/telemetry-plugin'
-import type { SWC_TARGET_TRIPLE } from '../../build/webpack/plugins/telemetry-plugin'
+import type { TelemetryPlugin } from '../../build/webpack/plugins/telemetry-plugin/telemetry-plugin'
+import type { SWC_TARGET_TRIPLE } from '../../build/webpack/plugins/telemetry-plugin/telemetry-plugin'
+import type { UseCacheTrackerKey } from '../../build/webpack/plugins/telemetry-plugin/use-cache-tracker-utils'
 
 const REGEXP_DIRECTORY_DUNDER =
   /[\\/]__[^\\/]+(?<![\\/]__(?:tests|mocks))__[\\/]/i
@@ -173,7 +174,7 @@ export type EventBuildFeatureUsage = {
     | 'skipTrailingSlashRedirect'
     | 'modularizeImports'
     | 'esmExternals'
-    | 'useCache'
+    | UseCacheTrackerKey
   invocationCount: number
 }
 export function eventBuildFeatureUsage(

--- a/test/integration/telemetry/_app/layout.jsx
+++ b/test/integration/telemetry/_app/layout.jsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/integration/telemetry/_app/use-cache/funtion-level-use-cache/page.jsx
+++ b/test/integration/telemetry/_app/use-cache/funtion-level-use-cache/page.jsx
@@ -1,0 +1,9 @@
+async function getCachedRandom(n) {
+  'use cache'
+  return String(Math.ceil(Math.random() * n))
+}
+
+export default async function Page() {
+  const random = await getCachedRandom(10)
+  return <h1>Hello from cached page! {random}</h1>
+}

--- a/test/integration/telemetry/_app/use-cache/funtion-level-use-cache/page.jsx
+++ b/test/integration/telemetry/_app/use-cache/funtion-level-use-cache/page.jsx
@@ -3,7 +3,17 @@ async function getCachedRandom(n) {
   return String(Math.ceil(Math.random() * n))
 }
 
+async function getCachedRandomV2(n) {
+  'use cache: custom'
+  return String(Math.ceil(Math.random() * n))
+}
+
 export default async function Page() {
   const random = await getCachedRandom(10)
-  return <h1>Hello from cached page! {random}</h1>
+  const randomV2 = await getCachedRandomV2(10)
+  return (
+    <h1>
+      Hello from cached page! {random} {randomV2}
+    </h1>
+  )
 }

--- a/test/integration/telemetry/_app/use-cache/page.jsx
+++ b/test/integration/telemetry/_app/use-cache/page.jsx
@@ -1,0 +1,5 @@
+'use cache'
+
+export default async function Page() {
+  return <h1>Hello from cached page!</h1>
+}

--- a/test/integration/telemetry/_app/use-cache/page2/page.jsx
+++ b/test/integration/telemetry/_app/use-cache/page2/page.jsx
@@ -1,0 +1,9 @@
+async function getCachedRandom(n) {
+  'use cache: custom'
+  return String(Math.ceil(Math.random() * n))
+}
+
+export default async function Page() {
+  'use cache: custom'
+  return 'Page 2: ' + getCachedRandom(10)
+}

--- a/test/integration/telemetry/next.config.use-cache
+++ b/test/integration/telemetry/next.config.use-cache
@@ -1,0 +1,8 @@
+module.exports = {
+  experimental: {
+    dynamicIO: true,
+    cacheHandlers: {
+      custom: require.resolve('next/dist/server/lib/cache-handlers/default'),
+    },
+  },
+}

--- a/test/integration/telemetry/test/config.test.js
+++ b/test/integration/telemetry/test/config.test.js
@@ -713,6 +713,38 @@ describe('config telemetry', () => {
           )
         }
       })
+
+      it('emits telemetry for useCache directive', async () => {
+        // use cache depends on dynamicIO flag
+        await fs.rename(
+          path.join(appDir, 'next.config.dynamic-io'),
+          path.join(appDir, 'next.config.js')
+        )
+
+        await fs.rename(path.join(appDir, '_app'), path.join(appDir, 'app'))
+
+        const { stderr } = await nextBuild(appDir, [], {
+          stderr: true,
+          env: { NEXT_TELEMETRY_DEBUG: 1 },
+        })
+
+        await fs.rename(
+          path.join(appDir, 'next.config.js'),
+          path.join(appDir, 'next.config.dynamic-io')
+        )
+
+        await fs.rename(path.join(appDir, 'app'), path.join(appDir, '_app'))
+
+        const featureUsageEvents = findAllTelemetryEvents(
+          stderr,
+          'NEXT_BUILD_FEATURE_USAGE'
+        )
+
+        expect(featureUsageEvents).toContainEqual({
+          featureName: 'useCache',
+          invocationCount: 2,
+        })
+      })
     }
   )
 })

--- a/test/integration/telemetry/test/config.test.js
+++ b/test/integration/telemetry/test/config.test.js
@@ -714,37 +714,48 @@ describe('config telemetry', () => {
         }
       })
 
-      it('emits telemetry for useCache directive', async () => {
-        // use cache depends on dynamicIO flag
-        await fs.rename(
-          path.join(appDir, 'next.config.dynamic-io'),
-          path.join(appDir, 'next.config.js')
-        )
+      // TODO: support use cache tracking in Turbopack
+      ;(process.env.TURBOPACK ? it.skip : it)(
+        'emits telemetry for useCache directive',
+        async () => {
+          // use cache depends on dynamicIO flag
+          await fs.rename(
+            path.join(appDir, 'next.config.use-cache'),
+            path.join(appDir, 'next.config.js')
+          )
 
-        await fs.rename(path.join(appDir, '_app'), path.join(appDir, 'app'))
+          await fs.move(path.join(appDir, '_app'), path.join(appDir, 'app'))
 
-        const { stderr } = await nextBuild(appDir, [], {
-          stderr: true,
-          env: { NEXT_TELEMETRY_DEBUG: 1 },
-        })
+          const { stderr } = await nextBuild(appDir, [], {
+            stderr: true,
+            env: { NEXT_TELEMETRY_DEBUG: 1 },
+          })
 
-        await fs.rename(
-          path.join(appDir, 'next.config.js'),
-          path.join(appDir, 'next.config.dynamic-io')
-        )
+          await fs.rename(
+            path.join(appDir, 'next.config.js'),
+            path.join(appDir, 'next.config.use-cache')
+          )
 
-        await fs.rename(path.join(appDir, 'app'), path.join(appDir, '_app'))
+          await fs.move(path.join(appDir, 'app'), path.join(appDir, '_app'))
 
-        const featureUsageEvents = findAllTelemetryEvents(
-          stderr,
-          'NEXT_BUILD_FEATURE_USAGE'
-        )
+          const featureUsageEvents = findAllTelemetryEvents(
+            stderr,
+            'NEXT_BUILD_FEATURE_USAGE'
+          )
 
-        expect(featureUsageEvents).toContainEqual({
-          featureName: 'useCache',
-          invocationCount: 2,
-        })
-      })
+          // eslint-disable-next-line jest/no-standalone-expect
+          expect(featureUsageEvents).toContainEqual({
+            featureName: 'useCache/default',
+            invocationCount: 2,
+          })
+
+          // eslint-disable-next-line jest/no-standalone-expect
+          expect(featureUsageEvents).toContainEqual({
+            featureName: 'useCache/custom',
+            invocationCount: 3,
+          })
+        }
+      )
     }
   )
 })


### PR DESCRIPTION
We’re updating the SWC transform to [track](https://nextjs.org/telemetry) how the "use cache" directive is used during builds. Each use of "use cache" is counted based on the handler it’s linked to.

By default, "use cache" counts toward a feature called "useCache/default". If a custom handler is defined in the Next.js config (e.g., "custom"), then "use cache: custom" will count toward "useCache/custom".

The build process will collect these counts and combine them across all source files and workers. This data is reported under the NEXT_BUILD_FEATURE_USAGE event, allowing us to filter by "useCache/*" to see how often each cache handler is used.

*Only support webpack prod build for now.

Closes NDX-683