### PR TITLE
chore(github): remove documentation label from area dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -81,7 +81,6 @@ body:
         - 'Not sure'
         - 'create-next-app'
         - 'Developer Experience'
-        - 'Documentation'
         - 'dynamicIO'
         - 'Lazy Loading'
         - 'Font (next/font)'


### PR DESCRIPTION
## Why?

Follow-up on https://github.com/vercel/next.js/pull/75006. We want to instead use the `Documentation` **Type**.