### PR TITLE
Fix missing revalidate with notFound()

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3851,9 +3851,18 @@ async function prerenderToStream(
       type: 'prerender-legacy',
       phase: 'render',
       implicitTags: implicitTags,
-      revalidate: INFINITE_CACHE,
-      expire: INFINITE_CACHE,
-      stale: INFINITE_CACHE,
+      revalidate:
+        typeof prerenderStore?.revalidate !== 'undefined'
+          ? prerenderStore.revalidate
+          : INFINITE_CACHE,
+      expire:
+        typeof prerenderStore?.expire !== 'undefined'
+          ? prerenderStore.expire
+          : INFINITE_CACHE,
+      stale:
+        typeof prerenderStore?.stale !== 'undefined'
+          ? prerenderStore.stale
+          : INFINITE_CACHE,
       tags: [...(prerenderStore?.tags || implicitTags)],
     })
     const errorRSCPayload = await workUnitAsyncStorage.run(

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -976,6 +976,10 @@ describe('app-dir static/dynamic handling', () => {
          "prerendered-not-found/first.rsc",
          "prerendered-not-found/second.html",
          "prerendered-not-found/second.rsc",
+         "prerendered-not-found/segment-revalidate.html",
+         "prerendered-not-found/segment-revalidate.rsc",
+         "prerendered-not-found/segment-revalidate/page.js",
+         "prerendered-not-found/segment-revalidate/page_client-reference-manifest.js",
          "react-fetch-deduping-edge/page.js",
          "react-fetch-deduping-edge/page_client-reference-manifest.js",
          "react-fetch-deduping-node/page.js",
@@ -2007,6 +2011,30 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialRevalidateSeconds": false,
            "srcRoute": "/prerendered-not-found/[slug]",
+         },
+         "/prerendered-not-found/segment-revalidate": {
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token",
+           ],
+           "dataRoute": "/prerendered-not-found/segment-revalidate.rsc",
+           "experimentalBypassFor": [
+             {
+               "key": "Next-Action",
+               "type": "header",
+             },
+             {
+               "key": "content-type",
+               "type": "header",
+               "value": "multipart/form-data;.*",
+             },
+           ],
+           "initialRevalidateSeconds": 3,
+           "srcRoute": "/prerendered-not-found/segment-revalidate",
          },
          "/route-handler/no-store-force-static": {
            "allowHeader": [

--- a/test/e2e/app-dir/app-static/app/prerendered-not-found/segment-revalidate/page.tsx
+++ b/test/e2e/app-dir/app-static/app/prerendered-not-found/segment-revalidate/page.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { notFound } from 'next/navigation'
+
+export const revalidate = 3
+
+export default async function Page() {
+  await fetch('https://next-data-api.vercel.app/api/random', {
+    next: {
+      tags: ['explicit-tag'],
+    },
+  })
+
+  if (process.env.NEXT_PHASE === 'phase-production-build') {
+    notFound()
+  }
+
+  return (
+    <>
+      <p>/prerendered-not-found/segment-revalidate</p>
+      <p>{Date.now()}</p>
+    </>
+  )
+}


### PR DESCRIPTION
This is follow-up to https://github.com/vercel/next.js/pull/74607 ensuring we also don't lose the revalidate value configured when `notFound()` or similar is used. 

x-ref: [slack thread](https://vercel.slack.com/archives/C02K2HCH5V4/p1736954974909349)