### PR TITLE
fix: always ensure element before set to weakmap

### DIFF
--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -156,6 +156,11 @@ function mountLinkInstance(
   router: AppRouterInstance,
   kind: PrefetchKind.AUTO | PrefetchKind.FULL
 ) {
+  // Element could be possible undefined which leads to failed on later
+  // WeakMap and IntersectionObserver operations.
+  if (!element) {
+    return
+  }
   let prefetchUrl: URL | null = null
   try {
     prefetchUrl = createPrefetchURL(href)
@@ -193,11 +198,9 @@ function mountLinkInstance(
     // case there's a logical error somewhere else.
     unmountLinkInstance(element)
   }
-  if (element) {
-    links.set(element, instance)
-    if (observer !== null) {
-      observer.observe(element)
-    }
+  links.set(element, instance)
+  if (observer !== null) {
+    observer.observe(element)
   }
 }
 

--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -642,13 +642,12 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
     const observeLinkVisibilityOnMount = React.useCallback(
       (element: HTMLAnchorElement | SVGAElement | null) => {
         if (prefetchEnabled && router !== null) {
-          // The useMergedRef could return null
+          // FIXME: element still can be null here in some cases. Require further investigation.
           if (element) {
             mountLinkInstance(element, href, router, appPrefetchKind)
           }
         }
         return () => {
-          // The useMergedRef could return null
           if (element) {
             unmountLinkInstance(element)
           }

--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -193,7 +193,9 @@ function mountLinkInstance(
     // case there's a logical error somewhere else.
     unmountLinkInstance(element)
   }
-  links.set(element, instance)
+  if (element) {
+    links.set(element, instance)
+  }
   if (observer !== null) {
     observer.observe(element)
   }

--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -156,11 +156,6 @@ function mountLinkInstance(
   router: AppRouterInstance,
   kind: PrefetchKind.AUTO | PrefetchKind.FULL
 ) {
-  // Element could be possible undefined which leads to failed on later
-  // WeakMap and IntersectionObserver operations.
-  if (!element) {
-    return
-  }
   let prefetchUrl: URL | null = null
   try {
     prefetchUrl = createPrefetchURL(href)
@@ -645,12 +640,18 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
     // currently mounted <Link> instances, e.g. so we can re-prefetch them after
     // a revalidation or refresh.
     const observeLinkVisibilityOnMount = React.useCallback(
-      (element: HTMLAnchorElement | SVGAElement) => {
+      (element: HTMLAnchorElement | SVGAElement | null) => {
         if (prefetchEnabled && router !== null) {
-          mountLinkInstance(element, href, router, appPrefetchKind)
+          // The useMergedRef could return null
+          if (element) {
+            mountLinkInstance(element, href, router, appPrefetchKind)
+          }
         }
         return () => {
-          unmountLinkInstance(element)
+          // The useMergedRef could return null
+          if (element) {
+            unmountLinkInstance(element)
+          }
         }
       },
       [prefetchEnabled, href, router, appPrefetchKind]

--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -195,9 +195,9 @@ function mountLinkInstance(
   }
   if (element) {
     links.set(element, instance)
-  }
-  if (observer !== null) {
-    observer.observe(element)
+    if (observer !== null) {
+      observer.observe(element)
+    }
   }
 }
 


### PR DESCRIPTION
### What

Regression introduced in #74670, where the element somehow is invalid to be observed by observer or be set as key in to WeakMap. The possible cause is `mountInstance` is calling with `null`. 

```
TypeError: Failed to execute 'observe' on 'IntersectionObserver': parameter 1 is not of type 'Element'.
```

```
TypeError: Invalid value used as weak map key
    at WeakMap.set (<anonymous>)
```

The root cause is the `useMergedRef` could return `null` in callback, we need to filter them out before passing to `mountLinkInstance` or `unmountLinkInstance`