### PR TITLE
fix: mpa navigate on ppr dynamic data mpa navigation

### DIFF
--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -485,34 +485,30 @@ export function listenForDynamicRequest(
 ) {
   responsePromise.then(
     ({ flightData }: FetchServerResponseResult) => {
-      if (typeof flightData === 'string') {
-        // Happens when navigating to page in `pages` from `app`. We shouldn't
-        // get here because should have already handled this during
-        // the prefetch.
-        return
-      }
-      for (const normalizedFlightData of flightData) {
-        const {
-          segmentPath,
-          tree: serverRouterState,
-          seedData: dynamicData,
-          head: dynamicHead,
-        } = normalizedFlightData
+      if (typeof flightData !== 'string') {
+        for (const normalizedFlightData of flightData) {
+          const {
+            segmentPath,
+            tree: serverRouterState,
+            seedData: dynamicData,
+            head: dynamicHead,
+          } = normalizedFlightData
 
-        if (!dynamicData) {
-          // This shouldn't happen. PPR should always send back a response.
-          // However, `FlightDataPath` is a shared type and the pre-PPR handling of
-          // this might return null.
-          continue
+          if (!dynamicData) {
+            // This shouldn't happen. PPR should always send back a response.
+            // However, `FlightDataPath` is a shared type and the pre-PPR handling of
+            // this might return null.
+            continue
+          }
+
+          writeDynamicDataIntoPendingTask(
+            task,
+            segmentPath,
+            serverRouterState,
+            dynamicData,
+            dynamicHead
+          )
         }
-
-        writeDynamicDataIntoPendingTask(
-          task,
-          segmentPath,
-          serverRouterState,
-          dynamicData,
-          dynamicHead
-        )
       }
 
       // Now that we've exhausted all the data we received from the server, if


### PR DESCRIPTION
### What?
Allow dynamic segments in a prefetched PPR page to force an MPA navigation

### Why?

Normally when a flight stream encounters an error or an updated build ID in fetchServerResponse it sets the flightData to the page URL which causes a hard MPA navigation in navigate-reducer through the use of handleExternalUrl

However when a page has been prefetched there may be an error when navigating to the page or the build ID may have been updated from a rebuild between the time of prefetching the page and the navigation happening. This causes the flightData to be a string of the URL but it is prevented from doing anything by just early returning in listenForDynamicRequest. This causes all the suspended components to stay in their fallback state and never render the data

### How?
Alter the early return in listenForDynamicRequest to abort the task causing a MPA navigation. The case in comment about going from an app router page to a pages page is already handled within navigate-reducer

Resolves #75047 