### PR TITLE
refactor(turbopack): Only perform strongly consistent reads/resolves on VcOperation

### DIFF
--- a/crates/napi/src/next_api/endpoint.rs
+++ b/crates/napi/src/next_api/endpoint.rs
@@ -102,17 +102,17 @@ impl Deref for ExternalEndpoint {
 // Await the source and return fatal issues if there are any, otherwise
 // propagate any actual error results.
 async fn strongly_consistent_catch_collectables<R: VcValueType + Send>(
-    source: OperationVc<R>,
+    source_op: OperationVc<R>,
 ) -> Result<(
     Option<ReadRef<R>>,
     Arc<Vec<ReadRef<PlainIssue>>>,
     Arc<Vec<ReadRef<PlainDiagnostic>>>,
     Arc<Effects>,
 )> {
-    let result = source.connect().strongly_consistent().await;
-    let issues = get_issues(source).await?;
-    let diagnostics = get_diagnostics(source).await?;
-    let effects = Arc::new(get_effects(source).await?);
+    let result = source_op.read_strongly_consistent().await;
+    let issues = get_issues(source_op).await?;
+    let diagnostics = get_diagnostics(source_op).await?;
+    let effects = Arc::new(get_effects(source_op).await?);
 
     let result = if result.is_err() && issues.iter().any(|i| i.severity <= IssueSeverity::Error) {
         None
@@ -131,13 +131,13 @@ struct WrittenEndpointWithIssues {
     effects: Arc<Effects>,
 }
 
-#[turbo_tasks::function]
-async fn get_written_endpoint_with_issues(
+#[turbo_tasks::function(operation)]
+async fn get_written_endpoint_with_issues_operation(
     endpoint_op: OperationVc<Box<dyn Endpoint>>,
 ) -> Result<Vc<WrittenEndpointWithIssues>> {
-    let write_to_disk = endpoint_write_to_disk_operation(endpoint_op);
+    let write_to_disk_op = endpoint_write_to_disk_operation(endpoint_op);
     let (written, issues, diagnostics, effects) =
-        strongly_consistent_catch_collectables(write_to_disk).await?;
+        strongly_consistent_catch_collectables(write_to_disk_op).await?;
     Ok(WrittenEndpointWithIssues {
         written,
         issues,
@@ -156,13 +156,16 @@ pub async fn endpoint_write_to_disk(
     let endpoint_op = ***endpoint;
     let (written, issues, diags) = turbo_tasks
         .run_once(async move {
-            let operation = get_written_endpoint_with_issues(endpoint_op);
+            let written_entrypoint_with_issues_op =
+                get_written_endpoint_with_issues_operation(endpoint_op);
             let WrittenEndpointWithIssues {
                 written,
                 issues,
                 diagnostics,
                 effects,
-            } = &*operation.strongly_consistent().await?;
+            } = &*written_entrypoint_with_issues_op
+                .read_strongly_consistent()
+                .await?;
             effects.apply().await?;
 
             Ok((written.clone(), issues.clone(), diagnostics.clone()))
@@ -189,8 +192,8 @@ pub fn endpoint_server_changed_subscribe(
         func,
         move || {
             async move {
-                let vc = subscribe_issues_and_diags(endpoint, issues);
-                let result = vc.strongly_consistent().await?;
+                let issues_and_diags_op = subscribe_issues_and_diags_operation(endpoint, issues);
+                let result = issues_and_diags_op.read_strongly_consistent().await?;
                 result.effects.apply().await?;
                 Ok(result)
             }
@@ -237,16 +240,16 @@ impl PartialEq for EndpointIssuesAndDiags {
 
 impl Eq for EndpointIssuesAndDiags {}
 
-#[turbo_tasks::function]
-async fn subscribe_issues_and_diags(
+#[turbo_tasks::function(operation)]
+async fn subscribe_issues_and_diags_operation(
     endpoint_op: OperationVc<Box<dyn Endpoint>>,
     should_include_issues: bool,
 ) -> Result<Vc<EndpointIssuesAndDiags>> {
-    let changed = endpoint_server_changed_operation(endpoint_op);
+    let changed_op = endpoint_server_changed_operation(endpoint_op);
 
     if should_include_issues {
         let (changed_value, issues, diagnostics, effects) =
-            strongly_consistent_catch_collectables(changed).await?;
+            strongly_consistent_catch_collectables(changed_op).await?;
         Ok(EndpointIssuesAndDiags {
             changed: changed_value,
             issues,
@@ -255,7 +258,7 @@ async fn subscribe_issues_and_diags(
         }
         .cell())
     } else {
-        let changed_value = changed.connect().strongly_consistent().await?;
+        let changed_value = changed_op.read_strongly_consistent().await?;
         Ok(EndpointIssuesAndDiags {
             changed: Some(changed_value),
             issues: Arc::new(vec![]),
@@ -266,22 +269,29 @@ async fn subscribe_issues_and_diags(
     }
 }
 
+#[turbo_tasks::function(operation)]
+fn endpoint_client_changed_operation(
+    endpoint_op: OperationVc<Box<dyn Endpoint>>,
+) -> Vc<Completion> {
+    endpoint_op.connect().client_changed()
+}
+
 #[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
 pub fn endpoint_client_changed_subscribe(
     #[napi(ts_arg_type = "{ __napiType: \"Endpoint\" }")] endpoint: External<ExternalEndpoint>,
     func: JsFunction,
 ) -> napi::Result<External<RootTask>> {
     let turbo_tasks = endpoint.turbo_tasks().clone();
-    let endpoint = ***endpoint;
+    let endpoint_op = ***endpoint;
     subscribe(
         turbo_tasks,
         func,
         move || {
             async move {
-                let changed = endpoint.connect().client_changed();
+                let changed_op = endpoint_client_changed_operation(endpoint_op);
                 // We don't capture issues and diagnostics here since we don't want to be
                 // notified when they change
-                changed.strongly_consistent().await?;
+                let _ = changed_op.resolve_strongly_consistent().await?;
                 Ok(())
             }
             .instrument(tracing::info_span!("client changes subscription"))

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -408,7 +408,7 @@ pub async fn project_new(
     let container = turbo_tasks
         .run_once(async move {
             let project = ProjectContainer::new("next.js".into(), options.dev);
-            let project = project.resolve().await?;
+            let project = project.to_resolved().await?;
             project.initialize(options).await?;
             Ok(project)
         })
@@ -423,7 +423,7 @@ pub async fn project_new(
     Ok(External::new_with_size_hint(
         ProjectInstance {
             turbo_tasks,
-            container,
+            container: *container,
             exit_receiver: tokio::sync::Mutex::new(Some(exit_receiver)),
         },
         100,
@@ -659,16 +659,13 @@ struct EntrypointsWithIssues {
     effects: Arc<Effects>,
 }
 
-#[turbo_tasks::function]
-async fn get_entrypoints_with_issues(
+#[turbo_tasks::function(operation)]
+async fn get_entrypoints_with_issues_operation(
     container: ResolvedVc<ProjectContainer>,
 ) -> Result<Vc<EntrypointsWithIssues>> {
     let entrypoints_operation =
         EntrypointsOperation::new(project_container_entrypoints_operation(container));
-    let entrypoints = entrypoints_operation
-        .connect()
-        .strongly_consistent()
-        .await?;
+    let entrypoints = entrypoints_operation.read_strongly_consistent().await?;
     let issues = get_issues(entrypoints_operation).await?;
     let diagnostics = get_diagnostics(entrypoints_operation).await?;
     let effects = Arc::new(get_effects(entrypoints_operation).await?);
@@ -702,13 +699,16 @@ pub fn project_entrypoints_subscribe(
         func,
         move || {
             async move {
-                let operation = get_entrypoints_with_issues(container);
+                let entrypoints_with_issues_op =
+                    get_entrypoints_with_issues_operation(container.to_resolved().await?);
                 let EntrypointsWithIssues {
                     entrypoints,
                     issues,
                     diagnostics,
                     effects,
-                } = &*operation.strongly_consistent().await?;
+                } = &*entrypoints_with_issues_op
+                    .read_strongly_consistent()
+                    .await?;
                 effects.apply().await?;
                 Ok((entrypoints.clone(), issues.clone(), diagnostics.clone()))
             }
@@ -771,17 +771,17 @@ struct HmrUpdateWithIssues {
     effects: Arc<Effects>,
 }
 
-#[turbo_tasks::function]
-async fn hmr_update(
+#[turbo_tasks::function(operation)]
+async fn hmr_update_with_issues_operation(
     project: ResolvedVc<Project>,
     identifier: RcStr,
     state: ResolvedVc<VersionState>,
 ) -> Result<Vc<HmrUpdateWithIssues>> {
-    let update_operation = project_hmr_update_operation(project, identifier, state);
-    let update = update_operation.connect().strongly_consistent().await?;
-    let issues = get_issues(update_operation).await?;
-    let diagnostics = get_diagnostics(update_operation).await?;
-    let effects = Arc::new(get_effects(update_operation).await?);
+    let update_op = project_hmr_update_operation(project, identifier, state);
+    let update = update_op.read_strongly_consistent().await?;
+    let issues = get_issues(update_op).await?;
+    let diagnostics = get_diagnostics(update_op).await?;
+    let effects = Arc::new(get_effects(update_op).await?);
     Ok(HmrUpdateWithIssues {
         update,
         issues,
@@ -819,11 +819,15 @@ pub fn project_hmr_events(
                 let identifier: RcStr = outer_identifier.clone().into();
                 let session = session.clone();
                 async move {
-                    let project = project.project().resolve().await?;
-                    let state = project.hmr_version_state(identifier.clone(), session);
+                    let project = project.project().to_resolved().await?;
+                    let state = project
+                        .hmr_version_state(identifier.clone(), session)
+                        .to_resolved()
+                        .await?;
 
-                    let operation = hmr_update(project, identifier.clone(), state);
-                    let update = operation.strongly_consistent().await?;
+                    let update_op =
+                        hmr_update_with_issues_operation(project, identifier.clone(), state);
+                    let update = update_op.read_strongly_consistent().await?;
                     let HmrUpdateWithIssues {
                         update,
                         issues,
@@ -898,18 +902,15 @@ struct HmrIdentifiersWithIssues {
     effects: Arc<Effects>,
 }
 
-#[turbo_tasks::function]
-async fn get_hmr_identifiers_with_issues(
+#[turbo_tasks::function(operation)]
+async fn get_hmr_identifiers_with_issues_operation(
     container: ResolvedVc<ProjectContainer>,
 ) -> Result<Vc<HmrIdentifiersWithIssues>> {
-    let hmr_identifiers_operation = project_container_hmr_identifiers_operation(container);
-    let hmr_identifiers = hmr_identifiers_operation
-        .connect()
-        .strongly_consistent()
-        .await?;
-    let issues = get_issues(hmr_identifiers_operation).await?;
-    let diagnostics = get_diagnostics(hmr_identifiers_operation).await?;
-    let effects = Arc::new(get_effects(hmr_identifiers_operation).await?);
+    let hmr_identifiers_op = project_container_hmr_identifiers_operation(container);
+    let hmr_identifiers = hmr_identifiers_op.read_strongly_consistent().await?;
+    let issues = get_issues(hmr_identifiers_op).await?;
+    let diagnostics = get_diagnostics(hmr_identifiers_op).await?;
+    let effects = Arc::new(get_effects(hmr_identifiers_op).await?);
     Ok(HmrIdentifiersWithIssues {
         identifiers: hmr_identifiers,
         issues,
@@ -937,13 +938,16 @@ pub fn project_hmr_identifiers_subscribe(
         turbo_tasks.clone(),
         func,
         move || async move {
-            let operation = get_hmr_identifiers_with_issues(container);
+            let hmr_identifiers_with_issues_op =
+                get_hmr_identifiers_with_issues_operation(container.to_resolved().await?);
             let HmrIdentifiersWithIssues {
                 identifiers,
                 issues,
                 diagnostics,
                 effects,
-            } = &*operation.strongly_consistent().await?;
+            } = &*hmr_identifiers_with_issues_op
+                .read_strongly_consistent()
+                .await?;
             effects.apply().await?;
 
             Ok((identifiers.clone(), issues.clone(), diagnostics.clone()))

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -587,10 +587,12 @@ pub async fn get_reduced_graphs_for_endpoint(
     // TODO get rid of this function once everything inside of
     // `get_reduced_graphs_for_endpoint_inner` calls `take_collectibles()` when needed
     let result_op = get_reduced_graphs_for_endpoint_inner_operation(module_graph, is_single_page);
-    let result_vc = result_op.connect();
-    if !is_single_page {
-        result_vc.strongly_consistent().await?;
+    let result_vc = if !is_single_page {
+        let result_vc = result_op.resolve_strongly_consistent().await?;
         let _issues = result_op.take_collectibles::<Box<dyn Issue>>();
-    }
+        *result_vc
+    } else {
+        result_op.connect()
+    };
     Ok(result_vc)
 }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -273,15 +273,27 @@ impl ProjectContainer {
     }
 }
 
+#[turbo_tasks::function(operation)]
+fn project_fs_operation(project: ResolvedVc<Project>) -> Vc<DiskFileSystem> {
+    project.project_fs()
+}
+
+#[turbo_tasks::function(operation)]
+fn output_fs_operation(project: ResolvedVc<Project>) -> Vc<DiskFileSystem> {
+    project.project_fs()
+}
+
 impl ProjectContainer {
     #[tracing::instrument(level = "info", name = "initialize project", skip_all)]
-    pub async fn initialize(self: Vc<Self>, options: ProjectOptions) -> Result<()> {
+    pub async fn initialize(self: ResolvedVc<Self>, options: ProjectOptions) -> Result<()> {
         let watch = options.watch;
 
         self.await?.options_state.set(Some(options));
 
-        let project = self.project();
-        let project_fs = project.project_fs().strongly_consistent().await?;
+        let project = self.project().to_resolved().await?;
+        let project_fs = project_fs_operation(project)
+            .read_strongly_consistent()
+            .await?;
         if watch.enable {
             project_fs
                 .start_watching_with_invalidation_reason(watch.poll_interval)
@@ -289,7 +301,9 @@ impl ProjectContainer {
         } else {
             project_fs.invalidate_with_reason();
         }
-        let output_fs = project.output_fs().strongly_consistent().await?;
+        let output_fs = output_fs_operation(project)
+            .read_strongly_consistent()
+            .await?;
         output_fs.invalidate_with_reason();
         Ok(())
     }
@@ -355,13 +369,22 @@ impl ProjectContainer {
         // TODO: Handle mode switch, should prevent mode being switched.
         let watch = new_options.watch;
 
-        let project = self.project();
-        let prev_project_fs = project.project_fs().strongly_consistent().await?;
-        let prev_output_fs = project.output_fs().strongly_consistent().await?;
+        let project = self.project().to_resolved().await?;
+        let prev_project_fs = project_fs_operation(project)
+            .read_strongly_consistent()
+            .await?;
+        let prev_output_fs = output_fs_operation(project)
+            .read_strongly_consistent()
+            .await?;
 
         this.options_state.set(Some(new_options));
-        let project_fs = project.project_fs().strongly_consistent().await?;
-        let output_fs = project.output_fs().strongly_consistent().await?;
+        let project = self.project().to_resolved().await?;
+        let project_fs = project_fs_operation(project)
+            .read_strongly_consistent()
+            .await?;
+        let output_fs = output_fs_operation(project)
+            .read_strongly_consistent()
+            .await?;
 
         if !ReadRef::ptr_eq(&prev_project_fs, &project_fs) {
             if watch.enable {
@@ -868,11 +891,10 @@ impl Project {
     #[turbo_tasks::function]
     pub async fn whole_app_module_graphs(self: ResolvedVc<Self>) -> Result<Vc<ModuleGraphs>> {
         async move {
-            let operation = whole_app_module_graph_operation(self);
-            let module_graphs = operation.connect();
-            let _ = module_graphs.resolve_strongly_consistent().await?;
-            let _ = operation.take_issues_with_path().await?;
-            Ok(module_graphs)
+            let module_graphs_op = whole_app_module_graph_operation(self);
+            let module_graphs_vc = module_graphs_op.resolve_strongly_consistent().await?;
+            let _ = module_graphs_op.take_issues_with_path().await?;
+            Ok(*module_graphs_vc)
         }
         .instrument(tracing::info_span!("module graph for app"))
         .await

--- a/crates/next-build-test/src/lib.rs
+++ b/crates/next-build-test/src/lib.rs
@@ -42,7 +42,7 @@ pub async fn main_inner(
     let project = tt
         .run_once(async {
             let project = ProjectContainer::new("next-build-test".into(), options.dev);
-            let project = project.resolve().await?;
+            let project = project.to_resolved().await?;
             project.initialize(options).await?;
             Ok(project)
         })
@@ -88,7 +88,7 @@ pub async fn main_inner(
     }
 
     if matches!(strat, Strategy::Development { .. }) {
-        hmr(tt, project).await?;
+        hmr(tt, *project).await?;
     }
 
     Ok(())

--- a/turbopack/crates/turbo-tasks-testing/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-testing/Cargo.toml
@@ -20,4 +20,4 @@ futures = { workspace = true }
 rustc-hash = { workspace = true }
 tokio = { workspace = true }
 turbo-rcstr = { workspace = true }
-turbo-tasks = { workspace = true }
+turbo-tasks = { workspace = true, features = ["non_operation_vc_strongly_consistent"] }

--- a/turbopack/crates/turbo-tasks/Cargo.toml
+++ b/turbopack/crates/turbo-tasks/Cargo.toml
@@ -14,6 +14,10 @@ tokio_tracing = ["tokio/tracing"]
 hanging_detection = []
 local_resolution = []
 
+# TODO(bgw): This feature is here to unblock turning on local tasks by default. It's only turned on
+# in unit tests. This will be removed very soon.
+non_operation_vc_strongly_consistent = []
+
 [lints]
 workspace = true
 

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -125,9 +125,10 @@ pub use turbo_tasks_macros::{function, value_impl, value_trait, KeyValuePair, Ta
 pub use value::{TransientInstance, TransientValue, Value};
 pub use value_type::{TraitMethod, TraitType, ValueType};
 pub use vc::{
-    Dynamic, NonLocalValue, OperationValue, OperationVc, OptionVcExt, ResolvedVc, TypedForInput,
-    Upcast, ValueDefault, Vc, VcCast, VcCellNewMode, VcCellSharedMode, VcDefaultRead, VcRead,
-    VcTransparentRead, VcValueTrait, VcValueTraitCast, VcValueType, VcValueTypeCast,
+    Dynamic, NonLocalValue, OperationValue, OperationVc, OptionVcExt, ReadVcFuture, ResolvedVc,
+    TypedForInput, Upcast, ValueDefault, Vc, VcCast, VcCellNewMode, VcCellSharedMode,
+    VcDefaultRead, VcRead, VcTransparentRead, VcValueTrait, VcValueTraitCast, VcValueType,
+    VcValueTypeCast,
 };
 
 pub type FxIndexSet<T> = indexmap::IndexSet<T, BuildHasherDefault<FxHasher>>;

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -498,16 +498,8 @@ where
         self.node.is_local()
     }
 
-    /// Resolve the reference until it points to a cell directly in a strongly
-    /// consistent way.
-    ///
-    /// Resolving will wait for task execution to be finished, so that the
-    /// returned Vc points to a cell that stores a value.
-    ///
-    /// Resolving is necessary to compare identities of Vcs.
-    ///
-    /// This is async and will rethrow any fatal error that happened during task
-    /// execution.
+    /// Do not use this: Use [`OperationVc::resolve_strongly_consistent`] instead.
+    #[cfg(feature = "non_operation_vc_strongly_consistent")]
     pub async fn resolve_strongly_consistent(self) -> Result<Self> {
         Ok(Self {
             node: self.node.resolve_strongly_consistent().await?,
@@ -639,8 +631,8 @@ impl<T> Vc<T>
 where
     T: VcValueType,
 {
-    /// Returns a strongly consistent read of the value. This ensures that all
-    /// internal tasks are finished before the read is returned.
+    /// Do not use this: Use [`OperationVc::read_strongly_consistent`] instead.
+    #[cfg(feature = "non_operation_vc_strongly_consistent")]
     #[must_use]
     pub fn strongly_consistent(self) -> ReadVcFuture<T> {
         self.node.into_strongly_consistent_read().into()

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -138,9 +138,9 @@ use crate::{
 ///
 /// Function calls are neither "eager", nor "lazy". Even if not awaited, they are guaranteed to
 /// execute (potentially emitting collectibles) before the root task finishes or before the
-/// completion of any strongly consistent read containing their call. However, the exact point when
-/// that execution begins is an implementation detail. Functions may execute more than once due to
-/// dirty task invalidation.
+/// completion of any [strongly consistent read][OperationVc::read_strongly_consistent] containing
+/// their call. However, the exact point when that execution begins is an implementation detail.
+/// Functions may execute more than once due to dirty task invalidation.
 ///
 ///
 /// ## Equality & Hashing
@@ -400,6 +400,13 @@ where
             _t: PhantomData,
         }
     }
+
+    /// Returns a untracked read of the value. This will not invalidate the current function when
+    /// the read value changed.
+    #[must_use]
+    pub fn untracked(self) -> ReadVcFuture<T> {
+        self.node.into_read_untracked().into()
+    }
 }
 
 impl<T, Inner, Repr> Vc<T>
@@ -456,15 +463,15 @@ where
         }
     }
 
-    /// Resolve the reference until it points to a cell directly.
+    /// Resolve the reference until it points to a cell directly using [eventual
+    /// consistency][crate::ReadConsistency::Eventual].
     ///
-    /// Resolving will wait for task execution to be finished, so that the
-    /// returned `Vc` points to a cell that stores a value.
+    /// Resolving will wait for task execution to be finished, so that the returned `Vc` points to a
+    /// cell that stores a value.
     ///
     /// Resolving is necessary to compare identities of `Vc`s.
     ///
-    /// This is async and will rethrow any fatal error that happened during task
-    /// execution.
+    /// This is async and will rethrow any fatal error that happened during task execution.
     pub async fn resolve(self) -> Result<Vc<T>> {
         Ok(Self {
             node: self.node.resolve().await?,
@@ -472,9 +479,8 @@ where
         })
     }
 
-    /// Resolve the reference until it points to a cell directly, and wrap the
-    /// result in a [`ResolvedVc`], which strongly guarantees that the
-    /// [`Vc`] was resolved.
+    /// Resolve the reference until it points to a cell directly, and wrap the result in a
+    /// [`ResolvedVc`], which guarantees that the [`Vc`] was resolved.
     pub async fn to_resolved(self) -> Result<ResolvedVc<T>> {
         Ok(ResolvedVc {
             node: self.resolve().await?,
@@ -496,23 +502,6 @@ where
     /// turbo-tasks.
     pub fn is_local(self) -> bool {
         self.node.is_local()
-    }
-
-    /// Resolve the reference until it points to a cell directly in a strongly
-    /// consistent way.
-    ///
-    /// Resolving will wait for task execution to be finished, so that the
-    /// returned Vc points to a cell that stores a value.
-    ///
-    /// Resolving is necessary to compare identities of Vcs.
-    ///
-    /// This is async and will rethrow any fatal error that happened during task
-    /// execution.
-    pub async fn resolve_strongly_consistent(self) -> Result<Self> {
-        Ok(Self {
-            node: self.node.resolve_strongly_consistent().await?,
-            _t: PhantomData,
-        })
     }
 }
 
@@ -634,25 +623,6 @@ macro_rules! into_future {
 into_future!(Vc<T>);
 into_future!(&Vc<T>);
 into_future!(&mut Vc<T>);
-
-impl<T> Vc<T>
-where
-    T: VcValueType,
-{
-    /// Returns a strongly consistent read of the value. This ensures that all
-    /// internal tasks are finished before the read is returned.
-    #[must_use]
-    pub fn strongly_consistent(self) -> ReadVcFuture<T> {
-        self.node.into_strongly_consistent_read().into()
-    }
-
-    /// Returns a untracked read of the value. This will not invalidate the current function when
-    /// the read value changed.
-    #[must_use]
-    pub fn untracked(self) -> ReadVcFuture<T> {
-        self.node.into_read_untracked().into()
-    }
-}
 
 impl<T> Unpin for Vc<T> where T: ?Sized {}
 

--- a/turbopack/crates/turbo-tasks/src/vc/operation.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/operation.rs
@@ -1,11 +1,13 @@
-use std::{fmt::Debug, hash::Hash};
+use std::{fmt::Debug, hash::Hash, marker::PhantomData};
 
+use anyhow::Result;
 use auto_hash_map::AutoSet;
 use serde::{Deserialize, Serialize};
+pub use turbo_tasks_macros::OperationValue;
 
 use crate::{
-    marker_trait::impl_auto_marker_trait, trace::TraceRawVcs, CollectiblesSource, RawVc, TaskInput,
-    Upcast, Vc, VcValueTrait,
+    marker_trait::impl_auto_marker_trait, trace::TraceRawVcs, CollectiblesSource, RawVc,
+    ReadVcFuture, ResolvedVc, TaskInput, Upcast, Vc, VcValueTrait, VcValueType,
 };
 
 /// A "subtype" (can be converted via [`.connect()`]) of [`Vc`] that
@@ -97,6 +99,37 @@ impl<T: ?Sized> OperationVc<T> {
         OperationVc {
             node: Vc::upcast(vc.node),
         }
+    }
+
+    /// [Connects the `OperationVc`][Self::connect] and [resolves][Vc::to_resolved] the reference
+    /// until it points to a cell directly in a [strongly
+    /// consistent][crate::ReadConsistency::Strong] way.
+    ///
+    /// Resolving will wait for task execution to be finished, so that the returned [`ResolvedVc`]
+    /// points to a cell that stores a value.
+    ///
+    /// Resolving is necessary to compare identities of [`Vc`]s.
+    ///
+    /// This is async and will rethrow any fatal error that happened during task execution.
+    pub async fn resolve_strongly_consistent(self) -> Result<ResolvedVc<T>> {
+        Ok(ResolvedVc {
+            node: Vc {
+                node: self.connect().node.resolve_strongly_consistent().await?,
+                _t: PhantomData,
+            },
+        })
+    }
+
+    /// [Connects the `OperationVc`][Self::connect] and returns a [strongly
+    /// consistent][crate::ReadConsistency::Strong] read of the value.
+    ///
+    /// This ensures that all internal tasks are finished before the read is returned.
+    #[must_use]
+    pub fn read_strongly_consistent(self) -> ReadVcFuture<T>
+    where
+        T: VcValueType,
+    {
+        self.connect().node.into_strongly_consistent_read().into()
     }
 }
 
@@ -209,5 +242,3 @@ pub unsafe trait OperationValue {}
 unsafe impl<T: ?Sized + Send> OperationValue for OperationVc<T> {}
 
 impl_auto_marker_trait!(OperationValue);
-
-pub use turbo_tasks_macros::OperationValue;

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -140,7 +140,7 @@ impl TurbopackBuildBuilder {
             );
 
             // Await the result to propagate any errors.
-            build_result_op.connect().strongly_consistent().await?;
+            build_result_op.read_strongly_consistent().await?;
 
             apply_effects(build_result_op).await?;
 

--- a/turbopack/crates/turbopack-cli/src/dev/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/mod.rs
@@ -32,7 +32,7 @@ use turbopack_dev_server::{
         combined::CombinedContentSource, router::PrefixedRouterContentSource,
         static_assets::StaticAssetsContentSource, ContentSource,
     },
-    DevServer, DevServerBuilder,
+    DevServer, DevServerBuilder, NonLocalSourceProvider,
 };
 use turbopack_ecmascript_runtime::RuntimeType;
 use turbopack_env::dotenv::load_env;
@@ -220,6 +220,8 @@ impl TurbopackDevServerBuilder {
                 browserslist_query.clone(),
             )
         };
+        // safety: Everything that `source` captures in its closure is a `NonLocalValue`
+        let source = unsafe { NonLocalSourceProvider::new(source) };
 
         let issue_reporter_arc = Arc::new(move || issue_provider.get_issue_reporter());
         Ok(server.serve(tasks, source, issue_reporter_arc))

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -1043,7 +1043,7 @@ pub async fn handle_issues<T: Send>(
     operation: Option<&str>,
 ) -> Result<()> {
     let source_vc = source_op.connect();
-    let _ = source_vc.resolve_strongly_consistent().await?;
+    let _ = source_op.resolve_strongly_consistent().await?;
     let issues = source_op.peek_issues_with_path().await?;
 
     let has_fatal = issue_reporter.report_issues(

--- a/turbopack/crates/turbopack-dev-server/src/http.rs
+++ b/turbopack/crates/turbopack-dev-server/src/http.rs
@@ -84,8 +84,7 @@ pub async fn process_request_with_content_source(
     let original_path = request.uri().path().to_string();
     let request = http_request_to_source_request(request).await?;
     let result_op = get_from_source_operation(source, TransientInstance::new(request));
-    let result_vc = result_op.connect();
-    let resolved_result = result_vc.resolve_strongly_consistent().await?;
+    let resolved_result = result_op.resolve_strongly_consistent().await?;
     apply_effects(result_op).await?;
     let side_effects: AutoSet<Vc<Box<dyn ContentSourceSideEffect>>> = result_op.peek_collectibles();
     handle_issues(

--- a/turbopack/crates/turbopack-dev-server/src/lib.rs
+++ b/turbopack/crates/turbopack-dev-server/src/lib.rs
@@ -61,6 +61,34 @@ where
     }
 }
 
+#[derive(Clone)]
+pub struct NonLocalSourceProvider<T>(T);
+
+impl<T> NonLocalSourceProvider<T> {
+    /// Wrap a `SourceProvider` in a type that implements `NonLocalValue`. This is useful for
+    /// closures that cannot implement `NonLocalValue` themselves.
+    ///
+    /// In the future, `auto_traits` may be be able to implement `NonLocalValue` for us, and avoid
+    /// this wrapper type and unsafe constructor.
+    ///
+    /// Safety: `source_provider` must be a type that could safely implement `NonLocalValue`. If
+    /// it's a closure, the closure must not capture any values that are not a `NonLocalValue`.
+    pub unsafe fn new(source_provider: T) -> Self {
+        Self(source_provider)
+    }
+}
+
+unsafe impl<T> NonLocalValue for NonLocalSourceProvider<T> {}
+
+impl<T> SourceProvider for NonLocalSourceProvider<T>
+where
+    T: SourceProvider,
+{
+    fn get_source(&self) -> OperationVc<Box<dyn ContentSource>> {
+        self.0.get_source()
+    }
+}
+
 #[derive(TraceRawVcs, Debug, NonLocalValue)]
 pub struct DevServerBuilder {
     #[turbo_tasks(trace_ignore)]
@@ -116,7 +144,7 @@ impl DevServerBuilder {
     pub fn serve(
         self,
         turbo_tasks: Arc<dyn TurboTasksApi>,
-        source_provider: impl SourceProvider + Sync,
+        source_provider: impl SourceProvider + NonLocalValue + Sync,
         get_issue_reporter: Arc<dyn Fn() -> Vc<Box<dyn IssueReporter>> + Send + Sync>,
     ) -> DevServer {
         let ongoing_side_effects = Arc::new(Mutex::new(VecDeque::<
@@ -210,12 +238,12 @@ impl DevServerBuilder {
 
                             let uri = request.uri();
                             let path = uri.path().to_string();
-                            let source = source_provider.get_source();
+                            let source_op = source_provider.get_source();
                             // HACK: Resolve `source` now so that we can get any issues on it
-                            let _ = source.connect().resolve_strongly_consistent().await?;
-                            apply_effects(source).await?;
+                            let _ = source_op.resolve_strongly_consistent().await?;
+                            apply_effects(source_op).await?;
                             handle_issues(
-                                source,
+                                source_op,
                                 issue_reporter,
                                 IssueSeverity::Fatal.cell(),
                                 Some(&path),
@@ -231,7 +259,7 @@ impl DevServerBuilder {
                                     // It's unlikely (the calls happen one-after-another), but this
                                     // could cause inconsistency between the reported issues and
                                     // the generated HTTP response.
-                                    source,
+                                    source_op,
                                     request,
                                     issue_reporter,
                                 )

--- a/turbopack/crates/turbopack-dev-server/src/lib.rs
+++ b/turbopack/crates/turbopack-dev-server/src/lib.rs
@@ -71,8 +71,10 @@ impl<T> NonLocalSourceProvider<T> {
     /// In the future, `auto_traits` may be be able to implement `NonLocalValue` for us, and avoid
     /// this wrapper type and unsafe constructor.
     ///
-    /// Safety: `source_provider` must be a type that could safely implement `NonLocalValue`. If
-    /// it's a closure, the closure must not capture any values that are not a `NonLocalValue`.
+    /// # Safety
+    ///
+    /// `source_provider` must be a type that could safely implement `NonLocalValue`. If it's a
+    /// closure, the closure must not capture any values that are not a `NonLocalValue`.
     pub unsafe fn new(source_provider: T) -> Self {
         Self(source_provider)
     }

--- a/turbopack/crates/turbopack-dev-server/src/source/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/mod.rs
@@ -485,7 +485,7 @@ pub enum RewriteType {
     ContentSource {
         /// [`ContentSource`]s from which to restart the lookup process. This _does not_ need to be
         /// the original content source.
-        source: ResolvedVc<Box<dyn ContentSource>>,
+        source: OperationVc<Box<dyn ContentSource>>,
         /// The new path and query used to lookup content. This _does not_ need
         /// to be the original path or query.
         path_and_query: RcStr,
@@ -493,7 +493,7 @@ pub enum RewriteType {
     Sources {
         /// [`GetContentSourceContent`]s from which to restart the lookup process. This _does not_
         /// need to be the original content source.
-        sources: ResolvedVc<GetContentSourceContents>,
+        sources: OperationVc<GetContentSourceContents>,
     },
 }
 
@@ -529,7 +529,7 @@ impl RewriteBuilder {
     }
 
     pub fn new_source_with_path_and_query(
-        source: ResolvedVc<Box<dyn ContentSource>>,
+        source: OperationVc<Box<dyn ContentSource>>,
         path_and_query: RcStr,
     ) -> Self {
         Self {
@@ -544,7 +544,7 @@ impl RewriteBuilder {
         }
     }
 
-    pub fn new_sources(sources: ResolvedVc<GetContentSourceContents>) -> Self {
+    pub fn new_sources(sources: OperationVc<GetContentSourceContents>) -> Self {
         Self {
             rewrite: Rewrite {
                 ty: RewriteType::Sources { sources },

--- a/turbopack/crates/turbopack-dev-server/src/source/resolve.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/resolve.rs
@@ -15,8 +15,10 @@ use super::{
     headers::{HeaderValue, Headers},
     query::Query,
     request::SourceRequest,
+    route_tree::RouteTree,
     ContentSource, ContentSourceContent, ContentSourceData, ContentSourceDataVary,
-    GetContentSourceContent, HeaderList, ProxyResult, RewriteType, StaticContent,
+    GetContentSourceContent, GetContentSourceContents, HeaderList, ProxyResult, RewriteType,
+    StaticContent,
 };
 
 /// The result of [`resolve_source_request`]. Similar to a
@@ -27,6 +29,37 @@ pub enum ResolveSourceRequestResult {
     NotFound,
     Static(ResolvedVc<StaticContent>, ResolvedVc<HeaderList>),
     HttpProxy(OperationVc<ProxyResult>),
+}
+
+#[turbo_tasks::function(operation)]
+fn content_source_get_routes_operation(
+    source: OperationVc<Box<dyn ContentSource>>,
+) -> Vc<RouteTree> {
+    source.connect().get_routes()
+}
+
+#[turbo_tasks::function(operation)]
+fn route_tree_get_operation(
+    route_tree: ResolvedVc<RouteTree>,
+    asset_path: RcStr,
+) -> Vc<GetContentSourceContents> {
+    route_tree.get(asset_path)
+}
+
+#[turbo_tasks::function(operation)]
+fn get_content_source_content_vary_operation(
+    get_content: ResolvedVc<Box<dyn GetContentSourceContent>>,
+) -> Vc<ContentSourceDataVary> {
+    get_content.vary()
+}
+
+#[turbo_tasks::function(operation)]
+fn get_content_source_content_get_operation(
+    get_content: ResolvedVc<Box<dyn GetContentSourceContent>>,
+    path: RcStr,
+    data: Value<ContentSourceData>,
+) -> Vc<ContentSourceContent> {
+    get_content.get(path, data)
 }
 
 /// Resolves a [SourceRequest] within a [super::ContentSource], returning the
@@ -47,20 +80,24 @@ pub async fn resolve_source_request(
     let mut current_asset_path: RcStr = urlencoding::decode(&original_path[1..])?.into();
     let mut request_overwrites = (*request).clone();
     let mut response_header_overwrites = Vec::new();
-    let mut route_tree = source
-        .connect()
-        .get_routes()
+    let mut route_tree = content_source_get_routes_operation(source)
         .resolve_strongly_consistent()
         .await?;
     'routes: loop {
-        let mut sources = route_tree.get(current_asset_path.clone());
+        let mut sources_op = route_tree_get_operation(route_tree, current_asset_path.clone());
         'sources: loop {
-            for get_content in sources.strongly_consistent().await?.iter() {
-                let content_vary = get_content.vary().strongly_consistent().await?;
+            for &get_content in sources_op.read_strongly_consistent().await?.iter() {
+                let content_vary = get_content_source_content_vary_operation(get_content)
+                    .read_strongly_consistent()
+                    .await?;
                 let content_data =
                     request_to_data(&request_overwrites, &request, &content_vary).await?;
-                let content = get_content.get(current_asset_path.clone(), Value::new(content_data));
-                match &*content.strongly_consistent().await? {
+                let content_op = get_content_source_content_get_operation(
+                    get_content,
+                    current_asset_path.clone(),
+                    Value::new(content_data),
+                );
+                match &*content_op.read_strongly_consistent().await? {
                     ContentSourceContent::Rewrite(rewrite) => {
                         let rewrite = rewrite.await?;
                         // apply rewrite extras
@@ -95,14 +132,15 @@ pub async fn resolve_source_request(
                                     urlencoding::decode(&new_uri.path()[1..])?.into_owned();
                                 request_overwrites.uri = new_uri;
                                 current_asset_path = new_asset_path.into();
-                                route_tree =
-                                    source.get_routes().resolve_strongly_consistent().await?;
+                                route_tree = content_source_get_routes_operation(*source)
+                                    .resolve_strongly_consistent()
+                                    .await?;
                                 continue 'routes;
                             }
                             RewriteType::Sources {
                                 sources: new_sources,
                             } => {
-                                sources = **new_sources;
+                                sources_op = *new_sources;
                                 continue 'sources;
                             }
                         }

--- a/turbopack/crates/turbopack-dev-server/src/source/wrapping_source.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/wrapping_source.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, Vc};
+use turbo_tasks::{OperationVc, ResolvedVc, TryJoinIterExt, Value, Vc};
 
 use super::{
     ContentSourceContent, ContentSourceData, ContentSourceDataVary, GetContentSourceContent,
-    Rewrite, RewriteType,
+    GetContentSourceContents, Rewrite, RewriteType,
 };
 
 /// A ContentSourceProcessor handles the final processing of an eventual
@@ -40,6 +40,27 @@ impl WrappedGetContentSourceContent {
     }
 }
 
+#[turbo_tasks::function(operation)]
+async fn wrap_sources_operation(
+    sources: OperationVc<GetContentSourceContents>,
+    processor: ResolvedVc<Box<dyn ContentSourceProcessor>>,
+) -> Result<Vc<GetContentSourceContents>> {
+    Ok(Vc::cell(
+        sources
+            .connect()
+            .await?
+            .iter()
+            .map(|s| {
+                Vc::upcast::<Box<dyn GetContentSourceContent>>(WrappedGetContentSourceContent::new(
+                    **s, *processor,
+                ))
+            })
+            .map(|v| async move { v.to_resolved().await })
+            .try_join()
+            .await?,
+    ))
+}
+
 #[turbo_tasks::value_impl]
 impl GetContentSourceContent for WrappedGetContentSourceContent {
     #[turbo_tasks::function]
@@ -63,22 +84,7 @@ impl GetContentSourceContent for WrappedGetContentSourceContent {
                             "Rewrites for WrappedGetContentSourceContent are not implemented yet"
                         ),
                         RewriteType::Sources { sources } => RewriteType::Sources {
-                            sources: ResolvedVc::cell(
-                                sources
-                                    .await?
-                                    .iter()
-                                    .map(|s| {
-                                        Vc::upcast::<Box<dyn GetContentSourceContent>>(
-                                            WrappedGetContentSourceContent::new(
-                                                **s,
-                                                *self.processor,
-                                            ),
-                                        )
-                                    })
-                                    .map(|v| async move { v.to_resolved().await })
-                                    .try_join()
-                                    .await?,
-                            ),
+                            sources: wrap_sources_operation(*sources, self.processor),
                         },
                     },
                     response_headers: rewrite.response_headers,

--- a/turbopack/crates/turbopack-dev-server/src/update/stream.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/stream.rs
@@ -33,7 +33,9 @@ pub struct GetContentFn(Box<dyn Fn() -> OperationVc<ResolveSourceRequestResult> 
 impl GetContentFn {
     /// Wrap a function in `GetContentFn`.
     ///
-    /// Safety: The closure must not include any types that aren't `NonLocalValue`, or that couldn't
+    /// # Safety
+    ///
+    /// The closure must not include any types that aren't `NonLocalValue`, or that couldn't
     /// otherwise safely implement `NonLocalValue`.
     ///
     /// In the future, `auto_traits` may be be able to implement `NonLocalValue` for us, and avoid
@@ -47,7 +49,9 @@ impl GetContentFn {
     /// Wrap a boxed function in `GetContentFn`. This specialized version of [`GetContentFn::new`]
     /// avoids double-boxing if you already have a boxed function.
     ///
-    /// Safety: Same as [`GetContentFn::new`].
+    /// # Safety
+    ///
+    /// Same as [`GetContentFn::new`].
     pub unsafe fn new_boxed(
         func: Box<dyn Fn() -> OperationVc<ResolveSourceRequestResult> + Send + Sync>,
     ) -> Self {

--- a/turbopack/crates/turbopack-dev-server/src/update/stream.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/stream.rs
@@ -1,4 +1,4 @@
-use std::pin::Pin;
+use std::{ops::Deref, pin::Pin};
 
 use anyhow::Result;
 use futures::prelude::*;
@@ -6,7 +6,9 @@ use tokio::sync::mpsc::Sender;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{IntoTraitRef, OperationVc, ReadRef, ResolvedVc, TransientInstance, Vc};
+use turbo_tasks::{
+    IntoTraitRef, NonLocalValue, OperationVc, ReadRef, ResolvedVc, TransientInstance, Vc,
+};
 use turbo_tasks_fs::{FileSystem, FileSystemPath};
 use turbopack_core::{
     error::PrettyPrintError,
@@ -23,7 +25,46 @@ use turbopack_core::{
 
 use crate::source::{resolve::ResolveSourceRequestResult, ProxyResult};
 
-type GetContentFn = Box<dyn Fn() -> OperationVc<ResolveSourceRequestResult> + Send + Sync>;
+/// A wrapper type returning
+/// [`OperationVc<ResolveSourceRequestResult>`][ResolveSourceRequestResult] that implements
+/// [`NonLocalValue`].
+pub struct GetContentFn(Box<dyn Fn() -> OperationVc<ResolveSourceRequestResult> + Send + Sync>);
+
+impl GetContentFn {
+    /// Wrap a function in `GetContentFn`.
+    ///
+    /// Safety: The closure must not include any types that aren't `NonLocalValue`, or that couldn't
+    /// otherwise safely implement `NonLocalValue`.
+    ///
+    /// In the future, `auto_traits` may be be able to implement `NonLocalValue` for us, and avoid
+    /// this wrapper type and unsafe constructor.
+    pub unsafe fn new(
+        func: impl Fn() -> OperationVc<ResolveSourceRequestResult> + Send + Sync + 'static,
+    ) -> Self {
+        Self::new_boxed(Box::new(func))
+    }
+
+    /// Wrap a boxed function in `GetContentFn`. This specialized version of [`GetContentFn::new`]
+    /// avoids double-boxing if you already have a boxed function.
+    ///
+    /// Safety: Same as [`GetContentFn::new`].
+    pub unsafe fn new_boxed(
+        func: Box<dyn Fn() -> OperationVc<ResolveSourceRequestResult> + Send + Sync>,
+    ) -> Self {
+        Self(func)
+    }
+}
+
+// Safety: It's up to the caller of `GetContentFn::new` to ensure this.
+unsafe impl NonLocalValue for GetContentFn {}
+
+impl Deref for GetContentFn {
+    type Target = Box<dyn Fn() -> OperationVc<ResolveSourceRequestResult> + Send + Sync>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 async fn peek_issues<T: Send>(source: OperationVc<T>) -> Result<Vec<ReadRef<PlainIssue>>> {
     let captured = source.peek_issues_with_path().await?;
@@ -49,15 +90,14 @@ fn versioned_content_update_operation(
     content.update(*from)
 }
 
-#[turbo_tasks::function]
-async fn get_update_stream_item(
+#[turbo_tasks::function(operation)]
+async fn get_update_stream_item_operation(
     resource: RcStr,
-    from: Vc<VersionState>,
+    from: ResolvedVc<VersionState>,
     get_content: TransientInstance<GetContentFn>,
 ) -> Result<Vc<UpdateStreamItem>> {
     let content_op = get_content();
-    let content_vc = content_op.connect();
-    let content_result = content_vc.strongly_consistent().await;
+    let content_result = content_op.read_strongly_consistent().await;
     let mut plain_issues = peek_issues(content_op).await?;
 
     let content_value = match content_result {
@@ -170,12 +210,12 @@ async fn get_update_stream_item(
 #[turbo_tasks::function]
 async fn compute_update_stream(
     resource: RcStr,
-    from: Vc<VersionState>,
+    from: ResolvedVc<VersionState>,
     get_content: TransientInstance<GetContentFn>,
     sender: TransientInstance<Sender<Result<ReadRef<UpdateStreamItem>>>>,
 ) -> Vc<()> {
-    let item = get_update_stream_item(resource, from, get_content)
-        .strongly_consistent()
+    let item = get_update_stream_item_operation(resource, from, get_content)
+        .read_strongly_consistent()
         .await;
 
     // Send update. Ignore channel closed error.

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -13,7 +13,8 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use turbo_tasks::{
     apply_effects, duration_span, fxindexmap, mark_finished, prevent_gc, util::SharedError,
-    Completion, FxIndexMap, RawVc, ResolvedVc, TaskInput, TryJoinIterExt, Value, Vc,
+    Completion, FxIndexMap, NonLocalValue, OperationVc, RawVc, ResolvedVc, TaskInput,
+    TryJoinIterExt, Value, Vc,
 };
 use turbo_tasks_bytes::{Bytes, Stream};
 use turbo_tasks_env::{EnvMap, ProcessEnv};
@@ -179,8 +180,8 @@ async fn emit_evaluate_pool_assets_operation(
     .cell())
 }
 
-#[turbo_tasks::function]
-async fn emit_evaluate_pool_assets_with_effects(
+#[turbo_tasks::function(operation)]
+async fn emit_evaluate_pool_assets_with_effects_operation(
     module_asset: ResolvedVc<Box<dyn Module>>,
     asset_context: ResolvedVc<Box<dyn AssetContext>>,
     chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
@@ -192,28 +193,30 @@ async fn emit_evaluate_pool_assets_with_effects(
         chunking_context,
         runtime_entries,
     );
-    let result = operation.connect().resolve_strongly_consistent().await?;
+    let result = operation.resolve_strongly_consistent().await?;
     apply_effects(operation).await?;
-    Ok(result)
+    Ok(*result)
 }
 
-#[derive(Clone, Copy, Hash, Debug, PartialEq, Eq, Serialize, Deserialize, TaskInput)]
+#[derive(
+    Clone, Copy, Hash, Debug, PartialEq, Eq, Serialize, Deserialize, TaskInput, NonLocalValue,
+)]
 pub enum EnvVarTracking {
     WholeEnvTracked,
     Untracked,
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation)]
 /// Pass the file you cared as `runtime_entries` to invalidate and reload the
 /// evaluated result automatically.
 pub async fn get_evaluate_pool(
-    module_asset: Vc<Box<dyn Module>>,
-    cwd: Vc<FileSystemPath>,
-    env: Vc<Box<dyn ProcessEnv>>,
-    asset_context: Vc<Box<dyn AssetContext>>,
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
-    runtime_entries: Option<Vc<EvaluatableAssets>>,
-    additional_invalidation: Vc<Completion>,
+    module_asset: ResolvedVc<Box<dyn Module>>,
+    cwd: ResolvedVc<FileSystemPath>,
+    env: ResolvedVc<Box<dyn ProcessEnv>>,
+    asset_context: ResolvedVc<Box<dyn AssetContext>>,
+    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    runtime_entries: Option<ResolvedVc<EvaluatableAssets>>,
+    additional_invalidation: ResolvedVc<Completion>,
     debug: bool,
     env_var_tracking: EnvVarTracking,
 ) -> Result<Vc<NodeJsPool>> {
@@ -221,16 +224,16 @@ pub async fn get_evaluate_pool(
         bootstrap,
         output_root,
         entrypoint,
-    } = *emit_evaluate_pool_assets_with_effects(
+    } = *emit_evaluate_pool_assets_with_effects_operation(
         module_asset,
         asset_context,
         chunking_context,
         runtime_entries,
     )
-    .strongly_consistent()
+    .read_strongly_consistent()
     .await?;
 
-    let (Some(cwd), Some(entrypoint)) = (to_sys_path(cwd).await?, to_sys_path(*entrypoint).await?)
+    let (Some(cwd), Some(entrypoint)) = (to_sys_path(*cwd).await?, to_sys_path(*entrypoint).await?)
     else {
         panic!("can only evaluate from a disk filesystem");
     };
@@ -244,7 +247,7 @@ pub async fn get_evaluate_pool(
         EnvVarTracking::WholeEnvTracked => env.read_all().await?,
         EnvVarTracking::Untracked => {
             // We always depend on some known env vars that are used by Node.js
-            common_node_env(env).await?;
+            common_node_env(*env).await?;
             for name in ["FORCE_COLOR", "NO_COLOR", "OPENSSL_CONF", "TZ"] {
                 env.read(name.into()).await?;
             }
@@ -311,7 +314,7 @@ pub trait EvaluateContext {
     type State: Default;
 
     fn compute(self, sender: Vc<JavaScriptStreamSender>);
-    fn pool(&self) -> Vc<NodeJsPool>;
+    fn pool(&self) -> OperationVc<NodeJsPool>;
     fn keep_alive(&self) -> bool {
         false
     }
@@ -419,12 +422,12 @@ pub async fn compute(
     };
 
     let stream = generator! {
-        let pool_operation = evaluate_context.pool();
+        let pool_op = evaluate_context.pool();
         let mut state = Default::default();
 
         // Read this strongly consistent, since we don't want to run inconsistent
         // node.js code.
-        let pool = pool_operation.strongly_consistent().await?;
+        let pool = pool_op.read_strongly_consistent().await?;
 
         let args = evaluate_context.args().iter().try_join().await?;
         // Assume this is a one-off operation, so we can kill the process
@@ -587,15 +590,15 @@ impl EvaluateContext for BasicEvaluateContext {
         let _ = basic_compute(self, sender);
     }
 
-    fn pool(&self) -> Vc<crate::pool::NodeJsPool> {
+    fn pool(&self) -> OperationVc<crate::pool::NodeJsPool> {
         get_evaluate_pool(
-            *self.module_asset,
-            *self.cwd,
-            *self.env,
-            *self.asset_context,
-            *self.chunking_context,
-            self.runtime_entries.map(|r| *r),
-            *self.additional_invalidation,
+            self.module_asset,
+            self.cwd,
+            self.env,
+            self.asset_context,
+            self.chunking_context,
+            self.runtime_entries,
+            self.additional_invalidation,
             self.debug,
             EnvVarTracking::WholeEnvTracked,
         )

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -68,12 +68,12 @@ struct SeparatedAssets {
 /// "internal" subgraph.
 #[turbo_tasks::function]
 async fn internal_assets(
-    intermediate_asset: Vc<Box<dyn OutputAsset>>,
-    intermediate_output_path: Vc<FileSystemPath>,
+    intermediate_asset: ResolvedVc<Box<dyn OutputAsset>>,
+    intermediate_output_path: ResolvedVc<FileSystemPath>,
 ) -> Result<Vc<OutputAssetsSet>> {
     Ok(
-        *separate_assets(intermediate_asset, intermediate_output_path)
-            .strongly_consistent()
+        *separate_assets_operation(intermediate_asset, intermediate_output_path)
+            .read_strongly_consistent()
             .await?
             .internal_assets,
     )
@@ -112,25 +112,25 @@ pub async fn external_asset_entrypoints(
     module: Vc<Box<dyn Module>>,
     runtime_entries: Vc<EvaluatableAssets>,
     chunking_context: Vc<Box<dyn ChunkingContext>>,
-    intermediate_output_path: Vc<FileSystemPath>,
+    intermediate_output_path: ResolvedVc<FileSystemPath>,
 ) -> Result<Vc<OutputAssetsSet>> {
-    Ok(*separate_assets(
+    Ok(*separate_assets_operation(
         get_intermediate_asset(chunking_context, module, runtime_entries)
-            .resolve()
+            .to_resolved()
             .await?,
         intermediate_output_path,
     )
-    .strongly_consistent()
+    .read_strongly_consistent()
     .await?
     .external_asset_entrypoints)
 }
 
 /// Splits the asset graph into "internal" assets and boundaries to "external"
 /// assets.
-#[turbo_tasks::function]
-async fn separate_assets(
+#[turbo_tasks::function(operation)]
+async fn separate_assets_operation(
     intermediate_asset: ResolvedVc<Box<dyn OutputAsset>>,
-    intermediate_output_path: Vc<FileSystemPath>,
+    intermediate_output_path: ResolvedVc<FileSystemPath>,
 ) -> Result<Vc<SeparatedAssets>> {
     let intermediate_output_path = &*intermediate_output_path.await?;
     #[derive(PartialEq, Eq, Hash, Clone, Copy)]
@@ -208,25 +208,25 @@ fn emit_package_json(dir: Vc<FileSystemPath>) -> Vc<()> {
 }
 
 /// Creates a node.js renderer pool for an entrypoint.
-#[turbo_tasks::function]
-pub async fn get_renderer_pool(
-    cwd: Vc<FileSystemPath>,
-    env: Vc<Box<dyn ProcessEnv>>,
-    intermediate_asset: Vc<Box<dyn OutputAsset>>,
-    intermediate_output_path: Vc<FileSystemPath>,
+#[turbo_tasks::function(operation)]
+pub async fn get_renderer_pool_operation(
+    cwd: ResolvedVc<FileSystemPath>,
+    env: ResolvedVc<Box<dyn ProcessEnv>>,
+    intermediate_asset: ResolvedVc<Box<dyn OutputAsset>>,
+    intermediate_output_path: ResolvedVc<FileSystemPath>,
     output_root: ResolvedVc<FileSystemPath>,
     project_dir: ResolvedVc<FileSystemPath>,
     debug: bool,
 ) -> Result<Vc<NodeJsPool>> {
-    emit_package_json(intermediate_output_path).await?;
+    emit_package_json(*intermediate_output_path).await?;
 
-    let _ = emit(intermediate_asset, *output_root).resolve().await?;
+    let _ = emit(*intermediate_asset, *output_root).resolve().await?;
     let assets_for_source_mapping =
-        internal_assets_for_source_mapping(intermediate_asset, *output_root);
+        internal_assets_for_source_mapping(*intermediate_asset, *output_root);
 
     let entrypoint = intermediate_asset.ident().path();
 
-    let Some(cwd) = to_sys_path(cwd).await? else {
+    let Some(cwd) = to_sys_path(*cwd).await? else {
         bail!(
             "can only render from a disk filesystem, but `cwd = {}`",
             cwd.to_string().await?
@@ -239,7 +239,7 @@ pub async fn get_renderer_pool(
         );
     };
     // Invalidate pool when code content changes
-    content_changed(Vc::upcast(intermediate_asset)).await?;
+    content_changed(*ResolvedVc::upcast(intermediate_asset)).await?;
 
     Ok(NodeJsPool::new(
         cwd,

--- a/turbopack/crates/turbopack-node/src/render/render_proxy.rs
+++ b/turbopack/crates/turbopack-node/src/render/render_proxy.rs
@@ -27,7 +27,7 @@ use super::{
     ResponseHeaders,
 };
 use crate::{
-    get_intermediate_asset, get_renderer_pool, pool::NodeJsOperation,
+    get_intermediate_asset, get_renderer_pool_operation, pool::NodeJsOperation,
     render::error_page::error_html, source_map::trace_stack,
 };
 
@@ -238,20 +238,20 @@ async fn render_stream_internal(
             *chunking_context,
             *module,
             *runtime_entries,
-        );
-        let pool = get_renderer_pool(
-            *cwd,
-            *env,
+        ).to_resolved().await?;
+        let pool_op = get_renderer_pool_operation(
+            cwd,
+            env,
             intermediate_asset,
-            *intermediate_output_path,
-            *output_root,
-            *project_dir,
+            intermediate_output_path,
+            output_root,
+            project_dir,
             debug,
         );
 
         // Read this strongly consistent, since we don't want to run inconsistent
         // node.js code.
-        let pool = pool.strongly_consistent().await?;
+        let pool = pool_op.read_strongly_consistent().await?;
         let data = data.await?;
         let mut operation = pool.operation().await?;
 
@@ -279,7 +279,7 @@ async fn render_stream_internal(
                 // 500 proxy error as if it were the proper result.
                 let trace = trace_stack(
                     error,
-                    intermediate_asset,
+                    *intermediate_asset,
                     *intermediate_output_path,
                     *project_dir
                 )
@@ -314,7 +314,7 @@ async fn render_stream_internal(
                     // headers/body to a proxy error.
                     operation.disallow_reuse();
                     let trace =
-                        trace_stack(error, intermediate_asset, *intermediate_output_path, *project_dir).await?;
+                        trace_stack(error, *intermediate_asset, *intermediate_output_path, *project_dir).await?;
                     Err(anyhow!("error during streaming render: {}", trace))?;
                     return;
                 }

--- a/turbopack/crates/turbopack-node/src/render/render_static.rs
+++ b/turbopack/crates/turbopack-node/src/render/render_static.rs
@@ -29,7 +29,7 @@ use super::{
     issue::RenderingIssue, RenderData, RenderStaticIncomingMessage, RenderStaticOutgoingMessage,
 };
 use crate::{
-    get_intermediate_asset, get_renderer_pool, pool::NodeJsOperation,
+    get_intermediate_asset, get_renderer_pool_operation, pool::NodeJsOperation,
     render::error_page::error_html_body, source_map::trace_stack, ResponseHeaders,
 };
 
@@ -288,20 +288,20 @@ async fn render_stream_internal(
             *chunking_context,
             *module,
             *runtime_entries,
-        );
-        let renderer_pool = get_renderer_pool(
-            *cwd,
-            *env,
+        ).to_resolved().await?;
+        let renderer_pool_op = get_renderer_pool_operation(
+            cwd,
+            env,
             intermediate_asset,
-            *intermediate_output_path,
-            *output_root,
-            *project_dir,
+            intermediate_output_path,
+            output_root,
+            project_dir,
             debug,
         );
 
         // Read this strongly consistent, since we don't want to run inconsistent
         // node.js code.
-        let pool = renderer_pool.strongly_consistent().await?;
+        let pool = renderer_pool_op.read_strongly_consistent().await?;
         let data = data.await?;
         let mut operation = pool.operation().await?;
 
@@ -343,7 +343,7 @@ async fn render_stream_internal(
                 // 500 proxy error as if it were the proper result.
                 let trace = trace_stack(
                     error,
-                    intermediate_asset,
+                    *intermediate_asset,
                     *intermediate_output_path,
                     *project_dir,
                 )
@@ -377,7 +377,7 @@ async fn render_stream_internal(
                     // headers/body to a proxy error.
                     operation.disallow_reuse();
                     let trace =
-                        trace_stack(error, intermediate_asset, *intermediate_output_path, *project_dir).await?;
+                        trace_stack(error, *intermediate_asset, *intermediate_output_path, *project_dir).await?;
                         drop(guard);
                     Err(anyhow!("error during streaming render: {}", trace))?;
                     return;

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -8,8 +8,8 @@ use serde_json::{json, Value as JsonValue};
 use serde_with::serde_as;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    trace::TraceRawVcs, Completion, NonLocalValue, OperationValue, ResolvedVc, TaskInput,
-    TryJoinIterExt, Value, ValueToString, Vc,
+    trace::TraceRawVcs, Completion, NonLocalValue, OperationValue, OperationVc, ResolvedVc,
+    TaskInput, TryJoinIterExt, Value, ValueToString, Vc,
 };
 use turbo_tasks_bytes::stream::SingleValue;
 use turbo_tasks_env::ProcessEnv;
@@ -415,15 +415,15 @@ impl EvaluateContext for WebpackLoaderContext {
         let _ = compute_webpack_loader_evaluation(self, sender);
     }
 
-    fn pool(&self) -> Vc<crate::pool::NodeJsPool> {
+    fn pool(&self) -> OperationVc<crate::pool::NodeJsPool> {
         get_evaluate_pool(
-            *self.module_asset,
-            *self.cwd,
-            *self.env,
-            *self.asset_context,
-            *self.chunking_context,
+            self.module_asset,
+            self.cwd,
+            self.env,
+            self.asset_context,
+            self.chunking_context,
             None,
-            *self.additional_invalidation,
+            self.additional_invalidation,
             should_debug("webpack_loader"),
             // Env vars are read untracked, since we want a more granular dependency on certain env
             // vars only. So the runtime code tracks which env vars are read and send a dependency


### PR DESCRIPTION
This PR only allows strongly consistent reads to happen on `VcOperation`:

- Moves `Vc::strongly_consistent` to `OperationVc::read_strongly_consistent`.
- Moves `Vc::resolve_strongly_consistent` to `OperationVc::resolve_strongly_consistent` (and makes it return a `ResolvedVc` instead of a `Vc`).

Both these use `OperationVc::connect()` to connect before reading/resolving.

## Why do this?

- For resolved Vcs, the task id associated with the Vc may be unintuitive, as it could be the task that constructs the cell, not the function you most recently called.

- For local Vcs, the task id is our own task. We can't strongly resolve ourselves.

So, the solution is to force strong resolution to occur on `OperationVc`s, where the task pointed to is as obvious as possible.

## Unit Tests

There are still some unit tests depending on `Vc::strongly_consistent`/`Vc::resolve_strongly_consistent`. I'll fix those and completely remove these methods in a subsequent PR.

Closes PACK-3777