### PR TITLE
build: Update `swc_core` to `v10.3.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7166,9 +7166,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "10.2.5"
+version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437683084ba049e2e1663453029d579da67ba156ae59b1e2168445d64a2e2806"
+checksum = "450f806fdb43a7c25c93a86745cfe51abf0b0dedf592bb7d740af9fc9ba6f7e9"
 dependencies = [
  "binding_macros",
  "swc",
@@ -7355,9 +7355,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "5.0.1"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f93692de35a77d920ce8d96a46217735e5f86bf42f76cc8f1a60628c347c4c8"
+checksum = "389a3f4f9f28425fe0e3994ade4f099ad4f3a788cfe781cba36a9f4288eae222"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -8279,9 +8279,9 @@ dependencies = [
 
 [[package]]
 name = "swc_typescript"
-version = "6.1.0"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "341407b6a3f640b0b2c813aa0ffe373286585c6587cc2b0cc469ec24b599aa79"
+checksum = "fec37f682d079c9c6afa3a637a6ea387066830dd56b47bb217c7f3502c0f71e4"
 dependencies = [
  "petgraph",
  "rustc-hash 1.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 
 # SWC crates
-swc_core = { version = "10.2.5", features = [
+swc_core = { version = "10.3.0", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }


### PR DESCRIPTION
### What?

Update SWC crates.

 - ChangeLog: https://github.com/swc-project/swc/compare/swc_core%40v10.2.5...swc_core%40v10.3.0


### Why?

To apply https://github.com/swc-project/swc/pull/9890, which reduces lots of allocations while generating ES code.

### How?



Closes PACK-3756