### PR TITLE
[DevOverlay] Open Error Overlay when DevTools Indicator clicked

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -115,12 +115,10 @@ const DevToolsPopover = ({
     }
   }, [])
 
-  const togglePopover = () =>
-    setIsPopoverOpen((prev) => {
-      console.log('togglePopover', prev)
-      return !prev
-    })
-  const onIssuesClick = () => setIsErrorOverlayOpen(true)
+  const togglePopover = () => setIsPopoverOpen((prev) => !prev)
+  const onIssuesClick = () =>
+    issueCount > 0 ? setIsErrorOverlayOpen(true) : null
+
   const onLogoClick = () => {
     togglePopover()
     onIssuesClick()
@@ -182,9 +180,7 @@ const DevToolsPopover = ({
               <IndicatorRow
                 label="Issues"
                 value={<IssueCount count={issueCount} />}
-                onClick={
-                  issueCount > 0 ? () => setIsErrorOverlayOpen(true) : undefined
-                }
+                onClick={onIssuesClick}
               />
             </div>
           </div>

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -36,14 +36,12 @@ export function DevToolsIndicator({
     isDevToolsIndicatorOpen && (
       <DevToolsPopover
         semver={state.versionInfo.installed}
-        onIssuesClick={() => {
-          setIsErrorOverlayOpen(true)
-        }}
         issueCount={readyErrorsLength}
         isStaticRoute={state.staticIndicator}
         hide={() => {
           setIsDevToolsIndicatorOpen(false)
         }}
+        setIsErrorOverlayOpen={setIsErrorOverlayOpen}
         isTurbopack={!!process.env.TURBOPACK}
       />
     )
@@ -54,19 +52,19 @@ const ANIMATE_OUT_DURATION_MS = 200
 const ANIMATE_OUT_TIMING_FUNCTION = 'cubic-bezier(0.175, 0.885, 0.32, 1.1)'
 
 const DevToolsPopover = ({
-  onIssuesClick,
   issueCount,
   isStaticRoute,
-  hide,
   semver,
   isTurbopack,
+  hide,
+  setIsErrorOverlayOpen,
 }: {
-  onIssuesClick: () => void
   issueCount: number
   isStaticRoute: boolean
-  hide: () => void
   semver: string | undefined
   isTurbopack: boolean
+  hide: () => void
+  setIsErrorOverlayOpen: (value: boolean) => void
 }) => {
   const popoverRef = useRef<HTMLDivElement>(null)
   const buttonRef = useRef<HTMLDivElement>(null)
@@ -174,7 +172,9 @@ const DevToolsPopover = ({
               <IndicatorRow
                 label="Issues"
                 value={<IssueCount count={issueCount} />}
-                onClick={issueCount > 0 ? onIssuesClick : undefined}
+                onClick={
+                  issueCount > 0 ? () => setIsErrorOverlayOpen(true) : undefined
+                }
               />
             </div>
           </div>

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -1,3 +1,4 @@
+import type { Dispatch, SetStateAction } from 'react'
 import type { OverlayState } from '../../../../../shared'
 
 import { useState, useEffect, useRef } from 'react'
@@ -19,7 +20,7 @@ export function DevToolsIndicator({
 }: {
   state: OverlayState
   readyErrorsLength: number
-  setIsErrorOverlayOpen: (value: boolean) => void
+  setIsErrorOverlayOpen: Dispatch<SetStateAction<boolean>>
 }) {
   const [isDevToolsIndicatorOpen, setIsDevToolsIndicatorOpen] = useState(true)
   // Register `(cmd|ctrl) + .` to show/hide the error indicator.
@@ -64,7 +65,7 @@ const DevToolsPopover = ({
   semver: string | undefined
   isTurbopack: boolean
   hide: () => void
-  setIsErrorOverlayOpen: (value: boolean) => void
+  setIsErrorOverlayOpen: Dispatch<SetStateAction<boolean>>
 }) => {
   const popoverRef = useRef<HTMLDivElement>(null)
   const buttonRef = useRef<HTMLDivElement>(null)
@@ -114,7 +115,16 @@ const DevToolsPopover = ({
     }
   }, [])
 
-  const togglePopover = () => setIsPopoverOpen((prev) => !prev)
+  const togglePopover = () =>
+    setIsPopoverOpen((prev) => {
+      console.log('togglePopover', prev)
+      return !prev
+    })
+  const onIssuesClick = () => setIsErrorOverlayOpen(true)
+  const onLogoClick = () => {
+    togglePopover()
+    onIssuesClick()
+  }
 
   return (
     <Toast
@@ -127,7 +137,7 @@ const DevToolsPopover = ({
         <NextLogo
           key={issueCount}
           issueCount={issueCount}
-          onClick={togglePopover}
+          onLogoClick={onLogoClick}
           onIssuesClick={onIssuesClick}
           isDevBuilding={useIsDevBuilding()}
           isDevRendering={useIsDevRendering()}

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -3,9 +3,9 @@ import { noop as css } from '../../../../../../internal/helpers/noop-template'
 
 interface Props extends React.ComponentProps<'button'> {
   issueCount: number
-  onClick: () => void
   isDevBuilding: boolean
   isDevRendering: boolean
+  onLogoClick: () => void
   onIssuesClick: () => void
 }
 
@@ -13,9 +13,9 @@ const SIZE = 36
 
 export const NextLogo = ({
   issueCount,
-  onClick,
   isDevBuilding,
   isDevRendering,
+  onLogoClick,
   onIssuesClick,
   ...props
 }: Props) => {
@@ -223,7 +223,7 @@ export const NextLogo = ({
       >
         <div ref={ref}>
           {/* Children */}
-          <button data-next-mark onClick={onClick} {...props}>
+          <button data-next-mark onClick={onLogoClick} {...props}>
             <NextMark isLoading={isLoading} />
           </button>
           {isErrorExpanded && (


### PR DESCRIPTION
Open the Error Overlay when DevTools Indicator is clicked to preserve the one-click away from the overlay UX.

### Before

https://github.com/user-attachments/assets/4dec6f30-988f-4ec8-acd3-49b28f42e5fe

### After

https://github.com/user-attachments/assets/ba2a6401-2c94-44f7-9c59-4ea1d02ae515

Closes NDX-685