### PR TITLE
Fix ping event being sent unintentionally for Pages Router with Turbopack

### DIFF
--- a/packages/next/src/client/dev/on-demand-entries-client.ts
+++ b/packages/next/src/client/dev/on-demand-entries-client.ts
@@ -2,6 +2,11 @@ import Router from '../router'
 import { sendMessage } from '../components/react-dev-overlay/pages/websocket'
 
 export default async (page?: string) => {
+  // Never send pings when using Turbopack as it's not used.
+  // Pings were originally used to keep track of active routes in on-demand-entries with webpack.
+  if (process.env.TURBOPACK) {
+    return
+  }
   if (page) {
     // in AMP the router isn't initialized on the client and
     // client-transitions don't occur so ping initial page


### PR DESCRIPTION
## What?

I missed a spot in #74584 where the `ping` event is sent for Pages Router. This ensures it's skipped for Pages Router. 

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
