### PR TITLE
fix: don't memory-leak promises passed to `waitUntil`

### DIFF
--- a/packages/next/src/server/after/awaiter.ts
+++ b/packages/next/src/server/after/awaiter.ts
@@ -18,22 +18,22 @@ export class AwaiterMulti {
     // if a promise settles before we await it, we should drop it --
     // storing them indefinitely could result in a memory leak.
     const cleanup = () => {
-      this.promises.delete(wrappedPromise)
+      this.promises.delete(promise)
     }
 
-    const wrappedPromise = promise.then(cleanup, (err) => {
+    promise.then(cleanup, (err) => {
       cleanup()
       this.onError(err)
     })
 
-    this.promises.add(wrappedPromise)
+    this.promises.add(promise)
   }
 
   public async awaiting(): Promise<void> {
     while (this.promises.size > 0) {
       const promises = Array.from(this.promises)
       this.promises.clear()
-      await Promise.all(promises)
+      await Promise.allSettled(promises)
     }
   }
 }

--- a/packages/next/src/server/after/awaiter.ts
+++ b/packages/next/src/server/after/awaiter.ts
@@ -15,17 +15,18 @@ export class AwaiterMulti {
   }
 
   public waitUntil = (promise: Promise<unknown>): void => {
-    // if a promise settles before we await it, we can drop it.
+    // if a promise settles before we await it, we should drop it --
+    // storing them indefinitely could result in a memory leak.
     const cleanup = () => {
-      this.promises.delete(promise)
+      this.promises.delete(wrappedPromise)
     }
 
-    this.promises.add(
-      promise.then(cleanup, (err) => {
-        cleanup()
-        this.onError(err)
-      })
-    )
+    const wrappedPromise = promise.then(cleanup, (err) => {
+      cleanup()
+      this.onError(err)
+    })
+
+    this.promises.add(wrappedPromise)
   }
 
   public async awaiting(): Promise<void> {


### PR DESCRIPTION
### Overview

`next start` stores pending promises passed to `waitUntil` so that we can await them before a (graceful) server shutdown and avoid interrupting work that's still running.
The problem here was that this set lives a long time (the whole lifetime of the server), but we weren't removing resolved promises from this set, so we'd end up holding onto them forever and leaking memory.

This bug would be triggered by any code using `waitUntil` in `next start` (notably, a recent change: https://github.com/vercel/next.js/pull/74164)

### Details 
The bug here is that `AwaiterMulti` would hold onto resolved promises indefinitely. `AwaiterMulti` ends up being used by `NextNodeServer.getInternalWaitUntil`, which is what provides `waitUntil` in `next start`.

The code was already attempting to clean up promises to avoid leaks. But the problem was that we weren't adding `promise` to `this.promises`, we were adding `promise.then(...)` which is a completely different object.
So the `this.promises.delete(promise)` that `cleanup` did was effectively doing nothing, and `this.promises` would keep growing.

