### PR TITLE
perf(turbo-tasks): Use the type information we already have for all ResolvedVc casts, expose synchronous versions of functions

### DIFF
--- a/turbopack/crates/turbo-tasks/src/raw_vc.rs
+++ b/turbopack/crates/turbo-tasks/src/raw_vc.rs
@@ -292,7 +292,7 @@ impl RawVc {
         }
     }
 
-    /// For a type that's already resolved, synchronously check if it implements a trait using the
+    /// For a cell that's already resolved, synchronously check if it implements a trait using the
     /// type information in `RawVc::TaskCell` (we don't actualy need to read the cell!).
     pub(crate) fn resolved_has_trait(&self, trait_id: TraitTypeId) -> bool {
         match self {
@@ -300,6 +300,15 @@ impl RawVc {
                 get_value_type(cell_id.type_id).has_trait(&trait_id)
             }
             _ => unreachable!("resolved_has_trait must be called with a RawVc::TaskCell"),
+        }
+    }
+
+    /// For a cell that's already resolved, synchronously check if it is a given type using the type
+    /// information in `RawVc::TaskCell` (we don't actualy need to read the cell!).
+    pub(crate) fn resolved_is_type(&self, type_id: ValueTypeId) -> bool {
+        match self {
+            RawVc::TaskCell(_task_id, cell_id) => cell_id.type_id == type_id,
+            _ => unreachable!("resolved_is_type must be called with a RawVc::TaskCell"),
         }
     }
 }


### PR DESCRIPTION
We already have type information for `ResolvedVc`, so we can avoid going through the codepath in `Vc`, which can fail and requires a cell read.

I did this for sidecasts in https://github.com/vercel/next.js/pull/74844 to unblock synchronous graph traversals. This does the same for the rest of the functions.

I expect any perf impact to be pretty small (casting isn't a particularly hot codepath), but it's also an easy change to make, and (once callsites are migrated) will lead to a nicer API.

Right now I'm continuing to expose the async fallible versions of these functions. I'll port the callsites (looks like there's 92 of them) to the synchronous infallible version in a later PR.

Closes PACK-3766