### PR TITLE
Remove `endpoint.write_to_disk()` in favor of standardized `endpoint.output()`

### DIFF
--- a/crates/napi/src/next_api/endpoint.rs
+++ b/crates/napi/src/next_api/endpoint.rs
@@ -6,7 +6,7 @@ use next_api::{
     paths::ServerPath,
     route::{
         endpoint_server_changed_operation, endpoint_write_to_disk_operation, Endpoint,
-        WrittenEndpoint,
+        EndpointOutputPaths,
     },
 };
 use tracing::Instrument;
@@ -52,10 +52,10 @@ pub struct NapiWrittenEndpoint {
     pub config: NapiEndpointConfig,
 }
 
-impl From<Option<WrittenEndpoint>> for NapiWrittenEndpoint {
-    fn from(written_endpoint: Option<WrittenEndpoint>) -> Self {
+impl From<Option<EndpointOutputPaths>> for NapiWrittenEndpoint {
+    fn from(written_endpoint: Option<EndpointOutputPaths>) -> Self {
         match written_endpoint {
-            Some(WrittenEndpoint::NodeJs {
+            Some(EndpointOutputPaths::NodeJs {
                 server_entry_path,
                 server_paths,
                 client_paths,
@@ -66,7 +66,7 @@ impl From<Option<WrittenEndpoint>> for NapiWrittenEndpoint {
                 server_paths: server_paths.into_iter().map(From::from).collect(),
                 ..Default::default()
             },
-            Some(WrittenEndpoint::Edge {
+            Some(EndpointOutputPaths::Edge {
                 server_paths,
                 client_paths,
             }) => Self {
@@ -125,7 +125,7 @@ async fn strongly_consistent_catch_collectables<R: VcValueType + Send>(
 
 #[turbo_tasks::value(serialization = "none")]
 struct WrittenEndpointWithIssues {
-    written: Option<ReadRef<WrittenEndpoint>>,
+    written: Option<ReadRef<EndpointOutputPaths>>,
     issues: Arc<Vec<ReadRef<PlainIssue>>>,
     diagnostics: Arc<Vec<ReadRef<PlainDiagnostic>>>,
     effects: Arc<Effects>,

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -81,7 +81,7 @@ use crate::{
         get_wasm_paths_from_root, paths_to_bindings, wasm_paths_to_bindings,
     },
     project::{ModuleGraphs, Project},
-    route::{AppPageRoute, Endpoint, Route, Routes, WrittenEndpoint},
+    route::{AppPageRoute, Endpoint, EndpointOutput, EndpointOutputPaths, Route, Routes},
     server_actions::{build_server_actions_loader, create_server_actions_manifest},
     webpack_stats::generate_webpack_stats,
 };
@@ -1709,7 +1709,7 @@ async fn create_app_paths_manifest(
 #[turbo_tasks::value_impl]
 impl Endpoint for AppEndpoint {
     #[turbo_tasks::function]
-    async fn write_to_disk(self: ResolvedVc<Self>) -> Result<Vc<WrittenEndpoint>> {
+    async fn output(self: ResolvedVc<Self>) -> Result<Vc<EndpointOutput>> {
         let this = self.await?;
         let page_name = this.page.to_string();
         let span = match this.ty {
@@ -1732,19 +1732,12 @@ impl Endpoint for AppEndpoint {
                 tracing::info_span!("app endpoint metadata", name = page_name)
             }
         };
+
         async move {
             let output = self.output().await?;
-            let output_assets_op = output_assets_operation(self);
-            let output_assets = output_assets_op.connect();
-
+            let output_assets = self.output().output_assets();
             let node_root = this.app_project.project().node_root();
-
             let node_root_ref = &node_root.await?;
-
-            let _ = this
-                .app_project
-                .project()
-                .emit_all_output_assets(output_assets_op);
 
             let (server_paths, client_paths) = if this
                 .app_project
@@ -1770,7 +1763,7 @@ impl Endpoint for AppEndpoint {
             };
 
             let written_endpoint = match *output {
-                AppEndpointOutput::NodeJs { rsc_chunk, .. } => WrittenEndpoint::NodeJs {
+                AppEndpointOutput::NodeJs { rsc_chunk, .. } => EndpointOutputPaths::NodeJs {
                     server_entry_path: node_root_ref
                         .get_path_to(&*rsc_chunk.ident().path().await?)
                         .context("Node.js chunk entry path must be inside the node root")?
@@ -1778,12 +1771,20 @@ impl Endpoint for AppEndpoint {
                     server_paths,
                     client_paths,
                 },
-                AppEndpointOutput::Edge { .. } => WrittenEndpoint::Edge {
+                AppEndpointOutput::Edge { .. } => EndpointOutputPaths::Edge {
                     server_paths,
                     client_paths,
                 },
             };
-            anyhow::Ok(written_endpoint.cell())
+
+            anyhow::Ok(
+                EndpointOutput {
+                    output_assets: output_assets.to_resolved().await?,
+                    output_paths: written_endpoint.resolved_cell(),
+                    project: this.app_project.project().to_resolved().await?,
+                }
+                .cell(),
+            )
         }
         .instrument(span)
         .await
@@ -1851,11 +1852,6 @@ impl Endpoint for AppEndpoint {
 
         Ok(Vc::cell(vec![server_actions_loader]))
     }
-}
-
-#[turbo_tasks::function(operation)]
-fn output_assets_operation(endpoint: ResolvedVc<AppEndpoint>) -> Vc<OutputAssets> {
-    endpoint.output().output_assets()
 }
 
 #[turbo_tasks::value]

--- a/crates/next-api/src/empty.rs
+++ b/crates/next-api/src/empty.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use turbo_tasks::{Completion, Vc};
 use turbopack_core::module::Modules;
 
-use crate::route::{Endpoint, WrittenEndpoint};
+use crate::route::{Endpoint, EndpointOutput};
 
 #[turbo_tasks::value]
 pub struct EmptyEndpoint;
@@ -18,8 +18,8 @@ impl EmptyEndpoint {
 #[turbo_tasks::value_impl]
 impl Endpoint for EmptyEndpoint {
     #[turbo_tasks::function]
-    fn write_to_disk(self: Vc<Self>) -> Result<Vc<WrittenEndpoint>> {
-        bail!("Empty endpoint can't be written to disk")
+    fn output(self: Vc<Self>) -> Result<Vc<EndpointOutput>> {
+        bail!("Empty endpoint can't have output")
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -31,7 +31,7 @@ use crate::{
         get_wasm_paths_from_root, paths_to_bindings, wasm_paths_to_bindings,
     },
     project::Project,
-    route::{Endpoint, WrittenEndpoint},
+    route::{Endpoint, EndpointOutput, EndpointOutputPaths},
 };
 
 #[turbo_tasks::value]
@@ -277,18 +277,11 @@ impl MiddlewareEndpoint {
 #[turbo_tasks::value_impl]
 impl Endpoint for MiddlewareEndpoint {
     #[turbo_tasks::function]
-    async fn write_to_disk(self: ResolvedVc<Self>) -> Result<Vc<WrittenEndpoint>> {
+    async fn output(self: ResolvedVc<Self>) -> Result<Vc<EndpointOutput>> {
         let span = tracing::info_span!("middleware endpoint");
         async move {
             let this = self.await?;
-            let output_assets_op = output_assets_operation(self);
-            let output_assets = output_assets_op.connect();
-            let _ = output_assets.resolve().await?;
-            let _ = this
-                .project
-                .emit_all_output_assets(output_assets_op)
-                .resolve()
-                .await?;
+            let output_assets = self.output_assets();
 
             let (server_paths, client_paths) = if this.project.next_mode().await?.is_development() {
                 let node_root = this.project.node_root();
@@ -308,9 +301,14 @@ impl Endpoint for MiddlewareEndpoint {
                 (vec![], vec![])
             };
 
-            Ok(WrittenEndpoint::Edge {
-                server_paths,
-                client_paths,
+            Ok(EndpointOutput {
+                output_paths: EndpointOutputPaths::Edge {
+                    server_paths,
+                    client_paths,
+                }
+                .resolved_cell(),
+                output_assets: output_assets.to_resolved().await?,
+                project: this.project,
             }
             .cell())
         }
@@ -332,9 +330,4 @@ impl Endpoint for MiddlewareEndpoint {
     async fn root_modules(self: Vc<Self>) -> Result<Vc<Modules>> {
         Ok(Vc::cell(vec![self.entry_module().to_resolved().await?]))
     }
-}
-
-#[turbo_tasks::function(operation)]
-fn output_assets_operation(endpoint: ResolvedVc<MiddlewareEndpoint>) -> Vc<OutputAssets> {
-    endpoint.output_assets()
 }

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -1,12 +1,13 @@
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     debug::ValueDebugFormat, trace::TraceRawVcs, Completion, FxIndexMap, NonLocalValue,
     OperationVc, ResolvedVc, Vc,
 };
-use turbopack_core::{module::Modules, module_graph::ModuleGraph};
+use turbopack_core::{module::Modules, module_graph::ModuleGraph, output::OutputAssets};
 
-use crate::paths::ServerPath;
+use crate::{paths::ServerPath, project::Project};
 
 #[derive(
     TraceRawVcs,
@@ -45,7 +46,8 @@ pub enum Route {
 
 #[turbo_tasks::value_trait(local)]
 pub trait Endpoint {
-    fn write_to_disk(self: Vc<Self>) -> Vc<WrittenEndpoint>;
+    fn output(self: Vc<Self>) -> Vc<EndpointOutput>;
+    // fn write_to_disk(self: Vc<Self>) -> Vc<EndpointOutputPaths>;
     fn server_changed(self: Vc<Self>) -> Vc<Completion>;
     fn client_changed(self: Vc<Self>) -> Vc<Completion>;
     /// The entry modules for the modules graph.
@@ -60,11 +62,42 @@ pub trait Endpoint {
 #[turbo_tasks::value(transparent)]
 pub struct Endpoints(Vec<ResolvedVc<Box<dyn Endpoint>>>);
 
+#[turbo_tasks::function]
+pub async fn endpoint_write_to_disk(
+    endpoint: ResolvedVc<Box<dyn Endpoint>>,
+) -> Result<Vc<EndpointOutputPaths>> {
+    let output_op = output_assets_operation(endpoint);
+    let EndpointOutput {
+        project,
+        output_paths,
+        ..
+    } = *output_op.connect().await?;
+
+    let _ = project
+        .emit_all_output_assets(endpoint_output_assets_operation(output_op))
+        .resolve()
+        .await?;
+
+    Ok(*output_paths)
+}
+
+#[turbo_tasks::function(operation)]
+fn output_assets_operation(endpoint: ResolvedVc<Box<dyn Endpoint>>) -> Vc<EndpointOutput> {
+    endpoint.output()
+}
+
+#[turbo_tasks::function(operation)]
+async fn endpoint_output_assets_operation(
+    output: OperationVc<EndpointOutput>,
+) -> Result<Vc<OutputAssets>> {
+    Ok(*output.connect().await?.output_assets)
+}
+
 #[turbo_tasks::function(operation)]
 pub fn endpoint_write_to_disk_operation(
     endpoint: OperationVc<Box<dyn Endpoint>>,
-) -> Vc<WrittenEndpoint> {
-    endpoint.connect().write_to_disk()
+) -> Vc<EndpointOutputPaths> {
+    endpoint_write_to_disk(endpoint.connect())
 }
 
 #[turbo_tasks::function(operation)]
@@ -76,7 +109,15 @@ pub fn endpoint_server_changed_operation(
 
 #[turbo_tasks::value(shared)]
 #[derive(Debug, Clone)]
-pub enum WrittenEndpoint {
+pub struct EndpointOutput {
+    pub output_assets: ResolvedVc<OutputAssets>,
+    pub output_paths: ResolvedVc<EndpointOutputPaths>,
+    pub project: ResolvedVc<Project>,
+}
+
+#[turbo_tasks::value(shared)]
+#[derive(Debug, Clone)]
+pub enum EndpointOutputPaths {
     NodeJs {
         /// Relative to the root_path
         server_entry_path: String,

--- a/crates/next-build-test/src/lib.rs
+++ b/crates/next-build-test/src/lib.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result};
 use futures_util::{StreamExt, TryStreamExt};
 use next_api::{
     project::{ProjectContainer, ProjectOptions},
-    route::{Endpoint, Route},
+    route::{endpoint_write_to_disk, Route},
 };
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ReadConsistency, TransientInstance, TurboTasks, Vc};
@@ -185,21 +185,21 @@ pub async fn render_routes(
                             html_endpoint,
                             data_endpoint: _,
                         } => {
-                            html_endpoint.write_to_disk().await?;
+                            endpoint_write_to_disk(*html_endpoint).await?;
                         }
                         Route::PageApi { endpoint } => {
-                            endpoint.write_to_disk().await?;
+                            endpoint_write_to_disk(*endpoint).await?;
                         }
                         Route::AppPage(routes) => {
                             for route in routes {
-                                route.html_endpoint.write_to_disk().await?;
+                                endpoint_write_to_disk(*route.html_endpoint).await?;
                             }
                         }
                         Route::AppRoute {
                             original_name: _,
                             endpoint,
                         } => {
-                            endpoint.write_to_disk().await?;
+                            endpoint_write_to_disk(*endpoint).await?;
                         }
                         Route::Conflict => {
                             tracing::info!("WARN: conflict {}", name);


### PR DESCRIPTION
This:
- Makes the Endpoint trait not manage any file writing on its own, instead returning a structure containing OutputAssets, the paths where the OutputAssets can be found, and the associated Project.
- Allows for OutputAssets to be written at a future point in Turbopack
- Implements `endpoint_write_to_disk` for compatibility in dev. This continues to be used for prod builds, but in the future it won’t.

In a future PR, production builds will dedupe and unify all output assets, writing them to disk at once, rather than exposing individual endpoint writes to JS to occur sequentially.

Test Plan: CI

Closes PACK-3791