### PR TITLE
[Turbopack] Low hanging fixes and improvement on module graph

### DIFF
--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -625,6 +625,7 @@ impl PagesProject {
             false,
             None,
         )
+        .await?
         .first_module()
         .await?
         .context("expected Next.js client runtime to resolve to a module")?;

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -125,8 +125,8 @@ pub use turbo_tasks_macros::{function, value_impl, value_trait, KeyValuePair, Ta
 pub use value::{TransientInstance, TransientValue, Value};
 pub use value_type::{TraitMethod, TraitType, ValueType};
 pub use vc::{
-    Dynamic, NonLocalValue, OperationValue, OperationVc, ResolvedVc, TypedForInput, Upcast,
-    ValueDefault, Vc, VcCast, VcCellNewMode, VcCellSharedMode, VcDefaultRead, VcRead,
+    Dynamic, NonLocalValue, OperationValue, OperationVc, OptionVcExt, ResolvedVc, TypedForInput,
+    Upcast, ValueDefault, Vc, VcCast, VcCellNewMode, VcCellSharedMode, VcDefaultRead, VcRead,
     VcTransparentRead, VcValueTrait, VcValueTraitCast, VcValueType, VcValueTypeCast,
 };
 

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -664,3 +664,23 @@ where
         T::value_default()
     }
 }
+
+pub trait OptionVcExt<T>
+where
+    T: VcValueType,
+{
+    fn to_resolved(self) -> impl Future<Output = Result<Option<ResolvedVc<T>>>> + Send;
+}
+
+impl<T> OptionVcExt<T> for Option<Vc<T>>
+where
+    T: VcValueType,
+{
+    async fn to_resolved(self) -> Result<Option<ResolvedVc<T>>> {
+        if let Some(vc) = self {
+            Ok(Some(vc.to_resolved().await?))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -317,6 +317,7 @@ async fn build_internal(
             let request = request_vc.await?;
             origin
                 .resolve_asset(request_vc, origin.resolve_options(ty.clone()), ty)
+                .await?
                 .first_module()
                 .await?
                 .with_context(|| {

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -128,6 +128,7 @@ pub async fn create_web_entry_source(
             let ty = Value::new(ReferenceType::Entry(EntryReferenceSubType::Web));
             Ok(origin
                 .resolve_asset(request, origin.resolve_options(ty.clone()), ty)
+                .await?
                 .resolve()
                 .await?
                 .primary_modules()

--- a/turbopack/crates/turbopack-core/src/resolve/origin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/origin.rs
@@ -1,3 +1,5 @@
+use std::future::Future;
+
 use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Upcast, Value, Vc};
@@ -39,7 +41,7 @@ pub trait ResolveOriginExt: Send {
         request: Vc<Request>,
         options: Vc<ResolveOptions>,
         reference_type: Value<ReferenceType>,
-    ) -> Vc<ModuleResolveResult>;
+    ) -> impl Future<Output = Result<Vc<ModuleResolveResult>>> + Send;
 
     /// Get the resolve options that apply for this origin.
     fn resolve_options(self: Vc<Self>, reference_type: Value<ReferenceType>) -> Vc<ResolveOptions>;
@@ -57,7 +59,7 @@ where
         request: Vc<Request>,
         options: Vc<ResolveOptions>,
         reference_type: Value<ReferenceType>,
-    ) -> Vc<ModuleResolveResult> {
+    ) -> impl Future<Output = Result<Vc<ModuleResolveResult>>> + Send {
         resolve_asset(Vc::upcast(self), request, options, reference_type)
     }
 
@@ -77,7 +79,6 @@ where
     }
 }
 
-#[turbo_tasks::function]
 async fn resolve_asset(
     resolve_origin: Vc<Box<dyn ResolveOrigin>>,
     request: Vc<Request>,
@@ -93,8 +94,8 @@ async fn resolve_asset(
         .await?
         .resolve_asset(
             resolve_origin.origin_path().resolve().await?,
-            request,
-            options,
+            request.resolve().await?,
+            options.resolve().await?,
             reference_type,
         ))
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -123,9 +123,7 @@ impl EsmAssetReference {
     }
 }
 
-#[turbo_tasks::value_impl]
 impl EsmAssetReference {
-    #[turbo_tasks::function]
     pub fn new(
         origin: ResolvedVc<Box<dyn ResolveOrigin>>,
         request: ResolvedVc<Request>,
@@ -143,7 +141,10 @@ impl EsmAssetReference {
             import_externals,
         })
     }
+}
 
+#[turbo_tasks::value_impl]
+impl EsmAssetReference {
     #[turbo_tasks::function]
     pub(crate) fn get_referenced_asset(self: Vc<Self>) -> Vc<ReferencedAsset> {
         ReferencedAsset::from_resolve_result(self.resolve_reference())

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -189,7 +189,8 @@ impl ModuleReference for EsmAssetReference {
             Value::new(ty),
             false,
             Some(*self.issue_source),
-        );
+        )
+        .await?;
 
         if let Some(part) = self.export_name {
             let part = part.await?;

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
@@ -30,9 +30,7 @@ pub struct EsmBindings {
     pub bindings: Vec<EsmBinding>,
 }
 
-#[turbo_tasks::value_impl]
 impl EsmBindings {
-    #[turbo_tasks::function]
     pub fn new(bindings: Vec<EsmBinding>) -> Vc<Self> {
         EsmBindings { bindings }.cell()
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -79,14 +79,14 @@ impl EsmAsyncAssetReference {
 impl ModuleReference for EsmAsyncAssetReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
-        Ok(esm_resolve(
+        esm_resolve(
             self.get_origin().resolve().await?,
             *self.request,
             Value::new(EcmaScriptModulesReferenceSubType::DynamicImport),
             self.in_try,
             Some(*self.issue_source),
         )
-        .await?)
+        .await
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -85,7 +85,8 @@ impl ModuleReference for EsmAsyncAssetReference {
             Value::new(EcmaScriptModulesReferenceSubType::DynamicImport),
             self.in_try,
             Some(*self.issue_source),
-        ))
+        )
+        .await?)
     }
 }
 
@@ -126,7 +127,8 @@ impl CodeGenerateable for EsmAsyncAssetReference {
                 Value::new(EcmaScriptModulesReferenceSubType::DynamicImport),
                 self.in_try,
                 Some(*self.issue_source),
-            ),
+            )
+            .await?,
             if matches!(
                 *chunking_context.environment().chunk_loading().await?,
                 ChunkLoading::Edge

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_item.rs
@@ -27,9 +27,7 @@ pub struct EsmModuleItem {
     pub path: ResolvedVc<AstPath>,
 }
 
-#[turbo_tasks::value_impl]
 impl EsmModuleItem {
-    #[turbo_tasks::function]
     pub fn new(path: ResolvedVc<AstPath>) -> Vc<Self> {
         Self::cell(EsmModuleItem { path })
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -603,41 +603,45 @@ pub(crate) async fn analyse_ecmascript_module_internal(
     // ast-grep-ignore: to-resolved-in-loop
     for (i, r) in eval_context.imports.references().enumerate() {
         let r = EsmAssetReference::new(
-            *origin,
+            origin,
             Request::parse(Value::new(RcStr::from(&*r.module_path).into()))
-                .resolve()
+                .to_resolved()
                 .await?,
             if let Some(issue_source) = r.issue_source {
-                issue_source.resolve().await?
+                issue_source.to_resolved().await?
             } else {
-                IssueSource::from_source_only(*source).resolve().await?
+                IssueSource::from_source_only(*source).to_resolved().await?
             },
             Value::new(r.annotations.clone()),
             match options.tree_shaking_mode {
                 Some(TreeShakingMode::ModuleFragments) => match &r.imported_symbol {
                     ImportedSymbol::ModuleEvaluation => {
                         evaluation_references.push(i);
-                        Some(ModulePart::evaluation().resolve().await?)
+                        Some(ModulePart::evaluation().to_resolved().await?)
                     }
                     ImportedSymbol::Symbol(name) => {
-                        Some(ModulePart::export((&**name).into()).resolve().await?)
+                        Some(ModulePart::export((&**name).into()).to_resolved().await?)
                     }
                     ImportedSymbol::PartEvaluation(part_id) => {
                         evaluation_references.push(i);
-                        Some(ModulePart::internal_evaluation(*part_id).resolve().await?)
+                        Some(
+                            ModulePart::internal_evaluation(*part_id)
+                                .to_resolved()
+                                .await?,
+                        )
                     }
                     ImportedSymbol::Part(part_id) => {
-                        Some(ModulePart::internal(*part_id).resolve().await?)
+                        Some(ModulePart::internal(*part_id).to_resolved().await?)
                     }
-                    ImportedSymbol::Exports => Some(ModulePart::exports().resolve().await?),
+                    ImportedSymbol::Exports => Some(ModulePart::exports().to_resolved().await?),
                 },
                 Some(TreeShakingMode::ReexportsOnly) => match &r.imported_symbol {
                     ImportedSymbol::ModuleEvaluation => {
                         evaluation_references.push(i);
-                        Some(ModulePart::evaluation().resolve().await?)
+                        Some(ModulePart::evaluation().to_resolved().await?)
                     }
                     ImportedSymbol::Symbol(name) => {
-                        Some(ModulePart::export((&**name).into()).resolve().await?)
+                        Some(ModulePart::export((&**name).into()).to_resolved().await?)
                     }
                     ImportedSymbol::PartEvaluation(_) | ImportedSymbol::Part(_) => {
                         bail!("Internal imports doesn't exist in reexports only mode")
@@ -912,7 +916,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
         match effect {
             Effect::Unreachable { start_ast_path } => {
                 analysis.add_code_gen(Unreachable::new(
-                    AstPathRange::StartAfter(start_ast_path.to_vec()).cell(),
+                    AstPathRange::StartAfter(start_ast_path.to_vec()).resolved_cell(),
                 ));
             }
             Effect::Conditional {
@@ -932,7 +936,8 @@ pub(crate) async fn analyse_ecmascript_module_internal(
 
                 macro_rules! inactive {
                     ($block:ident) => {
-                        analysis.add_code_gen(Unreachable::new($block.range.clone().cell()));
+                        analysis
+                            .add_code_gen(Unreachable::new($block.range.clone().resolved_cell()));
                     };
                 }
                 macro_rules! condition {
@@ -1226,11 +1231,11 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                                 if r_ref.export_name.is_none() && export.is_some() {
                                     let export = export.clone().unwrap();
                                     EsmAssetReference::new(
-                                        *r_ref.origin,
-                                        *r_ref.request,
-                                        *r_ref.issue_source,
+                                        r_ref.origin,
+                                        r_ref.request,
+                                        r_ref.issue_source,
                                         Value::new(r_ref.annotations.clone()),
-                                        Some(ModulePart::export(export)),
+                                        Some(ModulePart::export(export).to_resolved().await?),
                                         r_ref.import_externals,
                                     )
                                     .to_resolved()
@@ -2371,24 +2376,35 @@ async fn handle_free_var_reference(
             export,
         } => {
             let esm_reference = EsmAssetReference::new(
-                lookup_path.map_or(*state.origin, |lookup_path| {
-                    Vc::upcast(PlainResolveOrigin::new(
-                        state.origin.asset_context(),
-                        *lookup_path,
-                    ))
-                }),
-                Request::parse(Value::new(request.clone().into())),
+                if let Some(lookup_path) = lookup_path {
+                    ResolvedVc::upcast(
+                        PlainResolveOrigin::new(state.origin.asset_context(), **lookup_path)
+                            .to_resolved()
+                            .await?,
+                    )
+                } else {
+                    state.origin
+                },
+                Request::parse(Value::new(request.clone().into()))
+                    .to_resolved()
+                    .await?,
                 IssueSource::from_swc_offsets(
                     *state.source,
                     span.lo.to_usize(),
                     span.hi.to_usize(),
-                ),
+                )
+                .to_resolved()
+                .await?,
                 Default::default(),
                 match state.tree_shaking_mode {
                     Some(TreeShakingMode::ModuleFragments)
-                    | Some(TreeShakingMode::ReexportsOnly) => export
-                        .as_ref()
-                        .map(|export| ModulePart::export(export.clone())),
+                    | Some(TreeShakingMode::ReexportsOnly) => {
+                        if let Some(export) = export {
+                            Some(ModulePart::export(export.clone()).to_resolved().await?)
+                        } else {
+                            None
+                        }
+                    }
                     None => None,
                 },
                 state.import_externals,
@@ -3001,7 +3017,7 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
         export: &'ast ExportAll,
         ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
     ) {
-        let path = Vc::cell(as_parent_path(ast_path));
+        let path = ResolvedVc::cell(as_parent_path(ast_path));
         self.analysis.add_code_gen(EsmModuleItem::new(path));
         export.visit_children_with_ast_path(self, ast_path);
     }
@@ -3066,7 +3082,7 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
             }
         }
 
-        let path = Vc::cell(as_parent_path(ast_path));
+        let path = ResolvedVc::cell(as_parent_path(ast_path));
         self.analysis.add_code_gen(EsmModuleItem::new(path));
         export.visit_children_with_ast_path(self, ast_path);
     }
@@ -3081,7 +3097,9 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
                 .insert(name.clone(), EsmExport::LocalBinding(name, false));
         });
         self.analysis
-            .add_code_gen(EsmModuleItem::new(Vc::cell(as_parent_path(ast_path))));
+            .add_code_gen(EsmModuleItem::new(ResolvedVc::cell(as_parent_path(
+                ast_path,
+            ))));
         export.visit_children_with_ast_path(self, ast_path);
     }
 
@@ -3095,7 +3113,9 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
             EsmExport::LocalBinding(magic_identifier::mangle("default export").into(), false),
         );
         self.analysis
-            .add_code_gen(EsmModuleItem::new(Vc::cell(as_parent_path(ast_path))));
+            .add_code_gen(EsmModuleItem::new(ResolvedVc::cell(as_parent_path(
+                ast_path,
+            ))));
         export.visit_children_with_ast_path(self, ast_path);
     }
 
@@ -3122,7 +3142,9 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
             }
         }
         self.analysis
-            .add_code_gen(EsmModuleItem::new(Vc::cell(as_parent_path(ast_path))));
+            .add_code_gen(EsmModuleItem::new(ResolvedVc::cell(as_parent_path(
+                ast_path,
+            ))));
         export.visit_children_with_ast_path(self, ast_path);
     }
 
@@ -3131,7 +3153,7 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
         import: &'ast ImportDecl,
         ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
     ) {
-        let path = Vc::cell(as_parent_path(ast_path));
+        let path = ResolvedVc::cell(as_parent_path(ast_path));
         let src = import.src.value.to_string();
         import.visit_children_with_ast_path(self, ast_path);
         if import.type_only {

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -284,8 +284,10 @@ impl AnalyzeEcmascriptModuleResultBuilder {
         mut self,
         track_reexport_references: bool,
     ) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
-        let bindings = EsmBindings::new(take(&mut self.bindings));
-        if !bindings.await?.bindings.is_empty() {
+        let bindings = take(&mut self.bindings);
+        let has_bindings = !bindings.is_empty();
+        if has_bindings {
+            let bindings = EsmBindings::new(bindings);
             self.add_code_gen(bindings);
         }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/unreachable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/unreachable.rs
@@ -30,9 +30,7 @@ pub struct Unreachable {
     range: ResolvedVc<AstPathRange>,
 }
 
-#[turbo_tasks::value_impl]
 impl Unreachable {
-    #[turbo_tasks::function]
     pub fn new(range: ResolvedVc<AstPathRange>) -> Vc<Self> {
         Self::cell(Unreachable { range })
     }

--- a/turbopack/crates/turbopack-resolve/src/ecmascript.rs
+++ b/turbopack/crates/turbopack-resolve/src/ecmascript.rs
@@ -152,7 +152,9 @@ async fn specific_resolve(
     is_optional: bool,
     issue_source: Option<Vc<IssueSource>>,
 ) -> Result<Vc<ModuleResolveResult>> {
-    let result = origin.resolve_asset(request, options, reference_type.clone());
+    let result = origin
+        .resolve_asset(request, options, reference_type.clone())
+        .await?;
 
     handle_resolve_error(
         result,

--- a/turbopack/crates/turbopack-resolve/src/ecmascript.rs
+++ b/turbopack/crates/turbopack-resolve/src/ecmascript.rs
@@ -84,13 +84,12 @@ pub async fn apply_cjs_specific_options(options: Vc<ResolveOptions>) -> Result<V
     Ok(options.into())
 }
 
-#[turbo_tasks::function]
 pub async fn esm_resolve(
     origin: Vc<Box<dyn ResolveOrigin>>,
     request: Vc<Request>,
     ty: Value<EcmaScriptModulesReferenceSubType>,
     is_optional: bool,
-    issue_source: Option<ResolvedVc<IssueSource>>,
+    issue_source: Option<Vc<IssueSource>>,
 ) -> Result<Vc<ModuleResolveResult>> {
     let ty = Value::new(ReferenceType::EcmaScriptModules(ty.into_value()));
     let options = apply_esm_specific_options(origin.resolve_options(ty.clone()), ty.clone())
@@ -103,7 +102,7 @@ pub async fn esm_resolve(
 pub async fn cjs_resolve(
     origin: Vc<Box<dyn ResolveOrigin>>,
     request: Vc<Request>,
-    issue_source: Option<ResolvedVc<IssueSource>>,
+    issue_source: Option<Vc<IssueSource>>,
     is_optional: bool,
 ) -> Result<Vc<ModuleResolveResult>> {
     // TODO pass CommonJsReferenceSubType
@@ -118,7 +117,7 @@ pub async fn cjs_resolve(
 pub async fn cjs_resolve_source(
     origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     request: ResolvedVc<Request>,
-    issue_source: Option<ResolvedVc<IssueSource>>,
+    issue_source: Option<Vc<IssueSource>>,
     is_optional: bool,
 ) -> Result<Vc<ResolveResult>> {
     // TODO pass CommonJsReferenceSubType
@@ -151,7 +150,7 @@ async fn specific_resolve(
     options: Vc<ResolveOptions>,
     reference_type: Value<ReferenceType>,
     is_optional: bool,
-    issue_source: Option<ResolvedVc<IssueSource>>,
+    issue_source: Option<Vc<IssueSource>>,
 ) -> Result<Vc<ModuleResolveResult>> {
     let result = origin.resolve_asset(request, options, reference_type.clone());
 

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -23,7 +23,7 @@ use ecmascript::{
 };
 use graph::{aggregate, AggregatedGraph, AggregatedGraphNodeContent};
 use module_options::{ModuleOptions, ModuleOptionsContext, ModuleRuleEffect, ModuleType};
-use tracing::Instrument;
+use tracing::{field::Empty, Instrument};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
 use turbo_tasks_fs::{glob::Glob, FileSystemPath};
@@ -39,8 +39,8 @@ use turbopack_core::{
     raw_module::RawModule,
     reference::{ModuleReference, TracedModuleReference},
     reference_type::{
-        CssReferenceSubType, EcmaScriptModulesReferenceSubType, ImportWithType, InnerAssets,
-        ReferenceType,
+        CssReferenceSubType, EcmaScriptModulesReferenceSubType, ImportContext, ImportWithType,
+        InnerAssets, ReferenceType,
     },
     resolve::{
         options::ResolveOptions, origin::PlainResolveOrigin, parse::Request, resolve,
@@ -69,9 +69,9 @@ async fn apply_module_type(
     source: ResolvedVc<Box<dyn Source>>,
     module_asset_context: Vc<ModuleAssetContext>,
     module_type: Vc<ModuleType>,
-    reference_type: Value<ReferenceType>,
     part: Option<Vc<ModulePart>>,
     inner_assets: Option<ResolvedVc<InnerAssets>>,
+    css_import_context: Option<Vc<ImportContext>>,
     runtime_code: bool,
 ) -> Result<Vc<ProcessResult>> {
     let module_type = &*module_type.await?;
@@ -251,13 +251,7 @@ async fn apply_module_type(
                     .await?
                     .css
                     .minify_type,
-                if let ReferenceType::Css(CssReferenceSubType::AtImport(import)) =
-                    reference_type.into_value()
-                {
-                    import.map(|v| *v)
-                } else {
-                    None
-                },
+                css_import_context,
             )
             .to_resolved()
             .await?,
@@ -436,8 +430,9 @@ impl ModuleAssetContext {
             *this.layer,
         ))
     }
+}
 
-    #[turbo_tasks::function]
+impl ModuleAssetContext {
     async fn process_with_transition_rules(
         self: Vc<Self>,
         source: ResolvedVc<Box<dyn Source>>,
@@ -453,23 +448,20 @@ impl ModuleAssetContext {
             {
                 transition.process(*source, self, reference_type)
             } else {
-                self.process_default(*source, reference_type)
+                self.process_default(source, reference_type).await?
             },
         )
     }
-}
 
-impl ModuleAssetContext {
-    fn process_default(
+    async fn process_default(
         self: Vc<Self>,
-        source: Vc<Box<dyn Source>>,
+        source: ResolvedVc<Box<dyn Source>>,
         reference_type: Value<ReferenceType>,
-    ) -> Vc<ProcessResult> {
-        process_default(self, source, reference_type, Vec::new())
+    ) -> Result<Vc<ProcessResult>> {
+        process_default(self, source, reference_type, Vec::new()).await
     }
 }
 
-#[turbo_tasks::function]
 async fn process_default(
     module_asset_context: Vc<ModuleAssetContext>,
     source: ResolvedVc<Box<dyn Source>>,
@@ -478,9 +470,16 @@ async fn process_default(
 ) -> Result<Vc<ProcessResult>> {
     let span = tracing::info_span!(
         "process module",
-        name = source.ident().to_string().await?.to_string(),
+        name = %source.ident().to_string().await?,
+        layer = Empty,
         reference_type = display(&*reference_type)
     );
+    if !span.is_disabled() {
+        // Need to use record, otherwise future is not Send for some reason.
+        let module_asset_context_ref = module_asset_context.await?;
+        let layer = module_asset_context_ref.layer.await?;
+        span.record("layer", &**layer);
+    }
     process_default_internal(
         module_asset_context,
         source,
@@ -561,12 +560,13 @@ async fn process_default_internal(
                             } else {
                                 let mut processed_rules = processed_rules.clone();
                                 processed_rules.push(i);
-                                return Ok(process_default(
+                                return Ok(Box::pin(process_default(
                                     module_asset_context,
-                                    *current_source,
+                                    current_source,
                                     Value::new(reference_type),
                                     processed_rules,
-                                ));
+                                ))
+                                .await?);
                             }
                         }
                     }
@@ -648,9 +648,13 @@ async fn process_default_internal(
         *current_source,
         module_asset_context,
         module_type.cell(),
-        Value::new(reference_type.clone()),
         part,
         inner_assets.map(|v| *v),
+        if let ReferenceType::Css(CssReferenceSubType::AtImport(import)) = reference_type {
+            import.map(|v| *v)
+        } else {
+            None
+        },
         matches!(reference_type, ReferenceType::Runtime),
     ))
 }
@@ -857,14 +861,16 @@ impl AssetContext for ModuleAssetContext {
     #[turbo_tasks::function]
     async fn process(
         self: Vc<Self>,
-        asset: Vc<Box<dyn Source>>,
+        asset: ResolvedVc<Box<dyn Source>>,
         reference_type: Value<ReferenceType>,
     ) -> Result<Vc<ProcessResult>> {
         let this = self.await?;
         if let Some(transition) = this.transition {
-            Ok(transition.process(asset, self, reference_type))
+            Ok(transition.process(*asset, self, reference_type))
         } else {
-            Ok(self.process_with_transition_rules(asset, reference_type))
+            Ok(self
+                .process_with_transition_rules(asset, reference_type)
+                .await?)
         }
     }
 

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -136,7 +136,7 @@ async fn apply_module_type(
             if runtime_code {
                 ResolvedVc::upcast(builder.build().to_resolved().await?)
             } else {
-                let module = builder.build();
+                let module = builder.build().resolve().await?;
                 let part_ref = if let Some(part) = part {
                     Some((part.await?, part))
                 } else {

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -560,13 +560,13 @@ async fn process_default_internal(
                             } else {
                                 let mut processed_rules = processed_rules.clone();
                                 processed_rules.push(i);
-                                return Ok(Box::pin(process_default(
+                                return Box::pin(process_default(
                                     module_asset_context,
                                     current_source,
                                     Value::new(reference_type),
                                     processed_rules,
                                 ))
-                                .await?);
+                                .await;
                             }
                         }
                     }

--- a/turbopack/crates/turbopack/src/transition/mod.rs
+++ b/turbopack/crates/turbopack/src/transition/mod.rs
@@ -28,6 +28,7 @@ pub trait Transition {
     fn process_source(self: Vc<Self>, asset: Vc<Box<dyn Source>>) -> Vc<Box<dyn Source>> {
         asset
     }
+
     /// Apply modifications to the compile-time information
     fn process_compile_time_info(
         self: Vc<Self>,
@@ -35,10 +36,12 @@ pub trait Transition {
     ) -> Vc<CompileTimeInfo> {
         compile_time_info
     }
+
     /// Apply modifications to the layer
     fn process_layer(self: Vc<Self>, layer: Vc<RcStr>) -> Vc<RcStr> {
         layer
     }
+
     /// Apply modifications/wrapping to the module options context
     fn process_module_options_context(
         self: Vc<Self>,
@@ -46,6 +49,7 @@ pub trait Transition {
     ) -> Vc<ModuleOptionsContext> {
         module_options_context
     }
+
     /// Apply modifications/wrapping to the resolve options context
     fn process_resolve_options_context(
         self: Vc<Self>,
@@ -53,6 +57,7 @@ pub trait Transition {
     ) -> Vc<ResolveOptionsContext> {
         resolve_options_context
     }
+
     /// Apply modifications/wrapping to the final asset
     fn process_module(
         self: Vc<Self>,
@@ -61,6 +66,7 @@ pub trait Transition {
     ) -> Vc<Box<dyn Module>> {
         module
     }
+
     /// Apply modifications to the context
     async fn process_context(
         self: Vc<Self>,
@@ -83,6 +89,7 @@ pub trait Transition {
         );
         Ok(module_asset_context)
     }
+
     /// Apply modification on the processing of the asset
     async fn process(
         self: Vc<Self>,
@@ -92,9 +99,11 @@ pub trait Transition {
     ) -> Result<Vc<ProcessResult>> {
         let asset = self.process_source(asset);
         let module_asset_context = self.process_context(module_asset_context);
+        let asset = asset.to_resolved().await?;
 
         Ok(match &*module_asset_context
             .process_default(asset, reference_type)
+            .await?
             .await?
         {
             ProcessResult::Module(m) => ProcessResult::Module(


### PR DESCRIPTION
### What?

Performance and memory fixes during creation of the module graph

-30% memory on module graph, -20% runtime on module graph

* fix apply_esm_specific_options caching
* avoid resolve task for get_exports
* avoid analyse created items being turbo-tasks functions
* avoid reading created Vc
* determine module type per directory
* reduce resolve tasks
* make some functions in module processing non-turbo-tasks-functions, avoid reference type in apply_module_type
* add Option<Vc<T>>::to_resolved
* make esm_resolve a normal function
* make resolve_asset a non-turbo-tasks-function


Closes PACK-3775