### PR TITLE
Fix: domain routing redirects

### DIFF
--- a/packages/next/src/lib/load-custom-routes.test.ts
+++ b/packages/next/src/lib/load-custom-routes.test.ts
@@ -160,4 +160,131 @@ describe('loadCustomRoutes', () => {
       })
     })
   })
+
+  describe('redirects', () => {
+    it('missing redirects should not throw', async () => {
+      const customRoutes = await loadCustomRoutes({})
+
+      expect(customRoutes.redirects).toEqual([
+        {
+          source: '/:path+/',
+          destination: '/:path+',
+          permanent: true,
+          locale: undefined,
+          internal: true,
+        },
+      ])
+    })
+
+    it('array redirects should be preserved correctly', async () => {
+      const customRoutes = await loadCustomRoutes({
+        async redirects() {
+          return [
+            {
+              source: '/a',
+              destination: '/b',
+              permanent: true,
+            },
+          ]
+        },
+      })
+
+      expect(customRoutes.redirects).toEqual([
+        {
+          source: '/:path+/',
+          destination: '/:path+',
+          permanent: true,
+          locale: undefined,
+          internal: true,
+        },
+        {
+          source: '/a',
+          destination: '/b',
+          permanent: true,
+        },
+      ])
+    })
+
+    it('array redirects should be preserved correctly with locales', async () => {
+      const customRoutes = await loadCustomRoutes({
+        i18n: {
+          defaultLocale: 'en',
+          locales: ['en', 'nl'],
+        },
+        async redirects() {
+          return [
+            {
+              source: '/a',
+              destination: '/b',
+              permanent: true,
+            },
+          ]
+        },
+      })
+
+      expect(customRoutes.redirects).toEqual([
+        {
+          source: '/:path+/',
+          destination: '/:path+',
+          permanent: true,
+          locale: false,
+          internal: true,
+        },
+        {
+          source: '/en/a',
+          destination: '/b',
+          permanent: true,
+        },
+        {
+          source: '/:nextInternalLocale(en|nl)/a',
+          destination: '/:nextInternalLocale/b',
+          permanent: true,
+        },
+      ])
+    })
+
+    it('array redirects should be preserved correctly with locales and domain routing', async () => {
+      const customRoutes = await loadCustomRoutes({
+        i18n: {
+          defaultLocale: 'en',
+          locales: ['en', 'nl'],
+          domains: [
+            {
+              defaultLocale: 'nl',
+              domain: 'example.nl',
+            },
+          ],
+        },
+        async redirects() {
+          return [
+            {
+              source: '/a',
+              destination: '/b',
+              permanent: true,
+            },
+          ]
+        },
+      })
+
+      expect(customRoutes.redirects).toEqual([
+        {
+          source: '/:path+/',
+          destination: '/:path+',
+          permanent: true,
+          locale: false,
+          internal: true,
+        },
+        {
+          source: '/en/a',
+          destination: '/b',
+          permanent: true,
+        },
+        {
+          source: '/:nextInternalLocale(en|nl)/a',
+          destination: '/:nextInternalLocale/b',
+          permanent: true,
+        },
+      ])
+    })
+  })
 })

--- a/packages/next/src/lib/load-custom-routes.ts
+++ b/packages/next/src/lib/load-custom-routes.ts
@@ -508,13 +508,6 @@ function processRoutes<T>(
   }> = []
 
   if (config.i18n && type === 'redirect') {
-    // for (const item of config.i18n?.domains || []) {
-    //   defaultLocales.push({
-    //     locale: item.defaultLocale,
-    //     base: `http${item.http ? '' : 's'}://${item.domain}`,
-    //   })
-    // }
-
     defaultLocales.push({
       locale: config.i18n.defaultLocale,
       base: '',

--- a/packages/next/src/lib/load-custom-routes.ts
+++ b/packages/next/src/lib/load-custom-routes.ts
@@ -508,12 +508,12 @@ function processRoutes<T>(
   }> = []
 
   if (config.i18n && type === 'redirect') {
-    for (const item of config.i18n?.domains || []) {
-      defaultLocales.push({
-        locale: item.defaultLocale,
-        base: `http${item.http ? '' : 's'}://${item.domain}`,
-      })
-    }
+    // for (const item of config.i18n?.domains || []) {
+    //   defaultLocales.push({
+    //     locale: item.defaultLocale,
+    //     base: `http${item.http ? '' : 's'}://${item.domain}`,
+    //   })
+    // }
 
     defaultLocales.push({
       locale: config.i18n.defaultLocale,

--- a/test/e2e/i18n-domain-routing-locale-redirect/app/next.config.js
+++ b/test/e2e/i18n-domain-routing-locale-redirect/app/next.config.js
@@ -1,0 +1,25 @@
+module.exports = {
+  i18n: {
+    locales: ['en', 'nl'],
+    defaultLocale: 'en',
+    domains: [
+      {
+        domain: 'example.nl',
+        defaultLocale: 'nl',
+      },
+    ],
+  },
+  experimental: {
+    clientRouterFilter: true,
+    clientRouterFilterRedirects: true,
+  },
+  redirects() {
+    return [
+      {
+        source: '/to-new',
+        destination: '/new',
+        permanent: false,
+      },
+    ]
+  },
+}

--- a/test/e2e/i18n-domain-routing-locale-redirect/app/pages/index.js
+++ b/test/e2e/i18n-domain-routing-locale-redirect/app/pages/index.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <div>
+      <div>
+        <Link href="/to-new" id="to-new">
+          To new (Default Locale)
+        </Link>
+      </div>
+      <div>
+        <Link href="/to-new" id="to-new-nl" locale="nl">
+          To new (NL)
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/i18n-domain-routing-locale-redirect/app/pages/new.js
+++ b/test/e2e/i18n-domain-routing-locale-redirect/app/pages/new.js
@@ -1,0 +1,3 @@
+export default function New() {
+  return <div id="new">New</div>
+}

--- a/test/e2e/i18n-domain-routing-locale-redirect/i18n-default-locale-redirect.test.ts
+++ b/test/e2e/i18n-domain-routing-locale-redirect/i18n-default-locale-redirect.test.ts
@@ -1,0 +1,39 @@
+import { join } from 'path'
+import { nextTestSetup, FileRef } from 'e2e-utils'
+
+describe('i18-default-locale-redirect', () => {
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, './app/pages')),
+      'next.config.js': new FileRef(join(__dirname, './app/next.config.js')),
+    },
+  })
+
+  it('should not request a path prefixed with default locale', async () => {
+    const browser = await next.browser('/')
+    let requestedDefaultLocalePath = false
+    browser.on('request', (request: any) => {
+      if (new URL(request.url(), 'http://n').pathname === '/en/to-new') {
+        requestedDefaultLocalePath = true
+      }
+    })
+
+    await browser.elementByCss('#to-new').click().waitForElementByCss('#new')
+    expect(await browser.elementByCss('#new').text()).toBe('New')
+    expect(requestedDefaultLocalePath).toBe(false)
+  })
+
+  it('should request a path prefixed with non-default locale', async () => {
+    const browser = await next.browser('/')
+    let requestedNonDefaultLocalePath = false
+    browser.on('request', (request: any) => {
+      if (new URL(request.url(), 'http://n').pathname === '/nl/to-new') {
+        requestedNonDefaultLocalePath = true
+      }
+    })
+
+    await browser.elementByCss('#to-new-nl').click().waitForElementByCss('#new')
+    expect(await browser.elementByCss('#new').text()).toBe('New')
+    expect(requestedNonDefaultLocalePath).toBe(true)
+  })
+})


### PR DESCRIPTION
### What?
This PR aims to fix a redirection issue when domain routing and redirect rules are used together in `next.config.js`.
This generates rules with absolute URLs, redirecting the request to an incorrect domain and a different host from where it came from.

### How to replicate?
- add a domain route configuration to `test/e2e/i18n-default-locale-redirect/app/next.config.js`
- test fails
<img width="514" alt="image" src="https://github.com/user-attachments/assets/fd750ddd-3e12-4a60-9582-e9cdac164c67" />

<br/><br/>


<img width="605" alt="Screenshot 2025-01-20 at 19 52 14" src="https://github.com/user-attachments/assets/8e0b9674-2532-4527-9642-34665aa4dfae" />
<br/>
I'm navigating localhost, but once the redirection matches, I get redirected to example.nl as it's the first matched rule. I expect to be redirected `/nl/new` keeping the same host.


### How to fix?
Avoid adding domain routing to redirects array fixes the issue.

Tests added.

Fixes #68388 

