### PR TITLE
fix(turbopack/napi): Flush optional task cache hit statistics upon completion of build

### DIFF
--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -186,6 +186,22 @@ export declare function projectUpdate(
   project: { __napiType: 'Project' },
   options: NapiPartialProjectOptions
 ): Promise<void>
+/**
+ * Runs exit handlers for the project registered using the [`ExitHandler`] API.
+ *
+ * This is called by `project_shutdown`, so if you're calling that API, you shouldn't call this
+ * one.
+ */
+export declare function projectOnExit(project: {
+  __napiType: 'Project'
+}): Promise<void>
+/**
+ * Runs `project_on_exit`, and then waits for turbo_tasks to gracefully shut down.
+ *
+ * This is used in builds where it's important that we completely persist turbo-tasks to disk, but
+ * it's skipped in the development server (`project_on_exit` is used instead with a short timeout),
+ * where we prioritize fast exit and user responsiveness over all else.
+ */
 export declare function projectShutdown(project: {
   __napiType: 'Project'
 }): Promise<void>
@@ -291,10 +307,6 @@ export declare function projectGetSourceMapSync(
   project: { __napiType: 'Project' },
   filePath: string
 ): string | null
-/** Runs exit handlers for the project registered using the [`ExitHandler`] API. */
-export declare function projectOnExit(project: {
-  __napiType: 'Project'
-}): Promise<void>
 export declare function rootTaskDispose(rootTask: {
   __napiType: 'RootTask'
 }): void


### PR DESCRIPTION
```
cd ~/front/apps/next-site
rm -rf .next && NEXT_TURBOPACK_TASK_STATISTICS=~/build-stats.json TURBOPACK=1 TURBOPACK_BUILD=1 TURBOPACK_PERSISTENT_CACHE=0 /bin/time -v pnpm next build --experimental-build-mode=compile
jq 'to_entries | sort_by(.value.cache_hit, -.value.cache_miss) | from_entries' <build-stats.json >build-stats-sorted.json
```

Gives the following `build-stats-sorted.json` file: https://gist.github.com/bgw/cd3bafbbe08a428334ed9bec10885769

Closes PACK-3782