### PR TITLE
Fix chunk load handling during prerendering

### DIFF
--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-client.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-client.edge.development.js
@@ -78,7 +78,20 @@
       return promise;
     }
     function ignoreReject() {}
+    const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
     function preloadModule(metadata) {
+      const workUnitStore = workUnitAsyncStorage.getStore();
+      const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+      const promise = _preloadModule(metadata)
+    
+      if (promise && cacheSignal) {
+        cacheSignal.beginRead();
+        return promise.finally(() => cacheSignal.endRead());
+      }
+    
+      return promise
+    }
+    function _preloadModule(metadata) {
       for (
         var chunks = metadata[1], promises = [], i = 0;
         i < chunks.length;

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-client.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-client.edge.production.js
@@ -68,7 +68,20 @@ function requireAsyncModule(id) {
   return promise;
 }
 function ignoreReject() {}
+const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
 function preloadModule(metadata) {
+  const workUnitStore = workUnitAsyncStorage.getStore();
+  const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+  const promise = _preloadModule(metadata)
+
+  if (promise && cacheSignal) {
+    cacheSignal.beginRead();
+    return promise.finally(() => cacheSignal.endRead());
+  }
+
+  return promise
+}
+function _preloadModule(metadata) {
   for (var chunks = metadata[1], promises = [], i = 0; i < chunks.length; i++) {
     var chunkFilename = chunks[i],
       entry = chunkCache.get(chunkFilename);

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-client.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-client.node.development.js
@@ -78,7 +78,20 @@
       return promise;
     }
     function ignoreReject() {}
+    const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
     function preloadModule(metadata) {
+      const workUnitStore = workUnitAsyncStorage.getStore();
+      const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+      const promise = _preloadModule(metadata)
+    
+      if (promise && cacheSignal) {
+        cacheSignal.beginRead();
+        return promise.finally(() => cacheSignal.endRead());
+      }
+    
+      return promise
+    }
+    function _preloadModule(metadata) {
       for (
         var chunks = metadata[1], promises = [], i = 0;
         i < chunks.length;

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-client.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-client.node.production.js
@@ -69,7 +69,20 @@ function requireAsyncModule(id) {
   return promise;
 }
 function ignoreReject() {}
+const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
 function preloadModule(metadata) {
+  const workUnitStore = workUnitAsyncStorage.getStore();
+  const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+  const promise = _preloadModule(metadata)
+
+  if (promise && cacheSignal) {
+    cacheSignal.beginRead();
+    return promise.finally(() => cacheSignal.endRead());
+  }
+
+  return promise
+}
+function _preloadModule(metadata) {
   for (var chunks = metadata[1], promises = [], i = 0; i < chunks.length; i++) {
     var chunkFilename = chunks[i],
       entry = chunkCache.get(chunkFilename);

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.development.js
@@ -2899,7 +2899,20 @@
       return promise;
     }
     function ignoreReject() {}
+    const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
     function preloadModule(metadata) {
+      const workUnitStore = workUnitAsyncStorage.getStore();
+      const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+      const promise = _preloadModule(metadata)
+    
+      if (promise && cacheSignal) {
+        cacheSignal.beginRead();
+        return promise.finally(() => cacheSignal.endRead());
+      }
+    
+      return promise
+    }
+    function _preloadModule(metadata) {
       for (
         var chunks = metadata[1], promises = [], i = 0;
         i < chunks.length;

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.production.js
@@ -2079,7 +2079,20 @@ function requireAsyncModule(id) {
   return promise;
 }
 function ignoreReject() {}
+const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
 function preloadModule(metadata) {
+  const workUnitStore = workUnitAsyncStorage.getStore();
+  const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+  const promise = _preloadModule(metadata)
+
+  if (promise && cacheSignal) {
+    cacheSignal.beginRead();
+    return promise.finally(() => cacheSignal.endRead());
+  }
+
+  return promise
+}
+function _preloadModule(metadata) {
   for (var chunks = metadata[1], promises = [], i = 0; i < chunks.length; i++) {
     var chunkFilename = chunks[i],
       entry = chunkCache.get(chunkFilename);

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.development.js
@@ -2870,7 +2870,20 @@
       return promise;
     }
     function ignoreReject() {}
+    const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
     function preloadModule(metadata) {
+      const workUnitStore = workUnitAsyncStorage.getStore();
+      const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+      const promise = _preloadModule(metadata)
+    
+      if (promise && cacheSignal) {
+        cacheSignal.beginRead();
+        return promise.finally(() => cacheSignal.endRead());
+      }
+    
+      return promise
+    }
+    function _preloadModule(metadata) {
       for (
         var chunks = metadata[1], promises = [], i = 0;
         i < chunks.length;

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.production.js
@@ -2100,7 +2100,20 @@ function requireAsyncModule(id) {
   return promise;
 }
 function ignoreReject() {}
+const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
 function preloadModule(metadata) {
+  const workUnitStore = workUnitAsyncStorage.getStore();
+  const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+  const promise = _preloadModule(metadata)
+
+  if (promise && cacheSignal) {
+    cacheSignal.beginRead();
+    return promise.finally(() => cacheSignal.endRead());
+  }
+
+  return promise
+}
+function _preloadModule(metadata) {
   for (var chunks = metadata[1], promises = [], i = 0; i < chunks.length; i++) {
     var chunkFilename = chunks[i],
       entry = chunkCache.get(chunkFilename);

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-client.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-client.edge.development.js
@@ -78,7 +78,20 @@
       return promise;
     }
     function ignoreReject() {}
+    const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
     function preloadModule(metadata) {
+      const workUnitStore = workUnitAsyncStorage.getStore();
+      const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+      const promise = _preloadModule(metadata)
+    
+      if (promise && cacheSignal) {
+        cacheSignal.beginRead();
+        return promise.finally(() => cacheSignal.endRead());
+      }
+    
+      return promise
+    }
+    function _preloadModule(metadata) {
       for (
         var chunks = metadata[1], promises = [], i = 0;
         i < chunks.length;

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-client.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-client.edge.production.js
@@ -68,7 +68,20 @@ function requireAsyncModule(id) {
   return promise;
 }
 function ignoreReject() {}
+const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
 function preloadModule(metadata) {
+  const workUnitStore = workUnitAsyncStorage.getStore();
+  const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+  const promise = _preloadModule(metadata)
+
+  if (promise && cacheSignal) {
+    cacheSignal.beginRead();
+    return promise.finally(() => cacheSignal.endRead());
+  }
+
+  return promise
+}
+function _preloadModule(metadata) {
   for (var chunks = metadata[1], promises = [], i = 0; i < chunks.length; i++) {
     var chunkFilename = chunks[i],
       entry = chunkCache.get(chunkFilename);

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-client.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-client.node.development.js
@@ -78,7 +78,20 @@
       return promise;
     }
     function ignoreReject() {}
+    const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
     function preloadModule(metadata) {
+      const workUnitStore = workUnitAsyncStorage.getStore();
+      const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+      const promise = _preloadModule(metadata)
+    
+      if (promise && cacheSignal) {
+        cacheSignal.beginRead();
+        return promise.finally(() => cacheSignal.endRead());
+      }
+    
+      return promise
+    }
+    function _preloadModule(metadata) {
       for (
         var chunks = metadata[1], promises = [], i = 0;
         i < chunks.length;

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-client.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-client.node.production.js
@@ -69,7 +69,20 @@ function requireAsyncModule(id) {
   return promise;
 }
 function ignoreReject() {}
+const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
 function preloadModule(metadata) {
+  const workUnitStore = workUnitAsyncStorage.getStore();
+  const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+  const promise = _preloadModule(metadata)
+
+  if (promise && cacheSignal) {
+    cacheSignal.beginRead();
+    return promise.finally(() => cacheSignal.endRead());
+  }
+
+  return promise
+}
+function _preloadModule(metadata) {
   for (var chunks = metadata[1], promises = [], i = 0; i < chunks.length; i++) {
     var chunkFilename = chunks[i],
       entry = chunkCache.get(chunkFilename);

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.development.js
@@ -2493,7 +2493,20 @@
       return promise;
     }
     function ignoreReject() {}
+    const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
     function preloadModule(metadata) {
+      const workUnitStore = workUnitAsyncStorage.getStore();
+      const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+      const promise = _preloadModule(metadata)
+    
+      if (promise && cacheSignal) {
+        cacheSignal.beginRead();
+        return promise.finally(() => cacheSignal.endRead());
+      }
+    
+      return promise
+    }
+    function _preloadModule(metadata) {
       for (
         var chunks = metadata[1], promises = [], i = 0;
         i < chunks.length;

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.production.js
@@ -1953,7 +1953,20 @@ function requireAsyncModule(id) {
   return promise;
 }
 function ignoreReject() {}
+const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
 function preloadModule(metadata) {
+  const workUnitStore = workUnitAsyncStorage.getStore();
+  const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+  const promise = _preloadModule(metadata)
+
+  if (promise && cacheSignal) {
+    cacheSignal.beginRead();
+    return promise.finally(() => cacheSignal.endRead());
+  }
+
+  return promise
+}
+function _preloadModule(metadata) {
   for (var chunks = metadata[1], promises = [], i = 0; i < chunks.length; i++) {
     var chunkFilename = chunks[i],
       entry = chunkCache.get(chunkFilename);

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.development.js
@@ -2491,7 +2491,20 @@
       return promise;
     }
     function ignoreReject() {}
+    const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
     function preloadModule(metadata) {
+      const workUnitStore = workUnitAsyncStorage.getStore();
+      const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+      const promise = _preloadModule(metadata)
+    
+      if (promise && cacheSignal) {
+        cacheSignal.beginRead();
+        return promise.finally(() => cacheSignal.endRead());
+      }
+    
+      return promise
+    }
+    function _preloadModule(metadata) {
       for (
         var chunks = metadata[1], promises = [], i = 0;
         i < chunks.length;

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.production.js
@@ -1978,7 +1978,20 @@ function requireAsyncModule(id) {
   return promise;
 }
 function ignoreReject() {}
+const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
 function preloadModule(metadata) {
+  const workUnitStore = workUnitAsyncStorage.getStore();
+  const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+  const promise = _preloadModule(metadata)
+
+  if (promise && cacheSignal) {
+    cacheSignal.beginRead();
+    return promise.finally(() => cacheSignal.endRead());
+  }
+
+  return promise
+}
+function _preloadModule(metadata) {
   for (var chunks = metadata[1], promises = [], i = 0; i < chunks.length; i++) {
     var chunkFilename = chunks[i],
       entry = chunkCache.get(chunkFilename);

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-client.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-client.edge.development.js
@@ -80,7 +80,20 @@
       return promise;
     }
     function ignoreReject() {}
+    const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
     function preloadModule(metadata) {
+      const workUnitStore = workUnitAsyncStorage.getStore();
+      const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+      const promise = _preloadModule(metadata)
+    
+      if (promise && cacheSignal) {
+        cacheSignal.beginRead();
+        return promise.finally(() => cacheSignal.endRead());
+      }
+    
+      return promise
+    }
+    function _preloadModule(metadata) {
       for (
         var chunks = metadata[1], promises = [], i = 0;
         i < chunks.length;

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-client.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-client.edge.production.js
@@ -70,7 +70,20 @@ function requireAsyncModule(id) {
   return promise;
 }
 function ignoreReject() {}
+const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
 function preloadModule(metadata) {
+  const workUnitStore = workUnitAsyncStorage.getStore();
+  const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+  const promise = _preloadModule(metadata)
+
+  if (promise && cacheSignal) {
+    cacheSignal.beginRead();
+    return promise.finally(() => cacheSignal.endRead());
+  }
+
+  return promise
+}
+function _preloadModule(metadata) {
   for (var chunks = metadata[1], promises = [], i = 0; i < chunks.length; ) {
     var chunkId = chunks[i++];
     chunks[i++];

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-client.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-client.node.development.js
@@ -80,7 +80,20 @@
       return promise;
     }
     function ignoreReject() {}
+    const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
     function preloadModule(metadata) {
+      const workUnitStore = workUnitAsyncStorage.getStore();
+      const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+      const promise = _preloadModule(metadata)
+    
+      if (promise && cacheSignal) {
+        cacheSignal.beginRead();
+        return promise.finally(() => cacheSignal.endRead());
+      }
+    
+      return promise
+    }
+    function _preloadModule(metadata) {
       for (
         var chunks = metadata[1], promises = [], i = 0;
         i < chunks.length;

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-client.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-client.node.production.js
@@ -71,7 +71,20 @@ function requireAsyncModule(id) {
   return promise;
 }
 function ignoreReject() {}
+const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
 function preloadModule(metadata) {
+  const workUnitStore = workUnitAsyncStorage.getStore();
+  const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+  const promise = _preloadModule(metadata)
+
+  if (promise && cacheSignal) {
+    cacheSignal.beginRead();
+    return promise.finally(() => cacheSignal.endRead());
+  }
+
+  return promise
+}
+function _preloadModule(metadata) {
   for (var chunks = metadata[1], promises = [], i = 0; i < chunks.length; ) {
     var chunkId = chunks[i++];
     chunks[i++];

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-client.node.unbundled.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-client.node.unbundled.development.js
@@ -48,7 +48,20 @@
       id = id.slice(idx + 1);
       return { specifier: bundlerConfig, name: id };
     }
+    const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
     function preloadModule(metadata) {
+      const workUnitStore = workUnitAsyncStorage.getStore();
+      const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+      const promise = _preloadModule(metadata)
+    
+      if (promise && cacheSignal) {
+        cacheSignal.beginRead();
+        return promise.finally(() => cacheSignal.endRead());
+      }
+    
+      return promise
+    }
+    function _preloadModule(metadata) {
       var existingPromise = asyncModuleCache.get(metadata.specifier);
       if (existingPromise)
         return "fulfilled" === existingPromise.status ? null : existingPromise;

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-client.node.unbundled.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-client.node.unbundled.production.js
@@ -39,7 +39,20 @@ function resolveServerReference(bundlerConfig, id) {
   return { specifier: bundlerConfig, name: id };
 }
 var asyncModuleCache = new Map();
+const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
 function preloadModule(metadata) {
+  const workUnitStore = workUnitAsyncStorage.getStore();
+  const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+  const promise = _preloadModule(metadata)
+
+  if (promise && cacheSignal) {
+    cacheSignal.beginRead();
+    return promise.finally(() => cacheSignal.endRead());
+  }
+
+  return promise
+}
+function _preloadModule(metadata) {
   var existingPromise = asyncModuleCache.get(metadata.specifier);
   if (existingPromise)
     return "fulfilled" === existingPromise.status ? null : existingPromise;

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.development.js
@@ -2901,7 +2901,20 @@
       return promise;
     }
     function ignoreReject() {}
+    const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
     function preloadModule(metadata) {
+      const workUnitStore = workUnitAsyncStorage.getStore();
+      const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+      const promise = _preloadModule(metadata)
+    
+      if (promise && cacheSignal) {
+        cacheSignal.beginRead();
+        return promise.finally(() => cacheSignal.endRead());
+      }
+    
+      return promise
+    }
+    function _preloadModule(metadata) {
       for (
         var chunks = metadata[1], promises = [], i = 0;
         i < chunks.length;

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.production.js
@@ -2081,7 +2081,20 @@ function requireAsyncModule(id) {
   return promise;
 }
 function ignoreReject() {}
+const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
 function preloadModule(metadata) {
+  const workUnitStore = workUnitAsyncStorage.getStore();
+  const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+  const promise = _preloadModule(metadata)
+
+  if (promise && cacheSignal) {
+    cacheSignal.beginRead();
+    return promise.finally(() => cacheSignal.endRead());
+  }
+
+  return promise
+}
+function _preloadModule(metadata) {
   for (var chunks = metadata[1], promises = [], i = 0; i < chunks.length; ) {
     var chunkId = chunks[i++];
     chunks[i++];

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.development.js
@@ -2872,7 +2872,20 @@
       return promise;
     }
     function ignoreReject() {}
+    const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
     function preloadModule(metadata) {
+      const workUnitStore = workUnitAsyncStorage.getStore();
+      const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+      const promise = _preloadModule(metadata)
+    
+      if (promise && cacheSignal) {
+        cacheSignal.beginRead();
+        return promise.finally(() => cacheSignal.endRead());
+      }
+    
+      return promise
+    }
+    function _preloadModule(metadata) {
       for (
         var chunks = metadata[1], promises = [], i = 0;
         i < chunks.length;

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.production.js
@@ -2102,7 +2102,20 @@ function requireAsyncModule(id) {
   return promise;
 }
 function ignoreReject() {}
+const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
 function preloadModule(metadata) {
+  const workUnitStore = workUnitAsyncStorage.getStore();
+  const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+  const promise = _preloadModule(metadata)
+
+  if (promise && cacheSignal) {
+    cacheSignal.beginRead();
+    return promise.finally(() => cacheSignal.endRead());
+  }
+
+  return promise
+}
+function _preloadModule(metadata) {
   for (var chunks = metadata[1], promises = [], i = 0; i < chunks.length; ) {
     var chunkId = chunks[i++];
     chunks[i++];

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.unbundled.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.unbundled.development.js
@@ -2841,7 +2841,20 @@
       id = id.slice(idx + 1);
       return { specifier: bundlerConfig, name: id };
     }
+    const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
     function preloadModule(metadata) {
+      const workUnitStore = workUnitAsyncStorage.getStore();
+      const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+      const promise = _preloadModule(metadata)
+    
+      if (promise && cacheSignal) {
+        cacheSignal.beginRead();
+        return promise.finally(() => cacheSignal.endRead());
+      }
+    
+      return promise
+    }
+    function _preloadModule(metadata) {
       var existingPromise = asyncModuleCache.get(metadata.specifier);
       if (existingPromise)
         return "fulfilled" === existingPromise.status ? null : existingPromise;

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.unbundled.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.unbundled.production.js
@@ -2071,7 +2071,20 @@ function resolveServerReference(bundlerConfig, id) {
   return { specifier: bundlerConfig, name: id };
 }
 var asyncModuleCache = new Map();
+const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
 function preloadModule(metadata) {
+  const workUnitStore = workUnitAsyncStorage.getStore();
+  const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+  const promise = _preloadModule(metadata)
+
+  if (promise && cacheSignal) {
+    cacheSignal.beginRead();
+    return promise.finally(() => cacheSignal.endRead());
+  }
+
+  return promise
+}
+function _preloadModule(metadata) {
   var existingPromise = asyncModuleCache.get(metadata.specifier);
   if (existingPromise)
     return "fulfilled" === existingPromise.status ? null : existingPromise;

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.development.js
@@ -80,7 +80,20 @@
       return promise;
     }
     function ignoreReject() {}
+    const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
     function preloadModule(metadata) {
+      const workUnitStore = workUnitAsyncStorage.getStore();
+      const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+      const promise = _preloadModule(metadata)
+    
+      if (promise && cacheSignal) {
+        cacheSignal.beginRead();
+        return promise.finally(() => cacheSignal.endRead());
+      }
+    
+      return promise
+    }
+    function _preloadModule(metadata) {
       for (
         var chunks = metadata[1], promises = [], i = 0;
         i < chunks.length;

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.production.js
@@ -70,7 +70,20 @@ function requireAsyncModule(id) {
   return promise;
 }
 function ignoreReject() {}
+const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
 function preloadModule(metadata) {
+  const workUnitStore = workUnitAsyncStorage.getStore();
+  const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+  const promise = _preloadModule(metadata)
+
+  if (promise && cacheSignal) {
+    cacheSignal.beginRead();
+    return promise.finally(() => cacheSignal.endRead());
+  }
+
+  return promise
+}
+function _preloadModule(metadata) {
   for (var chunks = metadata[1], promises = [], i = 0; i < chunks.length; ) {
     var chunkId = chunks[i++];
     chunks[i++];

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.development.js
@@ -80,7 +80,20 @@
       return promise;
     }
     function ignoreReject() {}
+    const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
     function preloadModule(metadata) {
+      const workUnitStore = workUnitAsyncStorage.getStore();
+      const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+      const promise = _preloadModule(metadata)
+    
+      if (promise && cacheSignal) {
+        cacheSignal.beginRead();
+        return promise.finally(() => cacheSignal.endRead());
+      }
+    
+      return promise
+    }
+    function _preloadModule(metadata) {
       for (
         var chunks = metadata[1], promises = [], i = 0;
         i < chunks.length;

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.production.js
@@ -71,7 +71,20 @@ function requireAsyncModule(id) {
   return promise;
 }
 function ignoreReject() {}
+const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
 function preloadModule(metadata) {
+  const workUnitStore = workUnitAsyncStorage.getStore();
+  const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+  const promise = _preloadModule(metadata)
+
+  if (promise && cacheSignal) {
+    cacheSignal.beginRead();
+    return promise.finally(() => cacheSignal.endRead());
+  }
+
+  return promise
+}
+function _preloadModule(metadata) {
   for (var chunks = metadata[1], promises = [], i = 0; i < chunks.length; ) {
     var chunkId = chunks[i++];
     chunks[i++];

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.unbundled.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.unbundled.development.js
@@ -48,7 +48,20 @@
       id = id.slice(idx + 1);
       return { specifier: bundlerConfig, name: id };
     }
+    const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
     function preloadModule(metadata) {
+      const workUnitStore = workUnitAsyncStorage.getStore();
+      const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+      const promise = _preloadModule(metadata)
+    
+      if (promise && cacheSignal) {
+        cacheSignal.beginRead();
+        return promise.finally(() => cacheSignal.endRead());
+      }
+    
+      return promise
+    }
+    function _preloadModule(metadata) {
       var existingPromise = asyncModuleCache.get(metadata.specifier);
       if (existingPromise)
         return "fulfilled" === existingPromise.status ? null : existingPromise;

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.unbundled.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.unbundled.production.js
@@ -39,7 +39,20 @@ function resolveServerReference(bundlerConfig, id) {
   return { specifier: bundlerConfig, name: id };
 }
 var asyncModuleCache = new Map();
+const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
 function preloadModule(metadata) {
+  const workUnitStore = workUnitAsyncStorage.getStore();
+  const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+  const promise = _preloadModule(metadata)
+
+  if (promise && cacheSignal) {
+    cacheSignal.beginRead();
+    return promise.finally(() => cacheSignal.endRead());
+  }
+
+  return promise
+}
+function _preloadModule(metadata) {
   var existingPromise = asyncModuleCache.get(metadata.specifier);
   if (existingPromise)
     return "fulfilled" === existingPromise.status ? null : existingPromise;

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js
@@ -2495,7 +2495,20 @@
       return promise;
     }
     function ignoreReject() {}
+    const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
     function preloadModule(metadata) {
+      const workUnitStore = workUnitAsyncStorage.getStore();
+      const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+      const promise = _preloadModule(metadata)
+    
+      if (promise && cacheSignal) {
+        cacheSignal.beginRead();
+        return promise.finally(() => cacheSignal.endRead());
+      }
+    
+      return promise
+    }
+    function _preloadModule(metadata) {
       for (
         var chunks = metadata[1], promises = [], i = 0;
         i < chunks.length;

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.production.js
@@ -1955,7 +1955,20 @@ function requireAsyncModule(id) {
   return promise;
 }
 function ignoreReject() {}
+const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
 function preloadModule(metadata) {
+  const workUnitStore = workUnitAsyncStorage.getStore();
+  const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+  const promise = _preloadModule(metadata)
+
+  if (promise && cacheSignal) {
+    cacheSignal.beginRead();
+    return promise.finally(() => cacheSignal.endRead());
+  }
+
+  return promise
+}
+function _preloadModule(metadata) {
   for (var chunks = metadata[1], promises = [], i = 0; i < chunks.length; ) {
     var chunkId = chunks[i++];
     chunks[i++];

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
@@ -2493,7 +2493,20 @@
       return promise;
     }
     function ignoreReject() {}
+    const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
     function preloadModule(metadata) {
+      const workUnitStore = workUnitAsyncStorage.getStore();
+      const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+      const promise = _preloadModule(metadata)
+    
+      if (promise && cacheSignal) {
+        cacheSignal.beginRead();
+        return promise.finally(() => cacheSignal.endRead());
+      }
+    
+      return promise
+    }
+    function _preloadModule(metadata) {
       for (
         var chunks = metadata[1], promises = [], i = 0;
         i < chunks.length;

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.production.js
@@ -1980,7 +1980,20 @@ function requireAsyncModule(id) {
   return promise;
 }
 function ignoreReject() {}
+const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
 function preloadModule(metadata) {
+  const workUnitStore = workUnitAsyncStorage.getStore();
+  const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+  const promise = _preloadModule(metadata)
+
+  if (promise && cacheSignal) {
+    cacheSignal.beginRead();
+    return promise.finally(() => cacheSignal.endRead());
+  }
+
+  return promise
+}
+function _preloadModule(metadata) {
   for (var chunks = metadata[1], promises = [], i = 0; i < chunks.length; ) {
     var chunkId = chunks[i++];
     chunks[i++];

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.development.js
@@ -2462,7 +2462,20 @@
       id = id.slice(idx + 1);
       return { specifier: bundlerConfig, name: id };
     }
+    const { workUnitAsyncStorage } = require("next/dist/server/app-render/work-unit-async-storage.external");
     function preloadModule(metadata) {
+      const workUnitStore = workUnitAsyncStorage.getStore();
+      const cacheSignal = workUnitStore?.type === 'prerender' ? workUnitStore.cacheSignal : undefined;
+      const promise = _preloadModule(metadata)
+    
+      if (promise && cacheSignal) {
+        cacheSignal.beginRead();
+        return promise.finally(() => cacheSignal.endRead());
+      }
+    
+      return promise
+    }
+    function _preloadModule(metadata) {
       var existingPromise = asyncModuleCache.get(metadata.specifier);
       if (existingPromise)
         return "fulfilled" === existingPromise.status ? null : existingPromise;

--- a/packages/next/src/server/app-render/app-render-prerender-utils.ts
+++ b/packages/next/src/server/app-render/app-render-prerender-utils.ts
@@ -7,7 +7,7 @@ import { isPrerenderInterruptedError } from './dynamic-rendering'
  */
 export function prerenderAndAbortInSequentialTasks<R>(
   prerender: () => Promise<R>,
-  abort: () => void
+  abort: () => Promise<void>
 ): Promise<R> {
   if (process.env.NEXT_RUNTIME === 'edge') {
     throw new InvariantError(
@@ -26,7 +26,8 @@ export function prerenderAndAbortInSequentialTasks<R>(
       })
       setImmediate(() => {
         abort()
-        resolve(pendingResult)
+          .then(() => resolve(pendingResult))
+          .catch(() => {})
       })
     })
   }

--- a/packages/next/src/server/app-render/app-render-prerender-utils.ts
+++ b/packages/next/src/server/app-render/app-render-prerender-utils.ts
@@ -7,7 +7,7 @@ import { isPrerenderInterruptedError } from './dynamic-rendering'
  */
 export function prerenderAndAbortInSequentialTasks<R>(
   prerender: () => Promise<R>,
-  abort: () => Promise<void>
+  abort: () => void
 ): Promise<R> {
   if (process.env.NEXT_RUNTIME === 'edge') {
     throw new InvariantError(
@@ -26,8 +26,7 @@ export function prerenderAndAbortInSequentialTasks<R>(
       })
       setImmediate(() => {
         abort()
-          .then(() => resolve(pendingResult))
-          .catch(() => {})
+        resolve(pendingResult)
       })
     })
   }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2687,6 +2687,10 @@ async function prerenderToStream(
           }
         )
 
+        await cacheSignal.cacheReady()
+        initialServerRenderController.abort()
+        initialServerPrerenderController.abort()
+
         let initialServerResult
         try {
           initialServerResult = await createReactServerPrerenderResult(
@@ -2716,7 +2720,7 @@ async function prerenderToStream(
             implicitTags: implicitTags,
             renderSignal: initialClientController.signal,
             controller: initialClientController,
-            cacheSignal,
+            cacheSignal: null,
             dynamicTracking: null,
             revalidate: INFINITE_CACHE,
             expire: INFINITE_CACHE,
@@ -2769,11 +2773,8 @@ async function prerenderToStream(
                     : [bootstrapScript],
                 }
               ),
-            async () => {
-              await cacheSignal.cacheReady()
+            () => {
               initialClientController.abort()
-              initialServerRenderController.abort()
-              initialServerPrerenderController.abort()
             }
           ).catch((err) => {
             if (
@@ -2844,7 +2845,7 @@ async function prerenderToStream(
                 prerenderIsPending = false
                 return prerenderResult
               },
-              async () => {
+              () => {
                 if (finalServerController.signal.aborted) {
                   // If the server controller is already aborted we must have called something
                   // that required aborting the prerender synchronously such as with new Date()
@@ -2938,7 +2939,7 @@ async function prerenderToStream(
                   : [bootstrapScript],
               }
             ),
-          async () => {
+          () => {
             finalClientController.abort()
           }
         )

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2720,7 +2720,7 @@ async function prerenderToStream(
             implicitTags: implicitTags,
             renderSignal: initialClientController.signal,
             controller: initialClientController,
-            cacheSignal: null,
+            cacheSignal,
             dynamicTracking: null,
             revalidate: INFINITE_CACHE,
             expire: INFINITE_CACHE,
@@ -2773,7 +2773,8 @@ async function prerenderToStream(
                     : [bootstrapScript],
                 }
               ),
-            () => {
+            async () => {
+              await cacheSignal.cacheReady()
               initialClientController.abort()
             }
           ).catch((err) => {
@@ -2845,7 +2846,7 @@ async function prerenderToStream(
                 prerenderIsPending = false
                 return prerenderResult
               },
-              () => {
+              async () => {
                 if (finalServerController.signal.aborted) {
                   // If the server controller is already aborted we must have called something
                   // that required aborting the prerender synchronously such as with new Date()
@@ -2939,7 +2940,7 @@ async function prerenderToStream(
                   : [bootstrapScript],
               }
             ),
-          () => {
+          async () => {
             finalClientController.abort()
           }
         )

--- a/test/e2e/app-dir/use-cache/app/(cached-layout)/inner-cache-with-client-component/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(cached-layout)/inner-cache-with-client-component/page.tsx
@@ -1,0 +1,11 @@
+import { Foo } from '../../client'
+
+export default async function Page() {
+  'use cache'
+
+  return (
+    <p>
+      <Foo />
+    </p>
+  )
+}

--- a/test/e2e/app-dir/use-cache/app/(cached-layout)/layout.tsx
+++ b/test/e2e/app-dir/use-cache/app/(cached-layout)/layout.tsx
@@ -1,0 +1,13 @@
+'use cache'
+
+export default async function Root({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -460,7 +460,6 @@ describe('use-cache', () => {
     expect(text).toBe('This page could not be found.')
   })
 
-  // TODO: Fails with Turbopack.
   it('should not trigger dynamic I/O error for inner "use cache" functions with client components', async () => {
     const outputIndex = next.cliOutput.length
     const browser = await next.browser('/inner-cache-with-client-component')


### PR DESCRIPTION
It turns out that the following heuristic in `warmFlightResponse` is not sufficient for loading all necessary SSR chunks before handing off to prerendering:

```js
// We'll wait at least one task, and then if no chunks have started to load
// we infer that there are no chunks to load from this flight response
trackChunkLoading(waitAtLeastOneReactRenderTask())
return new Promise((r) => {
  chunkListeners.push(r)
})
```

An example demonstrating this issue has been added as a test case in this PR. In the example, we have a layout with `"use cache"` and a page with `"use cache"` that renders a client component. With Turbopack in particular, it often happens that the client component’s chunk hasn’t started loading before `warmFlightResponse` is resolved. As a result, dynamic I/O errors are triggered during subsequent SSR prerendering because the chunk may not resolve within microtasks.

A more robust approach is to avoid a separate `warmFlightResponse` and instead rely on the cache signal during the initial prerender to track these chunk loads.

However, using the cache signal in the existing `__next_chunk_load__` tracking is not sufficient because React caches loaded chunks in a module-scoped map and skips calling `__next_chunk_load__` if a cached promise for that chunk already exists. This becomes problematic when a chunk starts loading during a normal dev request (i.e., not a prerender) while, in parallel, a prerender request (for dynamic validation) also requires the same chunk. In that scenario, we have no way to track the chunk load via the prerender cache signal, causing the initial prerender to complete prematurely and trigger a dynamic I/O error during the final prerender.

To address this limitation, we need a way to hook into React’s `preloadModule` function so we can track any module loading regardless of React’s internal chunk caching. This would also allow us to cover the resolution phase of async modules.

Unfortunately, React does not yet offer this API. In the meantime, we are patching `preloadModule` when generating the vendored packages to include our tracking logic.

An additional benefit of this approach is that it should be faster during `next build` because pages that are rendered concurrently don't need to wait for each other's chunks to finish loading, even if they don't necessarily need them. With the `trackChunkLoading` approach this is currently an accepted limitation.