### PR TITLE
[Turbopack] allow to disable source maps

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -40,7 +40,7 @@ use turbopack_core::{
     changed::content_changed,
     chunk::{
         module_id_strategies::{DevModuleIdStrategy, ModuleIdStrategy},
-        ChunkingContext, EvaluatableAssets,
+        ChunkingContext, EvaluatableAssets, SourceMapsType,
     },
     compile_time_info::CompileTimeInfo,
     context::AssetContext,
@@ -728,6 +728,11 @@ impl Project {
                 node_build_environment().to_resolved().await?,
                 next_mode.runtime_type(),
             )
+            .source_maps(if *self.next_config().turbo_source_maps().await? {
+                SourceMapsType::Full
+            } else {
+                SourceMapsType::None
+            })
             .build(),
         );
 
@@ -921,6 +926,7 @@ impl Project {
             self.next_mode(),
             self.module_id_strategy(),
             self.next_config().turbo_minify(self.next_mode()),
+            self.next_config().turbo_source_maps(),
         )
     }
 
@@ -940,6 +946,7 @@ impl Project {
                 self.server_compile_time_info().environment(),
                 self.module_id_strategy(),
                 self.next_config().turbo_minify(self.next_mode()),
+                self.next_config().turbo_source_maps(),
             )
         } else {
             get_server_chunking_context(
@@ -950,6 +957,7 @@ impl Project {
                 self.server_compile_time_info().environment(),
                 self.module_id_strategy(),
                 self.next_config().turbo_minify(self.next_mode()),
+                self.next_config().turbo_source_maps(),
             )
         }
     }
@@ -970,6 +978,7 @@ impl Project {
                 self.edge_compile_time_info().environment(),
                 self.module_id_strategy(),
                 self.next_config().turbo_minify(self.next_mode()),
+                self.next_config().turbo_source_maps(),
             )
         } else {
             get_edge_chunking_context(
@@ -980,6 +989,7 @@ impl Project {
                 self.edge_compile_time_info().environment(),
                 self.module_id_strategy(),
                 self.next_config().turbo_minify(self.next_mode()),
+                self.next_config().turbo_source_maps(),
             )
         }
     }

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -14,7 +14,10 @@ use turbopack::{
 };
 use turbopack_browser::{react_refresh::assert_can_resolve_react_refresh, BrowserChunkingContext};
 use turbopack_core::{
-    chunk::{module_id_strategies::ModuleIdStrategy, ChunkingConfig, ChunkingContext, MinifyType},
+    chunk::{
+        module_id_strategies::ModuleIdStrategy, ChunkingConfig, ChunkingContext, MinifyType,
+        SourceMapsType,
+    },
     compile_time_info::{
         CompileTimeDefineValue, CompileTimeDefines, CompileTimeInfo, DefineableNameSegment,
         FreeVarReference, FreeVarReferences,
@@ -398,7 +401,8 @@ pub async fn get_client_chunking_context(
     environment: ResolvedVc<Environment>,
     mode: Vc<NextMode>,
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
-    turbo_minify: Vc<bool>,
+    minify: Vc<bool>,
+    source_maps: Vc<bool>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
     let next_mode = mode.await?;
     let mut builder = BrowserChunkingContext::builder(
@@ -415,10 +419,15 @@ pub async fn get_client_chunking_context(
         next_mode.runtime_type(),
     )
     .chunk_base_path(asset_prefix)
-    .minify_type(if *turbo_minify.await? {
+    .minify_type(if *minify.await? {
         MinifyType::Minify
     } else {
         MinifyType::NoMinify
+    })
+    .source_maps(if *source_maps.await? {
+        SourceMapsType::Full
+    } else {
+        SourceMapsType::None
     })
     .asset_base_path(asset_prefix)
     .module_id_strategy(module_id_strategy);

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -318,6 +318,11 @@ pub async fn get_client_module_options_context(
     let module_options_context = ModuleOptionsContext {
         ecmascript: EcmascriptOptionsContext {
             enable_typeof_window_inlining: Some(TypeofWindow::Object),
+            source_maps: if *next_config.turbo_source_maps().await? {
+                SourceMapsType::Full
+            } else {
+                SourceMapsType::None
+            },
             ..Default::default()
         },
         preset_env_versions: Some(env),

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -524,6 +524,7 @@ pub struct ExperimentalTurboConfig {
     pub tree_shaking: Option<bool>,
     pub module_id_strategy: Option<ModuleIdStrategy>,
     pub minify: Option<bool>,
+    pub source_maps: Option<bool>,
     pub unstable_persistent_caching: Option<bool>,
 }
 
@@ -1483,6 +1484,13 @@ impl NextConfig {
         Ok(Vc::cell(
             minify.unwrap_or(matches!(*mode.await?, NextMode::Build)),
         ))
+    }
+
+    #[turbo_tasks::function]
+    pub async fn turbo_source_maps(&self) -> Result<Vc<bool>> {
+        let minify = self.experimental.turbo.as_ref().and_then(|t| t.source_maps);
+
+        Ok(Vc::cell(minify.unwrap_or(true)))
     }
 }
 

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -6,7 +6,10 @@ use turbo_tasks_fs::FileSystemPath;
 use turbopack::resolve_options_context::ResolveOptionsContext;
 use turbopack_browser::BrowserChunkingContext;
 use turbopack_core::{
-    chunk::{module_id_strategies::ModuleIdStrategy, ChunkingConfig, ChunkingContext, MinifyType},
+    chunk::{
+        module_id_strategies::ModuleIdStrategy, ChunkingConfig, ChunkingContext, MinifyType,
+        SourceMapsType,
+    },
     compile_time_info::{
         CompileTimeDefineValue, CompileTimeDefines, CompileTimeInfo, DefineableNameSegment,
         FreeVarReference, FreeVarReferences,
@@ -208,6 +211,7 @@ pub async fn get_edge_chunking_context_with_client_assets(
     environment: ResolvedVc<Environment>,
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     turbo_minify: Vc<bool>,
+    turbo_source_maps: Vc<bool>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
     let output_root = node_root.join("server/edge".into()).to_resolved().await?;
     let next_mode = mode.await?;
@@ -230,6 +234,11 @@ pub async fn get_edge_chunking_context_with_client_assets(
     } else {
         MinifyType::NoMinify
     })
+    .source_maps(if *turbo_source_maps.await? {
+        SourceMapsType::Full
+    } else {
+        SourceMapsType::None
+    })
     .module_id_strategy(module_id_strategy);
 
     if !next_mode.is_development() {
@@ -251,6 +260,7 @@ pub async fn get_edge_chunking_context(
     environment: ResolvedVc<Environment>,
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     turbo_minify: Vc<bool>,
+    turbo_source_maps: Vc<bool>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
     let output_root = node_root.join("server/edge".into()).to_resolved().await?;
     let next_mode = mode.await?;
@@ -273,6 +283,11 @@ pub async fn get_edge_chunking_context(
         MinifyType::Minify
     } else {
         MinifyType::NoMinify
+    })
+    .source_maps(if *turbo_source_maps.await? {
+        SourceMapsType::Full
+    } else {
+        SourceMapsType::None
     })
     .module_id_strategy(module_id_strategy);
 

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -14,7 +14,7 @@ use turbopack::{
     transition::Transition,
 };
 use turbopack_core::{
-    chunk::{module_id_strategies::ModuleIdStrategy, ChunkingConfig, MinifyType},
+    chunk::{module_id_strategies::ModuleIdStrategy, ChunkingConfig, MinifyType, SourceMapsType},
     compile_time_info::{
         CompileTimeDefineValue, CompileTimeDefines, CompileTimeInfo, DefineableNameSegment,
         FreeVarReferences,
@@ -978,6 +978,7 @@ pub async fn get_server_chunking_context_with_client_assets(
     environment: ResolvedVc<Environment>,
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     turbo_minify: Vc<bool>,
+    turbo_source_maps: Vc<bool>,
 ) -> Result<Vc<NodeJsChunkingContext>> {
     let next_mode = mode.await?;
     // TODO(alexkirsz) This should return a trait that can be implemented by the
@@ -1005,6 +1006,11 @@ pub async fn get_server_chunking_context_with_client_assets(
     } else {
         MinifyType::NoMinify
     })
+    .source_maps(if *turbo_source_maps.await? {
+        SourceMapsType::Full
+    } else {
+        SourceMapsType::None
+    })
     .module_id_strategy(module_id_strategy)
     .file_tracing(next_mode.is_production());
 
@@ -1029,6 +1035,7 @@ pub async fn get_server_chunking_context(
     environment: ResolvedVc<Environment>,
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     turbo_minify: Vc<bool>,
+    turbo_source_maps: Vc<bool>,
 ) -> Result<Vc<NodeJsChunkingContext>> {
     let next_mode = mode.await?;
     // TODO(alexkirsz) This should return a trait that can be implemented by the
@@ -1048,6 +1055,11 @@ pub async fn get_server_chunking_context(
         MinifyType::Minify
     } else {
         MinifyType::NoMinify
+    })
+    .source_maps(if *turbo_source_maps.await? {
+        SourceMapsType::Full
+    } else {
+        SourceMapsType::None
     })
     .module_id_strategy(module_id_strategy)
     .file_tracing(next_mode.is_production());

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -533,6 +533,11 @@ pub async fn get_server_module_options_context(
             enable_typeof_window_inlining: Some(TypeofWindow::Undefined),
             import_externals: *next_config.import_externals().await?,
             ignore_dynamic_requests: true,
+            source_maps: if *next_config.turbo_source_maps().await? {
+                SourceMapsType::Full
+            } else {
+                SourceMapsType::None
+            },
             ..Default::default()
         },
         execution_context: Some(execution_context),

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -408,6 +408,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
             memoryLimit: z.number().optional(),
             moduleIdStrategy: z.enum(['named', 'deterministic']).optional(),
             minify: z.boolean().optional(),
+            sourceMaps: z.boolean().optional(),
           })
           .optional(),
         optimizePackageImports: z.array(z.string()).optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -182,6 +182,11 @@ export interface ExperimentalTurboOptions {
    * Enable minification. Defaults to true in build mode and false in dev mode.
    */
   minify?: boolean
+
+  /**
+   * Enable source maps. Defaults to true.
+   */
+  sourceMaps?: boolean
 }
 
 export interface WebpackConfigContext {

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -351,6 +351,14 @@ impl ChunkingContext for BrowserChunkingContext {
     }
 
     #[turbo_tasks::function]
+    fn reference_module_source_maps(&self, _module: Vc<Box<dyn Module>>) -> Vc<bool> {
+        Vc::cell(match self.source_maps_type {
+            SourceMapsType::Full => true,
+            SourceMapsType::None => false,
+        })
+    }
+
+    #[turbo_tasks::function]
     async fn asset_path(
         &self,
         content_hash: RcStr,

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -11,7 +11,7 @@ use turbopack_core::{
         module_id_strategies::{DevModuleIdStrategy, ModuleIdStrategy},
         Chunk, ChunkGroupResult, ChunkItem, ChunkableModule, ChunkableModules, ChunkingConfig,
         ChunkingConfigs, ChunkingContext, EntryChunkGroupResult, EvaluatableAssets, MinifyType,
-        ModuleId,
+        ModuleId, SourceMapsType,
     },
     environment::Environment,
     ident::AssetIdent,
@@ -67,16 +67,6 @@ impl BrowserChunkingContextBuilder {
         self
     }
 
-    pub fn reference_chunk_source_maps(mut self, source_maps: bool) -> Self {
-        self.chunking_context.reference_chunk_source_maps = source_maps;
-        self
-    }
-
-    pub fn reference_css_chunk_source_maps(mut self, source_maps: bool) -> Self {
-        self.chunking_context.reference_css_chunk_source_maps = source_maps;
-        self
-    }
-
     pub fn runtime_type(mut self, runtime_type: RuntimeType) -> Self {
         self.chunking_context.runtime_type = runtime_type;
         self
@@ -89,6 +79,11 @@ impl BrowserChunkingContextBuilder {
 
     pub fn minify_type(mut self, minify_type: MinifyType) -> Self {
         self.chunking_context.minify_type = minify_type;
+        self
+    }
+
+    pub fn source_maps(mut self, source_maps: SourceMapsType) -> Self {
+        self.chunking_context.source_maps_type = source_maps;
         self
     }
 
@@ -135,10 +130,6 @@ pub struct BrowserChunkingContext {
     client_root: ResolvedVc<FileSystemPath>,
     /// Chunks are placed at this path
     chunk_root_path: ResolvedVc<FileSystemPath>,
-    /// Chunks reference source maps assets
-    reference_chunk_source_maps: bool,
-    /// Css chunks reference source maps assets
-    reference_css_chunk_source_maps: bool,
     /// Static assets are placed at this path
     asset_root_path: ResolvedVc<FileSystemPath>,
     /// Base path that will be prepended to all chunk URLs when loading them.
@@ -157,6 +148,8 @@ pub struct BrowserChunkingContext {
     runtime_type: RuntimeType,
     /// Whether to minify resulting chunks
     minify_type: MinifyType,
+    /// Whether to generate source maps
+    source_maps_type: SourceMapsType,
     /// Whether to use manifest chunks for lazy compilation
     manifest_chunks: bool,
     /// The module id strategy to use
@@ -185,8 +178,6 @@ impl BrowserChunkingContext {
                 client_root,
                 chunk_root_path,
                 should_use_file_source_map_uris: false,
-                reference_chunk_source_maps: true,
-                reference_css_chunk_source_maps: true,
                 asset_root_path,
                 chunk_base_path: ResolvedVc::cell(None),
                 asset_base_path: ResolvedVc::cell(None),
@@ -195,6 +186,7 @@ impl BrowserChunkingContext {
                 environment,
                 runtime_type,
                 minify_type: MinifyType::NoMinify,
+                source_maps_type: SourceMapsType::Full,
                 manifest_chunks: false,
                 module_id_strategy: ResolvedVc::upcast(DevModuleIdStrategy::new_resolved()),
                 ecmascript_chunking_config: None,
@@ -351,21 +343,11 @@ impl ChunkingContext for BrowserChunkingContext {
     }
 
     #[turbo_tasks::function]
-    async fn reference_chunk_source_maps(
-        &self,
-        chunk: Vc<Box<dyn OutputAsset>>,
-    ) -> Result<Vc<bool>> {
-        let mut source_maps = self.reference_chunk_source_maps;
-        let path = chunk.ident().path().await?;
-        let extension = path.extension_ref().unwrap_or_default();
-        #[allow(clippy::single_match, reason = "future extensions")]
-        match extension {
-            ".css" => {
-                source_maps = self.reference_css_chunk_source_maps;
-            }
-            _ => {}
-        }
-        Ok(Vc::cell(source_maps))
+    fn reference_chunk_source_maps(&self, _chunk: Vc<Box<dyn OutputAsset>>) -> Vc<bool> {
+        Vc::cell(match self.source_maps_type {
+            SourceMapsType::Full => true,
+            SourceMapsType::None => false,
+        })
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -157,6 +157,7 @@ impl EcmascriptDevEvaluateChunk {
                     chunking_context.chunk_base_path(),
                     Value::new(chunking_context.runtime_type()),
                     output_root_to_root_path,
+                    source_maps,
                 );
                 code.push_code(&*runtime_code.await?);
             }
@@ -166,6 +167,7 @@ impl EcmascriptDevEvaluateChunk {
                     chunking_context.chunk_base_path(),
                     Value::new(chunking_context.runtime_type()),
                     output_root_to_root_path,
+                    source_maps,
                 );
                 code.push_code(&*runtime_code.await?);
             }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -76,6 +76,9 @@ impl EcmascriptDevEvaluateChunk {
 
         let output_root = this.chunking_context.output_root().await?;
         let output_root_to_root_path = this.chunking_context.output_root_to_root_path();
+        let source_maps = this
+            .chunking_context
+            .reference_chunk_source_maps(Vc::upcast(self));
         let chunk_path_vc = self.ident().path();
         let chunk_path = chunk_path_vc.await?;
         let chunk_public_path = if let Some(path) = output_root.get_path_to(&chunk_path) {
@@ -173,7 +176,7 @@ impl EcmascriptDevEvaluateChunk {
             }
         }
 
-        if code.has_source_map() {
+        if *source_maps.await? && code.has_source_map() {
             let filename = chunk_path.file_name();
             write!(
                 code,
@@ -189,7 +192,7 @@ impl EcmascriptDevEvaluateChunk {
             this.chunking_context.await?.minify_type(),
             MinifyType::Minify
         ) {
-            return Ok(minify(chunk_path_vc, code));
+            return Ok(minify(chunk_path_vc, code, source_maps));
         }
 
         Ok(code)

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -53,8 +53,10 @@ pub enum MinifyType {
     NonLocalValue,
 )]
 pub enum SourceMapsType {
+    /// Extracts source maps from input files and writes source maps for output files.
     #[default]
     Full,
+    /// Ignores the existance of source maps and does not write source maps for output files.
     None,
 }
 
@@ -125,9 +127,11 @@ pub trait ChunkingContext {
     // dependency first.
     fn chunk_path(self: Vc<Self>, ident: Vc<AssetIdent>, extension: RcStr) -> Vc<FileSystemPath>;
 
-    // TODO(alexkirsz) Remove this from the chunking context.
     /// Reference Source Map Assets for chunks
     fn reference_chunk_source_maps(self: Vc<Self>, chunk: Vc<Box<dyn OutputAsset>>) -> Vc<bool>;
+
+    /// Include Source Maps for modules
+    fn reference_module_source_maps(self: Vc<Self>, module: Vc<Box<dyn Module>>) -> Vc<bool>;
 
     /// Returns a URL (relative or absolute, depending on the asset prefix) to
     /// the static asset based on its `ident`.

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -39,6 +39,27 @@ pub enum MinifyType {
 
 #[derive(
     Debug,
+    Default,
+    TaskInput,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    DeterministicHash,
+    NonLocalValue,
+)]
+pub enum SourceMapsType {
+    #[default]
+    Full,
+    None,
+}
+
+#[derive(
+    Debug,
     TaskInput,
     Clone,
     Copy,

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -25,7 +25,7 @@ use turbo_tasks_hash::DeterministicHash;
 pub use self::{
     chunking_context::{
         ChunkGroupResult, ChunkGroupType, ChunkingConfig, ChunkingConfigs, ChunkingContext,
-        ChunkingContextExt, EntryChunkGroupResult, MinifyType,
+        ChunkingContextExt, EntryChunkGroupResult, MinifyType, SourceMapsType,
     },
     data::{ChunkData, ChunkDataOption, ChunksData},
     evaluate::{EvaluatableAsset, EvaluatableAssetExt, EvaluatableAssets},

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -394,17 +394,25 @@ impl EcmascriptChunkItem for ModuleChunkItem {
             )?;
         }
         code += "});\n";
+        let source_map = *self
+            .chunking_context
+            .reference_module_source_maps(*ResolvedVc::upcast(self.module))
+            .await?;
         Ok(EcmascriptChunkItemContent {
             inner_code: code.clone().into(),
             // We generate a minimal map for runtime code so that the filename is
             // displayed in dev tools.
-            source_map: Some(ResolvedVc::upcast(
-                generate_minimal_source_map(
-                    self.module.ident().to_string().await?.to_string(),
-                    code,
-                )
-                .await?,
-            )),
+            source_map: if source_map {
+                Some(ResolvedVc::upcast(
+                    generate_minimal_source_map(
+                        self.module.ident().to_string().await?.to_string(),
+                        code,
+                    )
+                    .await?,
+                ))
+            } else {
+                None
+            },
             ..Default::default()
         }
         .cell())

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/browser_runtime.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/browser_runtime.rs
@@ -20,11 +20,15 @@ pub async fn get_browser_runtime_code(
     chunk_base_path: Vc<Option<RcStr>>,
     runtime_type: Value<RuntimeType>,
     output_root_to_root_path: Vc<RcStr>,
+    generate_source_map: Vc<bool>,
 ) -> Result<Vc<Code>> {
     let asset_context = get_runtime_asset_context(environment).await?;
 
-    let shared_runtime_utils_code =
-        embed_static_code(asset_context, "shared/runtime-utils.ts".into());
+    let shared_runtime_utils_code = embed_static_code(
+        asset_context,
+        "shared/runtime-utils.ts".into(),
+        generate_source_map,
+    );
 
     let mut runtime_base_code = vec!["browser/runtime/base/runtime-base.ts"];
     match *runtime_type {
@@ -96,29 +100,46 @@ pub async fn get_browser_runtime_code(
 
     code.push_code(&*shared_runtime_utils_code.await?);
     for runtime_code in runtime_base_code {
-        code.push_code(&*embed_static_code(asset_context, runtime_code.into()).await?);
+        code.push_code(
+            &*embed_static_code(asset_context, runtime_code.into(), generate_source_map).await?,
+        );
     }
 
     if *environment.supports_commonjs_externals().await? {
         code.push_code(
-            &*embed_static_code(asset_context, "shared-node/base-externals-utils.ts".into())
-                .await?,
+            &*embed_static_code(
+                asset_context,
+                "shared-node/base-externals-utils.ts".into(),
+                generate_source_map,
+            )
+            .await?,
         );
     }
     if *environment.node_externals().await? {
         code.push_code(
-            &*embed_static_code(asset_context, "shared-node/node-externals-utils.ts".into())
-                .await?,
+            &*embed_static_code(
+                asset_context,
+                "shared-node/node-externals-utils.ts".into(),
+                generate_source_map,
+            )
+            .await?,
         );
     }
     if *environment.supports_wasm().await? {
         code.push_code(
-            &*embed_static_code(asset_context, "shared-node/node-wasm-utils.ts".into()).await?,
+            &*embed_static_code(
+                asset_context,
+                "shared-node/node-wasm-utils.ts".into(),
+                generate_source_map,
+            )
+            .await?,
         );
     }
 
     for backend_code in runtime_backend_code {
-        code.push_code(&*embed_static_code(asset_context, backend_code.into()).await?);
+        code.push_code(
+            &*embed_static_code(asset_context, backend_code.into(), generate_source_map).await?,
+        );
     }
 
     // Registering chunks depends on the BACKEND variable, which is set by the

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/embed_js.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/embed_js.rs
@@ -20,6 +20,10 @@ pub fn embed_file_path(path: RcStr) -> Vc<FileSystemPath> {
 }
 
 #[turbo_tasks::function]
-pub fn embed_static_code(asset_context: Vc<Box<dyn AssetContext>>, path: RcStr) -> Vc<Code> {
-    StaticEcmascriptCode::new(asset_context, embed_file_path(path)).code()
+pub fn embed_static_code(
+    asset_context: Vc<Box<dyn AssetContext>>,
+    path: RcStr,
+    generate_source_map: Vc<bool>,
+) -> Vc<Code> {
+    StaticEcmascriptCode::new(asset_context, embed_file_path(path), generate_source_map).code()
 }

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/nodejs_runtime.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/nodejs_runtime.rs
@@ -9,18 +9,37 @@ use crate::{asset_context::get_runtime_asset_context, embed_js::embed_static_cod
 
 /// Returns the code for the Node.js production ECMAScript runtime.
 #[turbo_tasks::function]
-pub async fn get_nodejs_runtime_code(environment: Vc<Environment>) -> Result<Vc<Code>> {
+pub async fn get_nodejs_runtime_code(
+    environment: Vc<Environment>,
+    generate_source_map: Vc<bool>,
+) -> Result<Vc<Code>> {
     let asset_context = get_runtime_asset_context(environment).await?;
 
-    let shared_runtime_utils_code =
-        embed_static_code(asset_context, "shared/runtime-utils.ts".into());
-    let shared_base_external_utils_code =
-        embed_static_code(asset_context, "shared-node/base-externals-utils.ts".into());
-    let shared_node_external_utils_code =
-        embed_static_code(asset_context, "shared-node/node-externals-utils.ts".into());
-    let shared_node_wasm_utils_code =
-        embed_static_code(asset_context, "shared-node/node-wasm-utils.ts".into());
-    let runtime_code = embed_static_code(asset_context, "nodejs/runtime.ts".into());
+    let shared_runtime_utils_code = embed_static_code(
+        asset_context,
+        "shared/runtime-utils.ts".into(),
+        generate_source_map,
+    );
+    let shared_base_external_utils_code = embed_static_code(
+        asset_context,
+        "shared-node/base-externals-utils.ts".into(),
+        generate_source_map,
+    );
+    let shared_node_external_utils_code = embed_static_code(
+        asset_context,
+        "shared-node/node-externals-utils.ts".into(),
+        generate_source_map,
+    );
+    let shared_node_wasm_utils_code = embed_static_code(
+        asset_context,
+        "shared-node/node-wasm-utils.ts".into(),
+        generate_source_map,
+    );
+    let runtime_code = embed_static_code(
+        asset_context,
+        "nodejs/runtime.ts".into(),
+        generate_source_map,
+    );
 
     let mut code = CodeBuilder::default();
     code.push_code(&*shared_runtime_utils_code.await?);

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -150,6 +150,9 @@ pub struct EcmascriptOptions {
     /// If false, they will reference the whole directory. If true, they won't
     /// reference anything and lead to an runtime error instead.
     pub ignore_dynamic_requests: bool,
+    /// If true, it reads a sourceMappingURL comment from the end of the file,
+    /// reads and generates a source map.
+    pub extract_source_map: bool,
 }
 
 #[turbo_tasks::value(serialization = "auto_for_input")]
@@ -390,6 +393,7 @@ impl EcmascriptAnalyzable for EcmascriptModuleAsset {
         let analyze = self.analyze().await?;
 
         let module_type_result = *self.determine_module_type().await?;
+        let generate_source_map = chunking_context.reference_module_source_maps(Vc::upcast(self));
 
         Ok(EcmascriptModuleContent::new(
             *parsed,
@@ -400,6 +404,7 @@ impl EcmascriptAnalyzable for EcmascriptModuleAsset {
             *analyze.references,
             *analyze.code_generation,
             *analyze.async_module,
+            generate_source_map,
             *analyze.source_map,
             *analyze.exports,
             async_module_info,
@@ -737,7 +742,8 @@ impl EcmascriptModuleContent {
         references: Vc<ModuleReferences>,
         code_generation: Vc<CodeGenerateables>,
         async_module: Vc<OptionAsyncModule>,
-        source_map: ResolvedVc<OptionSourceMap>,
+        generate_source_map: Vc<bool>,
+        original_source_map: ResolvedVc<OptionSourceMap>,
         exports: Vc<EcmascriptExports>,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<Self>> {
@@ -783,8 +789,15 @@ impl EcmascriptModuleContent {
         let code_gens = code_gens.into_iter().try_join().await?;
         let code_gens = code_gens.iter().map(|cg| &**cg).collect::<Vec<_>>();
 
-        gen_content_with_code_gens(parsed, ident, specified_module_type, &code_gens, source_map)
-            .await
+        gen_content_with_code_gens(
+            parsed,
+            ident,
+            specified_module_type,
+            &code_gens,
+            generate_source_map,
+            original_source_map,
+        )
+        .await
     }
 
     /// Creates a new [`Vc<EcmascriptModuleContent>`] without an analysis pass.
@@ -799,6 +812,7 @@ impl EcmascriptModuleContent {
             ident.to_resolved().await?,
             specified_module_type,
             &[],
+            Vc::cell(false),
             OptionSourceMap::none().to_resolved().await?,
         )
         .await
@@ -810,7 +824,8 @@ async fn gen_content_with_code_gens(
     ident: ResolvedVc<AssetIdent>,
     specified_module_type: SpecifiedModuleType,
     code_gens: &[&CodeGeneration],
-    original_src_map: ResolvedVc<OptionSourceMap>,
+    generate_source_map: Vc<bool>,
+    original_source_map: ResolvedVc<OptionSourceMap>,
 ) -> Result<Vc<EcmascriptModuleContent>> {
     let parsed = parsed.await?;
 
@@ -840,21 +855,34 @@ async fn gen_content_with_code_gens(
 
             let comments = comments.consumable();
 
+            let generate_source_map = *generate_source_map.await?;
+
             let mut emitter = Emitter {
                 cfg: swc_core::ecma::codegen::Config::default(),
                 cm: source_map.clone(),
                 comments: Some(&comments),
-                wr: JsWriter::new(source_map.clone(), "\n", &mut bytes, Some(&mut mappings)),
+                wr: JsWriter::new(
+                    source_map.clone(),
+                    "\n",
+                    &mut bytes,
+                    generate_source_map.then_some(&mut mappings),
+                ),
             };
 
             emitter.emit_program(&program)?;
 
-            let srcmap = ParseResultSourceMap::new(source_map.clone(), mappings, original_src_map)
-                .resolved_cell();
+            let source_map = if generate_source_map {
+                let srcmap =
+                    ParseResultSourceMap::new(source_map.clone(), mappings, original_source_map)
+                        .resolved_cell();
+                Some(ResolvedVc::upcast(srcmap))
+            } else {
+                None
+            };
 
             Ok(EcmascriptModuleContent {
                 inner_code: bytes.into(),
-                source_map: Some(ResolvedVc::upcast(srcmap)),
+                source_map,
                 is_esm: eval_context.is_esm(specified_module_type),
             }
             .cell())

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -29,95 +29,106 @@ use turbopack_core::{
 use crate::ParseResultSourceMap;
 
 #[turbo_tasks::function]
-pub async fn minify(path: Vc<FileSystemPath>, code: Vc<Code>) -> Result<Vc<Code>> {
+pub async fn minify(
+    path: Vc<FileSystemPath>,
+    code: Vc<Code>,
+    source_maps: Vc<bool>,
+) -> Result<Vc<Code>> {
     let path = path.await?;
-    let original_map = code.generate_source_map().to_resolved().await?;
+    let source_maps = source_maps.await?.then(|| code.generate_source_map());
     let code = code.await?;
 
     let cm = Arc::new(SwcSourceMap::new(FilePathMapping::empty()));
-    let compiler = Arc::new(Compiler::new(cm.clone()));
-    let fm = compiler.cm.new_source_file(
-        FileName::Custom(path.path.to_string()).into(),
-        code.source_code().to_str()?.to_string(),
-    );
+    let (src, src_map_buf) = {
+        let compiler = Arc::new(Compiler::new(cm.clone()));
+        let fm = compiler.cm.new_source_file(
+            FileName::Custom(path.path.to_string()).into(),
+            code.source_code().to_str()?.to_string(),
+        );
 
-    let lexer = Lexer::new(
-        Syntax::default(),
-        EsVersion::latest(),
-        StringInput::from(&*fm),
-        None,
-    );
-    let mut parser = Parser::new_from(lexer);
+        let lexer = Lexer::new(
+            Syntax::default(),
+            EsVersion::latest(),
+            StringInput::from(&*fm),
+            None,
+        );
+        let mut parser = Parser::new_from(lexer);
 
-    let program = try_with_handler(cm.clone(), Default::default(), |handler| {
-        GLOBALS.set(&Default::default(), || {
-            let program = match parser.parse_program() {
-                Ok(program) => program,
-                Err(err) => {
-                    err.into_diagnostic(handler).emit();
-                    bail!(
-                        "failed to parse source code\n{}",
-                        code.source_code().to_str()?
-                    )
-                }
-            };
-            let comments = SingleThreadedComments::default();
-            let unresolved_mark = Mark::new();
-            let top_level_mark = Mark::new();
+        let program = try_with_handler(cm.clone(), Default::default(), |handler| {
+            GLOBALS.set(&Default::default(), || {
+                let program = match parser.parse_program() {
+                    Ok(program) => program,
+                    Err(err) => {
+                        err.into_diagnostic(handler).emit();
+                        bail!(
+                            "failed to parse source code\n{}",
+                            code.source_code().to_str()?
+                        )
+                    }
+                };
+                let comments = SingleThreadedComments::default();
+                let unresolved_mark = Mark::new();
+                let top_level_mark = Mark::new();
 
-            Ok(compiler.run_transform(handler, false, || {
-                let program = program.apply(paren_remover(Some(&comments)));
+                Ok(compiler.run_transform(handler, false, || {
+                    let program = program.apply(paren_remover(Some(&comments)));
 
-                let mut program = program.apply(swc_core::ecma::transforms::base::resolver(
-                    unresolved_mark,
-                    top_level_mark,
-                    false,
-                ));
-
-                program = swc_core::ecma::minifier::optimize(
-                    program,
-                    cm.clone(),
-                    Some(&comments),
-                    None,
-                    &MinifyOptions {
-                        compress: Some(Default::default()),
-                        mangle: Some(MangleOptions {
-                            reserved: vec!["AbortSignal".into()],
-                            ..Default::default()
-                        }),
-                        ..Default::default()
-                    },
-                    &ExtraOptions {
-                        top_level_mark,
+                    let mut program = program.apply(swc_core::ecma::transforms::base::resolver(
                         unresolved_mark,
-                        mangle_name_cache: Default::default(),
-                    },
-                );
+                        top_level_mark,
+                        false,
+                    ));
 
-                program.apply(ecma::transforms::base::fixer::fixer(Some(
-                    &comments as &dyn Comments,
-                )))
-            }))
-        })
-    })?;
+                    program = swc_core::ecma::minifier::optimize(
+                        program,
+                        cm.clone(),
+                        Some(&comments),
+                        None,
+                        &MinifyOptions {
+                            compress: Some(Default::default()),
+                            mangle: Some(MangleOptions {
+                                reserved: vec!["AbortSignal".into()],
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        },
+                        &ExtraOptions {
+                            top_level_mark,
+                            unresolved_mark,
+                            mangle_name_cache: Default::default(),
+                        },
+                    );
 
-    let (src, src_map_buf) = print_program(cm.clone(), program)?;
+                    program.apply(ecma::transforms::base::fixer::fixer(Some(
+                        &comments as &dyn Comments,
+                    )))
+                }))
+            })
+        })?;
+
+        print_program(cm.clone(), program, source_maps.is_some())?
+    };
 
     let mut builder = CodeBuilder::default();
-    builder.push_source(
-        &src.into(),
-        Some(ResolvedVc::upcast(
-            ParseResultSourceMap::new(cm, src_map_buf, original_map).resolved_cell(),
-        )),
-    );
+    if let Some(original_map) = source_maps {
+        builder.push_source(
+            &src.into(),
+            Some(ResolvedVc::upcast(
+                ParseResultSourceMap::new(cm, src_map_buf, original_map.to_resolved().await?)
+                    .resolved_cell(),
+            )),
+        );
 
-    write!(
-        builder,
-        // findSourceMapURL assumes this co-located sourceMappingURL,
-        // and needs to be adjusted in case this is ever changed.
-        "\n\n//# sourceMappingURL={}.map",
-        urlencoding::encode(path.file_name())
-    )?;
+        write!(
+            builder,
+            // findSourceMapURL assumes this co-located sourceMappingURL,
+            // and needs to be adjusted in case this is ever changed.
+            "\n\n//# sourceMappingURL={}.map",
+            urlencoding::encode(path.file_name())
+        )?;
+    } else {
+        builder.push_source(&src.into(), None);
+    }
     Ok(builder.build().cell())
 }
 
@@ -125,6 +136,7 @@ pub async fn minify(path: Vc<FileSystemPath>, code: Vc<Code>) -> Result<Vc<Code>
 fn print_program(
     cm: Arc<SwcSourceMap>,
     program: Program,
+    source_maps: bool,
 ) -> Result<(String, Vec<(BytePos, LineCol)>)> {
     let mut src_map_buf = vec![];
 
@@ -135,7 +147,7 @@ fn print_program(
                 cm.clone(),
                 "\n",
                 &mut buf,
-                Some(&mut src_map_buf),
+                source_maps.then_some(&mut src_map_buf),
             )))) as Box<dyn WriteJs>;
 
             let mut emitter = Emitter {

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
@@ -49,6 +49,8 @@ impl EcmascriptChunkItem for EcmascriptModuleLocalsChunkItem {
             .module_options(async_module_info);
 
         let module_type_result = *original_module.determine_module_type().await?;
+        let generate_source_map =
+            chunking_context.reference_module_source_maps(*ResolvedVc::upcast(self.module));
 
         let content = EcmascriptModuleContent::new(
             parsed,
@@ -59,6 +61,7 @@ impl EcmascriptChunkItem for EcmascriptModuleLocalsChunkItem {
             *analyze_result.local_references,
             *analyze_result.code_generation,
             *analyze_result.async_module,
+            generate_source_map,
             *analyze_result.source_map,
             exports,
             async_module_info,

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -66,8 +66,12 @@ impl EcmascriptAnalyzable for EcmascriptModulePartAsset {
     }
 
     #[turbo_tasks::function]
-    fn module_content_without_analysis(&self) -> Vc<EcmascriptModuleContent> {
-        self.full_module.module_content_without_analysis()
+    fn module_content_without_analysis(
+        &self,
+        generate_source_map: Vc<bool>,
+    ) -> Vc<EcmascriptModuleContent> {
+        self.full_module
+            .module_content_without_analysis(generate_source_map)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
@@ -52,6 +52,9 @@ impl EcmascriptChunkItem for EcmascriptModulePartChunkItem {
         let async_module_options = analyze.async_module.module_options(async_module_info);
 
         let module_type_result = *module.full_module.determine_module_type().await?;
+        let generate_source_map = self
+            .chunking_context
+            .reference_module_source_maps(*ResolvedVc::upcast(self.module));
 
         let content = EcmascriptModuleContent::new(
             parsed,
@@ -62,6 +65,7 @@ impl EcmascriptChunkItem for EcmascriptModulePartChunkItem {
             *analyze.references,
             *analyze.code_generation,
             *analyze.async_module,
+            generate_source_map,
             *analyze.source_map,
             *analyze.exports,
             async_module_info,

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -290,6 +290,14 @@ impl ChunkingContext for NodeJsChunkingContext {
     }
 
     #[turbo_tasks::function]
+    fn reference_module_source_maps(&self, _module: Vc<Box<dyn Module>>) -> Vc<bool> {
+        Vc::cell(match self.source_maps_type {
+            SourceMapsType::Full => true,
+            SourceMapsType::None => false,
+        })
+    }
+
+    #[turbo_tasks::function]
     fn should_use_file_source_map_uris(&self) -> Vc<bool> {
         Vc::cell(self.should_use_file_source_map_uris)
     }

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -13,7 +13,7 @@ use turbopack_core::{
         module_id_strategies::{DevModuleIdStrategy, ModuleIdStrategy},
         Chunk, ChunkGroupResult, ChunkItem, ChunkableModule, ChunkableModules, ChunkingConfig,
         ChunkingConfigs, ChunkingContext, EntryChunkGroupResult, EvaluatableAssets, MinifyType,
-        ModuleId,
+        ModuleId, SourceMapsType,
     },
     environment::Environment,
     ident::AssetIdent,
@@ -45,6 +45,11 @@ impl NodeJsChunkingContextBuilder {
 
     pub fn minify_type(mut self, minify_type: MinifyType) -> Self {
         self.chunking_context.minify_type = minify_type;
+        self
+    }
+
+    pub fn source_maps(mut self, source_maps: SourceMapsType) -> Self {
+        self.chunking_context.source_maps_type = source_maps;
         self
     }
 
@@ -116,6 +121,8 @@ pub struct NodeJsChunkingContext {
     enable_file_tracing: bool,
     /// Whether to minify resulting chunks
     minify_type: MinifyType,
+    /// Whether to generate source maps
+    source_maps_type: SourceMapsType,
     /// Whether to use manifest chunks for lazy compilation
     manifest_chunks: bool,
     /// The strategy to use for generating module ids
@@ -151,6 +158,7 @@ impl NodeJsChunkingContext {
                 environment,
                 runtime_type,
                 minify_type: MinifyType::NoMinify,
+                source_maps_type: SourceMapsType::Full,
                 manifest_chunks: false,
                 should_use_file_source_map_uris: false,
                 module_id_strategy: ResolvedVc::upcast(DevModuleIdStrategy::new_resolved()),
@@ -275,7 +283,10 @@ impl ChunkingContext for NodeJsChunkingContext {
 
     #[turbo_tasks::function]
     fn reference_chunk_source_maps(&self, _chunk: Vc<Box<dyn OutputAsset>>) -> Vc<bool> {
-        Vc::cell(true)
+        Vc::cell(match self.source_maps_type {
+            SourceMapsType::Full => true,
+            SourceMapsType::None => false,
+        })
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -38,6 +38,9 @@ impl EcmascriptBuildNodeRuntimeChunk {
 
         let output_root_to_root_path = this.chunking_context.output_root_to_root_path().await?;
         let output_root = this.chunking_context.output_root().await?;
+        let generate_source_map = this
+            .chunking_context
+            .reference_chunk_source_maps(Vc::upcast(self));
         let runtime_path = self.ident().path().await?;
         let runtime_public_path = if let Some(path) = output_root.get_path_to(&runtime_path) {
             path
@@ -69,12 +72,14 @@ impl EcmascriptBuildNodeRuntimeChunk {
             RuntimeType::Development => {
                 let runtime_code = turbopack_ecmascript_runtime::get_nodejs_runtime_code(
                     this.chunking_context.environment(),
+                    generate_source_map,
                 );
                 code.push_code(&*runtime_code.await?);
             }
             RuntimeType::Production => {
                 let runtime_code = turbopack_ecmascript_runtime::get_nodejs_runtime_code(
                     this.chunking_context.environment(),
+                    generate_source_map,
                 );
                 code.push_code(&*runtime_code.await?);
             }

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -30,6 +30,7 @@ use turbo_tasks_fs::{glob::Glob, FileSystemPath};
 pub use turbopack_core::condition;
 use turbopack_core::{
     asset::Asset,
+    chunk::SourceMapsType,
     compile_time_info::CompileTimeInfo,
     context::{AssetContext, ProcessResult},
     environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
@@ -62,7 +63,7 @@ use turbopack_static::StaticModuleAsset;
 use turbopack_wasm::{module_asset::WebAssemblyModuleAsset, source::WebAssemblySource};
 
 use self::transition::{Transition, TransitionOptions};
-use crate::module_options::CustomModuleType;
+use crate::module_options::{CssOptionsContext, CustomModuleType, EcmascriptOptionsContext};
 
 #[turbo_tasks::function]
 async fn apply_module_type(
@@ -681,7 +682,19 @@ async fn externals_tracing_module_context(ty: ExternalType) -> Result<Vc<ModuleA
     Ok(ModuleAssetContext::new_without_replace_externals(
         Default::default(),
         CompileTimeInfo::builder(env).cell().await?,
-        ModuleOptionsContext::default().cell(),
+        ModuleOptionsContext {
+            ecmascript: EcmascriptOptionsContext {
+                source_maps: SourceMapsType::None,
+                ..Default::default()
+            },
+            css: CssOptionsContext {
+                // TODO add source maps handling for css
+                // source_maps: SourceMapsType::None,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+        .cell(),
         resolve_options.cell(),
         Vc::cell("externals-tracing".into()),
     ))

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -14,6 +14,7 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{glob::Glob, FileSystemPath};
 use turbopack_core::{
+    chunk::SourceMapsType,
     reference_type::{CssReferenceSubType, ReferenceType, UrlReferenceSubType},
     resolve::options::{ImportMap, ImportMapping},
 };
@@ -79,6 +80,7 @@ impl ModuleOptions {
                     import_externals,
                     esm_url_rewrite_behavior,
                     ref enable_typeof_window_inlining,
+                    source_maps: ecmascript_source_maps,
                     ..
                 },
             enable_mdx,
@@ -133,6 +135,7 @@ impl ModuleOptions {
             import_externals,
             ignore_dynamic_requests,
             refresh,
+            extract_source_map: matches!(ecmascript_source_maps, SourceMapsType::Full),
             ..Default::default()
         };
         let ecmascript_options_vc = ecmascript_options.resolved_cell();

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -3,7 +3,9 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{trace::TraceRawVcs, FxIndexMap, NonLocalValue, ResolvedVc, ValueDefault, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
-    chunk::MinifyType, condition::ContextCondition, environment::Environment,
+    chunk::{MinifyType, SourceMapsType},
+    condition::ContextCondition,
+    environment::Environment,
     resolve::options::ImportMapping,
 };
 use turbopack_ecmascript::{references::esm::UrlRewriteBehavior, TreeShakingMode};
@@ -160,6 +162,8 @@ pub struct EcmascriptOptionsContext {
     /// If false, they will reference the whole directory. If true, they won't
     /// reference anything and lead to an runtime error instead.
     pub ignore_dynamic_requests: bool,
+    /// Specifies how Source Maps are handled.
+    pub source_maps: SourceMapsType,
 
     pub placeholder_for_future_extensions: (),
 }
@@ -177,6 +181,9 @@ pub struct CssOptionsContext {
 
     pub minify_type: MinifyType,
 
+    // TODO add source maps handling for css
+    // Specifies how Source Maps are handled.
+    // pub source_maps: SourceMapsType,
     pub placeholder_for_future_extensions: (),
 }
 


### PR DESCRIPTION
### What?

add `experimental.turbo.sourceMaps: boolean` which defaults to `true`

When set to `false` it disables:
* emitting source maps for .js and .css
* extracting source map from input source files
* source maps handling in minify

The PR also disables source maps for externals tracing in general since we don't need that 


Closes PACK-3780