### PR TITLE
Turbopack: isolated chunking for css client references

### DIFF
--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -2,14 +2,17 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 use next_core::{
-    self, next_client_reference::EcmascriptClientReferenceModule,
+    self,
+    next_client_reference::{
+        CssClientReferenceModule, CssModuleClientReferenceModule, EcmascriptClientReferenceModule,
+    },
     next_server_component::server_component_module::NextServerComponentModule,
 };
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{
     debug::ValueDebugFormat, trace::TraceRawVcs, NonLocalValue, ResolvedVc, TryFlatJoinIterExt, Vc,
 };
-use turbopack::css::CssModuleAsset;
+use turbopack::css::chunk::CssChunkPlaceable;
 use turbopack_core::{module::Module, module_graph::SingleModuleGraph};
 
 #[derive(
@@ -20,7 +23,7 @@ pub enum ClientReferenceMapType {
         module: ResolvedVc<EcmascriptClientReferenceModule>,
         ssr_module: ResolvedVc<Box<dyn Module>>,
     },
-    CssClientReference(ResolvedVc<CssModuleAsset>),
+    CssClientReference(ResolvedVc<Box<dyn CssChunkPlaceable>>),
     ServerComponent(ResolvedVc<NextServerComponentModule>),
 }
 
@@ -38,7 +41,7 @@ pub async fn map_client_references(
             let module = node.module;
 
             if let Some(client_reference_module) =
-                ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(module).await?
+                ResolvedVc::try_downcast_type_sync::<EcmascriptClientReferenceModule>(module)
             {
                 Ok(Some((
                     module,
@@ -47,15 +50,26 @@ pub async fn map_client_references(
                         ssr_module: ResolvedVc::upcast(client_reference_module.await?.ssr_module),
                     },
                 )))
-            } else if let Some(css_client_reference_asset) =
-                ResolvedVc::try_downcast_type::<CssModuleAsset>(module).await?
+            } else if let Some(client_reference_module) =
+                ResolvedVc::try_downcast_type_sync::<CssClientReferenceModule>(module)
             {
                 Ok(Some((
                     module,
-                    ClientReferenceMapType::CssClientReference(css_client_reference_asset),
+                    ClientReferenceMapType::CssClientReference(ResolvedVc::upcast(
+                        client_reference_module.await?.client_module,
+                    )),
+                )))
+            } else if let Some(client_reference_module) =
+                ResolvedVc::try_downcast_type_sync::<CssModuleClientReferenceModule>(module)
+            {
+                Ok(Some((
+                    module,
+                    ClientReferenceMapType::CssClientReference(ResolvedVc::upcast(
+                        client_reference_module.await?.client_module,
+                    )),
                 )))
             } else if let Some(server_component) =
-                ResolvedVc::try_downcast_type::<NextServerComponentModule>(module).await?
+                ResolvedVc::try_downcast_type_sync::<NextServerComponentModule>(module)
             {
                 Ok(Some((
                     module,

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1201,7 +1201,7 @@ impl Project {
             transitions.push((
                 ECMASCRIPT_CLIENT_TRANSITION_NAME.into(),
                 app_project
-                    .edge_client_reference_transition()
+                    .edge_ecmascript_client_reference_transition()
                     .to_resolved()
                     .await?,
             ));
@@ -1287,7 +1287,7 @@ impl Project {
             transitions.push((
                 ECMASCRIPT_CLIENT_TRANSITION_NAME.into(),
                 app_project
-                    .client_reference_transition()
+                    .ecmascript_client_reference_transition()
                     .to_resolved()
                     .await?,
             ));
@@ -1342,7 +1342,7 @@ impl Project {
             transitions.push((
                 ECMASCRIPT_CLIENT_TRANSITION_NAME.into(),
                 app_project
-                    .edge_client_reference_transition()
+                    .edge_ecmascript_client_reference_transition()
                     .to_resolved()
                     .await?,
             ));

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -104,9 +104,12 @@ pub async fn get_app_client_references_chunks(
                                     },
                                 )
                             }
-                            ClientReferenceType::CssClientReference(css_module) => {
+                            ClientReferenceType::CssClientReference(css_client_reference) => {
                                 let client_chunk_group = client_chunking_context
-                                    .root_chunk_group(*ResolvedVc::upcast(css_module), module_graph)
+                                    .root_chunk_group(
+                                        *ResolvedVc::upcast(css_client_reference),
+                                        module_graph,
+                                    )
                                     .await?;
 
                                 (
@@ -226,13 +229,11 @@ pub async fn get_app_client_references_chunks(
                         Ok(match client_reference_ty {
                             ClientReferenceType::EcmascriptClientReference(
                                 ecmascript_client_reference,
-                            ) => {
-                                let ecmascript_client_reference_ref =
-                                    ecmascript_client_reference.await?;
-                                *ResolvedVc::upcast(ecmascript_client_reference_ref.client_module)
-                            }
-                            ClientReferenceType::CssClientReference(css_module) => {
-                                *ResolvedVc::upcast(*css_module)
+                            ) => *ResolvedVc::upcast(
+                                ecmascript_client_reference.await?.client_module,
+                            ),
+                            ClientReferenceType::CssClientReference(css_client_reference) => {
+                                *ResolvedVc::upcast(*css_client_reference)
                             }
                         })
                     })

--- a/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
@@ -1,0 +1,102 @@
+use anyhow::{bail, Result};
+use turbo_rcstr::RcStr;
+use turbo_tasks::{ResolvedVc, Vc};
+use turbopack::css::chunk::CssChunkPlaceable;
+use turbopack_core::{
+    asset::{Asset, AssetContent},
+    ident::AssetIdent,
+    module::Module,
+    reference::ModuleReferences,
+};
+
+use crate::next_client_reference::css_client_reference::css_client_reference_reference::CssClientReference;
+
+/// A [`CssClientReferenceModule`] is a marker module used to indicate which
+/// client reference should appear in the client reference manifest.
+#[turbo_tasks::value]
+pub struct CssClientReferenceModule {
+    /// The CSS module (in the client context)
+    pub client_module: ResolvedVc<Box<dyn CssChunkPlaceable>>,
+}
+
+#[turbo_tasks::value_impl]
+impl CssClientReferenceModule {
+    /// Create a new [`CssClientReferenceModule`] from the given source CSS
+    /// module.
+    #[turbo_tasks::function]
+    pub fn new(
+        client_module: ResolvedVc<Box<dyn CssChunkPlaceable>>,
+    ) -> Vc<CssClientReferenceModule> {
+        CssClientReferenceModule { client_module }.cell()
+    }
+}
+
+#[turbo_tasks::function]
+fn css_client_reference_modifier() -> Vc<RcStr> {
+    Vc::cell("css client reference".into())
+}
+
+#[turbo_tasks::value_impl]
+impl Module for CssClientReferenceModule {
+    #[turbo_tasks::function]
+    fn ident(&self) -> Vc<AssetIdent> {
+        self.client_module
+            .ident()
+            .with_modifier(css_client_reference_modifier())
+    }
+
+    #[turbo_tasks::function]
+    async fn references(self: Vc<Self>) -> Result<Vc<ModuleReferences>> {
+        let CssClientReferenceModule { client_module, .. } = &*self.await?;
+
+        Ok(Vc::cell(vec![ResolvedVc::upcast(
+            CssClientReference::new(*ResolvedVc::upcast(*client_module))
+                .to_resolved()
+                .await?,
+        )]))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for CssClientReferenceModule {
+    #[turbo_tasks::function]
+    fn content(&self) -> Result<Vc<AssetContent>> {
+        // The client reference asset only serves as a marker asset.
+        bail!("CssClientReferenceModule has no content")
+    }
+}
+
+// #[turbo_tasks::value_impl]
+// impl ParseCss for CssClientReferenceModule {
+//     #[turbo_tasks::function]
+//     async fn parse_css(&self) -> Result<Vc<ParseCssResult>> {
+//         let imp = ResolvedVc::try_sidecast_sync::<Box<dyn ParseCss>>(self.client_module)
+//             .context("CSS client reference client module must be CSS parseable")?;
+
+//         Ok(imp.parse_css())
+//     }
+// }
+
+// #[turbo_tasks::value_impl]
+// impl ProcessCss for CssClientReferenceModule {
+//     #[turbo_tasks::function]
+//     async fn get_css_with_placeholder(&self) -> Result<Vc<CssWithPlaceholderResult>> {
+//         let imp = ResolvedVc::try_sidecast_sync::<Box<dyn ProcessCss>>(self.client_module)
+//             .context("CSS client reference client module must be CSS processable")?;
+
+//         Ok(imp.get_css_with_placeholder())
+//     }
+
+//     #[turbo_tasks::function]
+//     async fn finalize_css(
+//         &self,
+//         module_graph: Vc<ModuleGraph>,
+//         chunking_context: Vc<Box<dyn ChunkingContext>>,
+//         minify_type: MinifyType,
+//     ) -> Result<Vc<FinalCssResult>> {
+//         let imp = ResolvedVc::try_sidecast_sync::<Box<dyn ProcessCss>>(self.client_module)
+//             .context("CSS client reference client module must be CSS processable")?;
+
+//         Ok(imp.finalize_css(module_graph, chunking_context, minify_type))
+//     }
+// }

--- a/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
@@ -65,38 +65,3 @@ impl Asset for CssClientReferenceModule {
         bail!("CssClientReferenceModule has no content")
     }
 }
-
-// #[turbo_tasks::value_impl]
-// impl ParseCss for CssClientReferenceModule {
-//     #[turbo_tasks::function]
-//     async fn parse_css(&self) -> Result<Vc<ParseCssResult>> {
-//         let imp = ResolvedVc::try_sidecast_sync::<Box<dyn ParseCss>>(self.client_module)
-//             .context("CSS client reference client module must be CSS parseable")?;
-
-//         Ok(imp.parse_css())
-//     }
-// }
-
-// #[turbo_tasks::value_impl]
-// impl ProcessCss for CssClientReferenceModule {
-//     #[turbo_tasks::function]
-//     async fn get_css_with_placeholder(&self) -> Result<Vc<CssWithPlaceholderResult>> {
-//         let imp = ResolvedVc::try_sidecast_sync::<Box<dyn ProcessCss>>(self.client_module)
-//             .context("CSS client reference client module must be CSS processable")?;
-
-//         Ok(imp.get_css_with_placeholder())
-//     }
-
-//     #[turbo_tasks::function]
-//     async fn finalize_css(
-//         &self,
-//         module_graph: Vc<ModuleGraph>,
-//         chunking_context: Vc<Box<dyn ChunkingContext>>,
-//         minify_type: MinifyType,
-//     ) -> Result<Vc<FinalCssResult>> {
-//         let imp = ResolvedVc::try_sidecast_sync::<Box<dyn ProcessCss>>(self.client_module)
-//             .context("CSS client reference client module must be CSS processable")?;
-
-//         Ok(imp.finalize_css(module_graph, chunking_context, minify_type))
-//     }
-// }

--- a/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_reference.rs
+++ b/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_reference.rs
@@ -1,0 +1,48 @@
+use turbo_rcstr::RcStr;
+use turbo_tasks::{ResolvedVc, ValueToString, Vc};
+use turbopack_core::{
+    chunk::{ChunkGroupType, ChunkableModuleReference, ChunkingType, ChunkingTypeOption},
+    module::Module,
+    reference::ModuleReference,
+    resolve::ModuleResolveResult,
+};
+
+#[turbo_tasks::value]
+pub(crate) struct CssClientReference {
+    module: ResolvedVc<Box<dyn Module>>,
+}
+
+#[turbo_tasks::value_impl]
+impl CssClientReference {
+    #[turbo_tasks::function]
+    pub fn new(module: ResolvedVc<Box<dyn Module>>) -> Vc<Self> {
+        Self::cell(CssClientReference { module })
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ChunkableModuleReference for CssClientReference {
+    #[turbo_tasks::function]
+    fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
+        Vc::cell(Some(ChunkingType::Isolated {
+            _ty: ChunkGroupType::Evaluated,
+            merge_tag: Some("client".into()),
+        }))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ModuleReference for CssClientReference {
+    #[turbo_tasks::function]
+    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
+        ModuleResolveResult::module(self.module).cell()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ValueToString for CssClientReference {
+    #[turbo_tasks::function]
+    fn to_string(&self) -> Vc<RcStr> {
+        Vc::cell("css client reference to client".into())
+    }
+}

--- a/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_transition.rs
+++ b/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_transition.rs
@@ -1,0 +1,79 @@
+use anyhow::{Context, Result};
+use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbopack::{
+    css::{chunk::CssChunkPlaceable, ModuleCssAsset},
+    transition::Transition,
+    ModuleAssetContext,
+};
+use turbopack_core::{
+    context::ProcessResult,
+    module::Module,
+    reference_type::{EntryReferenceSubType, ReferenceType},
+    source::Source,
+};
+
+use crate::next_client_reference::css_client_reference::{
+    css_client_reference_module::CssClientReferenceModule,
+    css_module_client_reference_module::CssModuleClientReferenceModule,
+};
+
+#[turbo_tasks::value(shared)]
+pub struct NextCssClientReferenceTransition {
+    client_transition: ResolvedVc<Box<dyn Transition>>,
+}
+
+#[turbo_tasks::value_impl]
+impl NextCssClientReferenceTransition {
+    #[turbo_tasks::function]
+    pub fn new(client_transition: ResolvedVc<Box<dyn Transition>>) -> Vc<Self> {
+        NextCssClientReferenceTransition { client_transition }.cell()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Transition for NextCssClientReferenceTransition {
+    #[turbo_tasks::function]
+    async fn process(
+        self: Vc<Self>,
+        source: Vc<Box<dyn Source>>,
+        module_asset_context: Vc<ModuleAssetContext>,
+        _reference_type: Value<ReferenceType>,
+    ) -> Result<Vc<ProcessResult>> {
+        let module_asset_context = self.process_context(module_asset_context);
+
+        let module = self.await?.client_transition.process(
+            source,
+            module_asset_context,
+            Value::new(ReferenceType::Entry(
+                EntryReferenceSubType::AppClientComponent,
+            )),
+        );
+        let ProcessResult::Module(module) = *module.await? else {
+            return Ok(ProcessResult::Ignore.cell());
+        };
+
+        let result: Vc<Box<dyn Module>> = if let Some(css_module_module) =
+            ResolvedVc::try_downcast_type_sync::<ModuleCssAsset>(module)
+        {
+            let ProcessResult::Module(client_module) = *css_module_module.inner().await? else {
+                return Ok(ProcessResult::Ignore.cell());
+            };
+
+            let client_module =
+                ResolvedVc::try_sidecast_sync::<Box<dyn CssChunkPlaceable>>(client_module)
+                    .context("client asset is not css chunk placeable")?;
+
+            Vc::upcast(CssModuleClientReferenceModule::new(
+                *client_module,
+                *ResolvedVc::upcast(css_module_module),
+            ))
+        } else {
+            let client_module = ResolvedVc::try_sidecast_sync::<Box<dyn CssChunkPlaceable>>(module)
+                .context("client asset is not css chunk placeable")?;
+
+            Vc::upcast(CssClientReferenceModule::new(*client_module))
+        };
+
+        Ok(ProcessResult::Module(result.to_resolved().await?).cell())
+    }
+}

--- a/crates/next-core/src/next_client_reference/css_client_reference/css_module_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/css_client_reference/css_module_client_reference_module.rs
@@ -1,0 +1,204 @@
+use std::collections::BTreeMap;
+
+use anyhow::{bail, Result};
+use indoc::formatdoc;
+use turbo_rcstr::RcStr;
+use turbo_tasks::{ResolvedVc, Vc};
+use turbopack::css::chunk::CssChunkPlaceable;
+use turbopack_core::{
+    asset::{Asset, AssetContent},
+    chunk::{ChunkItem, ChunkItemExt, ChunkType, ChunkableModule, ChunkingContext},
+    ident::AssetIdent,
+    module::Module,
+    module_graph::ModuleGraph,
+    reference::{ModuleReference, ModuleReferences, SingleChunkableModuleReference},
+};
+use turbopack_ecmascript::{
+    chunk::{
+        EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
+        EcmascriptChunkType, EcmascriptExports,
+    },
+    references::esm::{EsmExport, EsmExports},
+    utils::StringifyJs,
+};
+
+use crate::next_client_reference::css_client_reference::css_client_reference_reference::CssClientReference;
+
+/// A [`CssModuleClientReferenceModule`] is a marker module used to indicate which
+/// client reference should appear in the client reference manifest.
+#[turbo_tasks::value]
+pub struct CssModuleClientReferenceModule {
+    /// The CSS module (in the client context)
+    pub client_module: ResolvedVc<Box<dyn CssChunkPlaceable>>,
+    /// The Ecmascript CSS Module module (in the parent context)
+    pub module_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
+}
+
+#[turbo_tasks::function]
+fn reference_modifier() -> Vc<RcStr> {
+    Vc::cell("css module client reference".into())
+}
+
+#[turbo_tasks::value_impl]
+impl CssModuleClientReferenceModule {
+    /// Create a new [`CssModuleClientReferenceModule`] from the given source CSS
+    /// module.
+    #[turbo_tasks::function]
+    pub fn new(
+        client_module: ResolvedVc<Box<dyn CssChunkPlaceable>>,
+        module_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
+    ) -> Vc<CssModuleClientReferenceModule> {
+        CssModuleClientReferenceModule {
+            client_module,
+            module_module,
+        }
+        .cell()
+    }
+
+    #[turbo_tasks::function]
+    pub fn inner_module_reference(&self) -> Vc<Box<dyn ModuleReference>> {
+        Vc::upcast(SingleChunkableModuleReference::new(
+            Vc::upcast(*self.module_module),
+            reference_modifier(),
+        ))
+    }
+}
+
+#[turbo_tasks::function]
+fn css_client_reference_modifier() -> Vc<RcStr> {
+    Vc::cell("css module client reference module".into())
+}
+
+#[turbo_tasks::value_impl]
+impl Module for CssModuleClientReferenceModule {
+    #[turbo_tasks::function]
+    fn ident(&self) -> Vc<AssetIdent> {
+        self.module_module
+            .ident()
+            .with_modifier(css_client_reference_modifier())
+    }
+
+    #[turbo_tasks::function]
+    async fn references(self: Vc<Self>) -> Result<Vc<ModuleReferences>> {
+        let CssModuleClientReferenceModule { client_module, .. } = &*self.await?;
+
+        Ok(Vc::cell(vec![
+            self.inner_module_reference().to_resolved().await?,
+            ResolvedVc::upcast(
+                CssClientReference::new(*ResolvedVc::upcast(*client_module))
+                    .to_resolved()
+                    .await?,
+            ),
+        ]))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for CssModuleClientReferenceModule {
+    #[turbo_tasks::function]
+    fn content(&self) -> Result<Vc<AssetContent>> {
+        bail!("CSS module client reference module has no content")
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ChunkableModule for CssModuleClientReferenceModule {
+    #[turbo_tasks::function]
+    fn as_chunk_item(
+        self: ResolvedVc<Self>,
+        module_graph: ResolvedVc<ModuleGraph>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        Vc::upcast(
+            CssModuleClientReferenceChunkItem {
+                module_graph,
+                chunking_context,
+                inner: self,
+            }
+            .cell(),
+        )
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl EcmascriptChunkPlaceable for CssModuleClientReferenceModule {
+    #[turbo_tasks::function]
+    async fn get_exports(self: Vc<Self>) -> Result<Vc<EcmascriptExports>> {
+        let module_reference = self.inner_module_reference().to_resolved().await?;
+
+        let mut exports = BTreeMap::new();
+        exports.insert(
+            "default".into(),
+            EsmExport::ImportedBinding(module_reference, "default".into(), false),
+        );
+
+        Ok(EcmascriptExports::EsmExports(
+            EsmExports {
+                exports,
+                star_exports: vec![module_reference],
+            }
+            .resolved_cell(),
+        )
+        .cell())
+    }
+}
+
+#[turbo_tasks::value]
+struct CssModuleClientReferenceChunkItem {
+    module_graph: ResolvedVc<ModuleGraph>,
+    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    inner: ResolvedVc<CssModuleClientReferenceModule>,
+}
+
+#[turbo_tasks::value_impl]
+impl EcmascriptChunkItem for CssModuleClientReferenceChunkItem {
+    #[turbo_tasks::function]
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+        *self.chunking_context
+    }
+
+    #[turbo_tasks::function]
+    async fn content(&self) -> Result<Vc<EcmascriptChunkItemContent>> {
+        let inner = self.inner.await?;
+
+        let module_id = inner
+            .module_module
+            .as_chunk_item(*self.module_graph, Vc::upcast(*self.chunking_context))
+            .id()
+            .await?;
+        Ok(EcmascriptChunkItemContent {
+            inner_code: formatdoc!(
+                r#"
+                    __turbopack_export_namespace__(__turbopack_import__({}));
+                "#,
+                StringifyJs(&module_id),
+            )
+            .into(),
+            ..Default::default()
+        }
+        .cell())
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ChunkItem for CssModuleClientReferenceChunkItem {
+    #[turbo_tasks::function]
+    fn asset_ident(&self) -> Vc<AssetIdent> {
+        self.inner.ident()
+    }
+
+    #[turbo_tasks::function]
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+        *self.chunking_context
+    }
+
+    #[turbo_tasks::function]
+    fn ty(&self) -> Vc<Box<dyn ChunkType>> {
+        Vc::upcast(Vc::<EcmascriptChunkType>::default())
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        Vc::upcast(*self.inner)
+    }
+}

--- a/crates/next-core/src/next_client_reference/css_client_reference/mod.rs
+++ b/crates/next-core/src/next_client_reference/css_client_reference/mod.rs
@@ -1,0 +1,4 @@
+pub(crate) mod css_client_reference_module;
+pub(crate) mod css_client_reference_reference;
+pub(crate) mod css_client_reference_transition;
+pub(crate) mod css_module_client_reference_module;

--- a/crates/next-core/src/next_client_reference/mod.rs
+++ b/crates/next-core/src/next_client_reference/mod.rs
@@ -1,6 +1,12 @@
+pub(crate) mod css_client_reference;
 pub(crate) mod ecmascript_client_reference;
 pub(crate) mod visit_client_reference;
 
+pub use css_client_reference::{
+    css_client_reference_module::CssClientReferenceModule,
+    css_client_reference_transition::NextCssClientReferenceTransition,
+    css_module_client_reference_module::CssModuleClientReferenceModule,
+};
 pub use ecmascript_client_reference::{
     ecmascript_client_reference_module::EcmascriptClientReferenceModule,
     ecmascript_client_reference_transition::NextEcmascriptClientReferenceTransition,

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -156,7 +156,7 @@ struct ModuleCssClasses(FxIndexMap<String, Vec<ModuleCssClass>>);
 #[turbo_tasks::value_impl]
 impl ModuleCssAsset {
     #[turbo_tasks::function]
-    fn inner(&self) -> Vc<ProcessResult> {
+    pub fn inner(&self) -> Vc<ProcessResult> {
         self.asset_context.process(
             *self.source,
             Value::new(ReferenceType::Css(CssReferenceSubType::Internal)),


### PR DESCRIPTION
Create a dedicated CSS client reference transition and module

Closes PACK-3784