### PR TITLE
[Dev Badge] Focus states and fluid transitioning between states

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -23,6 +23,7 @@ export const NextLogo = ({
   const [isErrorExpanded, setIsErrorExpanded] = useState(hasError)
   const [isLoading, setIsLoading] = useState(false)
 
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
   const ref = useRef<HTMLDivElement | null>(null)
   const width = useMeasureWidth(ref)
 
@@ -39,14 +40,27 @@ export const NextLogo = ({
     }
   }, [isDevBuilding, isDevRendering])
 
+  useEffect(() => {
+    if (hasError) {
+      setIsErrorExpanded(true)
+    }
+  }, [hasError])
+
   return (
-    <>
+    <div
+      data-next-badge-root
+      style={
+        {
+          '--size': `${SIZE}px`,
+        } as React.CSSProperties
+      }
+    >
       {/* Styles */}
       <style>
         {css`
-          [data-next-badge] {
-            --timing: cubic-bezier(0.5, 0.36, 0.25, 1.1);
-            --duration: 300ms;
+          [data-next-badge-root] {
+            --timing: cubic-bezier(0.23, 0.88, 0.26, 0.92);
+            --duration: 250ms;
             --color-outer-border: #171717;
             --color-inner-border: hsla(0, 0%, 100%, 0.14);
             --color-hover-alpha: hsla(0, 0%, 100%, 0.14);
@@ -54,6 +68,15 @@ export const NextLogo = ({
             --padding: 2px;
             --mark-size: calc(var(--size) - var(--padding) * 2);
 
+            --focus-color: var(--color-blue-800);
+            --focus-ring: 2px solid var(--focus-color);
+
+            &:has([data-next-badge][data-error='true']) {
+              --focus-color: #fff;
+            }
+          }
+
+          [data-next-badge] {
             -webkit-font-smoothing: antialiased;
             width: var(--size);
             height: var(--size);
@@ -71,14 +94,20 @@ export const NextLogo = ({
             cursor: pointer;
             scale: 1;
             overflow: hidden;
+            will-change: scale, box-shadow, width, background;
             transition:
               scale 150ms var(--timing),
-              width 250ms var(--timing),
-              box-shadow 250ms var(--timing),
+              width var(--duration) var(--timing),
+              box-shadow var(--duration) var(--timing),
               background 150ms ease;
 
             &:active:not([data-error='true']) {
               scale: 0.95;
+            }
+
+            &[data-error='false']:has([data-next-mark]:focus-visible) {
+              outline: var(--focus-ring);
+              outline-offset: 3px;
             }
 
             &[data-error='true'] {
@@ -87,6 +116,12 @@ export const NextLogo = ({
 
               [data-next-mark] {
                 background: var(--color-hover-alpha);
+                outline-offset: 0px;
+
+                &:focus-visible {
+                  outline: var(--focus-ring);
+                  outline-offset: -1px;
+                }
 
                 &:hover {
                   background: var(--color-hover-alpha-2);
@@ -94,9 +129,38 @@ export const NextLogo = ({
               }
             }
 
+            &[data-error-expanded='false'][data-error='true'] ~ [data-dot] {
+              scale: 1;
+            }
+
             > div {
               display: flex;
             }
+          }
+
+          [data-issues-collapse]:focus-visible {
+            outline: var(--focus-ring);
+          }
+
+          [data-issues]:has([data-issues-open]:focus-visible) {
+            outline: var(--focus-ring);
+            outline-offset: -1px;
+          }
+
+          [data-dot] {
+            content: '';
+            width: 8px;
+            height: 8px;
+            background: #fff;
+            box-shadow: 0 0 0 1px var(--color-outer-border);
+            border-radius: 50%;
+            position: absolute;
+            top: 2px;
+            right: 0px;
+            scale: 0;
+            pointer-events: none;
+            transition: scale 200ms var(--timing);
+            transition-delay: 150ms;
           }
 
           [data-issues] {
@@ -115,7 +179,7 @@ export const NextLogo = ({
             }
 
             [data-cross] {
-              translate: 0 -1px;
+              translate: 0px -1px;
             }
           }
 
@@ -132,9 +196,13 @@ export const NextLogo = ({
             font-weight: 500;
             z-index: 2;
             white-space: nowrap;
+
+            &:focus-visible {
+              outline: 0;
+            }
           }
 
-          [data-issues-close] {
+          [data-issues-collapse] {
             width: 24px;
             height: 24px;
             border-radius: 9999px;
@@ -143,6 +211,10 @@ export const NextLogo = ({
             &:hover {
               background: var(--color-hover-alpha);
             }
+          }
+
+          [data-cross] {
+            color: #fff;
           }
 
           [data-next-mark] {
@@ -154,8 +226,24 @@ export const NextLogo = ({
             border-radius: 9999px;
             transition: background var(--duration) var(--timing);
 
+            &:focus-visible {
+              outline: 0;
+            }
+
             svg {
               flex-shrink: 0;
+            }
+          }
+
+          @keyframes pop {
+            0% {
+              scale: 0;
+            }
+            50% {
+              scale: 1.2;
+            }
+            100% {
+              scale: 1;
             }
           }
 
@@ -214,16 +302,19 @@ export const NextLogo = ({
       <div
         data-next-badge
         data-error={hasError}
-        style={
-          {
-            width: hasError && width > SIZE ? width : SIZE,
-            '--size': `${SIZE}px`,
-          } as React.CSSProperties
-        }
+        data-error-expanded={isErrorExpanded}
+        style={{
+          width: hasError && width > SIZE ? width : SIZE,
+        }}
       >
         <div ref={ref}>
           {/* Children */}
-          <button data-next-mark onClick={onLogoClick} {...props}>
+          <button
+            ref={triggerRef}
+            data-next-mark
+            onClick={onLogoClick}
+            {...props}
+          >
             <NextMark isLoading={isLoading} />
           </button>
           {isErrorExpanded && (
@@ -236,10 +327,12 @@ export const NextLogo = ({
                 {issueCount} {issueCount === 1 ? 'Issue' : 'Issues'}
               </button>
               <button
-                data-issues-close
-                aria-label="Dismiss"
+                data-issues-collapse
+                aria-label="Collapse issues badge"
                 onClick={() => {
                   setIsErrorExpanded(false)
+                  // Move focus to the trigger to prevent having it stuck on this element
+                  triggerRef.current?.focus()
                 }}
               >
                 <Cross />
@@ -248,7 +341,8 @@ export const NextLogo = ({
           )}
         </div>
       </div>
-    </>
+      <div aria-hidden data-dot />
+    </div>
   )
 }
 
@@ -335,17 +429,17 @@ function Cross() {
   return (
     <svg
       data-cross
-      width="14"
-      height="14"
+      width="12"
+      height="12"
       viewBox="0 0 14 14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        fill-rule="evenodd"
-        clip-rule="evenodd"
+        fillRule="evenodd"
+        clipRule="evenodd"
         d="M3.08889 11.8384L2.62486 12.3024L1.69678 11.3744L2.16082 10.9103L6.07178 6.99937L2.16082 3.08841L1.69678 2.62437L2.62486 1.69629L3.08889 2.16033L6.99986 6.07129L10.9108 2.16033L11.3749 1.69629L12.3029 2.62437L11.8389 3.08841L7.92793 6.99937L11.8389 10.9103L12.3029 11.3744L11.3749 12.3024L10.9108 11.8384L6.99986 7.92744L3.08889 11.8384Z"
-        fill="#EAEAEA"
+        fill="currentColor"
       />
     </svg>
   )

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -235,18 +235,6 @@ export const NextLogo = ({
             }
           }
 
-          @keyframes pop {
-            0% {
-              scale: 0;
-            }
-            50% {
-              scale: 1.2;
-            }
-            100% {
-              scale: 1;
-            }
-          }
-
           .path0 {
             animation: draw0 1.5s ease-in-out infinite;
           }


### PR DESCRIPTION
This PR builds a foundation for better keyboard support with good-looking focus states and sensible focus management. For example, we now transfer focus back to the Badge when collapsing the issues from ×.

 

https://github.com/user-attachments/assets/75df867b-0ab2-4e7c-9bb3-2edab2dda629

Furthermore, there are now animated transitions between states `Idle` → `Errored` → `Collapsed Errored` (notice the animated badge ⚪️ indicator.

https://github.com/user-attachments/assets/c13b04f2-4e39-4d8c-9122-a8e669a1f9b4

