### PR TITLE
[Turbopack] pass sourceMap flag to webpack loaders and postcss

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -325,6 +325,14 @@ pub async fn get_client_module_options_context(
             },
             ..Default::default()
         },
+        css: CssOptionsContext {
+            source_maps: if *next_config.turbo_source_maps().await? {
+                SourceMapsType::Full
+            } else {
+                SourceMapsType::None
+            },
+            ..Default::default()
+        },
         preset_env_versions: Some(env),
         execution_context: Some(execution_context),
         tree_shaking_mode: tree_shaking_mode_for_user_code,

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -542,6 +542,11 @@ pub async fn get_server_module_options_context(
         },
         execution_context: Some(execution_context),
         css: CssOptionsContext {
+            source_maps: if *next_config.turbo_source_maps().await? {
+                SourceMapsType::Full
+            } else {
+                SourceMapsType::None
+            },
             ..Default::default()
         },
         tree_shaking_mode: tree_shaking_mode_for_user_code,

--- a/turbopack/crates/turbopack-node/js/src/transforms/postcss.ts
+++ b/turbopack/crates/turbopack-node/js/src/transforms/postcss.ts
@@ -74,15 +74,16 @@ export const init = async (ipc: Ipc<IpcInfoMessage, IpcRequestMessage>) => {
 export default async function transform(
   ipc: Ipc<IpcInfoMessage, IpcRequestMessage>,
   cssContent: string,
-  name: string
+  name: string,
+  sourceMap: boolean
 ) {
   const { css, map, messages } = await processor!.process(cssContent, {
     from: name,
     to: name,
-    map: {
+    map: sourceMap ? {
       inline: false,
       annotation: false,
-    },
+    } : undefined,
   });
 
   const assets = [];
@@ -93,7 +94,9 @@ export default async function transform(
           file: msg.file,
           content: msg.content,
           sourceMap:
-            typeof msg.sourceMap === "string"
+            !sourceMap
+              ? undefined
+              : typeof msg.sourceMap === "string"
               ? msg.sourceMap
               : JSON.stringify(msg.sourceMap),
           // There is also an info field, which we currently ignore
@@ -133,7 +136,7 @@ export default async function transform(
   }
   return {
     css,
-    map: JSON.stringify(map),
+    map: sourceMap ? JSON.stringify(map) : undefined,
     assets,
   };
 }

--- a/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
+++ b/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
@@ -184,7 +184,8 @@ const transform = (
   content: string,
   name: string,
   query: string,
-  loaders: LoaderConfig[]
+  loaders: LoaderConfig[],
+  sourceMap: boolean
 ) => {
   return new Promise((resolve, reject) => {
     const resource = pathResolve(contextDir, name);
@@ -205,6 +206,7 @@ const transform = (
           },
           currentTraceSpan: new DummySpan(),
           rootContext: contextDir,
+          sourceMap,
           getOptions() {
             const entry = this.loaders[this.loaderIndex];
             return entry.options && typeof entry.options === "object"

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -688,8 +688,7 @@ async fn externals_tracing_module_context(ty: ExternalType) -> Result<Vc<ModuleA
                 ..Default::default()
             },
             css: CssOptionsContext {
-                // TODO add source maps handling for css
-                // source_maps: SourceMapsType::None,
+                source_maps: SourceMapsType::None,
                 ..Default::default()
             },
             ..Default::default()

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -578,6 +578,7 @@ impl ModuleOptions {
                                 *rule.loaders,
                                 rule.rename_as.clone(),
                                 resolve_options_context,
+                                matches!(ecmascript_source_maps, SourceMapsType::Full),
                             )
                             .to_resolved()
                             .await?,

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -85,7 +85,12 @@ impl ModuleOptions {
                 },
             enable_mdx,
             enable_mdx_rs,
-            css: CssOptionsContext { enable_raw_css, .. },
+            css:
+                CssOptionsContext {
+                    enable_raw_css,
+                    source_maps: css_source_maps,
+                    ..
+                },
             ref enable_postcss_transform,
             ref enable_webpack_loaders,
             preset_env_versions,
@@ -426,6 +431,7 @@ impl ModuleOptions {
                                 ),
                                 *execution_context,
                                 options.config_location,
+                                matches!(css_source_maps, SourceMapsType::Full),
                             )
                             .to_resolved()
                             .await?,

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -181,9 +181,9 @@ pub struct CssOptionsContext {
 
     pub minify_type: MinifyType,
 
-    // TODO add source maps handling for css
-    // Specifies how Source Maps are handled.
-    // pub source_maps: SourceMapsType,
+    /// Specifies how Source Maps are handled.
+    pub source_maps: SourceMapsType,
+
     pub placeholder_for_future_extensions: (),
 }
 


### PR DESCRIPTION
### What?

* pass sourceMap flag to webpack loaders
* run postcss transform without SourceMaps when specified


Closes PACK-3781