### PR TITLE
[Turbopack] allocation improvements for SingleModuleGraph

### DIFF
--- a/turbopack/crates/turbo-tasks/src/graph/adjacency_map.rs
+++ b/turbopack/crates/turbo-tasks/src/graph/adjacency_map.rs
@@ -1,8 +1,9 @@
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{HashSet, VecDeque},
     hash::Hash,
 };
 
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use turbo_tasks_macros::{TraceRawVcs, ValueDebugFormat};
 
@@ -16,7 +17,7 @@ use crate::{self as turbo_tasks, NonLocalValue};
     deserialize = "T: Deserialize<'de> + Eq + Hash"
 ))]
 pub struct AdjacencyMap<T> {
-    adjacency_map: HashMap<T, Vec<T>>,
+    adjacency_map: FxHashMap<T, Vec<T>>,
     roots: Vec<T>,
 }
 
@@ -49,7 +50,7 @@ where
     /// Creates a new adjacency map
     pub fn new() -> Self {
         Self {
-            adjacency_map: HashMap::new(),
+            adjacency_map: FxHashMap::default(),
             roots: Vec::new(),
         }
     }
@@ -161,7 +162,7 @@ pub struct IntoReverseTopologicalIter<T>
 where
     T: Eq + Hash + Clone,
 {
-    adjacency_map: HashMap<T, Vec<T>>,
+    adjacency_map: FxHashMap<T, Vec<T>>,
     stack: Vec<(ReverseTopologicalPass, T)>,
     visited: HashSet<T>,
 }
@@ -210,7 +211,7 @@ pub struct IntoBreadthFirstEdges<T>
 where
     T: Eq + std::hash::Hash + Clone,
 {
-    adjacency_map: HashMap<T, Vec<T>>,
+    adjacency_map: FxHashMap<T, Vec<T>>,
     stack: VecDeque<(Option<T>, T)>,
     expanded: HashSet<T>,
 }
@@ -246,7 +247,7 @@ pub struct ReverseTopologicalIter<'graph, T>
 where
     T: Eq + Hash + Clone,
 {
-    adjacency_map: &'graph HashMap<T, Vec<T>>,
+    adjacency_map: &'graph FxHashMap<T, Vec<T>>,
     stack: Vec<(ReverseTopologicalPass, &'graph T)>,
     visited: HashSet<&'graph T>,
 }

--- a/turbopack/crates/turbo-tasks/src/graph/adjacency_map.rs
+++ b/turbopack/crates/turbo-tasks/src/graph/adjacency_map.rs
@@ -3,7 +3,7 @@ use std::{
     hash::Hash,
 };
 
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use turbo_tasks_macros::{TraceRawVcs, ValueDebugFormat};
 
@@ -117,7 +117,7 @@ where
                 .rev()
                 .map(|root| (None, root))
                 .collect(),
-            expanded: HashSet::new(),
+            expanded: FxHashSet::default(),
         }
     }
 
@@ -132,7 +132,7 @@ where
                 .rev()
                 .map(|root| (ReverseTopologicalPass::Pre, root))
                 .collect(),
-            visited: HashSet::new(),
+            visited: FxHashSet::default(),
         }
     }
 
@@ -145,7 +145,7 @@ where
         ReverseTopologicalIter {
             adjacency_map: &self.adjacency_map,
             stack: vec![(ReverseTopologicalPass::Pre, node)],
-            visited: HashSet::new(),
+            visited: FxHashSet::default(),
         }
     }
 }
@@ -213,7 +213,7 @@ where
 {
     adjacency_map: FxHashMap<T, Vec<T>>,
     stack: VecDeque<(Option<T>, T)>,
-    expanded: HashSet<T>,
+    expanded: FxHashSet<T>,
 }
 
 impl<T> Iterator for IntoBreadthFirstEdges<T>
@@ -249,7 +249,7 @@ where
 {
     adjacency_map: &'graph FxHashMap<T, Vec<T>>,
     stack: Vec<(ReverseTopologicalPass, &'graph T)>,
-    visited: HashSet<&'graph T>,
+    visited: FxHashSet<&'graph T>,
 }
 
 impl<'graph, T> Iterator for ReverseTopologicalIter<'graph, T>

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{HashSet, VecDeque},
     future::Future,
     ops::Deref,
 };
@@ -9,6 +9,7 @@ use petgraph::{
     graph::{DiGraph, EdgeIndex, NodeIndex},
     visit::{Dfs, EdgeRef, IntoNodeReferences, VisitMap, Visitable},
 };
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use tracing::{Instrument, Span};
 use turbo_rcstr::RcStr;
@@ -148,7 +149,7 @@ pub struct SingleModuleGraph {
     //
     // This contains Vcs, but they are already contained in the graph, so no need to trace this.
     #[turbo_tasks(trace_ignore)]
-    modules: HashMap<ResolvedVc<Box<dyn Module>>, NodeIndex>,
+    modules: FxHashMap<ResolvedVc<Box<dyn Module>>, NodeIndex>,
 
     #[turbo_tasks(trace_ignore)]
     pub entries: Vec<ResolvedVc<Box<dyn Module>>>,
@@ -162,8 +163,6 @@ impl SingleModuleGraph {
         entries: &Vec<ResolvedVc<Box<dyn Module>>>,
         visited_modules: &FxIndexMap<ResolvedVc<Box<dyn Module>>, GraphNodeIndex>,
     ) -> Result<Vc<Self>> {
-        let mut graph = DiGraph::new();
-
         let root_edges = entries
             .iter()
             .map(|e| async move {
@@ -174,15 +173,25 @@ impl SingleModuleGraph {
             .try_join()
             .await?;
 
-        let children_nodes_iter = AdjacencyMap::new()
+        let (children_nodes_iter, visited_nodes) = AdjacencyMap::new()
             .skip_duplicates()
             .visit(root_edges, SingleModuleGraphBuilder { visited_modules })
             .await
             .completed()?
-            .into_inner();
+            .into_inner_with_visited();
+        let node_count = visited_nodes.0.len();
+        drop(visited_nodes);
+
+        let mut graph = DiGraph::with_capacity(
+            node_count,
+            // From real world measurements each module has about 3-4 children
+            // If it has more this would cause an additional allocation, but that's fine
+            node_count * 4,
+        );
 
         let mut number_of_modules = 0;
-        let mut modules: HashMap<ResolvedVc<Box<dyn Module>>, NodeIndex> = HashMap::new();
+        let mut modules: FxHashMap<ResolvedVc<Box<dyn Module>>, NodeIndex> =
+            FxHashMap::with_capacity_and_hasher(node_count, Default::default());
         {
             let _span = tracing::info_span!("build module graph").entered();
             for (parent, current) in children_nodes_iter.into_breadth_first_edges() {
@@ -258,6 +267,8 @@ impl SingleModuleGraph {
                 }
             }
         }
+
+        graph.shrink_to_fit();
 
         Ok(SingleModuleGraph {
             graph: TracedDiGraph(graph),


### PR DESCRIPTION
### What?

* allocate module graph with the correct size
* shrink it when finished
* store AdjacencyMap as FxHashMap
* convert to FxHashMaps


Closes PACK-3779