### PR TITLE
polish indicator loading behaviour for new dev overlay

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { noop as css } from '../../../../../../internal/helpers/noop-template'
+import { useMinimumLoadingTimeMultiple } from './use-minimum-loading-time-multiple'
 
 interface Props extends React.ComponentProps<'button'> {
   issueCount: number
@@ -21,24 +22,12 @@ export const NextLogo = ({
 }: Props) => {
   const hasError = issueCount > 0
   const [isErrorExpanded, setIsErrorExpanded] = useState(hasError)
-  const [isLoading, setIsLoading] = useState(false)
-
   const triggerRef = useRef<HTMLButtonElement | null>(null)
   const ref = useRef<HTMLDivElement | null>(null)
   const width = useMeasureWidth(ref)
-
-  // Only shows the loading state after a 200ms delay when building or rendering,
-  // to avoid flashing the loading state for quick updates
-  useEffect(() => {
-    if (isDevBuilding || isDevRendering) {
-      const timeout = setTimeout(() => {
-        setIsLoading(true)
-      }, 200)
-      return () => clearTimeout(timeout)
-    } else {
-      setIsLoading(false)
-    }
-  }, [isDevBuilding, isDevRendering])
+  const isLoading = useMinimumLoadingTimeMultiple(
+    isDevBuilding || isDevRendering
+  )
 
   useEffect(() => {
     if (hasError) {

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/use-minimum-loading-time-multiple.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/use-minimum-loading-time-multiple.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * A React hook that ensures a loading state persists
+ * at least up to the next multiple of a given interval (default: 750ms).
+ *
+ * For example, if you're done loading at 1200ms, it forces you to wait
+ * until 1500ms. If it’s 1800ms, it waits until 2250ms, etc.
+ *
+ * @param isLoadingTrigger - Boolean that triggers the loading state
+ * @param interval - The time interval multiple in ms (default: 750ms)
+ * @returns Current loading state that respects multiples of the interval
+ */
+export function useMinimumLoadingTimeMultiple(
+  isLoadingTrigger: boolean,
+  interval = 750
+) {
+  const [isLoading, setIsLoading] = useState(false)
+  const loadStartTimeRef = useRef<number | null>(null)
+  const timeoutIdRef = useRef<NodeJS.Timeout | null>(null)
+
+  useEffect(() => {
+    // Clear any pending timeout to avoid overlap
+    if (timeoutIdRef.current) {
+      clearTimeout(timeoutIdRef.current)
+      timeoutIdRef.current = null
+    }
+
+    if (isLoadingTrigger) {
+      // If we enter "loading" state, record start time if not already
+      if (loadStartTimeRef.current === null) {
+        loadStartTimeRef.current = Date.now()
+      }
+      setIsLoading(true)
+    } else {
+      // If we're exiting the "loading" state:
+      if (loadStartTimeRef.current === null) {
+        // No start time was recorded, so just stop loading immediately
+        setIsLoading(false)
+      } else {
+        // How long we've been "loading"
+        const timeDiff = Date.now() - loadStartTimeRef.current
+
+        // Next multiple of `interval` after `timeDiff`
+        const nextMultiple = interval * Math.ceil(timeDiff / interval)
+
+        // Remaining time needed to reach that multiple
+        const remainingTime = nextMultiple - timeDiff
+
+        if (remainingTime > 0) {
+          // If not yet at that multiple, schedule the final step
+          timeoutIdRef.current = setTimeout(() => {
+            setIsLoading(false)
+            loadStartTimeRef.current = null
+          }, remainingTime)
+        } else {
+          // We're already past the multiple boundary
+          setIsLoading(false)
+          loadStartTimeRef.current = null
+        }
+      }
+    }
+
+    // Cleanup when effect is about to re-run or component unmounts
+    return () => {
+      if (timeoutIdRef.current) {
+        clearTimeout(timeoutIdRef.current)
+      }
+    }
+  }, [isLoadingTrigger, interval])
+
+  return isLoading
+}


### PR DESCRIPTION
Previously, we delayed showing the loading state for 200 ms to avoid brief and jarring visual changes (“flashing”) for short loading durations. However, this approach had two significant drawbacks:

1. Longer loading times felt unresponsive because users wouldn’t see immediate feedback.
2. Very quick loading gave the impression that the loading functionality was broken since no loading state appeared.

To address these issues, we’ve updated the behavior so that the loading state appears immediately when an action begins. Instead of enforcing a strict 200 ms minimum, we now ensure that once loading starts, it remains active until reaching the next multiple of 750 ms. This has the dual benefit of:

1. Eliminating artificial delays for longer loads, since the loading indicator appears right away.
2. Preventing flashing for quick loads (under 750 ms), by continuing the loading state until the 750 ms mark (or 1500 ms mark, etc.).

We chose 750 ms because our loading animation itself lasts 750 ms; if we stopped the animation in the middle, it would feel abrupt or unsmooth. By keeping the loading state for at least one full animation cycle (or a multiple thereof), the experience remains consistent and visually polished.

Overall, this update ensures a more responsive and predictable user experience across both short and long loading times.


**Before**
https://github.com/user-attachments/assets/462b231f-81e1-4b23-a130-2d79364750f3


**After**
https://github.com/user-attachments/assets/9b3eaa65-81bf-43fb-bae6-16494fa36507


Closes: NDX-702