### PR TITLE
add hostname to default error boundary message

### DIFF
--- a/packages/next/src/client/components/error-boundary.tsx
+++ b/packages/next/src/client/components/error-boundary.tsx
@@ -155,11 +155,10 @@ export function GlobalError({ error }: { error: any }) {
         <div style={styles.error}>
           <div>
             <h2 style={styles.text}>
-              {`Application error: a ${
-                digest ? 'server' : 'client'
-              }-side exception has occurred (see the ${
-                digest ? 'server logs' : 'browser console'
-              } for more information).`}
+              Application error: a {digest ? 'server' : 'client'}-side exception
+              has occurred while loading {window.location.hostname} (see the{' '}
+              {digest ? 'server logs' : 'browser console'} for more
+              information).
             </h2>
             {digest ? <p style={styles.text}>{`Digest: ${digest}`}</p> : null}
           </div>

--- a/test/development/app-dir/serialize-circular-error/serialize-circular-error.test.ts
+++ b/test/development/app-dir/serialize-circular-error/serialize-circular-error.test.ts
@@ -35,7 +35,7 @@ describe('serialize-circular-error', () => {
 
     const bodyText = await browser.elementByCss('body').text()
     expect(bodyText).toContain(
-      'Application error: a client-side exception has occurred (see the browser console for more information).'
+      'Application error: a client-side exception has occurred while loading localhost (see the browser console for more information).'
     )
 
     const output = next.cliOutput

--- a/test/e2e/app-dir/errors/index.test.ts
+++ b/test/e2e/app-dir/errors/index.test.ts
@@ -153,7 +153,7 @@ describe('app-dir - errors', () => {
         expect(
           await browser.waitForElementByCss('body').elementByCss('h2').text()
         ).toBe(
-          'Application error: a client-side exception has occurred (see the browser console for more information).'
+          'Application error: a client-side exception has occurred while loading localhost (see the browser console for more information).'
         )
       }
     })
@@ -168,7 +168,7 @@ describe('app-dir - errors', () => {
         expect(
           await browser.waitForElementByCss('body').elementByCss('h2').text()
         ).toBe(
-          'Application error: a server-side exception has occurred (see the server logs for more information).'
+          'Application error: a server-side exception has occurred while loading localhost (see the server logs for more information).'
         )
         expect(
           await browser.waitForElementByCss('body').elementByCss('p').text()

--- a/test/integration/css/test/css-rendering.test.js
+++ b/test/integration/css/test/css-rendering.test.js
@@ -274,7 +274,7 @@ module.exports = {
               await browser.waitForElementByCss('#link-other').click()
               await check(
                 () => browser.eval(`document.body.innerText`),
-                'Application error: a client-side exception has occurred (see the browser console for more information).',
+                'Application error: a client-side exception has occurred while loading localhost (see the browser console for more information).',
                 true
               )
 

--- a/test/production/next-link-legacybehavior-ref-merging/index.test.ts
+++ b/test/production/next-link-legacybehavior-ref-merging/index.test.ts
@@ -19,7 +19,7 @@ describe('Link with legacyBehavior - handles buggy userspace ref merging', () =>
     // shouldn't cause a crash
     expect(await browser.elementByCss('h1').text()).toEqual('Home')
     expect(await browser.elementByCss('body').text()).not.toContain(
-      'Application error: a client-side exception has occurred (see the browser console for more information).'
+      'Application error: a client-side exception has occurred'
     )
   })
 })


### PR DESCRIPTION
Since it's possible to deploy an application that triggers our default exception handling, we should ensure the error text is personalized to the host application to avoid any potential incorrect canonicalization by search engines for containing duplicate content. 

[slack context](https://vercel.slack.com/archives/C01A2M9R8RZ/p1737475474278219?thread_ts=1737385764.035219&cid=C01A2M9R8RZ)