### PR TITLE
fix: remove unnecessary parentheses in draft mode API

### DIFF
--- a/docs/01-app/04-api-reference/04-functions/draft-mode.mdx
+++ b/docs/01-app/04-api-reference/04-functions/draft-mode.mdx
@@ -54,7 +54,7 @@ import { draftMode } from 'next/headers'
 
 export async function GET(request: Request) {
   const draft = await draftMode()
-  draft().enable()
+  draft.enable()
   return new Response('Draft mode is enabled')
 }
 ```
@@ -64,7 +64,7 @@ import { draftMode } from 'next/headers'
 
 export async function GET(request) {
   const draft = await draftMode()
-  draft().enable()
+  draft.enable()
   return new Response('Draft mode is enabled')
 }
 ```
@@ -80,7 +80,7 @@ import { draftMode } from 'next/headers'
 
 export async function GET(request: Request) {
   const draft = await draftMode()
-  draft().disable()
+  draft.disable()
   return new Response('Draft mode is disabled')
 }
 ```
@@ -90,7 +90,7 @@ import { draftMode } from 'next/headers'
 
 export async function GET(request) {
   const draft = await draftMode()
-  draft().disable()
+  draft.disable()
   return new Response('Draft mode is disabled')
 }
 ```


### PR DESCRIPTION
## What?
Updates the draft mode documentation to fix incorrect method calls in the code examples.

## Why?
The code examples were showing incorrect syntax for enabling and disabling draft mode, using `draft()` instead of accessing the methods directly on the `draft` object.

## How?
Removes the unnecessary parentheses when calling `enable()` and `disable()` methods on the draft mode object in the documentation examples.

Fixes https://github.com/vercel/feedback/issues/82345