### PR TITLE
[metadata] Fix streaming metadata was missing in ssr

### DIFF
--- a/packages/next/src/lib/metadata/async-metadata.tsx
+++ b/packages/next/src/lib/metadata/async-metadata.tsx
@@ -3,26 +3,19 @@
 import { use } from 'react'
 import { useServerInsertedHTML } from '../../client/components/navigation'
 
-// This is a SSR-only version that will wait the promise of metadata to resolve
-// and
+// We need to wait for metadata on server once it's resolved, and insert into
+// the HTML through `useServerInsertedHTML`. It will suspense in <head> during SSR.
 function ServerInsertMetadata({ promise }: { promise: Promise<any> }) {
-  let metadataToFlush: React.ReactNode = null
-  // Only inserted once to avoid multi insertion on re-renders
-  let inserted = false
-
-  promise.then((resolvedMetadata) => {
-    metadataToFlush = resolvedMetadata
-  })
+  let metadataToFlush: React.ReactNode = use(promise)
 
   useServerInsertedHTML(() => {
-    if (metadataToFlush && !inserted) {
+    if (metadataToFlush) {
       const flushing = metadataToFlush
+      // reset to null to ensure we only flush it once
       metadataToFlush = null
       return flushing
     }
   })
-
-  inserted = true
 
   return null
 }

--- a/test/e2e/app-dir/metadata-streaming/app/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming/app/page.tsx
@@ -3,7 +3,7 @@ export default function Page() {
 }
 
 export async function generateMetadata() {
-  await new Promise((resolve) => setTimeout(resolve, 3 * 1000))
+  await new Promise((resolve) => setTimeout(resolve, 1 * 1000))
   return {
     title: 'index page',
   }

--- a/test/e2e/app-dir/metadata-streaming/app/slow/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming/app/slow/page.tsx
@@ -3,7 +3,7 @@ export default function Page() {
 }
 
 export async function generateMetadata() {
-  await new Promise((resolve) => setTimeout(resolve, 1 * 1000))
+  await new Promise((resolve) => setTimeout(resolve, 3 * 1000))
   return {
     title: 'slow page',
     description: 'slow page description',

--- a/test/e2e/app-dir/metadata-streaming/metadata-streaming-customized-rule.test.ts
+++ b/test/e2e/app-dir/metadata-streaming/metadata-streaming-customized-rule.test.ts
@@ -25,7 +25,8 @@ describe('app-dir - metadata-streaming-customized-rule', () => {
         },
       }
     )
-    expect(await $('title').text()).toBe('index page')
+    expect(await $('head title').text()).toBe('index page')
+    expect(await $('body title').length).toBe(0)
   })
 
   it('should send streaming response for headless browser bots', async () => {
@@ -38,6 +39,7 @@ describe('app-dir - metadata-streaming-customized-rule', () => {
         },
       }
     )
-    expect(await $('title').length).toBe(0)
+    expect(await $('head title').length).toBe(0)
+    expect(await $('body title').length).toBe(1)
   })
 })

--- a/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
+++ b/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
@@ -89,7 +89,7 @@ describe('app-dir - metadata-streaming', () => {
   })
 
   describe('dynamic api', () => {
-    it('should delay metadata with dynamic to body', async () => {
+    it('should render metadata to body', async () => {
       const $ = await next.render$('/dynamic-api')
       expect($('head title').length).toBe(0)
       expect($('body title').length).toBe(1)

--- a/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
+++ b/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
@@ -6,9 +6,10 @@ describe('app-dir - metadata-streaming', () => {
     files: __dirname,
   })
 
-  it('should load the page without delayed metadata', async () => {
+  it('should delay the metadata render to body', async () => {
     const $ = await next.render$('/')
-    expect($('title').length).toBe(0)
+    expect($('head title').length).toBe(0)
+    expect($('body title').length).toBe(1)
   })
 
   it('should still load viewport meta tags even if metadata is delayed', async () => {
@@ -77,20 +78,27 @@ describe('app-dir - metadata-streaming', () => {
 
     // each metadata should be inserted only once
 
-    expect(await browser.hasElementByCssSelector('body meta')).toBe(false)
-    expect(await browser.hasElementByCssSelector('body title')).toBe(false)
+    expect(await browser.hasElementByCssSelector('head title')).toBe(false)
+
+    // only charset and viewport are rendered in head
+    expect((await browser.elementsByCss('head meta')).length).toBe(2)
+    expect((await browser.elementsByCss('body title')).length).toBe(1)
+
+    // all metadata should be rendered in body
+    expect((await browser.elementsByCss('body meta')).length).toBe(9)
   })
 
   describe('dynamic api', () => {
-    it('should only load streaming metadata on client', async () => {
+    it('should delay metadata with dynamic to body', async () => {
       const $ = await next.render$('/dynamic-api')
-      expect($('title').length).toBe(0)
+      expect($('head title').length).toBe(0)
+      expect($('body title').length).toBe(1)
     })
 
     it('should load the metadata in browser', async () => {
       const browser = await next.browser('/dynamic-api')
       await retry(async () => {
-        expect(await browser.elementByCss('title').text()).toMatch(
+        expect(await browser.elementByCss('body title').text()).toMatch(
           /Dynamic api \d+/
         )
       })


### PR DESCRIPTION
### What

@gnoff helped point out that the current implementation of streaming metadata is bit broken as it's missing the metadata in SSR but fully resolved on client. We're seeing it inside the `<head>` is because it's fully resolved by client rather than server, which means it wasn't correctly "streaming" metadata on server side.

We should still `use()` the promise, and let it hit suspense boundary on server so the `<head`> won't contain metadata on server. then when it's finally resolved, it can be emitted through body with the `useServerInsertedHTML` API, and the condition can be much simpler.

Improved the tests with more assertions where we need to differentiate wheather the metadata ended in `head` or `body`

Closes NDX-629