### PR TITLE
[Segment Cache] Remove segment access tokens

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -76,7 +76,6 @@ import { STATIC_STALETIME_MS } from '../router-reducer/prefetch-cache-utils'
 
 export type RouteTree = {
   key: string
-  token: string | null
   segment: FlightRouterStateSegment
   slots: null | {
     [parallelRouteKey: string]: RouteTree
@@ -720,7 +719,6 @@ function convertTreePrefetchToRouteTree(
   }
   return {
     key,
-    token: prefetch.token,
     segment: prefetch.segment,
     slots,
     isRootLayout: prefetch.isRootLayout,
@@ -769,10 +767,6 @@ function convertFlightRouterStateToRouteTree(
 
   return {
     key,
-    // NOTE: Dynamic server responses do not currently include an access token.
-    // (They may in the future.) Which means this tree cannot be used to issue
-    // a per-segment prefetch.
-    token: null,
     segment: flightRouterState[0],
     slots,
     isRootLayout: flightRouterState[4] === true,
@@ -946,8 +940,7 @@ export async function fetchSegmentOnCacheMiss(
   route: FulfilledRouteCacheEntry,
   segmentCacheEntry: PendingSegmentCacheEntry,
   routeKey: RouteCacheKey,
-  segmentKeyPath: string,
-  accessToken: string | null
+  segmentKeyPath: string
 ): Promise<PrefetchSubtaskResult<FulfilledSegmentCacheEntry> | null> {
   // This function is allowed to use async/await because it contains the actual
   // fetch that gets issued on a cache miss. Notice it writes the result to the
@@ -960,7 +953,7 @@ export async function fetchSegmentOnCacheMiss(
   try {
     const response = await fetchSegmentPrefetchResponse(
       href,
-      accessToken === '' ? segmentKeyPath : `${segmentKeyPath}.${accessToken}`,
+      segmentKeyPath,
       routeKey.nextUrl
     )
     if (


### PR DESCRIPTION
Previously I implemented a lightweight "access token" that the client must pass when prefetching a segment. The tokens were a hash of the parent segment path; the idea was to eventually add a secure salt to make the segment path's unguessable. Not for security, really, just as an extra precaution against Denial of Wallet attacks.

However, since we're not doing that yet, the access token as currently implemented doesn't do anything in practice besides add extra bytes to the requests.

The more immediate issue, though, is that because access tokens can't be inferred from the original URL, we need to add something to the prerender manifest so we can rewrite incoming requests to the correct path, which is a bit tricky in the case of parameterized URLs because the parent param values are part of the hash. To add this feature back in the future, we'll need to account for this somehow.

Since this is not an urgent feature, I'm removing it for now.