### PR TITLE
[Segment Cache] Minimize special root key handling

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -953,7 +953,15 @@ export async function fetchSegmentOnCacheMiss(
   try {
     const response = await fetchSegmentPrefetchResponse(
       href,
-      segmentKeyPath,
+      segmentKeyPath === ROOT_SEGMENT_KEY
+        ? // The root segment is a special case. To simplify the server-side
+          // handling of these requests, we encode the root segment path as
+          // `_index` instead of as an empty string. This should be treated as
+          // an implementation detail and not as a stable part of the protocol.
+          // It just needs to match the equivalent logic that happens when
+          // prerendering the responses. It should not leak outside of Next.js.
+          '/_index'
+        : '/' + segmentKeyPath,
       routeKey.nextUrl
     )
     if (

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -217,10 +217,7 @@ export async function exportAppPage(
       for (const [segmentPath, buffer] of segmentData) {
         segmentPaths.push(segmentPath)
         const segmentDataFilePath =
-          segmentPath === '/'
-            ? segmentsDir + '/_index' + RSC_SEGMENT_SUFFIX
-            : segmentsDir + segmentPath + RSC_SEGMENT_SUFFIX
-
+          segmentsDir + segmentPath + RSC_SEGMENT_SUFFIX
         fileWriter.append(segmentDataFilePath, buffer)
       }
     }

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -331,7 +331,11 @@ async function renderSegmentPrefetch(
     }
   )
   const segmentBuffer = await streamToBuffer(segmentStream)
-  return [key, segmentBuffer]
+  if (key === ROOT_SEGMENT_KEY) {
+    return ['/_index', segmentBuffer]
+  } else {
+    return ['/' + key, segmentBuffer]
+  }
 }
 
 async function isPartialRSCData(

--- a/packages/next/src/server/app-render/segment-value-encoding.ts
+++ b/packages/next/src/server/app-render/segment-value-encoding.ts
@@ -30,7 +30,7 @@ export function encodeSegment(
   return encodedName as EncodedSegment
 }
 
-export const ROOT_SEGMENT_KEY = '/'
+export const ROOT_SEGMENT_KEY = ''
 
 export function encodeChildSegmentKey(
   // TODO: Make segment keys an opaque type, too?
@@ -51,9 +51,7 @@ export function encodeChildSegmentKey(
       ? segment
       : `@${encodeToFilesystemAndURLSafeString(parallelRouteKey)}/${segment}`
 
-  return parentSegmentKey === ROOT_SEGMENT_KEY
-    ? '/' + slotKey
-    : parentSegmentKey + '/' + slotKey
+  return parentSegmentKey + '/' + slotKey
 }
 
 // Define a regex pattern to match the most common characters found in a route

--- a/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
@@ -208,9 +208,7 @@ export default class FileSystemCache implements CacheHandler {
             await Promise.all(
               meta.segmentPaths.map(async (segmentPath: string) => {
                 const segmentDataFilePath = this.getFilePath(
-                  segmentPath === '/'
-                    ? segmentsDir + '/_index' + RSC_SEGMENT_SUFFIX
-                    : segmentsDir + segmentPath + RSC_SEGMENT_SUFFIX,
+                  segmentsDir + segmentPath + RSC_SEGMENT_SUFFIX,
                   IncrementalCacheKind.APP_PAGE
                 )
                 try {
@@ -420,10 +418,7 @@ export default class FileSystemCache implements CacheHandler {
           for (const [segmentPath, buffer] of data.segmentData) {
             segmentPaths.push(segmentPath)
             const segmentDataFilePath =
-              segmentPath === '/'
-                ? segmentsDir + '/_index' + RSC_SEGMENT_SUFFIX
-                : segmentsDir + segmentPath + RSC_SEGMENT_SUFFIX
-
+              segmentsDir + segmentPath + RSC_SEGMENT_SUFFIX
             writer.append(segmentDataFilePath, buffer)
           }
         }


### PR DESCRIPTION
The root segment key is a special case: it's an empty string, so that it's not part of any of the child paths, but the response for the root segment itself is written to the filesystem as `_index`. I only did this to make debugging easier; it would be fine to remove the special case such that every segment path begins with `_index`. It's just a bit ugly/redundant.

But my main concern is that the special case handling does not leak outside of Next.js, e.g. into the Vercel builder. We should aim to keep the protocol as simple as possible. (However, I think it'd be fine if it leaked into the prerender manfiest, since that's generated by Next.js itself.)

For now, this moves the special case handling of the root key to as few places as possible: 1) when generating the prefetch responses, and 2) when the client issues a request. In all other places, the segment keys should be treated as arbitrary strings/paths.