### PR TITLE
[Turbopack] remove verbose new backend tracing

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1185,7 +1185,6 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         operation::UpdateOutputOperation::run(task_id, result, self.execute_context(turbo_tasks));
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
     fn task_execution_completed(
         &self,
         task_id: TaskId,


### PR DESCRIPTION
### What?

remove the span that is emitted for every function call as it blows up the tracing

Closes PACK-3783