### PR TITLE
add test case for intercepting route + catchall + generateStaticParams

### DIFF
--- a/test/e2e/app-dir/interception-dynamic-segment/app/@modal/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/@modal/[...catchAll]/page.tsx
@@ -1,0 +1,3 @@
+export default function CatchAll() {
+  return null
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/@modal/generate-static-params/(.)[slug]/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/@modal/generate-static-params/(.)[slug]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'intercepted'
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/generate-static-params/[slug]/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/generate-static-params/[slug]/page.tsx
@@ -1,0 +1,19 @@
+type Props = {
+  params: Promise<{ slug: string }>
+}
+
+export default async function Page({ params }: Props) {
+  const { slug } = await params
+  return <div>Hello {slug}</div>
+}
+
+export function generateStaticParams() {
+  return [
+    { slug: 'a' },
+    { slug: 'b' },
+    { slug: 'c' },
+    { slug: 'd' },
+    { slug: 'e' },
+    { slug: 'f' },
+  ]
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
+++ b/test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
@@ -2,7 +2,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
 describe('interception-dynamic-segment', () => {
-  const { next } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: __dirname,
   })
 
@@ -15,4 +15,13 @@ describe('interception-dynamic-segment', () => {
     await check(() => browser.elementById('modal').text(), '')
     await check(() => browser.elementById('children').text(), /not intercepted/)
   })
+
+  if (isNextStart) {
+    it('should correctly prerender segments with generateStaticParams', async () => {
+      expect(next.cliOutput).toContain('/generate-static-params/a')
+      const res = await next.fetch('/generate-static-params/a')
+      expect(res.status).toBe(200)
+      expect(res.headers.get('x-nextjs-cache')).toBe('HIT')
+    })
+  }
 })


### PR DESCRIPTION
This case is fixed on `canary`, but has a regression on 15.1. This PR adds a test case that succeeds on `canary` but fails on the backport branch. A fix for the backport branch is forthcoming. 