### PR TITLE
chore(turbopack): Mark `ResolvedVc::resolve` as deprecated to prevent resolving an already-resolved ResolvedVc

### DIFF
--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -50,18 +50,21 @@ pub async fn emit_assets(
         .iter()
         .copied()
         .map(|asset| async move {
-            let asset = asset.resolve().await?;
             let path = asset.ident().path();
             let span = tracing::info_span!("emit asset", name = %path.to_string().await?);
             async move {
                 let path = path.await?;
                 Ok(if path.is_inside_ref(&*node_root.await?) {
-                    Some(emit(asset))
+                    Some(emit(*asset))
                 } else if path.is_inside_ref(&*client_relative_path.await?) {
                     // Client assets are emitted to the client output path, which is prefixed
                     // with _next. We need to rebase them to remove that
                     // prefix.
-                    Some(emit_rebase(asset, client_relative_path, client_output_path))
+                    Some(emit_rebase(
+                        *asset,
+                        client_relative_path,
+                        client_output_path,
+                    ))
                 } else {
                     None
                 })

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -275,8 +275,6 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
             ]);
         };
 
-        let result = result.resolve().await?;
-        let result_from_original_location = result_from_original_location.resolve().await?;
         if result_from_original_location != result {
             let package_json_file = find_context_file(
                 result.ident().path().parent().resolve().await?,

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -73,13 +73,20 @@ where
     pub(crate) node: Vc<T>,
 }
 
-impl<T> ResolvedVc<T> {
+impl<T> ResolvedVc<T>
+where
+    T: ?Sized,
+{
     /// This function exists to intercept calls to Vc::to_resolved through dereferencing
     /// a ResolvedVc. Converting to Vc and re-resolving it puts unnecessary stress on
     /// the turbo tasks engine.
     #[deprecated(note = "No point in resolving a vc that is already resolved")]
     pub async fn to_resolved(self) -> Result<Self> {
         Ok(self)
+    }
+    #[deprecated(note = "No point in resolving a vc that is already resolved")]
+    pub async fn resolve(self) -> Result<Vc<T>> {
+        Ok(self.node)
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
@@ -70,10 +70,9 @@ impl EcmascriptChunkItem for EcmascriptModuleFacadeChunkItem {
         let references = self.module.references();
         let references_ref = references.await?;
         let mut code_gens = Vec::with_capacity(references_ref.len() + 2);
-        for r in references_ref.iter() {
-            let r = r.resolve().await?;
+        for r in &references_ref {
             if let Some(code_gen) =
-                Vc::try_resolve_sidecast::<Box<dyn CodeGenerateableWithAsyncModuleInfo>>(r).await?
+                ResolvedVc::try_sidecast_sync::<Box<dyn CodeGenerateableWithAsyncModuleInfo>>(*r)
             {
                 code_gens.push(code_gen.code_generation(
                     *self.module_graph,
@@ -81,7 +80,7 @@ impl EcmascriptChunkItem for EcmascriptModuleFacadeChunkItem {
                     async_module_info,
                 ));
             } else if let Some(code_gen) =
-                Vc::try_resolve_sidecast::<Box<dyn CodeGenerateable>>(r).await?
+                ResolvedVc::try_sidecast_sync::<Box<dyn CodeGenerateable>>(*r)
             {
                 code_gens.push(code_gen.code_generation(*self.module_graph, *chunking_context));
             }

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -285,7 +285,7 @@ pub async fn resolve_node_gyp_build_files(
                 if let Some(captured) =
                     GYP_BUILD_TARGET_NAME.captures(&config_file.content().to_str()?)
                 {
-                    let mut resolved: FxIndexMap<RcStr, Vc<Box<dyn Source>>> =
+                    let mut resolved: FxIndexMap<RcStr, ResolvedVc<Box<dyn Source>>> =
                         FxIndexMap::with_capacity_and_hasher(captured.len(), Default::default());
                     for found in captured.iter().skip(1).flatten() {
                         let name = found.as_str();
@@ -299,10 +299,7 @@ pub async fn resolve_node_gyp_build_files(
                         if let Some((_, ResolveResultItem::Source(source))) =
                             resolved_prebuilt_file.primary.first()
                         {
-                            resolved.insert(
-                                format!("build/Release/{name}.node").into(),
-                                source.resolve().await?,
-                            );
+                            resolved.insert(format!("build/Release/{name}.node").into(), *source);
                             merged_affecting_sources
                                 .extend(resolved_prebuilt_file.affecting_sources.iter().copied());
                         }
@@ -315,7 +312,7 @@ pub async fn resolve_node_gyp_build_files(
                                     Ok((
                                         RequestKey::new(key),
                                         ResolvedVc::upcast(
-                                            RawModule::new(source).to_resolved().await?,
+                                            RawModule::new(*source).to_resolved().await?,
                                         ),
                                     ))
                                 })

--- a/turbopack/crates/turbopack/src/graph/mod.rs
+++ b/turbopack/crates/turbopack/src/graph/mod.rs
@@ -45,18 +45,17 @@ impl AggregatedGraph {
 
     #[turbo_tasks::function]
     async fn references(self: Vc<Self>) -> Result<Vc<AggregatedGraphsSet>> {
-        Ok(match *self.await? {
+        Ok(match &*self.await? {
             AggregatedGraph::Leaf(asset) => {
                 let mut refs = HashSet::new();
-                for reference in asset.references().await?.iter() {
-                    let reference = reference.resolve().await?;
-                    if asset != reference.to_resolved().await? {
-                        refs.insert(AggregatedGraph::leaf(reference).to_resolved().await?);
+                for reference in asset.references().await? {
+                    if asset != reference {
+                        refs.insert(AggregatedGraph::leaf(**reference).to_resolved().await?);
                     }
                 }
                 AggregatedGraphsSet { set: refs }.into()
             }
-            AggregatedGraph::Node { ref references, .. } => {
+            AggregatedGraph::Node { references, .. } => {
                 let mut set = HashSet::new();
                 for item in references
                     .iter()


### PR DESCRIPTION
Same as we were already doing for `ResolvedVc::to_resolved`.

This function essentially just acts like a deref when called on `ResolvedVc`.

I'd eventually like to replace `Vc::resolve` with `Vc::to_resolved`. These are the easiest callsites to remove.

Closes PACK-3787