### PR TITLE
backport: fix prerender issue with intercepting routes + generateStaticParams

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1289,18 +1289,8 @@ export async function buildAppStaticPaths({
     minimalMode: ciEnvironment.hasNextSupport,
   })
 
-  const paramKeys = new Set<string>()
-
-  const staticParamKeys = new Set<string>()
-  for (const segment of segments) {
-    if (segment.param) {
-      paramKeys.add(segment.param)
-
-      if (segment.config?.dynamicParams === false) {
-        staticParamKeys.add(segment.param)
-      }
-    }
-  }
+  const regex = getRouteRegex(page)
+  const paramKeys = Object.keys(getRouteMatcher(regex)(page) || {})
 
   const afterRunner = new AfterRunner()
 
@@ -1417,7 +1407,7 @@ export async function buildAppStaticPaths({
   // Determine if all the segments have had their parameters provided. If there
   // was no dynamic parameters, then we've collected all the params.
   const hadAllParamsGenerated =
-    paramKeys.size === 0 ||
+    paramKeys.length === 0 ||
     (routeParams.length > 0 &&
       routeParams.every((params) => {
         for (const key of paramKeys) {

--- a/test/e2e/app-dir/interception-dynamic-segment/app/@modal/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/@modal/[...catchAll]/page.tsx
@@ -1,0 +1,3 @@
+export default function CatchAll() {
+  return null
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/@modal/generate-static-params/(.)[slug]/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/@modal/generate-static-params/(.)[slug]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'intercepted'
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/generate-static-params/[slug]/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/generate-static-params/[slug]/page.tsx
@@ -1,0 +1,19 @@
+type Props = {
+  params: Promise<{ slug: string }>
+}
+
+export default async function Page({ params }: Props) {
+  const { slug } = await params
+  return <div>Hello {slug}</div>
+}
+
+export function generateStaticParams() {
+  return [
+    { slug: 'a' },
+    { slug: 'b' },
+    { slug: 'c' },
+    { slug: 'd' },
+    { slug: 'e' },
+    { slug: 'f' },
+  ]
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
+++ b/test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
@@ -2,7 +2,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
 describe('interception-dynamic-segment', () => {
-  const { next } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: __dirname,
   })
 
@@ -15,4 +15,13 @@ describe('interception-dynamic-segment', () => {
     await check(() => browser.elementById('modal').text(), '')
     await check(() => browser.elementById('children').text(), /not intercepted/)
   })
+
+  if (isNextStart) {
+    it('should correctly prerender segments with generateStaticParams', async () => {
+      expect(next.cliOutput).toContain('/generate-static-params/a')
+      const res = await next.fetch('/generate-static-params/a')
+      expect(res.status).toBe(200)
+      expect(res.headers.get('x-nextjs-cache')).toBe('HIT')
+    })
+  }
 })


### PR DESCRIPTION
Backports the testcase added in https://github.com/vercel/next.js/pull/75167 in [9bf61bc](https://github.com/vercel/next.js/pull/75170/commits/9bf61bc76c25f3eb345aac7db34929ecde232569).

Confirmed failure via [this run](https://github.com/vercel/next.js/actions/runs/12898849331/job/35966678688?pr=75170)

Adds the fix in [0ab1e32](https://github.com/vercel/next.js/pull/75170/commits/0ab1e32f04f09de2b2651b7e889633e43f4834a2). This change is identical to the code used in canary, which was added as part of the `rootParams` feature via https://github.com/vercel/next.js/pull/73816 ([ref](https://github.com/vercel/next.js/blob/d12e2e82b778eef8393f47944a258a55c6c508fe/packages/next/src/build/static-paths/app.ts#L316-L317))

This regression was caused by `segments` containing all possible segments (including parallel routes), not just the page segment. As a result, `paramKeys` was incorrectly being calculated from non-page segments. We don't need to traverse the segments to determine the param keys: we have the route regex & matcher, it's more reliable to extract it from that. 