### PR TITLE
chore(turbo-tasks): Clean up consistency/untracked APIs around local outputs and cells

### DIFF
--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -248,18 +248,8 @@ impl TurboTasksApi for VcStorage {
 
     fn try_read_local_output(
         &self,
-        parent_task_id: TaskId,
-        local_task_id: LocalTaskId,
-        consistency: ReadConsistency,
-    ) -> Result<Result<RawVc, EventListener>> {
-        self.try_read_local_output_untracked(parent_task_id, local_task_id, consistency)
-    }
-
-    fn try_read_local_output_untracked(
-        &self,
         _parent_task_id: TaskId,
         _local_task_id: LocalTaskId,
-        _consistency: ReadConsistency,
     ) -> Result<Result<RawVc, EventListener>> {
         unimplemented!()
     }


### PR DESCRIPTION
We only read data owned by the the currently-executing task when reading from a local Vc, so:
- A separate "untracked" API doesn't make sense. There's never any tracking needed for reading local outputs or cells. (would we mark the current task as dependent on itself?)
- Allowing a `consistency` argument isn't useful because you can't strongly consistently await your own task.
- We don't need to call `notify_scheduled_tasks`, we're not adding any new task dependencies.

Closes PACK-3815