### PR TITLE
docs: add typescript switcher to logging.mdx

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/logging.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/logging.mdx
@@ -13,7 +13,21 @@ You can configure the logging level and whether the full URL is logged to the co
 
 Currently, `logging` only applies to data fetching using the `fetch` API. It does not yet apply to other logs inside of Next.js.
 
-```js filename="next.config.js"
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  logging: {
+    fetches: {
+      fullUrl: true,
+    },
+  },
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" switcher
 module.exports = {
   logging: {
     fetches: {
@@ -25,7 +39,21 @@ module.exports = {
 
 Any `fetch` requests that are restored from the [Server Components HMR cache](/docs/app/api-reference/config/next-config-js/serverComponentsHmrCache) are not logged by default. However, this can be enabled by setting `logging.fetches.hmrRefreshes` to `true`.
 
-```js filename="next.config.js"
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  logging: {
+    fetches: {
+      hmrRefreshes: true,
+    },
+  },
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" switcher
 module.exports = {
   logging: {
     fetches: {
@@ -40,7 +68,21 @@ module.exports = {
 By default all the incoming requests will be logged in the console during development. You can use the `incomingRequests` option to decide which requests to ignore.
 Since this is only logged in development, this option doesn't affect production builds.
 
-```js filename="next.config.js"
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  logging: {
+    incomingRequests: {
+      ignore: [/\api\/v1\/health/],
+    },
+  },
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" switcher
 module.exports = {
   logging: {
     incomingRequests: {
@@ -52,7 +94,19 @@ module.exports = {
 
 Or you can disable incoming request logging by setting `incomingRequests` to `false`.
 
-```js filename="next.config.js"
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  logging: {
+    incomingRequests: false,
+  },
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" switcher
 module.exports = {
   logging: {
     incomingRequests: false,
@@ -64,7 +118,17 @@ module.exports = {
 
 In addition, you can disable the development logging by setting `logging` to `false`.
 
-```js filename="next.config.js"
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  logging: false,
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" switcher
 module.exports = {
   logging: false,
 }


### PR DESCRIPTION
## Summary

Follow up #74349.
Add `next.config.ts` code block to [logging docs](https://nextjs.org/docs/app/api-reference/config/next-config-js/logging).

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide