### PR TITLE
chore(tests): Remove linguist-generated git attribute from test snapshot data/fixtures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,11 +3,3 @@ packages/next/compiled/** -text linguist-vendored
 
 # Make next/src/build folder indexable for github search
 build/** linguist-generated=false
-
-crates/next-custom-transforms/tests/fixture/**/output* linguist-generated=true
-
-turbopack/crates/turbo-tasks-macros-tests/tests/**/*.stderr linguist-generated=true
-turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/**/output.md linguist-generated=true
-turbopack/crates/turbopack-tests/tests/snapshot/**/output/** linguist-generated=true
-
-**/__snapshots__/** linguist-generated=true


### PR DESCRIPTION
Based on the results of this poll: https://vercel.slack.com/archives/C04KC8A53T7/p1734380259031279

> In my experience these fixtures need to be carefully reviewed, same as the code that changed them. Collapsing them by default will make this more difficult and possibly error-prone.

Closes PACK-3789