### PR TITLE
[Turbopack] fix invalidation and counting with collectibles

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -204,14 +204,6 @@ impl AggregatedDataUpdate {
                 collectibles_update.push((collectible, 1));
             }
         }
-        collectibles_update.extend(iter_many!(
-            task,
-            Collectible {
-                collectible
-            } count => {
-                (collectible, *count)
-            }
-        ));
         if let Some(dirty) = get!(task, Dirty) {
             dirty_container_count.update_with_dirty_state(dirty);
         }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -203,15 +203,15 @@ impl AggregatedDataUpdate {
             for collectible in collectibles {
                 collectibles_update.push((collectible, 1));
             }
-            collectibles_update.extend(iter_many!(
-                task,
-                Collectible {
-                    collectible
-                } count => {
-                    (collectible, *count)
-                }
-            ));
         }
+        collectibles_update.extend(iter_many!(
+            task,
+            Collectible {
+                collectible
+            } count => {
+                (collectible, *count)
+            }
+        ));
         if let Some(dirty) = get!(task, Dirty) {
             dirty_container_count.update_with_dirty_state(dirty);
         }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -1,5 +1,6 @@
 use std::mem::take;
 
+use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::TaskId;
 
@@ -7,7 +8,7 @@ use turbo_tasks::TaskId;
 use crate::backend::operation::invalidate::TaskDirtyCause;
 use crate::{
     backend::{
-        get,
+        get, get_many,
         operation::{
             aggregation_update::{
                 get_aggregation_number, get_uppers, is_aggregating_node, AggregationUpdateJob,
@@ -120,7 +121,7 @@ impl Operation for CleanupOldEdgesOperation {
                                     _ => true,
                                 });
                                 let mut task = ctx.task(task_id, TaskDataCategory::All);
-                                let mut emptied_collectables = HashSet::new();
+                                let mut emptied_collectables = FxHashSet::default();
                                 for (collectible, count) in collectibles.iter_mut() {
                                     if update_count!(
                                         task,


### PR DESCRIPTION
### What?

* invalidate tasks when collectibles change
* fix bug where collectibles are double counted


Closes PACK-3790