### PR TITLE
chore(github): remove Developer Experience area

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -80,7 +80,6 @@ body:
       options:
         - 'Not sure'
         - 'create-next-app'
-        - 'Developer Experience'
         - 'dynamicIO'
         - 'Lazy Loading'
         - 'Font (next/font)'


### PR DESCRIPTION
## Why?

The label is too broad and provides little help in filtering issues properly.