### PR TITLE
chore(github): add CSS area/label

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -80,6 +80,7 @@ body:
       options:
         - 'Not sure'
         - 'create-next-app'
+        - 'CSS'
         - 'dynamicIO'
         - 'Lazy Loading'
         - 'Font (next/font)'


### PR DESCRIPTION
## Why?

We should just use `CSS` instead of mixing `Webpack` and `Turbopack` issues together with "CSS" issues.