### PR TITLE
[Segment Cache] Prioritize route trees over segments

### DIFF
--- a/test/e2e/app-dir/segment-cache/prefetch-scheduling/app/cancellation/[pageNumber]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-scheduling/app/cancellation/[pageNumber]/page.tsx
@@ -4,6 +4,19 @@ type Params = {
   pageNumber: string
 }
 
+export async function generateViewport({
+  params,
+}: {
+  params: Promise<Params>
+}) {
+  const { pageNumber } = await params
+  return {
+    // Put the page number into the media query. This is just a trick to allow
+    // the test to detect when the viewport for this page has been prefetched.
+    themeColor: [{ media: `(min-width: ${pageNumber}px)`, color: 'light' }],
+  }
+}
+
 async function Content({ params }: { params: Promise<Params> }) {
   const { pageNumber } = await params
   return 'Content of page ' + pageNumber
@@ -23,7 +36,7 @@ export default async function LinkCancellationTargetPage({
 
 export async function generateStaticParams(): Promise<Array<Params>> {
   const result: Array<Params> = []
-  for (let n = 1; n <= 1; n++) {
+  for (let n = 1; n <= 10; n++) {
     result.push({ pageNumber: n.toString() })
   }
   return result


### PR DESCRIPTION
When processing the prefetch queue, we should prioritize fetching the route trees for all the links before we fetch any of the segments.

The reason the route tree is more important is because it tells us the structure of the target page; from this alone, we can determine which segments are already cached and skip them during the navigation. Whereas if the route tree is missing at the time of the navigation, we cannot instruct the server to skip over prefetched segments, because we don't know which ones to skip.

To implement this, I added a `phase` property to the PrefetchTask type. This is essentially a secondary priority field that changes as the task progresses. There are two phases: `RouteTree` and `Segments`. Any task in the `RouteTree` phase has higher priority than tasks in the `Segments` phase.

Another way to implement this would be to add a secondary queue for segment prefetches. This would require reference counting to clean up segments when there are no more tasks that depend on them. The ref count could also be used as an additional prioritization heuristic: shared layouts with many dependent tasks could be prioritized over segments with fewer. However, I'm not sure the benefits are worth the extra code/complexity, so I'm starting with this simpler approach.