### PR TITLE
chore(turbo-tasks): Remove argument resolution from backends, only allow local-task-based argument resolution

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -866,7 +866,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             panic!(
                 "Calling transient function {} from persistent function function {} is not allowed",
                 task_type.get_name(),
-                parent_task_type.map_or_else(|| "unknown".into(), |t| t.get_name())
+                parent_task_type.map_or("unknown", |t| t.get_name())
             );
         }
         if let Some(task_id) = self.task_cache.lookup_forward(&task_type) {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -963,10 +963,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
     fn try_get_function_id(&self, task_id: TaskId) -> Option<FunctionId> {
         self.lookup_task_type(task_id)
-            .and_then(|task_type| match &*task_type {
-                CachedTaskType::Native { fn_type, .. } => Some(*fn_type),
-                _ => None,
-            })
+            .map(|task_type| task_type.fn_type)
     }
 
     fn try_start_task_execution(
@@ -1105,64 +1102,13 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         }
 
         let (span, future) = match task_type {
-            TaskType::Cached(task_type) => match &*task_type {
-                CachedTaskType::Native { fn_type, this, arg } => (
+            TaskType::Cached(task_type) => {
+                let CachedTaskType { fn_type, this, arg } = &*task_type;
+                (
                     registry::get_function(*fn_type).span(task_id.persistence()),
                     registry::get_function(*fn_type).execute(*this, &**arg),
-                ),
-                CachedTaskType::ResolveNative { fn_type, .. } => {
-                    let span = registry::get_function(*fn_type).resolve_span(task_id.persistence());
-                    let turbo_tasks = turbo_tasks.pin();
-                    (
-                        span,
-                        Box::pin(async move {
-                            let CachedTaskType::ResolveNative { fn_type, this, arg } = &*task_type
-                            else {
-                                unreachable!()
-                            };
-                            CachedTaskType::run_resolve_native(
-                                *fn_type,
-                                *this,
-                                &**arg,
-                                task_id.persistence(),
-                                turbo_tasks,
-                            )
-                            .await
-                        }) as Pin<Box<dyn Future<Output = _> + Send + '_>>,
-                    )
-                }
-                CachedTaskType::ResolveTrait {
-                    trait_type,
-                    method_name,
-                    ..
-                } => {
-                    let span = registry::get_trait(*trait_type).resolve_span(method_name);
-                    let turbo_tasks = turbo_tasks.pin();
-                    (
-                        span,
-                        Box::pin(async move {
-                            let CachedTaskType::ResolveTrait {
-                                trait_type,
-                                method_name,
-                                this,
-                                arg,
-                            } = &*task_type
-                            else {
-                                unreachable!()
-                            };
-                            CachedTaskType::run_resolve_trait(
-                                *trait_type,
-                                method_name.clone(),
-                                *this,
-                                &**arg,
-                                task_id.persistence(),
-                                turbo_tasks,
-                            )
-                            .await
-                        }) as Pin<Box<dyn Future<Output = _> + Send + '_>>,
-                    )
-                }
-            },
+                )
+            }
             TaskType::Transient(task_type) => {
                 let task_type = task_type.clone();
                 let span = tracing::trace_span!("turbo_tasks::root_task");

--- a/turbopack/crates/turbo-tasks-memory/src/task.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/task.rs
@@ -602,7 +602,7 @@ impl Task {
         aggregation_context.apply_queued_updates();
     }
 
-    pub(crate) fn get_function_name(&self) -> Option<Cow<'static, str>> {
+    pub(crate) fn get_function_name(&self) -> Option<&'static str> {
         if let TaskType::Persistent { ty, .. } | TaskType::Transient { ty, .. } = &self.ty {
             Some(ty.get_name())
         } else {
@@ -743,7 +743,7 @@ impl Task {
                     )
                 }
             };
-            self.make_execution_future(backend, turbo_tasks)
+            self.make_execution_future()
         };
         aggregation_context.apply_queued_updates();
         Some(TaskExecutionSpec { future, span })
@@ -752,8 +752,6 @@ impl Task {
     /// Prepares task execution and returns a future that will execute the task.
     fn make_execution_future<'a>(
         self: &'a Task,
-        _backend: &MemoryBackend,
-        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) -> (
         Pin<Box<dyn Future<Output = Result<RawVc>> + Send + 'a>>,
         Span,
@@ -766,58 +764,19 @@ impl Task {
                 mutex.lock().take().expect("Task can only be executed once"),
                 tracing::trace_span!("turbo_tasks::once_task"),
             ),
-            TaskType::Persistent { ty, .. } | TaskType::Transient { ty, .. } => match &***ty {
-                CachedTaskType::Native {
+            TaskType::Persistent { ty, .. } | TaskType::Transient { ty, .. } => {
+                let CachedTaskType {
                     fn_type: native_fn_id,
                     this,
                     arg,
-                } => {
-                    let func = registry::get_function(*native_fn_id);
-                    let span = func.span(self.id.persistence());
-                    let entered = span.enter();
-                    let future = func.execute(*this, &**arg);
-                    drop(entered);
-                    (future, span)
-                }
-                CachedTaskType::ResolveNative {
-                    fn_type: native_fn_id,
-                    this,
-                    arg,
-                } => {
-                    let func = registry::get_function(*native_fn_id);
-                    let span = func.resolve_span(self.id.persistence());
-                    let entered = span.enter();
-                    let future = Box::pin(CachedTaskType::run_resolve_native(
-                        *native_fn_id,
-                        *this,
-                        &**arg,
-                        self.id.persistence(),
-                        turbo_tasks.pin(),
-                    ));
-                    drop(entered);
-                    (future, span)
-                }
-                CachedTaskType::ResolveTrait {
-                    trait_type: trait_type_id,
-                    method_name: name,
-                    this,
-                    arg,
-                } => {
-                    let trait_type = registry::get_trait(*trait_type_id);
-                    let span = trait_type.resolve_span(name);
-                    let entered = span.enter();
-                    let future = Box::pin(CachedTaskType::run_resolve_trait(
-                        *trait_type_id,
-                        name.clone(),
-                        *this,
-                        &**arg,
-                        self.id.persistence(),
-                        turbo_tasks.pin(),
-                    ));
-                    drop(entered);
-                    (future, span)
-                }
-            },
+                } = &***ty;
+                let func = registry::get_function(*native_fn_id);
+                let span = func.span(self.id.persistence());
+                let entered = span.enter();
+                let future = func.execute(*this, &**arg);
+                drop(entered);
+                (future, span)
+            }
         }
     }
 

--- a/turbopack/crates/turbo-tasks-memory/tests/task_statistics.rs
+++ b/turbopack/crates/turbo-tasks-memory/tests/task_statistics.rs
@@ -186,13 +186,13 @@ async fn test_no_execution() {
     .await;
 }
 
-// Internally, this function uses `CachedTaskType::Native`.
+// Internally, this function uses `PersistentTaskType`.
 #[turbo_tasks::function]
 fn double(val: u64) -> Vc<u64> {
     Vc::cell(val * 2)
 }
 
-// Internally, this function uses `CachedTaskType::ResolveNative`.
+// Internally, this function uses `LocalTaskType::ResolveNative`.
 #[turbo_tasks::function]
 async fn double_vc(val: Vc<u64>) -> Result<Vc<u64>> {
     let val = *val.await?;

--- a/turbopack/crates/turbo-tasks/Cargo.toml
+++ b/turbopack/crates/turbo-tasks/Cargo.toml
@@ -9,10 +9,8 @@ edition = "2021"
 bench = false
 
 [features]
-default = ["local_resolution"]
 tokio_tracing = ["tokio/tracing"]
 hanging_detection = []
-local_resolution = []
 
 # TODO(bgw): This feature is here to unblock turning on local tasks by default. It's only turned on
 # in unit tests. This will be removed very soon.

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -249,14 +249,12 @@ mod ser {
             S: ser::Serializer,
         {
             let CachedTaskType { fn_type, this, arg } = self;
-            let mut s = serializer.serialize_tuple(4)?;
+            let mut s = serializer.serialize_tuple(2)?;
             s.serialize_element(&FunctionAndArg::Borrowed {
                 fn_type: *fn_type,
                 arg: &**arg,
             })?;
             s.serialize_element(this)?;
-            s.serialize_element(&())?;
-            s.serialize_element(&())?;
             s.end()
         }
     }
@@ -284,16 +282,10 @@ mod ser {
                     let this = seq
                         .next_element()?
                         .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
-                    let () = seq
-                        .next_element()?
-                        .ok_or_else(|| serde::de::Error::invalid_length(2, &self))?;
-                    let () = seq
-                        .next_element()?
-                        .ok_or_else(|| serde::de::Error::invalid_length(3, &self))?;
                     Ok(CachedTaskType { fn_type, this, arg })
                 }
             }
-            deserializer.deserialize_tuple(4, Visitor)
+            deserializer.deserialize_tuple(2, Visitor)
         }
     }
 }

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -1,10 +1,9 @@
 use std::{
     borrow::Cow,
-    fmt::{self, Debug, Display, Write},
+    fmt::{self, Debug, Display},
     future::Future,
     hash::BuildHasherDefault,
     pin::Pin,
-    sync::Arc,
     time::Duration,
 };
 
@@ -21,10 +20,9 @@ use crate::{
     raw_vc::CellId,
     registry,
     task::shared_reference::TypedSharedReference,
-    trait_helpers::{get_trait_method, has_trait, traits},
     triomphe_utils::unchecked_sidecast_triomphe_arc,
-    FunctionId, RawVc, ReadRef, SharedReference, TaskId, TaskIdSet, TaskPersistence, TraitRef,
-    TraitTypeId, ValueTypeId, VcRead, VcValueTrait, VcValueType,
+    FunctionId, RawVc, ReadRef, SharedReference, TaskId, TaskIdSet, TraitRef, TraitTypeId,
+    ValueTypeId, VcRead, VcValueTrait, VcValueType,
 };
 
 pub type TransientTaskRoot =
@@ -59,38 +57,32 @@ impl Debug for TransientTaskType {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Hash)]
-pub enum CachedTaskType {
-    /// A normal task execution a native (rust) function
-    Native {
-        fn_type: FunctionId,
-        this: Option<RawVc>,
-        arg: Box<dyn MagicAny>,
-    },
-
-    /// A resolve task, which resolves arguments and calls the function with
-    /// resolve arguments. The inner function call will do a cache lookup.
-    ResolveNative {
-        fn_type: FunctionId,
-        this: Option<RawVc>,
-        arg: Box<dyn MagicAny>,
-    },
-
-    /// A trait method resolve task. It resolves the first (`self`) argument and
-    /// looks up the trait method on that value. Then it calls that method.
-    /// The method call will do a cache lookup and might resolve arguments
-    /// before.
-    ResolveTrait {
-        trait_type: TraitTypeId,
-        method_name: Cow<'static, str>,
-        this: RawVc,
-        arg: Box<dyn MagicAny>,
-    },
+/// A normal task execution containing a native (rust) function. This type is passed into the
+/// backend either to execute a function or to look up a cached result.
+#[derive(Debug, Eq, Hash)]
+pub struct CachedTaskType {
+    pub fn_type: FunctionId,
+    pub this: Option<RawVc>,
+    pub arg: Box<dyn MagicAny>,
 }
 
-impl Display for CachedTaskType {
+impl CachedTaskType {
+    pub fn get_name(&self) -> &'static str {
+        &registry::get_function(self.fn_type).name
+    }
+}
+
+// Manual implementation is needed because of a borrow issue with `Box<dyn Trait>`:
+// https://github.com/rust-lang/rust/issues/31740
+impl PartialEq for CachedTaskType {
+    fn eq(&self, other: &Self) -> bool {
+        self.fn_type == other.fn_type && self.this == other.this && &self.arg == &other.arg
+    }
+}
+
+impl fmt::Display for CachedTaskType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.get_name())
+        f.write_str(self.get_name())
     }
 }
 
@@ -217,7 +209,7 @@ mod ser {
                 type Value = FunctionAndArg<'de>;
 
                 fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                    write!(formatter, "a valid CachedTaskType")
+                    write!(formatter, "a valid FunctionAndArg")
                 }
 
                 fn visit_seq<A>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error>
@@ -245,53 +237,16 @@ mod ser {
         where
             S: ser::Serializer,
         {
-            match self {
-                CachedTaskType::Native { fn_type, this, arg } => {
-                    let mut s = serializer.serialize_tuple(5)?;
-                    s.serialize_element::<u8>(&0)?;
-                    s.serialize_element(&FunctionAndArg::Borrowed {
-                        fn_type: *fn_type,
-                        arg: &**arg,
-                    })?;
-                    s.serialize_element(this)?;
-                    s.serialize_element(&())?;
-                    s.serialize_element(&())?;
-                    s.end()
-                }
-                CachedTaskType::ResolveNative { fn_type, this, arg } => {
-                    let mut s = serializer.serialize_tuple(5)?;
-                    s.serialize_element::<u8>(&1)?;
-                    s.serialize_element(&FunctionAndArg::Borrowed {
-                        fn_type: *fn_type,
-                        arg: &**arg,
-                    })?;
-                    s.serialize_element(this)?;
-                    s.serialize_element(&())?;
-                    s.serialize_element(&())?;
-                    s.end()
-                }
-                CachedTaskType::ResolveTrait {
-                    trait_type,
-                    method_name,
-                    this,
-                    arg,
-                } => {
-                    let mut s = serializer.serialize_tuple(5)?;
-                    s.serialize_element::<u8>(&2)?;
-                    s.serialize_element(trait_type)?;
-                    s.serialize_element(method_name)?;
-                    s.serialize_element(this)?;
-                    let arg = if let Some(method) =
-                        registry::get_trait(*trait_type).methods.get(method_name)
-                    {
-                        method.arg_serializer.as_serialize(&**arg)
-                    } else {
-                        return Err(serde::ser::Error::custom("Method not found"));
-                    };
-                    s.serialize_element(arg)?;
-                    s.end()
-                }
-            }
+            let CachedTaskType { fn_type, this, arg } = self;
+            let mut s = serializer.serialize_tuple(4)?;
+            s.serialize_element(&FunctionAndArg::Borrowed {
+                fn_type: *fn_type,
+                arg: &**arg,
+            })?;
+            s.serialize_element(this)?;
+            s.serialize_element(&())?;
+            s.serialize_element(&())?;
+            s.end()
         }
     }
 
@@ -302,118 +257,32 @@ mod ser {
                 type Value = CachedTaskType;
 
                 fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                    write!(formatter, "a valid CachedTaskType")
+                    write!(formatter, "a valid PersistentTaskType")
                 }
 
                 fn visit_seq<A>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error>
                 where
                     A: serde::de::SeqAccess<'de>,
                 {
-                    let kind = seq
-                        .next_element::<u8>()?
-                        .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
-                    match kind {
-                        0 => {
-                            let FunctionAndArg::Owned { fn_type, arg } = seq
-                                .next_element()?
-                                .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?
-                            else {
-                                unreachable!();
-                            };
-                            let this = seq
-                                .next_element()?
-                                .ok_or_else(|| serde::de::Error::invalid_length(2, &self))?;
-                            let () = seq
-                                .next_element()?
-                                .ok_or_else(|| serde::de::Error::invalid_length(3, &self))?;
-                            let () = seq
-                                .next_element()?
-                                .ok_or_else(|| serde::de::Error::invalid_length(4, &self))?;
-                            Ok(CachedTaskType::Native { fn_type, this, arg })
-                        }
-                        1 => {
-                            let FunctionAndArg::Owned { fn_type, arg } = seq
-                                .next_element()?
-                                .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?
-                            else {
-                                unreachable!();
-                            };
-                            let this = seq
-                                .next_element()?
-                                .ok_or_else(|| serde::de::Error::invalid_length(2, &self))?;
-                            let () = seq
-                                .next_element()?
-                                .ok_or_else(|| serde::de::Error::invalid_length(3, &self))?;
-                            let () = seq
-                                .next_element()?
-                                .ok_or_else(|| serde::de::Error::invalid_length(4, &self))?;
-                            Ok(CachedTaskType::ResolveNative { fn_type, this, arg })
-                        }
-                        2 => {
-                            let trait_type = seq
-                                .next_element()?
-                                .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
-                            let method_name = seq
-                                .next_element()?
-                                .ok_or_else(|| serde::de::Error::invalid_length(2, &self))?;
-                            let this = seq
-                                .next_element()?
-                                .ok_or_else(|| serde::de::Error::invalid_length(3, &self))?;
-                            let Some(method) =
-                                registry::get_trait(trait_type).methods.get(&method_name)
-                            else {
-                                return Err(serde::de::Error::custom("Method not found"));
-                            };
-                            let arg = seq
-                                .next_element_seed(method.arg_deserializer)?
-                                .ok_or_else(|| serde::de::Error::invalid_length(4, &self))?;
-                            Ok(CachedTaskType::ResolveTrait {
-                                trait_type,
-                                method_name,
-                                this,
-                                arg,
-                            })
-                        }
-                        _ => Err(serde::de::Error::custom("Invalid variant")),
-                    }
+                    let FunctionAndArg::Owned { fn_type, arg } = seq
+                        .next_element()?
+                        .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?
+                    else {
+                        unreachable!();
+                    };
+                    let this = seq
+                        .next_element()?
+                        .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
+                    let () = seq
+                        .next_element()?
+                        .ok_or_else(|| serde::de::Error::invalid_length(2, &self))?;
+                    let () = seq
+                        .next_element()?
+                        .ok_or_else(|| serde::de::Error::invalid_length(3, &self))?;
+                    Ok(CachedTaskType { fn_type, this, arg })
                 }
             }
-            deserializer.deserialize_tuple(5, Visitor)
-        }
-    }
-}
-
-impl CachedTaskType {
-    /// Returns the name of the function in the code. Trait methods are
-    /// formatted as `TraitName::method_name`.
-    ///
-    /// Equivalent to [`ToString::to_string`], but potentially more efficient as
-    /// it can return a `&'static str` in many cases.
-    pub fn get_name(&self) -> Cow<'static, str> {
-        match self {
-            Self::Native {
-                fn_type: native_fn,
-                this: _,
-                arg: _,
-            } => Cow::Borrowed(&registry::get_function(*native_fn).name),
-            Self::ResolveNative {
-                fn_type: native_fn,
-                this: _,
-                arg: _,
-            } => format!("*{}", registry::get_function(*native_fn).name).into(),
-            Self::ResolveTrait {
-                trait_type: trait_id,
-                method_name: fn_name,
-                this: _,
-                arg: _,
-            } => format!("*{}::{}", registry::get_trait(*trait_id).name, fn_name).into(),
-        }
-    }
-
-    pub fn try_get_function_id(&self) -> Option<FunctionId> {
-        match self {
-            Self::Native { fn_type, .. } | Self::ResolveNative { fn_type, .. } => Some(*fn_type),
-            Self::ResolveTrait { .. } => None,
+            deserializer.deserialize_tuple(4, Visitor)
         }
     }
 }
@@ -732,125 +601,4 @@ pub trait Backend: Sync + Send {
     ) -> TaskId;
 
     fn dispose_root_task(&self, task: TaskId, turbo_tasks: &dyn TurboTasksBackendApi<Self>);
-}
-
-impl CachedTaskType {
-    pub async fn run_resolve_native<B: Backend + 'static>(
-        fn_id: FunctionId,
-        mut this: Option<RawVc>,
-        arg: &dyn MagicAny,
-        persistence: TaskPersistence,
-        turbo_tasks: Arc<dyn TurboTasksBackendApi<B>>,
-    ) -> Result<RawVc> {
-        if let Some(this) = this.as_mut() {
-            *this = this.resolve().await?;
-        }
-        let arg = registry::get_function(fn_id).arg_meta.resolve(arg).await?;
-        Ok(if let Some(this) = this {
-            turbo_tasks.this_call(fn_id, this, arg, persistence)
-        } else {
-            turbo_tasks.native_call(fn_id, arg, persistence)
-        })
-    }
-
-    pub async fn resolve_trait_method(
-        trait_type: TraitTypeId,
-        name: Cow<'static, str>,
-        this: RawVc,
-    ) -> Result<FunctionId> {
-        let TypedCellContent(value_type, _) = this.into_read().await?;
-        Self::resolve_trait_method_from_value(trait_type, value_type, name)
-    }
-
-    pub async fn run_resolve_trait<B: Backend + 'static>(
-        trait_type: TraitTypeId,
-        name: Cow<'static, str>,
-        this: RawVc,
-        arg: &dyn MagicAny,
-        persistence: TaskPersistence,
-        turbo_tasks: Arc<dyn TurboTasksBackendApi<B>>,
-    ) -> Result<RawVc> {
-        let this = this.resolve().await?;
-        let TypedCellContent(this_ty, _) = this.into_read().await?;
-
-        let native_fn = Self::resolve_trait_method_from_value(trait_type, this_ty, name)?;
-        let arg = registry::get_function(native_fn)
-            .arg_meta
-            .resolve(arg)
-            .await?;
-        Ok(turbo_tasks.dynamic_this_call(native_fn, this, arg, persistence))
-    }
-
-    /// Shared helper used by [`Self::resolve_trait_method`] and
-    /// [`Self::run_resolve_trait`].
-    fn resolve_trait_method_from_value(
-        trait_type: TraitTypeId,
-        value_type: ValueTypeId,
-        name: Cow<'static, str>,
-    ) -> Result<FunctionId> {
-        match get_trait_method(trait_type, value_type, name) {
-            Ok(native_fn) => Ok(native_fn),
-            Err(name) => {
-                if !has_trait(value_type, trait_type) {
-                    let traits = traits(value_type).iter().fold(String::new(), |mut out, t| {
-                        let _ = write!(out, " {}", t);
-                        out
-                    });
-                    Err(anyhow!(
-                        "{} doesn't implement {} (only{})",
-                        registry::get_value_type(value_type),
-                        registry::get_trait(trait_type),
-                        traits,
-                    ))
-                } else {
-                    Err(anyhow!(
-                        "{} implements trait {}, but method {} is missing",
-                        registry::get_value_type(value_type),
-                        registry::get_trait(trait_type),
-                        name
-                    ))
-                }
-            }
-        }
-    }
-}
-
-#[cfg(test)]
-pub(crate) mod tests {
-    use super::*;
-    use crate::{self as turbo_tasks, Vc};
-
-    #[turbo_tasks::function]
-    fn mock_func_task() -> Vc<()> {
-        Vc::cell(())
-    }
-
-    #[turbo_tasks::value_trait]
-    trait MockTrait {
-        fn mock_method_task() -> Vc<()>;
-    }
-
-    #[test]
-    fn test_get_name() {
-        crate::register();
-        assert_eq!(
-            CachedTaskType::Native {
-                fn_type: *MOCK_FUNC_TASK_FUNCTION_ID,
-                this: None,
-                arg: Box::new(()),
-            }
-            .get_name(),
-            "mock_func_task",
-        );
-        assert_eq!(
-            CachedTaskType::ResolveTrait {
-                trait_type: *MOCKTRAIT_TRAIT_TYPE_ID,
-                method_name: "mock_method_task".into(),
-                this: RawVc::TaskOutput(unsafe { TaskId::new_unchecked(1) }),
-                arg: Box::new(()),
-            }
-            .get_name(),
-            "*MockTrait::mock_method_task",
-        );
-    }
 }

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -683,7 +683,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
             this: None,
             arg,
         };
-        return self.schedule_local_task(task_type, persistence);
+        self.schedule_local_task(task_type, persistence)
     }
 
     pub fn dynamic_this_call(
@@ -701,7 +701,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
             this: Some(this),
             arg,
         };
-        return self.schedule_local_task(task_type, persistence);
+        self.schedule_local_task(task_type, persistence)
     }
 
     pub fn trait_call(
@@ -734,7 +734,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
             arg,
         };
 
-        return self.schedule_local_task(task_type, persistence);
+        self.schedule_local_task(task_type, persistence)
     }
 
     #[track_caller]

--- a/turbopack/crates/turbo-tasks/src/task/local_task.rs
+++ b/turbopack/crates/turbo-tasks/src/task/local_task.rs
@@ -1,7 +1,14 @@
+use std::{borrow::Cow, fmt, fmt::Write, sync::Arc};
+
+use anyhow::{anyhow, Result};
+
 use crate::{
-    backend::{Backend, CachedTaskType, TaskExecutionSpec},
+    backend::{Backend, TaskExecutionSpec, TypedCellContent},
     event::Event,
-    registry, OutputContent, TaskPersistence, TurboTasksBackendApi,
+    registry,
+    trait_helpers::{get_trait_method, has_trait, traits},
+    FunctionId, MagicAny, OutputContent, RawVc, TaskPersistence, TraitTypeId, TurboTasksBackendApi,
+    ValueTypeId,
 };
 
 /// A potentially in-flight local task stored in `CurrentGlobalTaskState::local_tasks`.
@@ -12,12 +19,12 @@ pub enum LocalTask {
 
 pub fn get_local_task_execution_spec<'a>(
     turbo_tasks: &'_ dyn TurboTasksBackendApi<impl Backend + 'static>,
-    ty: &'a CachedTaskType,
-    // if this is a `CachedTaskType::Resolve*`, we'll spawn another task with this persistence
+    ty: &'a LocalTaskType,
+    // if this is a `LocalTaskType::Resolve*`, we'll spawn another task with this persistence
     persistence: TaskPersistence,
 ) -> TaskExecutionSpec<'a> {
     match ty {
-        CachedTaskType::Native {
+        LocalTaskType::Native {
             fn_type: native_fn_id,
             this,
             arg,
@@ -30,7 +37,7 @@ pub fn get_local_task_execution_spec<'a>(
             drop(entered);
             TaskExecutionSpec { future, span }
         }
-        CachedTaskType::ResolveNative {
+        LocalTaskType::ResolveNative {
             fn_type: native_fn_id,
             this,
             arg,
@@ -38,7 +45,7 @@ pub fn get_local_task_execution_spec<'a>(
             let func = registry::get_function(*native_fn_id);
             let span = func.resolve_span(TaskPersistence::LocalCells);
             let entered = span.enter();
-            let future = Box::pin(CachedTaskType::run_resolve_native(
+            let future = Box::pin(LocalTaskType::run_resolve_native(
                 *native_fn_id,
                 *this,
                 &**arg,
@@ -48,7 +55,7 @@ pub fn get_local_task_execution_spec<'a>(
             drop(entered);
             TaskExecutionSpec { future, span }
         }
-        CachedTaskType::ResolveTrait {
+        LocalTaskType::ResolveTrait {
             trait_type: trait_type_id,
             method_name: name,
             this,
@@ -57,7 +64,7 @@ pub fn get_local_task_execution_spec<'a>(
             let trait_type = registry::get_trait(*trait_type_id);
             let span = trait_type.resolve_span(name);
             let entered = span.enter();
-            let future = Box::pin(CachedTaskType::run_resolve_trait(
+            let future = Box::pin(LocalTaskType::run_resolve_trait(
                 *trait_type_id,
                 name.clone(),
                 *this,
@@ -68,5 +75,181 @@ pub fn get_local_task_execution_spec<'a>(
             drop(entered);
             TaskExecutionSpec { future, span }
         }
+    }
+}
+
+pub enum LocalTaskType {
+    /// A normal task execution a native (rust) function
+    Native {
+        fn_type: FunctionId,
+        this: Option<RawVc>,
+        arg: Box<dyn MagicAny>,
+    },
+
+    /// A resolve task, which resolves arguments and calls the function with resolve arguments. The
+    /// inner function call will be a `PersistentTaskType` or `LocalTaskType::Native`.
+    ResolveNative {
+        fn_type: FunctionId,
+        this: Option<RawVc>,
+        arg: Box<dyn MagicAny>,
+    },
+
+    /// A trait method resolve task. It resolves the first (`self`) argument and looks up the trait
+    /// method on that value. Then it calls that method. The method call will do a cache lookup and
+    /// might resolve arguments before.
+    ResolveTrait {
+        trait_type: TraitTypeId,
+        method_name: Cow<'static, str>,
+        this: RawVc,
+        arg: Box<dyn MagicAny>,
+    },
+}
+
+impl fmt::Display for LocalTaskType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.get_name())
+    }
+}
+
+impl LocalTaskType {
+    /// Returns the name of the function in the code. Trait methods are
+    /// formatted as `TraitName::method_name`.
+    ///
+    /// Equivalent to [`ToString::to_string`], but potentially more efficient as
+    /// it can return a `&'static str` in many cases.
+    pub fn get_name(&self) -> Cow<'static, str> {
+        match self {
+            Self::Native {
+                fn_type: native_fn,
+                this: _,
+                arg: _,
+            } => Cow::Borrowed(&registry::get_function(*native_fn).name),
+            Self::ResolveNative {
+                fn_type: native_fn,
+                this: _,
+                arg: _,
+            } => format!("*{}", registry::get_function(*native_fn).name).into(),
+            Self::ResolveTrait {
+                trait_type: trait_id,
+                method_name: fn_name,
+                this: _,
+                arg: _,
+            } => format!("*{}::{}", registry::get_trait(*trait_id).name, fn_name).into(),
+        }
+    }
+
+    pub fn try_get_function_id(&self) -> Option<FunctionId> {
+        match self {
+            Self::Native { fn_type, .. } | Self::ResolveNative { fn_type, .. } => Some(*fn_type),
+            Self::ResolveTrait { .. } => None,
+        }
+    }
+
+    pub async fn run_resolve_native<B: Backend + 'static>(
+        fn_id: FunctionId,
+        mut this: Option<RawVc>,
+        arg: &dyn MagicAny,
+        persistence: TaskPersistence,
+        turbo_tasks: Arc<dyn TurboTasksBackendApi<B>>,
+    ) -> Result<RawVc> {
+        if let Some(this) = this.as_mut() {
+            *this = this.resolve().await?;
+        }
+        let arg = registry::get_function(fn_id).arg_meta.resolve(arg).await?;
+        Ok(if let Some(this) = this {
+            turbo_tasks.this_call(fn_id, this, arg, persistence)
+        } else {
+            turbo_tasks.native_call(fn_id, arg, persistence)
+        })
+    }
+
+    pub async fn run_resolve_trait<B: Backend + 'static>(
+        trait_type: TraitTypeId,
+        name: Cow<'static, str>,
+        this: RawVc,
+        arg: &dyn MagicAny,
+        persistence: TaskPersistence,
+        turbo_tasks: Arc<dyn TurboTasksBackendApi<B>>,
+    ) -> Result<RawVc> {
+        let this = this.resolve().await?;
+        let TypedCellContent(this_ty, _) = this.into_read().await?;
+
+        let native_fn = Self::resolve_trait_method_from_value(trait_type, this_ty, name)?;
+        let arg = registry::get_function(native_fn)
+            .arg_meta
+            .resolve(arg)
+            .await?;
+        Ok(turbo_tasks.dynamic_this_call(native_fn, this, arg, persistence))
+    }
+
+    fn resolve_trait_method_from_value(
+        trait_type: TraitTypeId,
+        value_type: ValueTypeId,
+        name: Cow<'static, str>,
+    ) -> Result<FunctionId> {
+        match get_trait_method(trait_type, value_type, name) {
+            Ok(native_fn) => Ok(native_fn),
+            Err(name) => {
+                if !has_trait(value_type, trait_type) {
+                    let traits = traits(value_type).iter().fold(String::new(), |mut out, t| {
+                        let _ = write!(out, " {}", t);
+                        out
+                    });
+                    Err(anyhow!(
+                        "{} doesn't implement {} (only{})",
+                        registry::get_value_type(value_type),
+                        registry::get_trait(trait_type),
+                        traits,
+                    ))
+                } else {
+                    Err(anyhow!(
+                        "{} implements trait {}, but method {} is missing",
+                        registry::get_value_type(value_type),
+                        registry::get_trait(trait_type),
+                        name
+                    ))
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::{self as turbo_tasks, TaskId, Vc};
+
+    #[turbo_tasks::function]
+    fn mock_func_task() -> Vc<()> {
+        Vc::cell(())
+    }
+
+    #[turbo_tasks::value_trait]
+    trait MockTrait {
+        fn mock_method_task() -> Vc<()>;
+    }
+
+    #[test]
+    fn test_get_name() {
+        crate::register();
+        assert_eq!(
+            LocalTaskType::Native {
+                fn_type: *MOCK_FUNC_TASK_FUNCTION_ID,
+                this: None,
+                arg: Box::new(()),
+            }
+            .get_name(),
+            "mock_func_task",
+        );
+        assert_eq!(
+            LocalTaskType::ResolveTrait {
+                trait_type: *MOCKTRAIT_TRAIT_TYPE_ID,
+                method_name: "mock_method_task".into(),
+                this: RawVc::TaskOutput(unsafe { TaskId::new_unchecked(1) }),
+                arg: Box::new(()),
+            }
+            .get_name(),
+            "*MockTrait::mock_method_task",
+        );
     }
 }


### PR DESCRIPTION
Removes the (now default) feature flag for local task argument resolution.

With local-task based argument resolution in place, we don't need to support argument resolution in the backend, which simplifies some code.

Closes PACK-3812