### PR TITLE
[WIP] refactor(turbopack): Remove `ReadRawVcFuture.turbo_task`

### DIFF
--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -594,8 +594,11 @@ impl<B: Backend + 'static> TurboTasks<B> {
         // track a dependency
         let raw_result =
             read_task_output_untracked(self, task_id, ReadConsistency::Eventual).await?;
-        ReadVcFuture::<Completion>::from(raw_result.into_read_untracked_with_turbo_tasks(self))
-            .await?;
+        turbo_tasks_future_scope(
+            self.pin(),
+            ReadVcFuture::<Completion>::from(raw_result.into_read_untracked_with_turbo_tasks(self)),
+        )
+        .await?;
 
         Ok(rx.await?)
     }


### PR DESCRIPTION
### What?

### Why?

`core::ptr::drop_in_place` of `ReadRawVcFuture.turbo_task` is consuming too much time.

### How?


Closes PACK-3792