### PR TITLE
perf(turbopack): Use `Cow::into_owned` instead of `.to_string()`

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -1291,7 +1291,7 @@ pub async fn project_get_source_for_asset(
                 bail!("Cannot find source for asset {}", file_path);
             };
 
-            Ok(Some(source_content.content().to_str()?.to_string()))
+            Ok(Some(source_content.content().to_str()?.into_owned()))
         })
         .await
         .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;
@@ -1313,7 +1313,7 @@ pub async fn project_get_source_map(
                 return Ok(None);
             };
 
-            Ok(Some(map.to_rope().await?.to_str()?.to_string()))
+            Ok(Some(map.to_rope().await?.to_str()?.into_owned()))
         })
         .await
         .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -672,7 +672,7 @@ pub async fn load_next_js_template(
     let path = virtual_next_js_template_path(project_path, path.to_string());
 
     let content = &*file_content_rope(path.read()).await?;
-    let content = content.to_str()?.to_string();
+    let content = content.to_str()?.into_owned();
 
     let parent_path = path.parent();
     let parent_path_value = &*parent_path.await?;

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -43,7 +43,7 @@ pub async fn minify(
         let compiler = Arc::new(Compiler::new(cm.clone()));
         let fm = compiler.cm.new_source_file(
             FileName::Custom(path.path.to_string()).into(),
-            code.source_code().to_str()?.to_string(),
+            code.source_code().to_str()?.into_owned(),
         );
 
         let lexer = Lexer::new(


### PR DESCRIPTION
### What?

`Cow::into_owned()` does not allocate in some cases, while `to_string()` always allocate.

### Why?

In the name of the performance.

### How?



Closes PACK-3793