### PR TITLE
fix: typeof msg should compare to object

### DIFF
--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -426,7 +426,12 @@ export async function startServer(
 
 if (process.env.NEXT_PRIVATE_WORKER && process.send) {
   process.addListener('message', async (msg: any) => {
-    if (msg && typeof msg === 'object' && msg.nextWorkerOptions && process.send) {
+    if (
+      msg &&
+      typeof msg === 'object' &&
+      msg.nextWorkerOptions &&
+      process.send
+    ) {
       startServerSpan = trace('start-dev-server', undefined, {
         cpus: String(os.cpus().length),
         platform: os.platform(),

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -426,7 +426,7 @@ export async function startServer(
 
 if (process.env.NEXT_PRIVATE_WORKER && process.send) {
   process.addListener('message', async (msg: any) => {
-    if (msg && typeof msg && msg.nextWorkerOptions && process.send) {
+    if (msg && typeof msg === 'object' && msg.nextWorkerOptions && process.send) {
       startServerSpan = trace('start-dev-server', undefined, {
         cpus: String(os.cpus().length),
         platform: os.platform(),


### PR DESCRIPTION
### Fixing a bug

The code is located at https://github.com/vercel/next.js/blob/c33eb2b6505f6717a1a1eac10e193da9d9fa1ece/packages/next/src/server/lib/start-server.ts#L429  `typeof msg` should be compared to `'object'`. Otherwise, it makes no sense.