### PR TITLE
eslint: allow ts extensions for config

### DIFF
--- a/packages/next/src/lib/eslint/runLintCheck.ts
+++ b/packages/next/src/lib/eslint/runLintCheck.ts
@@ -360,12 +360,11 @@ export async function runLintCheck(
           'eslint.config.js',
           'eslint.config.mjs',
           'eslint.config.cjs',
-          // TODO(jiwon): Support when it's stable.
-          // TS extensions are experimental and requires to install another package `jiti`.
+          // TS extensions require to install a separate package `jiti`.
           // https://eslint.org/docs/latest/use/configure/configuration-files#typescript-configuration-files
-          // 'eslint.config.ts',
-          // 'eslint.config.mts',
-          // 'eslint.config.cts',
+          'eslint.config.ts',
+          'eslint.config.mts',
+          'eslint.config.cts',
           // eslint <= v8
           '.eslintrc.js',
           '.eslintrc.cjs',


### PR DESCRIPTION
### Why?

`eslint.config.*ts` config files were not included to be calculated before as they are experimental but shouldn't be a blocker from us, so uncommented them from the supported config files.

Will follow up with eslint config test cases when we enable the flat config on `eslint-config-next`, but confirmed on local that `.(m|c)ts` extensions work.

Fixes #74900