### PR TITLE
[metadata] keep blocking metadata rendered in head

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -230,8 +230,7 @@ interface ParseRequestHeadersOptions {
   readonly isRoutePPREnabled: boolean
 }
 
-const flightDataPathMetadataKey = 'h'
-const flightDataPathViewportKey = 'v'
+const flightDataPathHeadKey = 'h'
 
 interface ParsedRequestHeaders {
   /**
@@ -498,10 +497,8 @@ async function generateDynamicRSCPayload(
     const { StreamingMetadata, StaticMetadata } =
       createDivergedMetadataComponents(() => {
         return (
-          <React.Fragment key={flightDataPathMetadataKey}>
-            {/* Adding requestId as react key to make metadata remount for each render */}
-            <MetadataTree key={requestId} />
-          </React.Fragment>
+          // Adding requestId as react key to make metadata remount for each render
+          <MetadataTree key={requestId} />
         )
       }, !!ctx.renderOpts.serveStreamingMetadata)
 
@@ -513,15 +510,13 @@ async function generateDynamicRSCPayload(
         flightRouterState,
         // For flight, render metadata inside leaf page
         rscHead: (
-          <>
-            <React.Fragment key={flightDataPathViewportKey}>
-              {/* noindex needs to be blocking */}
-              <NonIndex ctx={ctx} />
-              {/* Adding requestId as react key to make metadata remount for each render */}
-              <ViewportTree key={requestId} />
-            </React.Fragment>
+          <React.Fragment key={flightDataPathHeadKey}>
+            {/* noindex needs to be blocking */}
+            <NonIndex ctx={ctx} />
+            {/* \Adding requestId as react key to make metadata remount for each render */}
+            <ViewportTree key={requestId} />
             <StaticMetadata />
-          </>
+          </React.Fragment>
         ),
         injectedCSS: new Set(),
         injectedJS: new Set(),
@@ -808,10 +803,8 @@ async function getRSCPayload(
   const { StreamingMetadata, StaticMetadata } =
     createDivergedMetadataComponents(() => {
       return (
-        <React.Fragment key={flightDataPathMetadataKey}>
-          {/* Not add requestId as react key to ensure segment prefetch could result consistently if nothing changed */}
-          <MetadataTree />
-        </React.Fragment>
+        // Not add requestId as react key to ensure segment prefetch could result consistently if nothing changed
+        <MetadataTree />
       )
     }, !!ctx.renderOpts.serveStreamingMetadata)
 
@@ -838,14 +831,12 @@ async function getRSCPayload(
   const couldBeIntercepted =
     typeof varyHeader === 'string' && varyHeader.includes(NEXT_URL)
 
-  const initialHeadViewport = (
-    <>
-      <React.Fragment key={flightDataPathViewportKey}>
-        <NonIndex ctx={ctx} />
-        <ViewportTree key={ctx.requestId} />
-      </React.Fragment>
-      <StaticMetadata />
-    </>
+  const initialHead = (
+    <React.Fragment key={flightDataPathHeadKey}>
+      <NonIndex ctx={ctx} />
+      <ViewportTree key={ctx.requestId} />
+      <StaticMetadata key={flightDataPathHeadKey} />
+    </React.Fragment>
   )
 
   const globalErrorStyles = await getGlobalErrorStyles(tree, ctx)
@@ -871,7 +862,7 @@ async function getRSCPayload(
       [
         initialTree,
         seedData,
-        [initialHeadViewport, null],
+        initialHead,
         isPossiblyPartialHead,
       ] as FlightDataPath,
     ],
@@ -937,7 +928,7 @@ async function getErrorRSCPayload(
   const { StreamingMetadata, StaticMetadata } =
     createDivergedMetadataComponents(
       () => (
-        <React.Fragment key={flightDataPathMetadataKey}>
+        <React.Fragment key={flightDataPathHeadKey}>
           {/* Adding requestId as react key to make metadata remount for each render */}
           <MetadataTree key={requestId} />
         </React.Fragment>
@@ -945,8 +936,8 @@ async function getErrorRSCPayload(
       !!ctx.renderOpts.serveStreamingMetadata
     )
 
-  const initialHeadViewport = (
-    <React.Fragment key={flightDataPathViewportKey}>
+  const initialHead = (
+    <React.Fragment key={flightDataPathHeadKey}>
       <NonIndex ctx={ctx} />
       {/* Adding requestId as react key to make metadata remount for each render */}
       <ViewportTree key={requestId} />
@@ -1006,7 +997,7 @@ async function getErrorRSCPayload(
       [
         initialTree,
         seedData,
-        [initialHeadViewport, null],
+        initialHead,
         isPossiblyPartialHead,
       ] as FlightDataPath,
     ],

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -315,7 +315,6 @@ function createNotFoundLoaderTree(loaderTree: LoaderTree): LoaderTree {
   ]
 }
 
-const EmptyMetadata = () => null
 function createDivergedMetadataComponents(
   Metadata: React.ComponentType<{}>,
   serveStreamingMetadata: boolean
@@ -323,15 +322,18 @@ function createDivergedMetadataComponents(
   StaticMetadata: React.ComponentType<{}>
   StreamingMetadata: React.ComponentType<{}>
 } {
-  function StreamingMetadata() {
-    if (!serveStreamingMetadata) return null
-    return (
-      <React.Suspense fallback={null}>
-        <Metadata />
-      </React.Suspense>
-    )
-  }
-  const StaticMetadata = serveStreamingMetadata ? EmptyMetadata : Metadata
+  const EmptyMetadata = () => null
+  const StreamingMetadata: React.ComponentType<{}> = serveStreamingMetadata
+    ? () => (
+        <React.Suspense fallback={null}>
+          <Metadata />
+        </React.Suspense>
+      )
+    : EmptyMetadata
+
+  const StaticMetadata: React.ComponentType<{}> = serveStreamingMetadata
+    ? EmptyMetadata
+    : Metadata
 
   return {
     StaticMetadata,
@@ -513,7 +515,7 @@ async function generateDynamicRSCPayload(
           <React.Fragment key={flightDataPathHeadKey}>
             {/* noindex needs to be blocking */}
             <NonIndex ctx={ctx} />
-            {/* \Adding requestId as react key to make metadata remount for each render */}
+            {/* Adding requestId as react key to make metadata remount for each render */}
             <ViewportTree key={requestId} />
             <StaticMetadata />
           </React.Fragment>
@@ -835,7 +837,7 @@ async function getRSCPayload(
     <React.Fragment key={flightDataPathHeadKey}>
       <NonIndex ctx={ctx} />
       <ViewportTree key={ctx.requestId} />
-      <StaticMetadata key={flightDataPathHeadKey} />
+      <StaticMetadata />
     </React.Fragment>
   )
 

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -36,7 +36,7 @@ export function createComponentTree(props: {
   missingSlots?: Set<string>
   preloadCallbacks: PreloadCallbacks
   authInterrupts: boolean
-  MetadataComponent: React.ComponentType<{}>
+  StreamingMetadata: React.ComponentType<{}>
 }): Promise<CacheNodeSeedData> {
   return getTracer().trace(
     NextNodeServerSpan.createComponentTree,
@@ -72,7 +72,7 @@ async function createComponentTreeInternal({
   missingSlots,
   preloadCallbacks,
   authInterrupts,
-  MetadataComponent,
+  StreamingMetadata,
 }: {
   loaderTree: LoaderTree
   parentParams: Params
@@ -86,7 +86,7 @@ async function createComponentTreeInternal({
   missingSlots?: Set<string>
   preloadCallbacks: PreloadCallbacks
   authInterrupts: boolean
-  MetadataComponent: React.ComponentType<{}>
+  StreamingMetadata: React.ComponentType<{}>
 }): Promise<CacheNodeSeedData> {
   const {
     renderOpts: { nextConfigOutput, experimental },
@@ -395,7 +395,7 @@ async function createComponentTreeInternal({
   // Only render metadata on the actual SSR'd segment not the `default` segment,
   // as it's used as a placeholder for navigation.
   const metadata =
-    actualSegment !== DEFAULT_SEGMENT_KEY ? <MetadataComponent /> : undefined
+    actualSegment !== DEFAULT_SEGMENT_KEY ? <StreamingMetadata /> : undefined
 
   const notFoundElement = NotFound ? (
     <>
@@ -516,7 +516,7 @@ async function createComponentTreeInternal({
             missingSlots,
             preloadCallbacks,
             authInterrupts,
-            MetadataComponent,
+            StreamingMetadata,
           })
 
           childCacheNodeSeedData = seedData

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -40,7 +40,7 @@ export async function walkTreeWithFlightRouterState({
   getMetadataReady,
   ctx,
   preloadCallbacks,
-  MetadataComponent,
+  StreamingMetadata,
 }: {
   loaderTreeToFilter: LoaderTree
   parentParams: { [key: string]: string | string[] }
@@ -55,7 +55,7 @@ export async function walkTreeWithFlightRouterState({
   getViewportReady: () => Promise<void>
   ctx: AppRenderContext
   preloadCallbacks: PreloadCallbacks
-  MetadataComponent: React.ComponentType<{}>
+  StreamingMetadata: React.ComponentType<{}>
 }): Promise<FlightDataPath[]> {
   const {
     renderOpts: { nextFontManifest, experimental },
@@ -204,7 +204,7 @@ export async function walkTreeWithFlightRouterState({
         getMetadataReady,
         preloadCallbacks,
         authInterrupts: experimental.authInterrupts,
-        MetadataComponent,
+        StreamingMetadata,
       }
     )
 
@@ -264,7 +264,7 @@ export async function walkTreeWithFlightRouterState({
       getViewportReady,
       getMetadataReady,
       preloadCallbacks,
-      MetadataComponent,
+      StreamingMetadata,
     })
 
     for (const subPath of subPaths) {

--- a/packages/next/src/server/lib/streaming-metadata.ts
+++ b/packages/next/src/server/lib/streaming-metadata.ts
@@ -18,5 +18,8 @@ export function shouldServeStreamingMetadata(
     htmlLimitedBots || HTML_LIMITED_BOT_UA_RE_STRING,
     'i'
   )
-  return !blockingMetadataUARegex.test(userAgent)
+  return (
+    // When it's static generation, userAgents are not available - do not serve streaming metadata
+    !!userAgent && !blockingMetadataUARegex.test(userAgent)
+  )
 }

--- a/test/e2e/app-dir/metadata-static-generation/app/layout.tsx
+++ b/test/e2e/app-dir/metadata-static-generation/app/layout.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <div>
+          <Link href="/slow" id="to-slow">
+            {`to /slow`}
+          </Link>
+          <br />
+          <Link href="/" id="to-home">
+            {`to /`}
+          </Link>
+          <br />
+          <Link href="/suspenseful/dynamic" id="to-suspenseful-dynamic">
+            {`to /suspenseful/dynamic`}
+          </Link>
+          <br />
+          <Link href="/suspenseful/static" id="to-suspenseful-static">
+            {`to /suspenseful/static`}
+          </Link>
+        </div>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/metadata-static-generation/app/page.tsx
+++ b/test/e2e/app-dir/metadata-static-generation/app/page.tsx
@@ -1,0 +1,11 @@
+export default function Page() {
+  return <p>index</p>
+}
+
+export async function generateMetadata() {
+  await new Promise((resolve) => setTimeout(resolve, 1 * 1000))
+  return {
+    title: 'index page',
+    description: 'index page description',
+  }
+}

--- a/test/e2e/app-dir/metadata-static-generation/app/suspenseful/dynamic/page.tsx
+++ b/test/e2e/app-dir/metadata-static-generation/app/suspenseful/dynamic/page.tsx
@@ -1,0 +1,14 @@
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+  return <p>suspenseful - dynamic</p>
+}
+
+export async function generateMetadata() {
+  await connection()
+  await new Promise((resolve) => setTimeout(resolve, 1 * 1000))
+  return {
+    title: 'suspenseful page - dynamic',
+  }
+}

--- a/test/e2e/app-dir/metadata-static-generation/app/suspenseful/layout.tsx
+++ b/test/e2e/app-dir/metadata-static-generation/app/suspenseful/layout.tsx
@@ -1,0 +1,9 @@
+import { Suspense } from 'react'
+
+export default function Layout({ children }) {
+  return (
+    <div className="suspenseful-layout">
+      <Suspense>{children}</Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/metadata-static-generation/app/suspenseful/static/page.tsx
+++ b/test/e2e/app-dir/metadata-static-generation/app/suspenseful/static/page.tsx
@@ -1,0 +1,10 @@
+export default async function Page() {
+  return <p>suspenseful - static</p>
+}
+
+export async function generateMetadata() {
+  await new Promise((resolve) => setTimeout(resolve, 1 * 1000))
+  return {
+    title: 'suspenseful page - static',
+  }
+}

--- a/test/e2e/app-dir/metadata-static-generation/metadata-static-generation.test.ts
+++ b/test/e2e/app-dir/metadata-static-generation/metadata-static-generation.test.ts
@@ -1,0 +1,39 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('app-dir - metadata-static-generation', () => {
+  const { next, isNextStart } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextStart) {
+    // Precondition for the following tests in build mode
+    it('should generate all pages static', async () => {
+      const prerenderManifest = JSON.parse(
+        await next.readFile('.next/prerender-manifest.json')
+      )
+      const staticRoutes = prerenderManifest.routes
+      expect(Object.keys(staticRoutes).sort()).toEqual([
+        '/',
+        '/suspenseful/static',
+      ])
+    })
+  }
+
+  it('should contain async generated metadata in head for simple static page', async () => {
+    const $ = await next.render$('/')
+    expect($('head title').text()).toBe('index page')
+    expect($('head meta[name="description"]').attr('content')).toBe(
+      'index page description'
+    )
+  })
+
+  it('should contain async generated metadata in head static page with suspenseful content', async () => {
+    const $ = await next.render$('/suspenseful/static')
+    expect($('head title').text()).toBe('suspenseful page - static')
+  })
+
+  it('should contain async generated metadata in head for dynamic page', async () => {
+    const $ = await next.render$('/suspenseful/dynamic')
+    expect($('head title').text()).toBe('suspenseful page - dynamic')
+  })
+})

--- a/test/e2e/app-dir/metadata-static-generation/metadata-static-generation.test.ts
+++ b/test/e2e/app-dir/metadata-static-generation/metadata-static-generation.test.ts
@@ -11,6 +11,7 @@ describe('app-dir - metadata-static-generation', () => {
   // We'll visit PPR tests in the new test suite.
   if (isPPREnabled) {
     it('skip ppr test', () => {})
+    return
   }
 
   if (isNextStart) {

--- a/test/e2e/app-dir/metadata-static-generation/metadata-static-generation.test.ts
+++ b/test/e2e/app-dir/metadata-static-generation/metadata-static-generation.test.ts
@@ -1,9 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 
+const isPPREnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+
 describe('app-dir - metadata-static-generation', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,
   })
+
+  // /suspenseful/dynamic will behave differently when PPR is enabled.
+  // We'll visit PPR tests in the new test suite.
+  if (isPPREnabled) {
+    it('skip ppr test', () => {})
+  }
 
   if (isNextStart) {
     // Precondition for the following tests in build mode

--- a/test/e2e/app-dir/metadata-static-generation/next.config.js
+++ b/test/e2e/app-dir/metadata-static-generation/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/metadata-streaming-static-generation/app/layout.tsx
+++ b/test/e2e/app-dir/metadata-streaming-static-generation/app/layout.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <div>
+          <Link href="/slow" id="to-slow">
+            {`to /slow`}
+          </Link>
+          <br />
+          <Link href="/" id="to-home">
+            {`to /`}
+          </Link>
+          <br />
+          <Link href="/suspenseful/dynamic" id="to-suspenseful-dynamic">
+            {`to /suspenseful/dynamic`}
+          </Link>
+          <br />
+          <Link href="/suspenseful/static" id="to-suspenseful-static">
+            {`to /suspenseful/static`}
+          </Link>
+        </div>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/metadata-streaming-static-generation/app/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-static-generation/app/page.tsx
@@ -1,0 +1,10 @@
+export default function Page() {
+  return <p>index</p>
+}
+
+export async function generateMetadata() {
+  await new Promise((resolve) => setTimeout(resolve, 1 * 1000))
+  return {
+    title: 'index page',
+  }
+}

--- a/test/e2e/app-dir/metadata-streaming-static-generation/app/slow/dynamic/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-static-generation/app/slow/dynamic/page.tsx
@@ -1,0 +1,13 @@
+import { connection } from 'next/server'
+
+export default function Page() {
+  return <p>slow dynamic</p>
+}
+
+export async function generateMetadata() {
+  await connection()
+  await new Promise((resolve) => setTimeout(resolve, 3 * 1000))
+  return {
+    title: 'slow page - dynamic',
+  }
+}

--- a/test/e2e/app-dir/metadata-streaming-static-generation/app/slow/static/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-static-generation/app/slow/static/page.tsx
@@ -1,0 +1,10 @@
+export default function Page() {
+  return <p>slow static</p>
+}
+
+export async function generateMetadata() {
+  await new Promise((resolve) => setTimeout(resolve, 3 * 1000))
+  return {
+    title: 'slow page - static',
+  }
+}

--- a/test/e2e/app-dir/metadata-streaming-static-generation/app/suspenseful/dynamic/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-static-generation/app/suspenseful/dynamic/page.tsx
@@ -1,0 +1,14 @@
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+  return <p>suspenseful - dynamic</p>
+}
+
+export async function generateMetadata() {
+  await connection()
+  await new Promise((resolve) => setTimeout(resolve, 1 * 1000))
+  return {
+    title: 'suspenseful page - dynamic',
+  }
+}

--- a/test/e2e/app-dir/metadata-streaming-static-generation/app/suspenseful/layout.tsx
+++ b/test/e2e/app-dir/metadata-streaming-static-generation/app/suspenseful/layout.tsx
@@ -1,0 +1,9 @@
+import { Suspense } from 'react'
+
+export default function Layout({ children }) {
+  return (
+    <div className="suspenseful-layout">
+      <Suspense>{children}</Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/metadata-streaming-static-generation/app/suspenseful/static/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-static-generation/app/suspenseful/static/page.tsx
@@ -1,0 +1,10 @@
+export default async function Page() {
+  return <p>suspenseful - static</p>
+}
+
+export async function generateMetadata() {
+  await new Promise((resolve) => setTimeout(resolve, 1 * 1000))
+  return {
+    title: 'suspenseful page - static',
+  }
+}

--- a/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
+++ b/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
@@ -1,0 +1,51 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('app-dir - metadata-streaming-static-generation', () => {
+  const { next, isNextStart } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextStart) {
+    // Precondition for the following tests in build mode
+    it('should generate all pages static', async () => {
+      const prerenderManifest = JSON.parse(
+        await next.readFile('.next/prerender-manifest.json')
+      )
+      const staticRoutes = prerenderManifest.routes
+      expect(Object.keys(staticRoutes).sort()).toEqual([
+        '/',
+        '/slow/static',
+        '/suspenseful/static',
+      ])
+    })
+  }
+
+  describe('static pages', () => {
+    it('should contain async generated metadata in head for simple static page', async () => {
+      const $ = await next.render$('/')
+      expect($('head title').text()).toBe('index page')
+    })
+
+    it('should contain async generated metadata in head for slow static page', async () => {
+      const $ = await next.render$('/slow/static')
+      expect($('head title').text()).toBe('slow page - static')
+    })
+
+    it('should contain async generated metadata in head static page with suspenseful content', async () => {
+      const $ = await next.render$('/suspenseful/static')
+      expect($('head title').text()).toBe('suspenseful page - static')
+    })
+  })
+
+  describe('dynamic pages', () => {
+    it('should contain async generated metadata in body for simple dynamics page', async () => {
+      const $ = await next.render$('/suspenseful/dynamic')
+      expect($('body title').text()).toBe('suspenseful page - dynamic')
+    })
+
+    it('should contain async generated metadata in body for suspenseful dynamic page', async () => {
+      const $ = await next.render$('/slow/dynamic')
+      expect($('body title').text()).toBe('slow page - dynamic')
+    })
+  })
+})

--- a/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
+++ b/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
@@ -11,6 +11,7 @@ describe('app-dir - metadata-streaming-static-generation', () => {
   // We'll visit PPR tests in the new test suite.
   if (isPPREnabled) {
     it('skip ppr test', () => {})
+    return
   }
 
   if (isNextStart) {

--- a/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
+++ b/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
@@ -79,22 +79,22 @@ describe('app-dir - metadata-streaming-static-generation', () => {
   })
 
   describe('dynamic pages with html limited bots', () => {
-    it('should contain async generated metadata in body for simple dynamics page', async () => {
-      const $ = await next.render$('/suspenseful/dynamic', {
+    it('should contain async generated metadata in head for simple dynamics page', async () => {
+      const $ = await next.render$('/suspenseful/dynamic', undefined, {
         headers: {
           'User-Agent': 'Discordbot/2.0;',
         },
       })
-      expect($('body title').text()).toBe('suspenseful page - dynamic')
+      expect($('head title').text()).toBe('suspenseful page - dynamic')
     })
 
-    it('should contain async generated metadata in body for suspenseful dynamic page', async () => {
-      const $ = await next.render$('/slow/dynamic', {
+    it('should contain async generated metadata in head for suspenseful dynamic page', async () => {
+      const $ = await next.render$('/slow/dynamic', undefined, {
         headers: {
           'User-Agent': 'Discordbot/2.0;',
         },
       })
-      expect($('body title').text()).toBe('slow page - dynamic')
+      expect($('head title').text()).toBe('slow page - dynamic')
     })
   })
 })

--- a/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
+++ b/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('app-dir - metadata-streaming-static-generation', () => {
-  const { next, isNextStart } = nextTestSetup({
+  const { next, isNextDev, isNextStart } = nextTestSetup({
     files: __dirname,
   })
 
@@ -20,22 +20,41 @@ describe('app-dir - metadata-streaming-static-generation', () => {
     })
   }
 
-  describe('static pages', () => {
-    it('should contain async generated metadata in head for simple static page', async () => {
-      const $ = await next.render$('/')
-      expect($('head title').text()).toBe('index page')
-    })
+  if (isNextDev) {
+    describe('static pages (development)', () => {
+      it('should contain async generated metadata in body for simple static page', async () => {
+        const $ = await next.render$('/')
+        expect($('body title').text()).toBe('index page')
+      })
 
-    it('should contain async generated metadata in head for slow static page', async () => {
-      const $ = await next.render$('/slow/static')
-      expect($('head title').text()).toBe('slow page - static')
-    })
+      it('should contain async generated metadata in body for slow static page', async () => {
+        const $ = await next.render$('/slow/static')
+        expect($('body title').text()).toBe('slow page - static')
+      })
 
-    it('should contain async generated metadata in head static page with suspenseful content', async () => {
-      const $ = await next.render$('/suspenseful/static')
-      expect($('head title').text()).toBe('suspenseful page - static')
+      it('should contain async generated metadata in body static page with suspenseful content', async () => {
+        const $ = await next.render$('/suspenseful/static')
+        expect($('body title').text()).toBe('suspenseful page - static')
+      })
     })
-  })
+  } else {
+    describe('static pages (production)', () => {
+      it('should contain async generated metadata in head for simple static page', async () => {
+        const $ = await next.render$('/')
+        expect($('head title').text()).toBe('index page')
+      })
+
+      it('should contain async generated metadata in head for slow static page', async () => {
+        const $ = await next.render$('/slow/static')
+        expect($('head title').text()).toBe('slow page - static')
+      })
+
+      it('should contain async generated metadata in head static page with suspenseful content', async () => {
+        const $ = await next.render$('/suspenseful/static')
+        expect($('head title').text()).toBe('suspenseful page - static')
+      })
+    })
+  }
 
   describe('dynamic pages', () => {
     it('should contain async generated metadata in body for simple dynamics page', async () => {
@@ -45,6 +64,26 @@ describe('app-dir - metadata-streaming-static-generation', () => {
 
     it('should contain async generated metadata in body for suspenseful dynamic page', async () => {
       const $ = await next.render$('/slow/dynamic')
+      expect($('body title').text()).toBe('slow page - dynamic')
+    })
+  })
+
+  describe('dynamic pages with html limited bots', () => {
+    it('should contain async generated metadata in body for simple dynamics page', async () => {
+      const $ = await next.render$('/suspenseful/dynamic', {
+        headers: {
+          'User-Agent': 'Discordbot/2.0;',
+        },
+      })
+      expect($('body title').text()).toBe('suspenseful page - dynamic')
+    })
+
+    it('should contain async generated metadata in body for suspenseful dynamic page', async () => {
+      const $ = await next.render$('/slow/dynamic', {
+        headers: {
+          'User-Agent': 'Discordbot/2.0;',
+        },
+      })
       expect($('body title').text()).toBe('slow page - dynamic')
     })
   })

--- a/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
+++ b/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
@@ -1,9 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 
+const isPPREnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+
 describe('app-dir - metadata-streaming-static-generation', () => {
   const { next, isNextDev, isNextStart } = nextTestSetup({
     files: __dirname,
   })
+
+  // /suspenseful/dynamic will behave differently when PPR is enabled.
+  // We'll visit PPR tests in the new test suite.
+  if (isPPREnabled) {
+    it('skip ppr test', () => {})
+  }
 
   if (isNextStart) {
     // Precondition for the following tests in build mode
@@ -21,6 +29,7 @@ describe('app-dir - metadata-streaming-static-generation', () => {
   }
 
   if (isNextDev) {
+    // In development it's still dynamic rendering that metadata will be inserted into body
     describe('static pages (development)', () => {
       it('should contain async generated metadata in body for simple static page', async () => {
         const $ = await next.render$('/')

--- a/test/e2e/app-dir/metadata-streaming-static-generation/next.config.js
+++ b/test/e2e/app-dir/metadata-streaming-static-generation/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    streamingMetadata: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
### What

Keep original way of rendering metadata during static generation and requesting with html limited bots agent

### Why

When it's in static generation, we would like to sacrifice more time to output the more compatible result of HTML, which the metadata can be rendered in the head. Same for when streaming metadata is not enabled. Hence we reapproach the rendering strategy to move the metadata into top `<head>` position along with `veiwport` when it's needed.

In this way we can avoid the issues that metadata are rendered in the body for static generation which will makes html limited bots not able to handle it.

Related reports: https://github.com/vercel/next.js/issues/55524#issuecomment-2608975482