### PR TITLE
Remove `internal_disableSyncDynamicAPIWarnings` flag

### DIFF
--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -269,10 +269,6 @@ export function getDefineEnv({
     'process.env.__NEXT_LINK_NO_TOUCH_START':
       config.experimental.linkNoTouchStart ?? false,
     'process.env.__NEXT_ASSET_PREFIX': config.assetPrefix,
-    'process.env.__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS':
-      // Internal only so untyped to avoid discovery
-      (config.experimental as any).internal_disableSyncDynamicAPIWarnings ??
-      false,
     'process.env.__NEXT_EXPERIMENTAL_AUTH_INTERRUPTS':
       !!config.experimental.authInterrupts,
     ...(isNodeOrEdgeCompilation

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -314,7 +314,6 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         imgOptTimeoutInSeconds: z.number().int().optional(),
         imgOptMaxInputPixels: z.number().int().optional(),
         imgOptSequentialRead: z.boolean().optional().nullable(),
-        internal_disableSyncDynamicAPIWarnings: z.boolean().optional(),
         isrFlushToDisk: z.boolean().optional(),
         largePageDataBytes: z.number().optional(),
         linkNoTouchStart: z.boolean().optional(),

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -558,11 +558,9 @@ function syncIODev(route: string | undefined, expression: string) {
   warnForSyncAccess(route, expression)
 }
 
-const noop = () => {}
-
-const warnForSyncAccess = process.env.__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS
-  ? noop
-  : createDedupedByCallsiteServerErrorLoggerDev(createCookiesAccessError)
+const warnForSyncAccess = createDedupedByCallsiteServerErrorLoggerDev(
+  createCookiesAccessError
+)
 
 function createCookiesAccessError(
   route: string | undefined,

--- a/packages/next/src/server/request/draft-mode.ts
+++ b/packages/next/src/server/request/draft-mode.ts
@@ -202,11 +202,9 @@ function syncIODev(route: string | undefined, expression: string) {
   warnForSyncAccess(route, expression)
 }
 
-const noop = () => {}
-
-const warnForSyncAccess = process.env.__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS
-  ? noop
-  : createDedupedByCallsiteServerErrorLoggerDev(createDraftModeAccessError)
+const warnForSyncAccess = createDedupedByCallsiteServerErrorLoggerDev(
+  createDraftModeAccessError
+)
 
 function createDraftModeAccessError(
   route: string | undefined,

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -480,11 +480,9 @@ function syncIODev(route: string | undefined, expression: string) {
   warnForSyncAccess(route, expression)
 }
 
-const noop = () => {}
-
-const warnForSyncAccess = process.env.__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS
-  ? noop
-  : createDedupedByCallsiteServerErrorLoggerDev(createHeadersAccessError)
+const warnForSyncAccess = createDedupedByCallsiteServerErrorLoggerDev(
+  createHeadersAccessError
+)
 
 function createHeadersAccessError(
   route: string | undefined,

--- a/packages/next/src/server/request/params.browser.ts
+++ b/packages/next/src/server/request/params.browser.ts
@@ -91,43 +91,29 @@ function makeDynamicallyTrackedExoticParamsWithDevWarnings(
   return proxiedPromise
 }
 
-const noop = () => {}
+function warnForSyncAccess(expression: string) {
+  console.error(
+    `A param property was accessed directly with ${expression}. \`params\` is now a Promise and should be unwrapped with \`React.use()\` before accessing properties of the underlying params object. In this version of Next.js direct access to param properties is still supported to facilitate migration but in a future version you will be required to unwrap \`params\` with \`React.use()\`.`
+  )
+}
 
-const warnForSyncAccess = process.env.__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS
-  ? noop
-  : function warnForSyncAccess(expression: string) {
-      if (process.env.__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS) {
-        return
-      }
-
-      console.error(
-        `A param property was accessed directly with ${expression}. \`params\` is now a Promise and should be unwrapped with \`React.use()\` before accessing properties of the underlying params object. In this version of Next.js direct access to param properties is still supported to facilitate migration but in a future version you will be required to unwrap \`params\` with \`React.use()\`.`
-      )
-    }
-
-const warnForEnumeration = process.env.__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS
-  ? noop
-  : function warnForEnumeration(missingProperties: Array<string>) {
-      if (process.env.__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS) {
-        return
-      }
-
-      if (missingProperties.length) {
-        const describedMissingProperties =
-          describeListOfPropertyNames(missingProperties)
-        console.error(
-          `params are being enumerated incompletely missing these properties: ${describedMissingProperties}. ` +
-            `\`params\` should be unwrapped with \`React.use()\` before using its value. ` +
-            `Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis`
-        )
-      } else {
-        console.error(
-          `params are being enumerated. ` +
-            `\`params\` should be unwrapped with \`React.use()\` before using its value. ` +
-            `Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis`
-        )
-      }
-    }
+function warnForEnumeration(missingProperties: Array<string>) {
+  if (missingProperties.length) {
+    const describedMissingProperties =
+      describeListOfPropertyNames(missingProperties)
+    console.error(
+      `params are being enumerated incompletely missing these properties: ${describedMissingProperties}. ` +
+        `\`params\` should be unwrapped with \`React.use()\` before using its value. ` +
+        `Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis`
+    )
+  } else {
+    console.error(
+      `params are being enumerated. ` +
+        `\`params\` should be unwrapped with \`React.use()\` before using its value. ` +
+        `Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis`
+    )
+  }
+}
 
 function describeListOfPropertyNames(properties: Array<string>) {
   switch (properties.length) {

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -447,18 +447,12 @@ function syncIODev(
   }
 }
 
-const noop = () => {}
+const warnForSyncAccess = createDedupedByCallsiteServerErrorLoggerDev(
+  createParamsAccessError
+)
 
-const warnForSyncAccess = process.env.__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS
-  ? noop
-  : createDedupedByCallsiteServerErrorLoggerDev(createParamsAccessError)
-
-const warnForIncompleteEnumeration = process.env
-  .__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS
-  ? noop
-  : createDedupedByCallsiteServerErrorLoggerDev(
-      createIncompleteEnumerationError
-    )
+const warnForIncompleteEnumeration =
+  createDedupedByCallsiteServerErrorLoggerDev(createIncompleteEnumerationError)
 
 function createParamsAccessError(
   route: string | undefined,

--- a/packages/next/src/server/request/search-params.browser.ts
+++ b/packages/next/src/server/request/search-params.browser.ts
@@ -122,32 +122,18 @@ function makeUntrackedExoticSearchParams(
   return promise
 }
 
-const noop = () => {}
+function warnForSyncAccess(expression: string) {
+  console.error(
+    `A searchParam property was accessed directly with ${expression}. ` +
+      `\`searchParams\` should be unwrapped with \`React.use()\` before accessing its properties. ` +
+      `Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis`
+  )
+}
 
-const warnForSyncAccess = process.env.__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS
-  ? noop
-  : function warnForSyncAccess(expression: string) {
-      if (process.env.__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS) {
-        return
-      }
-
-      console.error(
-        `A searchParam property was accessed directly with ${expression}. ` +
-          `\`searchParams\` should be unwrapped with \`React.use()\` before accessing its properties. ` +
-          `Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis`
-      )
-    }
-
-const warnForSyncSpread = process.env.__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS
-  ? noop
-  : function warnForSyncSpread() {
-      if (process.env.__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS) {
-        return
-      }
-
-      console.error(
-        `The keys of \`searchParams\` were accessed directly. ` +
-          `\`searchParams\` should be unwrapped with \`React.use()\` before accessing its properties. ` +
-          `Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis`
-      )
-    }
+function warnForSyncSpread() {
+  console.error(
+    `The keys of \`searchParams\` were accessed directly. ` +
+      `\`searchParams\` should be unwrapped with \`React.use()\` before accessing its properties. ` +
+      `Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis`
+  )
+}

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -716,18 +716,12 @@ function syncIODev(
   }
 }
 
-const noop = () => {}
+const warnForSyncAccess = createDedupedByCallsiteServerErrorLoggerDev(
+  createSearchAccessError
+)
 
-const warnForSyncAccess = process.env.__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS
-  ? noop
-  : createDedupedByCallsiteServerErrorLoggerDev(createSearchAccessError)
-
-const warnForIncompleteEnumeration = process.env
-  .__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS
-  ? noop
-  : createDedupedByCallsiteServerErrorLoggerDev(
-      createIncompleteEnumerationError
-    )
+const warnForIncompleteEnumeration =
+  createDedupedByCallsiteServerErrorLoggerDev(createIncompleteEnumerationError)
 
 function createSearchAccessError(
   route: string | undefined,


### PR DESCRIPTION
No longer needed as of https://github.com/vercel/front/pull/37545

[Found no other mention of the option in GitHub codesearch](https://github.com/search?q=internal_disableSyncDynamicAPIWarnings&type=code&p=1) other than Next.js forks.