### PR TITLE
Turbopack: use raw_read_dir to create fewer FileSystemPaths

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
@@ -5,8 +5,8 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{Completion, ValueToString, Vc};
 
 use crate::{
-    DirectoryContent, DirectoryEntry, File, FileContent, FileMeta, FileSystem, FileSystemPath,
-    LinkContent,
+    File, FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent, RawDirectoryContent,
+    RawDirectoryEntry,
 };
 
 #[turbo_tasks::value(serialization = "none", cell = "new", eq = "manual")]
@@ -40,12 +40,12 @@ impl FileSystem for EmbeddedFileSystem {
     }
 
     #[turbo_tasks::function]
-    async fn read_dir(&self, path: Vc<FileSystemPath>) -> Result<Vc<DirectoryContent>> {
+    async fn raw_read_dir(&self, path: Vc<FileSystemPath>) -> Result<Vc<RawDirectoryContent>> {
         let path_str = &path.await?.path;
         let dir = match (path_str.as_str(), self.dir.get_dir(path_str)) {
             ("", _) => self.dir,
             (_, Some(dir)) => dir,
-            (_, None) => return Ok(DirectoryContent::NotFound.cell()),
+            (_, None) => return Ok(RawDirectoryContent::NotFound.cell()),
         };
 
         let mut converted_entries = AutoMap::new();
@@ -56,18 +56,17 @@ impl FileSystem for EmbeddedFileSystem {
                 .unwrap_or_default()
                 .to_string_lossy()
                 .into();
-            let entry_path = path.join(entry_name.clone()).to_resolved().await?;
 
             converted_entries.insert(
                 entry_name,
                 match e {
-                    DirEntry::Dir(_) => DirectoryEntry::Directory(entry_path),
-                    DirEntry::File(_) => DirectoryEntry::File(entry_path),
+                    DirEntry::Dir(_) => RawDirectoryEntry::Directory,
+                    DirEntry::File(_) => RawDirectoryEntry::File,
                 },
             );
         }
 
-        Ok(DirectoryContent::new(converted_entries))
+        Ok(RawDirectoryContent::new(converted_entries))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
@@ -2,7 +2,8 @@ use anyhow::{bail, Result};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{Completion, ValueDefault, ValueToString, Vc};
 
-use super::{DirectoryContent, FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent};
+use super::{FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent};
+use crate::RawDirectoryContent;
 
 #[turbo_tasks::value]
 pub struct VirtualFileSystem {
@@ -56,7 +57,7 @@ impl FileSystem for VirtualFileSystem {
     }
 
     #[turbo_tasks::function]
-    fn read_dir(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<DirectoryContent>> {
+    fn raw_read_dir(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<RawDirectoryContent>> {
         bail!("Reading is not possible on the virtual file system")
     }
 

--- a/turbopack/crates/turbopack-core/src/server_fs.rs
+++ b/turbopack/crates/turbopack-core/src/server_fs.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{Completion, ValueToString, Vc};
 use turbo_tasks_fs::{
-    DirectoryContent, FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent,
+    FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent, RawDirectoryContent,
 };
 
 #[turbo_tasks::value]
@@ -29,7 +29,7 @@ impl FileSystem for ServerFileSystem {
     }
 
     #[turbo_tasks::function]
-    fn read_dir(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<DirectoryContent>> {
+    fn raw_read_dir(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<RawDirectoryContent>> {
         bail!("Reading is not possible from the marker filesystem for the server")
     }
 


### PR DESCRIPTION
### What?

* use raw_read_dir to avoid creating many FileSystemPaths
* use raw_read_dir in resolving

Closes PACK-3804