### PR TITLE
test: Move `should not cause error when removing loading.js` to flaky manifest

### DIFF
--- a/test/e2e/app-dir/app-compilation/index.test.ts
+++ b/test/e2e/app-dir/app-compilation/index.test.ts
@@ -38,7 +38,7 @@ describe('app dir', () => {
 
         await retry(async () => {
           expect(next.cliOutput.slice(cliOutputLength)).toInclude('✓ Compiled')
-        }, 10_000)
+        })
 
         // It should not have an error
         await assertNoRedbox(browser)

--- a/test/e2e/app-dir/app-compilation/index.test.ts
+++ b/test/e2e/app-dir/app-compilation/index.test.ts
@@ -38,7 +38,7 @@ describe('app dir', () => {
 
         await retry(async () => {
           expect(next.cliOutput.slice(cliOutputLength)).toInclude('✓ Compiled')
-        })
+        }, 10_000)
 
         // It should not have an error
         await assertNoRedbox(browser)

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -3770,10 +3770,10 @@
     "runtimeError": false
   },
   "test/e2e/app-dir/app-compilation/index.test.ts": {
-    "passed": ["app dir HMR should not cause error when removing loading.js"],
+    "passed": [],
     "failed": [],
     "pending": [],
-    "flakey": [],
+    "flakey": ["app dir HMR should not cause error when removing loading.js"],
     "runtimeError": false
   },
   "test/e2e/app-dir/app-config-crossorigin/index.test.ts": {


### PR DESCRIPTION
Moved `should not cause error when removing loading.js` test to flaky manifest.

x-ref: [Flakiness Metrics](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20env%3Aci%20%40git.repository.id%3Agithub.com%2Fvercel%2Fnext.js%20%40test.service%3Anextjs%20%40test.status%3Afail%20%40test.name%3A%22app%20dir%20HMR%20should%20not%20cause%20error%20when%20removing%20loading.js%22&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&start=1720817553405&end=1721422353405&paused=false)