### PR TITLE
Gate `captureOwnerStack` access on `experimental.reactOwnerStack`

### DIFF
--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -293,6 +293,8 @@ export function getDefineEnv({
       process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ||
       config.experimental.newDevOverlay ||
       false,
+    'process.env.__NEXT_REACT_OWNER_STACK':
+      config.experimental.reactOwnerStack ?? false,
   }
 
   const userDefines = config.compiler?.define ?? {}

--- a/packages/next/src/client/components/errors/stitched-error.ts
+++ b/packages/next/src/client/components/errors/stitched-error.ts
@@ -6,12 +6,8 @@ const REACT_ERROR_STACK_BOTTOM_FRAME_REGEX = new RegExp(
   `(at ${REACT_ERROR_STACK_BOTTOM_FRAME} )|(${REACT_ERROR_STACK_BOTTOM_FRAME}\\@)`
 )
 
-const captureOwnerStack = React.captureOwnerStack
-  ? React.captureOwnerStack
-  : () => ''
-
 export function getReactStitchedError<T = unknown>(err: T): Error | T {
-  if (typeof React.captureOwnerStack !== 'function') {
+  if (!process.env.__NEXT_REACT_OWNER_STACK) {
     return err
   }
   const isErrorInstance = isError(err)
@@ -39,8 +35,9 @@ export function getReactStitchedError<T = unknown>(err: T): Error | T {
 
 function appendOwnerStack(error: Error) {
   let stack = error.stack || ''
+  // This module is only bundled in development mode so this is safe.
+  const ownerStack = React.captureOwnerStack()
   // Avoid duplicate overriding stack frames
-  const ownerStack = captureOwnerStack()
   if (ownerStack && stack.endsWith(ownerStack) === false) {
     stack += ownerStack
     // Override stack


### PR DESCRIPTION
The conditional access was only needed while we have the flag. So we might as well just gate it behind the flag so that we automatically clean it up when we remove the flag.

Since these modules are dev-only we'll never need the conditional access once the flag is on. 