### PR TITLE
[Turbopack] disable dependency tracking when running build without persistent caching

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -206,6 +206,8 @@ pub struct NapiTurboEngineOptions {
     pub persistent_caching: Option<bool>,
     /// An upper bound of memory that turbopack will attempt to stay under.
     pub memory_limit: Option<f64>,
+    /// Track dependencies between tasks. If false, any change during build will error.
+    pub dependency_tracking: Option<bool>,
 }
 
 impl From<NapiWatchOptions> for WatchOptions {
@@ -377,10 +379,12 @@ pub async fn project_new(
         .map(|m| m as usize)
         .unwrap_or(usize::MAX);
     let persistent_caching = turbo_engine_options.persistent_caching.unwrap_or_default();
+    let dependency_tracking = turbo_engine_options.dependency_tracking.unwrap_or(true);
     let turbo_tasks = create_turbo_tasks(
         PathBuf::from(&options.dist_dir),
         persistent_caching,
         memory_limit,
+        dependency_tracking,
     )?;
     if !persistent_caching {
         use std::io::Write;

--- a/crates/napi/src/next_api/utils.rs
+++ b/crates/napi/src/next_api/utils.rs
@@ -127,6 +127,7 @@ pub fn create_turbo_tasks(
     output_path: PathBuf,
     persistent_caching: bool,
     _memory_limit: usize,
+    dependency_tracking: bool,
 ) -> Result<NextTurboTasks> {
     Ok(if persistent_caching {
         let dirty_suffix = if crate::build::GIT_CLEAN
@@ -158,6 +159,7 @@ pub fn create_turbo_tasks(
                     } else {
                         turbo_tasks_backend::StorageMode::ReadWrite
                     }),
+                    dependency_tracking,
                     ..Default::default()
                 },
                 default_backing_storage(&output_path.join("cache/turbopack"), &version_info)?,

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -177,6 +177,8 @@ export interface NapiTurboEngineOptions {
   persistentCaching?: boolean
   /** An upper bound of memory that turbopack will attempt to stay under. */
   memoryLimit?: number
+  /** Track dependencies between tasks. If false, any change during build will error. */
+  dependencyTracking?: boolean
 }
 export declare function projectNew(
   options: NapiProjectOptions,

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -1,13 +1,19 @@
 import type { NextConfigComplete } from '../../server/config-shared'
 import type { __ApiPreviewProps } from '../../server/api-utils'
-import type { ExternalObject, RefCell } from './generated-native'
+import type {
+  ExternalObject,
+  RefCell,
+  NapiTurboEngineOptions,
+} from './generated-native'
+
+export type { NapiTurboEngineOptions as TurboEngineOptions }
 
 export interface Binding {
   isWasm: boolean
   turbo: {
     createProject(
       options: ProjectOptions,
-      turboEngineOptions?: TurboEngineOptions
+      turboEngineOptions?: NapiTurboEngineOptions
     ): Promise<Project>
     startTurbopackTraceServer(traceFilePath: string): void
 
@@ -97,18 +103,6 @@ export interface Diagnostics {
 export type TurbopackResult<T = {}> = T & {
   issues: Issue[]
   diagnostics: Diagnostics[]
-}
-
-export interface TurboEngineOptions {
-  /**
-   * Use the new backend with persistent caching enabled.
-   */
-  persistentCaching?: boolean
-
-  /**
-   * An upper bound of memory that turbopack will attempt to stay under.
-   */
-  memoryLimit?: number
 }
 
 export interface Middleware {

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -61,6 +61,7 @@ export async function turbopackBuild(): Promise<{
     'last 1 Chrome versions, last 1 Firefox versions, last 1 Safari versions, last 1 Edge versions',
   ]
 
+  const persistentCaching = isPersistentCachingEnabled(config)
   const project = await bindings.turbo.createProject(
     {
       projectPath: dir,
@@ -91,8 +92,9 @@ export async function turbopackBuild(): Promise<{
       browserslistQuery: supportedBrowsers.join(', '),
     },
     {
-      persistentCaching: isPersistentCachingEnabled(config),
+      persistentCaching,
       memoryLimit: config.experimental.turbo?.memoryLimit,
+      dependencyTracking: persistentCaching,
     }
   )
 

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -428,6 +428,7 @@ pub async fn build(args: &BuildArguments) -> Result<()> {
 
     let tt = TurboTasks::new(TurboTasksBackend::new(
         BackendOptions {
+            dependency_tracking: false,
             storage_mode: None,
             ..Default::default()
         },


### PR DESCRIPTION
### What?

When running next build there won't be any changes during build and we don't need to capture dependencies at all.

Closes PACK-3849