### PR TITLE
docs: Clarify available route intercepting conventions

### DIFF
--- a/docs/01-app/03-building-your-application/01-routing/12-intercepting-routes.mdx
+++ b/docs/01-app/03-building-your-application/01-routing/12-intercepting-routes.mdx
@@ -41,6 +41,8 @@ You can use:
 - `(..)(..)` to match segments **two levels above**
 - `(...)` to match segments from the **root** `app` directory
 
+> **Good to know:** these four are the only recognized conventions and cannot be composed together. For example `(..)(..)(..)` would **not** work. If you need to intercept routes that branch three or more levels above the one you wnat to intercept from, you’ll need to start from the root `app` directory with `(...)`.
+
 For example, you can intercept the `photo` segment from within the `feed` segment by creating a `(..)photo` directory.
 
 <Image


### PR DESCRIPTION
From the previous documentation it was not apparent that `(...)` and `(..)(..)` are specifically hard coded options. It seems that `(..)(..)` is just an example repetition of `(..)`.

This change clarifies that only the four cited conventions are available and they cannot be composed.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
