### PR TITLE
test: skip dev/deploy testing for `test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts`

### DIFF
--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -57,7 +57,8 @@
       "test/e2e/middleware-matcher/index.test.ts",
       "test/e2e/next-script/index.test.ts",
       "test/production/standalone-mode/**/*",
-      "test/e2e/app-dir/next-after-app-deploy/index.test.ts"
+      "test/e2e/app-dir/next-after-app-deploy/index.test.ts",
+      "test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts"
     ]
   }
 }

--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -57,8 +57,7 @@
       "test/e2e/middleware-matcher/index.test.ts",
       "test/e2e/next-script/index.test.ts",
       "test/production/standalone-mode/**/*",
-      "test/e2e/app-dir/next-after-app-deploy/index.test.ts",
-      "test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts"
+      "test/e2e/app-dir/next-after-app-deploy/index.test.ts"
     ]
   }
 }

--- a/test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts
+++ b/test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts
@@ -6,6 +6,11 @@ import { createTestLog } from 'test-log'
 import { findPort } from 'next-test-utils'
 
 describe('segment cache (revalidation)', () => {
+  if (isNextDev || isNextDeploy) {
+    test('disabled in development / deployment', () => {})
+    return
+  }
+
   let port = -1
   let server
   let pendingRequests = new Map()
@@ -44,11 +49,6 @@ describe('segment cache (revalidation)', () => {
     await next?.destroy()
     server?.close()
   })
-
-  if (isNextDev || isNextDeploy) {
-    test('disabled in development / deployment', () => {})
-    return
-  }
 
   it('evict client cache when Server Action calls revalidatePath', async () => {
     let act: ReturnType<typeof createRouterAct>


### PR DESCRIPTION
### Why?

Since this test creates a mock server to fetch before creating a Next.js instance, it will fail on the deployment test due to a mismatch in the location of the server and the instance. The test did try to skip when deployed but it was after the `createNext` logic, which triggered the deployment before skipping.

### How?

Move the skip before any `beforeAll` logic like creating an instance.