### PR TITLE
refactor(turbo-tasks): Merge dynamic_call/native_call with dynamic_this_call/native_this_call

### DIFF
--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -593,9 +593,9 @@ impl TurboFn<'_> {
                     let this = #converted_this;
                     let persistence = #persistence;
                     <#output as turbo_tasks::task::TaskOutput>::try_from_raw_vc(
-                        turbo_tasks::dynamic_this_call(
+                        turbo_tasks::dynamic_call(
                             *#native_function_id_ident,
-                            this,
+                            Some(this),
                             inputs as std::boxed::Box<dyn turbo_tasks::MagicAny>,
                             persistence,
                         )
@@ -612,6 +612,7 @@ impl TurboFn<'_> {
                     <#output as turbo_tasks::task::TaskOutput>::try_from_raw_vc(
                         turbo_tasks::dynamic_call(
                             *#native_function_id_ident,
+                            None,
                             inputs as std::boxed::Box<dyn turbo_tasks::MagicAny>,
                             persistence,
                         )

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -91,35 +91,16 @@ impl TurboTasksCallApi for VcStorage {
     fn dynamic_call(
         &self,
         func: turbo_tasks::FunctionId,
+        this: Option<RawVc>,
         arg: Box<dyn MagicAny>,
         _persistence: TaskPersistence,
     ) -> RawVc {
-        self.dynamic_call(func, None, arg)
+        self.dynamic_call(func, this, arg)
     }
-
-    fn dynamic_this_call(
-        &self,
-        func: turbo_tasks::FunctionId,
-        this_arg: RawVc,
-        arg: Box<dyn MagicAny>,
-        _persistence: TaskPersistence,
-    ) -> RawVc {
-        self.dynamic_call(func, Some(this_arg), arg)
-    }
-
     fn native_call(
         &self,
         _func: turbo_tasks::FunctionId,
-        _arg: Box<dyn MagicAny>,
-        _persistence: TaskPersistence,
-    ) -> RawVc {
-        unreachable!()
-    }
-
-    fn this_call(
-        &self,
-        _func: turbo_tasks::FunctionId,
-        _this: RawVc,
+        _this: Option<RawVc>,
         _arg: Box<dyn MagicAny>,
         _persistence: TaskPersistence,
     ) -> RawVc {

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -102,11 +102,10 @@ pub use join_iter_ext::{JoinIterExt, TryFlatJoinIterExt, TryJoinIterExt};
 pub use key_value_pair::KeyValuePair;
 pub use magic_any::MagicAny;
 pub use manager::{
-    dynamic_call, dynamic_this_call, emit, mark_finished, mark_session_dependent, mark_stateful,
-    prevent_gc, run_once, run_once_with_reason, spawn_blocking, spawn_thread, trait_call,
-    turbo_tasks, turbo_tasks_scope, CurrentCellRef, ReadConsistency, TaskPersistence, TurboTasks,
-    TurboTasksApi, TurboTasksBackendApi, TurboTasksBackendApiExt, TurboTasksCallApi, Unused,
-    UpdateInfo,
+    dynamic_call, emit, mark_finished, mark_session_dependent, mark_stateful, prevent_gc, run_once,
+    run_once_with_reason, spawn_blocking, spawn_thread, trait_call, turbo_tasks, turbo_tasks_scope,
+    CurrentCellRef, ReadConsistency, TaskPersistence, TurboTasks, TurboTasksApi,
+    TurboTasksBackendApi, TurboTasksBackendApiExt, TurboTasksCallApi, Unused, UpdateInfo,
 };
 pub use native_function::{FunctionMeta, NativeFunction};
 pub use output::OutputContent;

--- a/turbopack/crates/turbo-tasks/src/task/local_task.rs
+++ b/turbopack/crates/turbo-tasks/src/task/local_task.rs
@@ -156,11 +156,7 @@ impl LocalTaskType {
             *this = this.resolve().await?;
         }
         let arg = registry::get_function(fn_id).arg_meta.resolve(arg).await?;
-        Ok(if let Some(this) = this {
-            turbo_tasks.this_call(fn_id, this, arg, persistence)
-        } else {
-            turbo_tasks.native_call(fn_id, arg, persistence)
-        })
+        Ok(turbo_tasks.native_call(fn_id, this, arg, persistence))
     }
 
     pub async fn run_resolve_trait<B: Backend + 'static>(
@@ -179,7 +175,7 @@ impl LocalTaskType {
             .arg_meta
             .resolve(arg)
             .await?;
-        Ok(turbo_tasks.dynamic_this_call(native_fn, this, arg, persistence))
+        Ok(turbo_tasks.dynamic_call(native_fn, Some(this), arg, persistence))
     }
 
     fn resolve_trait_method_from_value(


### PR DESCRIPTION
The `_this` argument variants of these functions are 99% of the same, so this deduplicates them.

Closes PACK-3814