### PR TITLE
Turbopack: set env in tracing context

### DIFF
--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -6,8 +6,8 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, NonLocalValue, ResolvedVc, ValueDefault, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
-    chunk::SourceMapsType, condition::ContextCondition, environment::Environment,
-    resolve::options::ImportMapping,
+    chunk::SourceMapsType, compile_time_info::CompileTimeInfo, condition::ContextCondition,
+    environment::Environment, resolve::options::ImportMapping,
 };
 use turbopack_ecmascript::{TreeShakingMode, references::esm::UrlRewriteBehavior};
 pub use turbopack_mdx::MdxTransformOptions;
@@ -121,7 +121,6 @@ impl ValueDefault for TypescriptTransformOptions {
     }
 }
 
-// [TODO]: should enabled_react_refresh belong to this options?
 #[turbo_tasks::value(shared)]
 #[derive(Default, Clone, Debug)]
 pub struct JsxTransformOptions {
@@ -129,6 +128,14 @@ pub struct JsxTransformOptions {
     pub react_refresh: bool,
     pub import_source: Option<RcStr>,
     pub runtime: Option<RcStr>,
+}
+
+#[turbo_tasks::value(shared)]
+#[derive(Clone, Debug)]
+pub struct ExternalsTracingOptions {
+    /// The directory from which the bundled files will require the externals at runtime.
+    pub tracing_root: FileSystemPath,
+    pub compile_time_info: ResolvedVc<CompileTimeInfo>,
 }
 
 #[turbo_tasks::value(shared)]
@@ -152,10 +159,7 @@ pub struct ModuleOptionsContext {
 
     /// Generate (non-emitted) output assets for static assets and externals, to facilitate
     /// generating a list of all non-bundled files that will be required at runtime.
-    ///
-    /// The filepath is the directory from which the bundled files will require the externals at
-    /// runtime.
-    pub enable_externals_tracing: Option<FileSystemPath>,
+    pub enable_externals_tracing: Option<ResolvedVc<ExternalsTracingOptions>>,
 
     /// If true, it stores the last successful parse result in state and keeps using it when
     /// parsing fails. This is useful to keep the module graph structure intact when syntax errors


### PR DESCRIPTION
Part of PACK-4164

~~Set `NODE_ENV` in tracing context~~ For that, see https://github.com/vercel/next.js/pull/75254#issuecomment-2627686346
Set `TURBOPACK` in tracing context

This get rids of some constant build overhead (because we only analyze one instance of react-dom for NFT now, instead of all of the edge/server/client onces).
Otherwise no measureable perf/memory impact



Closes PACK-5175