### PR TITLE
perf(turbo-tasks): Add a 'local' option to `#[turbo_tasks::function(..)]`

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/tests/local_tasks.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/local_tasks.rs
@@ -1,0 +1,1 @@
+../../turbo-tasks-testing/tests/local_tasks.rs

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args.stderr
@@ -1,4 +1,4 @@
-error: unexpected token, expected one of: "fs", "network", "operation", or "local_cells"
+error: unexpected token, expected one of: "fs", "network", "operation", "local", or "local_cells"
  --> tests/function/fail_attribute_invalid_args.rs:9:25
   |
 9 | #[turbo_tasks::function(invalid_argument)]

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args_inherent_impl.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args_inherent_impl.stderr
@@ -1,4 +1,4 @@
-error: unexpected token, expected one of: "fs", "network", "operation", or "local_cells"
+error: unexpected token, expected one of: "fs", "network", "operation", "local", or "local_cells"
   --> tests/function/fail_attribute_invalid_args_inherent_impl.rs:14:29
    |
 14 |     #[turbo_tasks::function(invalid_argument)]

--- a/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
@@ -39,6 +39,7 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
     let args = syn::parse::<FunctionArguments>(args)
         .inspect_err(|err| errors.push(err.to_compile_error()))
         .unwrap_or_default();
+    let local = args.local.is_some();
     let local_cells = args.local_cells.is_some();
 
     let Some(turbo_fn) = TurboFn::new(&sig, DefinitionContext::NakedFn, args) else {
@@ -54,12 +55,13 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
     let (inline_signature, inline_block) = turbo_fn.inline_signature_and_block(&block);
     let inline_attrs = filter_inline_attributes(&attrs[..]);
 
-    let native_fn = NativeFn::new(
-        &ident.to_string(),
-        &parse_quote! { #inline_function_ident },
-        turbo_fn.is_method(),
+    let native_fn = NativeFn {
+        function_path_string: ident.to_string(),
+        function_path: parse_quote! { #inline_function_ident },
+        is_method: turbo_fn.is_method(),
+        local,
         local_cells,
-    );
+    };
     let native_function_ident = get_native_function_ident(ident);
     let native_function_ty = native_fn.ty();
     let native_function_def = native_fn.definition();

--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -122,6 +122,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                 let func_args = func_args
                     .inspect_err(|err| errors.push(err.to_compile_error()))
                     .unwrap_or_default();
+                let local = func_args.local.is_some();
                 let local_cells = func_args.local_cells.is_some();
 
                 let Some(turbo_fn) =
@@ -135,12 +136,13 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                 let (inline_signature, inline_block) = turbo_fn.inline_signature_and_block(block);
                 let inline_attrs = filter_inline_attributes(attrs.iter().copied());
 
-                let native_fn = NativeFn::new(
-                    &format!("{ty}::{ident}", ty = ty.to_token_stream()),
-                    &parse_quote! { <#ty>::#inline_function_ident },
-                    turbo_fn.is_method(),
+                let native_fn = NativeFn {
+                    function_path_string: format!("{ty}::{ident}", ty = ty.to_token_stream()),
+                    function_path: parse_quote! { <#ty>::#inline_function_ident },
+                    is_method: turbo_fn.is_method(),
+                    local,
                     local_cells,
-                );
+                };
 
                 let native_function_ident = get_inherent_impl_function_ident(ty_ident, ident);
                 let native_function_ty = native_fn.ty();
@@ -221,6 +223,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                 let func_args = func_args
                     .inspect_err(|err| errors.push(err.to_compile_error()))
                     .unwrap_or_default();
+                let local = func_args.local.is_some();
                 let local_cells = func_args.local_cells.is_some();
 
                 let Some(turbo_fn) =
@@ -239,18 +242,19 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                 let (inline_signature, inline_block) = turbo_fn.inline_signature_and_block(block);
                 let inline_attrs = filter_inline_attributes(attrs.iter().copied());
 
-                let native_fn = NativeFn::new(
-                    &format!(
+                let native_fn = NativeFn {
+                    function_path_string: format!(
                         "<{ty} as {trait_path}>::{ident}",
                         ty = ty.to_token_stream(),
                         trait_path = trait_path.to_token_stream()
                     ),
-                    &parse_quote! {
+                    function_path: parse_quote! {
                         <#ty as #inline_extension_trait_ident>::#inline_function_ident
                     },
-                    turbo_fn.is_method(),
+                    is_method: turbo_fn.is_method(),
+                    local,
                     local_cells,
-                );
+                };
 
                 let native_function_ident =
                     get_trait_impl_function_ident(ty_ident, &trait_ident, ident);

--- a/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -114,18 +114,19 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
             let (inline_signature, inline_block) = turbo_fn.inline_signature_and_block(default);
             let inline_attrs = filter_inline_attributes(&attrs[..]);
 
-            let native_function = NativeFn::new(
-                &format!("{trait_ident}::{ident}"),
-                &parse_quote! {
+            let native_function = NativeFn {
+                function_path_string: format!("{trait_ident}::{ident}"),
+                function_path: parse_quote! {
                     <Box<dyn #trait_ident> as #inline_extension_trait_ident>::#inline_function_ident
                 },
-                turbo_fn.is_method(),
-                // `inline_cells` is currently unsupported here because:
+                is_method: turbo_fn.is_method(),
+                // `local` and `local_cells` are currently unsupported here because:
                 // - The `#[turbo_tasks::function]` macro needs to be present for us to read this
-                //   argument.
+                //   argument. (This could be fixed)
                 // - This only makes sense when a default implementation is present.
-                false,
-            );
+                local: false,
+                local_cells: false,
+            };
 
             let native_function_ident = get_trait_default_impl_function_ident(trait_ident, ident);
             let native_function_ty = native_function.ty();

--- a/turbopack/crates/turbo-tasks-memory/tests/local_tasks.rs
+++ b/turbopack/crates/turbo-tasks-memory/tests/local_tasks.rs
@@ -1,0 +1,1 @@
+../../turbo-tasks-testing/tests/local_tasks.rs

--- a/turbopack/crates/turbo-tasks-testing/tests/local_tasks.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/local_tasks.rs
@@ -1,0 +1,34 @@
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+#![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
+
+use anyhow::Result;
+use turbo_tasks::{test_helpers::current_task_for_testing, Vc};
+use turbo_tasks_testing::{register, run, Registration};
+
+static REGISTRATION: Registration = register!();
+
+#[tokio::test]
+async fn test_local_task_id() -> Result<()> {
+    run(&REGISTRATION, || async {
+        let local_vc = get_local_task_id();
+        assert!(local_vc.is_local());
+        assert_eq!(*local_vc.await.unwrap(), *current_task_for_testing());
+
+        let non_local_vc = get_non_local_task_id();
+        assert!(!non_local_vc.is_local());
+        assert_ne!(*non_local_vc.await.unwrap(), *current_task_for_testing());
+        Ok(())
+    })
+    .await
+}
+
+#[turbo_tasks::function(local)]
+fn get_local_task_id() -> Vc<u32> {
+    Vc::cell(*current_task_for_testing())
+}
+
+#[turbo_tasks::function]
+fn get_non_local_task_id() -> Vc<u32> {
+    Vc::cell(*current_task_for_testing())
+}

--- a/turbopack/crates/turbo-tasks/src/native_function.rs
+++ b/turbopack/crates/turbo-tasks/src/native_function.rs
@@ -86,6 +86,10 @@ impl ArgMeta {
 
 #[derive(Debug)]
 pub struct FunctionMeta {
+    /// Does not run the function as a task, and instead runs it inside the parent task using
+    /// task-local state. The function call itself will not be cached, but cells will be created on
+    /// the parent task.
+    pub local: bool,
     /// Changes the behavior of `Vc::cell` to create local cells that are not
     /// cached across task executions. Cells can be converted to their non-local
     /// versions by calling `Vc::resolve`.
@@ -175,7 +179,7 @@ impl NativeFunction {
                     transient = true,
                 )
             }
-            TaskPersistence::LocalCells => {
+            TaskPersistence::Local => {
                 tracing::trace_span!(
                     "turbo_tasks::function",
                     name = self.name.as_str(),
@@ -197,11 +201,11 @@ impl NativeFunction {
                     transient = true,
                 )
             }
-            TaskPersistence::LocalCells => {
+            TaskPersistence::Local => {
                 tracing::trace_span!(
                     "turbo_tasks::resolve_call",
                     name = self.name.as_str(),
-                    local_cells = true,
+                    local = true,
                 )
             }
         }

--- a/turbopack/crates/turbo-tasks/src/task/local_task.rs
+++ b/turbopack/crates/turbo-tasks/src/task/local_task.rs
@@ -29,9 +29,9 @@ pub fn get_local_task_execution_spec<'a>(
             this,
             arg,
         } => {
-            debug_assert_eq!(persistence, TaskPersistence::LocalCells);
+            debug_assert_eq!(persistence, TaskPersistence::Local);
             let func = registry::get_function(*native_fn_id);
-            let span = func.span(TaskPersistence::LocalCells);
+            let span = func.span(TaskPersistence::Local);
             let entered = span.enter();
             let future = func.execute(*this, &**arg);
             drop(entered);
@@ -43,7 +43,7 @@ pub fn get_local_task_execution_spec<'a>(
             arg,
         } => {
             let func = registry::get_function(*native_fn_id);
-            let span = func.resolve_span(TaskPersistence::LocalCells);
+            let span = func.resolve_span(TaskPersistence::Local);
             let entered = span.enter();
             let future = Box::pin(LocalTaskType::run_resolve_native(
                 *native_fn_id,


### PR DESCRIPTION
Allows tasks to be marked as local using `#[turbo_tasks::function(local)]`.

Local tasks are cached only for the lifetime of the nearest non-Local parent caller.

Local tasks do not have a unique task id, and are not shared with the backend. Instead they use the parent task's id and store data in the backend-agnostic manager.

This is useful for functions that have a low cache hit rate. Those functions could be converted to non-task functions, but that would break their function signature. This provides a mechanism for skipping caching without changing the function signature.

Local tasks are already used for argument resolution, this allows other arbitrary functions to be opted-in.

Closes PACK-3819