### PR TITLE
perf(turbo-tasks): Mark a bunch of stuff as local

### DIFF
--- a/crates/next-core/src/next_image/module.rs
+++ b/crates/next-core/src/next_image/module.rs
@@ -69,7 +69,7 @@ impl StructuredImageModuleType {
 
 #[turbo_tasks::value_impl]
 impl CustomModuleType for StructuredImageModuleType {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     fn create_module(
         &self,
         source: Vc<Box<dyn Source>>,

--- a/turbopack/crates/turbopack-css/src/references/import.rs
+++ b/turbopack/crates/turbopack-css/src/references/import.rs
@@ -143,7 +143,7 @@ impl ValueToString for ImportAssetReference {
 
 #[turbo_tasks::value_impl]
 impl CodeGenerateable for ImportAssetReference {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     async fn code_generation(
         self: Vc<Self>,
         _context: Vc<Box<dyn ChunkingContext>>,

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
@@ -79,7 +79,7 @@ impl ChunkType for EcmascriptChunkType {
         Ok(Vc::upcast(EcmascriptChunk::new(chunking_context, content)))
     }
 
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     async fn chunk_item_size(
         &self,
         _chunking_context: Vc<Box<dyn ChunkingContext>>,

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -85,7 +85,7 @@ impl EcmascriptChunkItemContent {
         .cell())
     }
 
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     pub async fn module_factory(&self) -> Result<Vc<Code>> {
         let mut args = vec![
             "r: __turbopack_require__",

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -397,7 +397,7 @@ impl EcmascriptAnalyzable for EcmascriptModuleAsset {
         ))
     }
 
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     async fn module_content(
         self: Vc<Self>,
         module_graph: Vc<ModuleGraph>,
@@ -748,7 +748,7 @@ pub struct EcmascriptModuleContent {
 #[turbo_tasks::value_impl]
 impl EcmascriptModuleContent {
     /// Creates a new [`Vc<EcmascriptModuleContent>`].
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     pub async fn new(
         parsed: ResolvedVc<ParseResult>,
         ident: ResolvedVc<AssetIdent>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -156,7 +156,7 @@ impl AmdDefineWithDependenciesCodeGen {
 
 #[turbo_tasks::value_impl]
 impl CodeGenerateable for AmdDefineWithDependenciesCodeGen {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     async fn code_generation(
         &self,
         module_graph: Vc<ModuleGraph>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -133,7 +133,7 @@ impl ChunkableModuleReference for CjsRequireAssetReference {}
 
 #[turbo_tasks::value_impl]
 impl CodeGenerateable for CjsRequireAssetReference {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     async fn code_generation(
         &self,
         module_graph: Vc<ModuleGraph>,
@@ -242,7 +242,7 @@ impl ChunkableModuleReference for CjsRequireResolveAssetReference {}
 
 #[turbo_tasks::value_impl]
 impl CodeGenerateable for CjsRequireResolveAssetReference {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     async fn code_generation(
         &self,
         module_graph: Vc<ModuleGraph>,
@@ -305,7 +305,7 @@ pub struct CjsRequireCacheAccess {
 
 #[turbo_tasks::value_impl]
 impl CodeGenerateable for CjsRequireCacheAccess {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     async fn code_generation(
         &self,
         _module_graph: Vc<ModuleGraph>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/constant_condition.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/constant_condition.rs
@@ -36,7 +36,7 @@ impl ConstantCondition {
 
 #[turbo_tasks::value_impl]
 impl CodeGenerateable for ConstantCondition {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     async fn code_generation(
         &self,
         _module_graph: Vc<ModuleGraph>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
@@ -30,7 +30,7 @@ impl ConstantValue {
 
 #[turbo_tasks::value_impl]
 impl CodeGenerateable for ConstantValue {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     async fn code_generation(
         &self,
         _module_graph: Vc<ModuleGraph>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
@@ -150,7 +150,7 @@ impl EsmBinding {
 
 #[turbo_tasks::value_impl]
 impl CodeGenerateable for EsmBindings {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     async fn code_generation(
         &self,
         _module_graph: Vc<ModuleGraph>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -110,7 +110,7 @@ impl ChunkableModuleReference for EsmAsyncAssetReference {
 
 #[turbo_tasks::value_impl]
 impl CodeGenerateable for EsmAsyncAssetReference {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     async fn code_generation(
         &self,
         module_graph: Vc<ModuleGraph>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
@@ -97,7 +97,7 @@ impl ImportMetaRef {
 
 #[turbo_tasks::value_impl]
 impl CodeGenerateable for ImportMetaRef {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     async fn code_generation(
         &self,
         _module_graph: Vc<ModuleGraph>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
@@ -63,7 +63,7 @@ impl ChunkableModuleReference for EsmModuleIdAssetReference {
 
 #[turbo_tasks::value_impl]
 impl CodeGenerateable for EsmModuleIdAssetReference {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     async fn code_generation(
         &self,
         module_graph: Vc<ModuleGraph>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_item.rs
@@ -35,7 +35,7 @@ impl EsmModuleItem {
 
 #[turbo_tasks::value_impl]
 impl CodeGenerateable for EsmModuleItem {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     async fn code_generation(
         &self,
         _module_graph: Vc<ModuleGraph>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -139,7 +139,7 @@ impl CodeGenerateable for UrlAssetReference {
     │ None                          │ new URL(url, base)                                                      │ new URL(url, base)                             │ new URL(url, base)    │
     └───────────────────────────────┴─────────────────────────────────────────────────────────────────────────┴────────────────────────────────────────────────┴───────────────────────┘
     */
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     async fn code_generation(
         self: Vc<Self>,
         module_graph: Vc<ModuleGraph>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/ident.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/ident.rs
@@ -29,7 +29,7 @@ impl IdentReplacement {
 
 #[turbo_tasks::value_impl]
 impl CodeGenerateable for IdentReplacement {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     async fn code_generation(
         &self,
         _module_graph: Vc<ModuleGraph>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -288,7 +288,7 @@ impl ChunkableModuleReference for RequireContextAssetReference {}
 
 #[turbo_tasks::value_impl]
 impl CodeGenerateable for RequireContextAssetReference {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     async fn code_generation(
         &self,
         module_graph: Vc<ModuleGraph>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/unreachable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/unreachable.rs
@@ -38,7 +38,7 @@ impl Unreachable {
 
 #[turbo_tasks::value_impl]
 impl CodeGenerateable for Unreachable {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     async fn code_generation(
         &self,
         _module_graph: Vc<ModuleGraph>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -117,7 +117,7 @@ impl ChunkableModuleReference for WorkerAssetReference {}
 
 #[turbo_tasks::value_impl]
 impl CodeGenerateable for WorkerAssetReference {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(local)]
     async fn code_generation(
         &self,
         _module_graph: Vc<ModuleGraph>,

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -66,7 +66,7 @@ use turbopack_wasm::{module_asset::WebAssemblyModuleAsset, source::WebAssemblySo
 use self::transition::{Transition, TransitionOptions};
 use crate::module_options::{CssOptionsContext, CustomModuleType, EcmascriptOptionsContext};
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(local)]
 async fn apply_module_type(
     source: ResolvedVc<Box<dyn Source>>,
     module_asset_context: Vc<ModuleAssetContext>,


### PR DESCRIPTION
Cache hit numbers on dev + build: https://gist.github.com/bgw/1924f240a482377def4504e8d1fc3e18

Try marking a bunch of functions as local, see that no tests break. Measure numbers before/after:

**Mean memory consumption before (on canary):** 5.53 GiB
**Mean "compiled in" time before (on canary):** 18.7s

**Mean memory consumption after (this PR):** 5.67 GiB
**Mean "compiled in" time after (this PR):** 19.0s

<details>
Command run:

```
rm -rf .next && TURBOPACK=1 TURBOPACK_BUILD=1 TURBO_ENGINE_READ_ONLY=1 /bin/time -v pnpm next build --experimental-build-mode=compile
```

# Before, run 1

Compiled in: 19.1s

```
        Command being timed: "pnpm next build --experimental-build-mode=compile"
        User time (seconds): 121.55
        System time (seconds): 17.03
        Percent of CPU this job got: 513%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:27.00
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 5561800
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 61
        Minor (reclaiming a frame) page faults: 1090182
        Voluntary context switches: 1299111
        Involuntary context switches: 351305
        Swaps: 0
        File system inputs: 112584
        File system outputs: 737120
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

# Before, run 2

Compiled in: 18.9s

```
        Command being timed: "pnpm next build --experimental-build-mode=compile"
        User time (seconds): 118.63
        System time (seconds): 16.68
        Percent of CPU this job got: 503%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:26.88
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 6023472
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 2
        Minor (reclaiming a frame) page faults: 1420969
        Voluntary context switches: 1285934
        Involuntary context switches: 313524
        Swaps: 0
        File system inputs: 0
        File system outputs: 737168
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

# Before, run 3

Compiled in: 18.2s

```
        Command being timed: "pnpm next build --experimental-build-mode=compile"
        User time (seconds): 117.55
        System time (seconds): 14.76
        Percent of CPU this job got: 509%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:25.99
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 5835060
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 1
        Minor (reclaiming a frame) page faults: 1416925
        Voluntary context switches: 1229953
        Involuntary context switches: 341983
        Swaps: 0
        File system inputs: 0
        File system outputs: 737216
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

# After, run 1

Compiled in: 19.6s

```
        Command being timed: "pnpm next build --experimental-build-mode=compile"
        User time (seconds): 125.92
        System time (seconds): 17.09
        Percent of CPU this job got: 516%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:27.69
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 5853124
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 61
        Minor (reclaiming a frame) page faults: 1266331
        Voluntary context switches: 1289601
        Involuntary context switches: 361896
        Swaps: 0
        File system inputs: 101312
        File system outputs: 737456
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

# After, run 2

Compiled in: 18.9s

```
        Command being timed: "pnpm next build --experimental-build-mode=compile"
        User time (seconds): 123.56
        System time (seconds): 16.48
        Percent of CPU this job got: 519%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:26.95
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 5817016
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 1060747
        Voluntary context switches: 1309994
        Involuntary context switches: 363910
        Swaps: 0
        File system inputs: 0
        File system outputs: 736960
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```


# After, run 3

Compiled in: 18.5s

```
        Command being timed: "pnpm next build --experimental-build-mode=compile"
        User time (seconds): 119.21
        System time (seconds): 15.30
        Percent of CPU this job got: 510%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:26.36
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 6178220
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 1143656
        Voluntary context switches: 1297677
        Involuntary context switches: 363754
        Swaps: 0
        File system inputs: 0
        File system outputs: 737848
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```
</details>

Closes PACK-4040