### PR TITLE
perf(turbo-tasks): Filter out and do not cache unused arguments

### DIFF
--- a/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
@@ -59,6 +59,7 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
         function_path_string: ident.to_string(),
         function_path: parse_quote! { #inline_function_ident },
         is_method: turbo_fn.is_method(),
+        filter_trait_call_args: None, // not a trait method
         local,
         local_cells,
     };

--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -140,6 +140,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     function_path_string: format!("{ty}::{ident}", ty = ty.to_token_stream()),
                     function_path: parse_quote! { <#ty>::#inline_function_ident },
                     is_method: turbo_fn.is_method(),
+                    filter_trait_call_args: None, // not a trait method
                     local,
                     local_cells,
                 };
@@ -252,6 +253,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                         <#ty as #inline_extension_trait_ident>::#inline_function_ident
                     },
                     is_method: turbo_fn.is_method(),
+                    filter_trait_call_args: turbo_fn.filter_trait_call_args(),
                     local,
                     local_cells,
                 };

--- a/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -101,7 +101,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
         };
 
         let turbo_signature = turbo_fn.signature();
-        let arg_types = turbo_fn.input_types();
+        let arg_types = turbo_fn.exposed_input_types();
         let dynamic_block = turbo_fn.dynamic_block(&trait_type_id_ident);
         dynamic_trait_fns.push(quote! {
             #turbo_signature #dynamic_block
@@ -120,6 +120,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
                     <Box<dyn #trait_ident> as #inline_extension_trait_ident>::#inline_function_ident
                 },
                 is_method: turbo_fn.is_method(),
+                filter_trait_call_args: turbo_fn.filter_trait_call_args(),
                 // `local` and `local_cells` are currently unsupported here because:
                 // - The `#[turbo_tasks::function]` macro needs to be present for us to read this
                 //   argument. (This could be fixed)

--- a/turbopack/crates/turbo-tasks-testing/tests/collectibles.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/collectibles.rs
@@ -192,7 +192,8 @@ async fn my_multi_emitting_function() -> Result<Vc<Thing>> {
 }
 
 #[turbo_tasks::function(operation)]
-async fn my_transitive_emitting_function(key: RcStr, _key2: RcStr) -> Result<Vc<Thing>> {
+async fn my_transitive_emitting_function(key: RcStr, key2: RcStr) -> Result<Vc<Thing>> {
+    let _ = key2;
     my_emitting_function(key).await?;
     Ok(Thing::cell(Thing(0)))
 }
@@ -219,8 +220,9 @@ async fn my_transitive_emitting_function_collectibles(
 async fn my_transitive_emitting_function_with_child_scope(
     key: RcStr,
     key2: RcStr,
-    _key3: RcStr,
+    key3: RcStr,
 ) -> Result<Vc<Thing>> {
+    let _ = key3;
     let thing_op = my_transitive_emitting_function(key, key2);
     let thing_vc = thing_op.connect();
     thing_vc.await?;
@@ -230,7 +232,8 @@ async fn my_transitive_emitting_function_with_child_scope(
 }
 
 #[turbo_tasks::function]
-async fn my_emitting_function(_key: RcStr) -> Result<()> {
+async fn my_emitting_function(key: RcStr) -> Result<()> {
+    let _ = key;
     sleep(Duration::from_millis(100)).await;
     emit(ResolvedVc::upcast::<Box<dyn ValueToString>>(Thing::new(
         123,

--- a/turbopack/crates/turbo-tasks-testing/tests/performance.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/performance.rs
@@ -303,10 +303,8 @@ struct Value {
 }
 
 #[turbo_tasks::function]
-async fn calls_many_children(
-    _i: TransientInstance<()>,
-    j: Option<TransientInstance<()>>,
-) -> Vc<()> {
+async fn calls_many_children(i: TransientInstance<()>, j: Option<TransientInstance<()>>) -> Vc<()> {
+    let _ = i;
     let _ = many_children(j);
     Vc::cell(())
 }
@@ -325,7 +323,8 @@ fn many_children_inner(_i: u32) -> Vc<()> {
 }
 
 #[turbo_tasks::function]
-async fn calls_big_graph(mut counts: Vec<u32>, _i: TransientInstance<()>) -> Vc<()> {
+async fn calls_big_graph(mut counts: Vec<u32>, i: TransientInstance<()>) -> Vc<()> {
+    let _ = i;
     counts.reverse();
     let _ = big_graph(counts, vec![]);
     Vc::cell(())

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -107,7 +107,6 @@ pub use manager::{
     CurrentCellRef, ReadConsistency, TaskPersistence, TurboTasks, TurboTasksApi,
     TurboTasksBackendApi, TurboTasksBackendApiExt, TurboTasksCallApi, Unused, UpdateInfo,
 };
-pub use native_function::{FunctionMeta, NativeFunction};
 pub use output::OutputContent;
 pub use raw_vc::{CellId, RawVc, ReadRawVcFuture, ResolveTypeError};
 pub use read_ref::ReadRef;

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -6,13 +6,14 @@ pub use once_cell::sync::{Lazy, OnceCell};
 pub use serde;
 pub use tracing;
 
-pub use super::{
-    magic_any::MagicAny,
-    manager::{find_cell_by_type, notify_scheduled_tasks, spawn_detached_for_testing},
-};
 use crate::{
     debug::ValueDebugFormatString, shrink_to_fit::ShrinkToFit, task::TaskOutput, NonLocalValue,
     RawVc, TaskInput, TaskPersistence, Vc,
+};
+pub use crate::{
+    magic_any::MagicAny,
+    manager::{find_cell_by_type, notify_scheduled_tasks, spawn_detached_for_testing},
+    native_function::{downcast_args_owned, downcast_args_ref, FunctionMeta, NativeFunction},
 };
 
 #[inline(never)]

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -37,6 +37,7 @@ use crate::{
     },
     id_factory::{IdFactory, IdFactoryWithReuse},
     magic_any::MagicAny,
+    native_function::FunctionMeta,
     raw_vc::{CellId, RawVc},
     registry::{self, get_function},
     serialization_invalidation::SerializationInvalidator,
@@ -48,8 +49,8 @@ use crate::{
     trait_helpers::get_trait_method,
     util::StaticOrArc,
     vc::ReadVcFuture,
-    Completion, FunctionMeta, InvalidationReason, InvalidationReasonSet, ResolvedVc,
-    SharedReference, TaskId, TaskIdSet, ValueTypeId, Vc, VcRead, VcValueTrait, VcValueType,
+    Completion, InvalidationReason, InvalidationReasonSet, ResolvedVc, SharedReference, TaskId,
+    TaskIdSet, ValueTypeId, Vc, VcRead, VcValueTrait, VcValueType,
 };
 
 pub trait TurboTasksCallApi: Sync + Send {
@@ -638,6 +639,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
         if let RawVc::TaskCell(_, CellId { type_id, .. }) = this {
             match get_trait_method(trait_type, type_id, trait_fn_name) {
                 Ok(native_fn) => {
+                    let arg = registry::get_function(native_fn).arg_meta.filter_owned(arg);
                     return self.dynamic_call(native_fn, Some(this), arg, persistence);
                 }
                 Err(name) => {

--- a/turbopack/crates/turbo-tasks/src/native_function.rs
+++ b/turbopack/crates/turbo-tasks/src/native_function.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, hash::Hash, pin::Pin};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use futures::Future;
 use serde::{Deserialize, Serialize};
 use tracing::Span;
@@ -16,18 +16,29 @@ use crate::{
     RawVc, TaskInput, TaskPersistence,
 };
 
-type ResolveFunctor =
-    for<'a> fn(
-        &'a dyn MagicAny,
-    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn MagicAny>>> + Send + 'a>>;
+type ResolveFuture<'a> = Pin<Box<dyn Future<Output = Result<Box<dyn MagicAny>>> + Send + 'a>>;
+type ResolveFunctor = for<'a> fn(&'a dyn MagicAny) -> ResolveFuture<'a>;
 
 type IsResolvedFunctor = fn(&dyn MagicAny) -> bool;
+
+type FilterOwnedArgsFunctor = for<'a> fn(Box<dyn MagicAny>) -> Box<dyn MagicAny>;
+type FilterAndResolveFunctor = ResolveFunctor;
 
 pub struct ArgMeta {
     serializer: MagicAnySerializeSeed,
     deserializer: MagicAnyDeserializeSeed,
     is_resolved: IsResolvedFunctor,
     resolve: ResolveFunctor,
+    /// Used for trait methods, filters out unused arguments.
+    filter_owned: FilterOwnedArgsFunctor,
+    /// Accepts a reference (instead of ownership) of arguments, and does the filtering and
+    /// resolution in a single operation.
+    //
+    // When filtering a `&dyn MagicAny` while running a resolution task, we can't return a filtered
+    // `&dyn MagicAny`, we'd be forced to return a `Box<dyn MagicAny>`. However, the next thing we
+    // do is resolution, which also accepts a `&dyn MagicAny` and returns a `Box<dyn MagicAny>`.
+    // This functor combines the two operations to avoid extra cloning.
+    filter_and_resolve: FilterAndResolveFunctor,
 }
 
 impl ArgMeta {
@@ -35,35 +46,26 @@ impl ArgMeta {
     where
         T: TaskInput + Serialize + for<'de> Deserialize<'de> + 'static,
     {
-        fn downcast<T>(value: &dyn MagicAny) -> &T
-        where
-            T: MagicAny,
-        {
-            value
-                .downcast_ref::<T>()
-                .with_context(|| {
-                    #[cfg(debug_assertions)]
-                    return format!(
-                        "Invalid argument type, expected {} got {}",
-                        std::any::type_name::<T>(),
-                        value.magic_type_name()
-                    );
-                    #[cfg(not(debug_assertions))]
-                    return "Invalid argument type";
-                })
-                .unwrap()
+        fn noop_filter_args(args: Box<dyn MagicAny>) -> Box<dyn MagicAny> {
+            args
         }
+        Self::with_filter_trait_call::<T>(noop_filter_args, resolve_functor_impl::<T>)
+    }
+
+    pub fn with_filter_trait_call<T>(
+        filter_owned: FilterOwnedArgsFunctor,
+        filter_and_resolve: FilterAndResolveFunctor,
+    ) -> Self
+    where
+        T: TaskInput + Serialize + for<'de> Deserialize<'de> + 'static,
+    {
         Self {
             serializer: MagicAnySerializeSeed::new::<T>(),
             deserializer: MagicAnyDeserializeSeed::new::<T>(),
-            is_resolved: |value| downcast::<T>(value).is_resolved(),
-            resolve: |value| {
-                Box::pin(async {
-                    let value = downcast::<T>(value);
-                    let resolved = value.resolve().await?;
-                    Ok(Box::new(resolved) as Box<dyn MagicAny>)
-                })
-            },
+            is_resolved: |value| downcast_args_ref::<T>(value).is_resolved(),
+            resolve: resolve_functor_impl::<T>,
+            filter_owned,
+            filter_and_resolve,
         }
     }
 
@@ -82,6 +84,57 @@ impl ArgMeta {
     pub async fn resolve(&self, value: &dyn MagicAny) -> Result<Box<dyn MagicAny>> {
         (self.resolve)(value).await
     }
+
+    pub fn filter_owned(&self, args: Box<dyn MagicAny>) -> Box<dyn MagicAny> {
+        (self.filter_owned)(args)
+    }
+
+    pub async fn filter_and_resolve(&self, args: &dyn MagicAny) -> Result<Box<dyn MagicAny>> {
+        (self.filter_and_resolve)(args).await
+    }
+}
+
+fn resolve_functor_impl<T: MagicAny + TaskInput>(value: &dyn MagicAny) -> ResolveFuture<'_> {
+    Box::pin(async {
+        let value = downcast_args_ref::<T>(value);
+        let resolved = value.resolve().await?;
+        Ok(Box::new(resolved) as Box<dyn MagicAny>)
+    })
+}
+
+#[cfg(debug_assertions)]
+#[inline(never)]
+pub fn debug_downcast_args_error_msg(expected: &str, actual: &dyn MagicAny) -> String {
+    format!(
+        "Invalid argument type, expected {expected} got {}",
+        (*actual).magic_type_name()
+    )
+}
+
+pub fn downcast_args_owned<T: MagicAny>(args: Box<dyn MagicAny>) -> Box<T> {
+    #[allow(unused_variables)]
+    args.downcast::<T>()
+        .map_err(|args| {
+            #[cfg(debug_assertions)]
+            return debug_downcast_args_error_msg(std::any::type_name::<T>(), &*args);
+            #[cfg(not(debug_assertions))]
+            return anyhow::anyhow!("Invalid argument type");
+        })
+        .unwrap()
+}
+
+pub fn downcast_args_ref<T: MagicAny>(args: &dyn MagicAny) -> &T {
+    args.downcast_ref::<T>()
+        .ok_or_else(|| {
+            #[cfg(debug_assertions)]
+            return anyhow::anyhow!(debug_downcast_args_error_msg(
+                std::any::type_name::<T>(),
+                args
+            ));
+            #[cfg(not(debug_assertions))]
+            return anyhow::anyhow!("Invalid argument type");
+        })
+        .unwrap()
 }
 
 #[derive(Debug)]
@@ -144,6 +197,7 @@ impl NativeFunction {
     pub fn new_method<Mode, This, Inputs, I>(
         name: String,
         function_meta: FunctionMeta,
+        arg_filter: Option<(FilterOwnedArgsFunctor, FilterAndResolveFunctor)>,
         implementation: I,
     ) -> Self
     where
@@ -154,7 +208,11 @@ impl NativeFunction {
         Self {
             name,
             function_meta,
-            arg_meta: ArgMeta::new::<Inputs>(),
+            arg_meta: if let Some((filter_owned, filter_and_resolve)) = arg_filter {
+                ArgMeta::with_filter_trait_call::<Inputs>(filter_owned, filter_and_resolve)
+            } else {
+                ArgMeta::new::<Inputs>()
+            },
             implementation: Box::new(implementation.into_task_fn_with_this()),
         }
     }

--- a/turbopack/crates/turbo-tasks/src/registry.rs
+++ b/turbopack/crates/turbo-tasks/src/registry.rs
@@ -12,8 +12,9 @@ use rustc_hash::FxHasher;
 use crate::{
     id::{FunctionId, TraitTypeId, ValueTypeId},
     id_factory::IdFactory,
+    native_function::NativeFunction,
     no_move_vec::NoMoveVec,
-    NativeFunction, TraitType, ValueType,
+    TraitType, ValueType,
 };
 
 type FxDashMap<K, V> = DashMap<K, V, BuildHasherDefault<FxHasher>>;

--- a/turbopack/crates/turbo-tasks/src/task/function.rs
+++ b/turbopack/crates/turbo-tasks/src/task/function.rs
@@ -166,15 +166,6 @@ macro_rules! task_inputs_impl {
     }
 }
 
-#[cfg(debug_assertions)]
-#[inline(never)]
-fn get_debug_downcast_error_msg(expected: &str, actual: &dyn MagicAny) -> String {
-    format!(
-        "Invalid argument type, expected {expected} got {}",
-        (*actual).magic_type_name()
-    )
-}
-
 /// Downcast, and clone all the arguments in the singular `arg` tuple.
 ///
 /// This helper function for `task_fn_impl!()` reduces the amount of code inside the macro, and
@@ -184,7 +175,7 @@ fn get_args<T: MagicAny + Clone>(arg: &dyn MagicAny) -> Result<T> {
     let value = arg.downcast_ref::<T>().cloned();
     #[cfg(debug_assertions)]
     return anyhow::Context::with_context(value, || {
-        get_debug_downcast_error_msg(std::any::type_name::<T>(), arg)
+        crate::native_function::debug_downcast_args_error_msg(std::any::type_name::<T>(), arg)
     });
     #[cfg(not(debug_assertions))]
     return anyhow::Context::context(value, "Invalid argument type");

--- a/turbopack/crates/turbo-tasks/src/task/local_task.rs
+++ b/turbopack/crates/turbo-tasks/src/task/local_task.rs
@@ -170,12 +170,10 @@ impl LocalTaskType {
         let this = this.resolve().await?;
         let TypedCellContent(this_ty, _) = this.into_read().await?;
 
-        let native_fn = Self::resolve_trait_method_from_value(trait_type, this_ty, name)?;
-        let arg = registry::get_function(native_fn)
-            .arg_meta
-            .resolve(arg)
-            .await?;
-        Ok(turbo_tasks.dynamic_call(native_fn, Some(this), arg, persistence))
+        let native_fn_id = Self::resolve_trait_method_from_value(trait_type, this_ty, name)?;
+        let native_fn = registry::get_function(native_fn_id);
+        let arg = native_fn.arg_meta.filter_and_resolve(arg).await?;
+        Ok(turbo_tasks.dynamic_call(native_fn_id, Some(this), arg, persistence))
     }
 
     fn resolve_trait_method_from_value(


### PR DESCRIPTION
For trait methods, we often have underscore-prefixed arguments that are unused in method implementations, but must exist on the method signature because the trait requires it.

For example, look at `code_generation`: https://github.com/search?q=repo%3Avercel%2Fnext.js%20fn%20code_generation&type=code

We can filter those arguments as soon as we resolve the real method, and avoid storing them as part of the task's cache key.

This should mean less data stored per task, and better cache hit rates (so less tasks overall).

This appears to give a roughly 5% memory win:

![Screenshot 2025-01-28 at 11.54.37 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/3459c25e-c73b-4d56-92cc-f44479b2d016.png)

(Spreadsheet: https://docs.google.com/spreadsheets/d/1fz9Q-tDE6LebS9p4Mci8vZG7jkBSajiMYF1WbZEPnts/edit?usp=sharing)

Full data:

<details>
Tested with next-site in front.

Command run:

```
rm -rf .next && TURBOPACK=1 TURBOPACK_BUILD=1 TURBO_ENGINE_READ_ONLY=1 /bin/time -v pnpm next build --experimental-build-mode=compile
```


# Before, run 1

Compiled in: 19.3s

```
        Command being timed: "pnpm next build --experimental-build-mode=compile"
        User time (seconds): 121.88
        System time (seconds): 16.74
        Percent of CPU this job got: 501%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:27.61
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 5607868
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 58
        Minor (reclaiming a frame) page faults: 1816374
        Voluntary context switches: 1280636
        Involuntary context switches: 361414
        Swaps: 0
        File system inputs: 102088
        File system outputs: 738000
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```


# Before, run 2

Compiled in: 19.3s

```
        Command being timed: "pnpm next build --experimental-build-mode=compile"
        User time (seconds): 124.34
        System time (seconds): 16.97
        Percent of CPU this job got: 516%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:27.36
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 5455968
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 8
        Minor (reclaiming a frame) page faults: 2014509
        Voluntary context switches: 1267794
        Involuntary context switches: 358175
        Swaps: 0
        File system inputs: 6496
        File system outputs: 737296
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```


# Before, run 3

Compiled in: 18.4s

```
        Command being timed: "pnpm next build --experimental-build-mode=compile"
        User time (seconds): 117.81
        System time (seconds): 15.86
        Percent of CPU this job got: 505%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:26.46
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 5655912
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 5
        Minor (reclaiming a frame) page faults: 1868540
        Voluntary context switches: 1271444
        Involuntary context switches: 337236
        Swaps: 0
        File system inputs: 7784
        File system outputs: 737480
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status:
```


# Before, run 4

Compiled in: 18.2s

```
        Command being timed: "pnpm next build --experimental-build-mode=compile"
        User time (seconds): 116.98
        System time (seconds): 15.09
        Percent of CPU this job got: 504%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:26.15
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 5962764
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 1861147
        Voluntary context switches: 1253759
        Involuntary context switches: 333116
        Swaps: 0
        File system inputs: 0
        File system outputs: 737304
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```


# Before, run 5

Compiled in: 17.9s

```
        Command being timed: "pnpm next build --experimental-build-mode=compile"
        User time (seconds): 119.02
        System time (seconds): 14.84
        Percent of CPU this job got: 516%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:25.92
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 5745780
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 1542655
        Voluntary context switches: 1238600
        Involuntary context switches: 357049
        Swaps: 0
        File system inputs: 0
        File system outputs: 737000
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```


# After, run 1

Compiled in: 19.0s

```
        Command being timed: "pnpm next build --experimental-build-mode=compile"
        User time (seconds): 121.85
        System time (seconds): 16.69
        Percent of CPU this job got: 508%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:27.22
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 5402708
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 41
        Minor (reclaiming a frame) page faults: 1822829
        Voluntary context switches: 1221091
        Involuntary context switches: 361604
        Swaps: 0
        File system inputs: 110200
        File system outputs: 737048
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```


# After, run 2

Compiled in: 18.5s

```
        Command being timed: "pnpm next build --experimental-build-mode=compile"
        User time (seconds): 119.46
        System time (seconds): 15.32
        Percent of CPU this job got: 506%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:26.60
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 5413980
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 1
        Minor (reclaiming a frame) page faults: 1695775
        Voluntary context switches: 1269774
        Involuntary context switches: 328448
        Swaps: 0
        File system inputs: 800
        File system outputs: 736952
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```


# After, run 3

Compiled in: 18.5s

```
        Command being timed: "pnpm next build --experimental-build-mode=compile"
        User time (seconds): 118.15
        System time (seconds): 15.12
        Percent of CPU this job got: 503%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:26.48
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 5312528
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 1893778
        Voluntary context switches: 1277325
        Involuntary context switches: 324591
        Swaps: 0
        File system inputs: 128
        File system outputs: 737304
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```


# After, run 4

Compiled in: 18.2s

```
        Command being timed: "pnpm next build --experimental-build-mode=compile"
        User time (seconds): 115.60
        System time (seconds): 15.30
        Percent of CPU this job got: 499%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:26.22
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 5240892
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 1
        Minor (reclaiming a frame) page faults: 1514837
        Voluntary context switches: 1296049
        Involuntary context switches: 312076
        Swaps: 0
        File system inputs: 32
        File system outputs: 737664
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```


# After, run 5

Compiled in: 19.4s

```
        Command being timed: "pnpm next build --experimental-build-mode=compile"
        User time (seconds): 125.91
        System time (seconds): 15.63
        Percent of CPU this job got: 514%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:27.50
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 5346672
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 1
        Minor (reclaiming a frame) page faults: 1839175
        Voluntary context switches: 1280293
        Involuntary context switches: 358863
        Swaps: 0
        File system inputs: 32
        File system outputs: 737720
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```
</details>

Closes PACK-3833