### PR TITLE
perf(next-swc): Do not allocate from `styled-components` when not used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6887,9 +6887,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "styled_components"
-version = "0.98.1"
+version = "0.98.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a858b16946e8b2e2d18a4888edf06d7cef3de0e59a60ad2f93ceb62ff7a43f"
+checksum = "358eebb96614cbe52a1bd2c2afee17a791351e409d9cb1ccc9b5adcb7eedc6bc"
 dependencies = [
  "Inflector",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ browserslist-rs = { version = "0.16.0" }
 miette = { version = "5.10.0", features = ["fancy"] }
 mdxjs = "0.2.15"
 modularize_imports = { version = "0.70.1" }
-styled_components = { version = "0.98.1" }
+styled_components = { version = "0.98.2" }
 styled_jsx = { version = "0.75.2" }
 swc_emotion = { version = "0.74.2" }
 swc_relay = { version = "0.46.1" }

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/styled_components.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/styled_components.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use swc_core::{
     common::{comments::NoopComments, FileName},
-    ecma::{ast::Program, atoms::JsWord, visit::VisitMutWith},
+    ecma::{ast::Program, atoms::JsWord},
 };
 use turbo_tasks::{ValueDefault, Vc};
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
@@ -91,7 +91,7 @@ impl StyledComponentsTransformer {
 impl CustomTransformer for StyledComponentsTransformer {
     #[tracing::instrument(level = tracing::Level::TRACE, name = "styled_components", skip_all)]
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
-        program.visit_mut_with(&mut styled_components::styled_components(
+        program.mutate(styled_components::styled_components(
             FileName::Real(PathBuf::from(ctx.file_path_str)).into(),
             ctx.file_name_hash,
             self.config.clone(),


### PR DESCRIPTION
### What?

Apply https://github.com/swc-project/plugins/pull/392

### Why?

We should not create enormous amount of memory operations needlessly.



Closes PACK-3806