### PR TITLE
misc: add Rauno to CI approved

### DIFF
--- a/.github/labeler.json
+++ b/.github/labeler.json
@@ -17,7 +17,8 @@
     ],
     "CI approved": [
       { "type": "user", "pattern": "SukkaW" },
-      { "type": "user", "pattern": "vercel-release-bot" }
+      { "type": "user", "pattern": "vercel-release-bot" },
+      { "type": "user", "pattern": "raunofreiberg" }
     ],
     "created-by: Next.js team": [
       { "type": "user", "pattern": "acdlite" },


### PR DESCRIPTION
### Why?

Add @raunofreiberg to "CI Approved" labeler, as he's actively cooking the new dev overlay.