### PR TITLE
perf(turbopack): Use `Pass` API for `styled-jsx` SWC plugin

### DIFF
--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/styled_jsx.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/styled_jsx.rs
@@ -1,12 +1,8 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use swc_core::{
-    common::{util::take::Take, FileName},
-    ecma::{
-        ast::{Module, Program},
-        preset_env::Versions,
-        visit::FoldWith,
-    },
+    common::FileName,
+    ecma::{ast::Program, preset_env::Versions},
 };
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
 
@@ -25,8 +21,7 @@ impl StyledJsxTransformer {
 impl CustomTransformer for StyledJsxTransformer {
     #[tracing::instrument(level = tracing::Level::TRACE, name = "styled_jsx", skip_all)]
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
-        let p = std::mem::replace(program, Program::Module(Module::dummy()));
-        *program = p.fold_with(&mut styled_jsx::visitor::styled_jsx(
+        program.mutate(styled_jsx::visitor::styled_jsx(
             ctx.source_map.clone(),
             // styled_jsx don't really use that in a relevant way
             FileName::Anon,


### PR DESCRIPTION
### What?

It **removes** needless allocations.

### Why?

To avoid allocating memory needlessly.

### How?


Closes PACK-3808