### PR TITLE
Emit build error when `useCache` is enabled and Edge runtime is used

### DIFF
--- a/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
+++ b/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
@@ -35,10 +35,12 @@ pub async fn get_next_react_server_components_transform_rule(
 ) -> Result<ModuleRule> {
     let enable_mdx_rs = next_config.mdx_rs().await?.is_some();
     let dynamic_io_enabled = *next_config.enable_dynamic_io().await?;
+    let use_cache_enabled = *next_config.enable_use_cache().await?;
     Ok(get_ecma_transform_rule(
         Box::new(NextJsReactServerComponents::new(
             is_react_server_layer,
             dynamic_io_enabled,
+            use_cache_enabled,
             app_dir,
         )),
         enable_mdx_rs,
@@ -50,6 +52,7 @@ pub async fn get_next_react_server_components_transform_rule(
 struct NextJsReactServerComponents {
     is_react_server_layer: bool,
     dynamic_io_enabled: bool,
+    use_cache_enabled: bool,
     app_dir: Option<Vc<FileSystemPath>>,
 }
 
@@ -57,11 +60,13 @@ impl NextJsReactServerComponents {
     fn new(
         is_react_server_layer: bool,
         dynamic_io_enabled: bool,
+        use_cache_enabled: bool,
         app_dir: Option<Vc<FileSystemPath>>,
     ) -> Self {
         Self {
             is_react_server_layer,
             dynamic_io_enabled,
+            use_cache_enabled,
             app_dir,
         }
     }
@@ -82,6 +87,7 @@ impl CustomTransformer for NextJsReactServerComponents {
             Config::WithOptions(Options {
                 is_react_server_layer: self.is_react_server_layer,
                 dynamic_io_enabled: self.dynamic_io_enabled,
+                use_cache_enabled: self.use_cache_enabled,
             }),
             match self.app_dir {
                 None => None,

--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -91,7 +91,7 @@ enum RSCErrorKind {
     NextRscErrIncompatibleRouteSegmentConfig(Span, String, NextConfigProperty),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Copy)]
 enum NextConfigProperty {
     DynamicIo,
     UseCache,
@@ -877,7 +877,7 @@ impl ReactServerComponentValidator {
                             RSCErrorKind::NextRscErrIncompatibleRouteSegmentConfig(
                                 *span,
                                 export_name.clone(),
-                                property.clone(),
+                                *property,
                             ),
                         );
                     }

--- a/crates/next-custom-transforms/tests/errors.rs
+++ b/crates/next-custom-transforms/tests/errors.rs
@@ -94,6 +94,7 @@ fn react_server_components_errors(input: PathBuf) {
     use next_custom_transforms::transforms::react_server_components::{Config, Options};
     let is_react_server_layer = input.iter().any(|s| s.to_str() == Some("server-graph"));
     let dynamic_io_enabled = input.iter().any(|s| s.to_str() == Some("dynamic-io"));
+    let use_cache_enabled = input.iter().any(|s| s.to_str() == Some("use-cache"));
     let output = input.parent().unwrap().join("output.js");
     test_fixture(
         syntax(),
@@ -103,6 +104,7 @@ fn react_server_components_errors(input: PathBuf) {
                 Config::WithOptions(Options {
                     is_react_server_layer,
                     dynamic_io_enabled,
+                    use_cache_enabled,
                 }),
                 tr.comments.as_ref().clone(),
                 None,
@@ -154,6 +156,7 @@ fn react_server_actions_errors(input: PathBuf) {
                     Config::WithOptions(Options {
                         is_react_server_layer,
                         dynamic_io_enabled: true,
+                        use_cache_enabled: true,
                     }),
                     tr.comments.as_ref().clone(),
                     None,
@@ -213,6 +216,7 @@ fn use_cache_not_allowed(input: PathBuf) {
                     Config::WithOptions(Options {
                         is_react_server_layer: true,
                         dynamic_io_enabled: false,
+                        use_cache_enabled: false,
                     }),
                     tr.comments.as_ref().clone(),
                     None,

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/input.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/input.js
@@ -1,5 +1,5 @@
 export const runtime = 'edge'
-// The following route segment config are currently allowed:
+// The following route segment configs are currently allowed:
 export const dynamic = 'force-dynamic'
 export const dynamicParams = false
 export const fetchCache = 'force-no-store'

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/input.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/input.js
@@ -1,0 +1,6 @@
+export const runtime = 'edge'
+// The following route segment config are currently allowed:
+export const dynamic = 'force-dynamic'
+export const dynamicParams = false
+export const fetchCache = 'force-no-store'
+export const revalidate = 1

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/output.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/output.js
@@ -1,0 +1,6 @@
+export const runtime = 'edge';
+// The following route segment config are currently allowed:
+export const dynamic = 'force-dynamic';
+export const dynamicParams = false;
+export const fetchCache = 'force-no-store';
+export const revalidate = 1;

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/output.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/output.js
@@ -1,5 +1,5 @@
 export const runtime = 'edge';
-// The following route segment config are currently allowed:
+// The following route segment configs are currently allowed:
 export const dynamic = 'force-dynamic';
 export const dynamicParams = false;
 export const fetchCache = 'force-no-store';

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/output.stderr
@@ -1,0 +1,6 @@
+  x Route segment config "runtime" is not compatible with `nextConfig.experimental.useCache`. Please remove it.
+   ,-[input.js:1:1]
+ 1 | export const runtime = 'edge'
+   :              ^^^^^^^
+ 2 | // The following route segment config are currently allowed:
+   `----

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/output.stderr
@@ -2,5 +2,5 @@
    ,-[input.js:1:1]
  1 | export const runtime = 'edge'
    :              ^^^^^^^
- 2 | // The following route segment config are currently allowed:
+ 2 | // The following route segment configs are currently allowed:
    `----

--- a/crates/next-custom-transforms/tests/fixture.rs
+++ b/crates/next-custom-transforms/tests/fixture.rs
@@ -475,6 +475,7 @@ fn react_server_components_typescript(input: PathBuf) {
                 Config::WithOptions(Options {
                     is_react_server_layer: true,
                     dynamic_io_enabled: false,
+                    use_cache_enabled: false,
                 }),
                 tr.comments.as_ref().clone(),
                 None,
@@ -502,6 +503,7 @@ fn react_server_components_fixture(input: PathBuf) {
                 Config::WithOptions(Options {
                     is_react_server_layer,
                     dynamic_io_enabled: false,
+                    use_cache_enabled: false,
                 }),
                 tr.comments.as_ref().clone(),
                 None,

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -212,6 +212,7 @@ function getBaseSWCOptions({
         ? {
             isReactServerLayer,
             dynamicIoEnabled: isDynamicIo,
+            useCacheEnabled,
           }
         : undefined,
     serverActions:

--- a/test/e2e/app-dir/use-cache-segment-configs/app/layout.tsx
+++ b/test/e2e/app-dir/use-cache-segment-configs/app/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/use-cache-segment-configs/app/runtime/page.tsx
+++ b/test/e2e/app-dir/use-cache-segment-configs/app/runtime/page.tsx
@@ -1,0 +1,5 @@
+export const runtime = 'edge'
+
+export default function Page() {
+  return <div>This page uses `export const runtime`.</div>
+}

--- a/test/e2e/app-dir/use-cache-segment-configs/next.config.js
+++ b/test/e2e/app-dir/use-cache-segment-configs/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    useCache: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
+++ b/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
@@ -1,0 +1,120 @@
+import { nextTestSetup } from 'e2e-utils'
+import {
+  assertHasRedbox,
+  assertNoRedbox,
+  getRedboxDescription,
+  getRedboxSource,
+} from 'next-test-utils'
+import stripAnsi from 'strip-ansi'
+
+describe('use-cache-segment-configs', () => {
+  const { next, skipped, isNextDev, isTurbopack } = nextTestSetup({
+    files: __dirname,
+    skipStart: process.env.NEXT_TEST_MODE !== 'dev',
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it("it should error when using segment configs that aren't supported by useCache", async () => {
+    if (isNextDev) {
+      const browser = await next.browser('/runtime')
+
+      if (isTurbopack) {
+        await assertHasRedbox(browser)
+
+        const description = await getRedboxDescription(browser)
+        const source = await getRedboxSource(browser)
+
+        expect(description).toBe('Failed to compile')
+
+        expect(source).toMatchInlineSnapshot(`
+         "./app/runtime/page.tsx:1:14
+         Ecmascript file had an error
+         > 1 | export const runtime = 'edge'
+             |              ^^^^^^^
+           2 |
+           3 | export default function Page() {
+           4 |   return <div>This page uses \`export const runtime\`.</div>
+
+         Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it."
+        `)
+      } else {
+        // TODO(veil): Figure out why dev overlay is not shown with Webpack when
+        // the runtime is 'edge'. It's possibly related to the import trace
+        // being wrong (pointing at the Webpack loader resource).
+        await assertNoRedbox(browser)
+      }
+    } else {
+      const { cliOutput } = await next.build()
+
+      const buildOutput = getBuildOutput(cliOutput)
+
+      if (isTurbopack) {
+        expect(buildOutput).toMatchInlineSnapshot(`
+         "Error: Turbopack build failed with 1 errors:
+         Page: {"type":"app","side":"server","page":"/runtime/page"}
+         ./app/runtime/page.tsx:1:14
+         Ecmascript file had an error
+         > 1 | export const runtime = 'edge'
+             |              ^^^^^^^
+           2 |
+           3 | export default function Page() {
+           4 |   return <div>This page uses \`export const runtime\`.</div>
+
+         Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.
+
+
+             at <unknown> (./app/runtime/page.tsx:1:14)
+         "
+        `)
+      } else {
+        expect(buildOutput).toMatchInlineSnapshot(`
+         "
+         // TODO(veil): Fix broken import trace for Webpack loader resource.
+         Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.
+            ,-[1:1]
+          1 | export const runtime = 'edge'
+            :              ^^^^^^^
+          2 | 
+          3 | export default function Page() {
+          4 |   return <div>This page uses \`export const runtime\`.</div>
+            \`----
+
+         Import trace for requested module:
+         // TODO(veil): Fix broken import trace for Webpack loader resource.
+
+
+         > Build failed because of webpack errors
+         "
+        `)
+      }
+    }
+  })
+})
+
+function getBuildOutput(cliOutput: string): string {
+  const lines: string[] = []
+  let skipLines = true
+
+  for (const line of cliOutput.split('\n')) {
+    if (!skipLines) {
+      if (line.includes('__next_edge_ssr_entry__')) {
+        lines.push(
+          '// TODO(veil): Fix broken import trace for Webpack loader resource.'
+        )
+      } else {
+        lines.push(stripAnsi(line))
+      }
+    } else if (
+      line.includes('Build error occurred') ||
+      line.includes('Failed to compile')
+    ) {
+      skipLines = false
+    }
+  }
+
+  return lines.join('\n')
+}


### PR DESCRIPTION
The `"use cache"` directive is not compatible with the Edge runtime.

When the `experimental.useCache` flag is enabled, we now emit a build error for pages with `export const runtime = 'edge'`. This is analogous to using the `experimental.dynamicIO` flag.

The other route segment configs that are forbidden when `dynamicIO` is enabled, are currently still allowed for `useCache`:

- `dynamicParams`
- `dynamic`
- `fetchCache`
- `revalidate`