### PR TITLE
Turbopack: don't hardcode `edge-instrumentation.js`

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2457,7 +2457,10 @@ export default async function build(
           path.join(SERVER_DIRECTORY, `${INSTRUMENTATION_HOOK_FILENAME}.js`)
         )
         // If there's edge routes, append the edge instrumentation hook
-        if (edgeRuntimeAppCount || edgeRuntimePagesCount) {
+        if (
+          !process.env.TURBOPACK &&
+          (edgeRuntimeAppCount || edgeRuntimePagesCount)
+        ) {
           instrumentationHookEntryFiles.push(
             path.join(
               SERVER_DIRECTORY,

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2457,6 +2457,7 @@ export default async function build(
           path.join(SERVER_DIRECTORY, `${INSTRUMENTATION_HOOK_FILENAME}.js`)
         )
         // If there's edge routes, append the edge instrumentation hook
+        // Turbopack generates this chunk with a hashed name and references it in middleware-manifest.
         if (
           !process.env.TURBOPACK &&
           (edgeRuntimeAppCount || edgeRuntimePagesCount)


### PR DESCRIPTION
My understanding is:
- This is hardcoded to make sure everything in the middleware-manifest is copied over
- For Turbopack, we do that already anyway, no need for hardcoding
- The offending chunk has a different (non-fixed) name when using Turbopack (but is still listed in the middleware-manifest)
- Let's try to remove it from the NFT json








Closes PACK-3813