### PR TITLE
fix(turbo-tasks): Implement `is_transient` on `OperationVc`

### DIFF
--- a/turbopack/crates/turbo-tasks/src/vc/operation.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/operation.rs
@@ -175,7 +175,16 @@ where
     }
 }
 
-impl<T> TaskInput for OperationVc<T> where T: ?Sized + Send + Sync {}
+// NOTE: This uses the default implementation of `is_resolved` which returns `true` because we don't
+// want `OperationVc` arguments to get resolved when passed to a `#[turbo_tasks::function]`.
+impl<T> TaskInput for OperationVc<T>
+where
+    T: ?Sized + Send + Sync,
+{
+    fn is_transient(&self) -> bool {
+        self.node.is_transient()
+    }
+}
 
 impl<T> From<RawVc> for OperationVc<T>
 where


### PR DESCRIPTION
A function returning an `OperationVc` can call a transient function or have a transient argument.

IMO, `TaskInput` should not have default method implementations to avoid potential footguns like this.

Fixes breakage in canary: https://vercel.slack.com/archives/C04KC8A53T7/p1737746477519569

Closes PACK-3816