### PR TITLE
Add disableInstrumentation option to next.config.js

### DIFF
--- a/examples/basic-app/next.config.js
+++ b/examples/basic-app/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  disableInstrumentation: process.env.NODE_ENV !== 'production'
+}

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1058,6 +1058,11 @@ export interface NextConfig extends Record<string, any> {
   watchOptions?: {
     pollIntervalMs?: number
   }
+
+  /**
+   * Disable instrumentation in specific environments.
+   */
+  disableInstrumentation?: boolean | ((options: any) => boolean)
 }
 
 export const defaultConfig: NextConfig = {
@@ -1245,6 +1250,7 @@ export const defaultConfig: NextConfig = {
     useCache: undefined,
   },
   bundlePagesRouterDependencies: false,
+  disableInstrumentation: false,
 }
 
 export async function normalizeConfig(phase: string, config: any) {

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1024,6 +1024,14 @@ function assignDefaults(
     result.experimental.useCache = result.experimental.dynamicIO
   }
 
+  // Handle the disableInstrumentation option
+  if (typeof result.disableInstrumentation === 'function') {
+    result.disableInstrumentation = result.disableInstrumentation({
+      dev: process.env.NODE_ENV !== 'production',
+      isServer: typeof window === 'undefined',
+    })
+  }
+
   return result
 }
 

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -357,6 +357,9 @@ export default class NextNodeServer extends BaseServer<
   protected async runInstrumentationHookIfAvailable() {
     if (this.registeredInstrumentation) return
     this.registeredInstrumentation = true
+    if (this.nextConfig.disableInstrumentation) {
+      return
+    }
     await this.instrumentation?.register?.()
   }
 


### PR DESCRIPTION
Add `disableInstrumentation` configuration option to control environment-specific instrumentation.

* **Configuration Changes**
  - Add `disableInstrumentation` to the `NextConfig` type definition in `packages/next/src/server/config-shared.ts`.
  - Add `disableInstrumentation` to the `defaultConfig` object in `packages/next/src/server/config-shared.ts` with a default value of `false`.
  - Add logic to handle the `disableInstrumentation` option in the `assignDefaults` function in `packages/next/src/server/config.ts`.

* **Instrumentation Control**
  - Add a check for the `disableInstrumentation` option in the `runInstrumentationHookIfAvailable` function in `packages/next/src/server/next-server.ts`.
  - Skip the instrumentation registration if `disableInstrumentation` is `true` in `packages/next/src/server/next-server.ts`.

* **Example**
  - Add an example of using the `disableInstrumentation` option in the `next.config.js` file in `examples/basic-app/next.config.js`.

