### PR TITLE
Extend draftmode to support arbitrary context data

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/draft-mode.mdx
+++ b/docs/01-app/03-api-reference/04-functions/draft-mode.mdx
@@ -30,11 +30,12 @@ export default async function Page() {
 
 The following methods and properties are available:
 
-| Method      | Description                                                                       |
-| ----------- | --------------------------------------------------------------------------------- |
-| `isEnabled` | A boolean value that indicates if Draft Mode is enabled.                          |
-| `enable()`  | Enables Draft Mode in a Route Handler by setting a cookie (`__prerender_bypass`). |
-| `disable()` | Disables Draft Mode in a Route Handler by deleting a cookie.                      |
+| Method        | Description                                                                       |
+| ------------- | --------------------------------------------------------------------------------- |
+| `isEnabled`   | A boolean value that indicates if Draft Mode is enabled.                          |
+| `previewData` | A string containing ad-hoc data associated with the draft mode session            |
+| `enable()`    | Enables Draft Mode in a Route Handler by setting a cookie (`__prerender_bypass`). |
+| `disable()`   | Disables Draft Mode in a Route Handler by deleting a cookie.                      |
 
 ## Good to know
 
@@ -67,6 +68,34 @@ export async function GET(request) {
   draft().enable()
   return new Response('Draft mode is enabled')
 }
+```
+
+### Enabling Draft Mode with Contextual Data
+
+To enable Draft Mode with contextual data, pass a string to the `enable()` method:
+
+```tsx filename="app/draft/route.ts" switcher
+import { draftMode } from 'next/headers'
+
+export async function GET(request: Request) {
+  const context = {
+    customerType: 'premium',
+  }
+
+  const draft = await draftMode()
+  draft().enable(JSON.stringify(context))
+  return new Response('Draft mode is enabled')
+}
+```
+
+```js filename="app/draft/route.js" switcher
+const context = {
+  customerType: 'premium',
+}
+
+const draft = await draftMode()
+draft().enable(JSON.stringify(context))
+return new Response('Draft mode is enabled')
 ```
 
 ### Disabling Draft Mode
@@ -124,6 +153,40 @@ export default async function Page() {
     <main>
       <h1>My Blog Post</h1>
       <p>Draft Mode is currently {isEnabled ? 'Enabled' : 'Disabled'}</p>
+    </main>
+  )
+}
+```
+
+### Getting Draft Mode Contextual Data
+
+You can check if Draft Mode is enabled in a Server Component with the `isEnabled` property:
+
+```tsx filename="app/page.ts" switcher
+import { draftMode } from 'next/headers'
+
+export default async function Page() {
+  const { isEnabled, previewData } = await draftMode()
+  return (
+    <main>
+      <h1>My Blog Post</h1>
+      <p>Draft Mode is currently {isEnabled ? 'Enabled' : 'Disabled'}</p>
+      <p>Preview Data: {previewData}</p>
+    </main>
+  )
+}
+```
+
+```jsx filename="app/page.js" switcher
+import { draftMode } from 'next/headers'
+
+export default async function Page() {
+  const { isEnabled, previewData } = await draftMode()
+  return (
+    <main>
+      <h1>My Blog Post</h1>
+      <p>Draft Mode is currently {isEnabled ? 'Enabled' : 'Disabled'}</p>
+      <p>Preview Data: {previewData}</p>
     </main>
   )
 }

--- a/packages/next/src/server/api-utils/index.ts
+++ b/packages/next/src/server/api-utils/index.ts
@@ -96,6 +96,7 @@ export function checkIsOnDemandRevalidate(
 }
 
 export const COOKIE_NAME_PRERENDER_BYPASS = `__prerender_bypass`
+export const COOKIE_NAME_PRERENDER_BYPASS_PREVIEW = `__prerender_bypass_preview`
 export const COOKIE_NAME_PRERENDER_DATA = `__next_preview_data`
 
 export const RESPONSE_LIMIT_DEFAULT = 4 * 1024 * 1024

--- a/packages/next/src/server/async-storage/draft-mode-provider.ts
+++ b/packages/next/src/server/async-storage/draft-mode-provider.ts
@@ -6,7 +6,7 @@ import type { NextRequest } from '../web/spec-extension/request'
 
 import {
   COOKIE_NAME_PRERENDER_BYPASS,
-  COOKIE_NAME_PRERENDER_DATA,
+  COOKIE_NAME_PRERENDER_BYPASS_PREVIEW,
   checkIsOnDemandRevalidate,
 } from '../api-utils'
 import type { __ApiPreviewProps } from '../api-utils'
@@ -50,7 +50,9 @@ export class DraftModeProvider {
     )
 
     if (this.isEnabled) {
-      this.previewData = cookies.get(COOKIE_NAME_PRERENDER_DATA)?.value
+      this.previewData = cookies.get(
+        COOKIE_NAME_PRERENDER_BYPASS_PREVIEW
+      )?.value
     }
 
     this._previewModeId = previewProps?.previewModeId
@@ -75,7 +77,7 @@ export class DraftModeProvider {
 
     if (previewData) {
       this._mutableCookies.set({
-        name: COOKIE_NAME_PRERENDER_DATA,
+        name: COOKIE_NAME_PRERENDER_BYPASS_PREVIEW,
         value: previewData,
         httpOnly: true,
         sameSite: process.env.NODE_ENV !== 'development' ? 'none' : 'lax',
@@ -100,11 +102,12 @@ export class DraftModeProvider {
     })
 
     this._mutableCookies.set({
-      name: COOKIE_NAME_PRERENDER_DATA,
+      name: COOKIE_NAME_PRERENDER_BYPASS_PREVIEW,
       value: '',
       httpOnly: true,
       sameSite: process.env.NODE_ENV !== 'development' ? 'none' : 'lax',
       secure: process.env.NODE_ENV !== 'development',
+      expires: new Date(0),
     })
   }
 }

--- a/packages/next/src/server/request/draft-mode.ts
+++ b/packages/next/src/server/request/draft-mode.ts
@@ -106,6 +106,21 @@ function createExoticDraftMode(
     enumerable: true,
     configurable: true,
   })
+
+  Object.defineProperty(promise, 'previewData', {
+    get() {
+      return instance.previewData
+    },
+    set(newValue) {
+      Object.defineProperty(promise, 'previewData', {
+        value: newValue,
+        writable: true,
+        enumerable: true,
+      })
+    },
+    enumerable: true,
+    configurable: true,
+  })
   ;(promise as any).enable = instance.enable.bind(instance)
   ;(promise as any).disable = instance.disable.bind(instance)
 
@@ -127,6 +142,23 @@ function createExoticDraftModeWithDevWarnings(
     },
     set(newValue) {
       Object.defineProperty(promise, 'isEnabled', {
+        value: newValue,
+        writable: true,
+        enumerable: true,
+      })
+    },
+    enumerable: true,
+    configurable: true,
+  })
+
+  Object.defineProperty(promise, 'previewData', {
+    get() {
+      const expression = '`draftMode().previewData`'
+      syncIODev(route, expression)
+      return instance.previewData
+    },
+    set(newValue) {
+      Object.defineProperty(promise, 'previewData', {
         value: newValue,
         writable: true,
         enumerable: true,
@@ -164,18 +196,27 @@ class DraftMode {
   constructor(provider: null | DraftModeProvider) {
     this._provider = provider
   }
+
   get isEnabled() {
     if (this._provider !== null) {
       return this._provider.isEnabled
     }
     return false
   }
-  public enable() {
-    // We we have a store we want to track dynamic data access to ensure we
+
+  get previewData() {
+    if (this._provider !== null) {
+      return this._provider.previewData
+    }
+    return undefined
+  }
+
+  public enable(previewData?: string) {
+    // We have a store we want to track dynamic data access to ensure we
     // don't statically generate routes that manipulate draft mode.
     trackDynamicDraftMode('draftMode().enable()')
     if (this._provider !== null) {
-      this._provider.enable()
+      this._provider.enable(previewData)
     }
   }
   public disable() {

--- a/test/e2e/app-dir/draft-mode/app/enable-with-context/route.ts
+++ b/test/e2e/app-dir/draft-mode/app/enable-with-context/route.ts
@@ -1,0 +1,8 @@
+import { draftMode } from 'next/headers'
+
+export async function GET() {
+  ;(await draftMode()).enable('test-context')
+  return new Response(
+    "Enabled in Route Handler using `(await draftMode()).enable('test-context')`, check cookies"
+  )
+}

--- a/test/e2e/app-dir/draft-mode/app/page.tsx
+++ b/test/e2e/app-dir/draft-mode/app/page.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { draftMode } from 'next/headers'
 
 export default async function Page() {
-  const { isEnabled } = await draftMode()
+  const { isEnabled, previewData } = await draftMode()
 
   return (
     <>
@@ -12,6 +12,9 @@ export default async function Page() {
       </p>
       <p>
         State: <strong id="mode">{isEnabled ? 'ENABLED' : 'DISABLED'}</strong>
+      </p>
+      <p>
+        Context: <strong id="context">{isEnabled ? previewData : 'N/A'}</strong>
       </p>
     </>
   )

--- a/test/e2e/app-dir/draft-mode/app/with-edge/enable-with-context/route.ts
+++ b/test/e2e/app-dir/draft-mode/app/with-edge/enable-with-context/route.ts
@@ -1,0 +1,8 @@
+import { draftMode } from 'next/headers'
+
+export async function GET() {
+  ;(await draftMode()).enable('test-context')
+  return new Response(
+    "Enabled in Route Handler using `(await draftMode()).enable('test-context')`, check cookies"
+  )
+}

--- a/test/e2e/app-dir/draft-mode/app/with-edge/page.tsx
+++ b/test/e2e/app-dir/draft-mode/app/with-edge/page.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { draftMode } from 'next/headers'
 
 export default async function Page() {
-  const { isEnabled } = await draftMode()
+  const { isEnabled, previewData } = await draftMode()
 
   return (
     <>
@@ -12,6 +12,9 @@ export default async function Page() {
       </p>
       <p>
         State: <strong id="mode">{isEnabled ? 'ENABLED' : 'DISABLED'}</strong>
+      </p>
+      <p>
+        Context: <strong id="context">{isEnabled ? previewData : 'N/A'}</strong>
       </p>
     </>
   )

--- a/test/e2e/app-dir/draft-mode/draft-mode.test.ts
+++ b/test/e2e/app-dir/draft-mode/draft-mode.test.ts
@@ -55,6 +55,24 @@ describe('app dir - draft mode', () => {
       expect(Cookie).toBeDefined()
     })
 
+    it('should have set-cookie header with context data', async () => {
+      const res = await next.fetch(`${basePath}enable-with-context`)
+      const h = res.headers.get('set-cookie') || ''
+      const cookies = h
+        .split(',')
+        .filter((c) => c.trim().startsWith('__prerender_bypass'))
+      Cookie = cookies.map((c) => c.split(';')[0]).join('; ')
+      expect(Cookie).toBeDefined()
+      expect(cookies).toHaveLength(2)
+    })
+
+    it('should have accessible context data returned from draftmode', async () => {
+      const opts = { headers: { Cookie } }
+      const $ = await next.render$(basePath, {}, opts)
+      expect($('#mode').text()).toBe('ENABLED')
+      expect($('#context').text()).toBe('test-context')
+    })
+
     it('should have set-cookie header with redirect location', async () => {
       const res = await next.fetch(`${basePath}enable-and-redirect`, {
         redirect: 'manual',


### PR DESCRIPTION
### What?
Add support for storing contextual data with enabled draft mode.

### Why?
To better support large sites that deploy the majority of their site statically but need context to be associated with a preview mode.

### How?
By storing adhoc data in a separate cookie that is read by the draftMode API and does not require the use of independenlty using the `cookies` dynamic api (which deopts requests from static generation)

Fixes #75341 
