### PR TITLE
fix(dev-server): Terminate turbopack HMR websocket connections during exit

### DIFF
--- a/packages/next/src/server/dev/hot-middleware.ts
+++ b/packages/next/src/server/dev/hot-middleware.ts
@@ -72,16 +72,11 @@ class EventStream {
     this.clients = new Set()
   }
 
-  everyClient(fn: (client: ws) => void) {
-    for (const client of this.clients) {
-      fn(client)
-    }
-  }
-
   close() {
-    this.everyClient((client) => {
-      client.close()
-    })
+    for (const wsClient of this.clients) {
+      // it's okay to not cleanly close these websocket connections, this is dev
+      wsClient.terminate()
+    }
     this.clients.clear()
   }
 
@@ -93,9 +88,9 @@ class EventStream {
   }
 
   publish(payload: any) {
-    this.everyClient((client) => {
-      client.send(JSON.stringify(payload))
-    })
+    for (const wsClient of this.clients) {
+      wsClient.send(JSON.stringify(payload))
+    }
   }
 }
 

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1064,6 +1064,7 @@ export async function createHotReloaderTurbopack(
         // it's okay to not cleanly close these websocket connections, this is dev
         wsClient.terminate()
       }
+      clients.clear()
     },
   }
 

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1059,6 +1059,12 @@ export async function createHotReloaderTurbopack(
           }
         })
     },
+    close() {
+      for (const wsClient of clients) {
+        // it's okay to not cleanly close these websocket connections, this is dev
+        wsClient.terminate()
+      }
+    },
   }
 
   handleEntrypointsSubscription().catch((err) => {

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -182,4 +182,5 @@ export interface NextJsHotReloaderInterface {
     definition: RouteDefinition | undefined
     url?: string
   }): Promise<void>
+  close(): void
 }

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -1596,5 +1596,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       })
   }
 
-  public close() {}
+  public close() {
+    this.webpackHotMiddleware?.close()
+  }
 }

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -1595,4 +1595,6 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
         })
       })
   }
+
+  public close() {}
 }

--- a/packages/next/src/server/lib/dev-bundler-service.ts
+++ b/packages/next/src/server/lib/dev-bundler-service.ts
@@ -103,4 +103,8 @@ export class DevBundlerService {
       data: this.appIsrManifest,
     })
   }
+
+  public close() {
+    this.bundler.hotReloader.close()
+  }
 }

--- a/packages/next/src/server/lib/render-server.ts
+++ b/packages/next/src/server/lib/render-server.ts
@@ -9,6 +9,8 @@ export type ServerInitResult = {
   requestHandler: RequestHandler
   upgradeHandler: UpgradeHandler
   server: NextServer
+  // Make an effort to close upgraded HTTP requests (e.g. Turbopack HMR websockets)
+  closeUpgraded: () => void
 }
 
 let initializations: Record<string, Promise<ServerInitResult> | undefined> = {}
@@ -109,6 +111,9 @@ async function initializeImpl(opts: {
     requestHandler,
     upgradeHandler,
     server,
+    closeUpgraded() {
+      opts.bundlerService?.close()
+    },
   }
 }
 

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -751,5 +751,12 @@ export async function initialize(opts: {
     }
   }
 
-  return { requestHandler, upgradeHandler, server: handlers.server }
+  return {
+    requestHandler,
+    upgradeHandler,
+    server: handlers.server,
+    closeUpgraded() {
+      developmentBundler?.hotReloader?.close()
+    },
+  }
 }


### PR DESCRIPTION
Without this change, an open browser tab with an HMR websocket subscription (which is very common) can prevent next.js's dev server from exiting cleanly (falls back to a SIGKILL after a 100ms timeout).

That's bad (aside from the extra 100ms delay) because it prevents

```
            await Promise.all([
              nextServer?.close().catch(console.error),
              cleanupListeners?.runAll().catch(console.error),
            ])
```

from running, which can prevent us from flushing task statistics (https://github.com/vercel/next.js/pull/67164).

You can test this with:

```
NEXT_EXIT_TIMEOUT_MS=200000 node_modules/.bin/next dev
```

or

```
NEXT_EXIT_TIMEOUT_MS=200000 node_modules/.bin/next dev --turbo
```

Prior to this PR, after hitting ctrl+c, the processes will hang if there's a connected browser window open.

After this PR, the processes exit instantly.

Closes PACK-3839