### PR TITLE
fix(turbopack): Force vars declared with ts keyword `declare` as `FreeVar`s

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
@@ -56,8 +56,14 @@ pub fn benchmark(c: &mut Criterion) {
                 let top_level_mark = Mark::new();
                 program.visit_mut_with(&mut resolver(unresolved_mark, top_level_mark, false));
 
-                let eval_context =
-                    EvalContext::new(&program, unresolved_mark, top_level_mark, None, None);
+                let eval_context = EvalContext::new(
+                    &program,
+                    unresolved_mark,
+                    top_level_mark,
+                    Default::default(),
+                    None,
+                    None,
+                );
                 let var_graph = create_graph(&program, &eval_context);
 
                 let input = BenchInput {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -1,9 +1,10 @@
 use std::{
     iter,
     mem::{replace, take},
+    sync::Arc,
 };
 
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::{
     atoms::Atom,
     common::{comments::Comments, pass::AstNodePath, Mark, Span, Spanned, SyntaxContext, GLOBALS},
@@ -295,6 +296,7 @@ pub struct EvalContext {
     pub(crate) unresolved_mark: Mark,
     pub(crate) top_level_mark: Mark,
     pub(crate) imports: ImportMap,
+    pub(crate) force_free_values: Arc<FxHashSet<Id>>,
 }
 
 impl EvalContext {
@@ -305,6 +307,7 @@ impl EvalContext {
         module: &Program,
         unresolved_mark: Mark,
         top_level_mark: Mark,
+        force_free_values: Arc<FxHashSet<Id>>,
         comments: Option<&dyn Comments>,
         source: Option<Vc<Box<dyn Source>>>,
     ) -> Self {
@@ -312,6 +315,7 @@ impl EvalContext {
             unresolved_mark,
             top_level_mark,
             imports: ImportMap::analyze(module, source, comments),
+            force_free_values,
         }
     }
 
@@ -378,7 +382,7 @@ impl EvalContext {
         if let Some(imported) = self.imports.get_import(&id) {
             return imported;
         }
-        if is_unresolved(i, self.unresolved_mark) {
+        if is_unresolved(i, self.unresolved_mark) || self.force_free_values.contains(&id) {
             JsValue::FreeVar(i.sym.clone())
         } else {
             JsValue::Variable(id)
@@ -1874,7 +1878,9 @@ impl VisitAstPath for Analyzer<'_> {
                 span: ident.span(),
                 in_try: is_in_try(ast_path),
             })
-        } else if is_unresolved(ident, self.eval_context.unresolved_mark) {
+        } else if is_unresolved(ident, self.eval_context.unresolved_mark)
+            || self.eval_context.force_free_values.contains(&ident.to_id())
+        {
             self.add_effect(Effect::FreeVar {
                 var: Box::new(JsValue::FreeVar(ident.sym.clone())),
                 ast_path: as_parent_path(ast_path),

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -4035,8 +4035,14 @@ mod tests {
                 let top_level_mark = Mark::new();
                 m.visit_mut_with(&mut resolver(unresolved_mark, top_level_mark, false));
 
-                let eval_context =
-                    EvalContext::new(&m, unresolved_mark, top_level_mark, Some(&comments), None);
+                let eval_context = EvalContext::new(
+                    &m,
+                    unresolved_mark,
+                    top_level_mark,
+                    Default::default(),
+                    Some(&comments),
+                    None,
+                );
 
                 let mut var_graph = create_graph(&m, &eval_context);
 

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -1,6 +1,7 @@
 use std::{future::Future, sync::Arc};
 
 use anyhow::{anyhow, Context, Result};
+use rustc_hash::FxHashSet;
 use swc_core::{
     base::SwcComments,
     common::{
@@ -10,14 +11,14 @@ use swc_core::{
         BytePos, FileName, Globals, LineCol, Mark, SyntaxContext, GLOBALS,
     },
     ecma::{
-        ast::{EsVersion, Program},
+        ast::{EsVersion, Id, ObjectPatProp, Pat, Program, VarDecl},
         lints::{config::LintConfig, rules::LintParams},
         parser::{lexer::Lexer, EsSyntax, Parser, Syntax, TsSyntax},
         transforms::base::{
             helpers::{Helpers, HELPERS},
             resolver,
         },
-        visit::VisitMutWith,
+        visit::{noop_visit_type, Visit, VisitMutWith, VisitWith},
     },
 };
 use tracing::Instrument;
@@ -387,6 +388,12 @@ async fn parse_file_content(
 
             parsed_program.mutate(swc_core::ecma::transforms::proposal::explicit_resource_management::explicit_resource_management());
 
+            let var_with_ts_declare = if is_typescript {
+                VarDeclWithTsDeclareCollector::collect(&parsed_program)
+            } else {
+                FxHashSet::default()
+            };
+
             let transform_context = TransformContext {
                 comments: &comments,
                 source_map: &source_map,
@@ -433,6 +440,7 @@ async fn parse_file_content(
                 &parsed_program,
                 unresolved_mark,
                 top_level_mark,
+                Arc::new(var_with_ts_declare),
                 Some(&comments),
                 Some(*source),
             );
@@ -507,5 +515,72 @@ impl Issue for ReadSourceIssue {
     #[turbo_tasks::function]
     fn stage(&self) -> Vc<IssueStage> {
         IssueStage::Load.cell()
+    }
+}
+
+struct VarDeclWithTsDeclareCollector {
+    id_with_no_ts_declare: FxHashSet<Id>,
+    id_with_ts_declare: FxHashSet<Id>,
+}
+
+impl VarDeclWithTsDeclareCollector {
+    fn collect<N: VisitWith<VarDeclWithTsDeclareCollector>>(n: &N) -> FxHashSet<Id> {
+        let mut collector = VarDeclWithTsDeclareCollector {
+            id_with_no_ts_declare: Default::default(),
+            id_with_ts_declare: Default::default(),
+        };
+        n.visit_with(&mut collector);
+        collector
+            .id_with_ts_declare
+            .retain(|id| !collector.id_with_no_ts_declare.contains(id));
+        collector.id_with_ts_declare
+    }
+
+    fn handle_pat(&mut self, pat: &Pat, declare: bool) {
+        match pat {
+            Pat::Ident(binding_ident) => {
+                if declare {
+                    self.id_with_ts_declare.insert(binding_ident.to_id());
+                } else {
+                    self.id_with_no_ts_declare.insert(binding_ident.to_id());
+                }
+            }
+            Pat::Array(array_pat) => {
+                for pat in array_pat.elems.iter() {
+                    if let Some(pat) = pat {
+                        self.handle_pat(&pat, declare);
+                    }
+                }
+            }
+            Pat::Object(object_pat) => {
+                for prop in object_pat.props.iter() {
+                    match prop {
+                        ObjectPatProp::KeyValue(key_value_pat_prop) => {
+                            self.handle_pat(&key_value_pat_prop.value, declare);
+                        }
+                        ObjectPatProp::Assign(assign_pat_prop) => {
+                            if declare {
+                                self.id_with_ts_declare.insert(assign_pat_prop.key.to_id());
+                            } else {
+                                self.id_with_no_ts_declare
+                                    .insert(assign_pat_prop.key.to_id());
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Visit for VarDeclWithTsDeclareCollector {
+    noop_visit_type!();
+
+    fn visit_var_decl(&mut self, node: &VarDecl) {
+        for decl in node.decls.iter() {
+            self.handle_pat(&decl.name, node.declare);
+        }
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -577,6 +577,7 @@ pub(super) async fn split(
                         &program,
                         eval_context.unresolved_mark,
                         eval_context.top_level_mark,
+                        eval_context.force_free_values.clone(),
                         None,
                         Some(source),
                     );
@@ -701,6 +702,7 @@ pub(crate) async fn part_of_module(
                         &program,
                         eval_context.unresolved_mark,
                         eval_context.top_level_mark,
+                        eval_context.force_free_values.clone(),
                         None,
                         None,
                     );


### PR DESCRIPTION
fixes https://github.com/vercel/next.js/issues/72576

original fixes:
- https://github.com/vercel/next.js/pull/72604
- https://github.com/swc-project/swc/pull/9734

The reason why I fix it again is that the original fixes were so **ad hoc** that it introduced other issues: https://github.com/swc-project/swc/issues/9892. Besides the original fixes made the following result very counter-intuitive:
```ts
declare const a#0;
const b = a#2;
export { a#2 };
```

The new idea is collecting the var ids that are only declared with typescript keyword `declare`. The code may be a little verbose, but I think the idea is correct.

If this pr is accepted, I will also revert the changes in swc after new release.
