### PR TITLE
Turbopack: more tracing

### DIFF
--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -7,6 +7,7 @@ use std::{
 
 use anyhow::{bail, Context, Result};
 use rustc_hash::FxHashSet;
+use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     apply_effects, ReadConsistency, ResolvedVc, TransientInstance, TryJoinIterExt, TurboTasks,

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -1,19 +1,19 @@
 use std::{
     env::current_dir,
     mem::forget,
-    path::{PathBuf, MAIN_SEPARATOR},
+    path::{MAIN_SEPARATOR, PathBuf},
     sync::Arc,
 };
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use rustc_hash::FxHashSet;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    apply_effects, ReadConsistency, ResolvedVc, TransientInstance, TryJoinIterExt, TurboTasks,
-    Value, Vc,
+    ReadConsistency, ResolvedVc, TransientInstance, TryJoinIterExt, TurboTasks, Value, Vc,
+    apply_effects,
 };
 use turbo_tasks_backend::{
-    noop_backing_storage, BackendOptions, NoopBackingStorage, TurboTasksBackend,
+    BackendOptions, NoopBackingStorage, TurboTasksBackend, noop_backing_storage,
 };
 use turbo_tasks_fs::FileSystem;
 use turbopack::global_module_ids::get_global_module_id_strategy;
@@ -22,16 +22,16 @@ use turbopack_cli_utils::issue::{ConsoleUi, LogOptions};
 use turbopack_core::{
     asset::Asset,
     chunk::{
-        availability_info::AvailabilityInfo, ChunkingConfig, ChunkingContext, EvaluatableAsset,
-        EvaluatableAssets, MinifyType, SourceMapsType,
+        ChunkingConfig, ChunkingContext, EvaluatableAsset, EvaluatableAssets, MinifyType,
+        SourceMapsType, availability_info::AvailabilityInfo,
     },
     environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
     ident::AssetIdent,
-    issue::{handle_issues, IssueReporter, IssueSeverity},
+    issue::{IssueReporter, IssueSeverity, handle_issues},
     module::Module,
     module_graph::{
-        chunk_group_info::{ChunkGroup, ChunkGroupEntry},
         ModuleGraph,
+        chunk_group_info::{ChunkGroup, ChunkGroupEntry},
     },
     output::{OutputAsset, OutputAssets},
     reference::all_assets_from_entries,
@@ -48,9 +48,9 @@ use turbopack_nodejs::NodeJsChunkingContext;
 
 use crate::{
     arguments::{BuildArguments, Target},
-    contexts::{get_client_asset_context, get_client_compile_time_info, NodeEnv},
+    contexts::{NodeEnv, get_client_asset_context, get_client_compile_time_info},
     util::{
-        normalize_dirs, normalize_entries, output_fs, project_fs, EntryRequest, NormalizedDirs,
+        EntryRequest, NormalizedDirs, normalize_dirs, normalize_entries, output_fs, project_fs,
     },
 };
 
@@ -149,7 +149,9 @@ impl TurbopackBuildBuilder {
             // Await the result to propagate any errors.
             build_result_op.read_strongly_consistent().await?;
 
-            apply_effects(build_result_op).await?;
+            apply_effects(build_result_op)
+                .instrument(tracing::info_span!("apply effects"))
+                .await?;
 
             let issue_reporter: Vc<Box<dyn IssueReporter>> =
                 Vc::upcast(ConsoleUi::new(TransientInstance::new(LogOptions {
@@ -270,26 +272,30 @@ async fn build_internal(
 
     let origin = PlainResolveOrigin::new(asset_context, project_fs.root().join("_".into()));
     let project_dir = &project_dir;
-    let entries = entry_requests
-        .into_iter()
-        .map(|request_vc| async move {
-            let ty = Value::new(ReferenceType::Entry(EntryReferenceSubType::Undefined));
-            let request = request_vc.await?;
-            origin
-                .resolve_asset(request_vc, origin.resolve_options(ty.clone()), ty)
-                .await?
-                .first_module()
-                .await?
-                .with_context(|| {
-                    format!(
-                        "Unable to resolve entry {} from directory {}.",
-                        request.request().unwrap(),
-                        project_dir
-                    )
-                })
-        })
-        .try_join()
-        .await?;
+    let entries = async move {
+        entry_requests
+            .into_iter()
+            .map(|request_vc| async move {
+                let ty = Value::new(ReferenceType::Entry(EntryReferenceSubType::Undefined));
+                let request = request_vc.await?;
+                origin
+                    .resolve_asset(request_vc, origin.resolve_options(ty.clone()), ty)
+                    .await?
+                    .first_module()
+                    .await?
+                    .with_context(|| {
+                        format!(
+                            "Unable to resolve entry {} from directory {}.",
+                            request.request().unwrap(),
+                            project_dir
+                        )
+                    })
+            })
+            .try_join()
+            .await
+    }
+    .instrument(tracing::info_span!("resolve entries"))
+    .await?;
 
     let module_graph =
         ModuleGraph::from_modules(Vc::cell(vec![ChunkGroupEntry::Entry(entries.clone())]));
@@ -445,7 +451,11 @@ async fn build_internal(
 
     let mut chunks: FxHashSet<ResolvedVc<Box<dyn OutputAsset>>> = FxHashSet::default();
     for chunk_group in entry_chunk_groups {
-        chunks.extend(&*all_assets_from_entries(*chunk_group).await?);
+        chunks.extend(
+            &*async move { all_assets_from_entries(*chunk_group).await }
+                .instrument(tracing::info_span!("list chunks"))
+                .await?,
+        );
     }
 
     chunks

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -1,19 +1,19 @@
 use std::{
     env::current_dir,
     mem::forget,
-    path::{MAIN_SEPARATOR, PathBuf},
+    path::{PathBuf, MAIN_SEPARATOR},
     sync::Arc,
 };
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use rustc_hash::FxHashSet;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    ReadConsistency, ResolvedVc, TransientInstance, TryJoinIterExt, TurboTasks, Value, Vc,
-    apply_effects,
+    apply_effects, ReadConsistency, ResolvedVc, TransientInstance, TryJoinIterExt, TurboTasks,
+    Value, Vc,
 };
 use turbo_tasks_backend::{
-    BackendOptions, NoopBackingStorage, TurboTasksBackend, noop_backing_storage,
+    noop_backing_storage, BackendOptions, NoopBackingStorage, TurboTasksBackend,
 };
 use turbo_tasks_fs::FileSystem;
 use turbopack::global_module_ids::get_global_module_id_strategy;
@@ -22,16 +22,16 @@ use turbopack_cli_utils::issue::{ConsoleUi, LogOptions};
 use turbopack_core::{
     asset::Asset,
     chunk::{
-        ChunkingConfig, ChunkingContext, EvaluatableAsset, EvaluatableAssets, MinifyType,
-        SourceMapsType, availability_info::AvailabilityInfo,
+        availability_info::AvailabilityInfo, ChunkingConfig, ChunkingContext, EvaluatableAsset,
+        EvaluatableAssets, MinifyType, SourceMapsType,
     },
     environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
     ident::AssetIdent,
-    issue::{IssueReporter, IssueSeverity, handle_issues},
+    issue::{handle_issues, IssueReporter, IssueSeverity},
     module::Module,
     module_graph::{
-        ModuleGraph,
         chunk_group_info::{ChunkGroup, ChunkGroupEntry},
+        ModuleGraph,
     },
     output::{OutputAsset, OutputAssets},
     reference::all_assets_from_entries,
@@ -48,9 +48,9 @@ use turbopack_nodejs::NodeJsChunkingContext;
 
 use crate::{
     arguments::{BuildArguments, Target},
-    contexts::{NodeEnv, get_client_asset_context, get_client_compile_time_info},
+    contexts::{get_client_asset_context, get_client_compile_time_info, NodeEnv},
     util::{
-        EntryRequest, NormalizedDirs, normalize_dirs, normalize_entries, output_fs, project_fs,
+        normalize_dirs, normalize_entries, output_fs, project_fs, EntryRequest, NormalizedDirs,
     },
 };
 

--- a/turbopack/crates/turbopack-cli/src/lib.rs
+++ b/turbopack/crates/turbopack-cli/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(min_specialization)]
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
+#![feature(async_closure)]
 
 pub mod arguments;
 pub mod build;

--- a/turbopack/crates/turbopack-cli/src/lib.rs
+++ b/turbopack/crates/turbopack-cli/src/lib.rs
@@ -2,7 +2,6 @@
 #![feature(min_specialization)]
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
-#![feature(async_closure)]
 
 pub mod arguments;
 pub mod build;

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -1,4 +1,4 @@
-use std::{io::Write, sync::Arc};
+use std::{borrow::Cow, io::Write, sync::Arc};
 
 use anyhow::{bail, Context, Result};
 use swc_core::{
@@ -33,7 +33,7 @@ pub fn minify(path: &FileSystemPath, code: &Code, source_maps: bool, mangle: boo
     let (src, mut src_map_buf) = {
         let fm = cm.new_source_file(
             FileName::Custom(path.path.to_string()).into(),
-            code.source_code().to_str()?.into_owned(),
+            code_str.into_owned(),
         );
 
         let lexer = Lexer::new(

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -19,11 +19,13 @@ use swc_core::{
         transforms::base::fixer::paren_remover,
     },
 };
+use tracing::{instrument, Level};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::code_builder::{Code, CodeBuilder};
 
 use crate::parse::generate_js_source_map;
 
+#[instrument(level = Level::INFO, skip_all)]
 pub fn minify(path: &FileSystemPath, code: &Code, source_maps: bool, mangle: bool) -> Result<Code> {
     let source_maps = source_maps
         .then(|| code.generate_source_map_ref())

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, io::Write, sync::Arc};
+use std::{io::Write, sync::Arc};
 
 use anyhow::{bail, Context, Result};
 use swc_core::{
@@ -33,7 +33,7 @@ pub fn minify(path: &FileSystemPath, code: &Code, source_maps: bool, mangle: boo
     let (src, mut src_map_buf) = {
         let fm = cm.new_source_file(
             FileName::Custom(path.path.to_string()).into(),
-            code_str.into_owned(),
+            code.source_code().to_str()?.into_owned(),
         );
 
         let lexer = Lexer::new(


### PR DESCRIPTION
**View the diff without whitespace changes**

Add a few more spans similar to the ones that Next has (I don't know where these gaps come from), there are no gaps in the verbose trace below:
`TURBOPACK_TRACING=turbopack`:

![Bildschirmfoto 2025-01-27 um 10 23 01](https://github.com/user-attachments/assets/c06c10b5-ec4c-499d-883f-44e227ef5aa1)

`TURBOPACK_TRACING=turbo-tasks`:
![Bildschirmfoto 2025-01-27 um 10 23 16](https://github.com/user-attachments/assets/64a23237-db35-47b4-9d3a-0a717e4b0cd5)


Closes PACK-4172