### PR TITLE
Configure correct app dir when building `/_error` fallback in dev

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -304,13 +304,13 @@ export default async function getBaseWebpackConfig(
     dev?: boolean
     entrypoints: webpack.EntryObject
     isDevFallback?: boolean
-    pagesDir?: string
+    pagesDir: string | undefined
     reactProductionProfiling?: boolean
     rewrites: CustomRoutes['rewrites']
     originalRewrites: CustomRoutes['rewrites'] | undefined
     originalRedirects: CustomRoutes['redirects'] | undefined
     runWebpackSpan: Span
-    appDir?: string
+    appDir: string | undefined
     middlewareMatchers?: MiddlewareMatcher[]
     noMangling?: boolean
     jsConfig: any

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -692,6 +692,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       config: this.config,
       buildId: this.buildId,
       encryptionKey: this.encryptionKey,
+      appDir: this.appDir,
       pagesDir: this.pagesDir,
       rewrites: {
         beforeFiles: [],


### PR DESCRIPTION
Error is still catastrophic in case a custom `.babelrc` is used. 

Instead of
```
[TypeError: The "path" argument must be of type string. Received undefined] {
  code: 'ERR_INVALID_ARG_TYPE'
}
```
we now get
```
[Error: ENOENT: no such file or directory, open '/private/var/folders/pw/l2r2l0mn4gq7jg3bprfv_w740000gn/T/next-install-68e307a0ecd55c8dbe2f950c2e51318949c2c0f04369b26b867482de73d50e44/.next/fallback-build-manifest.json'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/private/var/folders/pw/l2r2l0mn4gq7jg3bprfv_w740000gn/T/next-install-68e307a0ecd55c8dbe2f950c2e51318949c2c0f04369b26b867482de73d50e44/.next/fallback-build-manifest.json'
}
```

But this was a clear oversight so we should land it regardless.