### PR TITLE
Fixed `null is not an object (evaluating 't.parallelRoutes.get')`

### DIFF
--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -38,7 +38,6 @@ export function createInitialRouterState({
     seedData: initialSeedData,
     head: initialHead,
   } = normalizedFlightData
-  const isServer = !location
   // For the SSR render, seed data should always be available (we only send back a `null` response
   // in the case of a `loading` segment, pre-PPR.)
   const rsc = initialSeedData?.[1]
@@ -51,7 +50,7 @@ export function createInitialRouterState({
     head: null,
     prefetchHead: null,
     // The cache gets seeded during the first render. `initialParallelRoutes` ensures the cache from the first render is there during the second render.
-    parallelRoutes: isServer ? new Map() : initialParallelRoutes,
+    parallelRoutes: initialParallelRoutes,
     loading,
   }
 

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1038,9 +1038,9 @@ function App<T>({
   const initialState = createInitialRouterState({
     initialFlightData: response.f,
     initialCanonicalUrlParts: response.c,
-    // location and initialParallelRoutes are not initialized in the SSR render
-    // they are set to an empty map and window.location, respectively during hydration
-    initialParallelRoutes: null!,
+    initialParallelRoutes: new Map(),
+    // location is not initialized in the SSR render
+    // it's set to window.location during hydration
     location: null,
     couldBeIntercepted: response.i,
     postponed: response.s,
@@ -1096,9 +1096,9 @@ function AppWithoutContext<T>({
   const initialState = createInitialRouterState({
     initialFlightData: response.f,
     initialCanonicalUrlParts: response.c,
-    // location and initialParallelRoutes are not initialized in the SSR render
-    // they are set to an empty map and window.location, respectively during hydration
-    initialParallelRoutes: null!,
+    initialParallelRoutes: new Map(),
+    // location is not initialized in the SSR render
+    // it's set to window.location during hydration
     location: null,
     couldBeIntercepted: response.i,
     postponed: response.s,


### PR DESCRIPTION
### Related issues

1. Fixes #69272
2. Fixes #69270
3. Fixes #67730
4. Relates to https://github.com/vercel/next.js/issues/55462#issuecomment-1896098700
5. Resolves https://github.com/vercel/next.js/discussions/67729
6. Relates to https://github.com/vercel/next.js/discussions/66752

### What?

Quite often we are getting `TypeError: null is not an object (evaluating 't.parallelRoutes.get')` error in our error tracker. 
There is no clear pattern; but it's daily count grows as DAU amount grows.

Error call trace is:
```
router-reducer/fill-lazy-items-till-leaf-with-head.ts at line 153:59
router-reducer/create-initial-router-state.ts at line 66:34
```

### Why?

In the code there is comment `location and initialParallelRoutes are not initialized in the SSR render they are set to an empty map and window.location, respectively during hydration`. However, it seems that it's not always set to an empty map on the client side.

### How?

To ensure it's always set, I have replaced wrong (from ts pov) `null!` with `new Map()` and redundant logic of passing `initialParallelRoutes` into `cache.parallelRoutes`