### PR TITLE
[metadata] new metadata insertion API and support PPR

### DIFF
--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -797,9 +797,6 @@ function finishPendingCacheNode(
   // a pending promise that needs to be resolved with the dynamic head from
   // the server.
   const head = cacheNode.head
-  // TODO: change head back to ReactNode when metadata
-  // is stably rendered in body
-  // Handle head[0] - viewport
   if (isDeferredRsc(head)) {
     head.resolve(dynamicHead)
   }

--- a/packages/next/src/export/types.ts
+++ b/packages/next/src/export/types.ts
@@ -62,6 +62,7 @@ export interface ExportPageInput {
   nextConfigOutput?: NextConfigComplete['output']
   enableExperimentalReact?: boolean
   sriEnabled: boolean
+  streamingMetadata: boolean | undefined
 }
 
 export type ExportRouteResult =

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -253,6 +253,13 @@ async function exportPageImpl(
     )
   }
 
+  // During the export phase in next build, if it's using PPR we can serve streaming metadata
+  // when it's available. When we're building the PPR rendering result, we don't need to rely
+  // on the user agent. The result can be determined to serve streaming on infrastructure level.
+  const serveStreamingMetadata = Boolean(
+    isRoutePPREnabled && input.streamingMetadata
+  )
+
   const renderOpts: WorkerRenderOpts = {
     ...components,
     ...input.renderOpts,
@@ -262,6 +269,7 @@ async function exportPageImpl(
     disableOptimizedLoading,
     locale,
     supportsDynamicResponse: false,
+    serveStreamingMetadata,
     experimental: {
       ...input.renderOpts.experimental,
       isRoutePPREnabled,
@@ -416,6 +424,7 @@ export async function exportPages(
             debugOutput: options.debugOutput,
             enableExperimentalReact: needsExperimentalReact(nextConfig),
             sriEnabled: Boolean(nextConfig.experimental.sri?.algorithm),
+            streamingMetadata: nextConfig.experimental.streamingMetadata,
             buildId: input.buildId,
           }),
           // If exporting the page takes longer than the timeout, reject the promise.

--- a/packages/next/src/lib/metadata/async-metadata.tsx
+++ b/packages/next/src/lib/metadata/async-metadata.tsx
@@ -1,21 +1,13 @@
 'use client'
 
-import { use } from 'react'
-import { useServerInsertedHTML } from '../../client/components/navigation'
+import { use, type JSX } from 'react'
+import { useServerInsertedMetadata } from '../../server/app-render/metadata-insertion/use-server-inserted-metadata'
 
-// We need to wait for metadata on server once it's resolved, and insert into
-// the HTML through `useServerInsertedHTML`. It will suspense in <head> during SSR.
-function ServerInsertMetadata({ promise }: { promise: Promise<any> }) {
-  let metadataToFlush: React.ReactNode = use(promise)
-
-  useServerInsertedHTML(() => {
-    if (metadataToFlush) {
-      const flushing = metadataToFlush
-      // reset to null to ensure we only flush it once
-      metadataToFlush = null
-      return flushing
-    }
-  })
+function ServerInsertMetadata({ promise }: { promise: Promise<JSX.Element> }) {
+  // Apply use() to the metadata promise to suspend the rendering in SSR.
+  const metadata = use(promise)
+  // Insert metadata into the HTML stream through the `useServerInsertedMetadata`
+  useServerInsertedMetadata(() => metadata)
 
   return null
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1958,10 +1958,17 @@ async function renderToStream(
      *        or throw an error. It is the sole responsibility of the caller to
      *        ensure they aren't e.g. requesting dynamic HTML for an AMP page.
      *
+     *   3.) If `shouldWaitOnAllReady` is true, which indicates we need to
+     *       resolve all suspenses and generate a full HTML. e.g. when it's a
+     *       html limited bot requests, we produce the full HTML content.
+     *
      * These rules help ensure that other existing features like request caching,
      * coalescing, and ISR continue working as intended.
      */
-    const generateStaticHTML = renderOpts.supportsDynamicResponse !== true
+    const generateStaticHTML =
+      renderOpts.supportsDynamicResponse !== true ||
+      !!renderOpts.shouldWaitOnAllReady
+
     const validateRootLayout = renderOpts.dev
     return await continueFizzStream(htmlStream, {
       inlinedDataStream: createInlinedDataReadableStream(
@@ -2094,11 +2101,16 @@ async function renderToStream(
        *    2.) If dynamic HTML support is requested, we must honor that request
        *        or throw an error. It is the sole responsibility of the caller to
        *        ensure they aren't e.g. requesting dynamic HTML for an AMP page.
+       *    3.) If `shouldWaitOnAllReady` is true, which indicates we need to
+       *        resolve all suspenses and generate a full HTML. e.g. when it's a
+       *        html limited bot requests, we produce the full HTML content.
        *
        * These rules help ensure that other existing features like request caching,
        * coalescing, and ISR continue working as intended.
        */
-      const generateStaticHTML = renderOpts.supportsDynamicResponse !== true
+      const generateStaticHTML =
+        renderOpts.supportsDynamicResponse !== true ||
+        !!renderOpts.shouldWaitOnAllReady
       const validateRootLayout = renderOpts.dev
       return await continueFizzStream(fizzStream, {
         inlinedDataStream: createInlinedDataReadableStream(

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1847,9 +1847,18 @@ async function renderToStream(
     // one task before continuing
     await waitAtLeastOneReactRenderTask()
 
+    // When streaming metadata is enabled and request UA is a html-limited bot, we should do a dynamic render.
+    const shouldDoDynamicRender =
+      ctx.renderOpts.botType === 'html-limited' &&
+      ctx.renderOpts.experimental.streamingMetadata
+
     // If provided, the postpone state should be parsed as JSON so it can be
     // provided to React.
-    if (typeof renderOpts.postponed === 'string') {
+    if (
+      typeof renderOpts.postponed === 'string' &&
+      // When we don't need to forcedly do a dynamic render, continue PPR renderer.
+      !shouldDoDynamicRender
+    ) {
       if (postponedState?.type === DynamicState.DATA) {
         // We have a complete HTML Document in the prerender but we need to
         // still include the new server component render because it was not included

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1849,7 +1849,7 @@ async function renderToStream(
 
     // When streaming metadata is enabled and request UA is a html-limited bot, we should do a dynamic render.
     const shouldDoDynamicRender =
-      ctx.renderOpts.botType === 'html-limited' &&
+      ctx.renderOpts.botType === 'html' &&
       ctx.renderOpts.experimental.streamingMetadata
 
     // If provided, the postpone state should be parsed as JSON so it can be

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1847,18 +1847,9 @@ async function renderToStream(
     // one task before continuing
     await waitAtLeastOneReactRenderTask()
 
-    // When streaming metadata is enabled and request UA is a html-limited bot, we should do a dynamic render.
-    const shouldDoDynamicRender =
-      ctx.renderOpts.botType === 'html' &&
-      ctx.renderOpts.experimental.streamingMetadata
-
     // If provided, the postpone state should be parsed as JSON so it can be
     // provided to React.
-    if (
-      typeof renderOpts.postponed === 'string' &&
-      // When we don't need to forcedly do a dynamic render, continue PPR renderer.
-      !shouldDoDynamicRender
-    ) {
+    if (typeof renderOpts.postponed === 'string') {
       if (postponedState?.type === DynamicState.DATA) {
         // We have a complete HTML Document in the prerender but we need to
         // still include the new server component render because it was not included

--- a/packages/next/src/server/app-render/metadata-insertion/create-server-inserted-metadata.tsx
+++ b/packages/next/src/server/app-render/metadata-insertion/create-server-inserted-metadata.tsx
@@ -1,0 +1,43 @@
+import React, { type JSX } from 'react'
+import { renderToReadableStream } from 'react-dom/server.edge'
+import {
+  ServerInsertedMetadataContext,
+  type MetadataResolver,
+} from '../../../shared/lib/server-inserted-metadata.shared-runtime'
+import { renderToString } from '../render-to-string'
+
+export function createServerInsertedMetadata() {
+  let metadataResolver: MetadataResolver | null = null
+  let metadataToFlush: JSX.Element | null = null
+  const setMetadataResolver = (resolver: MetadataResolver): void => {
+    metadataResolver = resolver
+  }
+
+  return {
+    ServerInsertedMetadataProvider: ({
+      children,
+    }: {
+      children: React.ReactNode
+    }) => {
+      return (
+        <ServerInsertedMetadataContext.Provider value={setMetadataResolver}>
+          {children}
+        </ServerInsertedMetadataContext.Provider>
+      )
+    },
+
+    async getServerInsertedMetadata(): Promise<string> {
+      if (!metadataResolver || metadataToFlush) {
+        return ''
+      }
+
+      metadataToFlush = metadataResolver()
+      const html = await renderToString({
+        renderToReadableStream,
+        element: <>{metadataToFlush}</>,
+      })
+
+      return html
+    },
+  }
+}

--- a/packages/next/src/server/app-render/metadata-insertion/use-server-inserted-metadata.ts
+++ b/packages/next/src/server/app-render/metadata-insertion/use-server-inserted-metadata.ts
@@ -1,0 +1,19 @@
+'use client'
+
+import { useContext } from 'react'
+import {
+  type MetadataResolver,
+  ServerInsertedMetadataContext,
+} from '../../../shared/lib/server-inserted-metadata.shared-runtime'
+
+// Receives a metadata resolver setter from the context, and will pass the metadata resolving promise to
+// the context where we gonna use it to resolve the metadata, and render as string to append in <body>.
+export const useServerInsertedMetadata = (
+  metadataResolver: MetadataResolver
+) => {
+  const setMetadataResolver = useContext(ServerInsertedMetadataContext)
+
+  if (setMetadataResolver) {
+    setMetadataResolver(metadataResolver)
+  }
+}

--- a/packages/next/src/server/app-render/render-to-string.tsx
+++ b/packages/next/src/server/app-render/render-to-string.tsx
@@ -1,17 +1,15 @@
 import { streamToString } from '../stream-utils/node-web-streams-helper'
-import { AppRenderSpan } from '../lib/trace/constants'
-import { getTracer } from '../lib/trace/tracer'
 
 export async function renderToString({
-  ReactDOMServer,
+  renderToReadableStream,
   element,
 }: {
-  ReactDOMServer: typeof import('react-dom/server.edge')
+  // `renderToReadableStream()` method could come from different react-dom/server implementations
+  // such as `react-dom/server.edge` or `react-dom/server.node`, etc.
+  renderToReadableStream: typeof import('react-dom/server.edge').renderToReadableStream
   element: React.ReactElement
-}) {
-  return getTracer().trace(AppRenderSpan.renderToString, async () => {
-    const renderStream = await ReactDOMServer.renderToReadableStream(element)
-    await renderStream.allReady
-    return streamToString(renderStream)
-  })
+}): Promise<string> {
+  const renderStream = await renderToReadableStream(element)
+  await renderStream.allReady
+  return streamToString(renderStream)
 }

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -222,6 +222,12 @@ export interface RenderOptsPartial {
   postponed?: string
 
   /**
+   * Should wait for react stream allReady to resolve all suspense boundaries,
+   * in order to perform a full page render.
+   */
+  shouldWaitOnAllReady?: boolean
+
+  /**
    * The resume data cache that was generated for this partially prerendered
    * page during dev warmup.
    */

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -177,7 +177,7 @@ export interface RenderOptsPartial {
   assetPrefix?: string
   crossOrigin?: '' | 'anonymous' | 'use-credentials' | undefined
   nextFontManifest?: DeepReadonly<NextFontManifest>
-  botType?: 'headless' | 'html-limited' | undefined
+  botType?: 'dom' | 'html' | undefined
   serveStreamingMetadata?: boolean
   incrementalCache?: import('../lib/incremental-cache').IncrementalCache
   cacheLifeProfiles?: {

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -177,6 +177,7 @@ export interface RenderOptsPartial {
   assetPrefix?: string
   crossOrigin?: '' | 'anonymous' | 'use-credentials' | undefined
   nextFontManifest?: DeepReadonly<NextFontManifest>
+  botType?: 'headless' | 'html-limited' | undefined
   serveStreamingMetadata?: boolean
   incrementalCache?: import('../lib/incremental-cache').IncrementalCache
   cacheLifeProfiles?: {

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -56,7 +56,6 @@ export type WorkStoreContext = {
     RenderOpts,
     | 'assetPrefix'
     | 'supportsDynamicResponse'
-    | 'serveStreamingMetadata'
     | 'isRevalidate'
     | 'nextExport'
     | 'isDraftMode'
@@ -99,16 +98,7 @@ export function createWorkStore({
   const isStaticGeneration =
     !renderOpts.supportsDynamicResponse &&
     !renderOpts.isDraftMode &&
-    !renderOpts.isServerAction &&
-    // Disable SSG when we cannot serve streaming metadata.
-    // TODO: refine this condition once we removed the experimental.streamingMetadata flag.
-    // Currently when supportsDynamicResponse is false (not supporting streaming response),
-    // isStaticGeneration becomes true. But in PPR it will serve partial content.
-    // We still need another flag to disable SSG but generate full page.
-    // e.g. rename supportsDynamicResponse -> support streaming response.
-    // rename serveStreamingMetadata -> is not html limited bots request.
-    // They're 2 dimensions to consider if we need to disable SSG to serve full page and wether serve the blocking response.
-    renderOpts.serveStreamingMetadata !== false
+    !renderOpts.isServerAction
 
   const store: WorkStore = {
     isStaticGeneration,

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -56,6 +56,7 @@ export type WorkStoreContext = {
     RenderOpts,
     | 'assetPrefix'
     | 'supportsDynamicResponse'
+    | 'serveStreamingMetadata'
     | 'isRevalidate'
     | 'nextExport'
     | 'isDraftMode'
@@ -98,7 +99,16 @@ export function createWorkStore({
   const isStaticGeneration =
     !renderOpts.supportsDynamicResponse &&
     !renderOpts.isDraftMode &&
-    !renderOpts.isServerAction
+    !renderOpts.isServerAction &&
+    // Disable SSG when we cannot serve streaming metadata.
+    // TODO: refine this condition once we removed the experimental.streamingMetadata flag.
+    // Currently when supportsDynamicResponse is false (not supporting streaming response),
+    // isStaticGeneration becomes true. But in PPR it will serve partial content.
+    // We still need another flag to disable SSG but generate full page.
+    // e.g. rename supportsDynamicResponse -> support streaming response.
+    // rename serveStreamingMetadata -> is not html limited bots request.
+    // They're 2 dimensions to consider if we need to disable SSG to serve full page and wether serve the blocking response.
+    renderOpts.serveStreamingMetadata !== false
 
   const store: WorkStore = {
     isStaticGeneration,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -83,7 +83,7 @@ import {
 } from './lib/revalidate'
 import { execOnce } from '../shared/lib/utils'
 import { isBlockedPage } from './utils'
-import { isBot } from '../shared/lib/router/utils/is-bot'
+import { getBotType, isBot } from '../shared/lib/router/utils/is-bot'
 import RenderResult from './render-result'
 import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-slash'
 import { denormalizePagePath } from '../shared/lib/page-path/denormalize-page-path'
@@ -1761,6 +1761,7 @@ export default abstract class Server<
       renderOpts: {
         ...this.renderOpts,
         supportsDynamicResponse: !isBotRequest,
+        botType: getBotType(ua),
         serveStreamingMetadata: shouldServeStreamingMetadata(
           ua,
           this.renderOpts.experimental

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2468,9 +2468,8 @@ export default abstract class Server<
         // If this is a dynamic RSC request, then this render supports dynamic
         // HTML (it's dynamic).
         isDynamicRSCRequest ||
-        // When we're not sending the postponed state, we don't serve the partial shell as well.
-        // Instead we need to proceed a full dynamic rendering.
-        (!isHtmlBotRequest && !opts.dev)
+        // We can generate dynamic HTML when it's not html bot request.
+        !isHtmlBotRequest
 
       const origQuery = parseUrl(req.url || '', true).query
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2467,9 +2467,7 @@ export default abstract class Server<
         typeof postponed === 'string' ||
         // If this is a dynamic RSC request, then this render supports dynamic
         // HTML (it's dynamic).
-        isDynamicRSCRequest ||
-        // We can generate dynamic HTML when it's not html bot request.
-        !isHtmlBotRequest
+        isDynamicRSCRequest
 
       const origQuery = parseUrl(req.url || '', true).query
 
@@ -3594,6 +3592,10 @@ export default abstract class Server<
       // When serves html bot request, we don't consume the `postponed` state from build cache.
       // Pass down a `undefined` postponed state to the renderer to avoid resume rendering.
       if (isHtmlBotRequest) {
+        // When it's PPR, disable SSG to perform the full blocking rendering
+        if (isRoutePPREnabled) {
+          isSSG = false
+        }
         const result = await doRender({
           // No postpone and no resume, this is a dynamic rendering.
           postponed: undefined,

--- a/packages/next/src/server/lib/streaming-metadata.ts
+++ b/packages/next/src/server/lib/streaming-metadata.ts
@@ -1,4 +1,8 @@
-import { HTML_LIMITED_BOT_UA_RE_STRING } from '../../shared/lib/router/utils/is-bot'
+import {
+  getBotType,
+  HTML_LIMITED_BOT_UA_RE_STRING,
+} from '../../shared/lib/router/utils/is-bot'
+import type { BaseNextRequest } from '../base-http'
 
 export function shouldServeStreamingMetadata(
   userAgent: string,
@@ -22,4 +26,16 @@ export function shouldServeStreamingMetadata(
     // When it's static generation, userAgents are not available - do not serve streaming metadata
     !!userAgent && !blockingMetadataUARegex.test(userAgent)
   )
+}
+
+// When streaming metadata is enabled and request UA is a html-limited bot, we should do a dynamic render.
+// In this case, postpone state is not sent.
+export function shouldSkipPostponedState(
+  req: BaseNextRequest,
+  streamingMetadata: boolean
+): boolean {
+  const ua = req.headers['user-agent'] || ''
+  const botType = getBotType(ua)
+
+  return botType === 'html' && streamingMetadata
 }

--- a/packages/next/src/server/lib/streaming-metadata.ts
+++ b/packages/next/src/server/lib/streaming-metadata.ts
@@ -30,7 +30,7 @@ export function shouldServeStreamingMetadata(
 
 // When streaming metadata is enabled and request UA is a html-limited bot, we should do a dynamic render.
 // In this case, postpone state is not sent.
-export function shouldSkipPostponedState(
+export function isHtmlBotRequestStreamingMetadata(
   req: BaseNextRequest,
   streamingMetadata: boolean
 ): boolean {

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -266,7 +266,7 @@ export type RenderOptsPartial = {
   domainLocales?: readonly DomainLocale[]
   disableOptimizedLoading?: boolean
   supportsDynamicResponse: boolean
-  botType?: 'headless' | 'html-limited' | undefined
+  botType?: 'dom' | 'html' | undefined
   serveStreamingMetadata?: boolean
   runtime?: ServerRuntime
   serverComponents?: boolean

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -266,6 +266,7 @@ export type RenderOptsPartial = {
   domainLocales?: readonly DomainLocale[]
   disableOptimizedLoading?: boolean
   supportsDynamicResponse: boolean
+  botType?: 'headless' | 'html-limited' | undefined
   serveStreamingMetadata?: boolean
   runtime?: ServerRuntime
   serverComponents?: boolean

--- a/packages/next/src/server/route-modules/app-page/vendored/contexts/entrypoints.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/contexts/entrypoints.ts
@@ -1,5 +1,6 @@
 export * as HeadManagerContext from '../../../../../shared/lib/head-manager-context.shared-runtime'
 export * as ServerInsertedHtml from '../../../../../shared/lib/server-inserted-html.shared-runtime'
+export * as ServerInsertedMetadata from '../../../../../shared/lib/server-inserted-metadata.shared-runtime'
 export * as AppRouterContext from '../../../../../shared/lib/app-router-context.shared-runtime'
 export * as HooksClientContext from '../../../../../shared/lib/hooks-client-context.shared-runtime'
 export * as RouterContext from '../../../../../shared/lib/router-context.shared-runtime'

--- a/packages/next/src/server/route-modules/app-page/vendored/contexts/server-inserted-metadata.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/contexts/server-inserted-metadata.ts
@@ -1,0 +1,3 @@
+module.exports = require('../../module.compiled').vendored[
+  'contexts'
+].ServerInsertedMetadata

--- a/packages/next/src/shared/lib/router/utils/is-bot.ts
+++ b/packages/next/src/shared/lib/router/utils/is-bot.ts
@@ -12,7 +12,7 @@ export const HTML_LIMITED_BOT_UA_RE = new RegExp(
   'i'
 )
 
-function isHeadlessBrowserBotUA(userAgent: string) {
+function isDomBotUA(userAgent: string) {
   return HEADLESS_BROWSER_BOT_UA_RE.test(userAgent)
 }
 
@@ -21,17 +21,15 @@ function isHtmlLimitedBotUA(userAgent: string) {
 }
 
 export function isBot(userAgent: string): boolean {
-  return isHeadlessBrowserBotUA(userAgent) || isHtmlLimitedBotUA(userAgent)
+  return isDomBotUA(userAgent) || isHtmlLimitedBotUA(userAgent)
 }
 
-export function getBotType(
-  userAgent: string
-): 'headless' | 'html-limited' | undefined {
-  if (isHeadlessBrowserBotUA(userAgent)) {
-    return 'headless'
+export function getBotType(userAgent: string): 'dom' | 'html' | undefined {
+  if (isDomBotUA(userAgent)) {
+    return 'dom'
   }
   if (isHtmlLimitedBotUA(userAgent)) {
-    return 'html-limited'
+    return 'html'
   }
   return undefined
 }

--- a/packages/next/src/shared/lib/router/utils/is-bot.ts
+++ b/packages/next/src/shared/lib/router/utils/is-bot.ts
@@ -23,3 +23,15 @@ function isHtmlLimitedBotUA(userAgent: string) {
 export function isBot(userAgent: string): boolean {
   return isHeadlessBrowserBotUA(userAgent) || isHtmlLimitedBotUA(userAgent)
 }
+
+export function getBotType(
+  userAgent: string
+): 'headless' | 'html-limited' | undefined {
+  if (isHeadlessBrowserBotUA(userAgent)) {
+    return 'headless'
+  }
+  if (isHtmlLimitedBotUA(userAgent)) {
+    return 'html-limited'
+  }
+  return undefined
+}

--- a/packages/next/src/shared/lib/server-inserted-metadata.shared-runtime.ts
+++ b/packages/next/src/shared/lib/server-inserted-metadata.shared-runtime.ts
@@ -1,0 +1,9 @@
+'use client'
+
+import { type JSX, createContext } from 'react'
+
+export type MetadataResolver = () => JSX.Element
+type MetadataResolverSetter = (m: MetadataResolver) => void
+
+export const ServerInsertedMetadataContext =
+  createContext<MetadataResolverSetter | null>(null)

--- a/test/e2e/app-dir/metadata-static-generation/metadata-static-generation.test.ts
+++ b/test/e2e/app-dir/metadata-static-generation/metadata-static-generation.test.ts
@@ -7,15 +7,10 @@ describe('app-dir - metadata-static-generation', () => {
     files: __dirname,
   })
 
-  // /suspenseful/dynamic will behave differently when PPR is enabled.
-  // We'll visit PPR tests in the new test suite.
-  if (isPPREnabled) {
-    it('skip ppr test', () => {})
-    return
-  }
-
-  if (isNextStart) {
-    // Precondition for the following tests in build mode
+  if (isNextStart && !isPPREnabled) {
+    // Precondition for the following tests in build mode.
+    // This test is only useful for non-PPR mode as in PPR mode those routes
+    // are all listed in the prerender manifest.
     it('should generate all pages static', async () => {
       const prerenderManifest = JSON.parse(
         await next.readFile('.next/prerender-manifest.json')

--- a/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
+++ b/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
@@ -7,15 +7,10 @@ describe('app-dir - metadata-streaming-static-generation', () => {
     files: __dirname,
   })
 
-  // /suspenseful/dynamic will behave differently when PPR is enabled.
-  // We'll visit PPR tests in the new test suite.
-  if (isPPREnabled) {
-    it('skip ppr test', () => {})
-    return
-  }
-
-  if (isNextStart) {
-    // Precondition for the following tests in build mode
+  if (isNextStart && !isPPREnabled) {
+    // Precondition for the following tests in build mode.
+    // This test is only useful for non-PPR mode as in PPR mode those routes
+    // are all listed in the prerender manifest.
     it('should generate all pages static', async () => {
       const prerenderManifest = JSON.parse(
         await next.readFile('.next/prerender-manifest.json')
@@ -79,6 +74,13 @@ describe('app-dir - metadata-streaming-static-generation', () => {
   })
 
   describe('dynamic pages with html limited bots', () => {
+    // TODO: dealing with bots in PPR mode
+    // Couldn't find all resumable slots by key/index during replaying. The tree doesn't match so React will fallback to client rendering
+    if (isPPREnabled) {
+      it('skip ppr test', () => {})
+      return
+    }
+
     it('should contain async generated metadata in head for simple dynamics page', async () => {
       const $ = await next.render$('/suspenseful/dynamic', undefined, {
         headers: {

--- a/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
+++ b/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
@@ -74,13 +74,6 @@ describe('app-dir - metadata-streaming-static-generation', () => {
   })
 
   describe('dynamic pages with html limited bots', () => {
-    // TODO: dealing with bots in PPR mode
-    // Couldn't find all resumable slots by key/index during replaying. The tree doesn't match so React will fallback to client rendering
-    if (isPPREnabled) {
-      it('skip ppr test', () => {})
-      return
-    }
-
     it('should contain async generated metadata in head for simple dynamics page', async () => {
       const $ = await next.render$('/suspenseful/dynamic', undefined, {
         headers: {

--- a/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
+++ b/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
@@ -73,7 +73,7 @@ describe('app-dir - metadata-streaming', () => {
     })
   })
 
-  it('should not insert metadata twice or inject into body', async () => {
+  it('should only insert metadata once into head or body', async () => {
     const browser = await next.browser('/slow')
 
     // each metadata should be inserted only once

--- a/test/e2e/app-dir/ppr-metadata-streaming/app/dynamic-metadata/page.tsx
+++ b/test/e2e/app-dir/ppr-metadata-streaming/app/dynamic-metadata/page.tsx
@@ -1,0 +1,18 @@
+import { connection } from 'next/server'
+
+export default function Home() {
+  return (
+    <div>
+      <h1>Dynamic Metadata</h1>
+    </div>
+  )
+}
+
+export async function generateMetadata() {
+  await connection()
+  await new Promise((resolve) => setTimeout(resolve, 2 * 1000))
+  return {
+    title: `dynamic metadata`,
+    description: `dynamic metadata - ${Math.random()}`,
+  }
+}

--- a/test/e2e/app-dir/ppr-metadata-streaming/app/dynamic-metadata/partial/layout.tsx
+++ b/test/e2e/app-dir/ppr-metadata-streaming/app/dynamic-metadata/partial/layout.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from 'react'
+
+export default function Layout({ children }) {
+  return (
+    <div>
+      <h2>Suspenseful Layout</h2>
+      <Suspense>{children}</Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/ppr-metadata-streaming/app/dynamic-metadata/partial/page.tsx
+++ b/test/e2e/app-dir/ppr-metadata-streaming/app/dynamic-metadata/partial/page.tsx
@@ -1,11 +1,29 @@
 import { connection } from 'next/server'
 
-export default function Home() {
+// Page is suspended and being caught by the layout Suspense boundary
+export default function Page() {
   return (
-    <div>
-      <h1>Dynamic Metadata</h1>
+    <div className="container">
+      <SuspendedComponent />
     </div>
   )
+}
+
+async function SuspendedComponent() {
+  await connection()
+  await new Promise((resolve) => setTimeout(resolve, 500))
+  return (
+    <div>
+      <div>suspended component</div>
+      <NestedSuspendedComponent />
+    </div>
+  )
+}
+
+async function NestedSuspendedComponent() {
+  await connection()
+  await new Promise((resolve) => setTimeout(resolve, 500))
+  return <div>nested suspended component</div>
 }
 
 export async function generateMetadata() {

--- a/test/e2e/app-dir/ppr-metadata-streaming/app/dynamic-metadata/partial/page.tsx
+++ b/test/e2e/app-dir/ppr-metadata-streaming/app/dynamic-metadata/partial/page.tsx
@@ -1,0 +1,18 @@
+import { connection } from 'next/server'
+
+export default function Home() {
+  return (
+    <div>
+      <h1>Dynamic Metadata</h1>
+    </div>
+  )
+}
+
+export async function generateMetadata() {
+  await connection()
+  await new Promise((resolve) => setTimeout(resolve, 3 * 1000))
+  return {
+    title: 'dynamic-metadata - partial',
+    description: `dynamic metadata - ${Math.random()}`,
+  }
+}

--- a/test/e2e/app-dir/ppr-metadata-streaming/app/dynamic-page/page.tsx
+++ b/test/e2e/app-dir/ppr-metadata-streaming/app/dynamic-page/page.tsx
@@ -1,0 +1,24 @@
+import { headers } from 'next/headers'
+
+// Dynamic usage in page, wrapped with Suspense boundary
+export default function Page() {
+  return (
+    <div>
+      <h1>Dynamic Page</h1>
+      <SubComponent />
+    </div>
+  )
+}
+
+async function SubComponent() {
+  await headers()
+  return <div>Dynamic Headers</div>
+}
+
+export async function generateMetadata() {
+  // Slow but static metadata
+  await new Promise((resolve) => setTimeout(resolve, 2 * 1000))
+  return {
+    title: `dynamic page`,
+  }
+}

--- a/test/e2e/app-dir/ppr-metadata-streaming/app/dynamic-page/partial/layout.tsx
+++ b/test/e2e/app-dir/ppr-metadata-streaming/app/dynamic-page/partial/layout.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from 'react'
+
+export default function Layout({ children }) {
+  return (
+    <div>
+      <h2>Suspenseful Layout</h2>
+      <Suspense>{children}</Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/ppr-metadata-streaming/app/dynamic-page/partial/layout.tsx
+++ b/test/e2e/app-dir/ppr-metadata-streaming/app/dynamic-page/partial/layout.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 
 export default function Layout({ children }) {
   return (
-    <div>
+    <div data-date={Number(new Date())}>
       <h2>Suspenseful Layout</h2>
       <Suspense>{children}</Suspense>
     </div>

--- a/test/e2e/app-dir/ppr-metadata-streaming/app/dynamic-page/partial/page.tsx
+++ b/test/e2e/app-dir/ppr-metadata-streaming/app/dynamic-page/partial/page.tsx
@@ -1,19 +1,29 @@
-import { cookies } from 'next/headers'
+import { connection } from 'next/server'
 
-// Dynamic usage in page, wrapped with Suspense boundary
+/// Page is suspended and being caught by the layout Suspense boundary
 export default function Page() {
   return (
-    <div>
-      <h1>Partial Dynamic Page</h1>
-      <SubComponent />
+    <div className="container">
+      <SuspendedComponent />
     </div>
   )
 }
 
-async function SubComponent() {
-  const cookieStore = await cookies()
-  const cookie = await cookieStore.get('test')
-  return <div>Cookie: {cookie?.value}</div>
+async function SuspendedComponent() {
+  await connection()
+  await new Promise((resolve) => setTimeout(resolve, 500))
+  return (
+    <div>
+      <div>suspended component</div>
+      <NestedSuspendedComponent />
+    </div>
+  )
+}
+
+async function NestedSuspendedComponent() {
+  await connection()
+  await new Promise((resolve) => setTimeout(resolve, 500))
+  return <div>nested suspended component</div>
 }
 
 export async function generateMetadata() {

--- a/test/e2e/app-dir/ppr-metadata-streaming/app/dynamic-page/partial/page.tsx
+++ b/test/e2e/app-dir/ppr-metadata-streaming/app/dynamic-page/partial/page.tsx
@@ -1,0 +1,25 @@
+import { cookies } from 'next/headers'
+
+// Dynamic usage in page, wrapped with Suspense boundary
+export default function Page() {
+  return (
+    <div>
+      <h1>Partial Dynamic Page</h1>
+      <SubComponent />
+    </div>
+  )
+}
+
+async function SubComponent() {
+  const cookieStore = await cookies()
+  const cookie = await cookieStore.get('test')
+  return <div>Cookie: {cookie?.value}</div>
+}
+
+export async function generateMetadata() {
+  // Slow but static metadata
+  await new Promise((resolve) => setTimeout(resolve, 2 * 1000))
+  return {
+    title: 'dynamic-page - partial',
+  }
+}

--- a/test/e2e/app-dir/ppr-metadata-streaming/app/fully-dynamic/page.tsx
+++ b/test/e2e/app-dir/ppr-metadata-streaming/app/fully-dynamic/page.tsx
@@ -1,0 +1,30 @@
+import { cookies } from 'next/headers'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export default function Home() {
+  return (
+    <div>
+      <h1>Fully Dynamic</h1>
+      <Suspense>
+        <SubComponent />
+      </Suspense>
+    </div>
+  )
+}
+
+async function SubComponent() {
+  const cookieStore = await cookies()
+  await new Promise((resolve) => setTimeout(resolve, 500))
+  const cookie = await cookieStore.get('test')
+  return <div>Cookie: {cookie?.value}</div>
+}
+
+export async function generateMetadata() {
+  await connection()
+  await new Promise((resolve) => setTimeout(resolve, 2 * 1000))
+  return {
+    title: `fully dynamic`,
+    description: `fully dynamic - ${Math.random()}`,
+  }
+}

--- a/test/e2e/app-dir/ppr-metadata-streaming/app/fully-static/page.tsx
+++ b/test/e2e/app-dir/ppr-metadata-streaming/app/fully-static/page.tsx
@@ -1,0 +1,11 @@
+export default function Page() {
+  return <p>slow</p>
+}
+
+export async function generateMetadata() {
+  await new Promise((resolve) => setTimeout(resolve, 2 * 1000))
+  return {
+    title: 'fully static',
+    description: 'fully static',
+  }
+}

--- a/test/e2e/app-dir/ppr-metadata-streaming/app/layout.tsx
+++ b/test/e2e/app-dir/ppr-metadata-streaming/app/layout.tsx
@@ -2,11 +2,13 @@ import Link from 'next/link'
 import { ReactNode } from 'react'
 
 const hrefs = [
-  '/slow/dynamic',
-  '/slow/static',
   '/',
-  '/suspenseful/dynamic',
-  '/suspenseful/static',
+  '/dynamic-metadata',
+  '/dynamic-metadata/partial',
+  '/dynamic-page',
+  '/dynamic-page/partial',
+  '/fully-dynamic',
+  '/fully-static',
 ]
 
 export default function Root({ children }: { children: ReactNode }) {
@@ -16,10 +18,9 @@ export default function Root({ children }: { children: ReactNode }) {
         <div>
           {hrefs.map((href) => (
             <div key={href}>
-              <Link href={href} id={`to-${href.replace('/', '')}`}>
+              <Link href={href} id={`to-${href}`} prefetch={false}>
                 {`to ${href}`}
               </Link>
-              <br />
             </div>
           ))}
         </div>

--- a/test/e2e/app-dir/ppr-metadata-streaming/app/layout.tsx
+++ b/test/e2e/app-dir/ppr-metadata-streaming/app/layout.tsx
@@ -2,7 +2,6 @@ import Link from 'next/link'
 import { ReactNode } from 'react'
 
 const hrefs = [
-  '/',
   '/dynamic-metadata',
   '/dynamic-metadata/partial',
   '/dynamic-page',

--- a/test/e2e/app-dir/ppr-metadata-streaming/next.config.js
+++ b/test/e2e/app-dir/ppr-metadata-streaming/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    ppr: true,
+    streamingMetadata: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/ppr-metadata-streaming/ppr-metadata-streaming.test.ts
+++ b/test/e2e/app-dir/ppr-metadata-streaming/ppr-metadata-streaming.test.ts
@@ -1,0 +1,92 @@
+import { nextTestSetup } from 'e2e-utils'
+import { assertNoConsoleErrors } from 'next-test-utils'
+
+function countSubstring(str: string, substr: string): number {
+  return str.split(substr).length - 1
+}
+
+describe('ppr-metadata-streaming', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // No dynamic APIs used in metadata
+  describe('static metadata', () => {
+    it('should generate metadata in head when page is fully static', async () => {
+      const $ = await next.render$('/fully-static')
+      expect($(`head title`).text()).toBe('fully static')
+      expect(countSubstring($.html(), '<title>')).toBe(1)
+
+      const browser = await next.browser('/fully-static')
+      expect(await browser.waitForElementByCss('head title').text()).toBe(
+        'fully static'
+      )
+      await assertNoConsoleErrors(browser)
+    })
+
+    it('should insert metadata in body when page is dynamic page content', async () => {
+      const $ = await next.render$('/dynamic-page')
+      expect($(`body title`).text()).toBe('dynamic page')
+      expect(countSubstring($.html(), '<title>')).toBe(1)
+
+      const browser = await next.browser('/dynamic-page')
+      expect(await browser.waitForElementByCss('body title').text()).toBe(
+        'dynamic page'
+      )
+      await assertNoConsoleErrors(browser)
+    })
+  })
+
+  // Dynamic APIs used in metadata, metadata should be suspended and inserted into body
+  describe('dynamic metadata', () => {
+    it('should generate metadata in head when page is fully dynamic', async () => {
+      const $ = await next.render$('/fully-dynamic')
+      expect($('body title').text()).toBe('fully dynamic')
+      expect(countSubstring($.html(), '<title>')).toBe(1)
+
+      const browser = await next.browser('/fully-dynamic')
+      expect(await browser.waitForElementByCss('body title').text()).toBe(
+        'fully dynamic'
+      )
+      await assertNoConsoleErrors(browser)
+    })
+
+    it('should generate metadata in head when page content is static', async () => {
+      const $ = await next.render$('/dynamic-metadata')
+      expect($('body title').text()).toBe('dynamic metadata')
+      expect(countSubstring($.html(), '<title>')).toBe(1)
+
+      const browser = await next.browser('/dynamic-metadata')
+      expect(await browser.waitForElementByCss('body title').text()).toBe(
+        'dynamic metadata'
+      )
+      await assertNoConsoleErrors(browser)
+    })
+  })
+
+  describe('partial shell', () => {
+    it('should insert metadata into body with dynamic metadata and wrapped under layout Suspense boundary', async () => {
+      const $ = await next.render$('/dynamic-metadata/partial')
+      expect($('body title').text()).toBe('dynamic-metadata - partial')
+      expect(countSubstring($.html(), '<title>')).toBe(1)
+
+      const browser = await next.browser('/dynamic-metadata/partial')
+      expect(await browser.waitForElementByCss('body title').text()).toBe(
+        'dynamic-metadata - partial'
+      )
+      await assertNoConsoleErrors(browser)
+    })
+
+    it('should insert metadata into head with dynamic metadata and dynamic page wrapped under layout Suspense boundary', async () => {
+      const $ = await next.render$('/dynamic-page/partial')
+      expect($('head title').text()).toBe('dynamic-page - partial')
+      expect(countSubstring($.html(), '<title>')).toBe(1)
+
+      const browser = await next.browser('/dynamic-page/partial')
+      expect(await browser.waitForElementByCss('head title').text()).toBe(
+        'dynamic-page - partial'
+      )
+      await assertNoConsoleErrors(browser)
+    })
+  })
+})

--- a/test/e2e/app-dir/ppr-metadata-streaming/ppr-metadata-streaming.test.ts
+++ b/test/e2e/app-dir/ppr-metadata-streaming/ppr-metadata-streaming.test.ts
@@ -6,21 +6,22 @@ function countSubstring(str: string, substr: string): number {
 }
 
 describe('ppr-metadata-streaming', () => {
-  const { next } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
   })
 
   // No dynamic APIs used in metadata
   describe('static metadata', () => {
     it('should generate metadata in head when page is fully static', async () => {
+      const rootSelector = isNextDev ? 'body' : 'head'
       const $ = await next.render$('/fully-static')
-      expect($(`head title`).text()).toBe('fully static')
+      expect($(`${rootSelector} title`).text()).toBe('fully static')
       expect(countSubstring($.html(), '<title>')).toBe(1)
 
       const browser = await next.browser('/fully-static')
-      expect(await browser.waitForElementByCss('head title').text()).toBe(
-        'fully static'
-      )
+      expect(
+        await browser.waitForElementByCss(`${rootSelector} title`).text()
+      ).toBe('fully static')
       await assertNoConsoleErrors(browser)
     })
 
@@ -39,7 +40,7 @@ describe('ppr-metadata-streaming', () => {
 
   // Dynamic APIs used in metadata, metadata should be suspended and inserted into body
   describe('dynamic metadata', () => {
-    it('should generate metadata in head when page is fully dynamic', async () => {
+    it('should generate metadata in body when page is fully dynamic', async () => {
       const $ = await next.render$('/fully-dynamic')
       expect($('body title').text()).toBe('fully dynamic')
       expect(countSubstring($.html(), '<title>')).toBe(1)
@@ -51,7 +52,7 @@ describe('ppr-metadata-streaming', () => {
       await assertNoConsoleErrors(browser)
     })
 
-    it('should generate metadata in head when page content is static', async () => {
+    it('should generate metadata in body when page content is static', async () => {
       const $ = await next.render$('/dynamic-metadata')
       expect($('body title').text()).toBe('dynamic metadata')
       expect(countSubstring($.html(), '<title>')).toBe(1)
@@ -78,14 +79,15 @@ describe('ppr-metadata-streaming', () => {
     })
 
     it('should insert metadata into head with dynamic metadata and dynamic page wrapped under layout Suspense boundary', async () => {
+      const rootSelector = isNextDev ? 'body' : 'head'
       const $ = await next.render$('/dynamic-page/partial')
-      expect($('head title').text()).toBe('dynamic-page - partial')
+      expect($(`${rootSelector} title`).text()).toBe('dynamic-page - partial')
       expect(countSubstring($.html(), '<title>')).toBe(1)
 
       const browser = await next.browser('/dynamic-page/partial')
-      expect(await browser.waitForElementByCss('head title').text()).toBe(
-        'dynamic-page - partial'
-      )
+      expect(
+        await browser.waitForElementByCss(`${rootSelector} title`).text()
+      ).toBe('dynamic-page - partial')
       await assertNoConsoleErrors(browser)
     })
   })

--- a/test/e2e/app-dir/ppr-metadata-streaming/ppr-metadata-streaming.test.ts
+++ b/test/e2e/app-dir/ppr-metadata-streaming/ppr-metadata-streaming.test.ts
@@ -7,7 +7,7 @@ function countSubstring(str: string, substr: string): number {
 }
 
 describe('ppr-metadata-streaming', () => {
-  const { next, isNextDev } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
 
@@ -93,7 +93,8 @@ describe('ppr-metadata-streaming', () => {
     })
   })
 
-  if (!isNextDev) {
+  // Disable deployment until we support it on infra
+  if (isNextStart && !isNextDeploy) {
     // This test is only relevant in production mode, as it's testing PPR results
     describe('html limited bots', () => {
       it('should serve partial static shell when normal UA requests the page', async () => {


### PR DESCRIPTION
### What

- We're introducing a new non-public API hook `useServerInsertedMetadata` internally for only inserting the metadata to rendered page.
- Add PPR test cases

### Why

We currently use the public API `useServerInsertedHTML` to insert streamed metadata, however that API has few flaws with PPR and contains too much logic for handling CSS-in-JS inserted html. For PPR it's not easy to get it work with it since there're server situatios in PPR such as different phases like "prerender" and "resume", then the different modes such as "static" and "partial static rendering". Not all of these cases we need to insert the metadata in the `<head>` which `useServerInsertedHTML` can do and has a lot of rendering tricks for it. After discussing with @gnoff that we'll leverage this new API to insert the streamed metadata, and then append them in the stream.

Another discussion about a case we're concerning it could happen but seems not possible, which is the metadata is inserted in **prerender** and get re-inserted during **resume**. In reality the metadata is next to the page element and react will still render the sibling metadata while the page itself is suspended. So that we always see it's included in prerender when metadata is static. We came up with a solution of saving "wether it's inserted in prerender" into postpone state, but it seems not necessary now. We have test cases covered. We'll gonna land this and see what's going on later. If there's any missing case of double inserted metadata, then we can revisit the postpone solution.


Closes NDX-705
