### PR TITLE
tweak static generation retry wait time

### DIFF
--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -475,7 +475,13 @@ export async function exportPages(
               `Failed to build ${pageKey} (attempt ${attempt + 1} of ${maxAttempts}). Retrying again shortly.`
             )
           }
-          await new Promise((r) => setTimeout(r, Math.random() * 500))
+
+          // Exponential backoff with random jitter to avoid thundering herd on retries
+          const baseDelay = 500 // 500ms
+          const maxDelay = 2000 // 2 seconds
+          const delay = Math.min(baseDelay * Math.pow(2, attempt), maxDelay)
+          const jitter = Math.random() * 0.3 * delay // Add up to 30% random jitter
+          await new Promise((r) => setTimeout(r, delay + jitter))
         }
       }
 


### PR DESCRIPTION
Currently when retrying workers we wait somewhere between 0-500ms. This is to add a variable amount of jitter but the timeout is still fairly short. This tweaks it to ensure we're somewhere between 500-2000ms and adds a jitter value up to 30% of the base delay value to ensure large amounts of SSG failures don't cause a thundering herd problem on retry.