### PR TITLE
docs: let searchParams be Promise in `<Form>` example.

### DIFF
--- a/docs/01-app/04-api-reference/02-components/form.mdx
+++ b/docs/01-app/04-api-reference/02-components/form.mdx
@@ -209,9 +209,9 @@ import { getSearchResults } from '@/lib/search'
 export default async function SearchPage({
   searchParams,
 }: {
-  searchParams: { [key: string]: string | string[] | undefined }
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
 }) {
-  const results = await getSearchResults(searchParams.query)
+  const results = await getSearchResults((await searchParams).query)
 
   return <div>...</div>
 }
@@ -221,7 +221,7 @@ export default async function SearchPage({
 import { getSearchResults } from '@/lib/search'
 
 export default async function SearchPage({ searchParams }) {
-  const results = await getSearchResults(searchParams.query)
+  const results = await getSearchResults((await searchParams).query)
 
   return <div>...</div>
 }


### PR DESCRIPTION
The searchParams of page.tsx used in the example about the `<Form>` component in the API Reference was synchronous.

https://nextjs.org/docs/app/api-reference/components/form#search-form-that-leads-to-a-search-result-page