### PR TITLE
Turbopack: Implement build worker

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1389,7 +1389,7 @@ export default async function build(
             duration: compilerDuration,
             shutdownPromise: p,
             ...rest
-          } = await turbopackBuild(false)
+          } = await turbopackBuild(true)
           shutdownPromise = p
           traceMemoryUsage('Finished build', nextBuildSpan)
 

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -23,6 +23,8 @@ import { promises as fs } from 'fs'
 import { PHASE_PRODUCTION_BUILD } from '../../shared/lib/constants'
 import loadConfig from '../../server/config'
 import { hasCustomExportOutput } from '../../export/utils'
+import { Telemetry } from '../../telemetry/storage'
+import { setGlobal } from '../../trace'
 
 const IS_TURBOPACK_BUILD = process.env.TURBOPACK && process.env.TURBOPACK_BUILD
 
@@ -320,6 +322,12 @@ export async function workerMain(workerData: {
   if (hasCustomExportOutput(NextBuildContext.config)) {
     NextBuildContext.config.distDir = '.next'
   }
+
+  // Clone the telemetry for worker
+  const telemetry = new Telemetry({
+    distDir: NextBuildContext.config.distDir,
+  })
+  setGlobal('telemetry', telemetry)
 
   const result = await turbopackBuild()
   return result

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -22,6 +22,7 @@ import * as Log from '../output/log'
 import { promises as fs } from 'fs'
 import { PHASE_PRODUCTION_BUILD } from '../../shared/lib/constants'
 import loadConfig from '../../server/config'
+import { hasCustomExportOutput } from '../../export/utils'
 
 const IS_TURBOPACK_BUILD = process.env.TURBOPACK && process.env.TURBOPACK_BUILD
 
@@ -313,5 +314,13 @@ export async function workerMain(workerData: {
     NextBuildContext.dir!
   )
 
-  return turbopackBuild()
+  // Matches handling in build/index.ts
+  // https://github.com/vercel/next.js/blob/84f347fc86f4efc4ec9f13615c215e4b9fb6f8f0/packages/next/src/build/index.ts#L815-L818
+  // Ensures the `config.distDir` option is matched.
+  if (hasCustomExportOutput(NextBuildContext.config)) {
+    NextBuildContext.config.distDir = '.next'
+  }
+
+  const result = await turbopackBuild()
+  return result
 }

--- a/packages/next/src/build/turbopack-build/index.ts
+++ b/packages/next/src/build/turbopack-build/index.ts
@@ -1,10 +1,42 @@
+import path from 'path'
+import {
+  formatNodeOptions,
+  getParsedNodeOptionsWithoutInspect,
+} from '../../server/lib/utils'
+import { Worker } from '../../lib/worker'
+import { NextBuildContext } from '../build-context'
+
+async function turbopackBuildWithWorker() {
+  const nodeOptions = getParsedNodeOptionsWithoutInspect()
+
+  const worker = new Worker(path.join(__dirname, 'impl.js'), {
+    exposedMethods: ['workerMain'],
+    numWorkers: 1,
+    maxRetries: 0,
+    forkOptions: {
+      env: {
+        ...process.env,
+        NEXT_PRIVATE_BUILD_WORKER: '1',
+        NODE_OPTIONS: formatNodeOptions(nodeOptions),
+      },
+    },
+  }) as Worker & typeof import('./impl')
+  const { nextBuildSpan, ...prunedBuildContext } = NextBuildContext
+  const result = await worker.workerMain({
+    buildContext: prunedBuildContext,
+  })
+
+  // destroy worker so it's not sticking around using memory
+  await worker.end()
+
+  return result
+}
+
 export function turbopackBuild(
   withWorker: boolean
 ): ReturnType<typeof import('./impl').turbopackBuild> {
   if (withWorker) {
-    // TODO implement worker in follow-up PR.
-    const build = (require('./impl') as typeof import('./impl')).turbopackBuild
-    return build()
+    return turbopackBuildWithWorker()
   } else {
     const build = (require('./impl') as typeof import('./impl')).turbopackBuild
     return build()


### PR DESCRIPTION
## What?

Runs Turbopack in a separate child process so that e.g. memory usage can be cleaned up before continuing with the rest of the Next.js build. This will lower the peak memory consumption given that before this change the Turbopack cache was kept around until the end of the build.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
