### PR TITLE
[DevOverlay] Display Correct Number of Errors on Indicator

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/app/react-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/app/react-dev-overlay.tsx
@@ -22,7 +22,7 @@ export default function ReactDevOverlay({
   children: React.ReactNode
 }) {
   const [isErrorOverlayOpen, setIsErrorOverlayOpen] = useState(false)
-  const { readyErrors, totalErrorsLength } = useErrorHook({
+  const { readyErrors, totalErrorCount } = useErrorHook({
     state,
     isAppDir: true,
   })
@@ -36,7 +36,7 @@ export default function ReactDevOverlay({
 
       <DevToolsIndicator
         state={state}
-        errorsLength={totalErrorsLength}
+        errorCount={totalErrorCount}
         setIsErrorOverlayOpen={setIsErrorOverlayOpen}
       />
 

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/app/react-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/app/react-dev-overlay.tsx
@@ -22,7 +22,10 @@ export default function ReactDevOverlay({
   children: React.ReactNode
 }) {
   const [isErrorOverlayOpen, setIsErrorOverlayOpen] = useState(false)
-  const { readyErrors } = useErrorHook({ errors: state.errors, isAppDir: true })
+  const { readyErrors, totalErrorsLength } = useErrorHook({
+    state,
+    isAppDir: true,
+  })
 
   const devOverlay = (
     <ShadowPortal>
@@ -33,7 +36,7 @@ export default function ReactDevOverlay({
 
       <DevToolsIndicator
         state={state}
-        readyErrorsLength={readyErrors.length}
+        errorsLength={totalErrorsLength}
         setIsErrorOverlayOpen={setIsErrorOverlayOpen}
       />
 

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.stories.tsx
@@ -57,7 +57,7 @@ const state: OverlayState = {
 
 export const NoErrors: Story = {
   args: {
-    readyErrorsLength: 0,
+    errorsLength: 0,
     state,
     setIsErrorOverlayOpen: () => {},
   },
@@ -65,7 +65,7 @@ export const NoErrors: Story = {
 
 export const SingleError: Story = {
   args: {
-    readyErrorsLength: 1,
+    errorsLength: 1,
     state,
     setIsErrorOverlayOpen: () => {},
   },
@@ -73,7 +73,7 @@ export const SingleError: Story = {
 
 export const MultipleErrors: Story = {
   args: {
-    readyErrorsLength: 3,
+    errorsLength: 3,
     state,
     setIsErrorOverlayOpen: () => {},
   },
@@ -81,7 +81,7 @@ export const MultipleErrors: Story = {
 
 export const WithStaticIndicator: Story = {
   args: {
-    readyErrorsLength: 3,
+    errorsLength: 3,
     state: {
       ...state,
       staticIndicator: true,

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.stories.tsx
@@ -57,7 +57,7 @@ const state: OverlayState = {
 
 export const NoErrors: Story = {
   args: {
-    errorsLength: 0,
+    errorCount: 0,
     state,
     setIsErrorOverlayOpen: () => {},
   },
@@ -65,7 +65,7 @@ export const NoErrors: Story = {
 
 export const SingleError: Story = {
   args: {
-    errorsLength: 1,
+    errorCount: 1,
     state,
     setIsErrorOverlayOpen: () => {},
   },
@@ -73,7 +73,7 @@ export const SingleError: Story = {
 
 export const MultipleErrors: Story = {
   args: {
-    errorsLength: 3,
+    errorCount: 3,
     state,
     setIsErrorOverlayOpen: () => {},
   },
@@ -81,7 +81,7 @@ export const MultipleErrors: Story = {
 
 export const WithStaticIndicator: Story = {
   args: {
-    errorsLength: 3,
+    errorCount: 3,
     state: {
       ...state,
       staticIndicator: true,

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -14,11 +14,11 @@ import { MODIFIERS } from '../../../hooks/use-keyboard-shortcut'
 
 export function DevToolsIndicator({
   state,
-  readyErrorsLength,
+  errorsLength,
   setIsErrorOverlayOpen,
 }: {
   state: OverlayState
-  readyErrorsLength: number
+  errorsLength: number
   setIsErrorOverlayOpen: Dispatch<SetStateAction<boolean>>
 }) {
   const [isDevToolsIndicatorOpen, setIsDevToolsIndicatorOpen] = useState(true)
@@ -36,7 +36,7 @@ export function DevToolsIndicator({
     isDevToolsIndicatorOpen && (
       <DevToolsPopover
         semver={state.versionInfo.installed}
-        issueCount={readyErrorsLength}
+        issueCount={errorsLength}
         isStaticRoute={state.staticIndicator}
         hide={() => {
           setIsDevToolsIndicatorOpen(false)

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -14,11 +14,11 @@ import { MODIFIERS } from '../../../hooks/use-keyboard-shortcut'
 
 export function DevToolsIndicator({
   state,
-  errorsLength,
+  errorCount,
   setIsErrorOverlayOpen,
 }: {
   state: OverlayState
-  errorsLength: number
+  errorCount: number
   setIsErrorOverlayOpen: Dispatch<SetStateAction<boolean>>
 }) {
   const [isDevToolsIndicatorOpen, setIsDevToolsIndicatorOpen] = useState(true)
@@ -36,7 +36,7 @@ export function DevToolsIndicator({
     isDevToolsIndicatorOpen && (
       <DevToolsPopover
         semver={state.versionInfo.installed}
-        issueCount={errorsLength}
+        issueCount={errorCount}
         isStaticRoute={state.staticIndicator}
         hide={() => {
           setIsDevToolsIndicatorOpen(false)

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/use-error-hook.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/use-error-hook.ts
@@ -1,5 +1,6 @@
 import type { ReadyRuntimeError } from '../../helpers/get-error-by-type'
 import type {
+  OverlayState,
   UnhandledErrorAction,
   UnhandledRejectionAction,
 } from '../../../../shared'
@@ -33,12 +34,14 @@ function getErrorSignature(ev: SupportedErrorEvent): string {
 }
 
 export function useErrorHook({
-  errors,
+  state,
   isAppDir,
 }: {
-  errors: SupportedErrorEvent[]
+  state: OverlayState
   isAppDir: boolean
 }) {
+  const { errors, rootLayoutMissingTags, buildError } = state
+
   const [lookups, setLookups] = useState<{
     [eventId: string]: ReadyRuntimeError
   }>({})
@@ -99,5 +102,14 @@ export function useErrorHook({
 
   return {
     readyErrors,
+    // Total number of errors are based on the priority that
+    // will be displayed. Since build error and root layout
+    // missing tags won't be dismissed until resolved, the
+    // total number of errors may be fixed to their length.
+    totalErrorsLength: rootLayoutMissingTags?.length
+      ? rootLayoutMissingTags.length
+      : !!buildError
+        ? 1
+        : errors.length,
   }
 }

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/use-error-hook.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/use-error-hook.ts
@@ -106,7 +106,7 @@ export function useErrorHook({
     // will be displayed. Since build error and root layout
     // missing tags won't be dismissed until resolved, the
     // total number of errors may be fixed to their length.
-    totalErrorsLength: rootLayoutMissingTags?.length
+    totalErrorCount: rootLayoutMissingTags?.length
       ? rootLayoutMissingTags.length
       : !!buildError
         ? 1

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/pages/react-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/pages/react-dev-overlay.tsx
@@ -28,8 +28,8 @@ export default function ReactDevOverlay({ children }: ReactDevOverlayProps) {
     hasBuildError,
   } = usePagesReactDevOverlay()
 
-  const { readyErrors } = useErrorHook({
-    errors: state.errors,
+  const { readyErrors, totalErrorsLength } = useErrorHook({
+    state,
     isAppDir: false,
   })
 
@@ -50,7 +50,7 @@ export default function ReactDevOverlay({ children }: ReactDevOverlayProps) {
 
           <DevToolsIndicator
             state={state}
-            readyErrorsLength={readyErrors.length}
+            errorsLength={totalErrorsLength}
             setIsErrorOverlayOpen={setIsErrorOverlayOpen}
           />
 

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/pages/react-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/pages/react-dev-overlay.tsx
@@ -28,7 +28,7 @@ export default function ReactDevOverlay({ children }: ReactDevOverlayProps) {
     hasBuildError,
   } = usePagesReactDevOverlay()
 
-  const { readyErrors, totalErrorsLength } = useErrorHook({
+  const { readyErrors, totalErrorCount } = useErrorHook({
     state,
     isAppDir: false,
   })
@@ -50,7 +50,7 @@ export default function ReactDevOverlay({ children }: ReactDevOverlayProps) {
 
           <DevToolsIndicator
             state={state}
-            errorsLength={totalErrorsLength}
+            errorCount={totalErrorCount}
             setIsErrorOverlayOpen={setIsErrorOverlayOpen}
           />
 


### PR DESCRIPTION
### Why?

The indicator has displayed only the number of Runtime errors.

### How?

If there is a build error or a missing HTML tag error, display the length of the errors as they need to be resolved before the runtime errors.

### Before

![CleanShot 2025-01-28 at 21 42 51](https://github.com/user-attachments/assets/dcbb284a-023f-4853-ac4a-64603a80a2be)

### After

![CleanShot 2025-01-28 at 21 42 33](https://github.com/user-attachments/assets/0adeda65-205a-497e-90ac-f41d3a1ab5c8)

Closes NDX-691