### PR TITLE
UI polish: dev overlay feedback button

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-footer/error-feedback/error-feedback.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-footer/error-feedback/error-feedback.tsx
@@ -5,8 +5,9 @@ import { noop as css } from '../../../../helpers/noop-template'
 
 interface ErrorFeedbackProps {
   errorCode: string
+  className?: string
 }
-export function ErrorFeedback({ errorCode }: ErrorFeedbackProps) {
+export function ErrorFeedback({ errorCode, className }: ErrorFeedbackProps) {
   const [votedMap, setVotedMap] = useState<Record<string, boolean>>({})
   const voted = votedMap[errorCode]
   const hasVoted = voted !== undefined
@@ -41,7 +42,11 @@ export function ErrorFeedback({ errorCode }: ErrorFeedbackProps) {
   )
 
   return (
-    <div className="error-feedback" role="region" aria-label="Error feedback">
+    <div
+      className={`error-feedback${className ? ` ${className}` : ''}`}
+      role="region"
+      aria-label="Error feedback"
+    >
       {hasVoted ? (
         <p className="error-feedback-thanks" role="status" aria-live="polite">
           Thanks for your feedback!

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-footer/error-overlay-footer.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-footer/error-overlay-footer.tsx
@@ -16,7 +16,9 @@ export function ErrorOverlayFooter({
       {footerMessage ? (
         <p className="error-overlay-footer-message">{footerMessage}</p>
       ) : null}
-      {errorCode ? <ErrorFeedback errorCode={errorCode} /> : null}
+      {errorCode ? (
+        <ErrorFeedback className="error-feedback" errorCode={errorCode} />
+      ) : null}
     </footer>
   )
 }
@@ -31,6 +33,10 @@ export const styles = css`
     padding: var(--size-3);
     background: var(--color-background-200);
     border-top: 1px solid var(--color-gray-400);
+  }
+
+  .error-feedback {
+    margin-left: auto;
   }
 
   .error-overlay-footer p {


### PR DESCRIPTION
Right align feedback button when there is no `footerMessage`.


Before:

![CleanShot 2025-01-28 at 12.05.22@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/rKSEEwxbNzdFs9t0yyxN/f5a53b41-e97e-4489-a426-9608c60311f3.png)

After:

![CleanShot 2025-01-28 at 12.04.48@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/rKSEEwxbNzdFs9t0yyxN/e0084c5c-2d53-4202-8226-7b4302d548c0.png)

Closes https://linear.app/vercel/issue/NDX-688/fix-footer-feedback-style-regression