### PR TITLE
[dev-overlay] fix: do not open error overlay when click indicator

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -157,7 +157,7 @@ function DevToolsPopover({
     }
   }
 
-  function onIssuesClick() {
+  function openErrorOverlay() {
     if (issueCount > 0) {
       setIsErrorOverlayOpen(true)
     }
@@ -165,7 +165,6 @@ function DevToolsPopover({
 
   function onTriggerClick() {
     setIsMenuOpen((prev) => !prev)
-    onIssuesClick()
   }
 
   function closeMenu() {
@@ -193,9 +192,9 @@ function DevToolsPopover({
         aria-label={`${isMenuOpen ? 'Close' : 'Open'} Next.js Dev Tools`}
         data-nextjs-dev-tools-button
         issueCount={issueCount}
-        onClick={onTriggerClick}
+        onTriggerClick={onTriggerClick}
         onKeyDown={onTriggerKeydown}
-        onIssuesClick={onIssuesClick}
+        openErrorOverlay={openErrorOverlay}
         isDevBuilding={useIsDevBuilding()}
         isDevRendering={useIsDevRendering()}
       />
@@ -231,7 +230,7 @@ function DevToolsPopover({
                 index={0}
                 label="Issues"
                 value={<IssueCount>{issueCount}</IssueCount>}
-                onClick={onIssuesClick}
+                onClick={openErrorOverlay}
               />
               <MenuItem
                 label="Route"

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -32,7 +32,6 @@ export const NextLogo = forwardRef(function NextLogo(
   const isLoading = useMinimumLoadingTimeMultiple(
     isDevBuilding || isDevRendering
   )
-  console.log({ isErrorExpanded })
   return (
     <div
       data-next-badge-root

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -7,8 +7,8 @@ interface Props extends React.ComponentProps<'button'> {
   issueCount: number
   isDevBuilding: boolean
   isDevRendering: boolean
-  onClick: () => void
-  onIssuesClick: () => void
+  onTriggerClick: () => void
+  openErrorOverlay: () => void
 }
 
 const SIZE = 36
@@ -18,8 +18,8 @@ export const NextLogo = forwardRef(function NextLogo(
     issueCount,
     isDevBuilding,
     isDevRendering,
-    onClick,
-    onIssuesClick,
+    onTriggerClick,
+    openErrorOverlay,
     ...props
   }: Props,
   propRef: React.Ref<HTMLButtonElement>
@@ -32,7 +32,7 @@ export const NextLogo = forwardRef(function NextLogo(
   const isLoading = useMinimumLoadingTimeMultiple(
     isDevBuilding || isDevRendering
   )
-
+  console.log({ isErrorExpanded })
   return (
     <div
       data-next-badge-root
@@ -287,7 +287,7 @@ export const NextLogo = forwardRef(function NextLogo(
           <button
             ref={mergeRefs(triggerRef, propRef)}
             data-next-mark
-            onClick={onClick}
+            onClick={onTriggerClick}
             {...props}
           >
             <NextMark isLoading={isLoading} />
@@ -297,7 +297,7 @@ export const NextLogo = forwardRef(function NextLogo(
               <button
                 data-issues-open
                 aria-label="Open issues overlay"
-                onClick={onIssuesClick}
+                onClick={openErrorOverlay}
               >
                 <span data-issues-count>{issueCount}</span>{' '}
                 {issueCount === 1 ? 'Issue' : 'Issues'}


### PR DESCRIPTION
### Why?

As we added back the "open/dismiss issues" label next to the indicator at https://github.com/vercel/next.js/pull/74975, no need to open error overlay when clicked the indicator.

### Before

https://github.com/user-attachments/assets/52fac449-7f92-4793-84d5-599f85b4a8bf

### After

https://github.com/user-attachments/assets/962bb3e2-9b25-4d16-88d7-1e5d05cc9a38

Closes https://linear.app/vercel/issue/NDX-721/fix-toggle-behavior-for-collapsed-pill-and-issue-button