### PR TITLE
[dev-overlay] do not close overlay when click indicator elements

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/dialog/dialog.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/dialog/dialog.tsx
@@ -26,7 +26,12 @@ const Dialog: React.FC<DialogProps> = function Dialog({
   const onDialog = React.useCallback((node: HTMLDivElement | null) => {
     setDialog(node)
   }, [])
-  useOnClickOutside(dialog, (e) => {
+  const excludes = [
+    '[data-next-mark]',
+    '[data-issues-open]',
+    '#nextjs-dev-tools-menu',
+  ]
+  useOnClickOutside(dialog, excludes, (e) => {
     e.preventDefault()
     return onClose?.()
   })

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/dialog/dialog.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/dialog/dialog.tsx
@@ -10,6 +10,12 @@ export type DialogProps = {
   onClose?: () => void
 }
 
+const CSS_SELECTORS_TO_EXCLUDE_ON_CLICK_OUTSIDE = [
+  '[data-next-mark]',
+  '[data-issues-open]',
+  '#nextjs-dev-tools-menu',
+]
+
 const Dialog: React.FC<DialogProps> = function Dialog({
   children,
   type,
@@ -26,12 +32,7 @@ const Dialog: React.FC<DialogProps> = function Dialog({
   const onDialog = React.useCallback((node: HTMLDivElement | null) => {
     setDialog(node)
   }, [])
-  const excludes = [
-    '[data-next-mark]',
-    '[data-issues-open]',
-    '#nextjs-dev-tools-menu',
-  ]
-  useOnClickOutside(dialog, excludes, (e) => {
+  useOnClickOutside(dialog, CSS_SELECTORS_TO_EXCLUDE_ON_CLICK_OUTSIDE, (e) => {
     e.preventDefault()
     return onClose?.()
   })

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/hooks/use-on-click-outside.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/hooks/use-on-click-outside.ts
@@ -2,6 +2,7 @@ import * as React from 'react'
 
 export function useOnClickOutside(
   el: Node | null,
+  excludes: string[],
   handler: ((e: MouseEvent | TouchEvent) => void) | undefined
 ) {
   React.useEffect(() => {
@@ -15,17 +16,22 @@ export function useOnClickOutside(
         return
       }
 
+      // Do nothing if clicking on an element that is excluded attribute(s)
+      if (excludes.some((exclude) => (e.target as Element).closest(exclude))) {
+        return
+      }
+
       handler(e)
     }
 
     const root = el.getRootNode()
-    root.addEventListener('mousedown', listener as EventListener)
-    root.addEventListener('touchstart', listener as EventListener, {
+    root.addEventListener('mouseup', listener as EventListener)
+    root.addEventListener('touchend', listener as EventListener, {
       passive: false,
     })
     return function () {
-      root.removeEventListener('mousedown', listener as EventListener)
-      root.removeEventListener('touchstart', listener as EventListener)
+      root.removeEventListener('mouseup', listener as EventListener)
+      root.removeEventListener('touchend', listener as EventListener)
     }
-  }, [handler, el])
+  }, [handler, el, excludes])
 }

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/hooks/use-on-click-outside.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/hooks/use-on-click-outside.ts
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 export function useOnClickOutside(
   el: Node | null,
-  excludes: string[],
+  cssSelectorsToExclude: string[],
   handler: ((e: MouseEvent | TouchEvent) => void) | undefined
 ) {
   React.useEffect(() => {
@@ -16,8 +16,12 @@ export function useOnClickOutside(
         return
       }
 
-      // Do nothing if clicking on an element that is excluded attribute(s)
-      if (excludes.some((exclude) => (e.target as Element).closest(exclude))) {
+      if (
+        // Do nothing if clicking on an element that is excluded by the CSS selector(s)
+        cssSelectorsToExclude.some((cssSelector) =>
+          (e.target as Element).closest(cssSelector)
+        )
+      ) {
         return
       }
 
@@ -33,5 +37,5 @@ export function useOnClickOutside(
       root.removeEventListener('mouseup', listener as EventListener)
       root.removeEventListener('touchend', listener as EventListener)
     }
-  }, [handler, el, excludes])
+  }, [handler, el, cssSelectorsToExclude])
 }


### PR DESCRIPTION
### Why?

1. When clicking the indicator, since closing the overlay was `mousedown`, it had a blink of the overlay to be closed and then open again.
2. When the overlay is opened, clicking the indicator elements closes the overlay.

### How?

1. Use `mouseup` and `touchend` event listeners to prevent hiding the overlay when clicking outside the overlay.
2. Added `excludes` array of attributes to exclude from click outside handler.

### Before

https://github.com/user-attachments/assets/af989294-d14e-4b3b-8638-bde75a067507

### After

https://github.com/user-attachments/assets/2cd4b974-a4b6-4e9e-a9dd-4964b9747055

Closes https://linear.app/vercel/issue/NDX-701/dont-close-overlay-when-on-click-indicator