### PR TITLE
[Turbopack] fix is_empty implementation

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -589,7 +589,20 @@ impl AggregationUpdateQueue {
 
     /// Returns true, when the queue is empty.
     pub fn is_empty(&self) -> bool {
-        self.jobs.is_empty()
+        let Self {
+            jobs,
+            number_updates,
+            find_and_schedule,
+            balance_queue,
+            optimize_queue,
+            done_find_and_schedule: _,
+            done_number_updates: _,
+        } = self;
+        jobs.is_empty()
+            && number_updates.is_empty()
+            && find_and_schedule.is_empty()
+            && balance_queue.is_empty()
+            && optimize_queue.is_empty()
     }
 
     /// Pushes a job to the queue.


### PR DESCRIPTION
### What?

The AggregationQueue has multiple queues that need to be checked for emptyness.

Closes PACK-3831