### PR TITLE
Turbopack: cache variables in linker

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
@@ -93,6 +93,7 @@ fn bench_link(b: &mut Bencher, input: &BenchInput) {
         .unwrap();
 
     b.to_async(rt).iter(|| async {
+        let var_cache = Default::default();
         for val in input.var_graph.values.values() {
             VcStorage::with(async {
                 let compile_time_info = CompileTimeInfo::builder(
@@ -114,7 +115,8 @@ fn bench_link(b: &mut Bencher, input: &BenchInput) {
                     val.clone(),
                     &early_visitor,
                     &(|val| visitor(val, compile_time_info, ImportAttributes::empty_ref())),
-                    Default::default(),
+                    &Default::default(),
+                    &var_cache,
                 )
                 .await
             })

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
@@ -1,6 +1,7 @@
-use std::{collections::hash_map::Entry, future::Future, mem::take};
+use std::{collections::hash_map::Entry, fmt::Display, future::Future, mem::take};
 
 use anyhow::Result;
+use parking_lot::Mutex;
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::ecma::ast::Id;
 
@@ -11,8 +12,9 @@ pub async fn link<'a, B, RB, F, RF>(
     mut val: JsValue,
     early_visitor: &B,
     visitor: &F,
-    fun_args_values: FxHashMap<u32, Vec<JsValue>>,
-) -> Result<JsValue>
+    fun_args_values: &Mutex<FxHashMap<u32, Vec<JsValue>>>,
+    var_cache: &Mutex<FxHashMap<Id, JsValue>>,
+) -> Result<(JsValue, u32)>
 where
     RB: 'a + Future<Output = Result<(JsValue, bool)>> + Send,
     B: 'a + Fn(JsValue) -> RB + Sync,
@@ -20,38 +22,72 @@ where
     F: 'a + Fn(JsValue) -> RF + Sync,
 {
     val.normalize();
-    let val = link_internal_iterative(graph, val, early_visitor, visitor, fun_args_values).await?;
-    Ok(val)
+    let (val, steps) = link_internal_iterative(
+        graph,
+        val,
+        early_visitor,
+        visitor,
+        fun_args_values,
+        var_cache,
+    )
+    .await?;
+    Ok((val, steps))
 }
 
-const LIMIT_NODE_SIZE: u32 = 300;
-const LIMIT_IN_PROGRESS_NODES: u32 = 1000;
+const LIMIT_NODE_SIZE: u32 = 100;
+const LIMIT_IN_PROGRESS_NODES: u32 = 500;
 const LIMIT_LINK_STEPS: u32 = 1500;
+
+#[derive(Debug, Hash, Clone, Eq, PartialEq)]
+enum Step {
+    /// Take all chlidren out of the value (replacing temporarily with unknown) and queue them
+    /// for processing using individual `Enter`s.
+    Enter(JsValue),
+    /// Pop however many children there are from `done` and reinsert them into the value
+    Leave(JsValue),
+    /// Remove the variable from `cycle_stack` which detects e.g. circular reassignments
+    LeaveVar(Id),
+    LeaveLate(JsValue),
+    /// Call the visitor callbacks, and requeue the value for further processing if it changed.
+    Visit(JsValue),
+    EarlyVisit(JsValue),
+    /// Remove the call from `fun_args_values`
+    LeaveCall(u32),
+    /// Placeholder that is used to momentarily reserve a slot that is only filled after
+    /// pushing some more steps
+    TemporarySlot,
+}
+
+impl Display for Step {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Step::Enter(val) => write!(f, "Enter({})", val),
+            Step::EarlyVisit(val) => write!(f, "EarlyVisit({})", val),
+            Step::Leave(val) => write!(f, "Leave({})", val),
+            Step::LeaveVar(var) => write!(f, "LeaveVar({:?})", var),
+            Step::LeaveLate(val) => write!(f, "LeaveLate({})", val),
+            Step::Visit(val) => write!(f, "Visit({})", val),
+            Step::LeaveCall(func_ident) => write!(f, "LeaveCall({})", func_ident),
+            Step::TemporarySlot => write!(f, "TemporarySlot"),
+        }
+    }
+}
+// If a variable was already visited in this linking call, don't visit it again.
 
 pub(crate) async fn link_internal_iterative<'a, B, RB, F, RF>(
     graph: &'a VarGraph,
     val: JsValue,
     early_visitor: &'a B,
     visitor: &'a F,
-    mut fun_args_values: FxHashMap<u32, Vec<JsValue>>,
-) -> Result<JsValue>
+    fun_args_values: &Mutex<FxHashMap<u32, Vec<JsValue>>>,
+    var_cache: &Mutex<FxHashMap<Id, JsValue>>,
+) -> Result<(JsValue, u32)>
 where
     RB: 'a + Future<Output = Result<(JsValue, bool)>> + Send,
     B: 'a + Fn(JsValue) -> RB + Sync,
     RF: 'a + Future<Output = Result<(JsValue, bool)>> + Send,
     F: 'a + Fn(JsValue) -> RF + Sync,
 {
-    #[derive(Debug)]
-    enum Step {
-        Enter(JsValue),
-        EarlyVisit(JsValue),
-        Leave(JsValue),
-        LeaveVar(Id),
-        LeaveLate(JsValue),
-        Visit(JsValue),
-        LeaveCall(u32),
-    }
-
     let mut work_queue_stack: Vec<Step> = Vec::new();
     let mut done: Vec<JsValue> = Vec::new();
     // Tracks the number of nodes in the queue and done combined
@@ -70,9 +106,8 @@ where
             // Enter a variable
             // - replace it with value from graph
             // - process value
-            // - on leave: cache value
+            // - (Step::LeaveVar potentially caches the value)
             Step::Enter(JsValue::Variable(var)) => {
-                // Replace with unknown for now
                 if cycle_stack.contains(&var) {
                     done.push(JsValue::unknown(
                         JsValue::Variable(var.clone()),
@@ -81,7 +116,13 @@ where
                     ));
                 } else {
                     total_nodes -= 1;
-                    if let Some(val) = graph.values.get(&var) {
+                    let var_cache_lock = (cycle_stack.is_empty()
+                        && fun_args_values.lock().is_empty())
+                    .then(|| var_cache.lock());
+                    if let Some(val) = var_cache_lock.as_deref().and_then(|cache| cache.get(&var)) {
+                        total_nodes += val.total_nodes();
+                        done.push(val.clone());
+                    } else if let Some(val) = graph.values.get(&var) {
                         cycle_stack.insert(var.clone());
                         work_queue_stack.push(Step::LeaveVar(var));
                         total_nodes += val.total_nodes();
@@ -93,18 +134,21 @@ where
                             false,
                             "no value of this variable analysed",
                         ));
-                    };
-                }
+                    }
+                };
             }
             // Leave a variable
             Step::LeaveVar(var) => {
                 cycle_stack.remove(&var);
+                if cycle_stack.is_empty() && fun_args_values.lock().is_empty() {
+                    var_cache.lock().insert(var, done.last().unwrap().clone());
+                }
             }
             // Enter a function argument
             // We want to replace the argument with the value from the function call
             Step::Enter(JsValue::Argument(func_ident, index)) => {
                 total_nodes -= 1;
-                if let Some(args) = fun_args_values.get(&func_ident) {
+                if let Some(args) = fun_args_values.lock().get(&func_ident) {
                     if let Some(val) = args.get(index) {
                         total_nodes += val.total_nodes();
                         done.push(val.clone());
@@ -133,7 +177,7 @@ where
                 args,
             )) => {
                 total_nodes -= 2; // Call + Function
-                if let Entry::Vacant(entry) = fun_args_values.entry(func_ident) {
+                if let Entry::Vacant(entry) = fun_args_values.lock().entry(func_ident) {
                     // Return value will stay in total_nodes
                     for arg in args.iter() {
                         total_nodes -= arg.total_nodes();
@@ -157,7 +201,7 @@ where
             // Leaving a function call evaluation
             // - remove function arguments from the map
             Step::LeaveCall(func_ident) => {
-                fun_args_values.remove(&func_ident);
+                fun_args_values.lock().remove(&func_ident);
             }
             // Enter a function
             // We don't want to process the function return value yet, this will happen after
@@ -170,22 +214,33 @@ where
             // - take and queue children for processing
             // - on leave: insert children again and optimize
             Step::Enter(mut val) => {
-                let i = work_queue_stack.len();
-                work_queue_stack.push(Step::Leave(JsValue::default()));
-                let mut has_early_children = false;
-                val.for_each_early_children_mut(&mut |child| {
-                    has_early_children = true;
-                    work_queue_stack.push(Step::Enter(take(child)));
-                    false
-                });
-                if has_early_children {
-                    work_queue_stack[i] = Step::EarlyVisit(val);
+                if !val.has_children() {
+                    visit(
+                        &mut total_nodes,
+                        &mut done,
+                        &mut work_queue_stack,
+                        visitor,
+                        val,
+                    )
+                    .await?;
                 } else {
-                    val.for_each_children_mut(&mut |child| {
+                    let i = work_queue_stack.len();
+                    work_queue_stack.push(Step::TemporarySlot);
+                    let mut has_early_children = false;
+                    val.for_each_early_children_mut(&mut |child| {
+                        has_early_children = true;
                         work_queue_stack.push(Step::Enter(take(child)));
                         false
                     });
-                    work_queue_stack[i] = Step::Leave(val);
+                    if has_early_children {
+                        work_queue_stack[i] = Step::EarlyVisit(val);
+                    } else {
+                        val.for_each_children_mut(&mut |child| {
+                            work_queue_stack.push(Step::Enter(take(child)));
+                            false
+                        });
+                        work_queue_stack[i] = Step::Leave(val);
+                    }
                 }
             }
             // Early visit a value
@@ -233,7 +288,7 @@ where
                 } else {
                     // Otherwise we can just process the late children
                     let i = work_queue_stack.len();
-                    work_queue_stack.push(Step::LeaveLate(JsValue::default()));
+                    work_queue_stack.push(Step::TemporarySlot);
                     val.for_each_late_children_mut(&mut |child| {
                         work_queue_stack.push(Step::Enter(take(child)));
                         false
@@ -290,43 +345,42 @@ where
             // Visit a value with the visitor
             // - visited value is put into done
             Step::Visit(val) => {
-                total_nodes -= val.total_nodes();
+                visit(
+                    &mut total_nodes,
+                    &mut done,
+                    &mut work_queue_stack,
+                    visitor,
+                    val,
+                )
+                .await?;
+            }
+            Step::TemporarySlot => unreachable!(),
+        }
 
-                let (mut val, visit_modified) = visitor(val).await?;
-                if visit_modified {
-                    val.normalize_shallow();
-                    #[cfg(debug_assertions)]
-                    val.debug_assert_total_nodes_up_to_date();
-                    if val.total_nodes() > LIMIT_NODE_SIZE {
-                        total_nodes += 1;
-                        done.push(JsValue::unknown_empty(true, "node limit reached"));
-                        continue;
+        if steps > LIMIT_LINK_STEPS {
+            // Unroll the stack and apply steps that modify "global" state.
+            for step in work_queue_stack.into_iter().rev() {
+                match step {
+                    Step::LeaveVar(var) => {
+                        cycle_stack.remove(&var);
+                        if cycle_stack.is_empty() && fun_args_values.lock().is_empty() {
+                            var_cache.lock().insert(
+                                var,
+                                JsValue::unknown_empty(true, "max number of linking steps reached"),
+                            );
+                        }
                     }
-                }
-
-                let count = val.total_nodes();
-                if total_nodes + count > LIMIT_IN_PROGRESS_NODES {
-                    // There is always space for one more node since we just popped at least one
-                    // count
-                    total_nodes += 1;
-                    done.push(JsValue::unknown_empty(
-                        true,
-                        "in progress nodes limit reached",
-                    ));
-                    continue;
-                }
-                total_nodes += count;
-                if visit_modified {
-                    work_queue_stack.push(Step::Enter(val));
-                } else {
-                    done.push(val);
+                    Step::LeaveCall(func_ident) => {
+                        fun_args_values.lock().remove(&func_ident);
+                    }
+                    _ => {}
                 }
             }
-        }
-        if steps > LIMIT_LINK_STEPS {
-            return Ok(JsValue::unknown_empty(
-                true,
-                "max number of linking steps reached",
+
+            tracing::trace!("link limit hit {}", steps);
+            return Ok((
+                JsValue::unknown_empty(true, "max number of linking steps reached"),
+                steps,
             ));
         }
     }
@@ -336,5 +390,50 @@ where
     debug_assert!(work_queue_stack.is_empty());
     debug_assert_eq!(total_nodes, final_value.total_nodes());
 
-    Ok(final_value)
+    Ok((final_value, steps))
+}
+
+async fn visit<'a, F, RF>(
+    total_nodes: &mut u32,
+    done: &mut Vec<JsValue>,
+    work_queue_stack: &mut Vec<Step>,
+    visitor: &'a F,
+    val: JsValue,
+) -> Result<()>
+where
+    RF: 'a + Future<Output = Result<(JsValue, bool)>> + Send,
+    F: 'a + Fn(JsValue) -> RF + Sync,
+{
+    *total_nodes -= val.total_nodes();
+
+    let (mut val, visit_modified) = visitor(val).await?;
+    if visit_modified {
+        val.normalize_shallow();
+        #[cfg(debug_assertions)]
+        val.debug_assert_total_nodes_up_to_date();
+        if val.total_nodes() > LIMIT_NODE_SIZE {
+            *total_nodes += 1;
+            done.push(JsValue::unknown_empty(true, "node limit reached"));
+            return Ok(());
+        }
+    }
+
+    let count = val.total_nodes();
+    if *total_nodes + count > LIMIT_IN_PROGRESS_NODES {
+        // There is always space for one more node since we just popped at least one
+        // count
+        *total_nodes += 1;
+        done.push(JsValue::unknown_empty(
+            true,
+            "in progress nodes limit reached",
+        ));
+        return Ok(());
+    }
+    *total_nodes += count;
+    if visit_modified {
+        work_queue_stack.push(Step::Enter(val));
+    } else {
+        done.push(val);
+    }
+    Ok(())
 }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -4083,9 +4083,15 @@ mod tests {
                     let large = large_marker.exists();
 
                     if !large {
-                        NormalizedOutput::from(format!("{:#?}", named_values))
-                            .compare_to_file(&graph_snapshot_path)
-                            .unwrap();
+                        NormalizedOutput::from(format!(
+                            "{:#?}",
+                            named_values
+                                .iter()
+                                .map(|(name, (_, value))| (name, value))
+                                .collect::<Vec<_>>()
+                        ))
+                        .compare_to_file(&graph_snapshot_path)
+                        .unwrap();
                     }
                     NormalizedOutput::from(explain_all(
                         named_values.iter().map(|(name, (_, value))| (name, value)),

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -1031,6 +1031,10 @@ impl JsValue {
 
 // Methods regarding node count
 impl JsValue {
+    pub fn has_children(&self) -> bool {
+        self.total_nodes() > 1
+    }
+
     pub fn total_nodes(&self) -> u32 {
         match self {
             JsValue::Constant(_)
@@ -3982,10 +3986,14 @@ pub mod test_utils {
 mod tests {
     use std::{mem::take, path::PathBuf, time::Instant};
 
+    use parking_lot::Mutex;
+    use rustc_hash::FxHashMap;
     use swc_core::{
         common::{comments::SingleThreadedComments, Mark},
         ecma::{
-            ast::EsVersion, parser::parse_file_as_program, transforms::base::resolver,
+            ast::{EsVersion, Id},
+            parser::parse_file_as_program,
+            transforms::base::resolver,
             visit::VisitMutWith,
         },
         testing::{fixture, run_test, NormalizedOutput},
@@ -4039,6 +4047,7 @@ mod tests {
                     EvalContext::new(&m, unresolved_mark, top_level_mark, Some(&comments), None);
 
                 let mut var_graph = create_graph(&m, &eval_context);
+                let var_cache = Default::default();
 
                 let mut named_values = var_graph
                     .values
@@ -4047,17 +4056,19 @@ mod tests {
                     .map(|((id, ctx), value)| {
                         let unique = var_graph.values.keys().filter(|(i, _)| &id == i).count() == 1;
                         if unique {
-                            (id.to_string(), value)
+                            (id.to_string(), ((id, ctx), value))
                         } else {
-                            (format!("{id}{ctx:?}"), value)
+                            (format!("{id}{ctx:?}"), ((id, ctx), value))
                         }
                     })
                     .collect::<Vec<_>>();
                 named_values.sort_by(|a, b| a.0.cmp(&b.0));
 
-                fn explain_all(values: &[(String, JsValue)]) -> String {
+                fn explain_all<'a>(
+                    values: impl IntoIterator<Item = (&'a String, &'a JsValue)>,
+                ) -> String {
                     values
-                        .iter()
+                        .into_iter()
                         .map(|(id, value)| {
                             let (explainer, hints) = value.explain(10, 5);
                             format!("{id} = {explainer}{hints}")
@@ -4076,9 +4087,11 @@ mod tests {
                             .compare_to_file(&graph_snapshot_path)
                             .unwrap();
                     }
-                    NormalizedOutput::from(explain_all(&named_values))
-                        .compare_to_file(&graph_explained_snapshot_path)
-                        .unwrap();
+                    NormalizedOutput::from(explain_all(
+                        named_values.iter().map(|(name, (_, value))| (name, value)),
+                    ))
+                    .compare_to_file(&graph_explained_snapshot_path)
+                    .unwrap();
                     if !large {
                         NormalizedOutput::from(format!("{:#?}", var_graph.effects))
                             .compare_to_file(&graph_effects_snapshot_path)
@@ -4091,21 +4104,28 @@ mod tests {
 
                     let start = Instant::now();
                     let mut resolved = Vec::new();
-                    for (id, val) in named_values.iter().cloned() {
+                    for (name, (id, _)) in named_values.iter().cloned() {
                         let start = Instant::now();
                         // Ideally this would use eval_context.imports.get_attributes(span), but the
                         // span isn't available here
-                        let res = resolve(&var_graph, val, ImportAttributes::empty_ref()).await;
+                        let (res, steps) = resolve(
+                            &var_graph,
+                            JsValue::Variable(id),
+                            ImportAttributes::empty_ref(),
+                            &var_cache,
+                        )
+                        .await;
                         let time = start.elapsed();
                         if time.as_millis() > 1 {
                             println!(
-                                "linking {} {id} took {}",
+                                "linking {} {name} took {} in {} steps",
                                 input.display(),
-                                FormatDuration(time)
+                                FormatDuration(time),
+                                steps
                             );
                         }
 
-                        resolved.push((id, res));
+                        resolved.push((name, res));
                     }
                     let time = start.elapsed();
                     if time.as_millis() > 1 {
@@ -4113,7 +4133,7 @@ mod tests {
                     }
 
                     let start = Instant::now();
-                    let explainer = explain_all(&resolved);
+                    let explainer = explain_all(resolved.iter().map(|(name, value)| (name, value)));
                     let time = start.elapsed();
                     if time.as_millis() > 1 {
                         println!(
@@ -4146,6 +4166,7 @@ mod tests {
                             args: Vec<EffectArg>,
                             queue: &mut Vec<(usize, Effect)>,
                             var_graph: &VarGraph,
+                            var_cache: &Mutex<FxHashMap<Id, JsValue>>,
                             i: usize,
                         ) -> Vec<JsValue> {
                             let mut new_args = Vec::new();
@@ -4153,14 +4174,26 @@ mod tests {
                                 match arg {
                                     EffectArg::Value(v) => {
                                         new_args.push(
-                                            resolve(var_graph, v, ImportAttributes::empty_ref())
-                                                .await,
+                                            resolve(
+                                                var_graph,
+                                                v,
+                                                ImportAttributes::empty_ref(),
+                                                var_cache,
+                                            )
+                                            .await
+                                            .0,
                                         );
                                     }
                                     EffectArg::Closure(v, effects) => {
                                         new_args.push(
-                                            resolve(var_graph, v, ImportAttributes::empty_ref())
-                                                .await,
+                                            resolve(
+                                                var_graph,
+                                                v,
+                                                ImportAttributes::empty_ref(),
+                                                var_cache,
+                                            )
+                                            .await
+                                            .0,
                                         );
                                         queue.extend(
                                             effects.effects.into_iter().rev().map(|e| (i, e)),
@@ -4173,13 +4206,17 @@ mod tests {
                             }
                             new_args
                         }
-                        match effect {
+                        let steps = match effect {
                             Effect::Conditional {
                                 condition, kind, ..
                             } => {
-                                let condition =
-                                    resolve(&var_graph, *condition, ImportAttributes::empty_ref())
-                                        .await;
+                                let (condition, steps) = resolve(
+                                    &var_graph,
+                                    *condition,
+                                    ImportAttributes::empty_ref(),
+                                    &var_cache,
+                                )
+                                .await;
                                 resolved.push((format!("{parent} -> {i} conditional"), condition));
                                 match *kind {
                                     ConditionalKind::If { then } => {
@@ -4218,6 +4255,7 @@ mod tests {
                                             .extend(expr.effects.into_iter().rev().map(|e| (i, e)));
                                     }
                                 };
+                                steps
                             }
                             Effect::Call {
                                 func,
@@ -4226,13 +4264,15 @@ mod tests {
                                 span,
                                 ..
                             } => {
-                                let func = resolve(
+                                let (func, steps) = resolve(
                                     &var_graph,
                                     *func,
                                     eval_context.imports.get_attributes(span),
+                                    &var_cache,
                                 )
                                 .await;
-                                let new_args = handle_args(args, &mut queue, &var_graph, i).await;
+                                let new_args =
+                                    handle_args(args, &mut queue, &var_graph, &var_cache, i).await;
                                 resolved.push((
                                     format!("{parent} -> {i} call"),
                                     if new {
@@ -4241,47 +4281,69 @@ mod tests {
                                         JsValue::call(Box::new(func), new_args)
                                     },
                                 ));
+                                steps
                             }
                             Effect::FreeVar { var, .. } => {
                                 resolved.push((format!("{parent} -> {i} free var"), *var));
+                                0
                             }
                             Effect::TypeOf { arg, .. } => {
-                                let arg =
-                                    resolve(&var_graph, *arg, ImportAttributes::empty_ref()).await;
+                                let (arg, steps) = resolve(
+                                    &var_graph,
+                                    *arg,
+                                    ImportAttributes::empty_ref(),
+                                    &var_cache,
+                                )
+                                .await;
                                 resolved.push((
                                     format!("{parent} -> {i} typeof"),
                                     JsValue::type_of(Box::new(arg)),
                                 ));
+                                steps
                             }
                             Effect::MemberCall {
                                 obj, prop, args, ..
                             } => {
-                                let obj =
-                                    resolve(&var_graph, *obj, ImportAttributes::empty_ref()).await;
-                                let prop =
-                                    resolve(&var_graph, *prop, ImportAttributes::empty_ref()).await;
-                                let new_args = handle_args(args, &mut queue, &var_graph, i).await;
+                                let (obj, obj_steps) = resolve(
+                                    &var_graph,
+                                    *obj,
+                                    ImportAttributes::empty_ref(),
+                                    &var_cache,
+                                )
+                                .await;
+                                let (prop, prop_steps) = resolve(
+                                    &var_graph,
+                                    *prop,
+                                    ImportAttributes::empty_ref(),
+                                    &var_cache,
+                                )
+                                .await;
+                                let new_args =
+                                    handle_args(args, &mut queue, &var_graph, &var_cache, i).await;
                                 resolved.push((
                                     format!("{parent} -> {i} member call"),
                                     JsValue::member_call(Box::new(obj), Box::new(prop), new_args),
                                 ));
+                                obj_steps + prop_steps
                             }
                             Effect::Unreachable { .. } => {
                                 resolved.push((
                                     format!("{parent} -> {i} unreachable"),
                                     JsValue::unknown_empty(true, "unreachable"),
                                 ));
+                                0
                             }
-                            Effect::ImportMeta { .. } => {}
-                            Effect::ImportedBinding { .. } => {}
-                            Effect::Member { .. } => {}
-                        }
+                            Effect::ImportMeta { .. }
+                            | Effect::ImportedBinding { .. }
+                            | Effect::Member { .. } => 0,
+                        };
                         let time = start.elapsed();
                         if time.as_millis() > 1 {
                             println!(
-                                "linking effect {} took {}",
+                                "linking effect {} took {} in {} steps",
                                 input.display(),
-                                FormatDuration(time)
+                                FormatDuration(time),
+                                steps
                             );
                         }
                     }
@@ -4295,7 +4357,7 @@ mod tests {
                     }
 
                     let start = Instant::now();
-                    let explainer = explain_all(&resolved);
+                    let explainer = explain_all(resolved.iter().map(|(name, value)| (name, value)));
                     let time = start.elapsed();
                     if time.as_millis() > 1 {
                         println!(
@@ -4316,7 +4378,12 @@ mod tests {
         .unwrap();
     }
 
-    async fn resolve(var_graph: &VarGraph, val: JsValue, attributes: &ImportAttributes) -> JsValue {
+    async fn resolve(
+        var_graph: &VarGraph,
+        val: JsValue,
+        attributes: &ImportAttributes,
+        var_cache: &Mutex<FxHashMap<Id, JsValue>>,
+    ) -> (JsValue, u32) {
         turbo_tasks_testing::VcStorage::with(async {
             let compile_time_info = CompileTimeInfo::builder(
                 Environment::new(Value::new(ExecutionEnvironment::NodeJsLambda(
@@ -4349,7 +4416,8 @@ mod tests {
                         attributes,
                     ))
                 }),
-                Default::default(),
+                &Default::default(),
+                var_cache,
             )
             .await
         })

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known.rs
@@ -1,7 +1,7 @@
 use std::mem::take;
 
 use anyhow::Result;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbopack_core::compile_time_info::CompileTimeInfo;
 use url::Url;
 
@@ -354,10 +354,7 @@ pub fn require(args: Vec<JsValue>) -> JsValue {
 }
 
 /// (try to) statically evaluate `require.context(...)()`
-async fn require_context_require(
-    val: ResolvedVc<RequireContextValue>,
-    args: Vec<JsValue>,
-) -> Result<JsValue> {
+async fn require_context_require(val: RequireContextValue, args: Vec<JsValue>) -> Result<JsValue> {
     if args.is_empty() {
         return Ok(JsValue::unknown(
             JsValue::call(
@@ -384,8 +381,7 @@ async fn require_context_require(
         ));
     };
 
-    let map = val.await?;
-    let Some(m) = map.get(s) else {
+    let Some(m) = val.0.get(s) else {
         return Ok(JsValue::unknown(
             JsValue::call(
                 Box::new(JsValue::WellKnownFunction(
@@ -407,12 +403,11 @@ async fn require_context_require(
 
 /// (try to) statically evaluate `require.context(...).keys()`
 async fn require_context_require_keys(
-    val: ResolvedVc<RequireContextValue>,
+    val: RequireContextValue,
     args: Vec<JsValue>,
 ) -> Result<JsValue> {
     Ok(if args.is_empty() {
-        let map = val.await?;
-        JsValue::array(map.keys().cloned().map(|k| k.into()).collect())
+        JsValue::array(val.0.keys().cloned().map(|k| k.into()).collect())
     } else {
         JsValue::unknown(
             JsValue::call(
@@ -429,7 +424,7 @@ async fn require_context_require_keys(
 
 /// (try to) statically evaluate `require.context(...).resolve()`
 async fn require_context_require_resolve(
-    val: ResolvedVc<RequireContextValue>,
+    val: RequireContextValue,
     args: Vec<JsValue>,
 ) -> Result<JsValue> {
     if args.len() != 1 {
@@ -458,8 +453,7 @@ async fn require_context_require_resolve(
         ));
     };
 
-    let map = val.await?;
-    let Some(m) = map.get(s) else {
+    let Some(m) = val.0.get(s) else {
         return Ok(JsValue::unknown(
             JsValue::call(
                 Box::new(JsValue::WellKnownFunction(

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1230,34 +1230,14 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                     span,
                     in_try: _,
                 } => {
-                    let obj_count = obj.total_nodes();
-                    let prop_count = prop.total_nodes();
-                    let s = tracing::info_span!(
-                        "link_value obj",
-                        depth = obj_count,
-                        obj = %obj,
-                        value = tracing::field::Empty
-                    );
                     let obj = analysis_state
-                        .link_value(*obj.clone(), ImportAttributes::empty_ref())
-                        .instrument(s.clone())
+                        .link_value(*obj, ImportAttributes::empty_ref())
                         .await?;
-                    s.record("value", obj.to_string());
-
-                    let s = tracing::info_span!(
-                        "link_value prop",
-                        depth = prop_count,
-                        prop = %prop,
-                        value = tracing::field::Empty
-                    );
                     let prop = analysis_state
-                        .link_value(*prop.clone(), ImportAttributes::empty_ref())
-                        .instrument(s.clone())
+                        .link_value(*prop, ImportAttributes::empty_ref())
                         .await?;
-                    s.record("value", prop.to_string());
 
                     handle_member(&ast_path, obj, prop, span, &analysis_state, &mut analysis)
-                        .instrument(tracing::info_span!("handle_member"))
                         .await?;
                 }
                 Effect::ImportedBinding {

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2880,9 +2880,7 @@ async fn require_context_visitor(
 
     Ok(JsValue::WellKnownFunction(
         WellKnownFunctionKind::RequireContextRequire(
-            RequireContextValue::from_context_map(map)
-                .to_resolved()
-                .await?,
+            RequireContextValue::from_context_map(map).await?,
         ),
     ))
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -315,6 +315,7 @@ struct AnalysisState<'a> {
     /// This is the current state of known values of function
     /// arguments.
     fun_args_values: Mutex<FxHashMap<u32, Vec<JsValue>>>,
+    var_cache: Mutex<FxHashMap<Id, JsValue>>,
     // There can be many references to import.meta, but only the first should hoist
     // the object allocation.
     first_import_meta: bool,
@@ -327,8 +328,7 @@ struct AnalysisState<'a> {
 impl AnalysisState<'_> {
     /// Links a value to the graph, returning the linked value.
     async fn link_value(&self, value: JsValue, attributes: &ImportAttributes) -> Result<JsValue> {
-        let fun_args_values = self.fun_args_values.lock().clone();
-        link(
+        Ok(link(
             self.var_graph,
             value,
             &early_value_visitor,
@@ -341,9 +341,11 @@ impl AnalysisState<'_> {
                     attributes,
                 )
             },
-            fun_args_values,
+            &self.fun_args_values,
+            &self.var_cache,
         )
-        .await
+        .await?
+        .0)
     }
 }
 
@@ -897,7 +899,8 @@ pub(crate) async fn analyse_ecmascript_module_internal(
             origin,
             compile_time_info,
             var_graph: &var_graph,
-            fun_args_values: Mutex::new(FxHashMap::<u32, Vec<JsValue>>::default()),
+            fun_args_values: Default::default(),
+            var_cache: Default::default(),
             first_import_meta: true,
             tree_shaking_mode: options.tree_shaking_mode,
             import_externals: options.import_externals,
@@ -1227,14 +1230,34 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                     span,
                     in_try: _,
                 } => {
+                    let obj_count = obj.total_nodes();
+                    let prop_count = prop.total_nodes();
+                    let s = tracing::info_span!(
+                        "link_value obj",
+                        depth = obj_count,
+                        obj = %obj,
+                        value = tracing::field::Empty
+                    );
                     let obj = analysis_state
-                        .link_value(*obj, ImportAttributes::empty_ref())
+                        .link_value(*obj.clone(), ImportAttributes::empty_ref())
+                        .instrument(s.clone())
                         .await?;
+                    s.record("value", obj.to_string());
+
+                    let s = tracing::info_span!(
+                        "link_value prop",
+                        depth = prop_count,
+                        prop = %prop,
+                        value = tracing::field::Empty
+                    );
                     let prop = analysis_state
-                        .link_value(*prop, ImportAttributes::empty_ref())
+                        .link_value(*prop.clone(), ImportAttributes::empty_ref())
+                        .instrument(s.clone())
                         .await?;
+                    s.record("value", prop.to_string());
 
                     handle_member(&ast_path, obj, prop, span, &analysis_state, &mut analysis)
+                        .instrument(tracing::info_span!("handle_member"))
                         .await?;
                 }
                 Effect::ImportedBinding {

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/2/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/2/resolved-explained.snapshot
@@ -1,9 +1,9 @@
 x = (1 | ???*0*)
-- *0* y
+- *0* x
   ⚠️  circular variable reference
 
 y = (1 | ???*0*)
-- *0* x
+- *0* y
   ⚠️  circular variable reference
 
 z = (1 | ???*0*)

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/assign/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/assign/resolved-explained.snapshot
@@ -1,7 +1,5 @@
-a = ("" | `${("" | ???*0*)}x`)
-- *0* `${???*1*}x`
-  ⚠️  nested operation
-- *1* a
+a = ("" | `${???*0*}x`)
+- *0* a
   ⚠️  circular variable reference
 
 b = (0 | ???*0*)

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/cycle-cache/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/cycle-cache/resolved-explained.snapshot
@@ -39,15 +39,15 @@
 *arrow function 578* = (...) => 1
 
 a = (1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | ???*0*)
-- *0* b
+- *0* a
   ⚠️  circular variable reference
 
 b = (4 | 5 | 6 | 7 | 8 | 9 | 1 | 2 | 3 | ???*0*)
-- *0* c
+- *0* b
   ⚠️  circular variable reference
 
 c = (7 | 8 | 9 | 1 | 2 | 3 | 4 | 5 | 6 | ???*0*)
-- *0* a
+- *0* c
   ⚠️  circular variable reference
 
 d = ???*0*

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/resolved-effects.snapshot
@@ -67,8 +67,8 @@
   | [generateBinPath(), []]
 )()
 
-0 -> 21 member call = ???*0*["concat"]("--service=0.14.12", "--ping")
-- *0* max number of linking steps reached
+0 -> 21 member call = (["bin/esbuild"] | ???*0* | [])["concat"]("--service=0.14.12", "--ping")
+- *0* unknown mutation
   ⚠️  This value might have side effects
 
 0 -> 22 free var = FreeVar(require)

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/resolved-explained.snapshot
@@ -8,8 +8,8 @@
   | [generateBinPath(), []]
 )
 
-args = ???*0*
-- *0* max number of linking steps reached
+args = (["bin/esbuild"] | ???*0* | [])
+- *0* unknown mutation
   ⚠️  This value might have side effects
 
 binPath = (???*0* | ???*1* | ???*8*)
@@ -59,8 +59,62 @@ binTargetPath = `"esbuild"/resolved/lib${("/" | "")}pnpapi-${(???*0* | ???*1* | 
 - *7* unknown mutation
   ⚠️  This value might have side effects
 
-command = ???*0*
-- *0* max number of linking steps reached
+command = (
+  | "node"
+  | ???*0*
+  | ???*1*
+  | `"esbuild"/resolved/lib${("/" | "")}pnpapi-${(???*2* | ???*3* | ???*4* | "esbuild-linux-64")}-${???*5*}`
+  | ???*10*
+  | ???*11*
+  | ???*18*
+)
+- *0* unknown mutation
+  ⚠️  This value might have side effects
+- *1* FreeVar(ESBUILD_BINARY_PATH)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *2* pkg
+  ⚠️  pattern without value
+- *3* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *4* unknown mutation
+  ⚠️  This value might have side effects
+- *5* ???*6*((???*8* | "esbuild.exe" | "bin/esbuild" | ???*9*))
+  ⚠️  unknown callee
+  ⚠️  This value might have side effects
+- *6* path*7*["basename"]
+  ⚠️  unsupported property on Node.js path module
+  ⚠️  This value might have side effects
+- *7* path: The Node.js path module: https://nodejs.org/api/path.html
+- *8* subpath
+  ⚠️  pattern without value
+- *9* unknown mutation
+  ⚠️  This value might have side effects
+- *10* binPath
+  ⚠️  pattern without value
+- *11* require.resolve*12*(
+        `${(???*13* | ???*14* | ???*15* | "esbuild-linux-64")}/${(???*16* | "esbuild.exe" | "bin/esbuild" | ???*17*)}`
+    )
+  ⚠️  require.resolve non constant
+  ⚠️  This value might have side effects
+- *12* require.resolve: The require.resolve method from CommonJS
+- *13* pkg
+  ⚠️  pattern without value
+- *14* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *15* unknown mutation
+  ⚠️  This value might have side effects
+- *16* subpath
+  ⚠️  pattern without value
+- *17* unknown mutation
+  ⚠️  This value might have side effects
+- *18* ???*19*(pkg, subpath)
+  ⚠️  unknown callee
+  ⚠️  This value might have side effects
+- *19* FreeVar(downloadedBinPath)
+  ⚠️  unknown global
   ⚠️  This value might have side effects
 
 e#10 = ???*0*
@@ -152,6 +206,9 @@ subpath#7 = (???*0* | "esbuild.exe" | "bin/esbuild" | ???*1*)
 - *1* unknown mutation
   ⚠️  This value might have side effects
 
-x = ???*0*
-- *0* max number of linking steps reached
+x = (["bin/esbuild", "--service=0.14.12", "--ping"] | ???*0* | ["--service=0.14.12", "--ping"])
+- *0* ???*1*["concat"]("--service=0.14.12", "--ping")
+  ⚠️  unknown callee object
+  ⚠️  This value might have side effects
+- *1* unknown mutation
   ⚠️  This value might have side effects

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/resolved-explained.snapshot
@@ -38,14 +38,10 @@ d#6 = ???*0*
 - *0* arguments[3]
   ⚠️  function calls are not analysed yet
 
-i = (???*0* | 0 | ((???*1* | 0 | ???*2*) + 16))
+i = (???*0* | 0 | (???*1* + 16))
 - *0* i
   ⚠️  pattern without value
 - *1* i
-  ⚠️  pattern without value
-- *2* (???*3* + 16)
-  ⚠️  nested operation
-- *3* i
   ⚠️  circular variable reference
 
 len = ???*0*

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5/resolved-explained.snapshot
@@ -135,40 +135,24 @@ i#3 = (0 | ???*0*)
 - *0* updated with update expression
   ⚠️  This value might have side effects
 
-i#5 = (???*0* | 0 | ((???*1* | 0 | ???*2*) + 8))
+i#5 = (???*0* | 0 | (???*1* + 8))
 - *0* i
   ⚠️  pattern without value
 - *1* i
-  ⚠️  pattern without value
-- *2* (???*3* + 8)
-  ⚠️  nested operation
-- *3* i
   ⚠️  circular variable reference
 
-i#7 = (???*0* | 0 | ((???*1* | 0 | ???*2*) + 16))
+i#7 = (???*0* | 0 | (???*1* + 16))
 - *0* i
   ⚠️  pattern without value
 - *1* i
-  ⚠️  pattern without value
-- *2* (???*3* + 16)
-  ⚠️  nested operation
-- *3* i
   ⚠️  circular variable reference
 
-i#9 = (???*0* | 0 | ((???*1* | 0 | ???*2*) + 1) | ((???*4* | 0 | ???*5*) + 8))
+i#9 = (???*0* | 0 | (???*1* + 1) | (???*2* + 8))
 - *0* i
   ⚠️  pattern without value
 - *1* i
-  ⚠️  pattern without value
-- *2* (???*3* + 1)
-  ⚠️  nested operation
-- *3* i
   ⚠️  circular variable reference
-- *4* i
-  ⚠️  pattern without value
-- *5* (???*6* + 1)
-  ⚠️  nested operation
-- *6* i
+- *2* i
   ⚠️  circular variable reference
 
 input#5 = ???*0*

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/resolved-effects.snapshot
@@ -3095,8 +3095,14 @@
 - *14* unsupported expression
   ⚠️  This value might have side effects
 
-0 -> 178 member call = module<crypt, {}>["endian"](???*0*)
+0 -> 178 member call = module<crypt, {}>["endian"]([???*0*, ???*1*, ???*2*, ???*3*])
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 179 unreachable = ???*0*

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/resolved-explained.snapshot
@@ -130,14 +130,10 @@ digestbytes = ???*0*
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-i = (0 | ???*0* | ((0 | ???*1* | ???*2*) + 16))
+i = (0 | ???*0* | (???*1* + 16))
 - *0* updated with update expression
   ⚠️  This value might have side effects
-- *1* updated with update expression
-  ⚠️  This value might have side effects
-- *2* (???*3* + 16)
-  ⚠️  nested operation
-- *3* i
+- *1* i
   ⚠️  circular variable reference
 
 isBuffer = module<is-buffer, {}>
@@ -174,81 +170,33 @@ message#11 = ???*0*
 
 message#4 = (
   | ???*0*
-  | module<charenc, {}>["bin"]["stringToBytes"]((???*1* | ???*2* | ???*4*))
-  | module<charenc, {}>["utf8"]["stringToBytes"]((???*8* | ???*9* | ???*11*))
-  | ???*15*
-  | ???*19*()
-  | ???*21*()
+  | module<charenc, {}>["bin"]["stringToBytes"](???*1*)
+  | module<charenc, {}>["utf8"]["stringToBytes"](???*2*)
+  | ???*3*
+  | ???*7*()
 )
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *2* module<charenc, {}>["bin"]["stringToBytes"](???*3*)
-  ⚠️  nested operation
-- *3* message
+- *1* message
   ⚠️  circular variable reference
-- *4* ???*5*["call"](message, 0)
-  ⚠️  unknown callee object
-  ⚠️  This value might have side effects
-- *5* ???*6*["slice"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *6* ???*7*["prototype"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *7* FreeVar(Array)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *8* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *9* module<charenc, {}>["bin"]["stringToBytes"](???*10*)
-  ⚠️  nested operation
-- *10* message
+- *2* message
   ⚠️  circular variable reference
-- *11* ???*12*["call"](message, 0)
+- *3* ???*4*["call"](message, 0)
   ⚠️  unknown callee object
   ⚠️  This value might have side effects
-- *12* ???*13*["slice"]
+- *4* ???*5*["slice"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *13* ???*14*["prototype"]
+- *5* ???*6*["prototype"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *14* FreeVar(Array)
+- *6* FreeVar(Array)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *15* ???*16*["call"](message, 0)
-  ⚠️  unknown callee object
-  ⚠️  This value might have side effects
-- *16* ???*17*["slice"]
+- *7* ???*8*["toString"]
   ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *17* ???*18*["prototype"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *18* FreeVar(Array)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *19* ???*20*["toString"]
-  ⚠️  unknown object
-- *20* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *21* ???*22*["toString"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *22* ???*23*["call"](message, 0)
-  ⚠️  unknown callee object
-  ⚠️  This value might have side effects
-- *23* ???*24*["slice"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *24* ???*25*["prototype"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *25* FreeVar(Array)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
+- *8* message
+  ⚠️  circular variable reference
 
 n#10 = (???*0* + ???*1* + ???*2* + ???*3*)
 - *0* arguments[0]

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/resolved-explained.snapshot
@@ -10,14 +10,10 @@ args = ???*0*
 - *0* args
   ⚠️  pattern without value
 
-clientComponentLoadTimes = (0 | ((0 | ???*0*) + ???*3*))
-- *0* (???*1* + ???*2*)
-  ⚠️  nested operation
-- *1* clientComponentLoadTimes
+clientComponentLoadTimes = (0 | (???*0* + ???*1*))
+- *0* clientComponentLoadTimes
   ⚠️  circular variable reference
-- *2* unsupported expression
-  ⚠️  This value might have side effects
-- *3* unsupported expression
+- *1* unsupported expression
   ⚠️  This value might have side effects
 
 getClientComponentLoaderMetrics = (...) => metrics

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/peg/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/peg/resolved-effects.snapshot
@@ -497,12 +497,20 @@
 - *2* arguments[1]
   ⚠️  function calls are not analysed yet
 
-0 -> 144 conditional = ???*0*
+0 -> 144 conditional = ((???*0* !== {}) | (???*1* === ???*2*))
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* ???*3*["length"]
+  ⚠️  unknown object
+- *3* arguments[0]
+  ⚠️  function calls are not analysed yet
 
-144 -> 146 conditional = ???*0*
+144 -> 146 conditional = ((???*0* !== {}) | ???*1*)
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* unsupported expression
   ⚠️  This value might have side effects
 
 146 -> 147 call = (...) => {"type": "end"}()
@@ -518,7 +526,7 @@
 144 -> 153 call = (...) => {
     "start": {"offset": startPos, "line": startPosDetails["line"], "column": startPosDetails["column"]},
     "end": {"offset": endPos, "line": endPosDetails["line"], "column": endPosDetails["column"]}
-}(???*0*, ???*1*)
+}(???*0*, (???*1* + 1))
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -1145,8 +1153,10 @@
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 342 conditional = ???*0*
+0 -> 342 conditional = (???*0* !== ???*1*)
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* unsupported expression
   ⚠️  This value might have side effects
 
 342 -> 343 call = (...) => {
@@ -1180,8 +1190,10 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 348 conditional = ???*0*
+0 -> 348 conditional = (???*0* !== ???*1*)
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* unsupported expression
   ⚠️  This value might have side effects
 
 348 -> 349 call = (...) => {
@@ -1315,13 +1327,13 @@
 
 0 -> 388 call = (...) => s0()
 
-0 -> 389 conditional = ???*0*
+0 -> 389 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 389 -> 390 call = (...) => s0()
 
-389 -> 391 conditional = ???*0*
+389 -> 391 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1341,7 +1353,7 @@
 
 0 -> 396 call = (...) => s0()
 
-0 -> 397 conditional = ???*0*
+0 -> 397 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1353,19 +1365,19 @@
 
 399 -> 400 call = (...) => s0()
 
-399 -> 401 conditional = ???*0*
+399 -> 401 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 401 -> 402 call = (...) => s0()
 
-401 -> 403 conditional = ???*0*
+401 -> 403 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 403 -> 404 call = (...) => s0()
 
-403 -> 405 conditional = ???*0*
+403 -> 405 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1373,43 +1385,43 @@
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-399 -> 407 conditional = ???*0*
+399 -> 407 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 407 -> 408 call = (...) => s0()
 
-407 -> 409 conditional = ???*0*
+407 -> 409 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 409 -> 410 call = (...) => s0()
 
-409 -> 411 conditional = ???*0*
+409 -> 411 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 411 -> 412 call = (...) => s0()
 
-411 -> 413 conditional = ???*0*
+411 -> 413 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 413 -> 414 call = (...) => s0()
 
-413 -> 415 conditional = ???*0*
+413 -> 415 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 415 -> 416 call = (...) => s0()
 
-415 -> 417 conditional = ???*0*
+415 -> 417 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 417 -> 418 call = (...) => s0()
 
-417 -> 419 conditional = ???*0*
+417 -> 419 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1421,31 +1433,31 @@
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-413 -> 421 conditional = ???*0*
+413 -> 421 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 421 -> 422 call = (...) => s0()
 
-421 -> 423 conditional = ???*0*
+421 -> 423 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 423 -> 424 call = (...) => s0()
 
-423 -> 425 conditional = ???*0*
+423 -> 425 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 425 -> 426 call = (...) => s0()
 
-425 -> 427 conditional = ???*0*
+425 -> 427 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 427 -> 428 call = (...) => s0()
 
-427 -> 429 conditional = ???*0*
+427 -> 429 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1459,19 +1471,19 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
-423 -> 431 conditional = ???*0*
+423 -> 431 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 431 -> 432 call = (...) => s0()
 
-431 -> 433 conditional = ???*0*
+431 -> 433 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 433 -> 434 call = (...) => s0()
 
-433 -> 435 conditional = ???*0*
+433 -> 435 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1483,7 +1495,7 @@
 
 437 -> 438 call = (...) => s0()
 
-437 -> 439 conditional = ???*0*
+437 -> 439 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1495,7 +1507,7 @@
 
 441 -> 442 call = (...) => s0()
 
-441 -> 443 conditional = ???*0*
+441 -> 443 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1511,7 +1523,7 @@
 - *4* max number of linking steps reached
   ⚠️  This value might have side effects
 
-433 -> 445 conditional = ???*0*
+433 -> 445 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1558,19 +1570,19 @@
     {"type": "literal", "text": "*", "ignoreCase": false}
 )
 
-0 -> 453 conditional = ???*0*
+0 -> 453 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 453 -> 454 call = (...) => {"type": "select_specification", "*": true}()
 
-0 -> 455 conditional = ???*0*
+0 -> 455 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 455 -> 456 call = (...) => s0()
 
-455 -> 457 conditional = ???*0*
+455 -> 457 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1578,13 +1590,13 @@
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-455 -> 459 conditional = ???*0*
+455 -> 459 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 459 -> 460 call = (...) => s0()
 
-459 -> 461 conditional = ???*0*
+459 -> 461 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1596,7 +1608,7 @@
 
 463 -> 464 call = (...) => s0()
 
-463 -> 465 conditional = ???*0*
+463 -> 465 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1610,13 +1622,13 @@
 
 0 -> 468 call = (...) => s0()
 
-0 -> 469 conditional = ???*0*
+0 -> 469 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 469 -> 470 call = (...) => s0()
 
-469 -> 471 conditional = ???*0*
+469 -> 471 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1652,7 +1664,7 @@
 
 479 -> 480 call = (...) => s0()
 
-479 -> 481 conditional = ???*0*
+479 -> 481 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1670,7 +1682,7 @@
 
 469 -> 485 call = (...) => s0()
 
-469 -> 486 conditional = ???*0*
+469 -> 486 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1706,7 +1718,7 @@
 
 494 -> 495 call = (...) => s0()
 
-494 -> 496 conditional = ???*0*
+494 -> 496 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1734,19 +1746,19 @@
 
 0 -> 501 call = (...) => s0()
 
-0 -> 502 conditional = ???*0*
+0 -> 502 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 502 -> 503 call = (...) => s0()
 
-502 -> 504 conditional = ???*0*
+502 -> 504 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 504 -> 505 call = (...) => s0()
 
-504 -> 506 conditional = ???*0*
+504 -> 506 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1758,7 +1770,7 @@
 
 508 -> 509 call = (...) => s0()
 
-508 -> 510 conditional = ???*0*
+508 -> 510 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1776,13 +1788,13 @@
 
 502 -> 514 call = (...) => s0()
 
-502 -> 515 conditional = ???*0*
+502 -> 515 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 515 -> 516 call = (...) => s0()
 
-515 -> 517 conditional = ???*0*
+515 -> 517 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1794,7 +1806,7 @@
 
 519 -> 520 call = (...) => s0()
 
-519 -> 521 conditional = ???*0*
+519 -> 521 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1820,31 +1832,31 @@
 
 0 -> 526 call = (...) => s0()
 
-0 -> 527 conditional = ???*0*
+0 -> 527 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 527 -> 528 call = (...) => s0()
 
-527 -> 529 conditional = ???*0*
+527 -> 529 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 529 -> 530 call = (...) => s0()
 
-529 -> 531 conditional = ???*0*
+529 -> 531 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 531 -> 532 call = (...) => s0()
 
-531 -> 533 conditional = ???*0*
+531 -> 533 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 533 -> 534 call = (...) => s0()
 
-533 -> 535 conditional = ???*0*
+533 -> 535 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1854,37 +1866,37 @@
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 537 conditional = ???*0*
+0 -> 537 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 537 -> 538 call = (...) => s0()
 
-537 -> 539 conditional = ???*0*
+537 -> 539 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 539 -> 540 call = (...) => s0()
 
-539 -> 541 conditional = ???*0*
+539 -> 541 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 541 -> 542 call = (...) => s0()
 
-539 -> 543 conditional = ???*0*
+539 -> 543 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 543 -> 544 call = (...) => s0()
 
-543 -> 545 conditional = ???*0*
+543 -> 545 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 545 -> 546 call = (...) => s0()
 
-545 -> 547 conditional = ???*0*
+545 -> 547 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1894,7 +1906,7 @@
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-539 -> 549 conditional = ???*0*
+539 -> 549 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1910,13 +1922,13 @@
 
 0 -> 552 call = (...) => s0()
 
-0 -> 553 conditional = ???*0*
+0 -> 553 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 553 -> 554 call = (...) => s0()
 
-553 -> 555 conditional = ???*0*
+553 -> 555 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1928,7 +1940,7 @@
 
 0 -> 558 call = (...) => s0()
 
-0 -> 559 conditional = ???*0*
+0 -> 559 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1942,13 +1954,13 @@
 
 0 -> 562 call = (...) => s0()
 
-0 -> 563 conditional = ???*0*
+0 -> 563 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 563 -> 564 call = (...) => s0()
 
-563 -> 565 conditional = ???*0*
+563 -> 565 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1984,7 +1996,7 @@
 
 573 -> 574 call = (...) => s0()
 
-573 -> 575 conditional = ???*0*
+573 -> 575 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2002,7 +2014,7 @@
 
 563 -> 579 call = (...) => s0()
 
-563 -> 580 conditional = ???*0*
+563 -> 580 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2038,7 +2050,7 @@
 
 588 -> 589 call = (...) => s0()
 
-588 -> 590 conditional = ???*0*
+588 -> 590 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2066,25 +2078,25 @@
 
 0 -> 595 call = (...) => s0()
 
-0 -> 596 conditional = ???*0*
+0 -> 596 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 596 -> 597 call = (...) => s0()
 
-596 -> 598 conditional = ???*0*
+596 -> 598 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 598 -> 599 call = (...) => s0()
 
-598 -> 600 conditional = ???*0*
+598 -> 600 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 600 -> 601 call = (...) => s0()
 
-598 -> 602 conditional = ???*0*
+598 -> 602 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2094,7 +2106,7 @@
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-596 -> 604 conditional = ???*0*
+596 -> 604 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2110,7 +2122,7 @@
 
 0 -> 607 call = (...) => s0()
 
-0 -> 608 conditional = ???*0*
+0 -> 608 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2152,7 +2164,7 @@
 
 618 -> 619 call = (...) => s0()
 
-618 -> 620 conditional = ???*0*
+618 -> 620 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2194,7 +2206,7 @@
 
 630 -> 631 call = (...) => s0()
 
-630 -> 632 conditional = ???*0*
+630 -> 632 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2234,13 +2246,13 @@
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 642 conditional = ???*0*
+0 -> 642 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 642 -> 643 call = (...) => s0()
 
-642 -> 644 conditional = ???*0*
+642 -> 644 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2282,7 +2294,7 @@
 
 654 -> 655 call = (...) => s0()
 
-654 -> 656 conditional = ???*0*
+654 -> 656 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2346,7 +2358,7 @@
     {"type": "literal", "text": "{", "ignoreCase": false}
 )
 
-0 -> 672 conditional = ???*0*
+0 -> 672 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2358,13 +2370,13 @@
 
 674 -> 675 call = (...) => s0()
 
-674 -> 676 conditional = ???*0*
+674 -> 676 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 676 -> 677 call = (...) => s0()
 
-676 -> 678 conditional = ???*0*
+676 -> 678 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2400,7 +2412,7 @@
 
 686 -> 687 call = (...) => s0()
 
-686 -> 688 conditional = ???*0*
+686 -> 688 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2418,7 +2430,7 @@
 
 676 -> 692 call = (...) => s0()
 
-676 -> 693 conditional = ???*0*
+676 -> 693 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2454,7 +2466,7 @@
 
 701 -> 702 call = (...) => s0()
 
-701 -> 703 conditional = ???*0*
+701 -> 703 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2470,7 +2482,7 @@
 
 705 -> 706 call = (...) => s0()
 
-705 -> 707 conditional = ???*0*
+705 -> 707 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2494,7 +2506,7 @@
     {"type": "literal", "text": "}", "ignoreCase": false}
 )
 
-707 -> 713 conditional = ???*0*
+707 -> 713 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2530,7 +2542,7 @@
     {"type": "literal", "text": "[", "ignoreCase": false}
 )
 
-0 -> 721 conditional = ???*0*
+0 -> 721 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2542,7 +2554,7 @@
 
 723 -> 724 call = (...) => s0()
 
-723 -> 725 conditional = ???*0*
+723 -> 725 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2586,37 +2598,37 @@
 
 0 -> 736 call = (...) => s0()
 
-0 -> 737 conditional = ???*0*
+0 -> 737 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 737 -> 738 call = (...) => s0()
 
-737 -> 739 conditional = ???*0*
+737 -> 739 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 739 -> 740 call = (...) => s0()
 
-739 -> 741 conditional = ???*0*
+739 -> 741 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 741 -> 742 call = (...) => s0()
 
-741 -> 743 conditional = ???*0*
+741 -> 743 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 743 -> 744 call = (...) => s0()
 
-743 -> 745 conditional = ???*0*
+743 -> 745 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 745 -> 746 call = (...) => s0()
 
-745 -> 747 conditional = ???*0*
+745 -> 747 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2658,7 +2670,7 @@
 
 0 -> 758 call = (...) => s0()
 
-0 -> 759 conditional = ???*0*
+0 -> 759 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2670,19 +2682,19 @@
 
 0 -> 762 call = (...) => s0()
 
-0 -> 763 conditional = ???*0*
+0 -> 763 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 763 -> 764 call = (...) => {"type": "boolean_constant", "value": false}()
 
-0 -> 765 conditional = ???*0*
+0 -> 765 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 765 -> 766 call = (...) => s0()
 
-765 -> 767 conditional = ???*0*
+765 -> 767 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2788,7 +2800,7 @@
     {"type": "class", "parts": [["0", "9"]], "inverted": false, "ignoreCase": false}
 )
 
-781 -> 791 conditional = ???*0*
+781 -> 791 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2944,7 +2956,7 @@
     {"type": "class", "parts": [["0", "9"]], "inverted": false, "ignoreCase": false}
 )
 
-803 -> 831 conditional = ???*0*
+803 -> 831 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3031,7 +3043,7 @@
     {"type": "literal", "text": "\"", "ignoreCase": false}
 )
 
-844 -> 850 conditional = ???*0*
+844 -> 850 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3039,7 +3051,7 @@
 - *0* s2
   ⚠️  pattern without value
 
-0 -> 852 conditional = ???*0*
+0 -> 852 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3115,7 +3127,7 @@
     {"type": "literal", "text": "'", "ignoreCase": false}
 )
 
-863 -> 869 conditional = ???*0*
+863 -> 869 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3147,7 +3159,7 @@
     {"type": "literal", "text": "[", "ignoreCase": false}
 )
 
-0 -> 877 conditional = ???*0*
+0 -> 877 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3159,13 +3171,13 @@
 
 879 -> 880 call = (...) => s0()
 
-879 -> 881 conditional = ???*0*
+879 -> 881 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 881 -> 882 call = (...) => s0()
 
-881 -> 883 conditional = ???*0*
+881 -> 883 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3201,7 +3213,7 @@
 
 891 -> 892 call = (...) => s0()
 
-891 -> 893 conditional = ???*0*
+891 -> 893 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3219,7 +3231,7 @@
 
 881 -> 897 call = (...) => s0()
 
-881 -> 898 conditional = ???*0*
+881 -> 898 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3255,7 +3267,7 @@
 
 906 -> 907 call = (...) => s0()
 
-906 -> 908 conditional = ???*0*
+906 -> 908 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3271,7 +3283,7 @@
 
 910 -> 911 call = (...) => s0()
 
-910 -> 912 conditional = ???*0*
+910 -> 912 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3295,7 +3307,7 @@
     {"type": "literal", "text": "]", "ignoreCase": false}
 )
 
-912 -> 918 conditional = ???*0*
+912 -> 918 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3331,7 +3343,7 @@
     {"type": "literal", "text": "{", "ignoreCase": false}
 )
 
-0 -> 926 conditional = ???*0*
+0 -> 926 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3343,13 +3355,13 @@
 
 928 -> 929 call = (...) => s0()
 
-928 -> 930 conditional = ???*0*
+928 -> 930 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 930 -> 931 call = (...) => s0()
 
-930 -> 932 conditional = ???*0*
+930 -> 932 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3385,7 +3397,7 @@
 
 940 -> 941 call = (...) => s0()
 
-940 -> 942 conditional = ???*0*
+940 -> 942 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3403,7 +3415,7 @@
 
 930 -> 946 call = (...) => s0()
 
-930 -> 947 conditional = ???*0*
+930 -> 947 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3439,7 +3451,7 @@
 
 955 -> 956 call = (...) => s0()
 
-955 -> 957 conditional = ???*0*
+955 -> 957 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3455,7 +3467,7 @@
 
 959 -> 960 call = (...) => s0()
 
-959 -> 961 conditional = ???*0*
+959 -> 961 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3479,7 +3491,7 @@
     {"type": "literal", "text": "}", "ignoreCase": false}
 )
 
-961 -> 967 conditional = ???*0*
+961 -> 967 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3497,7 +3509,7 @@
 
 0 -> 970 call = (...) => s0()
 
-0 -> 971 conditional = ???*0*
+0 -> 971 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3511,7 +3523,7 @@
 
 0 -> 975 call = (...) => s0()
 
-0 -> 976 conditional = ???*0*
+0 -> 976 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3617,7 +3629,7 @@
     {"type": "class", "parts": ["\n", "\r"], "inverted": false, "ignoreCase": false}
 )
 
-994 -> 1004 conditional = ???*0*
+994 -> 1004 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3661,7 +3673,7 @@
     {"type": "class", "parts": ["\n", "\r"], "inverted": false, "ignoreCase": false}
 )
 
-994 -> 1017 conditional = ???*0*
+994 -> 1017 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3707,7 +3719,7 @@
     {"type": "literal", "text": "SELECT", "ignoreCase": true}
 )
 
-0 -> 1029 conditional = ???*0*
+0 -> 1029 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3753,7 +3765,7 @@
     {"type": "literal", "text": "TOP", "ignoreCase": true}
 )
 
-0 -> 1041 conditional = ???*0*
+0 -> 1041 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3799,7 +3811,7 @@
     {"type": "literal", "text": "FROM", "ignoreCase": true}
 )
 
-0 -> 1053 conditional = ???*0*
+0 -> 1053 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3845,7 +3857,7 @@
     {"type": "literal", "text": "WHERE", "ignoreCase": true}
 )
 
-0 -> 1065 conditional = ???*0*
+0 -> 1065 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3891,7 +3903,7 @@
     {"type": "literal", "text": "ORDER", "ignoreCase": true}
 )
 
-0 -> 1077 conditional = ???*0*
+0 -> 1077 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3937,7 +3949,7 @@
     {"type": "literal", "text": "BY", "ignoreCase": true}
 )
 
-0 -> 1089 conditional = ???*0*
+0 -> 1089 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3983,7 +3995,7 @@
     {"type": "literal", "text": "AS", "ignoreCase": true}
 )
 
-0 -> 1101 conditional = ???*0*
+0 -> 1101 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4029,7 +4041,7 @@
     {"type": "literal", "text": "JOIN", "ignoreCase": true}
 )
 
-0 -> 1113 conditional = ???*0*
+0 -> 1113 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4075,7 +4087,7 @@
     {"type": "literal", "text": "IN", "ignoreCase": true}
 )
 
-0 -> 1125 conditional = ???*0*
+0 -> 1125 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4121,7 +4133,7 @@
     {"type": "literal", "text": "VALUE", "ignoreCase": true}
 )
 
-0 -> 1137 conditional = ???*0*
+0 -> 1137 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4177,7 +4189,7 @@
 
 1149 -> 1150 call = (...) => s0()
 
-1149 -> 1151 conditional = ???*0*
+1149 -> 1151 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4233,7 +4245,7 @@
 
 1163 -> 1164 call = (...) => s0()
 
-1163 -> 1165 conditional = ???*0*
+1163 -> 1165 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4289,7 +4301,7 @@
 
 1177 -> 1178 call = (...) => s0()
 
-1177 -> 1179 conditional = ???*0*
+1177 -> 1179 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4345,7 +4357,7 @@
 
 1191 -> 1192 call = (...) => s0()
 
-1191 -> 1193 conditional = ???*0*
+1191 -> 1193 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4401,7 +4413,7 @@
 
 1205 -> 1206 call = (...) => s0()
 
-1205 -> 1207 conditional = ???*0*
+1205 -> 1207 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4447,7 +4459,7 @@
     {"type": "literal", "text": "BETWEEN", "ignoreCase": true}
 )
 
-0 -> 1219 conditional = ???*0*
+0 -> 1219 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4493,7 +4505,7 @@
     {"type": "literal", "text": "EXISTS", "ignoreCase": true}
 )
 
-0 -> 1231 conditional = ???*0*
+0 -> 1231 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4539,7 +4551,7 @@
     {"type": "literal", "text": "ARRAY", "ignoreCase": true}
 )
 
-0 -> 1243 conditional = ???*0*
+0 -> 1243 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4569,7 +4581,7 @@
     {"type": "literal", "text": "null", "ignoreCase": false}
 )
 
-0 -> 1251 conditional = ???*0*
+0 -> 1251 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4599,7 +4611,7 @@
     {"type": "literal", "text": "true", "ignoreCase": false}
 )
 
-0 -> 1259 conditional = ???*0*
+0 -> 1259 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4629,7 +4641,7 @@
     {"type": "literal", "text": "false", "ignoreCase": false}
 )
 
-0 -> 1267 conditional = ???*0*
+0 -> 1267 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4659,7 +4671,7 @@
     {"type": "literal", "text": "udf", "ignoreCase": false}
 )
 
-0 -> 1275 conditional = ???*0*
+0 -> 1275 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4671,127 +4683,127 @@
 
 0 -> 1278 call = (...) => s0()
 
-0 -> 1279 conditional = ???*0*
+0 -> 1279 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1279 -> 1280 call = (...) => s0()
 
-1279 -> 1281 conditional = ???*0*
+1279 -> 1281 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1281 -> 1282 call = (...) => s0()
 
-1281 -> 1283 conditional = ???*0*
+1281 -> 1283 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1283 -> 1284 call = (...) => s0()
 
-1283 -> 1285 conditional = ???*0*
+1283 -> 1285 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1285 -> 1286 call = (...) => s0()
 
-1285 -> 1287 conditional = ???*0*
+1285 -> 1287 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1287 -> 1288 call = (...) => s0()
 
-1287 -> 1289 conditional = ???*0*
+1287 -> 1289 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1289 -> 1290 call = (...) => s0()
 
-1289 -> 1291 conditional = ???*0*
+1289 -> 1291 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1291 -> 1292 call = (...) => s0()
 
-1291 -> 1293 conditional = ???*0*
+1291 -> 1293 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1293 -> 1294 call = (...) => s0()
 
-1293 -> 1295 conditional = ???*0*
+1293 -> 1295 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1295 -> 1296 call = (...) => s0()
 
-1295 -> 1297 conditional = ???*0*
+1295 -> 1297 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1297 -> 1298 call = (...) => s0()
 
-1297 -> 1299 conditional = ???*0*
+1297 -> 1299 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1299 -> 1300 call = (...) => s0()
 
-1299 -> 1301 conditional = ???*0*
+1299 -> 1301 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1301 -> 1302 call = (...) => s0()
 
-1301 -> 1303 conditional = ???*0*
+1301 -> 1303 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1303 -> 1304 call = (...) => s0()
 
-1303 -> 1305 conditional = ???*0*
+1303 -> 1305 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1305 -> 1306 call = (...) => s0()
 
-1305 -> 1307 conditional = ???*0*
+1305 -> 1307 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1307 -> 1308 call = (...) => s0()
 
-1307 -> 1309 conditional = ???*0*
+1307 -> 1309 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1309 -> 1310 call = (...) => s0()
 
-1309 -> 1311 conditional = ???*0*
+1309 -> 1311 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1311 -> 1312 call = (...) => s0()
 
-1311 -> 1313 conditional = ???*0*
+1311 -> 1313 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1313 -> 1314 call = (...) => s0()
 
-1313 -> 1315 conditional = ???*0*
+1313 -> 1315 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1315 -> 1316 call = (...) => s0()
 
-1315 -> 1317 conditional = ???*0*
+1315 -> 1317 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1317 -> 1318 call = (...) => s0()
 
-1317 -> 1319 conditional = ???*0*
+1317 -> 1319 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4803,13 +4815,13 @@
 
 0 -> 1322 call = (...) => s0()
 
-0 -> 1323 conditional = ???*0*
+0 -> 1323 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1323 -> 1324 call = (...) => s0()
 
-1323 -> 1325 conditional = ???*0*
+1323 -> 1325 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5024,7 +5036,7 @@
 
 1368 -> 1369 call = (...) => s0()
 
-1368 -> 1370 conditional = ???*0*
+1368 -> 1370 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5054,7 +5066,7 @@
     {"type": "literal", "text": "+", "ignoreCase": false}
 )
 
-0 -> 1378 conditional = ???*0*
+0 -> 1378 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5078,7 +5090,7 @@
     {"type": "literal", "text": "-", "ignoreCase": false}
 )
 
-1378 -> 1384 conditional = ???*0*
+1378 -> 1384 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5102,7 +5114,7 @@
     {"type": "literal", "text": "~", "ignoreCase": false}
 )
 
-1384 -> 1390 conditional = ???*0*
+1384 -> 1390 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5132,7 +5144,7 @@
     {"type": "literal", "text": "\"", "ignoreCase": false}
 )
 
-0 -> 1398 conditional = ???*0*
+0 -> 1398 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5156,19 +5168,19 @@
     {"type": "literal", "text": "\\", "ignoreCase": false}
 )
 
-0 -> 1404 conditional = ???*0*
+0 -> 1404 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1404 -> 1405 call = (...) => s0()
 
-1404 -> 1406 conditional = ???*0*
+1404 -> 1406 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1406 -> 1407 call = (...) => text()()
 
-0 -> 1408 conditional = ???*0*
+0 -> 1408 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5192,13 +5204,13 @@
     {"type": "literal", "text": "\\", "ignoreCase": false}
 )
 
-1408 -> 1414 conditional = ???*0*
+1408 -> 1414 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1414 -> 1415 call = (...) => s0()
 
-1414 -> 1416 conditional = ???*0*
+1414 -> 1416 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5230,7 +5242,7 @@
     {"type": "literal", "text": "'", "ignoreCase": false}
 )
 
-0 -> 1424 conditional = ???*0*
+0 -> 1424 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5254,19 +5266,19 @@
     {"type": "literal", "text": "\\", "ignoreCase": false}
 )
 
-0 -> 1430 conditional = ???*0*
+0 -> 1430 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1430 -> 1431 call = (...) => s0()
 
-1430 -> 1432 conditional = ???*0*
+1430 -> 1432 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1432 -> 1433 call = (...) => text()()
 
-0 -> 1434 conditional = ???*0*
+0 -> 1434 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5290,13 +5302,13 @@
     {"type": "literal", "text": "\\", "ignoreCase": false}
 )
 
-1434 -> 1440 conditional = ???*0*
+1434 -> 1440 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1440 -> 1441 call = (...) => s0()
 
-1440 -> 1442 conditional = ???*0*
+1440 -> 1442 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5326,7 +5338,7 @@
 
 0 -> 1451 call = (...) => s0()
 
-0 -> 1452 conditional = ???*0*
+0 -> 1452 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5338,7 +5350,7 @@
 
 0 -> 1455 call = (...) => s0()
 
-0 -> 1456 conditional = ???*0*
+0 -> 1456 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5368,7 +5380,7 @@
     {"type": "literal", "text": "'", "ignoreCase": false}
 )
 
-0 -> 1464 conditional = ???*0*
+0 -> 1464 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5392,7 +5404,7 @@
     {"type": "literal", "text": "\"", "ignoreCase": false}
 )
 
-1464 -> 1470 conditional = ???*0*
+1464 -> 1470 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5416,7 +5428,7 @@
     {"type": "literal", "text": "\\", "ignoreCase": false}
 )
 
-1470 -> 1476 conditional = ???*0*
+1470 -> 1476 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5446,7 +5458,7 @@
 
 1482 -> 1483 call = (...) => "\b"()
 
-1476 -> 1484 conditional = ???*0*
+1476 -> 1484 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5476,7 +5488,7 @@
 
 1490 -> 1491 call = (...) => "\f"()
 
-1484 -> 1492 conditional = ???*0*
+1484 -> 1492 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5506,7 +5518,7 @@
 
 1498 -> 1499 call = (...) => "\n"()
 
-1492 -> 1500 conditional = ???*0*
+1492 -> 1500 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5536,7 +5548,7 @@
 
 1506 -> 1507 call = (...) => "\r"()
 
-1500 -> 1508 conditional = ???*0*
+1500 -> 1508 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5572,13 +5584,13 @@
 
 0 -> 1517 call = (...) => s0()
 
-0 -> 1518 conditional = ???*0*
+0 -> 1518 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1518 -> 1519 call = (...) => s0()
 
-1518 -> 1520 conditional = ???*0*
+1518 -> 1520 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5590,7 +5602,7 @@
 
 0 -> 1523 call = (...) => s0()
 
-0 -> 1524 conditional = ???*0*
+0 -> 1524 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5638,7 +5650,7 @@
     {"type": "literal", "text": "u", "ignoreCase": false}
 )
 
-0 -> 1536 conditional = ???*0*
+0 -> 1536 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5699,7 +5711,7 @@
 
 1542 -> 1543 call = (...) => s0()
 
-1536 -> 1544 conditional = ???*0*
+1536 -> 1544 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5711,7 +5723,7 @@
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-1536 -> 1547 conditional = ???*0*
+1536 -> 1547 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5761,31 +5773,31 @@
 
 0 -> 1560 call = (...) => s0()
 
-0 -> 1561 conditional = ???*0*
+0 -> 1561 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1561 -> 1562 call = (...) => s0()
 
-1561 -> 1563 conditional = ???*0*
+1561 -> 1563 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1563 -> 1564 call = (...) => s0()
 
-1561 -> 1565 conditional = ???*0*
+1561 -> 1565 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1565 -> 1566 call = (...) => s0()
 
-1565 -> 1567 conditional = ???*0*
+1565 -> 1567 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1567 -> 1568 call = (...) => s0()
 
-1567 -> 1569 conditional = ???*0*
+1567 -> 1569 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5795,7 +5807,7 @@
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-1561 -> 1571 conditional = ???*0*
+1561 -> 1571 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5811,37 +5823,37 @@
 
 0 -> 1574 call = (...) => s0()
 
-0 -> 1575 conditional = ???*0*
+0 -> 1575 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1575 -> 1576 call = (...) => s0()
 
-1575 -> 1577 conditional = ???*0*
+1575 -> 1577 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1577 -> 1578 call = (...) => s0()
 
-1577 -> 1579 conditional = ???*0*
+1577 -> 1579 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1579 -> 1580 call = (...) => s0()
 
-1579 -> 1581 conditional = ???*0*
+1579 -> 1581 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1581 -> 1582 call = (...) => s0()
 
-1581 -> 1583 conditional = ???*0*
+1581 -> 1583 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1583 -> 1584 call = (...) => s0()
 
-1583 -> 1585 conditional = ???*0*
+1583 -> 1585 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5865,7 +5877,7 @@
     {"type": "literal", "text": "(", "ignoreCase": false}
 )
 
-1585 -> 1591 conditional = ???*0*
+1585 -> 1591 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5877,7 +5889,7 @@
 
 1593 -> 1594 call = (...) => s0()
 
-1593 -> 1595 conditional = ???*0*
+1593 -> 1595 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5921,13 +5933,13 @@
 
 0 -> 1606 call = (...) => s0()
 
-0 -> 1607 conditional = ???*0*
+0 -> 1607 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1607 -> 1608 call = (...) => s0()
 
-1607 -> 1609 conditional = ???*0*
+1607 -> 1609 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5939,7 +5951,7 @@
 
 0 -> 1612 call = (...) => s0()
 
-0 -> 1613 conditional = ???*0*
+0 -> 1613 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5951,7 +5963,7 @@
 
 1615 -> 1616 call = (...) => s0()
 
-1615 -> 1617 conditional = ???*0*
+1615 -> 1617 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5965,7 +5977,7 @@
 
 0 -> 1620 call = (...) => s0()
 
-0 -> 1621 conditional = ???*0*
+0 -> 1621 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5977,7 +5989,7 @@
 
 1623 -> 1624 call = (...) => s0()
 
-1623 -> 1625 conditional = ???*0*
+1623 -> 1625 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5991,7 +6003,7 @@
 
 0 -> 1628 call = (...) => s0()
 
-0 -> 1629 conditional = ???*0*
+0 -> 1629 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6005,13 +6017,13 @@
 
 0 -> 1632 call = (...) => s0()
 
-0 -> 1633 conditional = ???*0*
+0 -> 1633 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1633 -> 1634 call = (...) => s0()
 
-1633 -> 1635 conditional = ???*0*
+1633 -> 1635 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6047,7 +6059,7 @@
 
 1643 -> 1644 call = (...) => s0()
 
-1643 -> 1645 conditional = ???*0*
+1643 -> 1645 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6063,13 +6075,13 @@
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-1633 -> 1649 conditional = ???*0*
+1633 -> 1649 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1649 -> 1650 call = (...) => s0()
 
-1649 -> 1651 conditional = ???*0*
+1649 -> 1651 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6105,19 +6117,19 @@
 
 1659 -> 1660 call = (...) => s0()
 
-1659 -> 1661 conditional = ???*0*
+1659 -> 1661 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1661 -> 1662 call = (...) => s0()
 
-1661 -> 1663 conditional = ???*0*
+1661 -> 1663 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1663 -> 1664 call = (...) => s0()
 
-1659 -> 1665 conditional = ???*0*
+1659 -> 1665 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6165,7 +6177,7 @@
 
 1633 -> 1677 call = (...) => s0()
 
-1633 -> 1678 conditional = ???*0*
+1633 -> 1678 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6201,7 +6213,7 @@
 
 1686 -> 1687 call = (...) => s0()
 
-1686 -> 1688 conditional = ???*0*
+1686 -> 1688 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6217,13 +6229,13 @@
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-1633 -> 1692 conditional = ???*0*
+1633 -> 1692 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1692 -> 1693 call = (...) => s0()
 
-1692 -> 1694 conditional = ???*0*
+1692 -> 1694 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6259,19 +6271,19 @@
 
 1702 -> 1703 call = (...) => s0()
 
-1702 -> 1704 conditional = ???*0*
+1702 -> 1704 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1704 -> 1705 call = (...) => s0()
 
-1704 -> 1706 conditional = ???*0*
+1704 -> 1706 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1706 -> 1707 call = (...) => s0()
 
-1702 -> 1708 conditional = ???*0*
+1702 -> 1708 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6327,19 +6339,19 @@
 
 0 -> 1721 call = (...) => s0()
 
-0 -> 1722 conditional = ???*0*
+0 -> 1722 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1722 -> 1723 call = (...) => s0()
 
-1722 -> 1724 conditional = ???*0*
+1722 -> 1724 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1724 -> 1725 call = (...) => s0()
 
-1724 -> 1726 conditional = ???*0*
+1724 -> 1726 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6351,7 +6363,7 @@
 
 1728 -> 1729 call = (...) => s0()
 
-1728 -> 1730 conditional = ???*0*
+1728 -> 1730 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6367,7 +6379,7 @@
 
 0 -> 1733 call = (...) => s0()
 
-0 -> 1734 conditional = ???*0*
+0 -> 1734 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6409,7 +6421,7 @@
 
 1744 -> 1745 call = (...) => s0()
 
-1744 -> 1746 conditional = ???*0*
+1744 -> 1746 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6451,7 +6463,7 @@
 
 1756 -> 1757 call = (...) => s0()
 
-1756 -> 1758 conditional = ???*0*
+1756 -> 1758 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6468,7 +6480,7 @@
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 1760 conditional = ???*0*
+0 -> 1760 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6480,19 +6492,19 @@
 
 0 -> 1763 call = (...) => s0()
 
-0 -> 1764 conditional = ???*0*
+0 -> 1764 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1764 -> 1765 call = (...) => s0()
 
-1764 -> 1766 conditional = ???*0*
+1764 -> 1766 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1766 -> 1767 call = (...) => s0()
 
-1766 -> 1768 conditional = ???*0*
+1766 -> 1768 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6516,7 +6528,7 @@
     {"type": "literal", "text": "??", "ignoreCase": false}
 )
 
-1766 -> 1774 conditional = ???*0*
+1766 -> 1774 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6536,13 +6548,13 @@
 
 1764 -> 1780 call = (...) => s0()
 
-1764 -> 1781 conditional = ???*0*
+1764 -> 1781 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1781 -> 1782 call = (...) => s0()
 
-1781 -> 1783 conditional = ???*0*
+1781 -> 1783 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6566,7 +6578,7 @@
     {"type": "literal", "text": "??", "ignoreCase": false}
 )
 
-1781 -> 1789 conditional = ???*0*
+1781 -> 1789 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6594,19 +6606,19 @@
 
 0 -> 1796 call = (...) => s0()
 
-0 -> 1797 conditional = ???*0*
+0 -> 1797 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1797 -> 1798 call = (...) => s0()
 
-1797 -> 1799 conditional = ???*0*
+1797 -> 1799 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1799 -> 1800 call = (...) => s0()
 
-1799 -> 1801 conditional = ???*0*
+1799 -> 1801 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6626,13 +6638,13 @@
 
 1797 -> 1807 call = (...) => s0()
 
-1797 -> 1808 conditional = ???*0*
+1797 -> 1808 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1808 -> 1809 call = (...) => s0()
 
-1808 -> 1810 conditional = ???*0*
+1808 -> 1810 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6660,13 +6672,13 @@
 
 0 -> 1817 call = (...) => s0()
 
-0 -> 1818 conditional = ???*0*
+0 -> 1818 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1818 -> 1819 call = (...) => s0()
 
-1818 -> 1820 conditional = ???*0*
+1818 -> 1820 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6758,7 +6770,7 @@
 
 1818 -> 1844 call = (...) => s0()
 
-1818 -> 1845 conditional = ???*0*
+1818 -> 1845 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6858,13 +6870,13 @@
 
 0 -> 1870 call = (...) => s0()
 
-0 -> 1871 conditional = ???*0*
+0 -> 1871 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1871 -> 1872 call = (...) => s0()
 
-1871 -> 1873 conditional = ???*0*
+1871 -> 1873 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6980,7 +6992,7 @@
 
 1871 -> 1903 call = (...) => s0()
 
-1871 -> 1904 conditional = ???*0*
+1871 -> 1904 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7104,7 +7116,7 @@
 
 0 -> 1935 call = (...) => s0()
 
-0 -> 1936 conditional = ???*0*
+0 -> 1936 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7116,7 +7128,7 @@
 
 1938 -> 1939 call = (...) => s0()
 
-1938 -> 1940 conditional = ???*0*
+1938 -> 1940 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7158,7 +7170,7 @@
 
 1950 -> 1951 call = (...) => s0()
 
-1950 -> 1952 conditional = ???*0*
+1950 -> 1952 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7198,7 +7210,7 @@
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 1962 conditional = ???*0*
+0 -> 1962 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7210,7 +7222,7 @@
 
 0 -> 1965 call = (...) => s0()
 
-0 -> 1966 conditional = ???*0*
+0 -> 1966 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7222,7 +7234,7 @@
 
 1968 -> 1969 call = (...) => s0()
 
-1968 -> 1970 conditional = ???*0*
+1968 -> 1970 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7234,7 +7246,7 @@
 
 1972 -> 1973 call = (...) => s0()
 
-1972 -> 1974 conditional = ???*0*
+1972 -> 1974 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7246,7 +7258,7 @@
 
 1976 -> 1977 call = (...) => s0()
 
-1976 -> 1978 conditional = ???*0*
+1976 -> 1978 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7258,7 +7270,7 @@
 
 1980 -> 1981 call = (...) => s0()
 
-1980 -> 1982 conditional = ???*0*
+1980 -> 1982 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7270,7 +7282,7 @@
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 1984 conditional = ???*0*
+0 -> 1984 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7282,13 +7294,13 @@
 
 0 -> 1987 call = (...) => s0()
 
-0 -> 1988 conditional = ???*0*
+0 -> 1988 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1988 -> 1989 call = (...) => s0()
 
-1988 -> 1990 conditional = ???*0*
+1988 -> 1990 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7332,7 +7344,7 @@
 
 1988 -> 2002 call = (...) => s0()
 
-1988 -> 2003 conditional = ???*0*
+1988 -> 2003 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7384,13 +7396,13 @@
 
 0 -> 2016 call = (...) => s0()
 
-0 -> 2017 conditional = ???*0*
+0 -> 2017 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2017 -> 2018 call = (...) => s0()
 
-2017 -> 2019 conditional = ???*0*
+2017 -> 2019 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7434,7 +7446,7 @@
 
 2017 -> 2031 call = (...) => s0()
 
-2017 -> 2032 conditional = ???*0*
+2017 -> 2032 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7486,13 +7498,13 @@
 
 0 -> 2045 call = (...) => s0()
 
-0 -> 2046 conditional = ???*0*
+0 -> 2046 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2046 -> 2047 call = (...) => s0()
 
-2046 -> 2048 conditional = ???*0*
+2046 -> 2048 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7536,7 +7548,7 @@
 
 2046 -> 2060 call = (...) => s0()
 
-2046 -> 2061 conditional = ???*0*
+2046 -> 2061 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7588,13 +7600,13 @@
 
 0 -> 2074 call = (...) => s0()
 
-0 -> 2075 conditional = ???*0*
+0 -> 2075 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2075 -> 2076 call = (...) => s0()
 
-2075 -> 2077 conditional = ???*0*
+2075 -> 2077 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7686,7 +7698,7 @@
 
 2075 -> 2101 call = (...) => s0()
 
-2075 -> 2102 conditional = ???*0*
+2075 -> 2102 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7786,13 +7798,13 @@
 
 0 -> 2127 call = (...) => s0()
 
-0 -> 2128 conditional = ???*0*
+0 -> 2128 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2128 -> 2129 call = (...) => s0()
 
-2128 -> 2130 conditional = ???*0*
+2128 -> 2130 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7884,7 +7896,7 @@
 
 2128 -> 2154 call = (...) => s0()
 
-2128 -> 2155 conditional = ???*0*
+2128 -> 2155 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7984,13 +7996,13 @@
 
 0 -> 2180 call = (...) => s0()
 
-0 -> 2181 conditional = ???*0*
+0 -> 2181 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2181 -> 2182 call = (...) => s0()
 
-2181 -> 2183 conditional = ???*0*
+2181 -> 2183 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8082,7 +8094,7 @@
 
 2181 -> 2207 call = (...) => s0()
 
-2181 -> 2208 conditional = ???*0*
+2181 -> 2208 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8182,13 +8194,13 @@
 
 0 -> 2233 call = (...) => s0()
 
-0 -> 2234 conditional = ???*0*
+0 -> 2234 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2234 -> 2235 call = (...) => s0()
 
-0 -> 2236 conditional = ???*0*
+0 -> 2236 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8230,7 +8242,7 @@
 
 2246 -> 2247 call = (...) => s0()
 
-2246 -> 2248 conditional = ???*0*
+2246 -> 2248 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8246,13 +8258,13 @@
 
 0 -> 2251 call = (...) => s0()
 
-0 -> 2252 conditional = ???*0*
+0 -> 2252 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2252 -> 2253 call = (...) => s0()
 
-0 -> 2254 conditional = ???*0*
+0 -> 2254 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8294,7 +8306,7 @@
 
 2264 -> 2265 call = (...) => s0()
 
-2264 -> 2266 conditional = ???*0*
+2264 -> 2266 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8310,7 +8322,7 @@
 
 0 -> 2269 call = (...) => s0()
 
-0 -> 2270 conditional = ???*0*
+0 -> 2270 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8324,13 +8336,13 @@
 
 0 -> 2273 call = (...) => s0()
 
-0 -> 2274 conditional = ???*0*
+0 -> 2274 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2274 -> 2275 call = (...) => s0()
 
-2274 -> 2276 conditional = ???*0*
+2274 -> 2276 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8366,7 +8378,7 @@
 
 2284 -> 2285 call = (...) => s0()
 
-2284 -> 2286 conditional = ???*0*
+2284 -> 2286 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8382,13 +8394,13 @@
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-2274 -> 2290 conditional = ???*0*
+2274 -> 2290 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2290 -> 2291 call = (...) => s0()
 
-2290 -> 2292 conditional = ???*0*
+2290 -> 2292 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8424,19 +8436,19 @@
 
 2300 -> 2301 call = (...) => s0()
 
-2300 -> 2302 conditional = ???*0*
+2300 -> 2302 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2302 -> 2303 call = (...) => s0()
 
-2302 -> 2304 conditional = ???*0*
+2302 -> 2304 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2304 -> 2305 call = (...) => s0()
 
-2300 -> 2306 conditional = ???*0*
+2300 -> 2306 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8476,7 +8488,7 @@
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-2274 -> 2316 conditional = ???*0*
+2274 -> 2316 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8488,7 +8500,7 @@
 
 2316 -> 2319 call = (...) => s0()
 
-2316 -> 2320 conditional = ???*0*
+2316 -> 2320 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8524,7 +8536,7 @@
 
 2328 -> 2329 call = (...) => s0()
 
-2328 -> 2330 conditional = ???*0*
+2328 -> 2330 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8540,13 +8552,13 @@
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-2316 -> 2334 conditional = ???*0*
+2316 -> 2334 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2334 -> 2335 call = (...) => s0()
 
-2334 -> 2336 conditional = ???*0*
+2334 -> 2336 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8582,19 +8594,19 @@
 
 2344 -> 2345 call = (...) => s0()
 
-2344 -> 2346 conditional = ???*0*
+2344 -> 2346 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2346 -> 2347 call = (...) => s0()
 
-2346 -> 2348 conditional = ???*0*
+2346 -> 2348 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2348 -> 2349 call = (...) => s0()
 
-2344 -> 2350 conditional = ???*0*
+2344 -> 2350 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8650,7 +8662,7 @@
 
 0 -> 2363 call = (...) => s0()
 
-0 -> 2364 conditional = ???*0*
+0 -> 2364 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8664,13 +8676,13 @@
 
 0 -> 2367 call = (...) => s0()
 
-0 -> 2368 conditional = ???*0*
+0 -> 2368 conditional = (???*0* === {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2368 -> 2369 call = (...) => s0()
 
-0 -> 2370 conditional = ???*0*
+0 -> 2370 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8788,13 +8800,13 @@
 
 0 -> 2397 call = (...) => s0()
 
-0 -> 2398 conditional = ???*0*
+0 -> 2398 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2398 -> 2399 call = (...) => s0()
 
-2398 -> 2400 conditional = ???*0*
+2398 -> 2400 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8830,7 +8842,7 @@
 
 2408 -> 2409 call = (...) => s0()
 
-2408 -> 2410 conditional = ???*0*
+2408 -> 2410 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8848,7 +8860,7 @@
 
 2398 -> 2414 call = (...) => s0()
 
-2398 -> 2415 conditional = ???*0*
+2398 -> 2415 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8884,7 +8896,7 @@
 
 2423 -> 2424 call = (...) => s0()
 
-2423 -> 2425 conditional = ???*0*
+2423 -> 2425 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8930,7 +8942,7 @@
     {"type": "literal", "text": "(", "ignoreCase": false}
 )
 
-0 -> 2435 conditional = ???*0*
+0 -> 2435 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8942,7 +8954,7 @@
 
 2437 -> 2438 call = (...) => s0()
 
-2437 -> 2439 conditional = ???*0*
+2437 -> 2439 conditional = (???*0* !== {})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/peg/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/peg/resolved-explained.snapshot
@@ -326,31 +326,19 @@ descriptions = new ???*0*(???*1*)
 - *2* arguments[0]
   ⚠️  function calls are not analysed yet
 
-details = (
-  | {"line": 1, "column": 1}
-  | ???*0*
-  | {"line": (1 | ???*2* | ???*3*), "column": (1 | ???*6* | ???*7*)}
-)
+details = ({"line": 1, "column": 1} | ???*0* | {"line": ???*2*, "column": ???*4*})
 - *0* [][???*1*]
   ⚠️  unknown array prototype methods or values
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
-- *2* unknown mutation
-  ⚠️  This value might have side effects
-- *3* ???*4*["line"]
+- *2* ???*3*["line"]
   ⚠️  unknown object
-- *4* [][???*5*]
-  ⚠️  unknown array prototype methods or values
-- *5* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *6* unknown mutation
-  ⚠️  This value might have side effects
-- *7* ???*8*["column"]
+- *3* details
+  ⚠️  circular variable reference
+- *4* ???*5*["column"]
   ⚠️  unknown object
-- *8* [][???*9*]
-  ⚠️  unknown array prototype methods or values
-- *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *5* details
+  ⚠️  circular variable reference
 
 digits = ???*0*
 - *0* arguments[0]
@@ -384,56 +372,34 @@ endPosDetails = (undefined | {"line": 1, "column": 1} | ???*0* | {"line": ???*2*
 
 error = (...) => undefined
 
-escapedParts = ("" | (("" | ???*0*) + ???*12*))
-- *0* (???*1* + ???*2*)
-  ⚠️  nested operation
-- *1* escapedParts
+escapedParts = ("" | (???*0* + ???*1*))
+- *0* escapedParts
   ⚠️  circular variable reference
-- *2* (???*3* ? ???*4* : ???*9*)
+- *1* (???*2* ? ???*3* : ???*10*)
   ⚠️  nested operation
-- *3* unsupported expression
+- *2* unsupported expression
   ⚠️  This value might have side effects
-- *4* `${???*5*}-${???*7*}`
+- *3* `${???*4*}-${???*7*}`
   ⚠️  nested operation
-- *5* ???*6*["replace"](/[\x10-\x1F\x7F-\x9F]/g, *anonymous function 2385*)
+- *4* ???*5*["replace"](/[\x10-\x1F\x7F-\x9F]/g, *anonymous function 2385*)
   ⚠️  unknown callee object
-- *6* ???["replace"](/[\x00-\x0F]/g, *anonymous function 2287*)
+- *5* ???*6*["replace"](/[\x00-\x0F]/g, *anonymous function 2287*)
+  ⚠️  unknown callee object
+- *6* ???["replace"](/\r/g, "\\r")
   ⚠️  unknown callee object
 - *7* ???*8*["replace"](/[\x10-\x1F\x7F-\x9F]/g, *anonymous function 2385*)
   ⚠️  unknown callee object
-- *8* ???["replace"](/[\x00-\x0F]/g, *anonymous function 2287*)
+- *8* ???*9*["replace"](/[\x00-\x0F]/g, *anonymous function 2287*)
   ⚠️  unknown callee object
-- *9* ???*10*["replace"](/[\x10-\x1F\x7F-\x9F]/g, *anonymous function 2385*)
+- *9* ???["replace"](/\r/g, "\\r")
   ⚠️  unknown callee object
-- *10* ???*11*["replace"](/[\x00-\x0F]/g, *anonymous function 2287*)
+- *10* ???*11*["replace"](/[\x10-\x1F\x7F-\x9F]/g, *anonymous function 2385*)
   ⚠️  unknown callee object
-- *11* ???["replace"](/\r/g, "\\r")
+- *11* ???*12*["replace"](/[\x00-\x0F]/g, *anonymous function 2287*)
   ⚠️  unknown callee object
-- *12* (???*13* ? ???*14* : ???*21*)
-  ⚠️  nested operation
-- *13* unsupported expression
-  ⚠️  This value might have side effects
-- *14* `${???*15*}-${???*18*}`
-  ⚠️  nested operation
-- *15* ???*16*["replace"](/[\x10-\x1F\x7F-\x9F]/g, *anonymous function 2385*)
+- *12* ???*13*["replace"](/\r/g, "\\r")
   ⚠️  unknown callee object
-- *16* ???*17*["replace"](/[\x00-\x0F]/g, *anonymous function 2287*)
-  ⚠️  unknown callee object
-- *17* ???["replace"](/\r/g, "\\r")
-  ⚠️  unknown callee object
-- *18* ???*19*["replace"](/[\x10-\x1F\x7F-\x9F]/g, *anonymous function 2385*)
-  ⚠️  unknown callee object
-- *19* ???*20*["replace"](/[\x00-\x0F]/g, *anonymous function 2287*)
-  ⚠️  unknown callee object
-- *20* ???["replace"](/\r/g, "\\r")
-  ⚠️  unknown callee object
-- *21* ???*22*["replace"](/[\x10-\x1F\x7F-\x9F]/g, *anonymous function 2385*)
-  ⚠️  unknown callee object
-- *22* ???*23*["replace"](/[\x00-\x0F]/g, *anonymous function 2287*)
-  ⚠️  unknown callee object
-- *23* ???*24*["replace"](/\r/g, "\\r")
-  ⚠️  unknown callee object
-- *24* ???["replace"](/\n/g, "\\n")
+- *13* ???["replace"](/\n/g, "\\n")
   ⚠️  unknown callee object
 
 expectation#11 = ???*0*
@@ -728,36 +694,16 @@ operator#87 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-options = (???*0* | (???*1* ? (???*9* | ???*10*) : {}))
+options = (???*0* | (???*1* ? ???*4* : {}))
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
-- *1* ((???*2* | ???*3*) !== ???*8*)
+- *1* (???*2* !== ???*3*)
   ⚠️  nested operation
-- *2* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *3* (???*4* ? ???*7* : {})
-  ⚠️  nested operation
-- *4* (???*5* !== ???*6*)
-  ⚠️  nested operation
-- *5* options
+- *2* options
   ⚠️  circular variable reference
-- *6* unsupported expression
+- *3* unsupported expression
   ⚠️  This value might have side effects
-- *7* options
-  ⚠️  circular variable reference
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *10* (???*11* ? ???*14* : {})
-  ⚠️  nested operation
-- *11* (???*12* !== ???*13*)
-  ⚠️  nested operation
-- *12* options
-  ⚠️  circular variable reference
-- *13* unsupported expression
-  ⚠️  This value might have side effects
-- *14* options
+- *4* options
   ⚠️  circular variable reference
 
 order = ???*0*
@@ -2177,21 +2123,12 @@ s1#609 = ???*0*
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-s1#617 = (
-  | ???*0*
-  | "--"
-  | {}
-  | [(???*1* | "--" | {} | [???*2*, (???*3* | [])]), (???*4* | [])]
-)
+s1#617 = (???*0* | "--" | {} | [???*1*, (???*2* | [])])
 - *0* s1
   ⚠️  pattern without value
 - *1* s1
-  ⚠️  pattern without value
-- *2* s1
   ⚠️  circular variable reference
-- *3* s2
-  ⚠️  pattern without value
-- *4* s2
+- *2* s2
   ⚠️  pattern without value
 
 s1#644 = ???*0*
@@ -2306,12 +2243,7 @@ s1#886 = ???*0*
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-s1#897 = (
-  | ???*0*
-  | ???*1*
-  | {}
-  | ((???*3* | ???*4* | {} | ???*6*) + (???*12* | ???*14*))
-)
+s1#897 = (???*0* | ???*1* | {} | (???*3* + (???*4* | ???*6*)))
 - *0* s1
   ⚠️  pattern without value
 - *1* ???*2*["charAt"](peg$currPos)
@@ -2319,30 +2251,14 @@ s1#897 = (
 - *2* arguments[0]
   ⚠️  function calls are not analysed yet
 - *3* s1
-  ⚠️  pattern without value
-- *4* ???*5*["charAt"](peg$currPos)
-  ⚠️  unknown callee object
-- *5* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *6* (???*7* + (???*8* | ???*10*))
-  ⚠️  nested operation
-- *7* s1
   ⚠️  circular variable reference
-- *8* ???*9*["join"]("")
+- *4* ???*5*["join"]("")
   ⚠️  unknown callee object
-- *9* s2
+- *5* s2
   ⚠️  pattern without value
-- *10* ???*11*("")
+- *6* ???*7*("")
   ⚠️  unknown callee
-- *11* []["join"]
-  ⚠️  non-num constant property on array
-- *12* ???*13*["join"]("")
-  ⚠️  unknown callee object
-- *13* s2
-  ⚠️  pattern without value
-- *14* ???*15*("")
-  ⚠️  unknown callee
-- *15* []["join"]
+- *7* []["join"]
   ⚠️  non-num constant property on array
 
 s1#909 = (???*0* | "@" | {} | {"type": "parameter_name", "name": ???*1*})
@@ -3037,17 +2953,7 @@ s4#1031 = (
   | ???*0*
   | ???*1*
   | {}
-  | [
-        (
-          | ???*3*
-          | ???*4*
-          | {}
-          | [???*6*, (???*7* | ???*8* | {}), (???*10* | ???*11* | {}), (???*13* | ???*14* | {})]
-        ),
-        (???*16* | ???*17* | {}),
-        (???*19* | ???*20* | {}),
-        (???*22* | ???*23* | {})
-    ]
+  | [???*3*, (???*4* | ???*5* | {}), (???*7* | ???*8* | {}), (???*10* | ???*11* | {})]
 )
 - *0* s4
   ⚠️  pattern without value
@@ -3056,48 +2962,24 @@ s4#1031 = (
 - *2* arguments[0]
   ⚠️  function calls are not analysed yet
 - *3* s4
-  ⚠️  pattern without value
-- *4* ???*5*["charAt"](peg$currPos)
-  ⚠️  unknown callee object
-- *5* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *6* s4
   ⚠️  circular variable reference
-- *7* s5
+- *4* s5
+  ⚠️  pattern without value
+- *5* ???*6*["charAt"](peg$currPos)
+  ⚠️  unknown callee object
+- *6* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *7* s6
   ⚠️  pattern without value
 - *8* ???*9*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *9* arguments[0]
   ⚠️  function calls are not analysed yet
-- *10* s6
+- *10* s7
   ⚠️  pattern without value
 - *11* ???*12*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *13* s7
-  ⚠️  pattern without value
-- *14* ???*15*["charAt"](peg$currPos)
-  ⚠️  unknown callee object
-- *15* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *16* s5
-  ⚠️  pattern without value
-- *17* ???*18*["charAt"](peg$currPos)
-  ⚠️  unknown callee object
-- *18* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *19* s6
-  ⚠️  pattern without value
-- *20* ???*21*["charAt"](peg$currPos)
-  ⚠️  unknown callee object
-- *21* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *22* s7
-  ⚠️  pattern without value
-- *23* ???*24*["charAt"](peg$currPos)
-  ⚠️  unknown callee object
-- *24* arguments[0]
   ⚠️  function calls are not analysed yet
 
 s4#1053 = ???*0*
@@ -3360,21 +3242,12 @@ s5#419 = (???*0* | "]" | {})
 - *0* s5
   ⚠️  pattern without value
 
-s5#454 = (
-  | ???*0*
-  | "."
-  | {}
-  | [(???*1* | "." | {} | [???*2*, (???*3* | [] | {})]), (???*4* | [] | {})]
-)
+s5#454 = (???*0* | "." | {} | [???*1*, (???*2* | [] | {})])
 - *0* s5
   ⚠️  pattern without value
 - *1* s5
-  ⚠️  pattern without value
-- *2* s5
   ⚠️  circular variable reference
-- *3* s6
-  ⚠️  pattern without value
-- *4* s6
+- *2* s6
   ⚠️  pattern without value
 
 s5#525 = ???*0*

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-effects.snapshot
@@ -855,7 +855,7 @@
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 71 conditional = ???*0*
+0 -> 71 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1181,7 +1181,7 @@
 
 0 -> 124 free var = FreeVar(exports)
 
-0 -> 125 conditional = ???*0*
+0 -> 125 conditional = (null == ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1189,24 +1189,37 @@
 - *0* unreachable
   ⚠️  This value might have side effects
 
-125 -> 128 conditional = ???*0*
-- *0* max number of linking steps reached
+125 -> 128 conditional = (1 === ???*0*)
+- *0* ???*1*["nodeType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 128 -> 129 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
-128 -> 131 conditional = ???*0*
-- *0* max number of linking steps reached
+128 -> 131 conditional = (???*0* === ???*1*)
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 131 -> 132 typeof = typeof(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["render"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-131 -> 134 conditional = ???*0*
-- *0* max number of linking steps reached
+131 -> 134 conditional = ("function" === ???*0*)
+- *0* typeof(???*1*)
+  ⚠️  nested operation
+- *1* ???*2*["render"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 134 -> 135 free var = FreeVar(Error)
@@ -1230,7 +1243,14 @@
   ⚠️  This value might have side effects
 
 131 -> 142 member call = ???*0*["join"](",")
-- *0* max number of linking steps reached
+- *0* ???*1*(???*3*)
+  ⚠️  unknown callee
+  ⚠️  This value might have side effects
+- *1* Object*2*["keys"]
+  ⚠️  unsupported property on global Object
+  ⚠️  This value might have side effects
+- *2* Object: The global Object variable
+- *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
 131 -> 143 free var = FreeVar(Error)
@@ -1239,18 +1259,20 @@
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-131 -> 145 call = ???*0*(???*1*)
+131 -> 145 call = ???*0*(
+    `Minified React error #${268}; visit ${???*1*} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`
+)
 - *0* FreeVar(Error)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
-  ⚠️  This value might have side effects
+- *1* `https://reactjs.org/docs/error-decoder.html?invariant=${268}`
+  ⚠️  nested operation
 
 128 -> 146 call = (...) => ((null !== a) ? $b(a) : null)(???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-128 -> 147 conditional = ???*0*
+128 -> 147 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1638,78 +1660,84 @@
 - *27* updated with update expression
   ⚠️  This value might have side effects
 
-181 -> 188 conditional = ???*0*
-- *0* max number of linking steps reached
+181 -> 188 conditional = (null == ???*0*)
+- *0* ???*1*["mutableSourceEagerHydrationData"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 188 -> 192 member call = ???*0*["push"](
-    (???*1* | (null != ???*2*)[(???*3* | 0 | ???*4*)] | ???*5* | null[(???*10* | 0 | ???*11*)]),
+    (???*2* | (null != ???*3*)[(???*4* | 0 | ???*5*)] | ???*6* | null[(???*11* | 0 | ???*12*)]),
     (
       | false
       | true
-      | ???*12*
-      | (null != ???*14*)[(???*15* | 0 | ???*16*)]["_getVersion"]
-      | ???*17*
-      | null[(???*23* | 0 | ???*24*)]["_getVersion"]
-      | ???*25*
+      | ???*13*
+      | (null != ???*15*)[(???*16* | 0 | ???*17*)]["_getVersion"]
+      | ???*18*
+      | null[(???*24* | 0 | ???*25*)]["_getVersion"]
+      | ???*26*
     )
 )
-- *0* max number of linking steps reached
+- *0* ???*1*["mutableSourceEagerHydrationData"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
-- *1* arguments[2]
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* arguments[2]
   ⚠️  function calls are not analysed yet
-- *2* c
+- *3* c
   ⚠️  circular variable reference
-- *3* arguments[0]
+- *4* arguments[0]
   ⚠️  function calls are not analysed yet
-- *4* updated with update expression
+- *5* updated with update expression
   ⚠️  This value might have side effects
-- *5* ???*6*[(???*8* | 0 | ???*9*)]
+- *6* ???*7*[(???*9* | 0 | ???*10*)]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *6* ???*7*["hydratedSources"]
+- *7* ???*8*["hydratedSources"]
   ⚠️  unknown object
-- *7* c
+- *8* c
   ⚠️  circular variable reference
-- *8* arguments[0]
+- *9* arguments[0]
   ⚠️  function calls are not analysed yet
-- *9* updated with update expression
+- *10* updated with update expression
   ⚠️  This value might have side effects
-- *10* arguments[0]
+- *11* arguments[0]
   ⚠️  function calls are not analysed yet
-- *11* updated with update expression
+- *12* updated with update expression
   ⚠️  This value might have side effects
-- *12* ???*13*["_getVersion"]
+- *13* ???*14*["_getVersion"]
   ⚠️  unknown object
-- *13* arguments[2]
+- *14* arguments[2]
   ⚠️  function calls are not analysed yet
-- *14* c
+- *15* c
   ⚠️  circular variable reference
-- *15* arguments[0]
+- *16* arguments[0]
   ⚠️  function calls are not analysed yet
-- *16* updated with update expression
+- *17* updated with update expression
   ⚠️  This value might have side effects
-- *17* ???*18*["_getVersion"]
+- *18* ???*19*["_getVersion"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *18* ???*19*[(???*21* | 0 | ???*22*)]
+- *19* ???*20*[(???*22* | 0 | ???*23*)]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *19* ???*20*["hydratedSources"]
+- *20* ???*21*["hydratedSources"]
   ⚠️  unknown object
-- *20* c
+- *21* c
   ⚠️  circular variable reference
-- *21* arguments[0]
+- *22* arguments[0]
   ⚠️  function calls are not analysed yet
-- *22* updated with update expression
+- *23* updated with update expression
   ⚠️  This value might have side effects
-- *23* arguments[0]
+- *24* arguments[0]
   ⚠️  function calls are not analysed yet
-- *24* updated with update expression
+- *25* updated with update expression
   ⚠️  This value might have side effects
-- *25* ???*26*(c["_source"])
+- *26* ???*27*(c["_source"])
   ⚠️  unknown callee
-- *26* e
+- *27* e
   ⚠️  circular variable reference
 
 0 -> 193 call = new (...) => undefined(???*0*)
@@ -6546,7 +6574,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *2* "cssFloat"["indexOf"]("--")
   ⚠️  nested operation
 
-1010 -> 1012 member call = (???*0* | ???*1*)["setProperty"]((???*3* | "cssFloat"), ???*4*)
+1010 -> 1012 member call = (???*0* | ???*1*)["setProperty"]((???*3* | "cssFloat"), (???*4* ? "" : ???*7*))
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["style"]
@@ -6555,8 +6583,47 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  circular variable reference
 - *3* c
   ⚠️  pattern without value
-- *4* max number of linking steps reached
+- *4* (null == ???*5*)
+  ⚠️  nested operation
+- *5* ???*6*[c]
+  ⚠️  unknown object
+- *6* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *7* ((???*8* | ???*12* | ???*16*) ? ???*17* : ???*21*)
+  ⚠️  nested operation
+- *8* (0 === (???*9* | ???*11*))
+  ⚠️  nested operation
+- *9* ???*10*["indexOf"]("--")
+  ⚠️  unknown callee object
+- *10* c
+  ⚠️  pattern without value
+- *11* "cssFloat"["indexOf"]("--")
+  ⚠️  nested operation
+- *12* (???*13* | ???*14*)((???*15* | "cssFloat"))
+  ⚠️  non-function callee
+- *13* FreeVar(undefined)
+  ⚠️  unknown global
   ⚠️  This value might have side effects
+- *14* unknown mutation
+  ⚠️  This value might have side effects
+- *15* c
+  ⚠️  pattern without value
+- *16* node limit reached
+  ⚠️  This value might have side effects
+- *17* ???*18*()
+  ⚠️  nested operation
+- *18* ???*19*["trim"]
+  ⚠️  unknown object
+- *19* ???*20*[c]
+  ⚠️  unknown object
+- *20* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *21* `${???*22*}px`
+  ⚠️  nested operation
+- *22* ???*23*[c]
+  ⚠️  unknown object
+- *23* arguments[1]
+  ⚠️  function calls are not analysed yet
 
 0 -> 1014 call = Object.assign*0*(
     {"menuitem": true},
@@ -9176,15 +9243,223 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
 
-0 -> 1393 conditional = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
+0 -> 1393 conditional = (null !== (
+  | ???*0*
+  | null[???*7*]
+  | null["parentNode"][???*12*]
+  | null[???*17*][???*22*]
+  | null["parentNode"]
+  | null[???*27*]["alternate"]
+  | null
+))
+- *0* ???*1*[`__reactFiber$${???*3*}`]
+  ⚠️  unknown object
+- *1* ???*2*["target"]
+  ⚠️  unknown object
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *3* ???*4*["slice"](2)
+  ⚠️  unknown callee object
+- *4* ???*5*(36)
+  ⚠️  unknown callee
+- *5* ???*6*["toString"]
+  ⚠️  unknown object
+- *6* ???()
+  ⚠️  nested operation
+- *7* `__reactFiber$${???*8*}`
+  ⚠️  nested operation
+- *8* ???*9*["slice"](2)
+  ⚠️  unknown callee object
+- *9* ???*10*(36)
+  ⚠️  unknown callee
+- *10* ???*11*["toString"]
+  ⚠️  unknown object
+- *11* ???()
+  ⚠️  nested operation
+- *12* `__reactContainer$${???*13*}`
+  ⚠️  nested operation
+- *13* ???*14*["slice"](2)
+  ⚠️  unknown callee object
+- *14* ???*15*(36)
+  ⚠️  unknown callee
+- *15* ???*16*["toString"]
+  ⚠️  unknown object
+- *16* ???()
+  ⚠️  nested operation
+- *17* `__reactFiber$${???*18*}`
+  ⚠️  nested operation
+- *18* ???*19*["slice"](2)
+  ⚠️  unknown callee object
+- *19* ???*20*(36)
+  ⚠️  unknown callee
+- *20* ???*21*["toString"]
+  ⚠️  unknown object
+- *21* ???()
+  ⚠️  nested operation
+- *22* `__reactContainer$${???*23*}`
+  ⚠️  nested operation
+- *23* ???*24*["slice"](2)
+  ⚠️  unknown callee object
+- *24* ???*25*(36)
+  ⚠️  unknown callee
+- *25* ???*26*["toString"]
+  ⚠️  unknown object
+- *26* ???()
+  ⚠️  nested operation
+- *27* `__reactFiber$${???*28*}`
+  ⚠️  nested operation
+- *28* ???*29*["slice"](2)
+  ⚠️  unknown callee object
+- *29* ???*30*(36)
+  ⚠️  unknown callee
+- *30* ???*31*["toString"]
+  ⚠️  unknown object
+- *31* ???()
+  ⚠️  nested operation
 
-1393 -> 1394 call = (...) => ((3 === b["tag"]) ? c : null)(???*0*)
-- *0* max number of linking steps reached
+1393 -> 1394 call = (...) => ((3 === b["tag"]) ? c : null)(
+    (
+      | ???*0*
+      | null[`__reactFiber$${???*7*}`]
+      | null["parentNode"][`__reactContainer$${???*12*}`]
+      | null[`__reactFiber$${???*17*}`][`__reactContainer$${???*22*}`]
+      | null["parentNode"][`__reactFiber$${???*27*}`]
+      | null[`__reactFiber$${???*32*}`][`__reactFiber$${???*37*}`]
+      | null["parentNode"]
+      | null[`__reactFiber$${???*42*}`]["alternate"]
+      | null
+      | (???*47* ? (???*50* | ???*51*) : null)["tag"]
+      | (???*53* ? (???*56* | ???*57*) : null)["memoizedState"]["dehydrated"]
+    )
+)
+- *0* ???*1*[`__reactFiber$${???*3*}`]
+  ⚠️  unknown object
+- *1* ???*2*["target"]
+  ⚠️  unknown object
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *3* ???*4*["slice"](2)
+  ⚠️  unknown callee object
+- *4* ???*5*(36)
+  ⚠️  unknown callee
+- *5* ???*6*["toString"]
+  ⚠️  unknown object
+- *6* ???()
+  ⚠️  nested operation
+- *7* ???*8*["slice"](2)
+  ⚠️  unknown callee object
+- *8* ???*9*(36)
+  ⚠️  unknown callee
+- *9* ???*10*["toString"]
+  ⚠️  unknown object
+- *10* ???*11*()
+  ⚠️  nested operation
+- *11* ???["random"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
+- *12* ???*13*["slice"](2)
+  ⚠️  unknown callee object
+- *13* ???*14*(36)
+  ⚠️  unknown callee
+- *14* ???*15*["toString"]
+  ⚠️  unknown object
+- *15* ???*16*()
+  ⚠️  nested operation
+- *16* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *17* ???*18*["slice"](2)
+  ⚠️  unknown callee object
+- *18* ???*19*(36)
+  ⚠️  unknown callee
+- *19* ???*20*["toString"]
+  ⚠️  unknown object
+- *20* ???*21*()
+  ⚠️  nested operation
+- *21* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *22* ???*23*["slice"](2)
+  ⚠️  unknown callee object
+- *23* ???*24*(36)
+  ⚠️  unknown callee
+- *24* ???*25*["toString"]
+  ⚠️  unknown object
+- *25* ???*26*()
+  ⚠️  nested operation
+- *26* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *27* ???*28*["slice"](2)
+  ⚠️  unknown callee object
+- *28* ???*29*(36)
+  ⚠️  unknown callee
+- *29* ???*30*["toString"]
+  ⚠️  unknown object
+- *30* ???*31*()
+  ⚠️  nested operation
+- *31* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *32* ???*33*["slice"](2)
+  ⚠️  unknown callee object
+- *33* ???*34*(36)
+  ⚠️  unknown callee
+- *34* ???*35*["toString"]
+  ⚠️  unknown object
+- *35* ???*36*()
+  ⚠️  nested operation
+- *36* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *37* ???*38*["slice"](2)
+  ⚠️  unknown callee object
+- *38* ???*39*(36)
+  ⚠️  unknown callee
+- *39* ???*40*["toString"]
+  ⚠️  unknown object
+- *40* ???*41*()
+  ⚠️  nested operation
+- *41* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *42* ???*43*["slice"](2)
+  ⚠️  unknown callee object
+- *43* ???*44*(36)
+  ⚠️  unknown callee
+- *44* ???*45*["toString"]
+  ⚠️  unknown object
+- *45* ???*46*()
+  ⚠️  nested operation
+- *46* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *47* (3 === ???*48*)
+  ⚠️  nested operation
+- *48* ???*49*["tag"]
+  ⚠️  unknown object
+- *49* b
+  ⚠️  circular variable reference
+- *50* b
+  ⚠️  circular variable reference
+- *51* ???*52*["return"]
+  ⚠️  unknown object
+- *52* b
+  ⚠️  circular variable reference
+- *53* (3 === ???*54*)
+  ⚠️  nested operation
+- *54* ???*55*["tag"]
+  ⚠️  unknown object
+- *55* b
+  ⚠️  circular variable reference
+- *56* b
+  ⚠️  circular variable reference
+- *57* ???*58*["return"]
+  ⚠️  unknown object
+- *58* b
+  ⚠️  circular variable reference
 
-1393 -> 1395 conditional = ???*0*
+1393 -> 1395 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -9213,12 +9488,102 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-1395 -> 1407 conditional = ???*0*
-- *0* max number of linking steps reached
+1395 -> 1407 conditional = (
+  | (3 === (
+      | ???*0*
+      | null[???*7*]
+      | null["parentNode"][???*12*]
+      | null[???*17*][???*22*]
+      | null["parentNode"]
+      | null[???*27*]["alternate"]
+      | null
+    ))
+  | ???*32*
+)
+- *0* ???*1*[`__reactFiber$${???*3*}`]
+  ⚠️  unknown object
+- *1* ???*2*["target"]
+  ⚠️  unknown object
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *3* ???*4*["slice"](2)
+  ⚠️  unknown callee object
+- *4* ???*5*(36)
+  ⚠️  unknown callee
+- *5* ???*6*["toString"]
+  ⚠️  unknown object
+- *6* ???()
+  ⚠️  nested operation
+- *7* `__reactFiber$${???*8*}`
+  ⚠️  nested operation
+- *8* ???*9*["slice"](2)
+  ⚠️  unknown callee object
+- *9* ???*10*(36)
+  ⚠️  unknown callee
+- *10* ???*11*["toString"]
+  ⚠️  unknown object
+- *11* ???()
+  ⚠️  nested operation
+- *12* `__reactContainer$${???*13*}`
+  ⚠️  nested operation
+- *13* ???*14*["slice"](2)
+  ⚠️  unknown callee object
+- *14* ???*15*(36)
+  ⚠️  unknown callee
+- *15* ???*16*["toString"]
+  ⚠️  unknown object
+- *16* ???()
+  ⚠️  nested operation
+- *17* `__reactFiber$${???*18*}`
+  ⚠️  nested operation
+- *18* ???*19*["slice"](2)
+  ⚠️  unknown callee object
+- *19* ???*20*(36)
+  ⚠️  unknown callee
+- *20* ???*21*["toString"]
+  ⚠️  unknown object
+- *21* ???()
+  ⚠️  nested operation
+- *22* `__reactContainer$${???*23*}`
+  ⚠️  nested operation
+- *23* ???*24*["slice"](2)
+  ⚠️  unknown callee object
+- *24* ???*25*(36)
+  ⚠️  unknown callee
+- *25* ???*26*["toString"]
+  ⚠️  unknown object
+- *26* ???()
+  ⚠️  nested operation
+- *27* `__reactFiber$${???*28*}`
+  ⚠️  nested operation
+- *28* ???*29*["slice"](2)
+  ⚠️  unknown callee object
+- *29* ???*30*(36)
+  ⚠️  unknown callee
+- *30* ???*31*["toString"]
+  ⚠️  unknown object
+- *31* ???()
+  ⚠️  nested operation
+- *32* ???*33*["isDehydrated"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *33* ???*34*["memoizedState"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *34* ???*35*["current"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *35* ???*36*["stateNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *36* max number of linking steps reached
   ⚠️  This value might have side effects
 
-1407 -> 1410 conditional = ???*0*
-- *0* max number of linking steps reached
+1407 -> 1410 conditional = (3 === ???*0*)
+- *0* ???*1*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1407 -> 1413 unreachable = ???*0*
@@ -9239,7 +9604,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   | a
   | ((3 === b["tag"]) ? b["stateNode"]["containerInfo"] : null)
   | null
-)(???*0*, ???*2*, ???*4*, ???*5*)
+)(???*0*, ???*2*, ???*4*, ???*6*)
 - *0* ???*1*["domEventName"]
   ⚠️  unknown object
 - *1* arguments[0]
@@ -9248,14 +9613,17 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  unknown object
 - *3* arguments[0]
   ⚠️  function calls are not analysed yet
-- *4* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *5* ???*6*["nativeEvent"]
+- *4* ???*5*[0]
   ⚠️  unknown object
-- *6* arguments[0]
+  ⚠️  This value might have side effects
+- *5* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *6* ???*7*["nativeEvent"]
+  ⚠️  unknown object
+- *7* arguments[0]
   ⚠️  function calls are not analysed yet
 
-1416 -> 1425 conditional = ???*0*
+1416 -> 1425 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -9280,18 +9648,24 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-1425 -> 1435 member call = ???*0*["constructor"](???*1*, ???*2*)
+1425 -> 1435 member call = ???*0*["constructor"](???*1*, ???*3*)
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* ???*2*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+
+1425 -> 1438 member call = ???*0*["dispatchEvent"](???*2*)
+- *0* ???*1*["target"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-1425 -> 1438 member call = ???*0*["dispatchEvent"](???*1*)
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 1439 unreachable = ???*0*
@@ -9703,20 +10077,182 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *3* arguments[3]
   ⚠️  function calls are not analysed yet
 
-1491 -> 1493 conditional = ???*0*
+1491 -> 1493 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-1493 -> 1494 call = (...) => (undefined | FreeVar(undefined))(???*0*, ???*1*, ???*2*, ???*3*, ???*4*)
+1493 -> 1494 call = (...) => (undefined | FreeVar(undefined))(
+    ???*0*,
+    ???*1*,
+    ???*2*,
+    (
+      | null
+      | ???*3*
+      | (???*4* ? (???*9* | ???*11*) : (???*13* | ???*14* | ???*16*))
+      | ???*17*
+      | null[`__reactFiber$${???*23*}`]
+      | null["parentNode"][`__reactContainer$${???*28*}`]
+      | null[`__reactFiber$${???*33*}`][`__reactContainer$${???*38*}`]
+      | null["parentNode"][`__reactFiber$${???*43*}`]
+      | null[`__reactFiber$${???*48*}`][`__reactFiber$${???*53*}`]
+      | null["parentNode"]
+      | null[`__reactFiber$${???*58*}`]["alternate"]
+      | (???*63* ? (???*66* | ???*67*) : null)["memoizedState"]["dehydrated"]
+    ),
+    ???*69*
+)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* arguments[1]
   ⚠️  function calls are not analysed yet
 - *2* arguments[3]
   ⚠️  function calls are not analysed yet
-- *3* max number of linking steps reached
+- *3* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *4* (3 === (???*5* | ???*7*))
+  ⚠️  nested operation
+- *5* ???*6*["nodeType"]
+  ⚠️  unknown object
+- *6* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *7* ???*8*["nodeType"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
-- *4* arguments[2]
+- *8* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *9* ???*10*["parentNode"]
+  ⚠️  unknown object
+- *10* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *11* ???*12*["parentNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *12* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *13* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *14* ???*15*["target"]
+  ⚠️  unknown object
+- *15* a
+  ⚠️  circular variable reference
+- *16* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *17* ???*18*[`__reactFiber$${???*19*}`]
+  ⚠️  unknown object
+- *18* a
+  ⚠️  circular variable reference
+- *19* ???*20*["slice"](2)
+  ⚠️  unknown callee object
+- *20* ???*21*(36)
+  ⚠️  unknown callee
+- *21* ???*22*["toString"]
+  ⚠️  unknown object
+- *22* ???()
+  ⚠️  nested operation
+- *23* ???*24*["slice"](2)
+  ⚠️  unknown callee object
+- *24* ???*25*(36)
+  ⚠️  unknown callee
+- *25* ???*26*["toString"]
+  ⚠️  unknown object
+- *26* ???*27*()
+  ⚠️  nested operation
+- *27* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *28* ???*29*["slice"](2)
+  ⚠️  unknown callee object
+- *29* ???*30*(36)
+  ⚠️  unknown callee
+- *30* ???*31*["toString"]
+  ⚠️  unknown object
+- *31* ???*32*()
+  ⚠️  nested operation
+- *32* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *33* ???*34*["slice"](2)
+  ⚠️  unknown callee object
+- *34* ???*35*(36)
+  ⚠️  unknown callee
+- *35* ???*36*["toString"]
+  ⚠️  unknown object
+- *36* ???*37*()
+  ⚠️  nested operation
+- *37* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *38* ???*39*["slice"](2)
+  ⚠️  unknown callee object
+- *39* ???*40*(36)
+  ⚠️  unknown callee
+- *40* ???*41*["toString"]
+  ⚠️  unknown object
+- *41* ???*42*()
+  ⚠️  nested operation
+- *42* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *43* ???*44*["slice"](2)
+  ⚠️  unknown callee object
+- *44* ???*45*(36)
+  ⚠️  unknown callee
+- *45* ???*46*["toString"]
+  ⚠️  unknown object
+- *46* ???*47*()
+  ⚠️  nested operation
+- *47* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *48* ???*49*["slice"](2)
+  ⚠️  unknown callee object
+- *49* ???*50*(36)
+  ⚠️  unknown callee
+- *50* ???*51*["toString"]
+  ⚠️  unknown object
+- *51* ???*52*()
+  ⚠️  nested operation
+- *52* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *53* ???*54*["slice"](2)
+  ⚠️  unknown callee object
+- *54* ???*55*(36)
+  ⚠️  unknown callee
+- *55* ???*56*["toString"]
+  ⚠️  unknown object
+- *56* ???*57*()
+  ⚠️  nested operation
+- *57* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *58* ???*59*["slice"](2)
+  ⚠️  unknown callee object
+- *59* ???*60*(36)
+  ⚠️  unknown callee
+- *60* ???*61*["toString"]
+  ⚠️  unknown object
+- *61* ???*62*()
+  ⚠️  nested operation
+- *62* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *63* (3 === ???*64*)
+  ⚠️  nested operation
+- *64* ???*65*["tag"]
+  ⚠️  unknown object
+- *65* a
+  ⚠️  circular variable reference
+- *66* a
+  ⚠️  circular variable reference
+- *67* ???*68*["return"]
+  ⚠️  unknown object
+- *68* b
+  ⚠️  circular variable reference
+- *69* arguments[2]
   ⚠️  function calls are not analysed yet
 
 1493 -> 1495 call = (...) => undefined(???*0*, ???*1*)
@@ -9740,8 +10276,9 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *5* arguments[3]
   ⚠️  function calls are not analysed yet
 
-1493 -> 1497 conditional = ???*0*
-- *0* max number of linking steps reached
+1493 -> 1497 conditional = (???*0* | true | false)
+- *0* !(0)
+  ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
 1497 -> 1499 member call = ???*0*["stopPropagation"]()
@@ -9785,16 +10322,178 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *3* arguments[3]
   ⚠️  function calls are not analysed yet
 
-1497 -> 1506 call = (...) => (undefined | FreeVar(undefined))(???*0*, ???*1*, ???*2*, ???*3*, ???*4*)
+1497 -> 1506 call = (...) => (undefined | FreeVar(undefined))(
+    ???*0*,
+    ???*1*,
+    ???*2*,
+    (
+      | null
+      | ???*3*
+      | (???*4* ? (???*9* | ???*11*) : (???*13* | ???*14* | ???*16*))
+      | ???*17*
+      | null[`__reactFiber$${???*23*}`]
+      | null["parentNode"][`__reactContainer$${???*28*}`]
+      | null[`__reactFiber$${???*33*}`][`__reactContainer$${???*38*}`]
+      | null["parentNode"][`__reactFiber$${???*43*}`]
+      | null[`__reactFiber$${???*48*}`][`__reactFiber$${???*53*}`]
+      | null["parentNode"]
+      | null[`__reactFiber$${???*58*}`]["alternate"]
+      | (???*63* ? (???*66* | ???*67*) : null)["memoizedState"]["dehydrated"]
+    ),
+    ???*69*
+)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* arguments[1]
   ⚠️  function calls are not analysed yet
 - *2* arguments[3]
   ⚠️  function calls are not analysed yet
-- *3* max number of linking steps reached
+- *3* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *4* (3 === (???*5* | ???*7*))
+  ⚠️  nested operation
+- *5* ???*6*["nodeType"]
+  ⚠️  unknown object
+- *6* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *7* ???*8*["nodeType"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
-- *4* arguments[2]
+- *8* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *9* ???*10*["parentNode"]
+  ⚠️  unknown object
+- *10* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *11* ???*12*["parentNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *12* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *13* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *14* ???*15*["target"]
+  ⚠️  unknown object
+- *15* a
+  ⚠️  circular variable reference
+- *16* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *17* ???*18*[`__reactFiber$${???*19*}`]
+  ⚠️  unknown object
+- *18* a
+  ⚠️  circular variable reference
+- *19* ???*20*["slice"](2)
+  ⚠️  unknown callee object
+- *20* ???*21*(36)
+  ⚠️  unknown callee
+- *21* ???*22*["toString"]
+  ⚠️  unknown object
+- *22* ???()
+  ⚠️  nested operation
+- *23* ???*24*["slice"](2)
+  ⚠️  unknown callee object
+- *24* ???*25*(36)
+  ⚠️  unknown callee
+- *25* ???*26*["toString"]
+  ⚠️  unknown object
+- *26* ???*27*()
+  ⚠️  nested operation
+- *27* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *28* ???*29*["slice"](2)
+  ⚠️  unknown callee object
+- *29* ???*30*(36)
+  ⚠️  unknown callee
+- *30* ???*31*["toString"]
+  ⚠️  unknown object
+- *31* ???*32*()
+  ⚠️  nested operation
+- *32* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *33* ???*34*["slice"](2)
+  ⚠️  unknown callee object
+- *34* ???*35*(36)
+  ⚠️  unknown callee
+- *35* ???*36*["toString"]
+  ⚠️  unknown object
+- *36* ???*37*()
+  ⚠️  nested operation
+- *37* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *38* ???*39*["slice"](2)
+  ⚠️  unknown callee object
+- *39* ???*40*(36)
+  ⚠️  unknown callee
+- *40* ???*41*["toString"]
+  ⚠️  unknown object
+- *41* ???*42*()
+  ⚠️  nested operation
+- *42* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *43* ???*44*["slice"](2)
+  ⚠️  unknown callee object
+- *44* ???*45*(36)
+  ⚠️  unknown callee
+- *45* ???*46*["toString"]
+  ⚠️  unknown object
+- *46* ???*47*()
+  ⚠️  nested operation
+- *47* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *48* ???*49*["slice"](2)
+  ⚠️  unknown callee object
+- *49* ???*50*(36)
+  ⚠️  unknown callee
+- *50* ???*51*["toString"]
+  ⚠️  unknown object
+- *51* ???*52*()
+  ⚠️  nested operation
+- *52* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *53* ???*54*["slice"](2)
+  ⚠️  unknown callee object
+- *54* ???*55*(36)
+  ⚠️  unknown callee
+- *55* ???*56*["toString"]
+  ⚠️  unknown object
+- *56* ???*57*()
+  ⚠️  nested operation
+- *57* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *58* ???*59*["slice"](2)
+  ⚠️  unknown callee object
+- *59* ???*60*(36)
+  ⚠️  unknown callee
+- *60* ???*61*["toString"]
+  ⚠️  unknown object
+- *61* ???*62*()
+  ⚠️  nested operation
+- *62* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *63* (3 === ???*64*)
+  ⚠️  nested operation
+- *64* ???*65*["tag"]
+  ⚠️  unknown object
+- *65* a
+  ⚠️  circular variable reference
+- *66* a
+  ⚠️  circular variable reference
+- *67* ???*68*["return"]
+  ⚠️  unknown object
+- *68* b
+  ⚠️  circular variable reference
+- *69* arguments[2]
   ⚠️  function calls are not analysed yet
 
 1497 -> 1508 member call = ???*0*["stopPropagation"]()
@@ -9815,40 +10514,581 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* arguments[3]
   ⚠️  function calls are not analysed yet
 
-0 -> 1511 call = (...) => (b | c | null)(???*0*)
-- *0* max number of linking steps reached
+0 -> 1511 call = (...) => (b | c | null)(
+    (
+      | ???*0*
+      | (???*1* ? (???*6* | ???*8*) : (???*10* | ???*11* | ???*13*))
+      | ???*14*
+      | null[`__reactFiber$${???*20*}`]
+      | null["parentNode"][`__reactContainer$${???*25*}`]
+      | null[`__reactFiber$${???*30*}`][`__reactContainer$${???*35*}`]
+      | null["parentNode"][`__reactFiber$${???*40*}`]
+      | null[`__reactFiber$${???*45*}`][`__reactFiber$${???*50*}`]
+      | null["parentNode"]
+      | null[`__reactFiber$${???*55*}`]["alternate"]
+      | null
+      | (???*60* ? (???*63* | ???*64*) : null)["memoizedState"]["dehydrated"]
+    )
+)
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* (3 === (???*2* | ???*4*))
+  ⚠️  nested operation
+- *2* ???*3*["nodeType"]
+  ⚠️  unknown object
+- *3* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *4* ???*5*["nodeType"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
+- *5* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *6* ???*7*["parentNode"]
+  ⚠️  unknown object
+- *7* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *8* ???*9*["parentNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *9* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *10* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *11* ???*12*["target"]
+  ⚠️  unknown object
+- *12* a
+  ⚠️  circular variable reference
+- *13* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *14* ???*15*[`__reactFiber$${???*16*}`]
+  ⚠️  unknown object
+- *15* a
+  ⚠️  circular variable reference
+- *16* ???*17*["slice"](2)
+  ⚠️  unknown callee object
+- *17* ???*18*(36)
+  ⚠️  unknown callee
+- *18* ???*19*["toString"]
+  ⚠️  unknown object
+- *19* ???()
+  ⚠️  nested operation
+- *20* ???*21*["slice"](2)
+  ⚠️  unknown callee object
+- *21* ???*22*(36)
+  ⚠️  unknown callee
+- *22* ???*23*["toString"]
+  ⚠️  unknown object
+- *23* ???*24*()
+  ⚠️  nested operation
+- *24* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *25* ???*26*["slice"](2)
+  ⚠️  unknown callee object
+- *26* ???*27*(36)
+  ⚠️  unknown callee
+- *27* ???*28*["toString"]
+  ⚠️  unknown object
+- *28* ???*29*()
+  ⚠️  nested operation
+- *29* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *30* ???*31*["slice"](2)
+  ⚠️  unknown callee object
+- *31* ???*32*(36)
+  ⚠️  unknown callee
+- *32* ???*33*["toString"]
+  ⚠️  unknown object
+- *33* ???*34*()
+  ⚠️  nested operation
+- *34* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *35* ???*36*["slice"](2)
+  ⚠️  unknown callee object
+- *36* ???*37*(36)
+  ⚠️  unknown callee
+- *37* ???*38*["toString"]
+  ⚠️  unknown object
+- *38* ???*39*()
+  ⚠️  nested operation
+- *39* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *40* ???*41*["slice"](2)
+  ⚠️  unknown callee object
+- *41* ???*42*(36)
+  ⚠️  unknown callee
+- *42* ???*43*["toString"]
+  ⚠️  unknown object
+- *43* ???*44*()
+  ⚠️  nested operation
+- *44* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *45* ???*46*["slice"](2)
+  ⚠️  unknown callee object
+- *46* ???*47*(36)
+  ⚠️  unknown callee
+- *47* ???*48*["toString"]
+  ⚠️  unknown object
+- *48* ???*49*()
+  ⚠️  nested operation
+- *49* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *50* ???*51*["slice"](2)
+  ⚠️  unknown callee object
+- *51* ???*52*(36)
+  ⚠️  unknown callee
+- *52* ???*53*["toString"]
+  ⚠️  unknown object
+- *53* ???*54*()
+  ⚠️  nested operation
+- *54* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *55* ???*56*["slice"](2)
+  ⚠️  unknown callee object
+- *56* ???*57*(36)
+  ⚠️  unknown callee
+- *57* ???*58*["toString"]
+  ⚠️  unknown object
+- *58* ???*59*()
+  ⚠️  nested operation
+- *59* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *60* (3 === ???*61*)
+  ⚠️  nested operation
+- *61* ???*62*["tag"]
+  ⚠️  unknown object
+- *62* a
+  ⚠️  circular variable reference
+- *63* a
+  ⚠️  circular variable reference
+- *64* ???*65*["return"]
+  ⚠️  unknown object
+- *65* b
+  ⚠️  circular variable reference
 
-0 -> 1512 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 1512 conditional = (null !== (
+  | ???*0*
+  | ???*1*
+  | ???*15*
+  | null[???*21*]
+  | null["parentNode"][???*26*]
+  | null[???*31*][???*36*]
+  | null["parentNode"]
+  | null[???*41*]["alternate"]
+  | null
+))
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* (???*2* ? (???*7* | ???*9*) : (???*11* | ???*12* | ???*14*))
+  ⚠️  nested operation
+- *2* (3 === (???*3* | ???*5*))
+  ⚠️  nested operation
+- *3* ???*4*["nodeType"]
+  ⚠️  unknown object
+- *4* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *5* ???*6*["nodeType"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
+- *6* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *7* ???*8*["parentNode"]
+  ⚠️  unknown object
+- *8* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *9* ???*10*["parentNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *10* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *11* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *12* ???*13*["target"]
+  ⚠️  unknown object
+- *13* a
+  ⚠️  circular variable reference
+- *14* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *15* ???*16*[`__reactFiber$${???*17*}`]
+  ⚠️  unknown object
+- *16* a
+  ⚠️  circular variable reference
+- *17* ???*18*["slice"](2)
+  ⚠️  unknown callee object
+- *18* ???*19*(36)
+  ⚠️  unknown callee
+- *19* ???*20*["toString"]
+  ⚠️  unknown object
+- *20* ???()
+  ⚠️  nested operation
+- *21* `__reactFiber$${???*22*}`
+  ⚠️  nested operation
+- *22* ???*23*["slice"](2)
+  ⚠️  unknown callee object
+- *23* ???*24*(36)
+  ⚠️  unknown callee
+- *24* ???*25*["toString"]
+  ⚠️  unknown object
+- *25* ???()
+  ⚠️  nested operation
+- *26* `__reactContainer$${???*27*}`
+  ⚠️  nested operation
+- *27* ???*28*["slice"](2)
+  ⚠️  unknown callee object
+- *28* ???*29*(36)
+  ⚠️  unknown callee
+- *29* ???*30*["toString"]
+  ⚠️  unknown object
+- *30* ???()
+  ⚠️  nested operation
+- *31* `__reactFiber$${???*32*}`
+  ⚠️  nested operation
+- *32* ???*33*["slice"](2)
+  ⚠️  unknown callee object
+- *33* ???*34*(36)
+  ⚠️  unknown callee
+- *34* ???*35*["toString"]
+  ⚠️  unknown object
+- *35* ???()
+  ⚠️  nested operation
+- *36* `__reactContainer$${???*37*}`
+  ⚠️  nested operation
+- *37* ???*38*["slice"](2)
+  ⚠️  unknown callee object
+- *38* ???*39*(36)
+  ⚠️  unknown callee
+- *39* ???*40*["toString"]
+  ⚠️  unknown object
+- *40* ???()
+  ⚠️  nested operation
+- *41* `__reactFiber$${???*42*}`
+  ⚠️  nested operation
+- *42* ???*43*["slice"](2)
+  ⚠️  unknown callee object
+- *43* ???*44*(36)
+  ⚠️  unknown callee
+- *44* ???*45*["toString"]
+  ⚠️  unknown object
+- *45* ???()
+  ⚠️  nested operation
 
-1512 -> 1513 call = (...) => ((3 === b["tag"]) ? c : null)(???*0*)
-- *0* max number of linking steps reached
+1512 -> 1513 call = (...) => ((3 === b["tag"]) ? c : null)(
+    (
+      | ???*0*
+      | (???*1* ? (???*6* | ???*8*) : (???*10* | ???*11* | ???*13*))
+      | ???*14*
+      | null[`__reactFiber$${???*20*}`]
+      | null["parentNode"][`__reactContainer$${???*25*}`]
+      | null[`__reactFiber$${???*30*}`][`__reactContainer$${???*35*}`]
+      | null["parentNode"][`__reactFiber$${???*40*}`]
+      | null[`__reactFiber$${???*45*}`][`__reactFiber$${???*50*}`]
+      | null["parentNode"]
+      | null[`__reactFiber$${???*55*}`]["alternate"]
+      | null
+      | (???*60* ? (???*63* | ???*64*) : null)["memoizedState"]["dehydrated"]
+    )
+)
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* (3 === (???*2* | ???*4*))
+  ⚠️  nested operation
+- *2* ???*3*["nodeType"]
+  ⚠️  unknown object
+- *3* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *4* ???*5*["nodeType"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
+- *5* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *6* ???*7*["parentNode"]
+  ⚠️  unknown object
+- *7* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *8* ???*9*["parentNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *9* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *10* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *11* ???*12*["target"]
+  ⚠️  unknown object
+- *12* a
+  ⚠️  circular variable reference
+- *13* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *14* ???*15*[`__reactFiber$${???*16*}`]
+  ⚠️  unknown object
+- *15* a
+  ⚠️  circular variable reference
+- *16* ???*17*["slice"](2)
+  ⚠️  unknown callee object
+- *17* ???*18*(36)
+  ⚠️  unknown callee
+- *18* ???*19*["toString"]
+  ⚠️  unknown object
+- *19* ???()
+  ⚠️  nested operation
+- *20* ???*21*["slice"](2)
+  ⚠️  unknown callee object
+- *21* ???*22*(36)
+  ⚠️  unknown callee
+- *22* ???*23*["toString"]
+  ⚠️  unknown object
+- *23* ???*24*()
+  ⚠️  nested operation
+- *24* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *25* ???*26*["slice"](2)
+  ⚠️  unknown callee object
+- *26* ???*27*(36)
+  ⚠️  unknown callee
+- *27* ???*28*["toString"]
+  ⚠️  unknown object
+- *28* ???*29*()
+  ⚠️  nested operation
+- *29* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *30* ???*31*["slice"](2)
+  ⚠️  unknown callee object
+- *31* ???*32*(36)
+  ⚠️  unknown callee
+- *32* ???*33*["toString"]
+  ⚠️  unknown object
+- *33* ???*34*()
+  ⚠️  nested operation
+- *34* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *35* ???*36*["slice"](2)
+  ⚠️  unknown callee object
+- *36* ???*37*(36)
+  ⚠️  unknown callee
+- *37* ???*38*["toString"]
+  ⚠️  unknown object
+- *38* ???*39*()
+  ⚠️  nested operation
+- *39* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *40* ???*41*["slice"](2)
+  ⚠️  unknown callee object
+- *41* ???*42*(36)
+  ⚠️  unknown callee
+- *42* ???*43*["toString"]
+  ⚠️  unknown object
+- *43* ???*44*()
+  ⚠️  nested operation
+- *44* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *45* ???*46*["slice"](2)
+  ⚠️  unknown callee object
+- *46* ???*47*(36)
+  ⚠️  unknown callee
+- *47* ???*48*["toString"]
+  ⚠️  unknown object
+- *48* ???*49*()
+  ⚠️  nested operation
+- *49* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *50* ???*51*["slice"](2)
+  ⚠️  unknown callee object
+- *51* ???*52*(36)
+  ⚠️  unknown callee
+- *52* ???*53*["toString"]
+  ⚠️  unknown object
+- *53* ???*54*()
+  ⚠️  nested operation
+- *54* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *55* ???*56*["slice"](2)
+  ⚠️  unknown callee object
+- *56* ???*57*(36)
+  ⚠️  unknown callee
+- *57* ???*58*["toString"]
+  ⚠️  unknown object
+- *58* ???*59*()
+  ⚠️  nested operation
+- *59* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *60* (3 === ???*61*)
+  ⚠️  nested operation
+- *61* ???*62*["tag"]
+  ⚠️  unknown object
+- *62* a
+  ⚠️  circular variable reference
+- *63* a
+  ⚠️  circular variable reference
+- *64* ???*65*["return"]
+  ⚠️  unknown object
+- *65* b
+  ⚠️  circular variable reference
 
 1512 -> 1515 call = (...) => (b["dehydrated"] | null)(???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-1512 -> 1516 conditional = ???*0*
-- *0* max number of linking steps reached
+1512 -> 1516 conditional = (null !== (
+  | ???*0*
+  | ???*1*
+  | ???*15*
+  | null[???*21*]
+  | null["parentNode"][???*26*]
+  | null[???*31*][???*36*]
+  | null["parentNode"]
+  | null[???*41*]["alternate"]
+  | null
+))
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* (???*2* ? (???*7* | ???*9*) : (???*11* | ???*12* | ???*14*))
+  ⚠️  nested operation
+- *2* (3 === (???*3* | ???*5*))
+  ⚠️  nested operation
+- *3* ???*4*["nodeType"]
+  ⚠️  unknown object
+- *4* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *5* ???*6*["nodeType"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
+- *6* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *7* ???*8*["parentNode"]
+  ⚠️  unknown object
+- *8* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *9* ???*10*["parentNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *10* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *11* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *12* ???*13*["target"]
+  ⚠️  unknown object
+- *13* a
+  ⚠️  circular variable reference
+- *14* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *15* ???*16*[`__reactFiber$${???*17*}`]
+  ⚠️  unknown object
+- *16* a
+  ⚠️  circular variable reference
+- *17* ???*18*["slice"](2)
+  ⚠️  unknown callee object
+- *18* ???*19*(36)
+  ⚠️  unknown callee
+- *19* ???*20*["toString"]
+  ⚠️  unknown object
+- *20* ???()
+  ⚠️  nested operation
+- *21* `__reactFiber$${???*22*}`
+  ⚠️  nested operation
+- *22* ???*23*["slice"](2)
+  ⚠️  unknown callee object
+- *23* ???*24*(36)
+  ⚠️  unknown callee
+- *24* ???*25*["toString"]
+  ⚠️  unknown object
+- *25* ???()
+  ⚠️  nested operation
+- *26* `__reactContainer$${???*27*}`
+  ⚠️  nested operation
+- *27* ???*28*["slice"](2)
+  ⚠️  unknown callee object
+- *28* ???*29*(36)
+  ⚠️  unknown callee
+- *29* ???*30*["toString"]
+  ⚠️  unknown object
+- *30* ???()
+  ⚠️  nested operation
+- *31* `__reactFiber$${???*32*}`
+  ⚠️  nested operation
+- *32* ???*33*["slice"](2)
+  ⚠️  unknown callee object
+- *33* ???*34*(36)
+  ⚠️  unknown callee
+- *34* ???*35*["toString"]
+  ⚠️  unknown object
+- *35* ???()
+  ⚠️  nested operation
+- *36* `__reactContainer$${???*37*}`
+  ⚠️  nested operation
+- *37* ???*38*["slice"](2)
+  ⚠️  unknown callee object
+- *38* ???*39*(36)
+  ⚠️  unknown callee
+- *39* ???*40*["toString"]
+  ⚠️  unknown object
+- *40* ???()
+  ⚠️  nested operation
+- *41* `__reactFiber$${???*42*}`
+  ⚠️  nested operation
+- *42* ???*43*["slice"](2)
+  ⚠️  unknown callee object
+- *43* ???*44*(36)
+  ⚠️  unknown callee
+- *44* ???*45*["toString"]
+  ⚠️  unknown object
+- *45* ???()
+  ⚠️  nested operation
 
 1516 -> 1517 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
-1512 -> 1518 conditional = ???*0*
+1512 -> 1518 conditional = (3 === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1518 -> 1523 conditional = ???*0*
-- *0* max number of linking steps reached
+- *0* ???*1*["isDehydrated"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* ???*2*["memoizedState"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* ???*3*["current"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* ???*4*["stateNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *4* max number of linking steps reached
   ⚠️  This value might have side effects
 
-1523 -> 1525 conditional = ???*0*
-- *0* max number of linking steps reached
+1523 -> 1525 conditional = (3 === ???*0*)
+- *0* ???*1*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1523 -> 1528 unreachable = ???*0*
@@ -10769,60 +12009,31 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
         "view": 0,
         "detail": 0
     },
-    {
-        "key": (...) => (
-          | b
-          | (("keypress" === a["type"]) ? ???*1* : ((("keydown" === a["type"]) || ("keyup" === a["type"])) ? (Nd[a["keyCode"]] || "Unidentified") : ""))
-        ),
-        "code": 0,
-        "location": 0,
-        "ctrlKey": 0,
-        "shiftKey": 0,
-        "altKey": 0,
-        "metaKey": 0,
-        "repeat": 0,
-        "locale": 0,
-        "getModifierState": (...) => Pd,
-        "charCode": (...) => (("keypress" === a["type"]) ? od(a) : 0),
-        "keyCode": (...) => ((("keydown" === a["type"]) || ("keyup" === a["type"])) ? a["keyCode"] : 0),
-        "which": (...) => (("keypress" === a["type"]) ? od(a) : ((("keydown" === a["type"]) || ("keyup" === a["type"])) ? a["keyCode"] : 0))
-    }
+    ???*1*
 )
 - *0* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-- *1* ((13 === a) ? "Enter" : FreeVar(String)["fromCharCode"](a))
-  ⚠️  sequence with side effects
+- *1* node limit reached
   ⚠️  This value might have side effects
 
-0 -> 1692 call = (...) => b(
-    {
-        "eventPhase": 0,
-        "bubbles": 0,
-        "cancelable": 0,
-        "timeStamp": (...) => (a["timeStamp"] || FreeVar(Date)["now"]()),
-        "defaultPrevented": 0,
-        "isTrusted": 0,
-        "view": 0,
-        "detail": 0,
-        "key": (...) => (
-          | b
-          | (("keypress" === a["type"]) ? ???*0* : ((("keydown" === a["type"]) || ("keyup" === a["type"])) ? (Nd[a["keyCode"]] || "Unidentified") : ""))
-        ),
-        "code": 0,
-        "location": 0,
-        "ctrlKey": 0,
-        "shiftKey": 0,
-        "altKey": 0,
-        "metaKey": 0,
-        "repeat": 0,
-        "locale": 0,
-        "getModifierState": (...) => Pd,
-        "charCode": (...) => (("keypress" === a["type"]) ? od(a) : 0),
-        "keyCode": (...) => ((("keydown" === a["type"]) || ("keyup" === a["type"])) ? a["keyCode"] : 0),
-        "which": (...) => (("keypress" === a["type"]) ? od(a) : ((("keydown" === a["type"]) || ("keyup" === a["type"])) ? a["keyCode"] : 0))
-    }
-)
-- *0* ((13 === a) ? "Enter" : FreeVar(String)["fromCharCode"](a))
-  ⚠️  sequence with side effects
+0 -> 1692 call = (...) => b(???*0*)
+- *0* Object.assign*1*(
+        {},
+        {
+            "eventPhase": 0,
+            "bubbles": 0,
+            "cancelable": 0,
+            "timeStamp": (...) => (a["timeStamp"] || FreeVar(Date)["now"]()),
+            "defaultPrevented": 0,
+            "isTrusted": 0,
+            "view": 0,
+            "detail": 0
+        },
+        ???*2*
+    )
+  ⚠️  only const object assign is supported
+  ⚠️  This value might have side effects
+- *1* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+- *2* node limit reached
   ⚠️  This value might have side effects
 
 0 -> 1693 call = Object.assign*0*(
@@ -10872,47 +12083,8 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *2* unsupported expression
   ⚠️  This value might have side effects
 
-0 -> 1694 call = (...) => b(
-    {
-        "eventPhase": 0,
-        "bubbles": 0,
-        "cancelable": 0,
-        "timeStamp": (...) => (a["timeStamp"] || FreeVar(Date)["now"]()),
-        "defaultPrevented": 0,
-        "isTrusted": 0,
-        "view": 0,
-        "detail": 0,
-        "screenX": 0,
-        "screenY": 0,
-        "clientX": 0,
-        "clientY": 0,
-        "pageX": 0,
-        "pageY": 0,
-        "ctrlKey": 0,
-        "shiftKey": 0,
-        "altKey": 0,
-        "metaKey": 0,
-        "getModifierState": (...) => Pd,
-        "button": 0,
-        "buttons": 0,
-        "relatedTarget": (...) => ((???*0* === a["relatedTarget"]) ? ((a["fromElement"] === a["srcElement"]) ? a["toElement"] : a["fromElement"]) : a["relatedTarget"]),
-        "movementX": (...) => (a["movementX"] | wd),
-        "movementY": (...) => (???*1* ? a["movementY"] : xd),
-        "pointerId": 0,
-        "width": 0,
-        "height": 0,
-        "pressure": 0,
-        "tangentialPressure": 0,
-        "tiltX": 0,
-        "tiltY": 0,
-        "twist": 0,
-        "pointerType": 0,
-        "isPrimary": 0
-    }
-)
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
+0 -> 1694 call = (...) => b(???*0*)
+- *0* node limit reached
   ⚠️  This value might have side effects
 
 0 -> 1695 call = Object.assign*0*(
@@ -11054,57 +12226,8 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *10* unsupported expression
   ⚠️  This value might have side effects
 
-0 -> 1707 call = (...) => b(
-    {
-        "eventPhase": 0,
-        "bubbles": 0,
-        "cancelable": 0,
-        "timeStamp": (...) => (a["timeStamp"] || FreeVar(Date)["now"]()),
-        "defaultPrevented": 0,
-        "isTrusted": 0,
-        "view": 0,
-        "detail": 0,
-        "screenX": 0,
-        "screenY": 0,
-        "clientX": 0,
-        "clientY": 0,
-        "pageX": 0,
-        "pageY": 0,
-        "ctrlKey": 0,
-        "shiftKey": 0,
-        "altKey": 0,
-        "metaKey": 0,
-        "getModifierState": (...) => Pd,
-        "button": 0,
-        "buttons": 0,
-        "relatedTarget": (...) => ((???*0* === a["relatedTarget"]) ? ((a["fromElement"] === a["srcElement"]) ? a["toElement"] : a["fromElement"]) : a["relatedTarget"]),
-        "movementX": (...) => (a["movementX"] | wd),
-        "movementY": (...) => (???*1* ? a["movementY"] : xd),
-        "deltaX": (...) => (???*2* ? a["deltaX"] : (???*3* ? ???*4* : 0)),
-        "deltaY": (...) => (???*5* ? a["deltaY"] : (???*6* ? ???*7* : (???*8* ? ???*9* : 0))),
-        "deltaZ": 0,
-        "deltaMode": 0
-    }
-)
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* unsupported expression
-  ⚠️  This value might have side effects
-- *3* unsupported expression
-  ⚠️  This value might have side effects
-- *4* unsupported expression
-  ⚠️  This value might have side effects
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* unsupported expression
-  ⚠️  This value might have side effects
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* unsupported expression
+0 -> 1707 call = (...) => b(???*0*)
+- *0* node limit reached
   ⚠️  This value might have side effects
 
 0 -> 1708 free var = FreeVar(window)
@@ -11255,9 +12378,73 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *17* arguments[1]
   ⚠️  function calls are not analysed yet
 
-1739 -> 1741 conditional = ???*0*
-- *0* max number of linking steps reached
+1739 -> 1741 conditional = (
+  | ("compositionend" === (???*0* | null | ???*1* | ???*15*))
+  | !((???*16* | ???*20*))
+  | undefined
+  | (???*21* !== ???*22*)
+  | (229 !== ???*26*)
+  | true
+  | false
+)
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* ???*2*((???*9* | 0 | ???*10*), ???*11*)
+  ⚠️  unknown callee
   ⚠️  This value might have side effects
+- *2* ???*3*["slice"]
+  ⚠️  unknown object
+- *3* (???*4* ? (null["value"] | ???*5*) : (null["textContent"] | ???*7*))
+  ⚠️  nested operation
+- *4* unsupported expression
+  ⚠️  This value might have side effects
+- *5* ???*6*["value"]
+  ⚠️  unknown object
+- *6* (??? ? (??? | ???) : (??? | ??? | ???))
+  ⚠️  nested operation
+- *7* ???*8*["textContent"]
+  ⚠️  unknown object
+- *8* (??? ? (??? | ???) : (??? | ??? | ???))
+  ⚠️  nested operation
+- *9* a
+  ⚠️  pattern without value
+- *10* updated with update expression
+  ⚠️  This value might have side effects
+- *11* (???*12* ? ???*13* : ???*14*)
+  ⚠️  nested operation
+- *12* unsupported expression
+  ⚠️  This value might have side effects
+- *13* unsupported expression
+  ⚠️  This value might have side effects
+- *14* unsupported expression
+  ⚠️  This value might have side effects
+- *15* unsupported expression
+  ⚠️  This value might have side effects
+- *16* !(???*17*)
+  ⚠️  nested operation
+- *17* ("undefined" === ???*18*)
+  ⚠️  nested operation
+- *18* typeof(???*19*)
+  ⚠️  nested operation
+- *19* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *20* unsupported expression
+  ⚠️  This value might have side effects
+- *21* unsupported expression
+  ⚠️  This value might have side effects
+- *22* ???*23*(???*24*)
+  ⚠️  unknown callee
+- *23* [9, 13, 27, 32]["indexOf"]
+  ⚠️  non-num constant property on array
+- *24* ???*25*["keyCode"]
+  ⚠️  unknown object
+- *25* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *26* ???*27*["keyCode"]
+  ⚠️  unknown object
+- *27* arguments[1]
+  ⚠️  function calls are not analysed yet
 
 1741 -> 1742 call = (...) => (md | ???*0*)()
 - *0* unsupported expression
@@ -12108,12 +13295,142 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 
 0 -> 1894 call = (...) => (undefined | null | (a["activeElement"] || a["body"]) | a["body"])()
 
-0 -> 1896 typeof = typeof(???*0*)
-- *0* max number of linking steps reached
+0 -> 1896 typeof = typeof((
+  | undefined["contentWindow"]["location"]["href"]
+  | null["contentWindow"]["location"]["href"]
+  | ???*0*
+  | (???*5* ? ???*8* : ???*9*)["activeElement"]["contentWindow"]["location"]["href"]
+  | (???*10* ? ???*13* : ???*14*)["body"]["contentWindow"]["location"]["href"]
+  | (???*15* ? ???*18* : ???*19*)["body"]["contentWindow"]["location"]["href"]
+  | ???*20*
+  | (???*25* ? ???*28* : ???*29*)["activeElement"]["contentWindow"]["location"]["href"]
+  | (???*30* ? ???*33* : ???*34*)["body"]["contentWindow"]["location"]["href"]
+  | (???*35* ? ???*38* : ???*39*)["body"]["contentWindow"]["location"]["href"]
+))
+- *0* ???*1*["href"]
+  ⚠️  unknown object
+- *1* ???*2*["location"]
+  ⚠️  unknown object
+- *2* ???*3*["contentWindow"]
+  ⚠️  unknown object
+- *3* ???*4*["activeElement"]
+  ⚠️  unknown object
+- *4* unknown function argument (out of bounds)
+- *5* ("undefined" !== ???*6*)
+  ⚠️  nested operation
+- *6* typeof(???*7*)
+  ⚠️  nested operation
+- *7* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *8* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *9* unsupported expression
+  ⚠️  This value might have side effects
+- *10* ("undefined" !== ???*11*)
+  ⚠️  nested operation
+- *11* typeof(???*12*)
+  ⚠️  nested operation
+- *12* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *13* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *14* unsupported expression
+  ⚠️  This value might have side effects
+- *15* ("undefined" !== ???*16*)
+  ⚠️  nested operation
+- *16* typeof(???*17*)
+  ⚠️  nested operation
+- *17* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *18* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *19* unsupported expression
+  ⚠️  This value might have side effects
+- *20* ???*21*["href"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *21* ???*22*["location"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *22* ???*23*["contentWindow"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *23* ???*24*["activeElement"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *24* ???["document"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *25* ("undefined" !== ???*26*)
+  ⚠️  nested operation
+- *26* typeof(???*27*)
+  ⚠️  nested operation
+- *27* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *28* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *29* unsupported expression
+  ⚠️  This value might have side effects
+- *30* ("undefined" !== ???*31*)
+  ⚠️  nested operation
+- *31* typeof(???*32*)
+  ⚠️  nested operation
+- *32* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *33* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *34* unsupported expression
+  ⚠️  This value might have side effects
+- *35* ("undefined" !== ???*36*)
+  ⚠️  nested operation
+- *36* typeof(???*37*)
+  ⚠️  nested operation
+- *37* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *38* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *39* unsupported expression
   ⚠️  This value might have side effects
 
-0 -> 1900 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 1900 conditional = (("string" === ???*0*) | false)
+- *0* typeof((
+      | undefined["contentWindow"]["location"]["href"]
+      | null["contentWindow"]["location"]["href"]
+      | ???*1*
+      | ???*5*
+    ))
+  ⚠️  nested operation
+- *1* ???*2*["href"]
+  ⚠️  unknown object
+- *2* ???*3*["location"]
+  ⚠️  unknown object
+- *3* ???*4*["contentWindow"]
+  ⚠️  unknown object
+- *4* ???["activeElement"]
+  ⚠️  unknown object
+- *5* ???*6*["href"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *6* ???*7*["location"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *7* ???*8*["contentWindow"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *8* ???["activeElement"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 
 0 -> 1903 call = (...) => (undefined | null | (a["activeElement"] || a["body"]) | a["body"])(
@@ -12232,19 +13549,103 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 
 0 -> 1916 call = (...) => b()
 
-0 -> 1922 call = (...) => ((a && b) ? ((a === b) ? !(0) : ((a && (3 === a["nodeType"])) ? !(1) : ((b && (3 === b["nodeType"])) ? Le(a, b["parentNode"]) : (???*0* ? a["contains"](b) : (a["compareDocumentPosition"] ? !(!(???*1*)) : !(1)))))) : !(1))(???*2*, ???*3*)
+0 -> 1922 call = (...) => ((a && b) ? ((a === b) ? !(0) : ((a && (3 === a["nodeType"])) ? !(1) : ((b && (3 === b["nodeType"])) ? Le(a, b["parentNode"]) : (???*0* ? a["contains"](b) : (a["compareDocumentPosition"] ? !(!(???*1*)) : !(1)))))) : !(1))(???*2*, ???*5*)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* unsupported expression
   ⚠️  This value might have side effects
-- *2* max number of linking steps reached
+- *2* ???*3*["documentElement"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
-- *3* max number of linking steps reached
+- *3* ???*4*["ownerDocument"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *4* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *5* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 1923 conditional = ???*0*
+0 -> 1923 conditional = ((???*0* !== ???*1*) | ???*2* | ???*3* | ((???*5* | ???*8*) ? ???*9* : false))
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *3* ???*4*["ownerDocument"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *4* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *5* ???*6*["documentElement"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *6* ???*7*["ownerDocument"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *7* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *8* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *9* (???*10* ? true : ???*15*)
+  ⚠️  nested operation
+- *10* (???*11* === ???*14*)
+  ⚠️  nested operation
+- *11* ???*12*["documentElement"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *12* ???*13*["ownerDocument"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *13* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *14* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *15* ((???*16* | ???*19*) ? false : ???*22*)
+  ⚠️  nested operation
+- *16* ???*17*["documentElement"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *17* ???*18*["ownerDocument"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *18* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *19* (3 === ???*20*)
+  ⚠️  nested operation
+- *20* ???*21*["nodeType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *21* ???["documentElement"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *22* ((???*23* | ???*24*) ? ???*26* : ???*29*)
+  ⚠️  nested operation
+- *23* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *24* (3 === ???*25*)
+  ⚠️  nested operation
+- *25* ???["nodeType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *26* (...) => ((a && b) ? ((a === b) ? !(0) : ((... && ...) ? !(...) : (... ? ... : ...))) : !(1))(???*27*, ???*28*)
+  ⚠️  recursive function call
+  ⚠️  This value might have side effects
+- *27* ???["documentElement"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *28* ???["parentNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *29* (???*30* ? ???*31* : ???*32*)
+  ⚠️  nested operation
+- *30* unsupported expression
+  ⚠️  This value might have side effects
+- *31* ???["contains"](b)
+  ⚠️  unknown callee object
+  ⚠️  This value might have side effects
+- *32* (??? ? ??? : false)
+  ⚠️  nested operation
 
 1923 -> 1924 call = (...) => (
  && b
@@ -12266,8 +13667,100 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-1923 -> 1925 conditional = ???*0*
+1923 -> 1925 conditional = (
+  | (null !== ???*0*)
+  | ???*1*
+  | ???*2*
+  | ???*4*()
+  | ("input" === (???*7* | ???*8* | ???*10*))
+  | ("text" === ???*14*)
+  | ("search" === ???*16*)
+  | ("tel" === ???*18*)
+  | ("url" === ???*20*)
+  | ("password" === ???*22*)
+  | ("textarea" === (???*24* | ???*25* | ???*27*))
+  | ("true" === ???*31*)
+)
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* ???*3*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *4* ???*5*["toLowerCase"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* ???*6*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *6* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *7* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *8* ???*9*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *9* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *10* ???*11*()
+  ⚠️  nested operation
+- *11* ???*12*["toLowerCase"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *12* ???*13*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *13* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *14* ???*15*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *15* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *16* ???*17*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *17* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *18* ???*19*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *19* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *20* ???*21*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *21* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *22* ???*23*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *23* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *24* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *25* ???*26*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *26* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *27* ???*28*()
+  ⚠️  nested operation
+- *28* ???*29*["toLowerCase"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *29* ???*30*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *30* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *31* ???*32*["contentEditable"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *32* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1925 -> 1931 free var = FreeVar(Math)
@@ -12278,7 +13771,13 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
-- *2* max number of linking steps reached
+- *2* ???*3*["length"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* ???*4*["value"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *4* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1925 -> 1936 free var = FreeVar(document)
@@ -12291,28 +13790,39 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 
 1925 -> 1945 free var = FreeVar(Math)
 
-1925 -> 1947 member call = ???*0*["min"](???*1*, ???*2*)
+1925 -> 1947 member call = ???*0*["min"](???*1*, ???*3*)
 - *0* FreeVar(Math)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["start"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
+- *3* max number of linking steps reached
+  ⚠️  This value might have side effects
 
-1925 -> 1949 conditional = ???*0*
-- *0* max number of linking steps reached
+1925 -> 1949 conditional = (???*0* === ???*1*)
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* ???*2*["end"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1949 -> 1951 free var = FreeVar(Math)
 
-1949 -> 1953 member call = ???*0*["min"](???*1*, ???*2*)
+1949 -> 1953 member call = ???*0*["min"](???*1*, ???*3*)
 - *0* FreeVar(Math)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["end"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1925 -> 1955 call = (...) => (undefined | {"node": c, "offset": ???*0*})(???*1*, ???*2*)
@@ -12335,12 +13845,18 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-1925 -> 1971 member call = ???*0*["setStart"](???*1*, ???*2*)
+1925 -> 1971 member call = ???*0*["setStart"](???*1*, ???*3*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["node"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *3* ???*4*["offset"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *4* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1925 -> 1973 member call = ???*0*["removeAllRanges"]()
@@ -12353,20 +13869,32 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-1925 -> 1979 member call = ???*0*["extend"](???*1*, ???*2*)
+1925 -> 1979 member call = ???*0*["extend"](???*1*, ???*3*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["node"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *3* ???*4*["offset"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *4* max number of linking steps reached
   ⚠️  This value might have side effects
 
-1925 -> 1983 member call = ???*0*["setEnd"](???*1*, ???*2*)
+1925 -> 1983 member call = ???*0*["setEnd"](???*1*, ???*3*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["node"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *3* ???*4*["offset"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *4* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1925 -> 1985 member call = ???*0*["addRange"](???*1*)
@@ -12375,14 +13903,27 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-1923 -> 1991 member call = ???*0*["push"](???*1*)
+1923 -> 1991 member call = ???*0*["push"]({"element": ???*1*, "left": ???*2*, "top": ???*4*})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
+- *2* ???*3*["scrollLeft"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *4* ???*5*["scrollTop"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* max number of linking steps reached
+  ⚠️  This value might have side effects
 
 1923 -> 1992 typeof = typeof(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["focus"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 1923 -> 1995 member call = ???*0*["focus"]()
@@ -12431,14 +13972,112 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 2015 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 2015 conditional = (
+  | ???*0*
+  | ???*1*
+  | ???*2*
+  | ???*4*()
+  | ("input" === (???*7* | ???*8* | ???*10*))
+  | ("text" === ???*14*)
+  | ("search" === ???*16*)
+  | ("tel" === ???*18*)
+  | ("url" === ???*20*)
+  | ("password" === ???*22*)
+  | ("textarea" === (???*24* | ???*25* | ???*27*))
+  | ("true" === ???*31*)
+)
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* ???*3*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *4* ???*5*["toLowerCase"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* ???*6*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *6* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *7* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *8* ???*9*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *9* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *10* ???*11*()
+  ⚠️  nested operation
+- *11* ???*12*["toLowerCase"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *12* ???*13*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *13* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *14* ???*15*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *15* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *16* ???*17*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *17* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *18* ???*19*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *19* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *20* ???*21*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *21* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *22* ???*23*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *23* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *24* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *25* ???*26*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *26* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *27* ???*28*()
+  ⚠️  nested operation
+- *28* ???*29*["toLowerCase"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *29* ???*30*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *30* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *31* ???*32*["contentEditable"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *32* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2015 -> 2022 free var = FreeVar(window)
 
-2015 -> 2023 member call = ???*0*["getSelection"]()
-- *0* max number of linking steps reached
+2015 -> 2023 member call = (???*0* | ???*2*)["getSelection"]()
+- *0* ???*1*["ownerDocument"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* FreeVar(window)
+  ⚠️  unknown global
   ⚠️  This value might have side effects
 
 0 -> 2028 call = (...) => (!(0) | !(1))(???*0*, ???*1*)
@@ -12447,8 +14086,124 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 2029 call = (...) => d(???*0*, "onSelect")
-- *0* max number of linking steps reached
+0 -> 2029 call = (...) => d(
+    (
+      | null
+      | ???*0*
+      | ???*1*
+      | ???*2*
+      | ???*4*
+      | null[`__reactFiber$${???*6*}`]
+      | null["parentNode"][`__reactContainer$${???*11*}`]
+      | null[`__reactFiber$${???*16*}`][`__reactContainer$${???*21*}`]
+      | null["parentNode"][`__reactFiber$${???*26*}`]
+      | null[`__reactFiber$${???*31*}`][`__reactFiber$${???*36*}`]
+      | null["parentNode"]
+      | null[`__reactFiber$${???*41*}`]["alternate"]
+      | []
+    ),
+    "onSelect"
+)
+- *0* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *1* unsupported expression
+  ⚠️  This value might have side effects
+- *2* ???*3*["return"]
+  ⚠️  unknown object
+- *3* d
+  ⚠️  circular variable reference
+- *4* ???*5*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* unsupported expression
+  ⚠️  This value might have side effects
+- *6* ???*7*["slice"](2)
+  ⚠️  unknown callee object
+- *7* ???*8*(36)
+  ⚠️  unknown callee
+- *8* ???*9*["toString"]
+  ⚠️  unknown object
+- *9* ???*10*()
+  ⚠️  nested operation
+- *10* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *11* ???*12*["slice"](2)
+  ⚠️  unknown callee object
+- *12* ???*13*(36)
+  ⚠️  unknown callee
+- *13* ???*14*["toString"]
+  ⚠️  unknown object
+- *14* ???*15*()
+  ⚠️  nested operation
+- *15* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *16* ???*17*["slice"](2)
+  ⚠️  unknown callee object
+- *17* ???*18*(36)
+  ⚠️  unknown callee
+- *18* ???*19*["toString"]
+  ⚠️  unknown object
+- *19* ???*20*()
+  ⚠️  nested operation
+- *20* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *21* ???*22*["slice"](2)
+  ⚠️  unknown callee object
+- *22* ???*23*(36)
+  ⚠️  unknown callee
+- *23* ???*24*["toString"]
+  ⚠️  unknown object
+- *24* ???*25*()
+  ⚠️  nested operation
+- *25* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *26* ???*27*["slice"](2)
+  ⚠️  unknown callee object
+- *27* ???*28*(36)
+  ⚠️  unknown callee
+- *28* ???*29*["toString"]
+  ⚠️  unknown object
+- *29* ???*30*()
+  ⚠️  nested operation
+- *30* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *31* ???*32*["slice"](2)
+  ⚠️  unknown callee object
+- *32* ???*33*(36)
+  ⚠️  unknown callee
+- *33* ???*34*["toString"]
+  ⚠️  unknown object
+- *34* ???*35*()
+  ⚠️  nested operation
+- *35* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *36* ???*37*["slice"](2)
+  ⚠️  unknown callee object
+- *37* ???*38*(36)
+  ⚠️  unknown callee
+- *38* ???*39*["toString"]
+  ⚠️  unknown object
+- *39* ???*40*()
+  ⚠️  nested operation
+- *40* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *41* ???*42*["slice"](2)
+  ⚠️  unknown callee object
+- *42* ???*43*(36)
+  ⚠️  unknown callee
+- *43* ???*44*["toString"]
+  ⚠️  unknown object
+- *44* ???*45*()
+  ⚠️  nested operation
+- *45* ???["random"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 
 0 -> 2031 call = new (...) => ???*0*(
@@ -12474,10 +14229,26 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *5* arguments[2]
   ⚠️  function calls are not analysed yet
 
-0 -> 2033 member call = ???*0*["push"](???*1*)
+0 -> 2033 member call = ???*0*["push"](
+    {
+        "event": (
+          | ???*1*
+          | new (...) => ???*2*("onSelect", "select", null, ???*3*, ???*4*)
+        ),
+        "listeners": ???*5*
+    }
+)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* max number of linking steps reached
+- *1* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *2* unsupported expression
+  ⚠️  This value might have side effects
+- *3* b
+  ⚠️  circular variable reference
+- *4* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *5* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 2037 member call = ???*0*["toLowerCase"]()
@@ -13379,16 +15150,221 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-2204 -> 2207 conditional = ???*0*
+2204 -> 2207 conditional = (
+  | (3 === (
+      | ???*0*
+      | ???*2*
+      | null[???*4*]
+      | null["parentNode"][???*9*]
+      | null[???*14*][???*19*]
+      | null["parentNode"]
+      | null[???*24*]["alternate"]
+      | null
+    ))
+  | (4 === (
+      | ???*29*
+      | ???*31*
+      | null[???*33*]
+      | null["parentNode"][???*38*]
+      | null[???*43*][???*48*]
+      | null["parentNode"]
+      | null[???*53*]["alternate"]
+      | null
+    ))
+)
+- *0* ???*1*["tag"]
+  ⚠️  unknown object
+- *1* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *2* ???*3*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* unsupported expression
+  ⚠️  This value might have side effects
+- *4* `__reactFiber$${???*5*}`
+  ⚠️  nested operation
+- *5* ???*6*["slice"](2)
+  ⚠️  unknown callee object
+- *6* ???*7*(36)
+  ⚠️  unknown callee
+- *7* ???*8*["toString"]
+  ⚠️  unknown object
+- *8* ???()
+  ⚠️  nested operation
+- *9* `__reactContainer$${???*10*}`
+  ⚠️  nested operation
+- *10* ???*11*["slice"](2)
+  ⚠️  unknown callee object
+- *11* ???*12*(36)
+  ⚠️  unknown callee
+- *12* ???*13*["toString"]
+  ⚠️  unknown object
+- *13* ???()
+  ⚠️  nested operation
+- *14* `__reactFiber$${???*15*}`
+  ⚠️  nested operation
+- *15* ???*16*["slice"](2)
+  ⚠️  unknown callee object
+- *16* ???*17*(36)
+  ⚠️  unknown callee
+- *17* ???*18*["toString"]
+  ⚠️  unknown object
+- *18* ???()
+  ⚠️  nested operation
+- *19* `__reactContainer$${???*20*}`
+  ⚠️  nested operation
+- *20* ???*21*["slice"](2)
+  ⚠️  unknown callee object
+- *21* ???*22*(36)
+  ⚠️  unknown callee
+- *22* ???*23*["toString"]
+  ⚠️  unknown object
+- *23* ???()
+  ⚠️  nested operation
+- *24* `__reactFiber$${???*25*}`
+  ⚠️  nested operation
+- *25* ???*26*["slice"](2)
+  ⚠️  unknown callee object
+- *26* ???*27*(36)
+  ⚠️  unknown callee
+- *27* ???*28*["toString"]
+  ⚠️  unknown object
+- *28* ???()
+  ⚠️  nested operation
+- *29* ???*30*["tag"]
+  ⚠️  unknown object
+- *30* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *31* ???*32*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *32* unsupported expression
+  ⚠️  This value might have side effects
+- *33* `__reactFiber$${???*34*}`
+  ⚠️  nested operation
+- *34* ???*35*["slice"](2)
+  ⚠️  unknown callee object
+- *35* ???*36*(36)
+  ⚠️  unknown callee
+- *36* ???*37*["toString"]
+  ⚠️  unknown object
+- *37* ???()
+  ⚠️  nested operation
+- *38* `__reactContainer$${???*39*}`
+  ⚠️  nested operation
+- *39* ???*40*["slice"](2)
+  ⚠️  unknown callee object
+- *40* ???*41*(36)
+  ⚠️  unknown callee
+- *41* ???*42*["toString"]
+  ⚠️  unknown object
+- *42* ???()
+  ⚠️  nested operation
+- *43* `__reactFiber$${???*44*}`
+  ⚠️  nested operation
+- *44* ???*45*["slice"](2)
+  ⚠️  unknown callee object
+- *45* ???*46*(36)
+  ⚠️  unknown callee
+- *46* ???*47*["toString"]
+  ⚠️  unknown object
+- *47* ???()
+  ⚠️  nested operation
+- *48* `__reactContainer$${???*49*}`
+  ⚠️  nested operation
+- *49* ???*50*["slice"](2)
+  ⚠️  unknown callee object
+- *50* ???*51*(36)
+  ⚠️  unknown callee
+- *51* ???*52*["toString"]
+  ⚠️  unknown object
+- *52* ???()
+  ⚠️  nested operation
+- *53* `__reactFiber$${???*54*}`
+  ⚠️  nested operation
+- *54* ???*55*["slice"](2)
+  ⚠️  unknown callee object
+- *55* ???*56*(36)
+  ⚠️  unknown callee
+- *56* ???*57*["toString"]
+  ⚠️  unknown object
+- *57* ???()
+  ⚠️  nested operation
+
+2207 -> 2212 conditional = (4 === (
+  | ???*0*
+  | ???*2*
+  | null[???*4*]
+  | null["parentNode"][???*9*]
+  | null[???*14*][???*19*]
+  | null["parentNode"]
+  | null[???*24*]["alternate"]
+  | null
+))
+- *0* ???*1*["tag"]
+  ⚠️  unknown object
+- *1* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *2* ???*3*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* unsupported expression
+  ⚠️  This value might have side effects
+- *4* `__reactFiber$${???*5*}`
+  ⚠️  nested operation
+- *5* ???*6*["slice"](2)
+  ⚠️  unknown callee object
+- *6* ???*7*(36)
+  ⚠️  unknown callee
+- *7* ???*8*["toString"]
+  ⚠️  unknown object
+- *8* ???()
+  ⚠️  nested operation
+- *9* `__reactContainer$${???*10*}`
+  ⚠️  nested operation
+- *10* ???*11*["slice"](2)
+  ⚠️  unknown callee object
+- *11* ???*12*(36)
+  ⚠️  unknown callee
+- *12* ???*13*["toString"]
+  ⚠️  unknown object
+- *13* ???()
+  ⚠️  nested operation
+- *14* `__reactFiber$${???*15*}`
+  ⚠️  nested operation
+- *15* ???*16*["slice"](2)
+  ⚠️  unknown callee object
+- *16* ???*17*(36)
+  ⚠️  unknown callee
+- *17* ???*18*["toString"]
+  ⚠️  unknown object
+- *18* ???()
+  ⚠️  nested operation
+- *19* `__reactContainer$${???*20*}`
+  ⚠️  nested operation
+- *20* ???*21*["slice"](2)
+  ⚠️  unknown callee object
+- *21* ???*22*(36)
+  ⚠️  unknown callee
+- *22* ???*23*["toString"]
+  ⚠️  unknown object
+- *23* ???()
+  ⚠️  nested operation
+- *24* `__reactFiber$${???*25*}`
+  ⚠️  nested operation
+- *25* ???*26*["slice"](2)
+  ⚠️  unknown callee object
+- *26* ???*27*(36)
+  ⚠️  unknown callee
+- *27* ???*28*["toString"]
+  ⚠️  unknown object
+- *28* ???()
+  ⚠️  nested operation
+
+2212 -> 2215 conditional = ((3 === ???*0*) | (4 === ???*1*))
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-
-2207 -> 2212 conditional = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-2212 -> 2215 conditional = ???*0*
-- *0* max number of linking steps reached
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2215 -> 2220 unreachable = ???*0*
@@ -13411,9 +15387,75 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *5* unsupported expression
   ⚠️  This value might have side effects
 
-2207 -> 2223 conditional = ???*0*
-- *0* max number of linking steps reached
+2207 -> 2223 conditional = (null === (
+  | ???*0*
+  | ???*2*
+  | null[???*4*]
+  | null["parentNode"][???*9*]
+  | null[???*14*][???*19*]
+  | null["parentNode"]
+  | null[???*24*]["alternate"]
+  | null
+))
+- *0* ???*1*["tag"]
+  ⚠️  unknown object
+- *1* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *2* ???*3*["tag"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
+- *3* unsupported expression
+  ⚠️  This value might have side effects
+- *4* `__reactFiber$${???*5*}`
+  ⚠️  nested operation
+- *5* ???*6*["slice"](2)
+  ⚠️  unknown callee object
+- *6* ???*7*(36)
+  ⚠️  unknown callee
+- *7* ???*8*["toString"]
+  ⚠️  unknown object
+- *8* ???()
+  ⚠️  nested operation
+- *9* `__reactContainer$${???*10*}`
+  ⚠️  nested operation
+- *10* ???*11*["slice"](2)
+  ⚠️  unknown callee object
+- *11* ???*12*(36)
+  ⚠️  unknown callee
+- *12* ???*13*["toString"]
+  ⚠️  unknown object
+- *13* ???()
+  ⚠️  nested operation
+- *14* `__reactFiber$${???*15*}`
+  ⚠️  nested operation
+- *15* ???*16*["slice"](2)
+  ⚠️  unknown callee object
+- *16* ???*17*(36)
+  ⚠️  unknown callee
+- *17* ???*18*["toString"]
+  ⚠️  unknown object
+- *18* ???()
+  ⚠️  nested operation
+- *19* `__reactContainer$${???*20*}`
+  ⚠️  nested operation
+- *20* ???*21*["slice"](2)
+  ⚠️  unknown callee object
+- *21* ???*22*(36)
+  ⚠️  unknown callee
+- *22* ???*23*["toString"]
+  ⚠️  unknown object
+- *23* ???()
+  ⚠️  nested operation
+- *24* `__reactFiber$${???*25*}`
+  ⚠️  nested operation
+- *25* ???*26*["slice"](2)
+  ⚠️  unknown callee object
+- *26* ???*27*(36)
+  ⚠️  unknown callee
+- *27* ???*28*["toString"]
+  ⚠️  unknown object
+- *28* ???()
+  ⚠️  nested operation
 
 2223 -> 2224 unreachable = ???*0*
 - *0* unreachable
@@ -13432,8 +15474,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
 
-2228 -> 2232 conditional = ???*0*
-- *0* max number of linking steps reached
+2228 -> 2232 conditional = (???*0* !== ???*1*)
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2232 -> 2233 call = (...) => ((???*0* || (13 === a)) ? a : 0)(???*1*)
@@ -13446,28 +15490,402 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-2235 -> 2236 conditional = ???*0*
+2235 -> 2236 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-2232 -> 2239 call = (...) => (null | c)(???*0*, ???*1*)
-- *0* max number of linking steps reached
+2232 -> 2239 call = (...) => (null | c)(
+    (
+      | ???*0*
+      | ???*1*
+      | ???*2*
+      | ???*4*
+      | null[`__reactFiber$${???*6*}`]
+      | null["parentNode"][`__reactContainer$${???*11*}`]
+      | null[`__reactFiber$${???*16*}`][`__reactContainer$${???*21*}`]
+      | null["parentNode"][`__reactFiber$${???*26*}`]
+      | null[`__reactFiber$${???*31*}`][`__reactFiber$${???*36*}`]
+      | null["parentNode"]
+      | null[`__reactFiber$${???*41*}`]["alternate"]
+      | null
+      | []
+      | "mouse"
+      | "pointer"
+      | 0
+      | ???*46*
+    ),
+    ???*47*
+)
+- *0* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *1* unsupported expression
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *2* ???*3*["return"]
+  ⚠️  unknown object
+- *3* d
+  ⚠️  circular variable reference
+- *4* ???*5*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* unsupported expression
+  ⚠️  This value might have side effects
+- *6* ???*7*["slice"](2)
+  ⚠️  unknown callee object
+- *7* ???*8*(36)
+  ⚠️  unknown callee
+- *8* ???*9*["toString"]
+  ⚠️  unknown object
+- *9* ???*10*()
+  ⚠️  nested operation
+- *10* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *11* ???*12*["slice"](2)
+  ⚠️  unknown callee object
+- *12* ???*13*(36)
+  ⚠️  unknown callee
+- *13* ???*14*["toString"]
+  ⚠️  unknown object
+- *14* ???*15*()
+  ⚠️  nested operation
+- *15* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *16* ???*17*["slice"](2)
+  ⚠️  unknown callee object
+- *17* ???*18*(36)
+  ⚠️  unknown callee
+- *18* ???*19*["toString"]
+  ⚠️  unknown object
+- *19* ???*20*()
+  ⚠️  nested operation
+- *20* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *21* ???*22*["slice"](2)
+  ⚠️  unknown callee object
+- *22* ???*23*(36)
+  ⚠️  unknown callee
+- *23* ???*24*["toString"]
+  ⚠️  unknown object
+- *24* ???*25*()
+  ⚠️  nested operation
+- *25* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *26* ???*27*["slice"](2)
+  ⚠️  unknown callee object
+- *27* ???*28*(36)
+  ⚠️  unknown callee
+- *28* ???*29*["toString"]
+  ⚠️  unknown object
+- *29* ???*30*()
+  ⚠️  nested operation
+- *30* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *31* ???*32*["slice"](2)
+  ⚠️  unknown callee object
+- *32* ???*33*(36)
+  ⚠️  unknown callee
+- *33* ???*34*["toString"]
+  ⚠️  unknown object
+- *34* ???*35*()
+  ⚠️  nested operation
+- *35* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *36* ???*37*["slice"](2)
+  ⚠️  unknown callee object
+- *37* ???*38*(36)
+  ⚠️  unknown callee
+- *38* ???*39*["toString"]
+  ⚠️  unknown object
+- *39* ???*40*()
+  ⚠️  nested operation
+- *40* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *41* ???*42*["slice"](2)
+  ⚠️  unknown callee object
+- *42* ???*43*(36)
+  ⚠️  unknown callee
+- *43* ???*44*["toString"]
+  ⚠️  unknown object
+- *44* ???*45*()
+  ⚠️  nested operation
+- *45* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *46* updated with update expression
+  ⚠️  This value might have side effects
+- *47* max number of linking steps reached
   ⚠️  This value might have side effects
 
-2232 -> 2241 call = (...) => {"instance": a, "listener": b, "currentTarget": c}(???*0*, ???*1*, ???*2*)
-- *0* max number of linking steps reached
+2232 -> 2241 call = (...) => {"instance": a, "listener": b, "currentTarget": c}(
+    (
+      | ???*0*
+      | ???*1*
+      | ???*2*
+      | ???*4*
+      | null[`__reactFiber$${???*6*}`]
+      | null["parentNode"][`__reactContainer$${???*11*}`]
+      | null[`__reactFiber$${???*16*}`][`__reactContainer$${???*21*}`]
+      | null["parentNode"][`__reactFiber$${???*26*}`]
+      | null[`__reactFiber$${???*31*}`][`__reactFiber$${???*36*}`]
+      | null["parentNode"]
+      | null[`__reactFiber$${???*41*}`]["alternate"]
+      | null
+      | []
+      | "mouse"
+      | "pointer"
+      | 0
+      | ???*46*
+    ),
+    ???*47*,
+    ???*48*
+)
+- *0* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *1* unsupported expression
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *2* ???*3*["return"]
+  ⚠️  unknown object
+- *3* d
+  ⚠️  circular variable reference
+- *4* ???*5*["tag"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
-- *2* max number of linking steps reached
+- *5* unsupported expression
+  ⚠️  This value might have side effects
+- *6* ???*7*["slice"](2)
+  ⚠️  unknown callee object
+- *7* ???*8*(36)
+  ⚠️  unknown callee
+- *8* ???*9*["toString"]
+  ⚠️  unknown object
+- *9* ???*10*()
+  ⚠️  nested operation
+- *10* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *11* ???*12*["slice"](2)
+  ⚠️  unknown callee object
+- *12* ???*13*(36)
+  ⚠️  unknown callee
+- *13* ???*14*["toString"]
+  ⚠️  unknown object
+- *14* ???*15*()
+  ⚠️  nested operation
+- *15* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *16* ???*17*["slice"](2)
+  ⚠️  unknown callee object
+- *17* ???*18*(36)
+  ⚠️  unknown callee
+- *18* ???*19*["toString"]
+  ⚠️  unknown object
+- *19* ???*20*()
+  ⚠️  nested operation
+- *20* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *21* ???*22*["slice"](2)
+  ⚠️  unknown callee object
+- *22* ???*23*(36)
+  ⚠️  unknown callee
+- *23* ???*24*["toString"]
+  ⚠️  unknown object
+- *24* ???*25*()
+  ⚠️  nested operation
+- *25* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *26* ???*27*["slice"](2)
+  ⚠️  unknown callee object
+- *27* ???*28*(36)
+  ⚠️  unknown callee
+- *28* ???*29*["toString"]
+  ⚠️  unknown object
+- *29* ???*30*()
+  ⚠️  nested operation
+- *30* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *31* ???*32*["slice"](2)
+  ⚠️  unknown callee object
+- *32* ???*33*(36)
+  ⚠️  unknown callee
+- *33* ???*34*["toString"]
+  ⚠️  unknown object
+- *34* ???*35*()
+  ⚠️  nested operation
+- *35* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *36* ???*37*["slice"](2)
+  ⚠️  unknown callee object
+- *37* ???*38*(36)
+  ⚠️  unknown callee
+- *38* ???*39*["toString"]
+  ⚠️  unknown object
+- *39* ???*40*()
+  ⚠️  nested operation
+- *40* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *41* ???*42*["slice"](2)
+  ⚠️  unknown callee object
+- *42* ???*43*(36)
+  ⚠️  unknown callee
+- *43* ???*44*["toString"]
+  ⚠️  unknown object
+- *44* ???*45*()
+  ⚠️  nested operation
+- *45* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *46* updated with update expression
+  ⚠️  This value might have side effects
+- *47* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *48* max number of linking steps reached
   ⚠️  This value might have side effects
 
-2232 -> 2242 member call = ???*0*["push"](???*1*)
+2232 -> 2242 member call = ???*0*["push"](
+    {
+        "instance": (
+          | ???*1*
+          | ???*2*
+          | ???*3*
+          | ???*5*
+          | null[`__reactFiber$${???*7*}`]
+          | null["parentNode"][`__reactContainer$${???*12*}`]
+          | null[`__reactFiber$${???*17*}`][`__reactContainer$${???*22*}`]
+          | null["parentNode"][`__reactFiber$${???*27*}`]
+          | null[`__reactFiber$${???*32*}`][`__reactFiber$${???*37*}`]
+          | null["parentNode"]
+          | null[`__reactFiber$${???*42*}`]["alternate"]
+          | null
+          | []
+          | "mouse"
+          | "pointer"
+          | 0
+          | ???*47*
+        ),
+        "listener": ???*48*,
+        "currentTarget": ???*49*
+    }
+)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *2* unsupported expression
+  ⚠️  This value might have side effects
+- *3* ???*4*["return"]
+  ⚠️  unknown object
+- *4* d
+  ⚠️  circular variable reference
+- *5* ???*6*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *6* unsupported expression
+  ⚠️  This value might have side effects
+- *7* ???*8*["slice"](2)
+  ⚠️  unknown callee object
+- *8* ???*9*(36)
+  ⚠️  unknown callee
+- *9* ???*10*["toString"]
+  ⚠️  unknown object
+- *10* ???*11*()
+  ⚠️  nested operation
+- *11* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *12* ???*13*["slice"](2)
+  ⚠️  unknown callee object
+- *13* ???*14*(36)
+  ⚠️  unknown callee
+- *14* ???*15*["toString"]
+  ⚠️  unknown object
+- *15* ???*16*()
+  ⚠️  nested operation
+- *16* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *17* ???*18*["slice"](2)
+  ⚠️  unknown callee object
+- *18* ???*19*(36)
+  ⚠️  unknown callee
+- *19* ???*20*["toString"]
+  ⚠️  unknown object
+- *20* ???*21*()
+  ⚠️  nested operation
+- *21* ...[...]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *22* ???*23*["slice"](2)
+  ⚠️  unknown callee object
+- *23* ???*24*(36)
+  ⚠️  unknown callee
+- *24* ???*25*["toString"]
+  ⚠️  unknown object
+- *25* ???*26*()
+  ⚠️  nested operation
+- *26* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *27* ???*28*["slice"](2)
+  ⚠️  unknown callee object
+- *28* ???*29*(36)
+  ⚠️  unknown callee
+- *29* ???*30*["toString"]
+  ⚠️  unknown object
+- *30* ???*31*()
+  ⚠️  nested operation
+- *31* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *32* ???*33*["slice"](2)
+  ⚠️  unknown callee object
+- *33* ???*34*(36)
+  ⚠️  unknown callee
+- *34* ???*35*["toString"]
+  ⚠️  unknown object
+- *35* ???*36*()
+  ⚠️  nested operation
+- *36* ...[...]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *37* ???*38*["slice"](2)
+  ⚠️  unknown callee object
+- *38* ???*39*(36)
+  ⚠️  unknown callee
+- *39* ???*40*["toString"]
+  ⚠️  unknown object
+- *40* ???*41*()
+  ⚠️  nested operation
+- *41* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *42* ???*43*["slice"](2)
+  ⚠️  unknown callee object
+- *43* ???*44*(36)
+  ⚠️  unknown callee
+- *44* ???*45*["toString"]
+  ⚠️  unknown object
+- *45* ???*46*()
+  ⚠️  nested operation
+- *46* ...[...]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *47* updated with update expression
+  ⚠️  This value might have side effects
+- *48* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *49* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2232 -> 2245 call = new ???*0*(
@@ -13526,8 +15944,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *19* e
   ⚠️  circular variable reference
 
-2232 -> 2247 member call = []["push"](???*0*)
+2232 -> 2247 member call = []["push"]({"event": ???*0*, "listeners": ???*1*})
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2228 -> 2248 conditional = (0 === ???*0*)
@@ -13630,11 +16050,13 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-2253 -> 2268 conditional = ???*0*
+2253 -> 2268 conditional = (???*0* !== ???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
 
-2268 -> 2269 conditional = ???*0*
+2268 -> 2269 conditional = (null == ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -13642,7 +16064,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-2268 -> 2271 conditional = ???*0*
+2268 -> 2271 conditional = (null == ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -13652,60 +16074,139 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 
 2268 -> 2273 call = new ???*0*(
     ???*1*,
-    ???*2*,
-    ???*3*,
-    ???*4*,
+    `${(
+          | ???*2*
+          | ???*3*
+          | ???*4*
+          | ???*6*
+          | null[???*8*]
+          | null["parentNode"][???*13*]
+          | null[???*18*][???*23*]
+          | null["parentNode"]
+          | null[???*28*]["alternate"]
+          | null
+          | []
+          | "mouse"
+          | "pointer"
+          | 0
+          | ???*33*
+        )}leave`,
+    ???*34*,
+    ???*35*,
     (
-      | (???*5* ? (???*10* | ???*12*) : (???*14* | ???*15* | ???*17*))
-      | new (...) => ???*18*("onBeforeInput", "beforeinput", null, ???*19*, ???*20*)
+      | (???*36* ? (???*41* | ???*43*) : (???*45* | ???*46* | ???*48*))
+      | new (...) => ???*49*("onBeforeInput", "beforeinput", null, ???*50*, ???*51*)
     )
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
-- *2* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *3* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *4* arguments[2]
+- *2* arguments[3]
   ⚠️  function calls are not analysed yet
-- *5* (3 === (???*6* | ???*8*))
-  ⚠️  nested operation
-- *6* ???*7*["nodeType"]
-  ⚠️  unknown object
-- *7* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *8* ???*9*["nodeType"]
-  ⚠️  unknown object
+- *3* unsupported expression
   ⚠️  This value might have side effects
-- *9* FreeVar(window)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *10* ???*11*["parentNode"]
+- *4* ???*5*["return"]
   ⚠️  unknown object
-- *11* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *12* ???*13*["parentNode"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *13* FreeVar(window)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *14* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *15* ???*16*["target"]
-  ⚠️  unknown object
-- *16* a
+- *5* d
   ⚠️  circular variable reference
-- *17* FreeVar(window)
+- *6* ???*7*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *7* unsupported expression
+  ⚠️  This value might have side effects
+- *8* `__reactFiber$${???*9*}`
+  ⚠️  nested operation
+- *9* ???*10*["slice"](2)
+  ⚠️  unknown callee object
+- *10* ???*11*(36)
+  ⚠️  unknown callee
+- *11* ???*12*["toString"]
+  ⚠️  unknown object
+- *12* ???()
+  ⚠️  nested operation
+- *13* `__reactContainer$${???*14*}`
+  ⚠️  nested operation
+- *14* ???*15*["slice"](2)
+  ⚠️  unknown callee object
+- *15* ???*16*(36)
+  ⚠️  unknown callee
+- *16* ???*17*["toString"]
+  ⚠️  unknown object
+- *17* ???()
+  ⚠️  nested operation
+- *18* `__reactFiber$${???*19*}`
+  ⚠️  nested operation
+- *19* ???*20*["slice"](2)
+  ⚠️  unknown callee object
+- *20* ???*21*(36)
+  ⚠️  unknown callee
+- *21* ???*22*["toString"]
+  ⚠️  unknown object
+- *22* ???()
+  ⚠️  nested operation
+- *23* `__reactContainer$${???*24*}`
+  ⚠️  nested operation
+- *24* ???*25*["slice"](2)
+  ⚠️  unknown callee object
+- *25* ???*26*(36)
+  ⚠️  unknown callee
+- *26* ???*27*["toString"]
+  ⚠️  unknown object
+- *27* ???()
+  ⚠️  nested operation
+- *28* `__reactFiber$${???*29*}`
+  ⚠️  nested operation
+- *29* ???*30*["slice"](2)
+  ⚠️  unknown callee object
+- *30* ???*31*(36)
+  ⚠️  unknown callee
+- *31* ???*32*["toString"]
+  ⚠️  unknown object
+- *32* ???()
+  ⚠️  nested operation
+- *33* updated with update expression
+  ⚠️  This value might have side effects
+- *34* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *35* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *36* (3 === (???*37* | ???*39*))
+  ⚠️  nested operation
+- *37* ???*38*["nodeType"]
+  ⚠️  unknown object
+- *38* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *39* ???*40*["nodeType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *40* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *18* unsupported expression
-  ⚠️  This value might have side effects
-- *19* arguments[2]
+- *41* ???*42*["parentNode"]
+  ⚠️  unknown object
+- *42* arguments[2]
   ⚠️  function calls are not analysed yet
-- *20* e
+- *43* ???*44*["parentNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *44* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *45* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *46* ???*47*["target"]
+  ⚠️  unknown object
+- *47* a
+  ⚠️  circular variable reference
+- *48* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *49* unsupported expression
+  ⚠️  This value might have side effects
+- *50* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *51* e
   ⚠️  circular variable reference
 
 2268 -> 2276 call = (...) => (b | c | null)(
@@ -13754,60 +16255,139 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 
 2268 -> 2277 call = new ???*0*(
     ???*1*,
-    ???*2*,
-    ???*3*,
-    ???*4*,
+    `${(
+          | ???*2*
+          | ???*3*
+          | ???*4*
+          | ???*6*
+          | null[???*8*]
+          | null["parentNode"][???*13*]
+          | null[???*18*][???*23*]
+          | null["parentNode"]
+          | null[???*28*]["alternate"]
+          | null
+          | []
+          | "mouse"
+          | "pointer"
+          | 0
+          | ???*33*
+        )}enter`,
+    ???*34*,
+    ???*35*,
     (
-      | (???*5* ? (???*10* | ???*12*) : (???*14* | ???*15* | ???*17*))
-      | new (...) => ???*18*("onBeforeInput", "beforeinput", null, ???*19*, ???*20*)
+      | (???*36* ? (???*41* | ???*43*) : (???*45* | ???*46* | ???*48*))
+      | new (...) => ???*49*("onBeforeInput", "beforeinput", null, ???*50*, ???*51*)
     )
 )
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
-- *2* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *3* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *4* arguments[2]
+- *2* arguments[3]
   ⚠️  function calls are not analysed yet
-- *5* (3 === (???*6* | ???*8*))
-  ⚠️  nested operation
-- *6* ???*7*["nodeType"]
-  ⚠️  unknown object
-- *7* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *8* ???*9*["nodeType"]
-  ⚠️  unknown object
+- *3* unsupported expression
   ⚠️  This value might have side effects
-- *9* FreeVar(window)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *10* ???*11*["parentNode"]
+- *4* ???*5*["return"]
   ⚠️  unknown object
-- *11* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *12* ???*13*["parentNode"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *13* FreeVar(window)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *14* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *15* ???*16*["target"]
-  ⚠️  unknown object
-- *16* a
+- *5* d
   ⚠️  circular variable reference
-- *17* FreeVar(window)
+- *6* ???*7*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *7* unsupported expression
+  ⚠️  This value might have side effects
+- *8* `__reactFiber$${???*9*}`
+  ⚠️  nested operation
+- *9* ???*10*["slice"](2)
+  ⚠️  unknown callee object
+- *10* ???*11*(36)
+  ⚠️  unknown callee
+- *11* ???*12*["toString"]
+  ⚠️  unknown object
+- *12* ???()
+  ⚠️  nested operation
+- *13* `__reactContainer$${???*14*}`
+  ⚠️  nested operation
+- *14* ???*15*["slice"](2)
+  ⚠️  unknown callee object
+- *15* ???*16*(36)
+  ⚠️  unknown callee
+- *16* ???*17*["toString"]
+  ⚠️  unknown object
+- *17* ???()
+  ⚠️  nested operation
+- *18* `__reactFiber$${???*19*}`
+  ⚠️  nested operation
+- *19* ???*20*["slice"](2)
+  ⚠️  unknown callee object
+- *20* ???*21*(36)
+  ⚠️  unknown callee
+- *21* ???*22*["toString"]
+  ⚠️  unknown object
+- *22* ???()
+  ⚠️  nested operation
+- *23* `__reactContainer$${???*24*}`
+  ⚠️  nested operation
+- *24* ???*25*["slice"](2)
+  ⚠️  unknown callee object
+- *25* ???*26*(36)
+  ⚠️  unknown callee
+- *26* ???*27*["toString"]
+  ⚠️  unknown object
+- *27* ???()
+  ⚠️  nested operation
+- *28* `__reactFiber$${???*29*}`
+  ⚠️  nested operation
+- *29* ???*30*["slice"](2)
+  ⚠️  unknown callee object
+- *30* ???*31*(36)
+  ⚠️  unknown callee
+- *31* ???*32*["toString"]
+  ⚠️  unknown object
+- *32* ???()
+  ⚠️  nested operation
+- *33* updated with update expression
+  ⚠️  This value might have side effects
+- *34* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *35* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *36* (3 === (???*37* | ???*39*))
+  ⚠️  nested operation
+- *37* ???*38*["nodeType"]
+  ⚠️  unknown object
+- *38* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *39* ???*40*["nodeType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *40* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *18* unsupported expression
-  ⚠️  This value might have side effects
-- *19* arguments[2]
+- *41* ???*42*["parentNode"]
+  ⚠️  unknown object
+- *42* arguments[2]
   ⚠️  function calls are not analysed yet
-- *20* e
+- *43* ???*44*["parentNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *44* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *45* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *46* ???*47*["target"]
+  ⚠️  unknown object
+- *47* a
+  ⚠️  circular variable reference
+- *48* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *49* unsupported expression
+  ⚠️  This value might have side effects
+- *50* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *51* e
   ⚠️  circular variable reference
 
 2268 -> 2280 conditional = ???*0*
@@ -13854,30 +16434,316 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-2248 -> 2290 conditional = ???*0*
-- *0* max number of linking steps reached
+2248 -> 2290 conditional = (
+  | ???*0*
+  | ???*1*
+  | ???*2*
+  | ???*4*
+  | null[`__reactFiber$${???*6*}`]
+  | null["parentNode"][`__reactContainer$${???*11*}`]
+  | null[`__reactFiber$${???*16*}`][`__reactContainer$${???*21*}`]
+  | null["parentNode"][`__reactFiber$${???*26*}`]
+  | null[`__reactFiber$${???*31*}`][`__reactFiber$${???*36*}`]
+  | null["parentNode"]
+  | null[`__reactFiber$${???*41*}`]["alternate"]
+  | null
+  | []
+)
+- *0* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *1* unsupported expression
+  ⚠️  This value might have side effects
+- *2* ???*3*["return"]
+  ⚠️  unknown object
+- *3* d
+  ⚠️  circular variable reference
+- *4* ???*5*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* unsupported expression
+  ⚠️  This value might have side effects
+- *6* ???*7*["slice"](2)
+  ⚠️  unknown callee object
+- *7* ???*8*(36)
+  ⚠️  unknown callee
+- *8* ???*9*["toString"]
+  ⚠️  unknown object
+- *9* ???*10*()
+  ⚠️  nested operation
+- *10* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *11* ???*12*["slice"](2)
+  ⚠️  unknown callee object
+- *12* ???*13*(36)
+  ⚠️  unknown callee
+- *13* ???*14*["toString"]
+  ⚠️  unknown object
+- *14* ???*15*()
+  ⚠️  nested operation
+- *15* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *16* ???*17*["slice"](2)
+  ⚠️  unknown callee object
+- *17* ???*18*(36)
+  ⚠️  unknown callee
+- *18* ???*19*["toString"]
+  ⚠️  unknown object
+- *19* ???*20*()
+  ⚠️  nested operation
+- *20* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *21* ???*22*["slice"](2)
+  ⚠️  unknown callee object
+- *22* ???*23*(36)
+  ⚠️  unknown callee
+- *23* ???*24*["toString"]
+  ⚠️  unknown object
+- *24* ???*25*()
+  ⚠️  nested operation
+- *25* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *26* ???*27*["slice"](2)
+  ⚠️  unknown callee object
+- *27* ???*28*(36)
+  ⚠️  unknown callee
+- *28* ???*29*["toString"]
+  ⚠️  unknown object
+- *29* ???*30*()
+  ⚠️  nested operation
+- *30* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *31* ???*32*["slice"](2)
+  ⚠️  unknown callee object
+- *32* ???*33*(36)
+  ⚠️  unknown callee
+- *33* ???*34*["toString"]
+  ⚠️  unknown object
+- *34* ???*35*()
+  ⚠️  nested operation
+- *35* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *36* ???*37*["slice"](2)
+  ⚠️  unknown callee object
+- *37* ???*38*(36)
+  ⚠️  unknown callee
+- *38* ???*39*["toString"]
+  ⚠️  unknown object
+- *39* ???*40*()
+  ⚠️  nested operation
+- *40* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *41* ???*42*["slice"](2)
+  ⚠️  unknown callee object
+- *42* ???*43*(36)
+  ⚠️  unknown callee
+- *43* ???*44*["toString"]
+  ⚠️  unknown object
+- *44* ???*45*()
+  ⚠️  nested operation
+- *45* ???["random"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 
-2290 -> 2291 call = (...) => (undefined | a["stateNode"])(???*0*)
-- *0* max number of linking steps reached
+2290 -> 2291 call = (...) => (undefined | a["stateNode"])(
+    (
+      | ???*0*
+      | ???*1*
+      | ???*2*
+      | ???*4*
+      | null[`__reactFiber$${???*6*}`]
+      | null["parentNode"][`__reactContainer$${???*11*}`]
+      | null[`__reactFiber$${???*16*}`][`__reactContainer$${???*21*}`]
+      | null["parentNode"][`__reactFiber$${???*26*}`]
+      | null[`__reactFiber$${???*31*}`][`__reactFiber$${???*36*}`]
+      | null["parentNode"]
+      | null[`__reactFiber$${???*41*}`]["alternate"]
+      | null
+      | []
+    )
+)
+- *0* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *1* unsupported expression
+  ⚠️  This value might have side effects
+- *2* ???*3*["return"]
+  ⚠️  unknown object
+- *3* d
+  ⚠️  circular variable reference
+- *4* ???*5*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* unsupported expression
+  ⚠️  This value might have side effects
+- *6* ???*7*["slice"](2)
+  ⚠️  unknown callee object
+- *7* ???*8*(36)
+  ⚠️  unknown callee
+- *8* ???*9*["toString"]
+  ⚠️  unknown object
+- *9* ???*10*()
+  ⚠️  nested operation
+- *10* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *11* ???*12*["slice"](2)
+  ⚠️  unknown callee object
+- *12* ???*13*(36)
+  ⚠️  unknown callee
+- *13* ???*14*["toString"]
+  ⚠️  unknown object
+- *14* ???*15*()
+  ⚠️  nested operation
+- *15* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *16* ???*17*["slice"](2)
+  ⚠️  unknown callee object
+- *17* ???*18*(36)
+  ⚠️  unknown callee
+- *18* ???*19*["toString"]
+  ⚠️  unknown object
+- *19* ???*20*()
+  ⚠️  nested operation
+- *20* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *21* ???*22*["slice"](2)
+  ⚠️  unknown callee object
+- *22* ???*23*(36)
+  ⚠️  unknown callee
+- *23* ???*24*["toString"]
+  ⚠️  unknown object
+- *24* ???*25*()
+  ⚠️  nested operation
+- *25* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *26* ???*27*["slice"](2)
+  ⚠️  unknown callee object
+- *27* ???*28*(36)
+  ⚠️  unknown callee
+- *28* ???*29*["toString"]
+  ⚠️  unknown object
+- *29* ???*30*()
+  ⚠️  nested operation
+- *30* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *31* ???*32*["slice"](2)
+  ⚠️  unknown callee object
+- *32* ???*33*(36)
+  ⚠️  unknown callee
+- *33* ???*34*["toString"]
+  ⚠️  unknown object
+- *34* ???*35*()
+  ⚠️  nested operation
+- *35* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *36* ???*37*["slice"](2)
+  ⚠️  unknown callee object
+- *37* ???*38*(36)
+  ⚠️  unknown callee
+- *38* ???*39*["toString"]
+  ⚠️  unknown object
+- *39* ???*40*()
+  ⚠️  nested operation
+- *40* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *41* ???*42*["slice"](2)
+  ⚠️  unknown callee object
+- *42* ???*43*(36)
+  ⚠️  unknown callee
+- *43* ???*44*["toString"]
+  ⚠️  unknown object
+- *44* ???*45*()
+  ⚠️  nested operation
+- *45* ???["random"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 
 2290 -> 2292 free var = FreeVar(window)
 
 2248 -> 2296 member call = ???*0*["toLowerCase"]()
-- *0* max number of linking steps reached
+- *0* ???*1*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-2248 -> 2298 conditional = ???*0*
+2248 -> 2298 conditional = (("select" === ???*0*) | ("input" === ???*1*) | ("file" === ???*2*))
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* ???*3*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2298 -> 2299 call = (...) => (("input" === b) ? !(!(le[a["type"]])) : (("textarea" === b) ? !(0) : !(1)))(???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-2298 -> 2300 conditional = ???*0*
-- *0* max number of linking steps reached
+2298 -> 2300 conditional = (???*0* ? ???*8* : ???*13*)
+- *0* ("input" === (???*1* | ???*2* | ???*4*))
+  ⚠️  nested operation
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* ???*3*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *4* ???*5*()
+  ⚠️  nested operation
+- *5* ???*6*["toLowerCase"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *6* ???*7*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *7* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *8* !(???*9*)
+  ⚠️  nested operation
+- *9* !((true | ???*10*))
+  ⚠️  nested operation
+- *10* {}[???*11*]
+  ⚠️  unknown object prototype methods or values
+  ⚠️  This value might have side effects
+- *11* ???*12*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *12* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *13* (???*14* ? true : false)
+  ⚠️  nested operation
+- *14* ("textarea" === (???*15* | ???*16* | ???*18*))
+  ⚠️  nested operation
+- *15* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *16* ???*17*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *17* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *18* ???*19*()
+  ⚠️  nested operation
+- *19* ???*20*["toLowerCase"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *20* ???["nodeName"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 
 2300 -> 2303 member call = ???*0*["toLowerCase"]()
@@ -13890,14 +16756,130 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   | (...) => (undefined | te(qe))
   | (...) => (undefined | te(b))
   | ???*0*
-)(???*2*, ???*3*)
+)(
+    ???*2*,
+    (
+      | ???*3*
+      | ???*4*
+      | ???*5*
+      | ???*7*
+      | null[`__reactFiber$${???*9*}`]
+      | null["parentNode"][`__reactContainer$${???*14*}`]
+      | null[`__reactFiber$${???*19*}`][`__reactContainer$${???*24*}`]
+      | null["parentNode"][`__reactFiber$${???*29*}`]
+      | null[`__reactFiber$${???*34*}`][`__reactFiber$${???*39*}`]
+      | null["parentNode"]
+      | null[`__reactFiber$${???*44*}`]["alternate"]
+      | null
+      | []
+    )
+)
 - *0* ???*1*(a, d)
   ⚠️  unknown callee
 - *1* na
   ⚠️  circular variable reference
 - *2* arguments[0]
   ⚠️  function calls are not analysed yet
-- *3* max number of linking steps reached
+- *3* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *4* unsupported expression
+  ⚠️  This value might have side effects
+- *5* ???*6*["return"]
+  ⚠️  unknown object
+- *6* d
+  ⚠️  circular variable reference
+- *7* ???*8*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *8* unsupported expression
+  ⚠️  This value might have side effects
+- *9* ???*10*["slice"](2)
+  ⚠️  unknown callee object
+- *10* ???*11*(36)
+  ⚠️  unknown callee
+- *11* ???*12*["toString"]
+  ⚠️  unknown object
+- *12* ???*13*()
+  ⚠️  nested operation
+- *13* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *14* ???*15*["slice"](2)
+  ⚠️  unknown callee object
+- *15* ???*16*(36)
+  ⚠️  unknown callee
+- *16* ???*17*["toString"]
+  ⚠️  unknown object
+- *17* ???*18*()
+  ⚠️  nested operation
+- *18* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *19* ???*20*["slice"](2)
+  ⚠️  unknown callee object
+- *20* ???*21*(36)
+  ⚠️  unknown callee
+- *21* ???*22*["toString"]
+  ⚠️  unknown object
+- *22* ???*23*()
+  ⚠️  nested operation
+- *23* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *24* ???*25*["slice"](2)
+  ⚠️  unknown callee object
+- *25* ???*26*(36)
+  ⚠️  unknown callee
+- *26* ???*27*["toString"]
+  ⚠️  unknown object
+- *27* ???*28*()
+  ⚠️  nested operation
+- *28* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *29* ???*30*["slice"](2)
+  ⚠️  unknown callee object
+- *30* ???*31*(36)
+  ⚠️  unknown callee
+- *31* ???*32*["toString"]
+  ⚠️  unknown object
+- *32* ???*33*()
+  ⚠️  nested operation
+- *33* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *34* ???*35*["slice"](2)
+  ⚠️  unknown callee object
+- *35* ???*36*(36)
+  ⚠️  unknown callee
+- *36* ???*37*["toString"]
+  ⚠️  unknown object
+- *37* ???*38*()
+  ⚠️  nested operation
+- *38* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *39* ???*40*["slice"](2)
+  ⚠️  unknown callee object
+- *40* ???*41*(36)
+  ⚠️  unknown callee
+- *41* ???*42*["toString"]
+  ⚠️  unknown object
+- *42* ???*43*()
+  ⚠️  nested operation
+- *43* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *44* ???*45*["slice"](2)
+  ⚠️  unknown callee object
+- *45* ???*46*(36)
+  ⚠️  unknown callee
+- *46* ???*47*["toString"]
+  ⚠️  unknown object
+- *47* ???*48*()
+  ⚠️  nested operation
+- *48* ???["random"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 
 2248 -> 2307 conditional = (
@@ -13974,28 +16956,376 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *18* e
   ⚠️  circular variable reference
 
-2248 -> 2309 call = ???*0*(???*1*, ???*2*, ???*3*)
+2248 -> 2309 call = ???*0*(
+    ???*1*,
+    ???*2*,
+    (
+      | ???*3*
+      | ???*4*
+      | ???*5*
+      | ???*7*
+      | null[`__reactFiber$${???*9*}`]
+      | null["parentNode"][`__reactContainer$${???*14*}`]
+      | null[`__reactFiber$${???*19*}`][`__reactContainer$${???*24*}`]
+      | null["parentNode"][`__reactFiber$${???*29*}`]
+      | null[`__reactFiber$${???*34*}`][`__reactFiber$${???*39*}`]
+      | null["parentNode"]
+      | null[`__reactFiber$${???*44*}`]["alternate"]
+      | null
+      | []
+    )
+)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
-- *3* max number of linking steps reached
+- *3* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *4* unsupported expression
+  ⚠️  This value might have side effects
+- *5* ???*6*["return"]
+  ⚠️  unknown object
+- *6* d
+  ⚠️  circular variable reference
+- *7* ???*8*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *8* unsupported expression
+  ⚠️  This value might have side effects
+- *9* ???*10*["slice"](2)
+  ⚠️  unknown callee object
+- *10* ???*11*(36)
+  ⚠️  unknown callee
+- *11* ???*12*["toString"]
+  ⚠️  unknown object
+- *12* ???*13*()
+  ⚠️  nested operation
+- *13* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *14* ???*15*["slice"](2)
+  ⚠️  unknown callee object
+- *15* ???*16*(36)
+  ⚠️  unknown callee
+- *16* ???*17*["toString"]
+  ⚠️  unknown object
+- *17* ???*18*()
+  ⚠️  nested operation
+- *18* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *19* ???*20*["slice"](2)
+  ⚠️  unknown callee object
+- *20* ???*21*(36)
+  ⚠️  unknown callee
+- *21* ???*22*["toString"]
+  ⚠️  unknown object
+- *22* ???*23*()
+  ⚠️  nested operation
+- *23* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *24* ???*25*["slice"](2)
+  ⚠️  unknown callee object
+- *25* ???*26*(36)
+  ⚠️  unknown callee
+- *26* ???*27*["toString"]
+  ⚠️  unknown object
+- *27* ???*28*()
+  ⚠️  nested operation
+- *28* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *29* ???*30*["slice"](2)
+  ⚠️  unknown callee object
+- *30* ???*31*(36)
+  ⚠️  unknown callee
+- *31* ???*32*["toString"]
+  ⚠️  unknown object
+- *32* ???*33*()
+  ⚠️  nested operation
+- *33* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *34* ???*35*["slice"](2)
+  ⚠️  unknown callee object
+- *35* ???*36*(36)
+  ⚠️  unknown callee
+- *36* ???*37*["toString"]
+  ⚠️  unknown object
+- *37* ???*38*()
+  ⚠️  nested operation
+- *38* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *39* ???*40*["slice"](2)
+  ⚠️  unknown callee object
+- *40* ???*41*(36)
+  ⚠️  unknown callee
+- *41* ???*42*["toString"]
+  ⚠️  unknown object
+- *42* ???*43*()
+  ⚠️  nested operation
+- *43* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *44* ???*45*["slice"](2)
+  ⚠️  unknown callee object
+- *45* ???*46*(36)
+  ⚠️  unknown callee
+- *46* ???*47*["toString"]
+  ⚠️  unknown object
+- *47* ???*48*()
+  ⚠️  nested operation
+- *48* ???["random"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 
 2248 -> 2314 call = (...) => undefined(???*0*, "number", ???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["value"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-2248 -> 2315 conditional = ???*0*
-- *0* max number of linking steps reached
+2248 -> 2315 conditional = (
+  | ???*0*
+  | ???*1*
+  | ???*2*
+  | ???*4*
+  | null[`__reactFiber$${???*6*}`]
+  | null["parentNode"][`__reactContainer$${???*11*}`]
+  | null[`__reactFiber$${???*16*}`][`__reactContainer$${???*21*}`]
+  | null["parentNode"][`__reactFiber$${???*26*}`]
+  | null[`__reactFiber$${???*31*}`][`__reactFiber$${???*36*}`]
+  | null["parentNode"]
+  | null[`__reactFiber$${???*41*}`]["alternate"]
+  | null
+  | []
+)
+- *0* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *1* unsupported expression
+  ⚠️  This value might have side effects
+- *2* ???*3*["return"]
+  ⚠️  unknown object
+- *3* d
+  ⚠️  circular variable reference
+- *4* ???*5*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* unsupported expression
+  ⚠️  This value might have side effects
+- *6* ???*7*["slice"](2)
+  ⚠️  unknown callee object
+- *7* ???*8*(36)
+  ⚠️  unknown callee
+- *8* ???*9*["toString"]
+  ⚠️  unknown object
+- *9* ???*10*()
+  ⚠️  nested operation
+- *10* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *11* ???*12*["slice"](2)
+  ⚠️  unknown callee object
+- *12* ???*13*(36)
+  ⚠️  unknown callee
+- *13* ???*14*["toString"]
+  ⚠️  unknown object
+- *14* ???*15*()
+  ⚠️  nested operation
+- *15* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *16* ???*17*["slice"](2)
+  ⚠️  unknown callee object
+- *17* ???*18*(36)
+  ⚠️  unknown callee
+- *18* ???*19*["toString"]
+  ⚠️  unknown object
+- *19* ???*20*()
+  ⚠️  nested operation
+- *20* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *21* ???*22*["slice"](2)
+  ⚠️  unknown callee object
+- *22* ???*23*(36)
+  ⚠️  unknown callee
+- *23* ???*24*["toString"]
+  ⚠️  unknown object
+- *24* ???*25*()
+  ⚠️  nested operation
+- *25* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *26* ???*27*["slice"](2)
+  ⚠️  unknown callee object
+- *27* ???*28*(36)
+  ⚠️  unknown callee
+- *28* ???*29*["toString"]
+  ⚠️  unknown object
+- *29* ???*30*()
+  ⚠️  nested operation
+- *30* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *31* ???*32*["slice"](2)
+  ⚠️  unknown callee object
+- *32* ???*33*(36)
+  ⚠️  unknown callee
+- *33* ???*34*["toString"]
+  ⚠️  unknown object
+- *34* ???*35*()
+  ⚠️  nested operation
+- *35* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *36* ???*37*["slice"](2)
+  ⚠️  unknown callee object
+- *37* ???*38*(36)
+  ⚠️  unknown callee
+- *38* ???*39*["toString"]
+  ⚠️  unknown object
+- *39* ???*40*()
+  ⚠️  nested operation
+- *40* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *41* ???*42*["slice"](2)
+  ⚠️  unknown callee object
+- *42* ???*43*(36)
+  ⚠️  unknown callee
+- *43* ???*44*["toString"]
+  ⚠️  unknown object
+- *44* ???*45*()
+  ⚠️  nested operation
+- *45* ???["random"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 
-2315 -> 2316 call = (...) => (undefined | a["stateNode"])(???*0*)
-- *0* max number of linking steps reached
+2315 -> 2316 call = (...) => (undefined | a["stateNode"])(
+    (
+      | ???*0*
+      | ???*1*
+      | ???*2*
+      | ???*4*
+      | null[`__reactFiber$${???*6*}`]
+      | null["parentNode"][`__reactContainer$${???*11*}`]
+      | null[`__reactFiber$${???*16*}`][`__reactContainer$${???*21*}`]
+      | null["parentNode"][`__reactFiber$${???*26*}`]
+      | null[`__reactFiber$${???*31*}`][`__reactFiber$${???*36*}`]
+      | null["parentNode"]
+      | null[`__reactFiber$${???*41*}`]["alternate"]
+      | null
+      | []
+    )
+)
+- *0* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *1* unsupported expression
+  ⚠️  This value might have side effects
+- *2* ???*3*["return"]
+  ⚠️  unknown object
+- *3* d
+  ⚠️  circular variable reference
+- *4* ???*5*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* unsupported expression
+  ⚠️  This value might have side effects
+- *6* ???*7*["slice"](2)
+  ⚠️  unknown callee object
+- *7* ???*8*(36)
+  ⚠️  unknown callee
+- *8* ???*9*["toString"]
+  ⚠️  unknown object
+- *9* ???*10*()
+  ⚠️  nested operation
+- *10* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *11* ???*12*["slice"](2)
+  ⚠️  unknown callee object
+- *12* ???*13*(36)
+  ⚠️  unknown callee
+- *13* ???*14*["toString"]
+  ⚠️  unknown object
+- *14* ???*15*()
+  ⚠️  nested operation
+- *15* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *16* ???*17*["slice"](2)
+  ⚠️  unknown callee object
+- *17* ???*18*(36)
+  ⚠️  unknown callee
+- *18* ???*19*["toString"]
+  ⚠️  unknown object
+- *19* ???*20*()
+  ⚠️  nested operation
+- *20* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *21* ???*22*["slice"](2)
+  ⚠️  unknown callee object
+- *22* ???*23*(36)
+  ⚠️  unknown callee
+- *23* ???*24*["toString"]
+  ⚠️  unknown object
+- *24* ???*25*()
+  ⚠️  nested operation
+- *25* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *26* ???*27*["slice"](2)
+  ⚠️  unknown callee object
+- *27* ???*28*(36)
+  ⚠️  unknown callee
+- *28* ???*29*["toString"]
+  ⚠️  unknown object
+- *29* ???*30*()
+  ⚠️  nested operation
+- *30* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *31* ???*32*["slice"](2)
+  ⚠️  unknown callee object
+- *32* ???*33*(36)
+  ⚠️  unknown callee
+- *33* ???*34*["toString"]
+  ⚠️  unknown object
+- *34* ???*35*()
+  ⚠️  nested operation
+- *35* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *36* ???*37*["slice"](2)
+  ⚠️  unknown callee object
+- *37* ???*38*(36)
+  ⚠️  unknown callee
+- *38* ???*39*["toString"]
+  ⚠️  unknown object
+- *39* ???*40*()
+  ⚠️  nested operation
+- *40* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *41* ???*42*["slice"](2)
+  ⚠️  unknown callee object
+- *42* ???*43*(36)
+  ⚠️  unknown callee
+- *43* ???*44*["toString"]
+  ⚠️  unknown object
+- *44* ???*45*()
+  ⚠️  nested operation
+- *45* ???["random"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 
 2315 -> 2317 free var = FreeVar(window)
@@ -14177,58 +17507,171 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 
 2248 -> 2331 call = (...) => d(
-    ???*0*,
+    (
+      | ???*0*
+      | ???*1*
+      | ???*2*
+      | ???*4*
+      | null[`__reactFiber$${???*6*}`]
+      | null["parentNode"][`__reactContainer$${???*11*}`]
+      | null[`__reactFiber$${???*16*}`][`__reactContainer$${???*21*}`]
+      | null["parentNode"][`__reactFiber$${???*26*}`]
+      | null[`__reactFiber$${???*31*}`][`__reactFiber$${???*36*}`]
+      | null["parentNode"]
+      | null[`__reactFiber$${???*41*}`]["alternate"]
+      | null
+      | []
+    ),
     (
       | "onCompositionStart"
       | "onCompositionEnd"
       | "onCompositionUpdate"
-      | ???*1*
-      | new (...) => ???*2*(???*3*, ???*4*, null, ???*5*, ???*6*)
+      | ???*46*
+      | new (...) => ???*47*(???*48*, ???*49*, null, ???*50*, ???*51*)
     )
 )
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
+- *0* arguments[3]
+  ⚠️  function calls are not analysed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
-- *2* unsupported expression
-  ⚠️  This value might have side effects
-- *3* ba
+- *2* ???*3*["return"]
+  ⚠️  unknown object
+- *3* d
   ⚠️  circular variable reference
-- *4* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *5* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *6* (???*7* ? (???*12* | ???*14*) : (???*16* | ???*17* | ???*19*))
-  ⚠️  nested operation
-- *7* (3 === (???*8* | ???*10*))
-  ⚠️  nested operation
-- *8* ???*9*["nodeType"]
-  ⚠️  unknown object
-- *9* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *10* ???*11*["nodeType"]
+- *4* ???*5*["tag"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *11* FreeVar(window)
+- *5* unsupported expression
+  ⚠️  This value might have side effects
+- *6* ???*7*["slice"](2)
+  ⚠️  unknown callee object
+- *7* ???*8*(36)
+  ⚠️  unknown callee
+- *8* ???*9*["toString"]
+  ⚠️  unknown object
+- *9* ???*10*()
+  ⚠️  nested operation
+- *10* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *11* ???*12*["slice"](2)
+  ⚠️  unknown callee object
+- *12* ???*13*(36)
+  ⚠️  unknown callee
+- *13* ???*14*["toString"]
+  ⚠️  unknown object
+- *14* ???*15*()
+  ⚠️  nested operation
+- *15* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *16* ???*17*["slice"](2)
+  ⚠️  unknown callee object
+- *17* ???*18*(36)
+  ⚠️  unknown callee
+- *18* ???*19*["toString"]
+  ⚠️  unknown object
+- *19* ???*20*()
+  ⚠️  nested operation
+- *20* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *21* ???*22*["slice"](2)
+  ⚠️  unknown callee object
+- *22* ???*23*(36)
+  ⚠️  unknown callee
+- *23* ???*24*["toString"]
+  ⚠️  unknown object
+- *24* ???*25*()
+  ⚠️  nested operation
+- *25* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *26* ???*27*["slice"](2)
+  ⚠️  unknown callee object
+- *27* ???*28*(36)
+  ⚠️  unknown callee
+- *28* ???*29*["toString"]
+  ⚠️  unknown object
+- *29* ???*30*()
+  ⚠️  nested operation
+- *30* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *31* ???*32*["slice"](2)
+  ⚠️  unknown callee object
+- *32* ???*33*(36)
+  ⚠️  unknown callee
+- *33* ???*34*["toString"]
+  ⚠️  unknown object
+- *34* ???*35*()
+  ⚠️  nested operation
+- *35* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *36* ???*37*["slice"](2)
+  ⚠️  unknown callee object
+- *37* ???*38*(36)
+  ⚠️  unknown callee
+- *38* ???*39*["toString"]
+  ⚠️  unknown object
+- *39* ???*40*()
+  ⚠️  nested operation
+- *40* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *41* ???*42*["slice"](2)
+  ⚠️  unknown callee object
+- *42* ???*43*(36)
+  ⚠️  unknown callee
+- *43* ???*44*["toString"]
+  ⚠️  unknown object
+- *44* ???*45*()
+  ⚠️  nested operation
+- *45* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *46* unsupported expression
+  ⚠️  This value might have side effects
+- *47* unsupported expression
+  ⚠️  This value might have side effects
+- *48* ba
+  ⚠️  circular variable reference
+- *49* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *50* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *51* (???*52* ? (???*57* | ???*59*) : (???*61* | ???*62* | ???*64*))
+  ⚠️  nested operation
+- *52* (3 === (???*53* | ???*55*))
+  ⚠️  nested operation
+- *53* ???*54*["nodeType"]
+  ⚠️  unknown object
+- *54* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *55* ???*56*["nodeType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *56* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *12* ???*13*["parentNode"]
+- *57* ???*58*["parentNode"]
   ⚠️  unknown object
-- *13* arguments[2]
+- *58* arguments[2]
   ⚠️  function calls are not analysed yet
-- *14* ???*15*["parentNode"]
+- *59* ???*60*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *15* FreeVar(window)
+- *60* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *16* arguments[2]
+- *61* arguments[2]
   ⚠️  function calls are not analysed yet
-- *17* ???*18*["target"]
+- *62* ???*63*["target"]
   ⚠️  unknown object
-- *18* a
+- *63* a
   ⚠️  circular variable reference
-- *19* FreeVar(window)
+- *64* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
 
@@ -14335,8 +17778,62 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *37* e
   ⚠️  circular variable reference
 
-2248 -> 2335 member call = []["push"](???*0*)
-- *0* max number of linking steps reached
+2248 -> 2335 member call = []["push"](
+    {
+        "event": (
+          | "onCompositionStart"
+          | "onCompositionEnd"
+          | "onCompositionUpdate"
+          | ???*0*
+          | new (...) => ???*1*(???*2*, ???*3*, null, ???*4*, ???*5*)
+        ),
+        "listeners": ???*19*
+    }
+)
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* unsupported expression
+  ⚠️  This value might have side effects
+- *2* ba
+  ⚠️  circular variable reference
+- *3* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *4* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *5* (???*6* ? (???*11* | ???*13*) : (???*15* | ???*16* | ???*18*))
+  ⚠️  nested operation
+- *6* (3 === (???*7* | ???*9*))
+  ⚠️  nested operation
+- *7* ???*8*["nodeType"]
+  ⚠️  unknown object
+- *8* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *9* ???*10*["nodeType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *10* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *11* ???*12*["parentNode"]
+  ⚠️  unknown object
+- *12* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *13* ???*14*["parentNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *14* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *15* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *16* ???*17*["target"]
+  ⚠️  unknown object
+- *17* a
+  ⚠️  circular variable reference
+- *18* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *19* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2248 -> 2336 conditional = ???*0*
@@ -14391,8 +17888,124 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *2* arguments[2]
   ⚠️  function calls are not analysed yet
 
-2248 -> 2343 call = (...) => d(???*0*, "onBeforeInput")
-- *0* max number of linking steps reached
+2248 -> 2343 call = (...) => d(
+    (
+      | ???*0*
+      | ???*1*
+      | ???*2*
+      | ???*4*
+      | null[`__reactFiber$${???*6*}`]
+      | null["parentNode"][`__reactContainer$${???*11*}`]
+      | null[`__reactFiber$${???*16*}`][`__reactContainer$${???*21*}`]
+      | null["parentNode"][`__reactFiber$${???*26*}`]
+      | null[`__reactFiber$${???*31*}`][`__reactFiber$${???*36*}`]
+      | null["parentNode"]
+      | null[`__reactFiber$${???*41*}`]["alternate"]
+      | null
+      | []
+    ),
+    "onBeforeInput"
+)
+- *0* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *1* unsupported expression
+  ⚠️  This value might have side effects
+- *2* ???*3*["return"]
+  ⚠️  unknown object
+- *3* d
+  ⚠️  circular variable reference
+- *4* ???*5*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* unsupported expression
+  ⚠️  This value might have side effects
+- *6* ???*7*["slice"](2)
+  ⚠️  unknown callee object
+- *7* ???*8*(36)
+  ⚠️  unknown callee
+- *8* ???*9*["toString"]
+  ⚠️  unknown object
+- *9* ???*10*()
+  ⚠️  nested operation
+- *10* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *11* ???*12*["slice"](2)
+  ⚠️  unknown callee object
+- *12* ???*13*(36)
+  ⚠️  unknown callee
+- *13* ???*14*["toString"]
+  ⚠️  unknown object
+- *14* ???*15*()
+  ⚠️  nested operation
+- *15* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *16* ???*17*["slice"](2)
+  ⚠️  unknown callee object
+- *17* ???*18*(36)
+  ⚠️  unknown callee
+- *18* ???*19*["toString"]
+  ⚠️  unknown object
+- *19* ???*20*()
+  ⚠️  nested operation
+- *20* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *21* ???*22*["slice"](2)
+  ⚠️  unknown callee object
+- *22* ???*23*(36)
+  ⚠️  unknown callee
+- *23* ???*24*["toString"]
+  ⚠️  unknown object
+- *24* ???*25*()
+  ⚠️  nested operation
+- *25* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *26* ???*27*["slice"](2)
+  ⚠️  unknown callee object
+- *27* ???*28*(36)
+  ⚠️  unknown callee
+- *28* ???*29*["toString"]
+  ⚠️  unknown object
+- *29* ???*30*()
+  ⚠️  nested operation
+- *30* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *31* ???*32*["slice"](2)
+  ⚠️  unknown callee object
+- *32* ???*33*(36)
+  ⚠️  unknown callee
+- *33* ???*34*["toString"]
+  ⚠️  unknown object
+- *34* ???*35*()
+  ⚠️  nested operation
+- *35* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *36* ???*37*["slice"](2)
+  ⚠️  unknown callee object
+- *37* ???*38*(36)
+  ⚠️  unknown callee
+- *38* ???*39*["toString"]
+  ⚠️  unknown object
+- *39* ???*40*()
+  ⚠️  nested operation
+- *40* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *41* ???*42*["slice"](2)
+  ⚠️  unknown callee object
+- *42* ???*43*(36)
+  ⚠️  unknown callee
+- *43* ???*44*["toString"]
+  ⚠️  unknown object
+- *44* ???*45*()
+  ⚠️  nested operation
+- *45* ???["random"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 
 2248 -> 2345 call = new (...) => ???*0*(
@@ -14447,8 +18060,166 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *17* e
   ⚠️  circular variable reference
 
-2248 -> 2347 member call = []["push"](???*0*)
-- *0* max number of linking steps reached
+2248 -> 2347 member call = []["push"](
+    {
+        "event": (
+          | (???*0* ? (???*5* | ???*7*) : (???*9* | ???*10* | ???*12*))
+          | new (...) => ???*13*("onBeforeInput", "beforeinput", null, ???*14*, ???*15*)
+        ),
+        "listeners": (
+          | ???*16*
+          | ???*17*
+          | ???*18*
+          | ???*20*
+          | null[`__reactFiber$${???*22*}`]
+          | null["parentNode"][`__reactContainer$${???*27*}`]
+          | null[`__reactFiber$${???*32*}`][`__reactContainer$${???*37*}`]
+          | null["parentNode"][`__reactFiber$${???*42*}`]
+          | null[`__reactFiber$${???*47*}`][`__reactFiber$${???*52*}`]
+          | null["parentNode"]
+          | null[`__reactFiber$${???*57*}`]["alternate"]
+          | null
+          | []
+        )
+    }
+)
+- *0* (3 === (???*1* | ???*3*))
+  ⚠️  nested operation
+- *1* ???*2*["nodeType"]
+  ⚠️  unknown object
+- *2* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *3* ???*4*["nodeType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *4* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *5* ???*6*["parentNode"]
+  ⚠️  unknown object
+- *6* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *7* ???*8*["parentNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *8* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *9* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *10* ???*11*["target"]
+  ⚠️  unknown object
+- *11* a
+  ⚠️  circular variable reference
+- *12* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *13* unsupported expression
+  ⚠️  This value might have side effects
+- *14* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *15* e
+  ⚠️  circular variable reference
+- *16* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *17* unsupported expression
+  ⚠️  This value might have side effects
+- *18* ???*19*["return"]
+  ⚠️  unknown object
+- *19* d
+  ⚠️  circular variable reference
+- *20* ???*21*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *21* unsupported expression
+  ⚠️  This value might have side effects
+- *22* ???*23*["slice"](2)
+  ⚠️  unknown callee object
+- *23* ???*24*(36)
+  ⚠️  unknown callee
+- *24* ???*25*["toString"]
+  ⚠️  unknown object
+- *25* ???*26*()
+  ⚠️  nested operation
+- *26* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *27* ???*28*["slice"](2)
+  ⚠️  unknown callee object
+- *28* ???*29*(36)
+  ⚠️  unknown callee
+- *29* ???*30*["toString"]
+  ⚠️  unknown object
+- *30* ???*31*()
+  ⚠️  nested operation
+- *31* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *32* ???*33*["slice"](2)
+  ⚠️  unknown callee object
+- *33* ???*34*(36)
+  ⚠️  unknown callee
+- *34* ???*35*["toString"]
+  ⚠️  unknown object
+- *35* ???*36*()
+  ⚠️  nested operation
+- *36* ...[...]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *37* ???*38*["slice"](2)
+  ⚠️  unknown callee object
+- *38* ???*39*(36)
+  ⚠️  unknown callee
+- *39* ???*40*["toString"]
+  ⚠️  unknown object
+- *40* ???*41*()
+  ⚠️  nested operation
+- *41* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *42* ???*43*["slice"](2)
+  ⚠️  unknown callee object
+- *43* ???*44*(36)
+  ⚠️  unknown callee
+- *44* ???*45*["toString"]
+  ⚠️  unknown object
+- *45* ???*46*()
+  ⚠️  nested operation
+- *46* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *47* ???*48*["slice"](2)
+  ⚠️  unknown callee object
+- *48* ???*49*(36)
+  ⚠️  unknown callee
+- *49* ???*50*["toString"]
+  ⚠️  unknown object
+- *50* ???*51*()
+  ⚠️  nested operation
+- *51* ...[...]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *52* ???*53*["slice"](2)
+  ⚠️  unknown callee object
+- *53* ???*54*(36)
+  ⚠️  unknown callee
+- *54* ???*55*["toString"]
+  ⚠️  unknown object
+- *55* ???*56*()
+  ⚠️  nested operation
+- *56* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *57* ???*58*["slice"](2)
+  ⚠️  unknown callee object
+- *58* ???*59*(36)
+  ⚠️  unknown callee
+- *59* ???*60*["toString"]
+  ⚠️  unknown object
+- *60* ???*61*()
+  ⚠️  nested operation
+- *61* ...[...]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 
 2228 -> 2349 call = (...) => undefined([], ???*0*)
@@ -14645,7 +18416,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  function calls are not analysed yet
 
 0 -> 2356 member call = []["unshift"](???*0*)
-- *0* max number of linking steps reached
+- *0* node limit reached
   ⚠️  This value might have side effects
 
 0 -> 2357 call = (...) => (null | c)((???*0* | ???*1*), ???*3*)
@@ -14834,7 +18605,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  function calls are not analysed yet
 
 0 -> 2360 member call = []["push"](???*0*)
-- *0* max number of linking steps reached
+- *0* node limit reached
   ⚠️  This value might have side effects
 
 0 -> 2362 unreachable = ???*0*
@@ -15696,9 +19467,155 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-2472 -> 2480 conditional = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
+2472 -> 2480 conditional = (
+  | (null !== (
+      | ???*0*
+      | null[???*6*]["child"]
+      | null["parentNode"][???*11*]["child"]
+      | null[???*16*][???*21*]["child"]
+      | null["parentNode"][???*26*]["child"]
+      | null[???*31*][???*36*]["child"]
+    ))
+  | (null !== (???*41* | null["parentNode"] | null[???*43*]["alternate"] | null[???*48*]))
+  | (null !== (
+      | ???*53*
+      | null["parentNode"]["child"]
+      | null[???*56*]["alternate"]["child"]
+      | null[???*61*]["child"]
+    ))
+)
+- *0* ???*1*["child"]
+  ⚠️  unknown object
+- *1* ???*2*[`__reactFiber$${???*3*}`]
+  ⚠️  unknown object
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *3* ???*4*["slice"](2)
+  ⚠️  unknown callee object
+- *4* ???*5*(36)
+  ⚠️  unknown callee
+- *5* ???["toString"]
+  ⚠️  unknown object
+- *6* `__reactFiber$${???*7*}`
+  ⚠️  nested operation
+- *7* ???*8*["slice"](2)
+  ⚠️  unknown callee object
+- *8* ???*9*(36)
+  ⚠️  unknown callee
+- *9* ???*10*["toString"]
+  ⚠️  unknown object
+- *10* ???()
+  ⚠️  nested operation
+- *11* `__reactContainer$${???*12*}`
+  ⚠️  nested operation
+- *12* ???*13*["slice"](2)
+  ⚠️  unknown callee object
+- *13* ???*14*(36)
+  ⚠️  unknown callee
+- *14* ???*15*["toString"]
+  ⚠️  unknown object
+- *15* ???()
+  ⚠️  nested operation
+- *16* `__reactFiber$${???*17*}`
+  ⚠️  nested operation
+- *17* ???*18*["slice"](2)
+  ⚠️  unknown callee object
+- *18* ???*19*(36)
+  ⚠️  unknown callee
+- *19* ???*20*["toString"]
+  ⚠️  unknown object
+- *20* ...()
+  ⚠️  nested operation
+- *21* `__reactContainer$${???*22*}`
+  ⚠️  nested operation
+- *22* ???*23*["slice"](2)
+  ⚠️  unknown callee object
+- *23* ???*24*(36)
+  ⚠️  unknown callee
+- *24* ???*25*["toString"]
+  ⚠️  unknown object
+- *25* ???()
+  ⚠️  nested operation
+- *26* `__reactFiber$${???*27*}`
+  ⚠️  nested operation
+- *27* ???*28*["slice"](2)
+  ⚠️  unknown callee object
+- *28* ???*29*(36)
+  ⚠️  unknown callee
+- *29* ???*30*["toString"]
+  ⚠️  unknown object
+- *30* ???()
+  ⚠️  nested operation
+- *31* `__reactFiber$${???*32*}`
+  ⚠️  nested operation
+- *32* ???*33*["slice"](2)
+  ⚠️  unknown callee object
+- *33* ???*34*(36)
+  ⚠️  unknown callee
+- *34* ???*35*["toString"]
+  ⚠️  unknown object
+- *35* ...()
+  ⚠️  nested operation
+- *36* `__reactFiber$${???*37*}`
+  ⚠️  nested operation
+- *37* ???*38*["slice"](2)
+  ⚠️  unknown callee object
+- *38* ???*39*(36)
+  ⚠️  unknown callee
+- *39* ???*40*["toString"]
+  ⚠️  unknown object
+- *40* ???()
+  ⚠️  nested operation
+- *41* ???*42*["parentNode"]
+  ⚠️  unknown object
+- *42* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *43* `__reactFiber$${???*44*}`
+  ⚠️  nested operation
+- *44* ???*45*["slice"](2)
+  ⚠️  unknown callee object
+- *45* ???*46*(36)
+  ⚠️  unknown callee
+- *46* ???*47*["toString"]
+  ⚠️  unknown object
+- *47* ???()
+  ⚠️  nested operation
+- *48* `__reactFiber$${???*49*}`
+  ⚠️  nested operation
+- *49* ???*50*["slice"](2)
+  ⚠️  unknown callee object
+- *50* ???*51*(36)
+  ⚠️  unknown callee
+- *51* ???*52*["toString"]
+  ⚠️  unknown object
+- *52* ???()
+  ⚠️  nested operation
+- *53* ???*54*["child"]
+  ⚠️  unknown object
+- *54* ???*55*["parentNode"]
+  ⚠️  unknown object
+- *55* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *56* `__reactFiber$${???*57*}`
+  ⚠️  nested operation
+- *57* ???*58*["slice"](2)
+  ⚠️  unknown callee object
+- *58* ???*59*(36)
+  ⚠️  unknown callee
+- *59* ???*60*["toString"]
+  ⚠️  unknown object
+- *60* ...()
+  ⚠️  nested operation
+- *61* `__reactFiber$${???*62*}`
+  ⚠️  nested operation
+- *62* ???*63*["slice"](2)
+  ⚠️  unknown callee object
+- *63* ???*64*(36)
+  ⚠️  unknown callee
+- *64* ???*65*["toString"]
+  ⚠️  unknown object
+- *65* ???()
+  ⚠️  nested operation
 
 2480 -> 2481 call = (...) => (a | null)((???*0* | ???*1* | ???*2* | null))
 - *0* arguments[0]
@@ -16243,30 +20160,63 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 
 0 -> 2628 member call = ???*0*["toLowerCase"]()
-- *0* max number of linking steps reached
+- *0* ???*1*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 2629 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 2629 conditional = ((1 !== ???*0*) | (???*2* !== ???*5*))
+- *0* ???*1*["nodeType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* ???*3*()
+  ⚠️  nested operation
+- *3* ???*4*["toLowerCase"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *4* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *5* ???*6*()
+  ⚠️  nested operation
+- *6* ???*7*["toLowerCase"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *7* ???*8*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *8* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 2630 conditional = ???*0*
+0 -> 2630 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2630 -> 2633 call = (...) => (null | a)(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["firstChild"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 2634 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 2637 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 2637 conditional = (("" === ???*0*) | (3 !== ???*2*))
+- *0* ???*1*["pendingProps"]
+  ⚠️  unknown object
+- *1* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *2* ???*3*["nodeType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 2638 conditional = ???*0*
+0 -> 2638 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -16274,15 +20224,18 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 2642 conditional = ???*0*
+0 -> 2642 conditional = (8 !== ???*0*)
+- *0* ???*1*["nodeType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+
+0 -> 2643 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 2643 conditional = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-2643 -> 2644 conditional = ???*0*
+2643 -> 2644 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -16353,7 +20306,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  nested operation
 
 2658 -> 2665 call = (...) => (null | a)(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["nextSibling"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2658 -> 2666 call = (...) => (undefined | ((null !== b) ? ???*0* : !(1)) | ???*1* | !(1))(???*3*, ???*4*)
@@ -16408,8 +20364,24 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* `https://reactjs.org/docs/error-decoder.html?invariant=${418}`
   ⚠️  nested operation
 
-0 -> 2683 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 2683 conditional = ((???*0* | ???*1* | ???*3*) !== ???*8*)
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* ???*2*["memoizedState"]
+  ⚠️  unknown object
+- *2* a
+  ⚠️  circular variable reference
+- *3* (???*4* ? ???*6* : null)
+  ⚠️  nested operation
+- *4* (null !== ???*5*)
+  ⚠️  nested operation
+- *5* a
+  ⚠️  circular variable reference
+- *6* ???*7*["dehydrated"]
+  ⚠️  unknown object
+- *7* a
+  ⚠️  circular variable reference
+- *8* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2683 -> 2684 unreachable = ???*0*
@@ -16477,8 +20449,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *11* a
   ⚠️  circular variable reference
 
-2685 -> 2694 conditional = ???*0*
+2685 -> 2694 conditional = (???*0* | ???*1*)
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* unsupported expression
   ⚠️  This value might have side effects
 
 2694 -> 2695 call = (...) => ((0 !== ???*0*) && (0 === ???*1*))((???*2* | ???*3* | (???*5* ? ???*7* : null)))
@@ -16541,7 +20515,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 
 2694 -> 2703 call = (...) => (null | a)(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["nextSibling"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2685 -> 2704 call = (...) => undefined((???*0* | ???*1* | (???*3* ? ???*5* : null)))
@@ -16627,7 +20604,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
 
-2718 -> 2719 conditional = ???*0*
+2718 -> 2719 conditional = (0 === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -16675,7 +20652,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 
 0 -> 2729 call = (...) => (null | a)(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["nextSibling"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 2730 conditional = (null === (null | [???*0*]))
@@ -16981,13 +20961,151 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *23* arguments[0]
   ⚠️  function calls are not analysed yet
 
-2840 -> 2846 conditional = ???*0*
-- *0* max number of linking steps reached
+2840 -> 2846 conditional = (null === (
+  | null
+  | {
+        "eventTime": (???*0* | ???*3* | ???*4*),
+        "lane": (???*5* | ???*8* | ???*9*),
+        "tag": (???*10* | ???*13* | ???*14*),
+        "payload": (???*15* | ???*18* | ???*19*),
+        "callback": (???*20* | ???*23* | ???*24*),
+        "next": null
+    }
+  | ???*25*
+  | ???*26*
+))
+- *0* ???*1*["eventTime"]
+  ⚠️  unknown object
+- *1* ???*2*["updateQueue"]
+  ⚠️  unknown object
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *3* FreeVar(undefined)
+  ⚠️  unknown global
   ⚠️  This value might have side effects
+- *4* unknown mutation
+  ⚠️  This value might have side effects
+- *5* ???*6*["lane"]
+  ⚠️  unknown object
+- *6* ???*7*["updateQueue"]
+  ⚠️  unknown object
+- *7* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *8* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *9* unknown mutation
+  ⚠️  This value might have side effects
+- *10* ???*11*["tag"]
+  ⚠️  unknown object
+- *11* ???*12*["updateQueue"]
+  ⚠️  unknown object
+- *12* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *13* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *14* unknown mutation
+  ⚠️  This value might have side effects
+- *15* ???*16*["payload"]
+  ⚠️  unknown object
+- *16* ???*17*["updateQueue"]
+  ⚠️  unknown object
+- *17* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *18* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *19* unknown mutation
+  ⚠️  This value might have side effects
+- *20* ???*21*["callback"]
+  ⚠️  unknown object
+- *21* ???*22*["updateQueue"]
+  ⚠️  unknown object
+- *22* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *23* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *24* unknown mutation
+  ⚠️  This value might have side effects
+- *25* unsupported expression
+  ⚠️  This value might have side effects
+- *26* arguments[1]
+  ⚠️  function calls are not analysed yet
 
-2840 -> 2849 conditional = ???*0*
-- *0* max number of linking steps reached
+2840 -> 2849 conditional = (null === (
+  | null
+  | {
+        "eventTime": (???*0* | ???*3* | ???*4*),
+        "lane": (???*5* | ???*8* | ???*9*),
+        "tag": (???*10* | ???*13* | ???*14*),
+        "payload": (???*15* | ???*18* | ???*19*),
+        "callback": (???*20* | ???*23* | ???*24*),
+        "next": null
+    }
+  | ???*25*
+  | ???*26*
+))
+- *0* ???*1*["eventTime"]
+  ⚠️  unknown object
+- *1* ???*2*["updateQueue"]
+  ⚠️  unknown object
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *3* FreeVar(undefined)
+  ⚠️  unknown global
   ⚠️  This value might have side effects
+- *4* unknown mutation
+  ⚠️  This value might have side effects
+- *5* ???*6*["lane"]
+  ⚠️  unknown object
+- *6* ???*7*["updateQueue"]
+  ⚠️  unknown object
+- *7* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *8* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *9* unknown mutation
+  ⚠️  This value might have side effects
+- *10* ???*11*["tag"]
+  ⚠️  unknown object
+- *11* ???*12*["updateQueue"]
+  ⚠️  unknown object
+- *12* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *13* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *14* unknown mutation
+  ⚠️  This value might have side effects
+- *15* ???*16*["payload"]
+  ⚠️  unknown object
+- *16* ???*17*["updateQueue"]
+  ⚠️  unknown object
+- *17* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *18* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *19* unknown mutation
+  ⚠️  This value might have side effects
+- *20* ???*21*["callback"]
+  ⚠️  unknown object
+- *21* ???*22*["updateQueue"]
+  ⚠️  unknown object
+- *22* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *23* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *24* unknown mutation
+  ⚠️  This value might have side effects
+- *25* unsupported expression
+  ⚠️  This value might have side effects
+- *26* arguments[1]
+  ⚠️  function calls are not analysed yet
 
 2838 -> 2855 unreachable = ???*0*
 - *0* unreachable
@@ -17041,24 +21159,26 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *15* unknown mutation
   ⚠️  This value might have side effects
 
-0 -> 2866 conditional = ???*0*
+0 -> 2866 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-2866 -> 2871 conditional = ???*0*
+2866 -> 2871 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-2866 -> 2876 conditional = ???*0*
+2866 -> 2876 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 2880 conditional = ???*0*
+0 -> 2880 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-2880 -> 2884 conditional = ???*0*
-- *0* max number of linking steps reached
+2880 -> 2884 conditional = (???*0* === ???*1*)
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 2884 -> 2891 typeof = typeof((
@@ -17284,7 +21404,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-2884 -> 2907 conditional = ???*0*
+2884 -> 2907 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -17294,11 +21414,11 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-2884 -> 2914 conditional = ???*0*
+2884 -> 2914 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-2880 -> 2917 conditional = ???*0*
+2880 -> 2917 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -20798,9 +24918,49 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 3241 conditional = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
+0 -> 3241 conditional = ((null === (???*0* | ???*1* | ???*3* | ???*13*)) | (4 !== ???*14*) | (???*16* !== ???*19*))
+- *0* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *1* ???*2*["mode"]
+  ⚠️  unknown object
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *3* new (...) => undefined(4, ???*4*, ???*10*, ???*12*)
+  ⚠️  nested operation
+- *4* (???*5* ? ???*8* : [])
+  ⚠️  nested operation
+- *5* (null !== ???*6*)
+  ⚠️  nested operation
+- *6* ???*7*["children"]
+  ⚠️  unknown object
+- *7* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *8* ???*9*["children"]
+  ⚠️  unknown object
+- *9* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *10* ???*11*["key"]
+  ⚠️  unknown object
+- *11* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *12* b
+  ⚠️  circular variable reference
+- *13* b
+  ⚠️  circular variable reference
+- *14* ???*15*["tag"]
+  ⚠️  unknown object
+- *15* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *16* ???*17*["containerInfo"]
+  ⚠️  unknown object
+- *17* ???*18*["stateNode"]
+  ⚠️  unknown object
+- *18* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *19* ???*20*["containerInfo"]
+  ⚠️  unknown object
+- *20* arguments[2]
+  ⚠️  function calls are not analysed yet
 
 3241 -> 3243 call = (...) => b(???*0*, ???*1*, ???*3*)
 - *0* arguments[2]
@@ -20968,139 +25128,977 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 3259 typeof = typeof(???*0*)
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-0 -> 3260 typeof = typeof(???*0*)
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-0 -> 3261 conditional = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-3261 -> 3263 call = (...) => a(???*0*, ???*1*, ???*3*)
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *1* ???*2*["mode"]
-  ⚠️  unknown object
-- *2* arguments[0]
+0 -> 3259 typeof = typeof((
+  | ???*0*
+  | ???*1*
+  | new (...) => undefined(6, ???*2*, null, ???*3*)
+  | ???*5*
+  | new (...) => undefined(4, ???*7*, ???*13*, ???*15*)
+  | new (...) => undefined(7, ???*16*, null, ???*17*)
+))
+- *0* arguments[1]
   ⚠️  function calls are not analysed yet
-- *3* max number of linking steps reached
+- *1* b
+  ⚠️  circular variable reference
+- *2* a
+  ⚠️  circular variable reference
+- *3* ???*4*["mode"]
+  ⚠️  unknown object
+- *4* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *5* ???*6*["mode"]
+  ⚠️  unknown object
+- *6* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *7* (???*8* ? ???*11* : [])
+  ⚠️  nested operation
+- *8* (null !== ???*9*)
+  ⚠️  nested operation
+- *9* ???*10*["children"]
+  ⚠️  unknown object
+- *10* b
+  ⚠️  circular variable reference
+- *11* ???*12*["children"]
+  ⚠️  unknown object
+- *12* b
+  ⚠️  circular variable reference
+- *13* ???*14*["key"]
+  ⚠️  unknown object
+- *14* b
+  ⚠️  circular variable reference
+- *15* b
+  ⚠️  circular variable reference
+- *16* a
+  ⚠️  circular variable reference
+- *17* ???*18*["mode"]
+  ⚠️  unknown object
+- *18* arguments[0]
+  ⚠️  function calls are not analysed yet
+
+0 -> 3260 typeof = typeof((
+  | ???*0*
+  | ???*1*
+  | new (...) => undefined(6, ???*2*, null, ???*3*)
+  | ???*5*
+  | new (...) => undefined(4, ???*7*, ???*13*, ???*15*)
+  | new (...) => undefined(7, ???*16*, null, ???*17*)
+))
+- *0* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *1* b
+  ⚠️  circular variable reference
+- *2* a
+  ⚠️  circular variable reference
+- *3* ???*4*["mode"]
+  ⚠️  unknown object
+- *4* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *5* ???*6*["mode"]
+  ⚠️  unknown object
+- *6* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *7* (???*8* ? ???*11* : [])
+  ⚠️  nested operation
+- *8* (null !== ???*9*)
+  ⚠️  nested operation
+- *9* ???*10*["children"]
+  ⚠️  unknown object
+- *10* b
+  ⚠️  circular variable reference
+- *11* ???*12*["children"]
+  ⚠️  unknown object
+- *12* b
+  ⚠️  circular variable reference
+- *13* ???*14*["key"]
+  ⚠️  unknown object
+- *14* b
+  ⚠️  circular variable reference
+- *15* b
+  ⚠️  circular variable reference
+- *16* a
+  ⚠️  circular variable reference
+- *17* ???*18*["mode"]
+  ⚠️  unknown object
+- *18* arguments[0]
+  ⚠️  function calls are not analysed yet
+
+0 -> 3261 conditional = (("string" === ???*0*) | ("" !== (???*9* | ???*10* | ???*11* | ???*15*)) | ("number" === ???*17*))
+- *0* typeof((???*1* | ???*2* | ???*3* | ???*7*))
+  ⚠️  nested operation
+- *1* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *2* b
+  ⚠️  circular variable reference
+- *3* new (...) => undefined(6, ???*4*, null, ???*5*)
+  ⚠️  nested operation
+- *4* a
+  ⚠️  circular variable reference
+- *5* ???*6*["mode"]
+  ⚠️  unknown object
+- *6* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *7* ???*8*["mode"]
+  ⚠️  unknown object
+- *8* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *9* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *10* b
+  ⚠️  circular variable reference
+- *11* new (...) => undefined(6, ???*12*, null, ???*13*)
+  ⚠️  nested operation
+- *12* a
+  ⚠️  circular variable reference
+- *13* ???*14*["mode"]
+  ⚠️  unknown object
+- *14* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *15* ???*16*["mode"]
+  ⚠️  unknown object
+- *16* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *17* typeof((???*18* | ???*19* | ???*20* | ???*24*))
+  ⚠️  nested operation
+- *18* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *19* b
+  ⚠️  circular variable reference
+- *20* new (...) => undefined(6, ???*21*, null, ???*22*)
+  ⚠️  nested operation
+- *21* a
+  ⚠️  circular variable reference
+- *22* ???*23*["mode"]
+  ⚠️  unknown object
+- *23* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *24* ???*25*["mode"]
+  ⚠️  unknown object
+- *25* arguments[0]
+  ⚠️  function calls are not analysed yet
+
+3261 -> 3263 call = (...) => a(
+    (
+      | ???*0*
+      | ???*1*
+      | new (...) => undefined(6, ???*2*, null, ???*3*)
+      | ???*5*
+      | new (...) => undefined(4, ???*7*, ???*13*, ???*15*)
+      | new (...) => undefined(7, ???*16*, null, ???*17*)
+    ),
+    ???*19*,
+    (???*21* | ???*22*)
+)
+- *0* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *1* b
+  ⚠️  circular variable reference
+- *2* a
+  ⚠️  circular variable reference
+- *3* ???*4*["mode"]
+  ⚠️  unknown object
+- *4* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *5* ???*6*["mode"]
+  ⚠️  unknown object
+- *6* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *7* (???*8* ? ???*11* : [])
+  ⚠️  nested operation
+- *8* (null !== ???*9*)
+  ⚠️  nested operation
+- *9* ???*10*["children"]
+  ⚠️  unknown object
+- *10* b
+  ⚠️  circular variable reference
+- *11* ???*12*["children"]
+  ⚠️  unknown object
+- *12* b
+  ⚠️  circular variable reference
+- *13* ???*14*["key"]
+  ⚠️  unknown object
+- *14* b
+  ⚠️  circular variable reference
+- *15* b
+  ⚠️  circular variable reference
+- *16* a
+  ⚠️  circular variable reference
+- *17* ???*18*["mode"]
+  ⚠️  unknown object
+- *18* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *19* ???*20*["mode"]
+  ⚠️  unknown object
+- *20* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *21* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *22* node limit reached
   ⚠️  This value might have side effects
 
 3261 -> 3265 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
-3261 -> 3266 typeof = typeof(???*0*)
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
+3261 -> 3266 typeof = typeof((
+  | ???*0*
+  | ???*1*
+  | new (...) => undefined(6, ???*2*, null, ???*3*)
+  | ???*5*
+  | new (...) => undefined(4, ???*7*, ???*13*, ???*15*)
+  | new (...) => undefined(7, ???*16*, null, ???*17*)
+))
+- *0* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *1* b
+  ⚠️  circular variable reference
+- *2* a
+  ⚠️  circular variable reference
+- *3* ???*4*["mode"]
+  ⚠️  unknown object
+- *4* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *5* ???*6*["mode"]
+  ⚠️  unknown object
+- *6* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *7* (???*8* ? ???*11* : [])
+  ⚠️  nested operation
+- *8* (null !== ???*9*)
+  ⚠️  nested operation
+- *9* ???*10*["children"]
+  ⚠️  unknown object
+- *10* b
+  ⚠️  circular variable reference
+- *11* ???*12*["children"]
+  ⚠️  unknown object
+- *12* b
+  ⚠️  circular variable reference
+- *13* ???*14*["key"]
+  ⚠️  unknown object
+- *14* b
+  ⚠️  circular variable reference
+- *15* b
+  ⚠️  circular variable reference
+- *16* a
+  ⚠️  circular variable reference
+- *17* ???*18*["mode"]
+  ⚠️  unknown object
+- *18* arguments[0]
+  ⚠️  function calls are not analysed yet
 
-3261 -> 3267 conditional = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
+3261 -> 3267 conditional = (("object" === ???*0*) | (null !== (???*9* | ???*10* | ???*11* | ???*15*)))
+- *0* typeof((???*1* | ???*2* | ???*3* | ???*7*))
+  ⚠️  nested operation
+- *1* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *2* b
+  ⚠️  circular variable reference
+- *3* new (...) => undefined(6, ???*4*, null, ???*5*)
+  ⚠️  nested operation
+- *4* a
+  ⚠️  circular variable reference
+- *5* ???*6*["mode"]
+  ⚠️  unknown object
+- *6* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *7* ???*8*["mode"]
+  ⚠️  unknown object
+- *8* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *9* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *10* b
+  ⚠️  circular variable reference
+- *11* new (...) => undefined(6, ???*12*, null, ???*13*)
+  ⚠️  nested operation
+- *12* a
+  ⚠️  circular variable reference
+- *13* ???*14*["mode"]
+  ⚠️  unknown object
+- *14* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *15* ???*16*["mode"]
+  ⚠️  unknown object
+- *16* arguments[0]
+  ⚠️  function calls are not analysed yet
 
-3267 -> 3273 call = (...) => (Ah(c["children"], e, f, b) | ???*0* | qj(c, e, f, b) | b)(???*1*, ???*2*, ???*3*, null, ???*4*, ???*6*)
+3267 -> 3273 call = (...) => (Ah(c["children"], e, f, b) | ???*0* | qj(c, e, f, b) | b)(
+    (
+      | ???*1*
+      | new (...) => undefined(6, ???*3*, null, ???*4*)["type"]
+      | new (...) => undefined(4, ???*6*, ???*12*, ???*14*)["type"]
+      | new (...) => undefined(7, ???*15*, null, ???*16*)["type"]
+    ),
+    (
+      | ???*18*
+      | new (...) => undefined(6, ???*20*, null, ???*21*)["key"]
+      | new (...) => undefined(4, ???*23*, ???*29*, ???*31*)["key"]
+      | new (...) => undefined(7, ???*32*, null, ???*33*)["key"]
+    ),
+    (
+      | ???*35*
+      | new (...) => undefined(6, ???*37*, null, ???*38*)["props"]
+      | new (...) => undefined(4, ???*40*, ???*46*, ???*48*)["props"]
+      | new (...) => undefined(7, ???*49*, null, ???*50*)["props"]
+    ),
+    null,
+    ???*52*,
+    (???*54* | ???*55*)
+)
 - *0* a
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *2* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *3* max number of linking steps reached
-  ⚠️  This value might have side effects
+- *1* ???*2*["type"]
+  ⚠️  unknown object
+- *2* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *3* a
+  ⚠️  circular variable reference
 - *4* ???*5*["mode"]
   ⚠️  unknown object
 - *5* arguments[0]
   ⚠️  function calls are not analysed yet
-- *6* max number of linking steps reached
+- *6* (???*7* ? ???*10* : [])
+  ⚠️  nested operation
+- *7* (null !== ???*8*)
+  ⚠️  nested operation
+- *8* ???*9*["children"]
+  ⚠️  unknown object
+- *9* b
+  ⚠️  circular variable reference
+- *10* ???*11*["children"]
+  ⚠️  unknown object
+- *11* b
+  ⚠️  circular variable reference
+- *12* ???*13*["key"]
+  ⚠️  unknown object
+- *13* b
+  ⚠️  circular variable reference
+- *14* b
+  ⚠️  circular variable reference
+- *15* a
+  ⚠️  circular variable reference
+- *16* ???*17*["mode"]
+  ⚠️  unknown object
+- *17* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *18* ???*19*["key"]
+  ⚠️  unknown object
+- *19* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *20* a
+  ⚠️  circular variable reference
+- *21* ???*22*["mode"]
+  ⚠️  unknown object
+- *22* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *23* (???*24* ? ???*27* : [])
+  ⚠️  nested operation
+- *24* (null !== ???*25*)
+  ⚠️  nested operation
+- *25* ???*26*["children"]
+  ⚠️  unknown object
+- *26* b
+  ⚠️  circular variable reference
+- *27* ???*28*["children"]
+  ⚠️  unknown object
+- *28* b
+  ⚠️  circular variable reference
+- *29* ???*30*["key"]
+  ⚠️  unknown object
+- *30* b
+  ⚠️  circular variable reference
+- *31* b
+  ⚠️  circular variable reference
+- *32* a
+  ⚠️  circular variable reference
+- *33* ???*34*["mode"]
+  ⚠️  unknown object
+- *34* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *35* ???*36*["props"]
+  ⚠️  unknown object
+- *36* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *37* a
+  ⚠️  circular variable reference
+- *38* ???*39*["mode"]
+  ⚠️  unknown object
+- *39* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *40* (???*41* ? ???*44* : [])
+  ⚠️  nested operation
+- *41* (null !== ???*42*)
+  ⚠️  nested operation
+- *42* ???*43*["children"]
+  ⚠️  unknown object
+- *43* b
+  ⚠️  circular variable reference
+- *44* ???*45*["children"]
+  ⚠️  unknown object
+- *45* b
+  ⚠️  circular variable reference
+- *46* ???*47*["key"]
+  ⚠️  unknown object
+- *47* b
+  ⚠️  circular variable reference
+- *48* b
+  ⚠️  circular variable reference
+- *49* a
+  ⚠️  circular variable reference
+- *50* ???*51*["mode"]
+  ⚠️  unknown object
+- *51* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *52* ???*53*["mode"]
+  ⚠️  unknown object
+- *53* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *54* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *55* node limit reached
   ⚠️  This value might have side effects
 
-3267 -> 3275 call = (...) => (b["ref"] | b | a)(???*0*, null, ???*1*)
+3267 -> 3275 call = (...) => (b["ref"] | b | a)(
+    ???*0*,
+    null,
+    (
+      | ???*1*
+      | ???*2*
+      | new (...) => undefined(6, ???*3*, null, ???*4*)
+      | ???*6*
+      | new (...) => undefined(4, ???*8*, ???*14*, ???*16*)
+      | new (...) => undefined(7, ???*17*, null, ???*18*)
+    )
+)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* max number of linking steps reached
-  ⚠️  This value might have side effects
+- *1* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *2* b
+  ⚠️  circular variable reference
+- *3* a
+  ⚠️  circular variable reference
+- *4* ???*5*["mode"]
+  ⚠️  unknown object
+- *5* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *6* ???*7*["mode"]
+  ⚠️  unknown object
+- *7* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *8* (???*9* ? ???*12* : [])
+  ⚠️  nested operation
+- *9* (null !== ???*10*)
+  ⚠️  nested operation
+- *10* ???*11*["children"]
+  ⚠️  unknown object
+- *11* b
+  ⚠️  circular variable reference
+- *12* ???*13*["children"]
+  ⚠️  unknown object
+- *13* b
+  ⚠️  circular variable reference
+- *14* ???*15*["key"]
+  ⚠️  unknown object
+- *15* b
+  ⚠️  circular variable reference
+- *16* b
+  ⚠️  circular variable reference
+- *17* a
+  ⚠️  circular variable reference
+- *18* ???*19*["mode"]
+  ⚠️  unknown object
+- *19* arguments[0]
+  ⚠️  function calls are not analysed yet
 
 3267 -> 3277 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
-3267 -> 3279 call = (...) => b(???*0*, ???*1*, ???*3*)
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *1* ???*2*["mode"]
-  ⚠️  unknown object
-- *2* arguments[0]
+3267 -> 3279 call = (...) => b(
+    (
+      | ???*0*
+      | ???*1*
+      | new (...) => undefined(6, ???*2*, null, ???*3*)
+      | ???*5*
+      | new (...) => undefined(4, ???*7*, ???*13*, ???*15*)
+      | new (...) => undefined(7, ???*16*, null, ???*17*)
+    ),
+    ???*19*,
+    (???*21* | ???*22*)
+)
+- *0* arguments[1]
   ⚠️  function calls are not analysed yet
-- *3* max number of linking steps reached
+- *1* b
+  ⚠️  circular variable reference
+- *2* a
+  ⚠️  circular variable reference
+- *3* ???*4*["mode"]
+  ⚠️  unknown object
+- *4* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *5* ???*6*["mode"]
+  ⚠️  unknown object
+- *6* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *7* (???*8* ? ???*11* : [])
+  ⚠️  nested operation
+- *8* (null !== ???*9*)
+  ⚠️  nested operation
+- *9* ???*10*["children"]
+  ⚠️  unknown object
+- *10* b
+  ⚠️  circular variable reference
+- *11* ???*12*["children"]
+  ⚠️  unknown object
+- *12* b
+  ⚠️  circular variable reference
+- *13* ???*14*["key"]
+  ⚠️  unknown object
+- *14* b
+  ⚠️  circular variable reference
+- *15* b
+  ⚠️  circular variable reference
+- *16* a
+  ⚠️  circular variable reference
+- *17* ???*18*["mode"]
+  ⚠️  unknown object
+- *18* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *19* ???*20*["mode"]
+  ⚠️  unknown object
+- *20* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *21* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *22* node limit reached
   ⚠️  This value might have side effects
 
 3267 -> 3281 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
-3267 -> 3284 call = ???*0*(???*1*)
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *1* max number of linking steps reached
-  ⚠️  This value might have side effects
+3267 -> 3284 call = (
+  | ???*0*
+  | new (...) => undefined(6, ???*2*, null, ???*3*)["_init"]
+  | new (...) => undefined(4, ???*5*, ???*11*, ???*13*)["_init"]
+  | new (...) => undefined(7, ???*14*, null, ???*15*)["_init"]
+)(
+    (
+      | ???*17*
+      | new (...) => undefined(6, ???*19*, null, ???*20*)["_payload"]
+      | new (...) => undefined(4, ???*22*, ???*28*, ???*30*)["_payload"]
+      | new (...) => undefined(7, ???*31*, null, ???*32*)["_payload"]
+    )
+)
+- *0* ???*1*["_init"]
+  ⚠️  unknown object
+- *1* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
+- *3* ???*4*["mode"]
+  ⚠️  unknown object
+- *4* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *5* (???*6* ? ???*9* : [])
+  ⚠️  nested operation
+- *6* (null !== ???*7*)
+  ⚠️  nested operation
+- *7* ???*8*["children"]
+  ⚠️  unknown object
+- *8* b
+  ⚠️  circular variable reference
+- *9* ???*10*["children"]
+  ⚠️  unknown object
+- *10* b
+  ⚠️  circular variable reference
+- *11* ???*12*["key"]
+  ⚠️  unknown object
+- *12* b
+  ⚠️  circular variable reference
+- *13* b
+  ⚠️  circular variable reference
+- *14* a
+  ⚠️  circular variable reference
+- *15* ???*16*["mode"]
+  ⚠️  unknown object
+- *16* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *17* ???*18*["_payload"]
+  ⚠️  unknown object
+- *18* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *19* a
+  ⚠️  circular variable reference
+- *20* ???*21*["mode"]
+  ⚠️  unknown object
+- *21* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *22* (???*23* ? ???*26* : [])
+  ⚠️  nested operation
+- *23* (null !== ???*24*)
+  ⚠️  nested operation
+- *24* ???*25*["children"]
+  ⚠️  unknown object
+- *25* b
+  ⚠️  circular variable reference
+- *26* ???*27*["children"]
+  ⚠️  unknown object
+- *27* b
+  ⚠️  circular variable reference
+- *28* ???*29*["key"]
+  ⚠️  unknown object
+- *29* b
+  ⚠️  circular variable reference
+- *30* b
+  ⚠️  circular variable reference
+- *31* a
+  ⚠️  circular variable reference
+- *32* ???*33*["mode"]
+  ⚠️  unknown object
+- *33* arguments[0]
+  ⚠️  function calls are not analysed yet
 
-3267 -> 3285 call = (...) => (???*0* | q(a, d(b["_payload"]), c) | null)(???*1*, ???*2*, ???*3*)
+3267 -> 3285 call = (...) => (???*0* | q(a, d(b["_payload"]), c) | null)(???*1*, ???*2*, (???*20* | ???*21*))
 - *0* b
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
-- *2* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *3* max number of linking steps reached
+- *2* (
+      | ???*3*
+      | new (...) => undefined(6, ???*5*, null, ???*6*)["_init"]
+      | new (...) => undefined(4, ???*8*, ???*14*, ???*16*)["_init"]
+      | new (...) => undefined(7, ???*17*, null, ???*18*)["_init"]
+    )(b["_payload"])
+  ⚠️  non-function callee
+- *3* ???*4*["_init"]
+  ⚠️  unknown object
+- *4* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *5* a
+  ⚠️  circular variable reference
+- *6* ???*7*["mode"]
+  ⚠️  unknown object
+- *7* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *8* (???*9* ? ???*12* : [])
+  ⚠️  nested operation
+- *9* (null !== ???*10*)
+  ⚠️  nested operation
+- *10* ???*11*["children"]
+  ⚠️  unknown object
+- *11* b
+  ⚠️  circular variable reference
+- *12* ???*13*["children"]
+  ⚠️  unknown object
+- *13* b
+  ⚠️  circular variable reference
+- *14* ???*15*["key"]
+  ⚠️  unknown object
+- *15* b
+  ⚠️  circular variable reference
+- *16* b
+  ⚠️  circular variable reference
+- *17* a
+  ⚠️  circular variable reference
+- *18* ???*19*["mode"]
+  ⚠️  unknown object
+- *19* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *20* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *21* node limit reached
   ⚠️  This value might have side effects
 
 3267 -> 3286 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
-3267 -> 3287 call = ???*0*(???*2*)
+3267 -> 3287 call = ???*0*(
+    (
+      | ???*2*
+      | ???*3*
+      | new (...) => undefined(6, ???*4*, null, ???*5*)
+      | ???*7*
+      | new (...) => undefined(4, ???*9*, ???*15*, ???*17*)
+      | new (...) => undefined(7, ???*18*, null, ???*19*)
+    )
+)
 - *0* ???*1*["isArray"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* FreeVar(Array)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *2* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-3267 -> 3288 call = (...) => (null | (("function" === typeof(a)) ? a : null))(???*0*)
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-3267 -> 3289 conditional = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-3289 -> 3291 call = (...) => a(???*0*, ???*1*, ???*3*, null)
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *1* ???*2*["mode"]
-  ⚠️  unknown object
-- *2* arguments[0]
+- *2* arguments[1]
   ⚠️  function calls are not analysed yet
-- *3* max number of linking steps reached
+- *3* b
+  ⚠️  circular variable reference
+- *4* a
+  ⚠️  circular variable reference
+- *5* ???*6*["mode"]
+  ⚠️  unknown object
+- *6* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *7* ???*8*["mode"]
+  ⚠️  unknown object
+- *8* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *9* (???*10* ? ???*13* : [])
+  ⚠️  nested operation
+- *10* (null !== ???*11*)
+  ⚠️  nested operation
+- *11* ???*12*["children"]
+  ⚠️  unknown object
+- *12* b
+  ⚠️  circular variable reference
+- *13* ???*14*["children"]
+  ⚠️  unknown object
+- *14* b
+  ⚠️  circular variable reference
+- *15* ???*16*["key"]
+  ⚠️  unknown object
+- *16* b
+  ⚠️  circular variable reference
+- *17* b
+  ⚠️  circular variable reference
+- *18* a
+  ⚠️  circular variable reference
+- *19* ???*20*["mode"]
+  ⚠️  unknown object
+- *20* arguments[0]
+  ⚠️  function calls are not analysed yet
+
+3267 -> 3288 call = (...) => (null | (("function" === typeof(a)) ? a : null))(
+    (
+      | ???*0*
+      | ???*1*
+      | new (...) => undefined(6, ???*2*, null, ???*3*)
+      | ???*5*
+      | new (...) => undefined(4, ???*7*, ???*13*, ???*15*)
+      | new (...) => undefined(7, ???*16*, null, ???*17*)
+    )
+)
+- *0* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *1* b
+  ⚠️  circular variable reference
+- *2* a
+  ⚠️  circular variable reference
+- *3* ???*4*["mode"]
+  ⚠️  unknown object
+- *4* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *5* ???*6*["mode"]
+  ⚠️  unknown object
+- *6* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *7* (???*8* ? ???*11* : [])
+  ⚠️  nested operation
+- *8* (null !== ???*9*)
+  ⚠️  nested operation
+- *9* ???*10*["children"]
+  ⚠️  unknown object
+- *10* b
+  ⚠️  circular variable reference
+- *11* ???*12*["children"]
+  ⚠️  unknown object
+- *12* b
+  ⚠️  circular variable reference
+- *13* ???*14*["key"]
+  ⚠️  unknown object
+- *14* b
+  ⚠️  circular variable reference
+- *15* b
+  ⚠️  circular variable reference
+- *16* a
+  ⚠️  circular variable reference
+- *17* ???*18*["mode"]
+  ⚠️  unknown object
+- *18* arguments[0]
+  ⚠️  function calls are not analysed yet
+
+3267 -> 3289 conditional = (
+  | ???*0*
+  | null
+  | (???*3* ? (???*15* | ???*16* | ???*17* | ???*21* | ???*23*) : null)
+)
+- *0* ???*1*(b)
+  ⚠️  unknown callee
+  ⚠️  This value might have side effects
+- *1* ???*2*["isArray"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* FreeVar(Array)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *3* ("function" === ???*4*)
+  ⚠️  nested operation
+- *4* typeof((???*5* | ???*6* | ???*7* | ???*11* | ???*13*))
+  ⚠️  nested operation
+- *5* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *6* b
+  ⚠️  circular variable reference
+- *7* new (...) => undefined(6, ???*8*, null, ???*9*)
+  ⚠️  nested operation
+- *8* a
+  ⚠️  circular variable reference
+- *9* ???*10*["mode"]
+  ⚠️  unknown object
+- *10* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *11* ???*12*["mode"]
+  ⚠️  unknown object
+- *12* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *13* ???*14*["iterator"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *14* FreeVar(Symbol)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *15* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *16* b
+  ⚠️  circular variable reference
+- *17* new (...) => undefined(6, ???*18*, null, ???*19*)
+  ⚠️  nested operation
+- *18* a
+  ⚠️  circular variable reference
+- *19* ???*20*["mode"]
+  ⚠️  unknown object
+- *20* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *21* ???*22*["mode"]
+  ⚠️  unknown object
+- *22* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *23* ???*24*["iterator"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *24* FreeVar(Symbol)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+
+3289 -> 3291 call = (...) => a(
+    (
+      | ???*0*
+      | ???*1*
+      | new (...) => undefined(6, ???*2*, null, ???*3*)
+      | ???*5*
+      | new (...) => undefined(4, ???*7*, ???*13*, ???*15*)
+      | new (...) => undefined(7, ???*16*, null, ???*17*)
+    ),
+    ???*19*,
+    (???*21* | ???*22*),
+    null
+)
+- *0* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *1* b
+  ⚠️  circular variable reference
+- *2* a
+  ⚠️  circular variable reference
+- *3* ???*4*["mode"]
+  ⚠️  unknown object
+- *4* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *5* ???*6*["mode"]
+  ⚠️  unknown object
+- *6* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *7* (???*8* ? ???*11* : [])
+  ⚠️  nested operation
+- *8* (null !== ???*9*)
+  ⚠️  nested operation
+- *9* ???*10*["children"]
+  ⚠️  unknown object
+- *10* b
+  ⚠️  circular variable reference
+- *11* ???*12*["children"]
+  ⚠️  unknown object
+- *12* b
+  ⚠️  circular variable reference
+- *13* ???*14*["key"]
+  ⚠️  unknown object
+- *14* b
+  ⚠️  circular variable reference
+- *15* b
+  ⚠️  circular variable reference
+- *16* a
+  ⚠️  circular variable reference
+- *17* ???*18*["mode"]
+  ⚠️  unknown object
+- *18* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *19* ???*20*["mode"]
+  ⚠️  unknown object
+- *20* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *21* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *22* node limit reached
   ⚠️  This value might have side effects
 
 3289 -> 3293 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
-3289 -> 3294 call = (...) => undefined(???*0*, ???*1*)
+3289 -> 3294 call = (...) => undefined(
+    ???*0*,
+    (
+      | ???*1*
+      | ???*2*
+      | new (...) => undefined(6, ???*3*, null, ???*4*)
+      | ???*6*
+      | new (...) => undefined(4, ???*8*, ???*14*, ???*16*)
+      | new (...) => undefined(7, ???*17*, null, ???*18*)
+    )
+)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* max number of linking steps reached
-  ⚠️  This value might have side effects
+- *1* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *2* b
+  ⚠️  circular variable reference
+- *3* a
+  ⚠️  circular variable reference
+- *4* ???*5*["mode"]
+  ⚠️  unknown object
+- *5* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *6* ???*7*["mode"]
+  ⚠️  unknown object
+- *7* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *8* (???*9* ? ???*12* : [])
+  ⚠️  nested operation
+- *9* (null !== ???*10*)
+  ⚠️  nested operation
+- *10* ???*11*["children"]
+  ⚠️  unknown object
+- *11* b
+  ⚠️  circular variable reference
+- *12* ???*13*["children"]
+  ⚠️  unknown object
+- *13* b
+  ⚠️  circular variable reference
+- *14* ???*15*["key"]
+  ⚠️  unknown object
+- *15* b
+  ⚠️  circular variable reference
+- *16* b
+  ⚠️  circular variable reference
+- *17* a
+  ⚠️  circular variable reference
+- *18* ???*19*["mode"]
+  ⚠️  unknown object
+- *19* arguments[0]
+  ⚠️  function calls are not analysed yet
 
 3261 -> 3295 unreachable = ???*0*
 - *0* unreachable
@@ -21728,7 +26726,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *4* updated with update expression
   ⚠️  This value might have side effects
 
-0 -> 3374 conditional = ???*0*
+0 -> 3374 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -21760,7 +26758,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-3377 -> 3381 conditional = ???*0*
+3377 -> 3381 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -21790,7 +26788,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *4* updated with update expression
   ⚠️  This value might have side effects
 
-3381 -> 3386 conditional = ???*0*
+3381 -> 3386 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -21831,14 +26829,31 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *7* arguments[3]
   ⚠️  function calls are not analysed yet
 
-3381 -> 3397 conditional = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-3381 -> 3399 member call = ???*0*["delete"](???*1*)
-- *0* max number of linking steps reached
+3381 -> 3397 conditional = (null === ???*0*)
+- *0* ???*1*["key"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+
+3381 -> 3399 member call = ???*0*["delete"]((???*1* ? (???*4* | ???*5*) : ???*6*))
+- *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* (null === ???*2*)
+  ⚠️  nested operation
+- *2* ???*3*["key"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *4* unsupported expression
+  ⚠️  This value might have side effects
+- *5* updated with update expression
+  ⚠️  This value might have side effects
+- *6* ???*7*["key"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *7* max number of linking steps reached
   ⚠️  This value might have side effects
 
 3381 -> 3400 call = (...) => (???*0* | c)(???*1*, ???*2*, (???*3* | ???*4*))
@@ -21854,7 +26869,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *4* updated with update expression
   ⚠️  This value might have side effects
 
-3381 -> 3401 conditional = ???*0*
+3381 -> 3401 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -21892,8 +26907,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 3411 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 3411 conditional = ("function" !== ???*0*)
+- *0* typeof(???*1*)
+  ⚠️  nested operation
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 3411 -> 3412 free var = FreeVar(Error)
@@ -21915,7 +26932,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 3417 conditional = ???*0*
+0 -> 3417 conditional = (null == ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -21947,7 +26964,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   | ???*0*
   | ((null !== e) ? null : m(a, b, c, d, null))
   | null
-)(???*1*, ???*2*, ???*3*, ???*4*)
+)(???*1*, ???*2*, ???*3*, ???*5*)
 - *0* r(a, b, e(c["_payload"]), d)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
@@ -21955,9 +26972,12 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  function calls are not analysed yet
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
-- *3* max number of linking steps reached
+- *3* ???*4*["value"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
-- *4* arguments[3]
+- *4* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *5* arguments[3]
   ⚠️  function calls are not analysed yet
 
 0 -> 3431 call = (...) => undefined(???*0*, ???*1*)
@@ -21979,12 +26999,15 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *4* updated with update expression
   ⚠️  This value might have side effects
 
-0 -> 3433 conditional = ???*0*
+0 -> 3433 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 3436 conditional = ???*0*
-- *0* max number of linking steps reached
+- *0* ???*1*["done"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 3436 -> 3437 call = (...) => null(???*0*, ???*1*)
@@ -22005,7 +27028,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-3436 -> 3440 conditional = ???*0*
+3436 -> 3440 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -22013,15 +27036,18 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-3440 -> 3445 call = (...) => (???*0* | q(a, d(b["_payload"]), c) | null)(???*1*, ???*2*, ???*3*)
+3440 -> 3445 call = (...) => (???*0* | q(a, d(b["_payload"]), c) | null)(???*1*, ???*2*, ???*4*)
 - *0* b
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
-- *2* max number of linking steps reached
+- *2* ???*3*["value"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
-- *3* arguments[3]
+- *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *4* arguments[3]
   ⚠️  function calls are not analysed yet
 
 3440 -> 3446 call = (...) => (???*0* | c)(???*1*, ???*2*, (???*3* | ???*4*))
@@ -22037,7 +27063,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *4* updated with update expression
   ⚠️  This value might have side effects
 
-3440 -> 3447 conditional = ???*0*
+3440 -> 3447 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -22063,7 +27089,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-3440 -> 3456 call = (...) => (???*0* | y(a, b, c, f(d["_payload"]), e) | null)(???*1*, ???*2*, (???*3* | ???*4*), ???*5*, ???*6*)
+3440 -> 3456 call = (...) => (???*0* | y(a, b, c, f(d["_payload"]), e) | null)(???*1*, ???*2*, (???*3* | ???*4*), ???*5*, ???*7*)
 - *0* h(b, a, ("" + d), e)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
@@ -22075,19 +27101,39 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 - *4* updated with update expression
   ⚠️  This value might have side effects
-- *5* max number of linking steps reached
+- *5* ???*6*["value"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
-- *6* arguments[3]
+- *6* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *7* arguments[3]
   ⚠️  function calls are not analysed yet
 
-3440 -> 3460 conditional = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-3440 -> 3462 member call = ???*0*["delete"](???*1*)
-- *0* max number of linking steps reached
+3440 -> 3460 conditional = (null === ???*0*)
+- *0* ???*1*["key"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+
+3440 -> 3462 member call = ???*0*["delete"]((???*1* ? (???*4* | ???*5*) : ???*6*))
+- *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* (null === ???*2*)
+  ⚠️  nested operation
+- *2* ???*3*["key"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *4* unsupported expression
+  ⚠️  This value might have side effects
+- *5* updated with update expression
+  ⚠️  This value might have side effects
+- *6* ???*7*["key"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *7* max number of linking steps reached
   ⚠️  This value might have side effects
 
 3440 -> 3463 call = (...) => (???*0* | c)(???*1*, ???*2*, (???*3* | ???*4*))
@@ -22103,7 +27149,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *4* updated with update expression
   ⚠️  This value might have side effects
 
-3440 -> 3464 conditional = ???*0*
+3440 -> 3464 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -22181,9 +27227,16 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *10* f
   ⚠️  circular variable reference
 
-3478 -> 3482 conditional = ???*0*
-- *0* max number of linking steps reached
+3478 -> 3482 conditional = (???*0* === ???*2*)
+- *0* ???*1*["key"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* ???*3*["key"]
+  ⚠️  unknown object
+- *3* arguments[2]
+  ⚠️  function calls are not analysed yet
 
 3482 -> 3484 conditional = (???*0* === ???*2*)
 - *0* ???*1*["key"]
@@ -22197,14 +27250,20 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  unknown global
   ⚠️  This value might have side effects
 
-3484 -> 3486 conditional = ???*0*
-- *0* max number of linking steps reached
+3484 -> 3486 conditional = (7 === ???*0*)
+- *0* ???*1*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 3486 -> 3488 call = (...) => null(???*0*, ???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["sibling"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 3486 -> 3491 call = (...) => a(???*0*, ???*1*)
@@ -22229,14 +27288,65 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* arguments[2]
   ⚠️  function calls are not analysed yet
 
-3484 -> 3498 conditional = ???*0*
-- *0* max number of linking steps reached
+3484 -> 3498 conditional = (
+  | (???*0* === ???*2*)
+  | ("object" === ???*4*)
+  | (null !== ???*7*)
+  | (???*9* === ???*12*)
+  | (???*14* === ???*18*)
+)
+- *0* ???*1*["elementType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* ???*3*["key"]
+  ⚠️  unknown object
+- *3* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *4* typeof(???*5*)
+  ⚠️  nested operation
+- *5* ???*6*["key"]
+  ⚠️  unknown object
+- *6* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *7* ???*8*["key"]
+  ⚠️  unknown object
+- *8* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *9* ???*10*["$$typeof"]
+  ⚠️  unknown object
+- *10* ???*11*["key"]
+  ⚠️  unknown object
+- *11* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *12* ???*13*["for"]("react.lazy")
+  ⚠️  unknown callee object
+  ⚠️  This value might have side effects
+- *13* FreeVar(Symbol)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *14* ???*15*(a["_payload"])
+  ⚠️  unknown callee
+- *15* ???*16*["_init"]
+  ⚠️  unknown object
+- *16* ???*17*["key"]
+  ⚠️  unknown object
+- *17* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *18* ???*19*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *19* max number of linking steps reached
   ⚠️  This value might have side effects
 
 3498 -> 3500 call = (...) => null(???*0*, ???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["sibling"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 3498 -> 3502 call = (...) => a(???*0*, ???*1*)
@@ -22287,23 +27397,26 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  unknown global
   ⚠️  This value might have side effects
 
-3510 -> 3515 call = (...) => a(???*0*, ???*3*, ???*4*, ???*5*)
+3510 -> 3515 call = (...) => a(???*0*, ???*3*, ???*5*, ???*6*)
 - *0* ???*1*["children"]
   ⚠️  unknown object
 - *1* ???*2*["props"]
   ⚠️  unknown object
 - *2* arguments[2]
   ⚠️  function calls are not analysed yet
-- *3* max number of linking steps reached
+- *3* ???*4*["mode"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *4* max number of linking steps reached
   ⚠️  This value might have side effects
-- *5* ???*6*["key"]
+- *5* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *6* ???*7*["key"]
   ⚠️  unknown object
-- *6* arguments[2]
+- *7* arguments[2]
   ⚠️  function calls are not analysed yet
 
-3510 -> 3521 call = (...) => (Ah(c["children"], e, f, b) | ???*0* | qj(c, e, f, b) | b)(???*1*, ???*3*, ???*5*, null, ???*7*, ???*8*)
+3510 -> 3521 call = (...) => (Ah(c["children"], e, f, b) | ???*0* | qj(c, e, f, b) | b)(???*1*, ???*3*, ???*5*, null, ???*7*, ???*9*)
 - *0* a
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
@@ -22319,9 +27432,12 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  unknown object
 - *6* arguments[2]
   ⚠️  function calls are not analysed yet
-- *7* max number of linking steps reached
+- *7* ???*8*["mode"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *8* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *9* max number of linking steps reached
   ⚠️  This value might have side effects
 
 3510 -> 3523 call = (...) => (b["ref"] | b | a)(???*0*, ???*1*, (???*2* | ???*3* | ???*6*))
@@ -22348,18 +27464,41 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-3478 -> 3529 conditional = ???*0*
-- *0* max number of linking steps reached
+3478 -> 3529 conditional = (???*0* === ???*2*)
+- *0* ???*1*["key"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-3529 -> 3537 conditional = ???*0*
-- *0* max number of linking steps reached
+3529 -> 3537 conditional = ((4 === ???*0*) | (???*2* === ???*5*))
+- *0* ???*1*["tag"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* ???*3*["containerInfo"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* ???*4*["stateNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *4* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *5* ???*6*["containerInfo"]
+  ⚠️  unknown object
+- *6* arguments[2]
+  ⚠️  function calls are not analysed yet
 
 3537 -> 3539 call = (...) => null(???*0*, ???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["sibling"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 3537 -> 3541 call = (...) => a(???*0*, (???*1* | []){truthy})
@@ -22382,7 +27521,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-3478 -> 3547 call = (...) => b((???*0* | ???*1* | ???*4*), ???*5*, ???*6*)
+3478 -> 3547 call = (...) => b((???*0* | ???*1* | ???*4*), ???*5*, ???*7*)
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["children"]
@@ -22393,9 +27532,12 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  circular variable reference
 - *4* f
   ⚠️  circular variable reference
-- *5* max number of linking steps reached
+- *5* ???*6*["mode"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *6* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *7* max number of linking steps reached
   ⚠️  This value might have side effects
 
 3478 -> 3549 call = (...) => b(???*0*)
@@ -22420,7 +27562,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   | n(a, d, f, h)
   | t(a, d, f, h)
   | (((("string" === typeof(f)) && ("" !== f)) || ("number" === typeof(f))) ? ???*1* : c(a, d))
-)(???*2*, ???*3*, ???*4*, ???*5*)
+)(???*2*, ???*3*, ???*4*, ???*6*)
 - *0* J(a, d, l(f["_payload"]), h)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
@@ -22431,9 +27573,12 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
-- *4* max number of linking steps reached
+- *4* ???*5*(f["_payload"])
+  ⚠️  unknown callee
   ⚠️  This value might have side effects
 - *5* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *6* max number of linking steps reached
   ⚠️  This value might have side effects
 
 3478 -> 3555 unreachable = ???*0*
@@ -22646,14 +27791,22 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *16* f
   ⚠️  circular variable reference
 
-3567 -> 3569 conditional = ???*0*
+3567 -> 3569 conditional = ((null !== ???*0*) | (6 === ???*1*))
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* ???*2*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 3569 -> 3571 call = (...) => null(???*0*, ???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["sibling"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 3569 -> 3572 call = (...) => a(???*0*, (???*1* | ???*2* | ???*5*))
@@ -22676,7 +27829,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-3569 -> 3576 call = (...) => a((???*0* | ???*1* | ???*4*), ???*5*, ???*6*)
+3569 -> 3576 call = (...) => a((???*0* | ???*1* | ???*4*), ???*5*, ???*7*)
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["children"]
@@ -22687,9 +27840,12 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  circular variable reference
 - *4* f
   ⚠️  circular variable reference
-- *5* max number of linking steps reached
+- *5* ???*6*["mode"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *6* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *7* max number of linking steps reached
   ⚠️  This value might have side effects
 
 3567 -> 3578 call = (...) => b(???*0*)
@@ -23742,8 +28898,8 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *27* a
   ⚠️  circular variable reference
 
-0 -> 3704 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 3704 conditional = (null !== ???*0*)
+- *0* node limit reached
   ⚠️  This value might have side effects
 
 3704 -> 3705 conditional = (null === (
@@ -23934,8 +29090,8 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 
 0 -> 3721 call = (...) => P()
 
-0 -> 3723 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 3723 conditional = (null === ???*0*)
+- *0* node limit reached
   ⚠️  This value might have side effects
 
 3723 -> 3724 free var = FreeVar(Error)
@@ -23951,39 +29107,52 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* `https://reactjs.org/docs/error-decoder.html?invariant=${311}`
   ⚠️  nested operation
 
-0 -> 3730 conditional = ???*0*
+0 -> 3730 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-3730 -> 3731 conditional = ???*0*
+3730 -> 3731 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 3738 conditional = ???*0*
+0 -> 3738 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-3738 -> 3742 conditional = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-3742 -> 3748 conditional = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-3748 -> 3751 call = ???*0*(???*1*, ???*2*)
-- *0* max number of linking steps reached
+3738 -> 3742 conditional = (???*0* === ???*1*)
+- *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
-- *2* max number of linking steps reached
+
+3742 -> 3748 conditional = ???*0*
+- *0* ???*1*["hasEagerState"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-3742 -> 3755 conditional = ???*0*
+3748 -> 3751 call = (???*0* | ???*1*)(???*3*, ???*4*)
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* ???*2*["interleaved"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* node limit reached
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *4* ???*5*["action"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* max number of linking steps reached
+  ⚠️  This value might have side effects
+
+3742 -> 3755 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-3738 -> 3759 conditional = ???*0*
+3738 -> 3759 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -24008,11 +29177,16 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 - *9* max number of linking steps reached
   ⚠️  This value might have side effects
-- *10* max number of linking steps reached
+- *10* node limit reached
   ⚠️  This value might have side effects
 
-0 -> 3768 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 3768 conditional = (null !== (???*0* | ???*1*))
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* ???*2*["interleaved"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* node limit reached
   ⚠️  This value might have side effects
 
 0 -> 3775 unreachable = ???*0*
@@ -24021,8 +29195,8 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 
 0 -> 3776 call = (...) => P()
 
-0 -> 3778 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 3778 conditional = (null === ???*0*)
+- *0* node limit reached
   ⚠️  This value might have side effects
 
 3778 -> 3779 free var = FreeVar(Error)
@@ -24038,28 +29212,39 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* `https://reactjs.org/docs/error-decoder.html?invariant=${311}`
   ⚠️  nested operation
 
-0 -> 3786 conditional = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-3786 -> 3790 call = ???*0*(???*1*, (???*2* | ???*4*))
-- *0* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *1* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *2* ???*3*["action"]
+0 -> 3786 conditional = (null !== (???*0* | ???*2*))
+- *0* ???*1*["pending"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *3* unsupported expression
+- *1* node limit reached
   ⚠️  This value might have side effects
-- *4* ???*5*["action"]
+- *2* ???*3*["next"]
   ⚠️  unknown object
-- *5* ???*6*["next"]
-  ⚠️  unknown object
-- *6* g
+- *3* e
   ⚠️  circular variable reference
 
-3786 -> 3793 call = (???*0* ? ???*4* : (...) => ???*6*)(???*9*, ???*10*)
+3786 -> 3790 call = ???*0*((???*1* | ???*2*), (???*4* | ???*6*))
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* node limit reached
+  ⚠️  This value might have side effects
+- *2* ???*3*(f, g["action"])
+  ⚠️  unknown callee
+- *3* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *4* ???*5*["action"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* unsupported expression
+  ⚠️  This value might have side effects
+- *6* ???*7*["action"]
+  ⚠️  unknown object
+- *7* ???*8*["next"]
+  ⚠️  unknown object
+- *8* g
+  ⚠️  circular variable reference
+
+3786 -> 3793 call = (???*0* ? ???*4* : (...) => ???*6*)((???*9* | ???*10*), ???*12*)
 - *0* ("function" === ???*1*)
   ⚠️  nested operation
 - *1* typeof(???*2*)
@@ -24078,9 +29263,13 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 - *8* unsupported expression
   ⚠️  This value might have side effects
-- *9* max number of linking steps reached
+- *9* node limit reached
   ⚠️  This value might have side effects
-- *10* max number of linking steps reached
+- *10* ???*11*(f, g["action"])
+  ⚠️  unknown callee
+- *11* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *12* node limit reached
   ⚠️  This value might have side effects
 
 0 -> 3798 unreachable = ???*0*
@@ -24112,7 +29301,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 - *8* unsupported expression
   ⚠️  This value might have side effects
-- *9* max number of linking steps reached
+- *9* node limit reached
   ⚠️  This value might have side effects
 - *10* arguments[1]
   ⚠️  function calls are not analysed yet
@@ -24290,13 +29479,131 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  function calls are not analysed yet
 
 0 -> 3807 call = (...) => ui(2048, 8, a, b)(???*0*, [???*1*])
-- *0* max number of linking steps reached
+- *0* node limit reached
   ⚠️  This value might have side effects
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
 
-0 -> 3811 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 3811 conditional = (
+  | (???*0* !== ???*1*)
+  | !(???*2*)
+  | (null !== (
+      | null
+      | ???*16*
+      | {"memoizedState": null, "baseState": null, "baseQueue": null, "queue": null, "next": null}
+      | ???*17*
+      | null["alternate"]
+      | ???*24*
+      | null["next"]
+      | ???*26*
+      | {
+            "memoizedState": (null["memoizedState"] | ???*28* | ???*30*),
+            "baseState": (null["baseState"] | ???*32* | ???*34*),
+            "baseQueue": (null["baseQueue"] | ???*36* | ???*38*),
+            "queue": (null["queue"] | ???*40* | ???*42*),
+            "next": null
+        }
+    ))
+  | ???*44*
+)
+- *0* node limit reached
+  ⚠️  This value might have side effects
+- *1* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *2* ???*3*(???*13*, ???*14*)
+  ⚠️  unknown callee
+  ⚠️  This value might have side effects
+- *3* (???*4* ? ???*8* : (...) => ???*10*)
+  ⚠️  nested operation
+- *4* ("function" === ???*5*)
+  ⚠️  nested operation
+- *5* typeof(???*6*)
+  ⚠️  nested operation
+- *6* Object*7*["is"]
+  ⚠️  unsupported property on global Object
+  ⚠️  This value might have side effects
+- *7* Object: The global Object variable
+- *8* Object*9*["is"]
+  ⚠️  unsupported property on global Object
+  ⚠️  This value might have side effects
+- *9* Object: The global Object variable
+- *10* (
+     || ((a === b) && ((0 !== a) || (???*11* === ???*12*)))
+     || ((a !== a) && (b !== b))
+    )
+  ⚠️  nested operation
+- *11* unsupported expression
+  ⚠️  This value might have side effects
+- *12* unsupported expression
+  ⚠️  This value might have side effects
+- *13* node limit reached
+  ⚠️  This value might have side effects
+- *14* ???*15*()
+  ⚠️  nested operation
+- *15* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *16* unsupported expression
+  ⚠️  This value might have side effects
+- *17* (???*18* ? (null["memoizedState"] | ???*20*) : ???*22*)
+  ⚠️  nested operation
+- *18* (null === ???*19*)
+  ⚠️  nested operation
+- *19* P
+  ⚠️  circular variable reference
+- *20* ???*21*["memoizedState"]
+  ⚠️  unknown object
+- *21* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *22* ???*23*["next"]
+  ⚠️  unknown object
+- *23* P
+  ⚠️  circular variable reference
+- *24* ???*25*["alternate"]
+  ⚠️  unknown object
+- *25* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *26* ???*27*["next"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *27* unsupported expression
+  ⚠️  This value might have side effects
+- *28* ???*29*["memoizedState"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *29* unsupported expression
+  ⚠️  This value might have side effects
+- *30* ???*31*["memoizedState"]
+  ⚠️  unknown object
+- *31* a
+  ⚠️  circular variable reference
+- *32* ???*33*["baseState"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *33* unsupported expression
+  ⚠️  This value might have side effects
+- *34* ???*35*["baseState"]
+  ⚠️  unknown object
+- *35* a
+  ⚠️  circular variable reference
+- *36* ???*37*["baseQueue"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *37* unsupported expression
+  ⚠️  This value might have side effects
+- *38* ???*39*["baseQueue"]
+  ⚠️  unknown object
+- *39* a
+  ⚠️  circular variable reference
+- *40* ???*41*["queue"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *41* unsupported expression
+  ⚠️  This value might have side effects
+- *42* ???*43*["queue"]
+  ⚠️  unknown object
+- *43* a
+  ⚠️  circular variable reference
+- *44* unsupported expression
   ⚠️  This value might have side effects
 
 3811 -> 3814 member call = (...) => undefined["bind"](
@@ -24475,7 +29782,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  function calls are not analysed yet
 
 3811 -> 3815 call = (...) => a(9, ???*0*, ???*1*, null)
-- *0* max number of linking steps reached
+- *0* node limit reached
   ⚠️  This value might have side effects
 - *1* unsupported expression
   ⚠️  This value might have side effects
@@ -24645,7 +29952,54 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   | (null !== (null["next"] | ???*19* | ???*21* | null | ???*24*))["updateQueue"]["stores"]
   | null
   | ???*25*
-)["push"](???*26*)
+)["push"](
+    (
+      | ???*26*
+      | {
+            "getSnapshot": (
+              | ???*27*
+              | null["updateQueue"]
+              | ???*28*
+              | (null !== (
+                  | null
+                  | ???*30*
+                  | ???*31*
+                  | ???*33*
+                  | {
+                        "memoizedState": ???*38*,
+                        "baseState": ???*40*,
+                        "baseQueue": ???*42*,
+                        "queue": ???*44*,
+                        "next": null
+                    }
+                ))["updateQueue"]
+              | (null !== (null["next"] | ???*46* | ???*48* | null | ???*51*))["updateQueue"]
+              | {"lastEffect": null, "stores": null}
+            ),
+            "value": (
+              | ???*52*
+              | ???*53*
+              | null["updateQueue"]["stores"]
+              | (null !== (
+                  | null
+                  | ???*55*
+                  | ???*56*
+                  | ???*58*
+                  | {
+                        "memoizedState": ???*63*,
+                        "baseState": ???*65*,
+                        "baseQueue": ???*67*,
+                        "queue": ???*69*,
+                        "next": null
+                    }
+                ))["updateQueue"]["stores"]
+              | (null !== (null["next"] | ???*71* | ???*73* | null | ???*76*))["updateQueue"]["stores"]
+              | null
+              | ???*77*
+            )
+        }
+    )
+)
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["stores"]
@@ -24699,7 +30053,111 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 - *25* unknown mutation
   ⚠️  This value might have side effects
-- *26* max number of linking steps reached
+- *26* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *27* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *28* ???*29*["updateQueue"]
+  ⚠️  unknown object
+- *29* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *30* unsupported expression
+  ⚠️  This value might have side effects
+- *31* ???*32*["alternate"]
+  ⚠️  unknown object
+- *32* N
+  ⚠️  circular variable reference
+- *33* (???*34* ? ???*36* : null)
+  ⚠️  nested operation
+- *34* (null !== ???*35*)
+  ⚠️  nested operation
+- *35* a
+  ⚠️  circular variable reference
+- *36* ???*37*["memoizedState"]
+  ⚠️  unknown object
+- *37* a
+  ⚠️  circular variable reference
+- *38* ???*39*["memoizedState"]
+  ⚠️  unknown object
+- *39* O
+  ⚠️  circular variable reference
+- *40* ???*41*["baseState"]
+  ⚠️  unknown object
+- *41* O
+  ⚠️  circular variable reference
+- *42* ???*43*["baseQueue"]
+  ⚠️  unknown object
+- *43* O
+  ⚠️  circular variable reference
+- *44* ???*45*["queue"]
+  ⚠️  unknown object
+- *45* O
+  ⚠️  circular variable reference
+- *46* ???*47*["next"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *47* unsupported expression
+  ⚠️  This value might have side effects
+- *48* ???*49*["next"]
+  ⚠️  unknown object
+- *49* ???*50*["alternate"]
+  ⚠️  unknown object
+- *50* N
+  ⚠️  circular variable reference
+- *51* unknown mutation
+  ⚠️  This value might have side effects
+- *52* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *53* ???*54*["stores"]
+  ⚠️  unknown object
+- *54* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *55* unsupported expression
+  ⚠️  This value might have side effects
+- *56* ???*57*["alternate"]
+  ⚠️  unknown object
+- *57* N
+  ⚠️  circular variable reference
+- *58* (???*59* ? ???*61* : null)
+  ⚠️  nested operation
+- *59* (null !== ???*60*)
+  ⚠️  nested operation
+- *60* a
+  ⚠️  circular variable reference
+- *61* ???*62*["memoizedState"]
+  ⚠️  unknown object
+- *62* a
+  ⚠️  circular variable reference
+- *63* ???*64*["memoizedState"]
+  ⚠️  unknown object
+- *64* O
+  ⚠️  circular variable reference
+- *65* ???*66*["baseState"]
+  ⚠️  unknown object
+- *66* O
+  ⚠️  circular variable reference
+- *67* ???*68*["baseQueue"]
+  ⚠️  unknown object
+- *68* O
+  ⚠️  circular variable reference
+- *69* ???*70*["queue"]
+  ⚠️  unknown object
+- *70* O
+  ⚠️  circular variable reference
+- *71* ???*72*["next"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *72* unsupported expression
+  ⚠️  This value might have side effects
+- *73* ???*74*["next"]
+  ⚠️  unknown object
+- *74* ???*75*["alternate"]
+  ⚠️  unknown object
+- *75* N
+  ⚠️  circular variable reference
+- *76* unknown mutation
+  ⚠️  This value might have side effects
+- *77* unknown mutation
   ⚠️  This value might have side effects
 
 0 -> 3834 call = (...) => (undefined | !(He(a, c)) | !(0))(???*0*)
@@ -25444,12 +30902,27 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  circular variable reference
 - *4* b
   ⚠️  circular variable reference
-- *5* max number of linking steps reached
+- *5* ???*6*[1]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *6* node limit reached
   ⚠️  This value might have side effects
 
-0 -> 3926 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 3926 conditional = ((null !== ???*0*) | (null !== (???*1* | ???*2*)) | false | true)
+- *0* node limit reached
   ⚠️  This value might have side effects
+- *1* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *2* (???*3* ? null : ???*6*)
+  ⚠️  nested operation
+- *3* (???*4* === ???*5*)
+  ⚠️  nested operation
+- *4* unsupported expression
+  ⚠️  This value might have side effects
+- *5* b
+  ⚠️  circular variable reference
+- *6* b
+  ⚠️  circular variable reference
 
 3926 -> 3928 unreachable = ???*0*
 - *0* unreachable
@@ -25488,12 +30961,27 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  circular variable reference
 - *4* b
   ⚠️  circular variable reference
-- *5* max number of linking steps reached
+- *5* ???*6*[1]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *6* node limit reached
   ⚠️  This value might have side effects
 
-0 -> 3936 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 3936 conditional = ((null !== ???*0*) | (null !== (???*1* | ???*2*)) | false | true)
+- *0* node limit reached
   ⚠️  This value might have side effects
+- *1* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *2* (???*3* ? null : ???*6*)
+  ⚠️  nested operation
+- *3* (???*4* === ???*5*)
+  ⚠️  nested operation
+- *4* unsupported expression
+  ⚠️  This value might have side effects
+- *5* b
+  ⚠️  circular variable reference
+- *6* b
+  ⚠️  circular variable reference
 
 3936 -> 3938 unreachable = ???*0*
 - *0* unreachable
@@ -27470,9 +32958,36 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 
 0 -> 4049 call = (...) => [b["memoizedState"], a](false)
 
-0 -> 4053 member call = (...) => undefined["bind"](null, ???*0*)
-- *0* max number of linking steps reached
+0 -> 4053 member call = (...) => undefined["bind"](
+    null,
+    (
+      | false
+      | ???*0*()
+      | {
+            "pending": null,
+            "interleaved": null,
+            "lanes": 0,
+            "dispatch": null,
+            "lastRenderedReducer": (...) => (("function" === typeof(b)) ? b(a) : b),
+            "lastRenderedState": ???*1*
+        }
+      | ???*2*
+      | ???*3*
+      | (...) => undefined["bind"](null, ???*4*)[1]
+    )
+)
+- *0* a
+  ⚠️  circular variable reference
+- *1* a
+  ⚠️  circular variable reference
+- *2* unsupported expression
   ⚠️  This value might have side effects
+- *3* unknown mutation
+  ⚠️  This value might have side effects
+- *4* ???*5*[1]
+  ⚠️  unknown object
+- *5* a
+  ⚠️  circular variable reference
 
 0 -> 4055 call = (...) => P()
 
@@ -29378,9 +34893,66 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *42* f
   ⚠️  circular variable reference
 
-4244 -> 4251 conditional = ???*0*
-- *0* max number of linking steps reached
+4244 -> 4251 conditional = (
+  | ("function" === ???*0*)
+  | !(???*5*)
+  | (???*11* === (???*12* | ???*15* | null["child"]["defaultProps"]))
+  | (null === ???*18*)
+  | (???*20* === ???*21*)
+)
+- *0* typeof((???*1* | ???*3* | null["child"]))
+  ⚠️  nested operation
+- *1* ???*2*["type"]
+  ⚠️  unknown object
+- *2* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *3* ???*4*["child"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
+- *4* a
+  ⚠️  sequence with side effects
+  ⚠️  This value might have side effects
+- *5* !(???*6*)
+  ⚠️  nested operation
+- *6* !((???*7* | ???*9* | null["child"]))
+  ⚠️  nested operation
+- *7* ???*8*["type"]
+  ⚠️  unknown object
+- *8* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *9* ???*10*["child"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *10* a
+  ⚠️  sequence with side effects
+  ⚠️  This value might have side effects
+- *11* unsupported expression
+  ⚠️  This value might have side effects
+- *12* ???*13*["defaultProps"]
+  ⚠️  unknown object
+- *13* ???*14*["type"]
+  ⚠️  unknown object
+- *14* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *15* ???*16*["defaultProps"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *16* ???*17*["child"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *17* a
+  ⚠️  sequence with side effects
+  ⚠️  This value might have side effects
+- *18* ???*19*["compare"]
+  ⚠️  unknown object
+- *19* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *20* unsupported expression
+  ⚠️  This value might have side effects
+- *21* ???*22*["defaultProps"]
+  ⚠️  unknown object
+- *22* arguments[2]
+  ⚠️  function calls are not analysed yet
 
 4251 -> 4254 call = (...) => (???*0* | dj(a, b, c, d, e))(
     (
@@ -30608,8 +36180,12 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-4361 -> 4368 conditional = ???*0*
-- *0* max number of linking steps reached
+4361 -> 4368 conditional = (("object" === ???*0*) | (null !== ???*2*))
+- *0* typeof(???*1*)
+  ⚠️  nested operation
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 4368 -> 4369 call = (...) => b(???*0*)
@@ -30704,8 +36280,47 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *4* arguments[4]
   ⚠️  function calls are not analysed yet
 
-4361 -> 4388 conditional = ???*0*
+4361 -> 4388 conditional = (
+  | (???*0* !== ???*1*)
+  | (???*2* !== (???*4* | ???*7* | ???*8* | ???*9* | {}))
+  | false
+  | ???*16*
+  | true
+)
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* ???*3*["memoizedState"]
+  ⚠️  unknown object
+- *3* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *4* ???*5*["context"]
+  ⚠️  unknown object
+- *5* ???*6*["stateNode"]
+  ⚠️  unknown object
+- *6* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *7* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *8* unknown mutation
+  ⚠️  This value might have side effects
+- *9* (???*10* ? ({} | ???*14*) : ({} | ???*15*))
+  ⚠️  nested operation
+- *10* (null !== (???*11* | ???*12*))
+  ⚠️  nested operation
+- *11* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *12* ???*13*["childContextTypes"]
+  ⚠️  unknown object
+- *13* a
+  ⚠️  circular variable reference
+- *14* unknown mutation
+  ⚠️  This value might have side effects
+- *15* unknown mutation
+  ⚠️  This value might have side effects
+- *16* unknown mutation
   ⚠️  This value might have side effects
 
 4388 -> 4389 typeof = typeof((???*0* | ("function" === ???*2*)))
@@ -31118,8 +36733,36 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *4* arguments[4]
   ⚠️  function calls are not analysed yet
 
-4361 -> 4452 conditional = ???*0*
+4361 -> 4452 conditional = ((???*0* !== (???*1* | ???*8*)) | (???*10* !== ???*12*) | false | ???*14* | true)
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* ("function" === ???*2*)
+  ⚠️  nested operation
+- *2* typeof((???*3* | ???*5*))
+  ⚠️  nested operation
+- *3* ???*4*["getDerivedStateFromProps"]
+  ⚠️  unknown object
+- *4* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *5* ("function" === ???*6*)
+  ⚠️  nested operation
+- *6* typeof(???*7*)
+  ⚠️  nested operation
+- *7* ???["getDerivedStateFromProps"]
+  ⚠️  unknown object
+- *8* ???*9*["pendingProps"]
+  ⚠️  unknown object
+- *9* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *10* ???*11*["memoizedState"]
+  ⚠️  unknown object
+- *11* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *12* ???*13*["memoizedState"]
+  ⚠️  unknown object
+- *13* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *14* unknown mutation
   ⚠️  This value might have side effects
 
 4452 -> 4453 typeof = typeof(???*0*)
@@ -31584,8 +37227,13 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 4551 conditional = ???*0*
+0 -> 4551 conditional = ((null !== ???*0*) | (null === ???*1*))
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* ???*2*["memoizedState"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 4552 conditional = ???*0*
@@ -31596,7 +37244,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-0 -> 4556 conditional = ???*0*
+0 -> 4556 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -31604,16 +37252,22 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 
-4556 -> 4560 conditional = ???*0*
+4556 -> 4560 conditional = ((null !== ???*0*) | ???*1*)
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* (null !== a)
+  ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
 4560 -> 4562 conditional = (0 === ???*0*)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-4562 -> 4565 conditional = ???*0*
-- *0* max number of linking steps reached
+4562 -> 4565 conditional = ("$!" === ???*0*)
+- *0* ???*1*["data"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 4560 -> 4568 unreachable = ???*0*
@@ -31624,8 +37278,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-4571 -> 4574 conditional = ???*0*
-- *0* max number of linking steps reached
+4571 -> 4574 conditional = ((0 === ???*0*) | (null !== ???*1*))
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 4574 -> 4577 call = (...) => a(???*0*, ???*1*, 0, null)
@@ -31666,8 +37322,11 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-4556 -> 4591 conditional = ???*0*
+4556 -> 4591 conditional = ((null !== ???*0*) | ???*1*)
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* (null !== h)
+  ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
 4591 -> 4592 call = (...) => (???*0* | f | tj(a, b, g, null) | tj(a, b, g, d) | b)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, ???*6*, (???*7* | ???*8*))
@@ -31701,8 +37360,14 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-4594 -> 4601 conditional = ???*0*
-- *0* max number of linking steps reached
+4594 -> 4601 conditional = ((0 === ???*0*) | (???*1* !== ???*3*))
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* ???*2*["child"]
+  ⚠️  unknown object
+- *2* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
 4601 -> 4606 call = (...) => c(???*0*, ???*1*)
@@ -31711,7 +37376,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-4594 -> 4609 conditional = ???*0*
+4594 -> 4609 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -31733,7 +37398,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *4* arguments[1]
   ⚠️  function calls are not analysed yet
 
-4594 -> 4620 conditional = ???*0*
+4594 -> 4620 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -31749,10 +37414,13 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-4594 -> 4632 call = (...) => c(???*0*, ???*1*)
+4594 -> 4632 call = (...) => c(???*0*, {"mode": "visible", "children": ???*1*})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["children"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 4594 -> 4638 conditional = (null === (???*0* | ???*1*))
@@ -31895,26 +37563,124 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-4660 -> 4670 conditional = ???*0*
-- *0* max number of linking steps reached
+4660 -> 4670 conditional = (null !== ???*0*)
+- *0* ???*1*["memoizedState"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 4670 -> 4674 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
-4670 -> 4678 call = (...) => a(???*0*, ???*1*, 0, null)
-- *0* max number of linking steps reached
+4670 -> 4678 call = (...) => a(
+    {"mode": "visible", "children": ???*0*},
+    (
+      | ???*2*
+      | ???*3*
+      | (...) => undefined["bind"](
+            null,
+            (???*5* | ???*6* | ???*8* | null["fallback"]["treeContext"])
+        )["mode"]
+      | ???*10*
+      | 2
+      | 8
+      | 32
+      | 268435456
+      | 0
+      | (???*12* ? 0 : ???*14*)
+    ),
+    0,
+    null
+)
+- *0* ???*1*["children"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
+- *2* arguments[4]
+  ⚠️  function calls are not analysed yet
+- *3* ???*4*["mode"]
+  ⚠️  unknown object
+- *4* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *5* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *6* ???*7*["treeContext"]
+  ⚠️  unknown object
+- *7* arguments[5]
+  ⚠️  function calls are not analysed yet
+- *8* ???*9*["treeContext"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *9* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *10* ???*11*["mode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *11* unsupported expression
+  ⚠️  This value might have side effects
+- *12* (0 !== ???*13*)
+  ⚠️  nested operation
+- *13* unsupported expression
+  ⚠️  This value might have side effects
+- *14* e
+  ⚠️  circular variable reference
 
-4670 -> 4679 call = (...) => a(???*0*, ???*1*, ???*2*, null)
+4670 -> 4679 call = (...) => a(
+    ???*0*,
+    (
+      | ???*1*
+      | ???*2*
+      | (...) => undefined["bind"](
+            null,
+            (???*4* | ???*5* | ???*7* | null["fallback"]["treeContext"])
+        )["mode"]
+      | ???*9*
+      | 2
+      | 8
+      | 32
+      | 268435456
+      | 0
+      | (???*11* ? 0 : ???*13*)
+    ),
+    ???*14*,
+    null
+)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* arguments[4]
+  ⚠️  function calls are not analysed yet
+- *2* ???*3*["mode"]
+  ⚠️  unknown object
+- *3* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *4* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *5* ???*6*["treeContext"]
+  ⚠️  unknown object
+- *6* arguments[5]
+  ⚠️  function calls are not analysed yet
+- *7* ???*8*["treeContext"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
-- *2* arguments[6]
+- *8* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *9* ???*10*["mode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *10* unsupported expression
+  ⚠️  This value might have side effects
+- *11* (0 !== ???*12*)
+  ⚠️  nested operation
+- *12* unsupported expression
+  ⚠️  This value might have side effects
+- *13* e
+  ⚠️  circular variable reference
+- *14* arguments[6]
   ⚠️  function calls are not analysed yet
 
 4670 -> 4687 call = (...) => (
@@ -31923,7 +37689,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   | n(a, d, f, h)
   | t(a, d, f, h)
   | (((("string" === typeof(f)) && ("" !== f)) || ("number" === typeof(f))) ? ???*1* : c(a, d))
-)(???*2*, ???*3*, null, ???*4*)
+)(???*2*, ???*3*, null, ???*5*)
 - *0* J(a, d, l(f["_payload"]), h)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
@@ -31932,9 +37698,12 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
-- *3* max number of linking steps reached
+- *3* ???*4*["child"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
-- *4* arguments[6]
+- *4* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *5* arguments[6]
   ⚠️  function calls are not analysed yet
 
 4670 -> 4690 call = (...) => {"baseLanes": a, "cachePool": null, "transitions": null}(???*0*)
@@ -31961,8 +37730,18 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-4694 -> 4698 conditional = ???*0*
-- *0* max number of linking steps reached
+4694 -> 4698 conditional = ("$!" === (???*0* | ???*2* | 2["data"] | 8["data"] | 32["data"] | 268435456["data"] | 0["data"]))
+- *0* ???*1*["data"]
+  ⚠️  unknown object
+- *1* arguments[4]
+  ⚠️  function calls are not analysed yet
+- *2* ???*3*["data"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* ???*4*["mode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *4* unsupported expression
   ⚠️  This value might have side effects
 
 4698 -> 4702 conditional = ???*0*
@@ -32004,11 +37783,15 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-4698 -> 4711 conditional = ???*0*
-- *0* max number of linking steps reached
+4698 -> 4711 conditional = (true | false | (???*0* ? true : false) | ???*2*)
+- *0* (0 !== ???*1*)
+  ⚠️  nested operation
+- *1* unsupported expression
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-4711 -> 4712 conditional = ???*0*
+4711 -> 4712 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -32016,20 +37799,110 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-4712 -> 4717 call = (...) => ((3 === c["tag"]) ? c["stateNode"] : null)(???*0*, ???*1*)
+4712 -> 4717 call = (...) => ((3 === c["tag"]) ? c["stateNode"] : null)(
+    ???*0*,
+    (
+      | ???*1*
+      | ???*2*
+      | (...) => undefined["bind"](
+            null,
+            (???*4* | ???*5* | ???*7* | null["fallback"]["treeContext"])
+        )["mode"]
+      | ???*9*
+      | 2
+      | 8
+      | 32
+      | 268435456
+      | 0
+      | (???*11* ? 0 : ???*13*)
+    )
+)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* arguments[4]
+  ⚠️  function calls are not analysed yet
+- *2* ???*3*["mode"]
+  ⚠️  unknown object
+- *3* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *4* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *5* ???*6*["treeContext"]
+  ⚠️  unknown object
+- *6* arguments[5]
+  ⚠️  function calls are not analysed yet
+- *7* ???*8*["treeContext"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
+- *8* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *9* ???*10*["mode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *10* unsupported expression
+  ⚠️  This value might have side effects
+- *11* (0 !== ???*12*)
+  ⚠️  nested operation
+- *12* unsupported expression
+  ⚠️  This value might have side effects
+- *13* e
+  ⚠️  circular variable reference
 
-4712 -> 4718 call = (...) => undefined(???*0*, ???*1*, ???*2*, ???*3*)
+4712 -> 4718 call = (...) => undefined(
+    ???*0*,
+    ???*1*,
+    (
+      | ???*2*
+      | ???*3*
+      | (...) => undefined["bind"](
+            null,
+            (???*5* | ???*6* | ???*8* | null["fallback"]["treeContext"])
+        )["mode"]
+      | ???*10*
+      | 2
+      | 8
+      | 32
+      | 268435456
+      | 0
+      | (???*12* ? 0 : ???*14*)
+    ),
+    ???*15*
+)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
-- *2* max number of linking steps reached
+- *2* arguments[4]
+  ⚠️  function calls are not analysed yet
+- *3* ???*4*["mode"]
+  ⚠️  unknown object
+- *4* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *5* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *6* ???*7*["treeContext"]
+  ⚠️  unknown object
+- *7* arguments[5]
+  ⚠️  function calls are not analysed yet
+- *8* ???*9*["treeContext"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
-- *3* unsupported expression
+- *9* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *10* ???*11*["mode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *11* unsupported expression
+  ⚠️  This value might have side effects
+- *12* (0 !== ???*13*)
+  ⚠️  nested operation
+- *13* unsupported expression
+  ⚠️  This value might have side effects
+- *14* e
+  ⚠️  circular variable reference
+- *15* unsupported expression
   ⚠️  This value might have side effects
 
 4711 -> 4719 call = (...) => undefined()
@@ -32069,8 +37942,18 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-4711 -> 4727 conditional = ???*0*
-- *0* max number of linking steps reached
+4711 -> 4727 conditional = ("$?" === (???*0* | ???*2* | 2["data"] | 8["data"] | 32["data"] | 268435456["data"] | 0["data"]))
+- *0* ???*1*["data"]
+  ⚠️  unknown object
+- *1* arguments[4]
+  ⚠️  function calls are not analysed yet
+- *2* ???*3*["data"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* ???*4*["mode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *4* unsupported expression
   ⚠️  This value might have side effects
 
 4727 -> 4732 member call = (...) => undefined["bind"](null, ???*0*)
@@ -32081,16 +37964,62 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-4727 -> 4737 call = (...) => (null | a)(???*0*)
-- *0* max number of linking steps reached
+4727 -> 4737 call = (...) => (null | a)(
+    (
+      | ???*0*
+      | (...) => undefined["bind"](
+            null,
+            (???*2* | ???*3* | ???*5* | null["fallback"]["treeContext"])
+        )["mode"]["nextSibling"]
+      | ???*7*
+      | 2["nextSibling"]
+      | 8["nextSibling"]
+      | 32["nextSibling"]
+      | 268435456["nextSibling"]
+      | 0["nextSibling"]
+      | (???*10* ? 0 : ???*12*)["nextSibling"]
+    )
+)
+- *0* ???*1*["nextSibling"]
+  ⚠️  unknown object
+- *1* arguments[4]
+  ⚠️  function calls are not analysed yet
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *3* ???*4*["treeContext"]
+  ⚠️  unknown object
+- *4* arguments[5]
+  ⚠️  function calls are not analysed yet
+- *5* ???*6*["treeContext"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
+- *6* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *7* ???*8*["nextSibling"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *8* ???*9*["mode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *9* unsupported expression
+  ⚠️  This value might have side effects
+- *10* (0 !== ???*11*)
+  ⚠️  nested operation
+- *11* unsupported expression
+  ⚠️  This value might have side effects
+- *12* e
+  ⚠️  circular variable reference
 
 4727 -> 4744 call = (...) => ???*0*(???*1*, ???*2*)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
-- *2* max number of linking steps reached
+- *2* ???*3*["children"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
 4727 -> 4746 unreachable = ???*0*
@@ -32509,8 +38438,58 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *5* unknown mutation
   ⚠️  This value might have side effects
 
-4794 -> 4810 conditional = ???*0*
-- *0* max number of linking steps reached
+4794 -> 4810 conditional = (
+  | (null !== (
+      | ???*0*
+      | ???*1*
+      | 0["revealOrder"]["alternate"]
+      | ???*3*
+      | null["alternate"]
+      | null["sibling"]["alternate"]
+      | 0["revealOrder"]["sibling"]
+      | null["sibling"]
+      | null["sibling"]["sibling"]
+    ))
+  | (null === (
+      | ???*6*
+      | ???*7*
+      | 0["revealOrder"]["alternate"]
+      | ???*9*
+      | null["alternate"]
+      | null["sibling"]["alternate"]
+      | 0["revealOrder"]["sibling"]
+      | null["sibling"]
+      | null["sibling"]["sibling"]
+      | null
+    ))
+)
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* ???*2*["child"]
+  ⚠️  unknown object
+- *2* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *3* ???*4*["alternate"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *4* ???*5*["revealOrder"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* unknown mutation
+  ⚠️  This value might have side effects
+- *6* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *7* ???*8*["child"]
+  ⚠️  unknown object
+- *8* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *9* ???*10*["alternate"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *10* ???*11*["revealOrder"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *11* unknown mutation
   ⚠️  This value might have side effects
 
 4794 -> 4814 call = (...) => undefined(
@@ -34063,8 +40042,334 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *16* f
   ⚠️  circular variable reference
 
-4933 -> 4970 conditional = ???*0*
-- *0* max number of linking steps reached
+4933 -> 4970 conditional = (
+  | ???*0*
+  | ???*4*
+  | ((???*21* | ???*25* | ???*42*) !== (???*47* | ???*52* | ???*69*))
+  | (null != (???*106* | ???*110* | ???*127*))
+)
+- *0* ???*1*["hasOwnProperty"]((???*2* | null | [] | ???*3*))
+  ⚠️  unknown callee object
+- *1* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *2* l
+  ⚠️  pattern without value
+- *3* f
+  ⚠️  circular variable reference
+- *4* ???*5*["hasOwnProperty"]((???*19* | null | [] | ???*20*))
+  ⚠️  unknown callee object
+  ⚠️  This value might have side effects
+- *5* Object.assign*6*(
+        {},
+        ???*7*,
+        {
+            "defaultChecked": ???*8*,
+            "defaultValue": ???*9*,
+            "value": ???*10*,
+            "checked": (???*11* ? ???*14* : ???*16*)
+        }
+    )
+  ⚠️  only const object assign is supported
+  ⚠️  This value might have side effects
+- *6* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+- *7* d
+  ⚠️  circular variable reference
+- *8* unsupported expression
+  ⚠️  This value might have side effects
+- *9* unsupported expression
+  ⚠️  This value might have side effects
+- *10* unsupported expression
+  ⚠️  This value might have side effects
+- *11* (null != ???*12*)
+  ⚠️  nested operation
+- *12* ???*13*["checked"]
+  ⚠️  unknown object
+- *13* d
+  ⚠️  circular variable reference
+- *14* ???*15*["checked"]
+  ⚠️  unknown object
+- *15* d
+  ⚠️  circular variable reference
+- *16* ???*17*["initialChecked"]
+  ⚠️  unknown object
+- *17* ???*18*["_wrapperState"]
+  ⚠️  unknown object
+- *18* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *19* l
+  ⚠️  pattern without value
+- *20* f
+  ⚠️  circular variable reference
+- *21* ???*22*[(???*23* | null | [] | ???*24*)]
+  ⚠️  unknown object
+- *22* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *23* l
+  ⚠️  pattern without value
+- *24* f
+  ⚠️  circular variable reference
+- *25* ???*26*[(???*40* | null | [] | ???*41*)]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *26* Object.assign*27*(
+        {},
+        ???*28*,
+        {
+            "defaultChecked": ???*29*,
+            "defaultValue": ???*30*,
+            "value": ???*31*,
+            "checked": (???*32* ? ???*35* : ???*37*)
+        }
+    )
+  ⚠️  only const object assign is supported
+  ⚠️  This value might have side effects
+- *27* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+- *28* d
+  ⚠️  circular variable reference
+- *29* unsupported expression
+  ⚠️  This value might have side effects
+- *30* unsupported expression
+  ⚠️  This value might have side effects
+- *31* unsupported expression
+  ⚠️  This value might have side effects
+- *32* (null != ???*33*)
+  ⚠️  nested operation
+- *33* ???*34*["checked"]
+  ⚠️  unknown object
+- *34* d
+  ⚠️  circular variable reference
+- *35* ???*36*["checked"]
+  ⚠️  unknown object
+- *36* d
+  ⚠️  circular variable reference
+- *37* ???*38*["initialChecked"]
+  ⚠️  unknown object
+- *38* ???*39*["_wrapperState"]
+  ⚠️  unknown object
+- *39* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *40* l
+  ⚠️  pattern without value
+- *41* f
+  ⚠️  circular variable reference
+- *42* (???*43* ? ???*44* : ???*46*)
+  ⚠️  nested operation
+- *43* k
+  ⚠️  circular variable reference
+- *44* ???*45*["__html"]
+  ⚠️  unknown object
+- *45* k
+  ⚠️  circular variable reference
+- *46* unsupported expression
+  ⚠️  This value might have side effects
+- *47* ???*48*[(???*50* | null | [] | ???*51*)]
+  ⚠️  unknown object
+- *48* ???*49*["memoizedProps"]
+  ⚠️  unknown object
+- *49* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *50* l
+  ⚠️  pattern without value
+- *51* f
+  ⚠️  circular variable reference
+- *52* ???*53*[(???*67* | null | [] | ???*68*)]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *53* Object.assign*54*(
+        {},
+        ???*55*,
+        {
+            "defaultChecked": ???*56*,
+            "defaultValue": ???*57*,
+            "value": ???*58*,
+            "checked": (???*59* ? ???*62* : ???*64*)
+        }
+    )
+  ⚠️  only const object assign is supported
+  ⚠️  This value might have side effects
+- *54* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+- *55* e
+  ⚠️  circular variable reference
+- *56* unsupported expression
+  ⚠️  This value might have side effects
+- *57* unsupported expression
+  ⚠️  This value might have side effects
+- *58* unsupported expression
+  ⚠️  This value might have side effects
+- *59* (null != ???*60*)
+  ⚠️  nested operation
+- *60* ???*61*["checked"]
+  ⚠️  unknown object
+- *61* e
+  ⚠️  circular variable reference
+- *62* ???*63*["checked"]
+  ⚠️  unknown object
+- *63* e
+  ⚠️  circular variable reference
+- *64* ???*65*["initialChecked"]
+  ⚠️  unknown object
+- *65* ???*66*["_wrapperState"]
+  ⚠️  unknown object
+- *66* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *67* l
+  ⚠️  pattern without value
+- *68* f
+  ⚠️  circular variable reference
+- *69* (???*70* ? (???*85* | ???*90*) : ???*105*)
+  ⚠️  nested operation
+- *70* (null != (???*71* | ???*73*))
+  ⚠️  nested operation
+- *71* ???*72*["memoizedProps"]
+  ⚠️  unknown object
+- *72* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *73* Object.assign*74*(
+        {},
+        ???*75*,
+        {
+            "defaultChecked": ???*76*,
+            "defaultValue": ???*77*,
+            "value": ???*78*,
+            "checked": (???*79* ? ???*81* : ???*83*)
+        }
+    )
+  ⚠️  only const object assign is supported
+  ⚠️  This value might have side effects
+- *74* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+- *75* e
+  ⚠️  circular variable reference
+- *76* unsupported expression
+  ⚠️  This value might have side effects
+- *77* unsupported expression
+  ⚠️  This value might have side effects
+- *78* unsupported expression
+  ⚠️  This value might have side effects
+- *79* (null != ???*80*)
+  ⚠️  nested operation
+- *80* ...[...]
+  ⚠️  unknown object
+- *81* ???*82*["checked"]
+  ⚠️  unknown object
+- *82* e
+  ⚠️  circular variable reference
+- *83* ???*84*["initialChecked"]
+  ⚠️  unknown object
+- *84* ...[...]
+  ⚠️  unknown object
+- *85* ???*86*[(???*88* | null | [] | ???*89*)]
+  ⚠️  unknown object
+- *86* ???*87*["memoizedProps"]
+  ⚠️  unknown object
+- *87* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *88* l
+  ⚠️  pattern without value
+- *89* f
+  ⚠️  circular variable reference
+- *90* ???*91*[(???*103* | null | [] | ???*104*)]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *91* Object.assign*92*(
+        {},
+        ???*93*,
+        {
+            "defaultChecked": ???*94*,
+            "defaultValue": ???*95*,
+            "value": ???*96*,
+            "checked": (???*97* ? ???*99* : ???*101*)
+        }
+    )
+  ⚠️  only const object assign is supported
+  ⚠️  This value might have side effects
+- *92* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+- *93* e
+  ⚠️  circular variable reference
+- *94* unsupported expression
+  ⚠️  This value might have side effects
+- *95* unsupported expression
+  ⚠️  This value might have side effects
+- *96* unsupported expression
+  ⚠️  This value might have side effects
+- *97* (null != ???*98*)
+  ⚠️  nested operation
+- *98* ...[...]
+  ⚠️  unknown object
+- *99* ???*100*["checked"]
+  ⚠️  unknown object
+- *100* e
+  ⚠️  circular variable reference
+- *101* ???*102*["initialChecked"]
+  ⚠️  unknown object
+- *102* ...[...]
+  ⚠️  unknown object
+- *103* l
+  ⚠️  pattern without value
+- *104* f
+  ⚠️  circular variable reference
+- *105* unsupported expression
+  ⚠️  This value might have side effects
+- *106* ???*107*[(???*108* | null | [] | ???*109*)]
+  ⚠️  unknown object
+- *107* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *108* l
+  ⚠️  pattern without value
+- *109* f
+  ⚠️  circular variable reference
+- *110* ???*111*[(???*125* | null | [] | ???*126*)]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *111* Object.assign*112*(
+        {},
+        ???*113*,
+        {
+            "defaultChecked": ???*114*,
+            "defaultValue": ???*115*,
+            "value": ???*116*,
+            "checked": (???*117* ? ???*120* : ???*122*)
+        }
+    )
+  ⚠️  only const object assign is supported
+  ⚠️  This value might have side effects
+- *112* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+- *113* d
+  ⚠️  circular variable reference
+- *114* unsupported expression
+  ⚠️  This value might have side effects
+- *115* unsupported expression
+  ⚠️  This value might have side effects
+- *116* unsupported expression
+  ⚠️  This value might have side effects
+- *117* (null != ???*118*)
+  ⚠️  nested operation
+- *118* ???*119*["checked"]
+  ⚠️  unknown object
+- *119* d
+  ⚠️  circular variable reference
+- *120* ???*121*["checked"]
+  ⚠️  unknown object
+- *121* d
+  ⚠️  circular variable reference
+- *122* ???*123*["initialChecked"]
+  ⚠️  unknown object
+- *123* ???*124*["_wrapperState"]
+  ⚠️  unknown object
+- *124* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *125* l
+  ⚠️  pattern without value
+- *126* f
+  ⚠️  circular variable reference
+- *127* (???*128* ? ???*129* : ???*131*)
+  ⚠️  nested operation
+- *128* k
+  ⚠️  circular variable reference
+- *129* ???*130*["__html"]
+  ⚠️  unknown object
+- *130* k
+  ⚠️  circular variable reference
+- *131* unsupported expression
   ⚠️  This value might have side effects
 
 4970 -> 4971 conditional = ("style" === (???*0* | null | [] | ???*1*))
@@ -35328,7 +41633,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 0 -> 5055 call = (...) => ((null !== a) && (???*0* !== a))(???*1*)
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 5056 call = (...) => undefined()
@@ -35349,8 +41657,13 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 
 0 -> 5063 call = (...) => undefined()
 
-0 -> 5069 conditional = ???*0*
+0 -> 5069 conditional = ((null === ???*0*) | (null === ???*1*))
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* ???*2*["child"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5069 -> 5070 call = (...) => (!(1) | ???*0* | !(0))(???*1*)
@@ -35360,8 +41673,9 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5069 -> 5071 conditional = ???*0*
-- *0* max number of linking steps reached
+5069 -> 5071 conditional = (false | ???*0* | true)
+- *0* !(1)
+  ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
 5071 -> 5077 call = (...) => undefined((null | [???*0*]))
@@ -35392,8 +41706,13 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unknown mutation
   ⚠️  This value might have side effects
 
-0 -> 5086 conditional = ???*0*
+0 -> 5086 conditional = ((null !== ???*0*) | (null != ???*1*))
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* ???*2*["stateNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5086 -> 5087 call = (???*0* | (...) => undefined)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*)
@@ -35410,12 +41729,15 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *5* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5086 -> 5092 conditional = ???*0*
+5086 -> 5092 conditional = !(???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5092 -> 5094 conditional = ???*0*
-- *0* max number of linking steps reached
+5092 -> 5094 conditional = (null === ???*0*)
+- *0* ???*1*["stateNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5094 -> 5095 free var = FreeVar(Error)
@@ -35450,8 +41772,9 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5092 -> 5103 conditional = ???*0*
-- *0* max number of linking steps reached
+5092 -> 5103 conditional = (false | ???*0* | true)
+- *0* !(1)
+  ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
 5103 -> 5110 call = (...) => undefined("cancel", ???*0*)
@@ -35466,7 +41789,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5103 -> 5115 call = (...) => undefined(???*0*, ???*1*)
+5103 -> 5115 call = (...) => undefined(
+    "abort canplay canplaythrough durationchange emptied encrypted ended error loadeddata loadedmetadata loadstart pause play playing progress ratechange resize seeked seeking stalled suspend timeupdate volumechange waiting"["split"](" ")[???*0*],
+    ???*1*
+)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -35525,10 +41851,13 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 
 5103 -> 5130 conditional = ???*0*
-- *0* max number of linking steps reached
+- *0* ???*1*["hasOwnProperty"](g)
+  ⚠️  unknown callee object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5130 -> 5132 conditional = ???*0*
+5130 -> 5132 conditional = ("children" === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -35536,28 +41865,36 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5132 -> 5134 conditional = ???*0*
-- *0* max number of linking steps reached
+5132 -> 5134 conditional = ("string" === ???*0*)
+- *0* typeof(???*1*)
+  ⚠️  nested operation
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5134 -> 5138 call = (...) => undefined(???*0*, ???*1*, ???*2*)
-- *0* max number of linking steps reached
+5134 -> 5138 call = (...) => undefined(???*0*, ???*2*, ???*3*)
+- *0* ???*1*["textContent"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5134 -> 5139 typeof = typeof(???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5134 -> 5143 call = (...) => undefined(???*0*, ???*1*, ???*2*)
-- *0* max number of linking steps reached
+5134 -> 5143 call = (...) => undefined(???*0*, ???*2*, ???*3*)
+- *0* ???*1*["textContent"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5132 -> 5145 member call = {}["hasOwnProperty"](???*0*)
@@ -35587,11 +41924,17 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 
 5103 -> 5151 typeof = typeof(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["onClick"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5103 -> 5157 conditional = ???*0*
-- *0* max number of linking steps reached
+5103 -> 5157 conditional = (9 === ???*0*)
+- *0* ???*1*["nodeType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5103 -> 5159 call = (...) => (
@@ -35603,11 +41946,11 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5103 -> 5160 conditional = ???*0*
+5103 -> 5160 conditional = ("http://www.w3.org/1999/xhtml" === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5160 -> 5161 conditional = ???*0*
+5160 -> 5161 conditional = ("script" === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -35618,23 +41961,37 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 5161 -> 5167 member call = ???*0*["removeChild"](???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["firstChild"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5161 -> 5168 typeof = typeof(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["is"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5161 -> 5170 conditional = ???*0*
-- *0* max number of linking steps reached
+5161 -> 5170 conditional = ("string" === ???*0*)
+- *0* typeof(???*1*)
+  ⚠️  nested operation
+- *1* ???*2*["is"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5170 -> 5173 member call = ???*0*["createElement"](???*1*, ???*2*)
+5170 -> 5173 member call = ???*0*["createElement"](???*1*, {"is": ???*2*})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
-- *2* max number of linking steps reached
+- *2* ???*3*["is"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5170 -> 5175 member call = ???*0*["createElement"](???*1*)
@@ -35644,7 +42001,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 
 5170 -> 5177 conditional = ???*0*
-- *0* max number of linking steps reached
+- *0* ???*1*["multiple"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5160 -> 5183 member call = ???*0*["createElementNS"](???*1*, ???*2*)
@@ -35681,7 +42041,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5103 -> 5194 call = (...) => undefined(???*0*, ???*1*)
+5103 -> 5194 call = (...) => undefined(
+    "abort canplay canplaythrough durationchange emptied encrypted ended error loadeddata loadedmetadata loadstart pause play playing progress ratechange resize seeked seeking stalled suspend timeupdate volumechange waiting"["split"](" ")[???*0*],
+    ???*1*
+)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
@@ -35786,10 +42149,13 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 
 5103 -> 5212 conditional = ???*0*
-- *0* max number of linking steps reached
+- *0* ???*1*["hasOwnProperty"](f)
+  ⚠️  unknown callee object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5212 -> 5214 conditional = ???*0*
+5212 -> 5214 conditional = ("style" === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -35799,7 +42165,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5214 -> 5216 conditional = ???*0*
+5214 -> 5216 conditional = ("dangerouslySetInnerHTML" === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -35817,7 +42183,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5216 -> 5220 conditional = ???*0*
+5216 -> 5220 conditional = ("children" === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -35825,8 +42191,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5220 -> 5222 conditional = ???*0*
-- *0* max number of linking steps reached
+5220 -> 5222 conditional = ("string" === ???*0*)
+- *0* typeof(???*1*)
+  ⚠️  nested operation
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5222 -> 5223 call = (...) => (undefined | FreeVar(undefined))(???*0*, ???*1*)
@@ -35850,7 +42218,15 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 
 5220 -> 5228 conditional = ???*0*
-- *0* max number of linking steps reached
+- *0* (???*1* | ???*2*)(???*3*)
+  ⚠️  non-function callee
+  ⚠️  This value might have side effects
+- *1* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *2* unknown mutation
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5228 -> 5229 call = (...) => undefined("scroll", ???*0*)
@@ -35886,37 +42262,59 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 
 5103 -> 5238 call = (...) => (undefined | a | "")(???*0*)
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-5103 -> 5239 member call = ???*0*["setAttribute"]("value", ???*1*)
-- *0* max number of linking steps reached
+- *0* ???*1*["value"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5103 -> 5243 conditional = ???*0*
+5103 -> 5239 member call = ???*0*["setAttribute"]("value", (undefined | ???*1* | ""))
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-
-5243 -> 5245 call = (...) => (undefined | FreeVar(undefined))(???*0*, ???*1*, ???*2*, false)
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["value"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5243 -> 5249 call = (...) => (undefined | FreeVar(undefined))(???*0*, ???*1*, ???*2*, true)
+5103 -> 5243 conditional = (null != ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+
+5243 -> 5245 call = (...) => (undefined | FreeVar(undefined))(???*0*, !(???*1*), ???*4*, false)
+- *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *2* max number of linking steps reached
+- *1* !(???*2*)
+  ⚠️  nested operation
+- *2* ???*3*["multiple"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *4* max number of linking steps reached
+  ⚠️  This value might have side effects
+
+5243 -> 5249 call = (...) => (undefined | FreeVar(undefined))(???*0*, !(???*1*), ???*4*, true)
+- *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* !(???*2*)
+  ⚠️  nested operation
+- *2* ???*3*["multiple"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *4* ???*5*["defaultValue"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5103 -> 5250 typeof = typeof(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["onClick"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 5258 call = (...) => b(???*0*)
@@ -35927,28 +42325,43 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 5261 conditional = ???*0*
+0 -> 5261 conditional = (???*0* | (null != ???*1*))
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
+- *1* ???*2*["stateNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
+  ⚠️  This value might have side effects
 
-5261 -> 5263 call = (???*0* | (...) => undefined)(???*1*, ???*2*, ???*3*, ???*4*)
+5261 -> 5263 call = (???*0* | (...) => undefined)(???*1*, ???*2*, ???*3*, ???*5*)
 - *0* Dj
   ⚠️  pattern without value
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
-- *3* max number of linking steps reached
+- *3* ???*4*["memoizedProps"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *4* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *5* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5261 -> 5264 typeof = typeof(???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5261 -> 5266 conditional = ???*0*
-- *0* max number of linking steps reached
+5261 -> 5266 conditional = (("string" !== ???*0*) | (null === ???*2*))
+- *0* typeof(???*1*)
+  ⚠️  nested operation
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* ???*3*["stateNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5266 -> 5267 free var = FreeVar(Error)
@@ -35979,34 +42392,56 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5261 -> 5275 conditional = ???*0*
-- *0* max number of linking steps reached
+5261 -> 5275 conditional = (false | ???*0* | true)
+- *0* !(1)
+  ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-5275 -> 5283 call = (...) => undefined(???*0*, ???*1*, (0 !== ???*2*))
-- *0* max number of linking steps reached
+5275 -> 5283 call = (...) => undefined(???*0*, ???*2*, (0 !== ???*3*))
+- *0* ???*1*["nodeValue"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
-- *2* unsupported expression
+- *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *3* unsupported expression
   ⚠️  This value might have side effects
 
-5275 -> 5288 call = (...) => undefined(???*0*, ???*1*, (0 !== ???*2*))
-- *0* max number of linking steps reached
+5275 -> 5288 call = (...) => undefined(???*0*, ???*2*, (0 !== ???*3*))
+- *0* ???*1*["nodeValue"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
-- *2* unsupported expression
+- *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *3* unsupported expression
   ⚠️  This value might have side effects
 
-5275 -> 5292 conditional = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-5275 -> 5294 member call = ???*0*["createTextNode"](???*1*)
-- *0* max number of linking steps reached
+5275 -> 5292 conditional = (9 === ???*0*)
+- *0* ???*1*["nodeType"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+
+5275 -> 5294 member call = (???*0* ? ???*3* : ???*4*)["createTextNode"](???*6*)
+- *0* (9 === ???*1*)
+  ⚠️  nested operation
+- *1* ???*2*["nodeType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *4* ???*5*["ownerDocument"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *6* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 5297 call = (...) => b(???*0*)
@@ -36019,12 +42454,21 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 
 0 -> 5299 call = (...) => undefined({"current": 0})
 
-0 -> 5304 conditional = ???*0*
+0 -> 5304 conditional = ((null === ???*0*) | (null !== ???*1*))
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
+- *1* ???*2*["memoizedState"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
+  ⚠️  This value might have side effects
 
-5304 -> 5307 conditional = ???*0*
+5304 -> 5307 conditional = (false | true | (null !== ???*0*) | (0 !== ???*1*) | (0 === ???*2*))
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* unsupported expression
+  ⚠️  This value might have side effects
+- *2* unsupported expression
   ⚠️  This value might have side effects
 
 5307 -> 5308 call = (...) => undefined()
@@ -36038,11 +42482,11 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5307 -> 5313 conditional = ???*0*
+5307 -> 5313 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5313 -> 5314 conditional = ???*0*
+5313 -> 5314 conditional = !(???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -36059,11 +42503,11 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* `https://reactjs.org/docs/error-decoder.html?invariant=${318}`
   ⚠️  nested operation
 
-5313 -> 5319 conditional = ???*0*
+5313 -> 5319 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5313 -> 5321 conditional = ???*0*
+5313 -> 5321 conditional = !(???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -36090,7 +42534,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-5304 -> 5332 conditional = ???*0*
+5304 -> 5332 conditional = !(???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -36106,8 +42550,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-5336 -> 5344 conditional = ???*0*
+5336 -> 5344 conditional = ((null === ???*0*) | (0 !== ???*1*))
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* unsupported expression
   ⚠️  This value might have side effects
 
 5344 -> 5345 call = (...) => undefined()
@@ -36131,7 +42577,13 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 
 0 -> 5354 call = (...) => undefined(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["containerInfo"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* ???*2*["stateNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 5355 call = (...) => b(???*0*)
@@ -36143,7 +42595,13 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 
 0 -> 5359 call = (...) => undefined(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["_context"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* ???*2*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 5360 call = (...) => b(???*0*)
@@ -36157,7 +42615,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 0 -> 5363 call = (...) => ((null !== a) && (???*0* !== a))(???*1*)
 - *0* unsupported expression
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 5364 call = (...) => undefined()
@@ -36172,7 +42633,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 
 0 -> 5367 call = (...) => undefined({"current": 0})
 
-0 -> 5369 conditional = ???*0*
+0 -> 5369 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -36184,7 +42645,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-5369 -> 5374 conditional = ???*0*
+5369 -> 5374 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -36196,15 +42657,17 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5375 -> 5378 conditional = ???*0*
+5375 -> 5378 conditional = ((0 !== (3 | 0 | 1 | 2 | 4 | 6 | 5)) | (null !== ???*0*) | (0 !== ???*1*))
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* unsupported expression
   ⚠️  This value might have side effects
 
 5378 -> 5380 call = (...) => (b | null)(???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5378 -> 5381 conditional = ???*0*
+5378 -> 5381 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -36212,11 +42675,11 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5381 -> 5391 conditional = ???*0*
+5381 -> 5391 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5391 -> 5419 conditional = ???*0*
+5391 -> 5419 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -36234,7 +42697,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5374 -> 5433 conditional = ???*0*
+5374 -> 5433 conditional = !(???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -36261,15 +42724,21 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 
 5374 -> 5451 conditional = ???*0*
+- *0* ???*1*["isBackwards"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+
+5451 -> 5456 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5451 -> 5456 conditional = ???*0*
-- *0* max number of linking steps reached
+5369 -> 5461 conditional = (null !== ???*0*)
+- *0* ???*1*["tail"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
-
-5369 -> 5461 conditional = ???*0*
-- *0* max number of linking steps reached
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5461 -> 5467 call = module<scheduler, {}>["unstable_now"]()
@@ -36278,8 +42747,12 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5461 -> 5471 call = (...) => undefined({"current": 0}, ???*0*)
+5461 -> 5471 call = (...) => undefined({"current": 0}, (???*0* ? ???*1* : ???*2*))
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* unsupported expression
+  ⚠️  This value might have side effects
+- *2* unsupported expression
   ⚠️  This value might have side effects
 
 5461 -> 5472 unreachable = ???*0*
@@ -36296,8 +42769,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 
 0 -> 5475 call = (...) => undefined()
 
-0 -> 5480 conditional = ???*0*
+0 -> 5480 conditional = (???*0* | (0 !== ???*1*))
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* unsupported expression
   ⚠️  This value might have side effects
 
 5480 -> 5481 call = (...) => b(???*0*)
@@ -36323,15 +42798,20 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 0 -> 5488 free var = FreeVar(Error)
 
 0 -> 5490 call = (...) => `Minified React error #${a}; visit ${b} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`(156, ???*0*)
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-0 -> 5491 call = ???*0*(???*1*)
-- *0* FreeVar(Error)
-  ⚠️  unknown global
+- *0* ???*1*["tag"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
+
+0 -> 5491 call = ???*0*(
+    `Minified React error #${156}; visit ${???*1*} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`
+)
+- *0* FreeVar(Error)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *1* `https://reactjs.org/docs/error-decoder.html?invariant=${156}`
+  ⚠️  nested operation
 
 0 -> 5492 call = (...) => undefined(???*0*)
 - *0* arguments[1]
@@ -36540,8 +43020,97 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 5551 conditional = ???*0*
+0 -> 5551 conditional = (
+  | ???*0*
+  | ???*1*
+  | ???*3*()
+  | ("input" === (???*6* | ???*7* | ???*9*))
+  | ("text" === ???*13*)
+  | ("search" === ???*15*)
+  | ("tel" === ???*17*)
+  | ("url" === ???*19*)
+  | ("password" === ???*21*)
+  | ("textarea" === (???*23* | ???*24* | ???*26*))
+  | ("true" === ???*30*)
+)
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* ???*2*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *3* ???*4*["toLowerCase"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *4* ???*5*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *6* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *7* ???*8*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *8* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *9* ???*10*()
+  ⚠️  nested operation
+- *10* ???*11*["toLowerCase"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *11* ???*12*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *12* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *13* ???*14*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *14* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *15* ???*16*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *16* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *17* ???*18*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *18* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *19* ???*20*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *20* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *21* ???*22*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *22* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *23* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *24* ???*25*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *25* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *26* ???*27*()
+  ⚠️  nested operation
+- *27* ???*28*["toLowerCase"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *28* ???*29*["nodeName"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *29* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *30* ???*31*["contentEditable"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *31* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5551 -> 5556 free var = FreeVar(window)
@@ -36550,48 +43119,92 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5551 -> 5561 conditional = ???*0*
+5551 -> 5561 conditional = (???*0* | (0 !== ???*1*))
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
+- *1* ???*2*["rangeCount"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
+  ⚠️  This value might have side effects
 
-5561 -> 5576 conditional = ???*0*
-- *0* max number of linking steps reached
+5561 -> 5576 conditional = (???*0* === ???*1*)
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 5582 conditional = (0 !== ???*0*)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-5582 -> 5584 conditional = ???*0*
+5582 -> 5584 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5584 -> 5591 conditional = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-5591 -> 5593 call = (...) => b(???*0*, ???*1*)
-- *0* max number of linking steps reached
+5584 -> 5591 conditional = (???*0* === ???*2*)
+- *0* ???*1*["elementType"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
+- *2* ???*3*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
+  ⚠️  This value might have side effects
 
-5584 -> 5594 member call = ???*0*["getSnapshotBeforeUpdate"](???*1*, ???*2*)
-- *0* max number of linking steps reached
+5591 -> 5593 call = (...) => b(???*0*, ???*2*)
+- *0* ???*1*["type"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5582 -> 5599 conditional = ???*0*
+5584 -> 5594 member call = ???*0*["getSnapshotBeforeUpdate"]((???*1* ? ???*6* : (???*7* | ???*8*)), ???*11*)
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* (???*2* === ???*4*)
+  ⚠️  nested operation
+- *2* ???*3*["elementType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *4* ???*5*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *6* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *7* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *8* Object.assign*9*({}, ???*10*)
+  ⚠️  only const object assign is supported
+  ⚠️  This value might have side effects
+- *9* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+- *10* b
+  ⚠️  circular variable reference
+- *11* max number of linking steps reached
+  ⚠️  This value might have side effects
+
+5582 -> 5599 conditional = (1 === ???*0*)
+- *0* ???*1*["nodeType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5599 -> 5605 member call = ???*0*["removeChild"](???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["documentElement"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5582 -> 5606 free var = FreeVar(Error)
@@ -36607,15 +43220,18 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* `https://reactjs.org/docs/error-decoder.html?invariant=${163}`
   ⚠️  nested operation
 
-0 -> 5610 call = (...) => undefined(???*0*, ???*1*, ???*2*)
+0 -> 5610 call = (...) => undefined(???*0*, ???*1*, ???*3*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["return"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
-- *2* F
+- *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *3* F
   ⚠️  pattern without value
 
-0 -> 5612 conditional = ???*0*
+0 -> 5612 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -37129,18 +43745,24 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *3* e
   ⚠️  circular variable reference
 
-5749 -> 5752 conditional = ???*0*
-- *0* max number of linking steps reached
+5749 -> 5752 conditional = (8 === ???*0*)
+- *0* ???*1*["nodeType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5752 -> 5755 member call = ???*0*["removeChild"]((???*1* | ???*2*))
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *1* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *2* ???*3*["stateNode"]
+5752 -> 5755 member call = ???*0*["removeChild"]((???*2* | ???*3*))
+- *0* ???*1*["parentNode"]
   ⚠️  unknown object
-- *3* c
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *3* ???*4*["stateNode"]
+  ⚠️  unknown object
+- *4* c
   ⚠️  circular variable reference
 
 5752 -> 5757 member call = ???*0*["removeChild"]((???*1* | ???*2*))
@@ -37171,18 +43793,24 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *3* e
   ⚠️  circular variable reference
 
-5761 -> 5764 conditional = ???*0*
-- *0* max number of linking steps reached
+5761 -> 5764 conditional = (8 === ???*0*)
+- *0* ???*1*["nodeType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5764 -> 5766 call = (...) => (undefined | FreeVar(undefined))(???*0*, (???*1* | ???*2*))
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *1* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *2* ???*3*["stateNode"]
+5764 -> 5766 call = (...) => (undefined | FreeVar(undefined))(???*0*, (???*2* | ???*3*))
+- *0* ???*1*["parentNode"]
   ⚠️  unknown object
-- *3* c
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *3* ???*4*["stateNode"]
+  ⚠️  unknown object
+- *4* c
   ⚠️  circular variable reference
 
 5764 -> 5768 call = (...) => (undefined | FreeVar(undefined))(???*0*, (???*1* | ???*2*))
@@ -37219,8 +43847,14 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *4* c
   ⚠️  circular variable reference
 
-0 -> 5777 conditional = ???*0*
+0 -> 5777 conditional = (!(???*0*) | ???*1*)
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* ((null !== d) && ???*2*)
+  ⚠️  sequence with side effects
+  ⚠️  This value might have side effects
+- *2* (null !== d)
+  ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
 5777 -> 5781 conditional = (0 !== ???*0*)
@@ -37296,11 +43930,17 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  function calls are not analysed yet
 
 0 -> 5788 typeof = typeof(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["componentWillUnmount"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 5790 conditional = ???*0*
+0 -> 5790 conditional = (!(???*0*) | ???*1*)
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* ("function" === typeof(d["componentWillUnmount"]))
+  ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
 5790 -> 5796 member call = ???*0*["componentWillUnmount"]()
@@ -37450,7 +44090,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* arguments[1]
   ⚠️  function calls are not analysed yet
 
-5822 -> 5832 conditional = ???*0*
+5822 -> 5832 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -37572,7 +44212,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 0 -> 5862 call = (...) => undefined(???*0*, ???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["return"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 5863 call = (...) => undefined(???*0*, ???*1*)
@@ -37588,7 +44231,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 0 -> 5866 call = (...) => undefined(???*0*, ???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["return"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 5869 call = (...) => (undefined | FreeVar(undefined))((???*0* | ???*2*), "")
@@ -37619,7 +44265,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-5873 -> 5875 conditional = ???*0*
+5873 -> 5875 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -37724,7 +44370,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *14* unsupported expression
   ⚠️  This value might have side effects
 
-5880 -> 5889 conditional = ???*0*
+5880 -> 5889 conditional = ("style" === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -37749,7 +44395,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *8* arguments[0]
   ⚠️  function calls are not analysed yet
 
-5889 -> 5891 conditional = ???*0*
+5889 -> 5891 conditional = ("dangerouslySetInnerHTML" === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -37778,7 +44424,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *10* arguments[0]
   ⚠️  function calls are not analysed yet
 
-5891 -> 5893 conditional = ???*0*
+5891 -> 5893 conditional = ("children" === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -37902,7 +44548,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *14* unsupported expression
   ⚠️  This value might have side effects
 
-5880 -> 5904 conditional = ???*0*
+5880 -> 5904 conditional = (null != ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -38162,12 +44808,25 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-0 -> 5936 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 5936 conditional = (???*0* | (null !== ???*1*) | ???*2*)
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* ???*3*["isDehydrated"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* ???*4*["memoizedState"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *4* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5936 -> 5938 call = (...) => undefined(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["containerInfo"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5936 -> 5940 call = (...) => undefined(???*0*, ???*1*, ???*3*)
@@ -38222,28 +44881,46 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-0 -> 5964 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 5964 conditional = (???*0* | !(???*1*) | (0 !== ???*2*))
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* unsupported expression
   ⚠️  This value might have side effects
 
 5964 -> 5969 call = (...) => undefined(4, ???*0*, ???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["return"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5964 -> 5971 call = (...) => undefined(???*0*, ???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["return"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5964 -> 5973 typeof = typeof(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["componentWillUnmount"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5964 -> 5975 conditional = ???*0*
-- *0* max number of linking steps reached
+5964 -> 5975 conditional = ("function" === ???*0*)
+- *0* typeof(???*1*)
+  ⚠️  nested operation
+- *1* ???*2*["componentWillUnmount"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5975 -> 5982 member call = ???*0*["componentWillUnmount"]()
@@ -38261,11 +44938,17 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 5964 -> 5985 call = (...) => undefined(???*0*, ???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["return"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-5964 -> 5987 conditional = ???*0*
-- *0* max number of linking steps reached
+5964 -> 5987 conditional = (null !== ???*0*)
+- *0* ???*1*["memoizedState"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5987 -> 5988 call = (...) => undefined((???*0* | ???*3* | ???*4*))
@@ -38280,7 +44963,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *4* arguments[0]
   ⚠️  function calls are not analysed yet
 
-5964 -> 5989 conditional = ???*0*
+5964 -> 5989 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -38311,7 +44994,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *5* unsupported expression
   ⚠️  This value might have side effects
 
-5994 -> 5995 conditional = ???*0*
+5994 -> 5995 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -38489,7 +45172,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *5* unsupported expression
   ⚠️  This value might have side effects
 
-6018 -> 6019 conditional = ???*0*
+6018 -> 6019 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -38699,27 +45382,42 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *2* arguments[2]
   ⚠️  function calls are not analysed yet
 
-0 -> 6076 conditional = ???*0*
+0 -> 6076 conditional = ((22 === ???*0*) | (0 !== ???*2*))
+- *0* ???*1*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* unsupported expression
+  ⚠️  This value might have side effects
+
+6076 -> 6078 conditional = !(???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6076 -> 6078 conditional = ???*0*
-- *0* max number of linking steps reached
+6078 -> 6081 conditional = (???*0* | !(???*1*))
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6078 -> 6081 conditional = ???*0*
-- *0* max number of linking steps reached
+6081 -> 6085 conditional = ((22 === ???*0*) | (null !== ???*2*))
+- *0* ???*1*["tag"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
-
-6081 -> 6085 conditional = ???*0*
-- *0* max number of linking steps reached
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* ???*3*["memoizedState"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6085 -> 6086 call = (...) => undefined(???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6085 -> 6087 conditional = ???*0*
+6085 -> 6087 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -38743,8 +45441,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *2* arguments[2]
   ⚠️  function calls are not analysed yet
 
-6076 -> 6094 conditional = ???*0*
-- *0* max number of linking steps reached
+6076 -> 6094 conditional = ((0 !== ???*0*) | (null !== ???*1*))
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6094 -> 6096 call = (...) => undefined(???*0*, ???*1*, ???*2*)
@@ -38767,11 +45467,13 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6101 -> 6106 conditional = ???*0*
-- *0* max number of linking steps reached
+6101 -> 6106 conditional = (???*0* | !(???*1*))
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6106 -> 6107 conditional = ???*0*
+6106 -> 6107 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -38779,24 +45481,44 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6107 -> 6112 conditional = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-6112 -> 6116 call = (...) => b(???*0*, ???*1*)
-- *0* max number of linking steps reached
+6107 -> 6112 conditional = (???*0* === ???*2*)
+- *0* ???*1*["elementType"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
-
-6107 -> 6120 member call = ???*0*["componentDidUpdate"](???*1*, ???*2*, ???*3*)
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *1* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *2* max number of linking steps reached
+- *2* ???*3*["type"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+
+6112 -> 6116 call = (...) => b(???*0*, ???*2*)
+- *0* ???*1*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* ???*3*["memoizedProps"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+
+6107 -> 6120 member call = ???*0*["componentDidUpdate"](???*1*, ???*2*, ???*4*)
+- *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* ???*3*["memoizedState"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *4* ???*5*["__reactInternalSnapshotBeforeUpdate"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6101 -> 6122 call = (...) => undefined(???*0*, ???*1*, ???*2*)
@@ -38807,12 +45529,15 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6101 -> 6124 conditional = ???*0*
+6101 -> 6124 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6124 -> 6126 conditional = ???*0*
-- *0* max number of linking steps reached
+6124 -> 6126 conditional = (null !== ???*0*)
+- *0* ???*1*["child"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6124 -> 6133 call = (...) => undefined(???*0*, ???*1*, ???*2*)
@@ -38823,23 +45548,28 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6101 -> 6136 conditional = ???*0*
+6101 -> 6136 conditional = ((null === ???*0*) | ???*1*)
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* unsupported expression
   ⚠️  This value might have side effects
 
 6136 -> 6141 member call = ???*0*["focus"]()
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6101 -> 6146 conditional = ???*0*
+6101 -> 6146 conditional = (null === ???*0*)
+- *0* ???*1*["memoizedState"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+
+6146 -> 6148 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6146 -> 6148 conditional = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-6148 -> 6150 conditional = ???*0*
+6148 -> 6150 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -38864,19 +45594,22 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6098 -> 6159 call = (...) => undefined(???*0*, ???*1*, ???*2*)
+6098 -> 6159 call = (...) => undefined(???*0*, ???*1*, ???*3*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["return"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
-- *2* r
+- *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *3* r
   ⚠️  pattern without value
 
-0 -> 6161 conditional = ???*0*
+0 -> 6161 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 6166 conditional = ???*0*
+0 -> 6166 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -38893,11 +45626,19 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  pattern without value
 
 0 -> 6175 typeof = typeof(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["componentDidMount"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 6177 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 6177 conditional = ("function" === ???*0*)
+- *0* typeof(???*1*)
+  ⚠️  nested operation
+- *1* ???*2*["componentDidMount"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6177 -> 6180 member call = ???*0*["componentDidMount"]()
@@ -38936,15 +45677,18 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *2* k
   ⚠️  pattern without value
 
-0 -> 6189 call = (...) => undefined(???*0*, ???*1*, ???*2*)
+0 -> 6189 call = (...) => undefined(???*0*, ???*1*, ???*3*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["return"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
-- *2* k
+- *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *3* k
   ⚠️  pattern without value
 
-0 -> 6191 conditional = ???*0*
+0 -> 6191 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -39609,8 +46353,12 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 
 0 -> 6266 call = (...) => (d | !(1))()
 
-0 -> 6268 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 6268 conditional = (false | true | (???*0* !== ???*2*))
+- *0* ???*1*["callbackNode"]
+  ⚠️  unknown object
+- *1* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6268 -> 6269 unreachable = ???*0*
@@ -39699,7 +46447,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *20* unsupported expression
   ⚠️  This value might have side effects
 
-6268 -> 6272 conditional = ???*0*
+6268 -> 6272 conditional = (0 === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -39707,8 +46455,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-6272 -> 6275 conditional = ???*0*
-- *0* max number of linking steps reached
+6272 -> 6275 conditional = ((0 !== ???*0*) | ???*1*)
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6275 -> 6276 call = (...) => T(???*0*, ???*1*)
@@ -39719,8 +46469,46 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 
 6275 -> 6277 call = (...) => ((null === a) ? ai : a)()
 
-6275 -> 6278 conditional = ???*0*
-- *0* max number of linking steps reached
+6275 -> 6278 conditional = (((null | ???*0* | ???*1* | ???*4*) !== ???*17*) | ((0 | ???*18*) !== ???*19*))
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* ???*2*["alternate"]
+  ⚠️  unknown object
+- *2* ???*3*["current"]
+  ⚠️  unknown object
+- *3* a
+  ⚠️  circular variable reference
+- *4* new (...) => undefined(???*5*, (null | ???*8*), ???*11*, ???*14*)
+  ⚠️  nested operation
+- *5* ???*6*["tag"]
+  ⚠️  unknown object
+- *6* ???*7*["current"]
+  ⚠️  unknown object
+- *7* a
+  ⚠️  circular variable reference
+- *8* ???*9*["dependencies"]
+  ⚠️  unknown object
+- *9* ???*10*["current"]
+  ⚠️  unknown object
+- *10* a
+  ⚠️  circular variable reference
+- *11* ???*12*["key"]
+  ⚠️  unknown object
+- *12* ???*13*["current"]
+  ⚠️  unknown object
+- *13* a
+  ⚠️  circular variable reference
+- *14* ???*15*["mode"]
+  ⚠️  unknown object
+- *15* ???*16*["current"]
+  ⚠️  unknown object
+- *16* a
+  ⚠️  circular variable reference
+- *17* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *18* unsupported expression
+  ⚠️  This value might have side effects
+- *19* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6278 -> 6279 call = module<scheduler, {}>["unstable_now"]()
@@ -39741,11 +46529,11 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 
 6275 -> 6283 call = (...) => undefined()
 
-6275 -> 6285 conditional = ???*0*
+6275 -> 6285 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6272 -> 6286 conditional = ???*0*
+6272 -> 6286 conditional = (0 !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -39761,7 +46549,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6286 -> 6289 conditional = ???*0*
+6286 -> 6289 conditional = (1 === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -39781,7 +46569,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-6286 -> 6294 conditional = ???*0*
+6286 -> 6294 conditional = (6 === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -39855,8 +46643,11 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *9* unsupported expression
   ⚠️  This value might have side effects
 
-6294 -> 6302 conditional = ???*0*
-- *0* max number of linking steps reached
+6294 -> 6302 conditional = ((0 === ???*0*) | !((false | true)) | ???*1*)
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* (1 === b)
+  ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
 6302 -> 6303 call = (...) => a(???*0*, 0)
@@ -39902,16 +46693,25 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 
 6294 -> 6314 call = module<scheduler, {}>["unstable_now"]()
 
-6294 -> 6315 conditional = ???*0*
-- *0* max number of linking steps reached
+6294 -> 6315 conditional = ((???*0* === ???*1*) | ???*2*)
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* ???*3*
+  ⚠️  sequence with side effects
+  ⚠️  This value might have side effects
+- *3* unsupported expression
   ⚠️  This value might have side effects
 
 6315 -> 6316 call = (...) => (0 | b | d)(???*0*, 0)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-6315 -> 6318 conditional = ???*0*
-- *0* max number of linking steps reached
+6315 -> 6318 conditional = (???*0* !== ???*1*)
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6318 -> 6319 call = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : ???*2*))()
@@ -39928,7 +46728,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6315 -> 6325 call = (???*0* ? ???*3* : ???*4*)(???*5*, ???*6*)
+6315 -> 6325 call = (???*0* ? ???*3* : ???*4*)((...) => null["bind"](null, ???*5*, ???*6*, null), ???*7*)
 - *0* ("function" === ???*1*)
   ⚠️  nested operation
 - *1* typeof(???*2*)
@@ -39941,9 +46741,11 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 - *4* unsupported expression
   ⚠️  This value might have side effects
-- *5* max number of linking steps reached
-  ⚠️  This value might have side effects
+- *5* arguments[0]
+  ⚠️  function calls are not analysed yet
 - *6* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *7* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6294 -> 6326 call = (...) => null(???*0*, ???*1*, null)
@@ -39996,7 +46798,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6294 -> 6336 call = (???*0* ? ???*3* : ???*4*)(???*5*, ???*6*)
+6294 -> 6336 call = (???*0* ? ???*3* : ???*4*)((...) => null["bind"](null, ???*5*, ???*6*, null), ???*7*)
 - *0* ("function" === ???*1*)
   ⚠️  nested operation
 - *1* typeof(???*2*)
@@ -40009,9 +46811,11 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 - *4* unsupported expression
   ⚠️  This value might have side effects
-- *5* max number of linking steps reached
-  ⚠️  This value might have side effects
+- *5* arguments[0]
+  ⚠️  function calls are not analysed yet
 - *6* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *7* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6294 -> 6337 call = (...) => null(???*0*, ???*1*, null)
@@ -40045,8 +46849,12 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-6272 -> 6345 conditional = ???*0*
-- *0* max number of linking steps reached
+6272 -> 6345 conditional = (???*0* === ???*2*)
+- *0* ???*1*["callbackNode"]
+  ⚠️  unknown object
+- *1* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6345 -> 6347 member call = (...) => (
@@ -40080,16 +46888,19 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 6357 conditional = ???*0*
+0 -> 6357 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6357 -> 6360 member call = ???*0*["apply"](???*1*, ???*2*)
-- *0* max number of linking steps reached
+6357 -> 6360 member call = ???*0*["apply"](???*2*, ???*3*)
+- *0* ???*1*["push"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
-- *2* arguments[0]
+- *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *3* arguments[0]
   ⚠️  function calls are not analysed yet
 
 0 -> 6364 conditional = ((null !== ???*0*) | ???*2*)
@@ -40324,8 +47135,12 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *11* unsupported expression
   ⚠️  This value might have side effects
 
-6400 -> 6406 conditional = ???*0*
-- *0* max number of linking steps reached
+6400 -> 6406 conditional = ((0 !== ???*0*) | (2 === ???*2*))
+- *0* ???*1*["tag"]
+  ⚠️  unknown object
+- *1* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6406 -> 6407 call = (...) => ((0 !== a) ? a : (???*0* ? 1073741824 : 0))(???*1*)
@@ -40352,7 +47167,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
-6400 -> 6409 conditional = ???*0*
+6400 -> 6409 conditional = (1 === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -40412,7 +47227,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-6400 -> 6414 conditional = ???*0*
+6400 -> 6414 conditional = (6 === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -40489,7 +47304,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *5* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 6445 conditional = ???*0*
+0 -> 6445 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -40518,7 +47333,13 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 6445 -> 6459 call = (...) => undefined({"current": 0})
 
 6445 -> 6462 call = (...) => undefined(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["_context"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* ???*2*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6445 -> 6463 call = (...) => undefined()
@@ -40563,7 +47384,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-6467 -> 6474 conditional = ???*0*
+6467 -> 6474 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -40580,15 +47401,35 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 
 0 -> 6492 typeof = typeof(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["then"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 6494 conditional = ???*0*
+0 -> 6494 conditional = ((null !== ???*0*) | ("object" === ???*1*) | ("function" === ???*3*))
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
+- *1* typeof(???*2*)
+  ⚠️  nested operation
+- *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *3* typeof(???*4*)
+  ⚠️  nested operation
+- *4* ???*5*["then"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* max number of linking steps reached
+  ⚠️  This value might have side effects
 
-6494 -> 6497 conditional = ???*0*
-- *0* max number of linking steps reached
+6494 -> 6497 conditional = ((0 === ???*0*) | (0 === ???*1*) | (11 === ???*2*) | (15 === ???*3*))
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6497 -> 6499 conditional = ???*0*
@@ -40599,7 +47440,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6494 -> 6509 conditional = ???*0*
+6494 -> 6509 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -40626,7 +47467,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6509 -> 6515 conditional = ???*0*
+6509 -> 6515 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -40685,7 +47526,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6530 -> 6532 conditional = ???*0*
+6530 -> 6532 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -40710,9 +47551,69 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6532 -> 6537 call = (...) => undefined(???*0*)
+6532 -> 6537 call = (...) => undefined(
+    {
+        "value": ???*0*,
+        "source": ???*1*,
+        "stack": (
+          | ""
+          | (???*2* + (undefined | ???*3* | ???*18* | ""))
+          | `
+Error generating stack: ${???*19*}
+${???*21*}`
+        ),
+        "digest": null
+    }
+)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* c
+  ⚠️  circular variable reference
+- *3* `
+${(???*4* | ???*5* | ???*9* | "")}${(???*13* | ???*15* | ""["type"])}`
+  ⚠️  nested operation
+- *4* La
+  ⚠️  pattern without value
+- *5* ???*6*(/\n( *(at )?)/)
+  ⚠️  unknown callee
+- *6* ???*7*["match"]
+  ⚠️  unknown object
+- *7* ???*8*()
+  ⚠️  nested operation
+- *8* ...[...]
+  ⚠️  unknown object
+- *9* ???*10*[1]
+  ⚠️  unknown object
+- *10* ???*11*(/\n( *(at )?)/)
+  ⚠️  unknown callee
+- *11* ???*12*["match"]
+  ⚠️  unknown object
+- *12* ...()
+  ⚠️  nested operation
+- *13* ???*14*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *14* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *15* ???*16*["type"]
+  ⚠️  unknown object
+- *16* ???*17*["return"]
+  ⚠️  unknown object
+- *17* d
+  ⚠️  circular variable reference
+- *18* a
+  ⚠️  sequence with side effects
+  ⚠️  This value might have side effects
+- *19* ???*20*["message"]
+  ⚠️  unknown object
+- *20* f
+  ⚠️  pattern without value
+- *21* ???*22*["stack"]
+  ⚠️  unknown object
+- *22* f
+  ⚠️  pattern without value
 
 0 -> 6538 call = (...) => {"value": a, "source": b, "stack": e, "digest": null}(???*0*, ???*1*)
 - *0* max number of linking steps reached
@@ -40720,7 +47621,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 6539 conditional = ???*0*
+0 -> 6539 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -40745,11 +47646,17 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 
 0 -> 6550 typeof = typeof(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["getDerivedStateFromError"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 6552 typeof = typeof(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["componentDidCatch"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 6555 member call = (new ???*0*([???*1*]) | null)["has"](???*2*)
@@ -40761,8 +47668,48 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 6556 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 6556 conditional = (
+  | (0 === ???*0*)
+  | ("function" === ???*1*)
+  | (null !== ???*4*)
+  | (null === (???*5* | null))
+  | !((???*8* | ???*14*))
+)
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* typeof(???*2*)
+  ⚠️  nested operation
+- *2* ???*3*["getDerivedStateFromError"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *4* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *5* new ???*6*([???*7*])
+  ⚠️  nested operation
+- *6* FreeVar(Set)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *7* unsupported expression
+  ⚠️  This value might have side effects
+- *8* ???*9*(???*13*)
+  ⚠️  unknown callee
+  ⚠️  This value might have side effects
+- *9* ???*10*["has"]
+  ⚠️  unknown object
+- *10* new ???*11*([???*12*])
+  ⚠️  nested operation
+- *11* FreeVar(Set)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *12* unsupported expression
+  ⚠️  This value might have side effects
+- *13* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *14* null["has"](???*15*)
+  ⚠️  nested operation
+- *15* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6556 -> 6559 call = (...) => c(???*0*, ???*1*, ???*2*)
@@ -40893,7 +47840,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 
 0 -> 6574 call = (...) => undefined()
 
-0 -> 6576 conditional = ???*0*
+0 -> 6576 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -41034,7 +47981,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *8* b
   ⚠️  circular variable reference
 
-6594 -> 6598 conditional = ???*0*
+6594 -> 6598 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -41443,7 +48390,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-6686 -> 6688 conditional = ???*0*
+6686 -> 6688 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -41453,7 +48400,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6688 -> 6694 conditional = ???*0*
+6688 -> 6694 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -41461,20 +48408,22 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6694 -> 6699 conditional = ???*0*
+6694 -> 6699 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6688 -> 6702 conditional = ???*0*
+6688 -> 6702 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6702 -> 6704 conditional = ???*0*
+6702 -> 6704 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6678 -> 6709 conditional = ???*0*
-- *0* max number of linking steps reached
+6678 -> 6709 conditional = ((0 !== ???*0*) | (null !== ???*1*))
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6709 -> 6712 conditional = (0 !== ???*0*)
@@ -41484,15 +48433,20 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 6712 -> 6715 call = (...) => undefined(9, ???*0*, ???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
+- *1* ???*2*["return"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+
+6709 -> 6717 conditional = (null !== ???*0*)
+- *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+
+6678 -> 6724 conditional = ((0 !== ???*0*) | (null !== ???*1*))
+- *0* unsupported expression
+  ⚠️  This value might have side effects
 - *1* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-6709 -> 6717 conditional = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-6678 -> 6724 conditional = ???*0*
-- *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6724 -> 6727 conditional = (0 !== ???*0*)
@@ -41503,15 +48457,18 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6727 -> 6731 call = (...) => undefined(???*0*, ???*1*, ???*2*)
+6727 -> 6731 call = (...) => undefined(???*0*, ???*1*, ???*3*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["return"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
-- *2* na
+- *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *3* na
   ⚠️  pattern without value
 
-6724 -> 6733 conditional = ???*0*
+6724 -> 6733 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -41613,8 +48570,11 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 6753 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 6753 conditional = (3 === ???*0*)
+- *0* ???*1*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6753 -> 6754 call = (...) => undefined(???*0*, ???*1*, ???*2*)
@@ -41625,8 +48585,11 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *2* arguments[2]
   ⚠️  function calls are not analysed yet
 
-6753 -> 6756 conditional = ???*0*
-- *0* max number of linking steps reached
+6753 -> 6756 conditional = (3 === ???*0*)
+- *0* ???*1*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6756 -> 6757 call = (...) => undefined(???*0*, ???*1*, ???*2*)
@@ -41637,16 +48600,28 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *2* arguments[2]
   ⚠️  function calls are not analysed yet
 
-6756 -> 6759 conditional = ???*0*
-- *0* max number of linking steps reached
+6756 -> 6759 conditional = (1 === ???*0*)
+- *0* ???*1*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6759 -> 6761 typeof = typeof(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["getDerivedStateFromError"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* ???*2*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6759 -> 6764 typeof = typeof(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["componentDidCatch"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6759 -> 6767 member call = (new ???*0*([???*1*]) | null)["has"](???*2*)
@@ -41658,8 +48633,41 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6759 -> 6768 conditional = ???*0*
-- *0* max number of linking steps reached
+6759 -> 6768 conditional = (("function" === ???*0*) | (null === (???*4* | null)) | !((???*7* | ???*13*)))
+- *0* typeof(???*1*)
+  ⚠️  nested operation
+- *1* ???*2*["getDerivedStateFromError"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* ???*3*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *4* new ???*5*([???*6*])
+  ⚠️  nested operation
+- *5* FreeVar(Set)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *6* unsupported expression
+  ⚠️  This value might have side effects
+- *7* ???*8*(???*12*)
+  ⚠️  unknown callee
+  ⚠️  This value might have side effects
+- *8* ???*9*["has"]
+  ⚠️  unknown object
+- *9* new ???*10*([???*11*])
+  ⚠️  nested operation
+- *10* FreeVar(Set)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *11* unsupported expression
+  ⚠️  This value might have side effects
+- *12* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *13* null["has"](???*14*)
+  ⚠️  nested operation
+- *14* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6768 -> 6769 call = (...) => {"value": a, "source": b, "stack": e, "digest": null}(???*0*, ???*1*)
@@ -41948,12 +48956,22 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *3* arguments[0]
   ⚠️  function calls are not analysed yet
 
-0 -> 6806 conditional = ???*0*
+0 -> 6806 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6806 -> 6810 conditional = ???*0*
-- *0* max number of linking steps reached
+6806 -> 6810 conditional = ((???*0* !== ???*2*) | false | ???*4*)
+- *0* ???*1*["memoizedProps"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* ???*3*["pendingProps"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *4* unknown mutation
   ⚠️  This value might have side effects
 
 6810 -> 6813 conditional = (0 === ???*0*)
@@ -41988,7 +49006,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  unknown array prototype methods or values
 - *3* unsupported expression
   ⚠️  This value might have side effects
-- *4* max number of linking steps reached
+- *4* ???*5*["index"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 6824 call = (...) => undefined(???*0*, ???*1*)
@@ -42028,11 +49049,32 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 
 0 -> 6833 typeof = typeof(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["render"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 6836 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 6836 conditional = (("object" === ???*0*) | (null !== ???*2*) | ("function" === ???*3*) | (???*6* === ???*7*))
+- *0* typeof(???*1*)
+  ⚠️  nested operation
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *3* typeof(???*4*)
+  ⚠️  nested operation
+- *4* ???*5*["render"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *6* unsupported expression
+  ⚠️  This value might have side effects
+- *7* ???*8*["$$typeof"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *8* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6836 -> 6840 call = (...) => ((null !== a) && (???*0* !== a))(???*1*)
@@ -42041,16 +49083,38 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6836 -> 6841 conditional = ???*0*
+6836 -> 6841 conditional = ((null !== (???*0* | ???*1*)) | (???*3* !== (???*4* | ???*5*)))
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
+- *1* ???*2*["childContextTypes"]
+  ⚠️  unknown object
+- *2* a
+  ⚠️  circular variable reference
+- *3* unsupported expression
+  ⚠️  This value might have side effects
+- *4* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *5* ???*6*["childContextTypes"]
+  ⚠️  unknown object
+- *6* a
+  ⚠️  circular variable reference
 
 6841 -> 6842 call = (...) => !(0)(???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6836 -> 6846 conditional = ???*0*
-- *0* max number of linking steps reached
+6836 -> 6846 conditional = ((null !== ???*0*) | (???*2* !== ???*3*))
+- *0* ???*1*["state"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* unsupported expression
+  ⚠️  This value might have side effects
+- *3* ???*4*["state"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *4* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6836 -> 6848 call = (...) => undefined(???*0*)
@@ -42105,7 +49169,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 0 -> 6864 call = ???*0*(???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["_payload"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 6867 call = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)(???*0*)
@@ -42154,13 +49221,16 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *4* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 6873 call = (...) => b(???*0*, ???*1*)
-- *0* max number of linking steps reached
+0 -> 6873 call = (...) => b(???*0*, ???*2*)
+- *0* ???*1*["type"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
+- *2* max number of linking steps reached
+  ⚠️  This value might have side effects
 
-0 -> 6874 call = (...) => (???*0* | ???*1* | $i(a, b, e))(null, ???*2*, ???*3*, ???*4*, ???*5*)
+0 -> 6874 call = (...) => (???*0* | ???*1* | $i(a, b, e))(null, ???*2*, ???*3*, (???*4* | ???*5*), ???*8*)
 - *0* cj(a, b, f, d, e)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
@@ -42172,7 +49242,13 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 - *4* max number of linking steps reached
   ⚠️  This value might have side effects
-- *5* max number of linking steps reached
+- *5* Object.assign*6*({}, ???*7*)
+  ⚠️  only const object assign is supported
+  ⚠️  This value might have side effects
+- *6* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+- *7* b
+  ⚠️  circular variable reference
+- *8* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 6875 free var = FreeVar(Error)
@@ -42181,19 +49257,26 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 6877 call = ???*0*(???*1*)
+0 -> 6877 call = ???*0*(
+    `Minified React error #${306}; visit ${???*1*} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`
+)
 - *0* FreeVar(Error)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
-  ⚠️  This value might have side effects
+- *1* `https://reactjs.org/docs/error-decoder.html?invariant=${306}`
+  ⚠️  nested operation
 
 0 -> 6878 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 6882 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 6882 conditional = (???*0* === ???*2*)
+- *0* ???*1*["elementType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6882 -> 6883 call = (...) => b(???*0*, ???*1*)
@@ -42221,8 +49304,13 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 6889 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 6889 conditional = (???*0* === ???*2*)
+- *0* ???*1*["elementType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6889 -> 6890 call = (...) => b(???*0*, ???*1*)
@@ -42251,7 +49339,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 6894 conditional = ???*0*
+0 -> 6894 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -42283,7 +49371,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 
 0 -> 6906 conditional = ???*0*
-- *0* max number of linking steps reached
+- *0* ???*1*["isDehydrated"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6906 -> 6914 free var = FreeVar(Error)
@@ -42321,8 +49412,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *4* max number of linking steps reached
   ⚠️  This value might have side effects
 
-6906 -> 6919 conditional = ???*0*
+6906 -> 6919 conditional = (???*0* !== ???*1*)
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6919 -> 6920 free var = FreeVar(Error)
@@ -42361,7 +49454,16 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 
 6919 -> 6928 call = (...) => (null | a)(???*0*)
-- *0* max number of linking steps reached
+- *0* ???*1*["firstChild"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* ???*2*["containerInfo"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* ???*3*["stateNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6919 -> 6929 call = (...) => (
@@ -42386,8 +49488,10 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 
 6906 -> 6934 call = (...) => undefined()
 
-6906 -> 6935 conditional = ???*0*
+6906 -> 6935 conditional = (???*0* === ???*1*)
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6935 -> 6936 call = (...) => (null | b["child"])(???*0*, ???*1*, ???*2*)
@@ -42420,7 +49524,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 6944 conditional = ???*0*
+0 -> 6944 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -42440,8 +49544,52 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 6948 conditional = ???*0*
+0 -> 6948 conditional = (
+  | ("textarea" === ???*0*)
+  | ("noscript" === ???*1*)
+  | ("string" === ???*2*)
+  | ("number" === ???*5*)
+  | ("object" === ???*8*)
+  | (null !== ???*11*)
+  | (null != ???*13*)
+)
 - *0* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* typeof(???*3*)
+  ⚠️  nested operation
+- *3* ???*4*["children"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *4* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *5* typeof(???*6*)
+  ⚠️  nested operation
+- *6* ???*7*["children"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *7* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *8* typeof(???*9*)
+  ⚠️  nested operation
+- *9* ???*10*["dangerouslySetInnerHTML"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *10* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *11* ???*12*["dangerouslySetInnerHTML"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *12* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *13* ???*14*["__html"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *14* ???*15*["dangerouslySetInnerHTML"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *15* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6948 -> 6949 call = (...) => (
@@ -42509,10 +49657,16 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 0 -> 6961 call = (...) => undefined(???*0*, ???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["containerInfo"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* ???*3*["stateNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 6963 conditional = ???*0*
+0 -> 6963 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -42550,8 +49704,13 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 6972 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 6972 conditional = (???*0* === ???*2*)
+- *0* ???*1*["elementType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6972 -> 6973 call = (...) => b(???*0*, ???*1*)
@@ -42579,42 +49738,57 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 6977 call = (...) => undefined(???*0*, ???*1*, ???*2*, ???*3*)
+0 -> 6977 call = (...) => undefined(???*0*, ???*1*, ???*2*, ???*4*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
-- *2* max number of linking steps reached
+- *2* ???*3*["pendingProps"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *4* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 6979 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 6982 call = (...) => undefined(???*0*, ???*1*, ???*2*, ???*3*)
+0 -> 6982 call = (...) => undefined(???*0*, ???*1*, ???*2*, ???*5*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
-- *2* max number of linking steps reached
+- *2* ???*3*["children"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
-- *3* max number of linking steps reached
+- *3* ???*4*["pendingProps"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *4* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *5* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 6984 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 6987 call = (...) => undefined(???*0*, ???*1*, ???*2*, ???*3*)
+0 -> 6987 call = (...) => undefined(???*0*, ???*1*, ???*2*, ???*5*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
-- *2* max number of linking steps reached
+- *2* ???*3*["children"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
-- *3* max number of linking steps reached
+- *3* ???*4*["pendingProps"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *4* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *5* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 6989 unreachable = ???*0*
@@ -42622,14 +49796,17 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 
 0 -> 6996 call = (...) => undefined({"current": null}, ???*0*)
+- *0* ???*1*["_currentValue"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+
+0 -> 6998 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 6998 conditional = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-6998 -> 7000 call = (???*0* ? ???*4* : (...) => ???*6*)(???*9*, ???*10*)
+6998 -> 7000 call = (???*0* ? ???*4* : (...) => ???*6*)(???*9*, ???*11*)
 - *0* ("function" === ???*1*)
   ⚠️  nested operation
 - *1* typeof(???*2*)
@@ -42648,17 +49825,58 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 - *8* unsupported expression
   ⚠️  This value might have side effects
-- *9* max number of linking steps reached
+- *9* ???*10*["value"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *10* max number of linking steps reached
   ⚠️  This value might have side effects
-
-6998 -> 7001 conditional = ???*0*
-- *0* max number of linking steps reached
+- *11* max number of linking steps reached
   ⚠️  This value might have side effects
 
-7001 -> 7005 conditional = ???*0*
-- *0* max number of linking steps reached
+6998 -> 7001 conditional = ???*0*
+- *0* ???*1*(???*11*, ???*13*)
+  ⚠️  unknown callee
+  ⚠️  This value might have side effects
+- *1* (???*2* ? ???*6* : (...) => ???*8*)
+  ⚠️  nested operation
+- *2* ("function" === ???*3*)
+  ⚠️  nested operation
+- *3* typeof(???*4*)
+  ⚠️  nested operation
+- *4* Object*5*["is"]
+  ⚠️  unsupported property on global Object
+  ⚠️  This value might have side effects
+- *5* Object: The global Object variable
+- *6* Object*7*["is"]
+  ⚠️  unsupported property on global Object
+  ⚠️  This value might have side effects
+- *7* Object: The global Object variable
+- *8* (((a === b) && ((0 !== a) || (???*9* === ???*10*))) || ((a !== a) && (b !== b)))
+  ⚠️  nested operation
+- *9* unsupported expression
+  ⚠️  This value might have side effects
+- *10* unsupported expression
+  ⚠️  This value might have side effects
+- *11* ???*12*["value"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *12* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *13* max number of linking steps reached
+  ⚠️  This value might have side effects
+
+7001 -> 7005 conditional = ((???*0* === ???*2*) | !((false | ???*4*)))
+- *0* ???*1*["children"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* ???*3*["children"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *4* unknown mutation
   ⚠️  This value might have side effects
 
 7005 -> 7006 call = (...) => (null | b["child"])(???*0*, ???*1*, ???*2*)
@@ -42669,16 +49887,24 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-7001 -> 7010 conditional = ???*0*
+7001 -> 7010 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-7010 -> 7014 conditional = ???*0*
-- *0* max number of linking steps reached
+7010 -> 7014 conditional = (???*0* === ???*2*)
+- *0* ???*1*["context"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-7014 -> 7016 conditional = ???*0*
-- *0* max number of linking steps reached
+7014 -> 7016 conditional = (1 === ???*0*)
+- *0* ???*1*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 7016 -> 7017 call = (...) => {"eventTime": a, "lane": b, "tag": 0, "payload": null, "callback": null, "next": null}(???*0*, ???*1*)
@@ -42687,35 +49913,52 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
-7016 -> 7020 conditional = ???*0*
+7016 -> 7020 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-7020 -> 7023 conditional = ???*0*
+7020 -> 7023 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-7014 -> 7033 call = (...) => undefined(???*0*, ???*1*, ???*2*)
-- *0* max number of linking steps reached
+7014 -> 7033 call = (...) => undefined(???*0*, ???*2*, ???*3*)
+- *0* ???*1*["return"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
-
-7010 -> 7037 conditional = ???*0*
-- *0* max number of linking steps reached
+- *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
-7037 -> 7040 conditional = ???*0*
-- *0* max number of linking steps reached
+7010 -> 7037 conditional = (10 === ???*0*)
+- *0* ???*1*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-7037 -> 7043 conditional = ???*0*
-- *0* max number of linking steps reached
+7037 -> 7040 conditional = (???*0* === ???*2*)
+- *0* ???*1*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* ???*3*["type"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
-7043 -> 7045 conditional = ???*0*
+7037 -> 7043 conditional = (18 === ???*0*)
+- *0* ???*1*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+
+7043 -> 7045 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -42740,22 +49983,25 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-7001 -> 7055 conditional = ???*0*
+7001 -> 7055 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-7055 -> 7058 conditional = ???*0*
+7055 -> 7058 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 7063 call = (...) => undefined(???*0*, ???*1*, ???*2*, ???*3*)
+0 -> 7063 call = (...) => undefined(???*0*, ???*1*, ???*2*, ???*4*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
-- *2* max number of linking steps reached
+- *2* ???*3*["children"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *3* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *4* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 7065 unreachable = ???*0*
@@ -42795,13 +50041,19 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 0 -> 7078 call = (...) => b(???*0*, ???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
-- *1* max number of linking steps reached
+- *1* ???*2*["pendingProps"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 7080 call = (...) => b(???*0*, ???*1*)
-- *0* max number of linking steps reached
+0 -> 7080 call = (...) => b(???*0*, ???*2*)
+- *0* ???*1*["type"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 7081 call = (...) => (???*0* | ???*1* | $i(a, b, e))(???*2*, ???*3*, ???*4*, ???*5*, ???*6*)
@@ -42825,7 +50077,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 7085 call = (...) => (???*0* | dj(a, b, c, d, e))(???*1*, ???*2*, ???*3*, ???*4*, ???*5*)
+0 -> 7085 call = (...) => (???*0* | dj(a, b, c, d, e))(???*1*, ???*2*, ???*3*, ???*5*, ???*7*)
 - *0* $i(a, b, e)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
@@ -42833,19 +50085,30 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
-- *3* max number of linking steps reached
+- *3* ???*4*["type"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *4* max number of linking steps reached
   ⚠️  This value might have side effects
-- *5* max number of linking steps reached
+- *5* ???*6*["pendingProps"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *6* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *7* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 7086 unreachable = ???*0*
 - *0* unreachable
   ⚠️  This value might have side effects
 
-0 -> 7090 conditional = ???*0*
-- *0* max number of linking steps reached
+0 -> 7090 conditional = (???*0* === ???*2*)
+- *0* ???*1*["elementType"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 7090 -> 7091 call = (...) => b(???*0*, ???*1*)
@@ -42866,9 +50129,21 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-0 -> 7095 conditional = ???*0*
+0 -> 7095 conditional = ((null !== (???*0* | ???*1*)) | (???*3* !== (???*4* | ???*5*)))
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
+- *1* ???*2*["childContextTypes"]
+  ⚠️  unknown object
+- *2* a
+  ⚠️  circular variable reference
+- *3* unsupported expression
+  ⚠️  This value might have side effects
+- *4* max number of linking steps reached
+  ⚠️  This value might have side effects
+- *5* ???*6*["childContextTypes"]
+  ⚠️  unknown object
+- *6* a
+  ⚠️  circular variable reference
 
 7095 -> 7096 call = (...) => !(0)(???*0*)
 - *0* max number of linking steps reached
@@ -42945,15 +50220,20 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 0 -> 7106 free var = FreeVar(Error)
 
 0 -> 7108 call = (...) => `Minified React error #${a}; visit ${b} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`(156, ???*0*)
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-
-0 -> 7109 call = ???*0*(???*1*)
-- *0* FreeVar(Error)
-  ⚠️  unknown global
+- *0* ???*1*["tag"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
+
+0 -> 7109 call = ???*0*(
+    `Minified React error #${156}; visit ${???*1*} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`
+)
+- *0* FreeVar(Error)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *1* `https://reactjs.org/docs/error-decoder.html?invariant=${156}`
+  ⚠️  nested operation
 
 0 -> 7110 call = module<scheduler, {}>["unstable_scheduleCallback"](???*0*, ???*1*)
 - *0* arguments[0]
@@ -44201,47 +51481,47 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  This value might have side effects
 
 0 -> 7326 call = (...) => a(
-    ???*0*,
-    (???*1* | (???*2* ? ???*4* : ???*5*)),
-    true,
     (
-      | ???*13*
-      | ???*14*
-      | new (...) => undefined(???*16*, (???*17* | ???*18* | 1 | ???*30* | 0), true, ???*31*, ???*32*)
+      | ???*0*
+      | ???*1*
+      | new (...) => undefined(???*3*, (???*4* | ???*5* | 1 | ???*17* | 0), true, ???*18*, ???*19*)["current"]
     ),
+    (???*20* | (???*21* ? ???*23* : ???*24*)),
+    true,
+    (???*32* | ???*33*),
     (
-      | ???*33*
-      | 1
       | ???*34*
+      | 1
       | ???*35*
       | ???*36*
-      | new (...) => undefined(???*38*, (???*39* | ???*40* | 1 | ???*52* | 0), true, ???*53*, ???*54*)["current"]
+      | ???*37*
+      | new (...) => undefined(???*39*, (???*40* | ???*41* | 1 | ???*53* | 0), true, ???*54*, ???*55*)["current"]
       | 0
-      | ???*55*
+      | ???*56*
       | 4
-      | ((???*56* | ???*58*) ? ???*59* : 4)
-      | (???*60* ? 16 : (???*61* | null | ???*68* | ???*69*))
-      | ???*71*
-      | (???*73* ? 16 : (undefined | 1 | 4 | 16 | 536870912))
+      | ((???*57* | ???*59*) ? ???*60* : 4)
+      | (???*61* ? 16 : (???*62* | null | ???*69* | ???*70*))
+      | ???*72*
+      | (???*74* ? 16 : (undefined | 1 | 4 | 16 | 536870912))
     ),
     (
-      | ???*76*
+      | ???*77*
       | {
-            "eventTime": (???*77* | (???*78* ? ???*80* : ???*81*)),
+            "eventTime": (???*78* | (???*79* ? ???*81* : ???*82*)),
             "lane": (
-              | ???*89*
-              | 1
               | ???*90*
+              | 1
               | ???*91*
               | ???*92*
-              | new (...) => undefined(???*94*, (???*95* | ???*96* | 1 | ???*106* | 0), true, ???*107*, ???*108*)["current"]
+              | ???*93*
+              | new (...) => undefined(???*95*, (???*96* | ???*97* | 1 | ???*107* | 0), true, ???*108*, ???*109*)["current"]
               | 0
-              | ???*109*
+              | ???*110*
               | 4
-              | ((???*110* | ???*112*) ? ???*113* : 4)
-              | (???*114* ? 16 : (???*115* | null | ???*122* | ???*123*))
-              | ???*125*
-              | (???*127* ? 16 : (undefined | 1 | 4 | 16 | 536870912))
+              | ((???*111* | ???*113*) ? ???*114* : 4)
+              | (???*115* ? 16 : (???*116* | null | ???*123* | ???*124*))
+              | ???*126*
+              | (???*128* ? 16 : (undefined | 1 | 4 | 16 | 536870912))
             ),
             "tag": 0,
             "payload": null,
@@ -44249,281 +51529,283 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
             "next": null
         }
     ),
-    ???*130*,
     ???*131*,
-    ???*132*
+    ???*132*,
+    ???*133*
 )
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *1* arguments[3]
+- *0* arguments[2]
   ⚠️  function calls are not analysed yet
-- *2* (0 !== ???*3*)
+- *1* ???*2*["current"]
+  ⚠️  unknown object
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *3* a
+  ⚠️  circular variable reference
+- *4* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *5* (???*6* ? ???*8* : ???*9*)
   ⚠️  nested operation
-- *3* unsupported expression
-  ⚠️  This value might have side effects
-- *4* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *5* (???*6* ? (???*10* | ???*11*) : ???*12*)
-  ⚠️  nested operation
-- *6* (???*7* !== (???*8* | ???*9*))
+- *6* (0 !== ???*7*)
   ⚠️  nested operation
 - *7* unsupported expression
   ⚠️  This value might have side effects
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* module<scheduler, {}>["unstable_now"]()
+- *8* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *10* unsupported expression
-  ⚠️  This value might have side effects
-- *11* module<scheduler, {}>["unstable_now"]()
+- *9* (???*10* ? (???*14* | ???*15*) : ???*16*)
   ⚠️  nested operation
+- *10* (???*11* !== (???*12* | ???*13*))
+  ⚠️  nested operation
+- *11* unsupported expression
+  ⚠️  This value might have side effects
 - *12* unsupported expression
   ⚠️  This value might have side effects
-- *13* arguments[0]
+- *13* ...[...]()
+  ⚠️  nested operation
+- *14* unsupported expression
+  ⚠️  This value might have side effects
+- *15* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *16* unsupported expression
+  ⚠️  This value might have side effects
+- *17* unsupported assign operation
+  ⚠️  This value might have side effects
+- *18* arguments[7]
   ⚠️  function calls are not analysed yet
-- *14* ???*15*["current"]
-  ⚠️  unknown object
-- *15* a
-  ⚠️  circular variable reference
-- *16* a
-  ⚠️  circular variable reference
-- *17* arguments[3]
+- *19* arguments[8]
   ⚠️  function calls are not analysed yet
-- *18* (???*19* ? ???*21* : ???*22*)
+- *20* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *21* (0 !== ???*22*)
   ⚠️  nested operation
-- *19* (0 !== ???*20*)
-  ⚠️  nested operation
-- *20* unsupported expression
+- *22* unsupported expression
   ⚠️  This value might have side effects
-- *21* module<scheduler, {}>["unstable_now"]()
+- *23* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *22* (???*23* ? (???*27* | ???*28*) : ???*29*)
+- *24* (???*25* ? (???*29* | ???*30*) : ???*31*)
   ⚠️  nested operation
-- *23* (???*24* !== (???*25* | ???*26*))
+- *25* (???*26* !== (???*27* | ???*28*))
   ⚠️  nested operation
-- *24* unsupported expression
+- *26* unsupported expression
   ⚠️  This value might have side effects
-- *25* unsupported expression
-  ⚠️  This value might have side effects
-- *26* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
 - *27* unsupported expression
   ⚠️  This value might have side effects
 - *28* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
 - *29* unsupported expression
   ⚠️  This value might have side effects
-- *30* unsupported assign operation
+- *30* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *31* unsupported expression
   ⚠️  This value might have side effects
-- *31* arguments[7]
+- *32* arguments[0]
   ⚠️  function calls are not analysed yet
-- *32* arguments[8]
-  ⚠️  function calls are not analysed yet
-- *33* arguments[4]
-  ⚠️  function calls are not analysed yet
-- *34* unsupported expression
+- *33* node limit reached
   ⚠️  This value might have side effects
-- *35* Ck
+- *34* arguments[4]
+  ⚠️  function calls are not analysed yet
+- *35* unsupported expression
+  ⚠️  This value might have side effects
+- *36* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
-- *36* ???*37*["current"]
+- *37* ???*38*["current"]
   ⚠️  unknown object
-- *37* arguments[0]
+- *38* arguments[0]
   ⚠️  function calls are not analysed yet
-- *38* a
+- *39* a
   ⚠️  circular variable reference
-- *39* arguments[3]
+- *40* arguments[3]
   ⚠️  function calls are not analysed yet
-- *40* (???*41* ? ???*43* : ???*44*)
+- *41* (???*42* ? ???*44* : ???*45*)
   ⚠️  nested operation
-- *41* (0 !== ???*42*)
+- *42* (0 !== ???*43*)
   ⚠️  nested operation
-- *42* unsupported expression
+- *43* unsupported expression
   ⚠️  This value might have side effects
-- *43* module<scheduler, {}>["unstable_now"]()
+- *44* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *44* (???*45* ? (???*49* | ???*50*) : ???*51*)
+- *45* (???*46* ? (???*50* | ???*51*) : ???*52*)
   ⚠️  nested operation
-- *45* (???*46* !== (???*47* | ???*48*))
+- *46* (???*47* !== (???*48* | ???*49*))
   ⚠️  nested operation
-- *46* unsupported expression
-  ⚠️  This value might have side effects
 - *47* unsupported expression
   ⚠️  This value might have side effects
-- *48* ...[...]()
+- *48* unsupported expression
+  ⚠️  This value might have side effects
+- *49* ...[...]()
   ⚠️  nested operation
-- *49* unsupported expression
+- *50* unsupported expression
   ⚠️  This value might have side effects
-- *50* module<scheduler, {}>["unstable_now"]()
+- *51* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *51* unsupported expression
+- *52* unsupported expression
   ⚠️  This value might have side effects
-- *52* unsupported assign operation
+- *53* unsupported assign operation
   ⚠️  This value might have side effects
-- *53* arguments[7]
+- *54* arguments[7]
   ⚠️  function calls are not analysed yet
-- *54* arguments[8]
+- *55* arguments[8]
   ⚠️  function calls are not analysed yet
-- *55* C
+- *56* C
   ⚠️  circular variable reference
-- *56* (0 !== ???*57*)
+- *57* (0 !== ???*58*)
   ⚠️  nested operation
-- *57* C
+- *58* C
   ⚠️  circular variable reference
-- *58* unsupported expression
+- *59* unsupported expression
   ⚠️  This value might have side effects
-- *59* C
+- *60* C
   ⚠️  circular variable reference
-- *60* unsupported expression
+- *61* unsupported expression
   ⚠️  This value might have side effects
-- *61* (???*62* ? ???*63* : 1)
+- *62* (???*63* ? ???*64* : 1)
   ⚠️  nested operation
-- *62* unsupported expression
+- *63* unsupported expression
   ⚠️  This value might have side effects
-- *63* (???*64* ? ???*65* : 4)
+- *64* (???*65* ? ???*66* : 4)
   ⚠️  nested operation
-- *64* unsupported expression
+- *65* unsupported expression
   ⚠️  This value might have side effects
-- *65* (???*66* ? 16 : 536870912)
+- *66* (???*67* ? 16 : 536870912)
   ⚠️  nested operation
-- *66* (0 !== ???*67*)
+- *67* (0 !== ???*68*)
   ⚠️  nested operation
-- *67* unsupported expression
+- *68* unsupported expression
   ⚠️  This value might have side effects
-- *68* arguments[0]
+- *69* arguments[0]
   ⚠️  function calls are not analysed yet
-- *69* ???*70*["value"]
+- *70* ???*71*["value"]
   ⚠️  unknown object
-- *70* arguments[1]
+- *71* arguments[1]
   ⚠️  function calls are not analysed yet
-- *71* ???*72*["event"]
+- *72* ???*73*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *72* FreeVar(window)
+- *73* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *73* (???*74* === ???*75*)
+- *74* (???*75* === ???*76*)
   ⚠️  nested operation
-- *74* unsupported expression
+- *75* unsupported expression
   ⚠️  This value might have side effects
-- *75* a
+- *76* a
   ⚠️  circular variable reference
-- *76* arguments[5]
+- *77* arguments[5]
   ⚠️  function calls are not analysed yet
-- *77* arguments[3]
+- *78* arguments[3]
   ⚠️  function calls are not analysed yet
-- *78* (0 !== ???*79*)
+- *79* (0 !== ???*80*)
   ⚠️  nested operation
-- *79* unsupported expression
+- *80* unsupported expression
   ⚠️  This value might have side effects
-- *80* module<scheduler, {}>["unstable_now"]()
+- *81* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *81* (???*82* ? (???*86* | ???*87*) : ???*88*)
+- *82* (???*83* ? (???*87* | ???*88*) : ???*89*)
   ⚠️  nested operation
-- *82* (???*83* !== (???*84* | ???*85*))
+- *83* (???*84* !== (???*85* | ???*86*))
   ⚠️  nested operation
-- *83* unsupported expression
-  ⚠️  This value might have side effects
 - *84* unsupported expression
   ⚠️  This value might have side effects
-- *85* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *86* unsupported expression
+- *85* unsupported expression
   ⚠️  This value might have side effects
-- *87* module<scheduler, {}>["unstable_now"]()
+- *86* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *88* unsupported expression
+- *87* unsupported expression
   ⚠️  This value might have side effects
-- *89* arguments[4]
+- *88* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *89* unsupported expression
+  ⚠️  This value might have side effects
+- *90* arguments[4]
   ⚠️  function calls are not analysed yet
-- *90* unsupported expression
+- *91* unsupported expression
   ⚠️  This value might have side effects
-- *91* Ck
+- *92* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
-- *92* ???*93*["current"]
+- *93* ???*94*["current"]
   ⚠️  unknown object
-- *93* arguments[0]
+- *94* arguments[0]
   ⚠️  function calls are not analysed yet
-- *94* a
+- *95* a
   ⚠️  circular variable reference
-- *95* arguments[3]
+- *96* arguments[3]
   ⚠️  function calls are not analysed yet
-- *96* (???*97* ? ???*99* : ???*100*)
+- *97* (???*98* ? ???*100* : ???*101*)
   ⚠️  nested operation
-- *97* (0 !== ???*98*)
+- *98* (0 !== ???*99*)
   ⚠️  nested operation
-- *98* unsupported expression
+- *99* unsupported expression
   ⚠️  This value might have side effects
-- *99* module<scheduler, {}>["unstable_now"]()
+- *100* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
-- *100* (???*101* ? (???*103* | ???*104*) : ???*105*)
+- *101* (???*102* ? (???*104* | ???*105*) : ???*106*)
   ⚠️  nested operation
-- *101* (???*102* !== (... | ...))
+- *102* (???*103* !== (... | ...))
   ⚠️  nested operation
-- *102* unsupported expression
-  ⚠️  This value might have side effects
 - *103* unsupported expression
   ⚠️  This value might have side effects
-- *104* ...()
+- *104* unsupported expression
+  ⚠️  This value might have side effects
+- *105* ...()
   ⚠️  nested operation
-- *105* unsupported expression
+- *106* unsupported expression
   ⚠️  This value might have side effects
-- *106* unsupported assign operation
+- *107* unsupported assign operation
   ⚠️  This value might have side effects
-- *107* arguments[7]
+- *108* arguments[7]
   ⚠️  function calls are not analysed yet
-- *108* arguments[8]
+- *109* arguments[8]
   ⚠️  function calls are not analysed yet
-- *109* C
+- *110* C
   ⚠️  circular variable reference
-- *110* (0 !== ???*111*)
+- *111* (0 !== ???*112*)
   ⚠️  nested operation
-- *111* C
+- *112* C
   ⚠️  circular variable reference
-- *112* unsupported expression
+- *113* unsupported expression
   ⚠️  This value might have side effects
-- *113* C
+- *114* C
   ⚠️  circular variable reference
-- *114* unsupported expression
+- *115* unsupported expression
   ⚠️  This value might have side effects
-- *115* (???*116* ? ???*117* : 1)
+- *116* (???*117* ? ???*118* : 1)
   ⚠️  nested operation
-- *116* unsupported expression
+- *117* unsupported expression
   ⚠️  This value might have side effects
-- *117* (???*118* ? ???*119* : 4)
+- *118* (???*119* ? ???*120* : 4)
   ⚠️  nested operation
-- *118* unsupported expression
+- *119* unsupported expression
   ⚠️  This value might have side effects
-- *119* (???*120* ? 16 : 536870912)
+- *120* (???*121* ? 16 : 536870912)
   ⚠️  nested operation
-- *120* (0 !== ???*121*)
+- *121* (0 !== ???*122*)
   ⚠️  nested operation
-- *121* unsupported expression
+- *122* unsupported expression
   ⚠️  This value might have side effects
-- *122* arguments[0]
+- *123* arguments[0]
   ⚠️  function calls are not analysed yet
-- *123* ???*124*["value"]
+- *124* ???*125*["value"]
   ⚠️  unknown object
-- *124* arguments[1]
+- *125* arguments[1]
   ⚠️  function calls are not analysed yet
-- *125* ???*126*["event"]
+- *126* ???*127*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *126* FreeVar(window)
+- *127* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *127* (???*128* === ???*129*)
+- *128* (???*129* === ???*130*)
   ⚠️  nested operation
-- *128* unsupported expression
+- *129* unsupported expression
   ⚠️  This value might have side effects
-- *129* a
+- *130* a
   ⚠️  circular variable reference
-- *130* arguments[6]
+- *131* arguments[6]
   ⚠️  function calls are not analysed yet
-- *131* arguments[7]
+- *132* arguments[7]
   ⚠️  function calls are not analysed yet
-- *132* arguments[8]
+- *133* arguments[8]
   ⚠️  function calls are not analysed yet
 
 0 -> 7328 call = (...) => (Vf | bg(a, c, b) | b)(null)
@@ -44536,14 +51818,58 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *2* unsupported expression
   ⚠️  This value might have side effects
 
-0 -> 7331 call = (...) => (1 | ???*0* | ???*1* | a)(???*2*)
+0 -> 7331 call = (...) => (1 | ???*0* | ???*1* | a)(
+    (
+      | ???*2*
+      | ???*3*
+      | new (...) => undefined(???*5*, (???*6* | ???*7* | 1 | ???*19* | 0), true, ???*20*, ???*21*)["current"]
+    )
+)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
-- *2* max number of linking steps reached
+- *2* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *3* ???*4*["current"]
+  ⚠️  unknown object
+- *4* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *5* a
+  ⚠️  circular variable reference
+- *6* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *7* (???*8* ? ???*10* : ???*11*)
+  ⚠️  nested operation
+- *8* (0 !== ???*9*)
+  ⚠️  nested operation
+- *9* unsupported expression
   ⚠️  This value might have side effects
+- *10* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *11* (???*12* ? (???*16* | ???*17*) : ???*18*)
+  ⚠️  nested operation
+- *12* (???*13* !== (???*14* | ???*15*))
+  ⚠️  nested operation
+- *13* unsupported expression
+  ⚠️  This value might have side effects
+- *14* unsupported expression
+  ⚠️  This value might have side effects
+- *15* ...[...]()
+  ⚠️  nested operation
+- *16* unsupported expression
+  ⚠️  This value might have side effects
+- *17* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *18* unsupported expression
+  ⚠️  This value might have side effects
+- *19* unsupported assign operation
+  ⚠️  This value might have side effects
+- *20* arguments[7]
+  ⚠️  function calls are not analysed yet
+- *21* arguments[8]
+  ⚠️  function calls are not analysed yet
 
 0 -> 7332 call = (...) => {"eventTime": a, "lane": b, "tag": 0, "payload": null, "callback": null, "next": null}(
     (???*0* | (???*1* ? ???*3* : ???*4*)),
@@ -44686,25 +52012,29 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
   ⚠️  function calls are not analysed yet
 
 0 -> 7335 call = (...) => (null | Zg(a, c))(
-    ???*0*,
     (
+      | ???*0*
       | ???*1*
+      | new (...) => undefined(???*3*, (???*4* | ???*5* | 1 | ???*17* | 0), true, ???*18*, ???*19*)["current"]
+    ),
+    (
+      | ???*20*
       | {
-            "eventTime": (???*2* | (???*3* ? ???*5* : ???*6*)),
+            "eventTime": (???*21* | (???*22* ? ???*24* : ???*25*)),
             "lane": (
-              | ???*14*
+              | ???*33*
               | 1
-              | ???*15*
-              | ???*16*
-              | ???*17*
-              | new (...) => undefined(???*19*, (???*20* | ???*21* | 1 | ???*31* | 0), true, ???*32*, ???*33*)["current"]
-              | 0
               | ???*34*
+              | ???*35*
+              | ???*36*
+              | new (...) => undefined(???*38*, (???*39* | ???*40* | 1 | ???*50* | 0), true, ???*51*, ???*52*)["current"]
+              | 0
+              | ???*53*
               | 4
-              | ((???*35* | ???*37*) ? ???*38* : 4)
-              | (???*39* ? 16 : (???*40* | null | ???*47* | ???*48*))
-              | ???*50*
-              | (???*52* ? 16 : (undefined | 1 | 4 | 16 | 536870912))
+              | ((???*54* | ???*56*) ? ???*57* : 4)
+              | (???*58* ? 16 : (???*59* | null | ???*66* | ???*67*))
+              | ???*69*
+              | (???*71* ? 16 : (undefined | 1 | 4 | 16 | 536870912))
             ),
             "tag": 0,
             "payload": null,
@@ -44713,25 +52043,404 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
         }
     ),
     (
-      | ???*55*
+      | ???*74*
       | 1
-      | ???*56*
-      | ???*57*
-      | ???*58*
-      | new (...) => undefined(???*60*, (???*61* | ???*62* | 1 | ???*74* | 0), true, ???*75*, ???*76*)["current"]
-      | 0
+      | ???*75*
+      | ???*76*
       | ???*77*
+      | new (...) => undefined(???*79*, (???*80* | ???*81* | 1 | ???*93* | 0), true, ???*94*, ???*95*)["current"]
+      | 0
+      | ???*96*
       | 4
-      | ((???*78* | ???*80*) ? ???*81* : 4)
-      | (???*82* ? 16 : (???*83* | null | ???*90* | ???*91*))
-      | ???*93*
-      | (???*95* ? 16 : (undefined | 1 | 4 | 16 | 536870912))
+      | ((???*97* | ???*99*) ? ???*100* : 4)
+      | (???*101* ? 16 : (???*102* | null | ???*109* | ???*110*))
+      | ???*112*
+      | (???*114* ? 16 : (undefined | 1 | 4 | 16 | 536870912))
     )
 )
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *1* arguments[5]
+- *0* arguments[2]
   ⚠️  function calls are not analysed yet
+- *1* ???*2*["current"]
+  ⚠️  unknown object
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *3* a
+  ⚠️  circular variable reference
+- *4* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *5* (???*6* ? ???*8* : ???*9*)
+  ⚠️  nested operation
+- *6* (0 !== ???*7*)
+  ⚠️  nested operation
+- *7* unsupported expression
+  ⚠️  This value might have side effects
+- *8* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *9* (???*10* ? (???*14* | ???*15*) : ???*16*)
+  ⚠️  nested operation
+- *10* (???*11* !== (???*12* | ???*13*))
+  ⚠️  nested operation
+- *11* unsupported expression
+  ⚠️  This value might have side effects
+- *12* unsupported expression
+  ⚠️  This value might have side effects
+- *13* ...[...]()
+  ⚠️  nested operation
+- *14* unsupported expression
+  ⚠️  This value might have side effects
+- *15* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *16* unsupported expression
+  ⚠️  This value might have side effects
+- *17* unsupported assign operation
+  ⚠️  This value might have side effects
+- *18* arguments[7]
+  ⚠️  function calls are not analysed yet
+- *19* arguments[8]
+  ⚠️  function calls are not analysed yet
+- *20* arguments[5]
+  ⚠️  function calls are not analysed yet
+- *21* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *22* (0 !== ???*23*)
+  ⚠️  nested operation
+- *23* unsupported expression
+  ⚠️  This value might have side effects
+- *24* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *25* (???*26* ? (???*30* | ???*31*) : ???*32*)
+  ⚠️  nested operation
+- *26* (???*27* !== (???*28* | ???*29*))
+  ⚠️  nested operation
+- *27* unsupported expression
+  ⚠️  This value might have side effects
+- *28* unsupported expression
+  ⚠️  This value might have side effects
+- *29* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *30* unsupported expression
+  ⚠️  This value might have side effects
+- *31* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *32* unsupported expression
+  ⚠️  This value might have side effects
+- *33* arguments[4]
+  ⚠️  function calls are not analysed yet
+- *34* unsupported expression
+  ⚠️  This value might have side effects
+- *35* Ck
+  ⚠️  sequence with side effects
+  ⚠️  This value might have side effects
+- *36* ???*37*["current"]
+  ⚠️  unknown object
+- *37* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *38* a
+  ⚠️  circular variable reference
+- *39* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *40* (???*41* ? ???*43* : ???*44*)
+  ⚠️  nested operation
+- *41* (0 !== ???*42*)
+  ⚠️  nested operation
+- *42* unsupported expression
+  ⚠️  This value might have side effects
+- *43* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *44* (???*45* ? (???*47* | ???*48*) : ???*49*)
+  ⚠️  nested operation
+- *45* (???*46* !== (... | ...))
+  ⚠️  nested operation
+- *46* unsupported expression
+  ⚠️  This value might have side effects
+- *47* unsupported expression
+  ⚠️  This value might have side effects
+- *48* ...()
+  ⚠️  nested operation
+- *49* unsupported expression
+  ⚠️  This value might have side effects
+- *50* unsupported assign operation
+  ⚠️  This value might have side effects
+- *51* arguments[7]
+  ⚠️  function calls are not analysed yet
+- *52* arguments[8]
+  ⚠️  function calls are not analysed yet
+- *53* C
+  ⚠️  circular variable reference
+- *54* (0 !== ???*55*)
+  ⚠️  nested operation
+- *55* C
+  ⚠️  circular variable reference
+- *56* unsupported expression
+  ⚠️  This value might have side effects
+- *57* C
+  ⚠️  circular variable reference
+- *58* unsupported expression
+  ⚠️  This value might have side effects
+- *59* (???*60* ? ???*61* : 1)
+  ⚠️  nested operation
+- *60* unsupported expression
+  ⚠️  This value might have side effects
+- *61* (???*62* ? ???*63* : 4)
+  ⚠️  nested operation
+- *62* unsupported expression
+  ⚠️  This value might have side effects
+- *63* (???*64* ? 16 : 536870912)
+  ⚠️  nested operation
+- *64* (0 !== ???*65*)
+  ⚠️  nested operation
+- *65* unsupported expression
+  ⚠️  This value might have side effects
+- *66* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *67* ???*68*["value"]
+  ⚠️  unknown object
+- *68* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *69* ???*70*["event"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *70* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *71* (???*72* === ???*73*)
+  ⚠️  nested operation
+- *72* unsupported expression
+  ⚠️  This value might have side effects
+- *73* a
+  ⚠️  circular variable reference
+- *74* arguments[4]
+  ⚠️  function calls are not analysed yet
+- *75* unsupported expression
+  ⚠️  This value might have side effects
+- *76* Ck
+  ⚠️  sequence with side effects
+  ⚠️  This value might have side effects
+- *77* ???*78*["current"]
+  ⚠️  unknown object
+- *78* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *79* a
+  ⚠️  circular variable reference
+- *80* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *81* (???*82* ? ???*84* : ???*85*)
+  ⚠️  nested operation
+- *82* (0 !== ???*83*)
+  ⚠️  nested operation
+- *83* unsupported expression
+  ⚠️  This value might have side effects
+- *84* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *85* (???*86* ? (???*90* | ???*91*) : ???*92*)
+  ⚠️  nested operation
+- *86* (???*87* !== (???*88* | ???*89*))
+  ⚠️  nested operation
+- *87* unsupported expression
+  ⚠️  This value might have side effects
+- *88* unsupported expression
+  ⚠️  This value might have side effects
+- *89* ...[...]()
+  ⚠️  nested operation
+- *90* unsupported expression
+  ⚠️  This value might have side effects
+- *91* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *92* unsupported expression
+  ⚠️  This value might have side effects
+- *93* unsupported assign operation
+  ⚠️  This value might have side effects
+- *94* arguments[7]
+  ⚠️  function calls are not analysed yet
+- *95* arguments[8]
+  ⚠️  function calls are not analysed yet
+- *96* C
+  ⚠️  circular variable reference
+- *97* (0 !== ???*98*)
+  ⚠️  nested operation
+- *98* C
+  ⚠️  circular variable reference
+- *99* unsupported expression
+  ⚠️  This value might have side effects
+- *100* C
+  ⚠️  circular variable reference
+- *101* unsupported expression
+  ⚠️  This value might have side effects
+- *102* (???*103* ? ???*104* : 1)
+  ⚠️  nested operation
+- *103* unsupported expression
+  ⚠️  This value might have side effects
+- *104* (???*105* ? ???*106* : 4)
+  ⚠️  nested operation
+- *105* unsupported expression
+  ⚠️  This value might have side effects
+- *106* (???*107* ? 16 : 536870912)
+  ⚠️  nested operation
+- *107* (0 !== ???*108*)
+  ⚠️  nested operation
+- *108* unsupported expression
+  ⚠️  This value might have side effects
+- *109* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *110* ???*111*["value"]
+  ⚠️  unknown object
+- *111* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *112* ???*113*["event"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *113* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *114* (???*115* === ???*116*)
+  ⚠️  nested operation
+- *115* unsupported expression
+  ⚠️  This value might have side effects
+- *116* a
+  ⚠️  circular variable reference
+
+0 -> 7338 call = (...) => undefined(
+    (???*0* | ???*1*),
+    (
+      | ???*2*
+      | 1
+      | ???*3*
+      | ???*4*
+      | ???*5*
+      | new (...) => undefined(???*7*, (???*8* | ???*9* | 1 | ???*21* | 0), true, ???*22*, ???*23*)["current"]
+      | 0
+      | ???*24*
+      | 4
+      | ((???*25* | ???*27*) ? ???*28* : 4)
+      | (???*29* ? 16 : (???*30* | null | ???*37* | ???*38*))
+      | ???*40*
+      | (???*42* ? 16 : (undefined | 1 | 4 | 16 | 536870912))
+    ),
+    (???*45* | (???*46* ? ???*48* : ???*49*))
+)
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* node limit reached
+  ⚠️  This value might have side effects
+- *2* arguments[4]
+  ⚠️  function calls are not analysed yet
+- *3* unsupported expression
+  ⚠️  This value might have side effects
+- *4* Ck
+  ⚠️  sequence with side effects
+  ⚠️  This value might have side effects
+- *5* ???*6*["current"]
+  ⚠️  unknown object
+- *6* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *7* a
+  ⚠️  circular variable reference
+- *8* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *9* (???*10* ? ???*12* : ???*13*)
+  ⚠️  nested operation
+- *10* (0 !== ???*11*)
+  ⚠️  nested operation
+- *11* unsupported expression
+  ⚠️  This value might have side effects
+- *12* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *13* (???*14* ? (???*18* | ???*19*) : ???*20*)
+  ⚠️  nested operation
+- *14* (???*15* !== (???*16* | ???*17*))
+  ⚠️  nested operation
+- *15* unsupported expression
+  ⚠️  This value might have side effects
+- *16* unsupported expression
+  ⚠️  This value might have side effects
+- *17* ...[...]()
+  ⚠️  nested operation
+- *18* unsupported expression
+  ⚠️  This value might have side effects
+- *19* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *20* unsupported expression
+  ⚠️  This value might have side effects
+- *21* unsupported assign operation
+  ⚠️  This value might have side effects
+- *22* arguments[7]
+  ⚠️  function calls are not analysed yet
+- *23* arguments[8]
+  ⚠️  function calls are not analysed yet
+- *24* C
+  ⚠️  circular variable reference
+- *25* (0 !== ???*26*)
+  ⚠️  nested operation
+- *26* C
+  ⚠️  circular variable reference
+- *27* unsupported expression
+  ⚠️  This value might have side effects
+- *28* C
+  ⚠️  circular variable reference
+- *29* unsupported expression
+  ⚠️  This value might have side effects
+- *30* (???*31* ? ???*32* : 1)
+  ⚠️  nested operation
+- *31* unsupported expression
+  ⚠️  This value might have side effects
+- *32* (???*33* ? ???*34* : 4)
+  ⚠️  nested operation
+- *33* unsupported expression
+  ⚠️  This value might have side effects
+- *34* (???*35* ? 16 : 536870912)
+  ⚠️  nested operation
+- *35* (0 !== ???*36*)
+  ⚠️  nested operation
+- *36* unsupported expression
+  ⚠️  This value might have side effects
+- *37* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *38* ???*39*["value"]
+  ⚠️  unknown object
+- *39* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *40* ???*41*["event"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *41* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *42* (???*43* === ???*44*)
+  ⚠️  nested operation
+- *43* unsupported expression
+  ⚠️  This value might have side effects
+- *44* a
+  ⚠️  circular variable reference
+- *45* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *46* (0 !== ???*47*)
+  ⚠️  nested operation
+- *47* unsupported expression
+  ⚠️  This value might have side effects
+- *48* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *49* (???*50* ? (???*54* | ???*55*) : ???*56*)
+  ⚠️  nested operation
+- *50* (???*51* !== (???*52* | ???*53*))
+  ⚠️  nested operation
+- *51* unsupported expression
+  ⚠️  This value might have side effects
+- *52* unsupported expression
+  ⚠️  This value might have side effects
+- *53* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *54* unsupported expression
+  ⚠️  This value might have side effects
+- *55* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *56* unsupported expression
+  ⚠️  This value might have side effects
+
+0 -> 7339 call = (...) => undefined((???*0* | ???*1*), (???*2* | (???*3* ? ???*5* : ???*6*)))
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* node limit reached
+  ⚠️  This value might have side effects
 - *2* arguments[3]
   ⚠️  function calls are not analysed yet
 - *3* (0 !== ???*4*)
@@ -44755,430 +52464,6 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *12* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
 - *13* unsupported expression
-  ⚠️  This value might have side effects
-- *14* arguments[4]
-  ⚠️  function calls are not analysed yet
-- *15* unsupported expression
-  ⚠️  This value might have side effects
-- *16* Ck
-  ⚠️  sequence with side effects
-  ⚠️  This value might have side effects
-- *17* ???*18*["current"]
-  ⚠️  unknown object
-- *18* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *19* a
-  ⚠️  circular variable reference
-- *20* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *21* (???*22* ? ???*24* : ???*25*)
-  ⚠️  nested operation
-- *22* (0 !== ???*23*)
-  ⚠️  nested operation
-- *23* unsupported expression
-  ⚠️  This value might have side effects
-- *24* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *25* (???*26* ? (???*28* | ???*29*) : ???*30*)
-  ⚠️  nested operation
-- *26* (???*27* !== (... | ...))
-  ⚠️  nested operation
-- *27* unsupported expression
-  ⚠️  This value might have side effects
-- *28* unsupported expression
-  ⚠️  This value might have side effects
-- *29* ...()
-  ⚠️  nested operation
-- *30* unsupported expression
-  ⚠️  This value might have side effects
-- *31* unsupported assign operation
-  ⚠️  This value might have side effects
-- *32* arguments[7]
-  ⚠️  function calls are not analysed yet
-- *33* arguments[8]
-  ⚠️  function calls are not analysed yet
-- *34* C
-  ⚠️  circular variable reference
-- *35* (0 !== ???*36*)
-  ⚠️  nested operation
-- *36* C
-  ⚠️  circular variable reference
-- *37* unsupported expression
-  ⚠️  This value might have side effects
-- *38* C
-  ⚠️  circular variable reference
-- *39* unsupported expression
-  ⚠️  This value might have side effects
-- *40* (???*41* ? ???*42* : 1)
-  ⚠️  nested operation
-- *41* unsupported expression
-  ⚠️  This value might have side effects
-- *42* (???*43* ? ???*44* : 4)
-  ⚠️  nested operation
-- *43* unsupported expression
-  ⚠️  This value might have side effects
-- *44* (???*45* ? 16 : 536870912)
-  ⚠️  nested operation
-- *45* (0 !== ???*46*)
-  ⚠️  nested operation
-- *46* unsupported expression
-  ⚠️  This value might have side effects
-- *47* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *48* ???*49*["value"]
-  ⚠️  unknown object
-- *49* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *50* ???*51*["event"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *51* FreeVar(window)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *52* (???*53* === ???*54*)
-  ⚠️  nested operation
-- *53* unsupported expression
-  ⚠️  This value might have side effects
-- *54* a
-  ⚠️  circular variable reference
-- *55* arguments[4]
-  ⚠️  function calls are not analysed yet
-- *56* unsupported expression
-  ⚠️  This value might have side effects
-- *57* Ck
-  ⚠️  sequence with side effects
-  ⚠️  This value might have side effects
-- *58* ???*59*["current"]
-  ⚠️  unknown object
-- *59* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *60* a
-  ⚠️  circular variable reference
-- *61* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *62* (???*63* ? ???*65* : ???*66*)
-  ⚠️  nested operation
-- *63* (0 !== ???*64*)
-  ⚠️  nested operation
-- *64* unsupported expression
-  ⚠️  This value might have side effects
-- *65* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *66* (???*67* ? (???*71* | ???*72*) : ???*73*)
-  ⚠️  nested operation
-- *67* (???*68* !== (???*69* | ???*70*))
-  ⚠️  nested operation
-- *68* unsupported expression
-  ⚠️  This value might have side effects
-- *69* unsupported expression
-  ⚠️  This value might have side effects
-- *70* ...[...]()
-  ⚠️  nested operation
-- *71* unsupported expression
-  ⚠️  This value might have side effects
-- *72* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *73* unsupported expression
-  ⚠️  This value might have side effects
-- *74* unsupported assign operation
-  ⚠️  This value might have side effects
-- *75* arguments[7]
-  ⚠️  function calls are not analysed yet
-- *76* arguments[8]
-  ⚠️  function calls are not analysed yet
-- *77* C
-  ⚠️  circular variable reference
-- *78* (0 !== ???*79*)
-  ⚠️  nested operation
-- *79* C
-  ⚠️  circular variable reference
-- *80* unsupported expression
-  ⚠️  This value might have side effects
-- *81* C
-  ⚠️  circular variable reference
-- *82* unsupported expression
-  ⚠️  This value might have side effects
-- *83* (???*84* ? ???*85* : 1)
-  ⚠️  nested operation
-- *84* unsupported expression
-  ⚠️  This value might have side effects
-- *85* (???*86* ? ???*87* : 4)
-  ⚠️  nested operation
-- *86* unsupported expression
-  ⚠️  This value might have side effects
-- *87* (???*88* ? 16 : 536870912)
-  ⚠️  nested operation
-- *88* (0 !== ???*89*)
-  ⚠️  nested operation
-- *89* unsupported expression
-  ⚠️  This value might have side effects
-- *90* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *91* ???*92*["value"]
-  ⚠️  unknown object
-- *92* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *93* ???*94*["event"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *94* FreeVar(window)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *95* (???*96* === ???*97*)
-  ⚠️  nested operation
-- *96* unsupported expression
-  ⚠️  This value might have side effects
-- *97* a
-  ⚠️  circular variable reference
-
-0 -> 7338 call = (...) => undefined(
-    (
-      | ???*0*
-      | ???*1*
-      | new (...) => undefined(???*3*, (???*4* | ???*5* | 1 | ???*17* | 0), true, ???*18*, ???*19*)
-    ),
-    (
-      | ???*20*
-      | 1
-      | ???*21*
-      | ???*22*
-      | ???*23*
-      | new (...) => undefined(???*25*, (???*26* | ???*27* | 1 | ???*39* | 0), true, ???*40*, ???*41*)["current"]
-      | 0
-      | ???*42*
-      | 4
-      | ((???*43* | ???*45*) ? ???*46* : 4)
-      | (???*47* ? 16 : (???*48* | null | ???*55* | ???*56*))
-      | ???*58*
-      | (???*60* ? 16 : (undefined | 1 | 4 | 16 | 536870912))
-    ),
-    (???*63* | (???*64* ? ???*66* : ???*67*))
-)
-- *0* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *1* ???*2*["current"]
-  ⚠️  unknown object
-- *2* a
-  ⚠️  circular variable reference
-- *3* a
-  ⚠️  circular variable reference
-- *4* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *5* (???*6* ? ???*8* : ???*9*)
-  ⚠️  nested operation
-- *6* (0 !== ???*7*)
-  ⚠️  nested operation
-- *7* unsupported expression
-  ⚠️  This value might have side effects
-- *8* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *9* (???*10* ? (???*14* | ???*15*) : ???*16*)
-  ⚠️  nested operation
-- *10* (???*11* !== (???*12* | ???*13*))
-  ⚠️  nested operation
-- *11* unsupported expression
-  ⚠️  This value might have side effects
-- *12* unsupported expression
-  ⚠️  This value might have side effects
-- *13* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *14* unsupported expression
-  ⚠️  This value might have side effects
-- *15* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *16* unsupported expression
-  ⚠️  This value might have side effects
-- *17* unsupported assign operation
-  ⚠️  This value might have side effects
-- *18* arguments[7]
-  ⚠️  function calls are not analysed yet
-- *19* arguments[8]
-  ⚠️  function calls are not analysed yet
-- *20* arguments[4]
-  ⚠️  function calls are not analysed yet
-- *21* unsupported expression
-  ⚠️  This value might have side effects
-- *22* Ck
-  ⚠️  sequence with side effects
-  ⚠️  This value might have side effects
-- *23* ???*24*["current"]
-  ⚠️  unknown object
-- *24* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *25* a
-  ⚠️  circular variable reference
-- *26* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *27* (???*28* ? ???*30* : ???*31*)
-  ⚠️  nested operation
-- *28* (0 !== ???*29*)
-  ⚠️  nested operation
-- *29* unsupported expression
-  ⚠️  This value might have side effects
-- *30* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *31* (???*32* ? (???*36* | ???*37*) : ???*38*)
-  ⚠️  nested operation
-- *32* (???*33* !== (???*34* | ???*35*))
-  ⚠️  nested operation
-- *33* unsupported expression
-  ⚠️  This value might have side effects
-- *34* unsupported expression
-  ⚠️  This value might have side effects
-- *35* ...[...]()
-  ⚠️  nested operation
-- *36* unsupported expression
-  ⚠️  This value might have side effects
-- *37* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *38* unsupported expression
-  ⚠️  This value might have side effects
-- *39* unsupported assign operation
-  ⚠️  This value might have side effects
-- *40* arguments[7]
-  ⚠️  function calls are not analysed yet
-- *41* arguments[8]
-  ⚠️  function calls are not analysed yet
-- *42* C
-  ⚠️  circular variable reference
-- *43* (0 !== ???*44*)
-  ⚠️  nested operation
-- *44* C
-  ⚠️  circular variable reference
-- *45* unsupported expression
-  ⚠️  This value might have side effects
-- *46* C
-  ⚠️  circular variable reference
-- *47* unsupported expression
-  ⚠️  This value might have side effects
-- *48* (???*49* ? ???*50* : 1)
-  ⚠️  nested operation
-- *49* unsupported expression
-  ⚠️  This value might have side effects
-- *50* (???*51* ? ???*52* : 4)
-  ⚠️  nested operation
-- *51* unsupported expression
-  ⚠️  This value might have side effects
-- *52* (???*53* ? 16 : 536870912)
-  ⚠️  nested operation
-- *53* (0 !== ???*54*)
-  ⚠️  nested operation
-- *54* unsupported expression
-  ⚠️  This value might have side effects
-- *55* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *56* ???*57*["value"]
-  ⚠️  unknown object
-- *57* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *58* ???*59*["event"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *59* FreeVar(window)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *60* (???*61* === ???*62*)
-  ⚠️  nested operation
-- *61* unsupported expression
-  ⚠️  This value might have side effects
-- *62* a
-  ⚠️  circular variable reference
-- *63* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *64* (0 !== ???*65*)
-  ⚠️  nested operation
-- *65* unsupported expression
-  ⚠️  This value might have side effects
-- *66* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *67* (???*68* ? (???*72* | ???*73*) : ???*74*)
-  ⚠️  nested operation
-- *68* (???*69* !== (???*70* | ???*71*))
-  ⚠️  nested operation
-- *69* unsupported expression
-  ⚠️  This value might have side effects
-- *70* unsupported expression
-  ⚠️  This value might have side effects
-- *71* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *72* unsupported expression
-  ⚠️  This value might have side effects
-- *73* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *74* unsupported expression
-  ⚠️  This value might have side effects
-
-0 -> 7339 call = (...) => undefined(
-    (
-      | ???*0*
-      | ???*1*
-      | new (...) => undefined(???*3*, (???*4* | ???*5* | 1 | ???*17* | 0), true, ???*18*, ???*19*)
-    ),
-    (???*20* | (???*21* ? ???*23* : ???*24*))
-)
-- *0* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *1* ???*2*["current"]
-  ⚠️  unknown object
-- *2* a
-  ⚠️  circular variable reference
-- *3* a
-  ⚠️  circular variable reference
-- *4* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *5* (???*6* ? ???*8* : ???*9*)
-  ⚠️  nested operation
-- *6* (0 !== ???*7*)
-  ⚠️  nested operation
-- *7* unsupported expression
-  ⚠️  This value might have side effects
-- *8* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *9* (???*10* ? (???*14* | ???*15*) : ???*16*)
-  ⚠️  nested operation
-- *10* (???*11* !== (???*12* | ???*13*))
-  ⚠️  nested operation
-- *11* unsupported expression
-  ⚠️  This value might have side effects
-- *12* unsupported expression
-  ⚠️  This value might have side effects
-- *13* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *14* unsupported expression
-  ⚠️  This value might have side effects
-- *15* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *16* unsupported expression
-  ⚠️  This value might have side effects
-- *17* unsupported assign operation
-  ⚠️  This value might have side effects
-- *18* arguments[7]
-  ⚠️  function calls are not analysed yet
-- *19* arguments[8]
-  ⚠️  function calls are not analysed yet
-- *20* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *21* (0 !== ???*22*)
-  ⚠️  nested operation
-- *22* unsupported expression
-  ⚠️  This value might have side effects
-- *23* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *24* (???*25* ? (???*29* | ???*30*) : ???*31*)
-  ⚠️  nested operation
-- *25* (???*26* !== (???*27* | ???*28*))
-  ⚠️  nested operation
-- *26* unsupported expression
-  ⚠️  This value might have side effects
-- *27* unsupported expression
-  ⚠️  This value might have side effects
-- *28* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *29* unsupported expression
-  ⚠️  This value might have side effects
-- *30* module<scheduler, {}>["unstable_now"]()
-  ⚠️  nested operation
-- *31* unsupported expression
   ⚠️  This value might have side effects
 
 0 -> 7340 unreachable = ???*0*
@@ -46113,14 +53398,28 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* arguments[3]
   ⚠️  function calls are not analysed yet
 
-7431 -> 7432 call = (...) => (undefined | null | a["child"]["stateNode"])(???*0*)
-- *0* max number of linking steps reached
+7431 -> 7432 call = (...) => (undefined | null | a["child"]["stateNode"])((???*0* | ???*1*))
+- *0* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *1* node limit reached
   ⚠️  This value might have side effects
 
-7431 -> 7434 member call = (???*0* | (...) => undefined)["call"](???*1*)
+7431 -> 7434 member call = (???*0* | (...) => undefined)["call"]((undefined | null | ???*1* | ???*4*))
 - *0* arguments[3]
   ⚠️  function calls are not analysed yet
-- *1* max number of linking steps reached
+- *1* ???*2*["stateNode"]
+  ⚠️  unknown object
+- *2* ???*3*["child"]
+  ⚠️  unknown object
+- *3* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *4* ???*5*["stateNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* ???*6*["child"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *6* node limit reached
   ⚠️  This value might have side effects
 
 7429 -> 7435 call = (...) => a(???*0*, (???*1* | (...) => undefined), ???*2*, 0, null, false, false, "", (...) => undefined)
@@ -46279,24 +53578,87 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* arguments[4]
   ⚠️  function calls are not analysed yet
 
-7467 -> 7468 call = (...) => (undefined | null | a["child"]["stateNode"])(???*0*)
-- *0* max number of linking steps reached
+7467 -> 7468 call = (...) => (undefined | null | a["child"]["stateNode"])(
+    (
+      | ???*0*
+      | ???*2*
+      | ???*3*
+      | new (...) => undefined(???*4*, (0 | 1 | ???*5*), false, "", (...) => undefined)
+    )
+)
+- *0* ???*1*["_reactRootContainer"]
+  ⚠️  unknown object
+- *1* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *2* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *3* node limit reached
+  ⚠️  This value might have side effects
+- *4* a
+  ⚠️  circular variable reference
+- *5* unsupported assign operation
   ⚠️  This value might have side effects
 
-7467 -> 7470 member call = (???*0* | (...) => undefined)["call"](???*1*)
+7467 -> 7470 member call = (???*0* | (...) => undefined)["call"](
+    (
+      | undefined
+      | null
+      | ???*1*
+      | ???*5*
+      | new (...) => undefined(???*8*, (0 | 1 | ???*9*), false, "", (...) => undefined)["child"]["stateNode"]
+    )
+)
 - *0* arguments[4]
   ⚠️  function calls are not analysed yet
-- *1* max number of linking steps reached
+- *1* ???*2*["stateNode"]
+  ⚠️  unknown object
+- *2* ???*3*["child"]
+  ⚠️  unknown object
+- *3* ???*4*["_reactRootContainer"]
+  ⚠️  unknown object
+- *4* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *5* ???*6*["stateNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *6* ???*7*["child"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *7* node limit reached
+  ⚠️  This value might have side effects
+- *8* a
+  ⚠️  circular variable reference
+- *9* unsupported assign operation
   ⚠️  This value might have side effects
 
-7465 -> 7471 call = (...) => g(???*0*, ???*1*, ???*2*, (???*3* | (...) => undefined))
+7465 -> 7471 call = (...) => g(
+    ???*0*,
+    (
+      | ???*1*
+      | ???*3*
+      | ???*4*
+      | new (...) => undefined(???*5*, (0 | 1 | ???*6*), false, "", (...) => undefined)
+    ),
+    ???*7*,
+    (???*8* | (...) => undefined)
+)
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
-- *1* max number of linking steps reached
-  ⚠️  This value might have side effects
-- *2* arguments[0]
+- *1* ???*2*["_reactRootContainer"]
+  ⚠️  unknown object
+- *2* arguments[2]
   ⚠️  function calls are not analysed yet
-- *3* arguments[4]
+- *3* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *4* node limit reached
+  ⚠️  This value might have side effects
+- *5* a
+  ⚠️  circular variable reference
+- *6* unsupported assign operation
+  ⚠️  This value might have side effects
+- *7* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *8* arguments[4]
   ⚠️  function calls are not analysed yet
 
 7465 -> 7472 call = (...) => (g | k)(???*0*, ???*1*, ???*2*, (???*3* | (...) => undefined), ???*4*)
@@ -46311,8 +53673,25 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *4* arguments[3]
   ⚠️  function calls are not analysed yet
 
-0 -> 7473 call = (...) => (undefined | null | a["child"]["stateNode"])(???*0*)
-- *0* max number of linking steps reached
+0 -> 7473 call = (...) => (undefined | null | a["child"]["stateNode"])(
+    (
+      | ???*0*
+      | ???*2*
+      | ???*3*
+      | new (...) => undefined(???*4*, (0 | 1 | ???*5*), false, "", (...) => undefined)
+    )
+)
+- *0* ???*1*["_reactRootContainer"]
+  ⚠️  unknown object
+- *1* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *2* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *3* node limit reached
+  ⚠️  This value might have side effects
+- *4* a
+  ⚠️  circular variable reference
+- *5* unsupported assign operation
   ⚠️  This value might have side effects
 
 0 -> 7474 unreachable = ???*0*

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-explained.snapshot
@@ -21,27 +21,8 @@ $f = (...) => undefined
 
 $g = (false | true)
 
-$h = {
-    "readContext": (...) => b,
-    "useCallback": (...) => (d[0] | a),
-    "useContext": (...) => b,
-    "useEffect": (...) => ui(2048, 8, a, b),
-    "useImperativeHandle": (...) => ui(4, 4, yi["bind"](null, b, a), c),
-    "useInsertionEffect": (...) => ui(4, 2, a, b),
-    "useLayoutEffect": (...) => ui(4, 4, a, b),
-    "useMemo": (...) => (d[0] | a),
-    "useReducer": (...) => [f, d],
-    "useRef": (...) => di()["memoizedState"],
-    "useState": (...) => gi(ei),
-    "useDebugValue": (...) => undefined,
-    "useDeferredValue": (...) => ((null === O) ? ???*0* : Di(b, O["memoizedState"], a)),
-    "useTransition": (...) => [a, b],
-    "useMutableSource": (...) => undefined,
-    "useSyncExternalStore": (...) => e,
-    "useId": (...) => di()["memoizedState"],
-    "unstable_isNewReconciler": false
-}
-- *0* unsupported expression
+$h = ???*0*
+- *0* node limit reached
   ⚠️  This value might have side effects
 
 $i = (...) => (null | b["child"])
@@ -457,9 +438,49 @@ Bk = (???*0* | module<scheduler, {}>["unstable_now"]())
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-C = ???*0*
-- *0* max number of linking steps reached
+C = (
+  | 0
+  | 1
+  | ???*0*
+  | 4
+  | ((???*1* | ???*3*) ? ???*4* : 4)
+  | (???*5* ? 16 : (???*6* | null | ???*13* | ???*14*))
+  | ???*16*
+)
+- *0* C
+  ⚠️  circular variable reference
+- *1* (0 !== ???*2*)
+  ⚠️  nested operation
+- *2* C
+  ⚠️  circular variable reference
+- *3* unsupported expression
   ⚠️  This value might have side effects
+- *4* C
+  ⚠️  circular variable reference
+- *5* unsupported expression
+  ⚠️  This value might have side effects
+- *6* (???*7* ? ???*8* : 1)
+  ⚠️  nested operation
+- *7* unsupported expression
+  ⚠️  This value might have side effects
+- *8* (???*9* ? ???*10* : 4)
+  ⚠️  nested operation
+- *9* unsupported expression
+  ⚠️  This value might have side effects
+- *10* (???*11* ? 16 : 536870912)
+  ⚠️  nested operation
+- *11* (0 !== ???*12*)
+  ⚠️  nested operation
+- *12* unsupported expression
+  ⚠️  This value might have side effects
+- *13* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *14* ???*15*["value"]
+  ⚠️  unknown object
+- *15* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *16* arguments[0]
+  ⚠️  function calls are not analysed yet
 
 Ca = ???*0*
 - *0* ???*1*["for"]("react.context")
@@ -511,9 +532,9 @@ Cd = {
 Ce = (...) => undefined
 
 Cf = (null | true | false | !(???*0*))
-- *0* !((null | ???*1*))
+- *0* !(???*1*)
   ⚠️  nested operation
-- *1* dd
+- *1* Cf
   ⚠️  circular variable reference
 
 Cg = (...) => (undefined | ((null !== b) ? ???*0* : !(1)) | ???*1* | !(1))
@@ -1101,13 +1122,6 @@ Lc = (
         "nativeEvent": ???*14*,
         "targetContainers": [???*15*]
     }
-  | {
-        "blockedOn": (???*16* | (???*17* ? null : (???*21* | ???*22*)) | ???*24*),
-        "domEventName": ???*26*,
-        "eventSystemFlags": ???*27*,
-        "nativeEvent": ???*28*,
-        "targetContainers": [???*29*]
-    }
 )
 - *0* a
   ⚠️  sequence with side effects
@@ -1141,34 +1155,6 @@ Lc = (
 - *14* arguments[4]
   ⚠️  function calls are not analysed yet
 - *15* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *16* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *17* !((???*18* | ???*19*))
-  ⚠️  nested operation
-- *18* b
-  ⚠️  circular variable reference
-- *19* ???*20*[Of]
-  ⚠️  unknown object
-- *20* a
-  ⚠️  circular variable reference
-- *21* b
-  ⚠️  circular variable reference
-- *22* ???*23*[Of]
-  ⚠️  unknown object
-- *23* a
-  ⚠️  circular variable reference
-- *24* ???*25*["targetContainers"]
-  ⚠️  unknown object
-- *25* a
-  ⚠️  circular variable reference
-- *26* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *27* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *28* arguments[4]
-  ⚠️  function calls are not analysed yet
-- *29* arguments[3]
   ⚠️  function calls are not analysed yet
 
 Ld = (...) => ???*0*
@@ -1224,13 +1210,6 @@ Mc = (
         "nativeEvent": ???*14*,
         "targetContainers": [???*15*]
     }
-  | {
-        "blockedOn": (???*16* | (???*17* ? null : (???*21* | ???*22*)) | ???*24*),
-        "domEventName": ???*26*,
-        "eventSystemFlags": ???*27*,
-        "nativeEvent": ???*28*,
-        "targetContainers": [???*29*]
-    }
 )
 - *0* a
   ⚠️  sequence with side effects
@@ -1264,34 +1243,6 @@ Mc = (
 - *14* arguments[4]
   ⚠️  function calls are not analysed yet
 - *15* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *16* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *17* !((???*18* | ???*19*))
-  ⚠️  nested operation
-- *18* b
-  ⚠️  circular variable reference
-- *19* ???*20*[Of]
-  ⚠️  unknown object
-- *20* a
-  ⚠️  circular variable reference
-- *21* b
-  ⚠️  circular variable reference
-- *22* ???*23*[Of]
-  ⚠️  unknown object
-- *23* a
-  ⚠️  circular variable reference
-- *24* ???*25*["targetContainers"]
-  ⚠️  unknown object
-- *25* a
-  ⚠️  circular variable reference
-- *26* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *27* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *28* arguments[4]
-  ⚠️  function calls are not analysed yet
-- *29* arguments[3]
   ⚠️  function calls are not analysed yet
 
 Md = {
@@ -1329,7 +1280,6 @@ N = (
   | (null !== (
       | null
       | ???*1*
-      | null["alternate"]
       | ???*2*
       | ???*4*
       | {
@@ -1340,7 +1290,7 @@ N = (
             "next": null
         }
     ))
-  | (null !== (null["next"] | ???*17* | null["alternate"]["next"] | ???*19* | null | ???*22*))
+  | (null !== (null["next"] | ???*17* | ???*19* | null | ???*22*))
 )
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
@@ -1348,7 +1298,7 @@ N = (
   ⚠️  This value might have side effects
 - *2* ???*3*["alternate"]
   ⚠️  unknown object
-- *3* b
+- *3* N
   ⚠️  circular variable reference
 - *4* (???*5* ? ???*7* : null)
   ⚠️  nested operation
@@ -1385,7 +1335,7 @@ N = (
   ⚠️  unknown object
 - *20* ???*21*["alternate"]
   ⚠️  unknown object
-- *21* b
+- *21* N
   ⚠️  circular variable reference
 - *22* unknown mutation
   ⚠️  This value might have side effects
@@ -1404,13 +1354,6 @@ Nc = (
         "eventSystemFlags": ???*13*,
         "nativeEvent": ???*14*,
         "targetContainers": [???*15*]
-    }
-  | {
-        "blockedOn": (???*16* | (???*17* ? null : (???*21* | ???*22*)) | ???*24*),
-        "domEventName": ???*26*,
-        "eventSystemFlags": ???*27*,
-        "nativeEvent": ???*28*,
-        "targetContainers": [???*29*]
     }
 )
 - *0* a
@@ -1445,34 +1388,6 @@ Nc = (
 - *14* arguments[4]
   ⚠️  function calls are not analysed yet
 - *15* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *16* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *17* !((???*18* | ???*19*))
-  ⚠️  nested operation
-- *18* b
-  ⚠️  circular variable reference
-- *19* ???*20*[Of]
-  ⚠️  unknown object
-- *20* a
-  ⚠️  circular variable reference
-- *21* b
-  ⚠️  circular variable reference
-- *22* ???*23*[Of]
-  ⚠️  unknown object
-- *23* a
-  ⚠️  circular variable reference
-- *24* ???*25*["targetContainers"]
-  ⚠️  unknown object
-- *25* a
-  ⚠️  circular variable reference
-- *26* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *27* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *28* arguments[4]
-  ⚠️  function calls are not analysed yet
-- *29* arguments[3]
   ⚠️  function calls are not analysed yet
 
 Nd = {
@@ -1579,16 +1494,14 @@ O = (
   | ???*0*
   | null["alternate"]
   | ???*1*
-  | (null !== (null | ???*3* | ???*4*))["alternate"]
-  | (null !== (null["next"] | ???*5* | ???*7*))["alternate"]
-  | (???*9* ? ???*11* : null)
-  | null["next"]
-  | ???*13*
+  | (null !== ???*3*)["alternate"]
+  | (null !== ???*4*)["alternate"]
+  | (???*6* ? ???*8* : null)
   | {
-        "memoizedState": (null["memoizedState"] | ???*15* | ???*17*),
-        "baseState": (null["baseState"] | ???*19* | ???*21*),
-        "baseQueue": (null["baseQueue"] | ???*23* | ???*25*),
-        "queue": (null["queue"] | ???*27* | ???*29*),
+        "memoizedState": ???*10*,
+        "baseState": ???*12*,
+        "baseQueue": ???*14*,
+        "queue": ???*16*,
         "next": null
     }
 )
@@ -1598,67 +1511,35 @@ O = (
   ⚠️  unknown object
 - *2* arguments[1]
   ⚠️  function calls are not analysed yet
-- *3* unsupported expression
-  ⚠️  This value might have side effects
-- *4* a
+- *3* O
   ⚠️  circular variable reference
-- *5* ???*6*["next"]
+- *4* ???*5*["next"]
   ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* ???*8*["next"]
-  ⚠️  unknown object
-- *8* a
+- *5* O
   ⚠️  circular variable reference
-- *9* (null !== ???*10*)
+- *6* (null !== ???*7*)
   ⚠️  nested operation
-- *10* a
+- *7* a
   ⚠️  circular variable reference
-- *11* ???*12*["memoizedState"]
+- *8* ???*9*["memoizedState"]
   ⚠️  unknown object
-- *12* a
+- *9* a
   ⚠️  circular variable reference
-- *13* ???*14*["next"]
+- *10* ???*11*["memoizedState"]
   ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *14* unsupported expression
-  ⚠️  This value might have side effects
-- *15* ???*16*["memoizedState"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *16* unsupported expression
-  ⚠️  This value might have side effects
-- *17* ???*18*["memoizedState"]
-  ⚠️  unknown object
-- *18* a
+- *11* O
   ⚠️  circular variable reference
-- *19* ???*20*["baseState"]
+- *12* ???*13*["baseState"]
   ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *20* unsupported expression
-  ⚠️  This value might have side effects
-- *21* ???*22*["baseState"]
-  ⚠️  unknown object
-- *22* a
+- *13* O
   ⚠️  circular variable reference
-- *23* ???*24*["baseQueue"]
+- *14* ???*15*["baseQueue"]
   ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *24* unsupported expression
-  ⚠️  This value might have side effects
-- *25* ???*26*["baseQueue"]
-  ⚠️  unknown object
-- *26* a
+- *15* O
   ⚠️  circular variable reference
-- *27* ???*28*["queue"]
+- *16* ???*17*["queue"]
   ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *28* unsupported expression
-  ⚠️  This value might have side effects
-- *29* ???*30*["queue"]
-  ⚠️  unknown object
-- *30* a
+- *17* O
   ⚠️  circular variable reference
 
 Oa = (...) => ("" | k | (???*0* ? Ma(a) : ""))
@@ -1714,9 +1595,106 @@ Oj = false
 
 Ok = (...) => a
 
-P = ???*0*
-- *0* max number of linking steps reached
+P = (
+  | null
+  | ???*0*
+  | {"memoizedState": null, "baseState": null, "baseQueue": null, "queue": null, "next": null}
+  | (???*1* ? (null["memoizedState"] | ???*3*) : ???*5*)
+  | null["alternate"]
+  | ???*7*
+  | (null !== (null | ???*9* | ???*10*))["alternate"]
+  | (null !== (null["next"] | ???*11* | ???*13*))["alternate"]
+  | (???*15* ? ???*17* : null)
+  | null["next"]
+  | ???*19*
+  | {
+        "memoizedState": (null["memoizedState"] | ???*21* | ???*23*),
+        "baseState": (null["baseState"] | ???*25* | ???*27*),
+        "baseQueue": (null["baseQueue"] | ???*29* | ???*31*),
+        "queue": (null["queue"] | ???*33* | ???*35*),
+        "next": null
+    }
+)
+- *0* unsupported expression
   ⚠️  This value might have side effects
+- *1* (null === ???*2*)
+  ⚠️  nested operation
+- *2* P
+  ⚠️  circular variable reference
+- *3* ???*4*["memoizedState"]
+  ⚠️  unknown object
+- *4* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *5* ???*6*["next"]
+  ⚠️  unknown object
+- *6* P
+  ⚠️  circular variable reference
+- *7* ???*8*["alternate"]
+  ⚠️  unknown object
+- *8* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *9* unsupported expression
+  ⚠️  This value might have side effects
+- *10* a
+  ⚠️  circular variable reference
+- *11* ???*12*["next"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *12* unsupported expression
+  ⚠️  This value might have side effects
+- *13* ???*14*["next"]
+  ⚠️  unknown object
+- *14* a
+  ⚠️  circular variable reference
+- *15* (null !== ???*16*)
+  ⚠️  nested operation
+- *16* a
+  ⚠️  circular variable reference
+- *17* ???*18*["memoizedState"]
+  ⚠️  unknown object
+- *18* a
+  ⚠️  circular variable reference
+- *19* ???*20*["next"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *20* unsupported expression
+  ⚠️  This value might have side effects
+- *21* ???*22*["memoizedState"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *22* unsupported expression
+  ⚠️  This value might have side effects
+- *23* ???*24*["memoizedState"]
+  ⚠️  unknown object
+- *24* a
+  ⚠️  circular variable reference
+- *25* ???*26*["baseState"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *26* unsupported expression
+  ⚠️  This value might have side effects
+- *27* ???*28*["baseState"]
+  ⚠️  unknown object
+- *28* a
+  ⚠️  circular variable reference
+- *29* ???*30*["baseQueue"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *30* unsupported expression
+  ⚠️  This value might have side effects
+- *31* ???*32*["baseQueue"]
+  ⚠️  unknown object
+- *32* a
+  ⚠️  circular variable reference
+- *33* ???*34*["queue"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *34* unsupported expression
+  ⚠️  This value might have side effects
+- *35* ???*36*["queue"]
+  ⚠️  unknown object
+- *36* a
+  ⚠️  circular variable reference
 
 Pa = (...) => (undefined | Ma(a["type"]) | Ma("Lazy") | Ma("Suspense") | Ma("SuspenseList") | ???*0* | "")
 - *0* a
@@ -1797,34 +1775,25 @@ Qb = (false | true)
 
 Qc = []
 
-Qd = {
-    "eventPhase": 0,
-    "bubbles": 0,
-    "cancelable": 0,
-    "timeStamp": (...) => (a["timeStamp"] || FreeVar(Date)["now"]()),
-    "defaultPrevented": 0,
-    "isTrusted": 0,
-    "view": 0,
-    "detail": 0,
-    "key": (...) => (
-      | b
-      | (("keypress" === a["type"]) ? ???*0* : ((("keydown" === a["type"]) || ("keyup" === a["type"])) ? (Nd[a["keyCode"]] || "Unidentified") : ""))
-    ),
-    "code": 0,
-    "location": 0,
-    "ctrlKey": 0,
-    "shiftKey": 0,
-    "altKey": 0,
-    "metaKey": 0,
-    "repeat": 0,
-    "locale": 0,
-    "getModifierState": (...) => Pd,
-    "charCode": (...) => (("keypress" === a["type"]) ? od(a) : 0),
-    "keyCode": (...) => ((("keydown" === a["type"]) || ("keyup" === a["type"])) ? a["keyCode"] : 0),
-    "which": (...) => (("keypress" === a["type"]) ? od(a) : ((("keydown" === a["type"]) || ("keyup" === a["type"])) ? a["keyCode"] : 0))
-}
-- *0* ((13 === a) ? "Enter" : FreeVar(String)["fromCharCode"](a))
-  ⚠️  sequence with side effects
+Qd = ???*0*
+- *0* Object.assign*1*(
+        {},
+        {
+            "eventPhase": 0,
+            "bubbles": 0,
+            "cancelable": 0,
+            "timeStamp": (...) => (a["timeStamp"] || FreeVar(Date)["now"]()),
+            "defaultPrevented": 0,
+            "isTrusted": 0,
+            "view": 0,
+            "detail": 0
+        },
+        ???*2*
+    )
+  ⚠️  only const object assign is supported
+  ⚠️  This value might have side effects
+- *1* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+- *2* node limit reached
   ⚠️  This value might have side effects
 
 Qe = ???*0*
@@ -1936,8 +1905,121 @@ Rd = (...) => ???*0*
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-Re = ???*0*
-- *0* max number of linking steps reached
+Re = (
+  | null
+  | ???*0*
+  | ???*1*
+  | ???*2*
+  | ???*4*
+  | null[`__reactFiber$${???*6*}`]
+  | null["parentNode"][`__reactContainer$${???*11*}`]
+  | null[`__reactFiber$${???*16*}`][`__reactContainer$${???*21*}`]
+  | null["parentNode"][`__reactFiber$${???*26*}`]
+  | null[`__reactFiber$${???*31*}`][`__reactFiber$${???*36*}`]
+  | null["parentNode"]
+  | null[`__reactFiber$${???*41*}`]["alternate"]
+  | []
+)
+- *0* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *1* unsupported expression
+  ⚠️  This value might have side effects
+- *2* ???*3*["return"]
+  ⚠️  unknown object
+- *3* d
+  ⚠️  circular variable reference
+- *4* ???*5*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* unsupported expression
+  ⚠️  This value might have side effects
+- *6* ???*7*["slice"](2)
+  ⚠️  unknown callee object
+- *7* ???*8*(36)
+  ⚠️  unknown callee
+- *8* ???*9*["toString"]
+  ⚠️  unknown object
+- *9* ???*10*()
+  ⚠️  nested operation
+- *10* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *11* ???*12*["slice"](2)
+  ⚠️  unknown callee object
+- *12* ???*13*(36)
+  ⚠️  unknown callee
+- *13* ???*14*["toString"]
+  ⚠️  unknown object
+- *14* ???*15*()
+  ⚠️  nested operation
+- *15* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *16* ???*17*["slice"](2)
+  ⚠️  unknown callee object
+- *17* ???*18*(36)
+  ⚠️  unknown callee
+- *18* ???*19*["toString"]
+  ⚠️  unknown object
+- *19* ???*20*()
+  ⚠️  nested operation
+- *20* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *21* ???*22*["slice"](2)
+  ⚠️  unknown callee object
+- *22* ???*23*(36)
+  ⚠️  unknown callee
+- *23* ???*24*["toString"]
+  ⚠️  unknown object
+- *24* ???*25*()
+  ⚠️  nested operation
+- *25* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *26* ???*27*["slice"](2)
+  ⚠️  unknown callee object
+- *27* ???*28*(36)
+  ⚠️  unknown callee
+- *28* ???*29*["toString"]
+  ⚠️  unknown object
+- *29* ???*30*()
+  ⚠️  nested operation
+- *30* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *31* ???*32*["slice"](2)
+  ⚠️  unknown callee object
+- *32* ???*33*(36)
+  ⚠️  unknown callee
+- *33* ???*34*["toString"]
+  ⚠️  unknown object
+- *34* ???*35*()
+  ⚠️  nested operation
+- *35* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *36* ???*37*["slice"](2)
+  ⚠️  unknown callee object
+- *37* ???*38*(36)
+  ⚠️  unknown callee
+- *38* ???*39*["toString"]
+  ⚠️  unknown object
+- *39* ???*40*()
+  ⚠️  nested operation
+- *40* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *41* ???*42*["slice"](2)
+  ⚠️  unknown callee object
+- *42* ???*43*(36)
+  ⚠️  unknown callee
+- *43* ???*44*["toString"]
+  ⚠️  unknown object
+- *44* ???*45*()
+  ⚠️  nested operation
+- *45* ???["random"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 
 Rf = `__reactHandles$${???*0*}`
@@ -1975,45 +2057,8 @@ Sb = {"onError": (...) => undefined}
 
 Sc = (...) => undefined
 
-Sd = {
-    "eventPhase": 0,
-    "bubbles": 0,
-    "cancelable": 0,
-    "timeStamp": (...) => (a["timeStamp"] || FreeVar(Date)["now"]()),
-    "defaultPrevented": 0,
-    "isTrusted": 0,
-    "view": 0,
-    "detail": 0,
-    "screenX": 0,
-    "screenY": 0,
-    "clientX": 0,
-    "clientY": 0,
-    "pageX": 0,
-    "pageY": 0,
-    "ctrlKey": 0,
-    "shiftKey": 0,
-    "altKey": 0,
-    "metaKey": 0,
-    "getModifierState": (...) => Pd,
-    "button": 0,
-    "buttons": 0,
-    "relatedTarget": (...) => ((???*0* === a["relatedTarget"]) ? ((a["fromElement"] === a["srcElement"]) ? a["toElement"] : a["fromElement"]) : a["relatedTarget"]),
-    "movementX": (...) => (a["movementX"] | wd),
-    "movementY": (...) => (???*1* ? a["movementY"] : xd),
-    "pointerId": 0,
-    "width": 0,
-    "height": 0,
-    "pressure": 0,
-    "tangentialPressure": 0,
-    "tiltX": 0,
-    "tiltY": 0,
-    "twist": 0,
-    "pointerType": 0,
-    "isPrimary": 0
-}
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
+Sd = ???*0*
+- *0* node limit reached
   ⚠️  This value might have side effects
 
 Se = ???*0*
@@ -2286,55 +2331,8 @@ Yc = (...) => (
   | null
 )
 
-Yd = {
-    "eventPhase": 0,
-    "bubbles": 0,
-    "cancelable": 0,
-    "timeStamp": (...) => (a["timeStamp"] || FreeVar(Date)["now"]()),
-    "defaultPrevented": 0,
-    "isTrusted": 0,
-    "view": 0,
-    "detail": 0,
-    "screenX": 0,
-    "screenY": 0,
-    "clientX": 0,
-    "clientY": 0,
-    "pageX": 0,
-    "pageY": 0,
-    "ctrlKey": 0,
-    "shiftKey": 0,
-    "altKey": 0,
-    "metaKey": 0,
-    "getModifierState": (...) => Pd,
-    "button": 0,
-    "buttons": 0,
-    "relatedTarget": (...) => ((???*0* === a["relatedTarget"]) ? ((a["fromElement"] === a["srcElement"]) ? a["toElement"] : a["fromElement"]) : a["relatedTarget"]),
-    "movementX": (...) => (a["movementX"] | wd),
-    "movementY": (...) => (???*1* ? a["movementY"] : xd),
-    "deltaX": (...) => (???*2* ? a["deltaX"] : (???*3* ? ???*4* : 0)),
-    "deltaY": (...) => (???*5* ? a["deltaY"] : (???*6* ? ???*7* : (???*8* ? ???*9* : 0))),
-    "deltaZ": 0,
-    "deltaMode": 0
-}
-- *0* unsupported expression
-  ⚠️  This value might have side effects
-- *1* unsupported expression
-  ⚠️  This value might have side effects
-- *2* unsupported expression
-  ⚠️  This value might have side effects
-- *3* unsupported expression
-  ⚠️  This value might have side effects
-- *4* unsupported expression
-  ⚠️  This value might have side effects
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* unsupported expression
-  ⚠️  This value might have side effects
-- *8* unsupported expression
-  ⚠️  This value might have side effects
-- *9* unsupported expression
+Yd = ???*0*
+- *0* node limit reached
   ⚠️  This value might have side effects
 
 Ye = ({} | ???*0*)
@@ -2381,8 +2379,8 @@ Yh = {
 
 Yi = (...) => undefined
 
-Yj = (false | ???*0* | true | ???*1* | ???*2*)
-- *0* e
+Yj = (false | ???*0* | ???*1* | ???*2* | true)
+- *0* Yj
   ⚠️  circular variable reference
 - *1* unsupported expression
   ⚠️  This value might have side effects
@@ -2417,26 +2415,9 @@ Zf = (...) => ((null !== a) && (???*0* !== a))
 
 Zg = (...) => ((3 === c["tag"]) ? c["stateNode"] : null)
 
-Zh = {
-    "readContext": (...) => b,
-    "useCallback": (...) => (d[0] | a),
-    "useContext": (...) => b,
-    "useEffect": (...) => ui(2048, 8, a, b),
-    "useImperativeHandle": (...) => ui(4, 4, yi["bind"](null, b, a), c),
-    "useInsertionEffect": (...) => ui(4, 2, a, b),
-    "useLayoutEffect": (...) => ui(4, 4, a, b),
-    "useMemo": (...) => (d[0] | a),
-    "useReducer": (...) => [b["memoizedState"], c["dispatch"]],
-    "useRef": (...) => di()["memoizedState"],
-    "useState": (...) => fi(ei),
-    "useDebugValue": (...) => undefined,
-    "useDeferredValue": (...) => Di(b, O["memoizedState"], a),
-    "useTransition": (...) => [a, b],
-    "useMutableSource": (...) => undefined,
-    "useSyncExternalStore": (...) => e,
-    "useId": (...) => di()["memoizedState"],
-    "unstable_isNewReconciler": false
-}
+Zh = ???*0*
+- *0* node limit reached
+  ⚠️  This value might have side effects
 
 Zi = (...) => (???*0* | b["child"])
 - *0* $i(a, b, e)
@@ -2506,8 +2487,8 @@ a#102 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["style"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#1020 = ???*0*
 - *0* arguments[0]
@@ -2525,71 +2506,33 @@ a#107 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#108 = (???*0* | ???*1* | ???*3* | ???*5*)
+a#108 = (???*0* | ???*1* | ???*3*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["target"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *3* ???*4*["target"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *4* FreeVar(window)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *5* FreeVar(window)
+- *2* a
+  ⚠️  circular variable reference
+- *3* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
 
-a#109 = (???*0* | (???*1* ? null : (???*13* | ???*14* | ???*22*)))
+a#109 = (???*0* | (???*1* ? null : (???*5* | ???*6*)))
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* !((???*2* | ???*3* | ???*11*))
+- *1* !((???*2* | ???*3*))
   ⚠️  nested operation
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *3* (???*4* ? null : (???*8* | ???*9*))
-  ⚠️  nested operation
-- *4* !((???*5* | ???*6*))
-  ⚠️  nested operation
+- *2* a
+  ⚠️  circular variable reference
+- *3* ???*4*[Of]
+  ⚠️  unknown object
+- *4* a
+  ⚠️  circular variable reference
 - *5* a
   ⚠️  circular variable reference
 - *6* ???*7*[Of]
   ⚠️  unknown object
 - *7* a
-  ⚠️  circular variable reference
-- *8* a
-  ⚠️  circular variable reference
-- *9* ???*10*[Of]
-  ⚠️  unknown object
-- *10* a
-  ⚠️  circular variable reference
-- *11* ???*12*[Of]
-  ⚠️  unknown object
-- *12* a
-  ⚠️  circular variable reference
-- *13* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *14* (???*15* ? null : (???*19* | ???*20*))
-  ⚠️  nested operation
-- *15* !((???*16* | ???*17*))
-  ⚠️  nested operation
-- *16* a
-  ⚠️  circular variable reference
-- *17* ???*18*[Of]
-  ⚠️  unknown object
-- *18* a
-  ⚠️  circular variable reference
-- *19* a
-  ⚠️  circular variable reference
-- *20* ???*21*[Of]
-  ⚠️  unknown object
-- *21* a
-  ⚠️  circular variable reference
-- *22* ???*23*[Of]
-  ⚠️  unknown object
-- *23* a
   ⚠️  circular variable reference
 
 a#11 = ???*0*
@@ -2614,20 +2557,13 @@ a#116 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#119 = (
-  | ???*0*
-  | ???*1*
-  | !((???*3* | null | ???*6*))["type"]
-  | false["type"]
-  | !((???*9* | false["stateNode"][???*16*] | null | ???*21*))
-  | false
-)
+a#119 = (???*0* | ???*1* | !((???*3* | null | ???*6*)) | false)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["type"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 - *3* ???*4*[Pf]
   ⚠️  unknown object
 - *4* ???*5*["stateNode"]
@@ -2639,36 +2575,6 @@ a#119 = (
 - *7* ???*8*["disabled"]
   ⚠️  unknown object
 - *8* d
-  ⚠️  circular variable reference
-- *9* ???*10*[`__reactProps$${???*12*}`]
-  ⚠️  unknown object
-- *10* ???*11*["stateNode"]
-  ⚠️  unknown object
-- *11* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *12* ???*13*["slice"](2)
-  ⚠️  unknown callee object
-- *13* ???*14*(36)
-  ⚠️  unknown callee
-- *14* ???*15*["toString"]
-  ⚠️  unknown object
-- *15* ???()
-  ⚠️  nested operation
-- *16* `__reactProps$${???*17*}`
-  ⚠️  nested operation
-- *17* ???*18*["slice"](2)
-  ⚠️  unknown callee object
-- *18* ???*19*(36)
-  ⚠️  unknown callee
-- *19* ???*20*["toString"]
-  ⚠️  unknown object
-- *20* ???()
-  ⚠️  nested operation
-- *21* !(???*22*)
-  ⚠️  nested operation
-- *22* ???*23*["disabled"]
-  ⚠️  unknown object
-- *23* d
   ⚠️  circular variable reference
 
 a#12 = ???*0*
@@ -2702,7 +2608,7 @@ a#13 = ???*0*
 a#131 = (???*0* | ???*1* | ???*2*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* b
+- *1* a
   ⚠️  circular variable reference
 - *2* ???*3*["return"]
   ⚠️  unknown object
@@ -2714,8 +2620,8 @@ a#133 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#135 = ???*0*
 - *0* arguments[0]
@@ -2733,17 +2639,92 @@ a#15 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#151 = ???*0*
-- *0* max number of linking steps reached
+a#151 = (???*0* | (???*1* ? null : ???*12*) | ???*13* | (???*14* ? ???*28* : (???*29* | ???*31*)))
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* ((???*2* | ???*4*) !== ???*11*)
+  ⚠️  nested operation
+- *2* ???*3*["alternate"]
+  ⚠️  unknown object
+- *3* a
+  ⚠️  circular variable reference
+- *4* (???*5* ? (???*8* | ???*9*) : null)
+  ⚠️  nested operation
+- *5* (3 === ???*6*)
+  ⚠️  nested operation
+- *6* ???*7*["tag"]
+  ⚠️  unknown object
+- *7* a
+  ⚠️  circular variable reference
+- *8* a
+  ⚠️  circular variable reference
+- *9* ???*10*["return"]
+  ⚠️  unknown object
+- *10* b
+  ⚠️  circular variable reference
+- *11* a
+  ⚠️  circular variable reference
+- *12* a
+  ⚠️  circular variable reference
+- *13* a
+  ⚠️  sequence with side effects
   ⚠️  This value might have side effects
+- *14* (???*15* === (???*18* | ???*19* | ???*21*))
+  ⚠️  nested operation
+- *15* ???*16*["current"]
+  ⚠️  unknown object
+- *16* ???*17*["stateNode"]
+  ⚠️  unknown object
+- *17* a
+  ⚠️  circular variable reference
+- *18* a
+  ⚠️  circular variable reference
+- *19* ???*20*["alternate"]
+  ⚠️  unknown object
+- *20* a
+  ⚠️  circular variable reference
+- *21* (???*22* ? (???*25* | ???*26*) : null)
+  ⚠️  nested operation
+- *22* (3 === ???*23*)
+  ⚠️  nested operation
+- *23* ???*24*["tag"]
+  ⚠️  unknown object
+- *24* a
+  ⚠️  circular variable reference
+- *25* a
+  ⚠️  circular variable reference
+- *26* ???*27*["return"]
+  ⚠️  unknown object
+- *27* b
+  ⚠️  circular variable reference
+- *28* a
+  ⚠️  circular variable reference
+- *29* ???*30*["alternate"]
+  ⚠️  unknown object
+- *30* a
+  ⚠️  circular variable reference
+- *31* (???*32* ? (???*35* | ???*36*) : null)
+  ⚠️  nested operation
+- *32* (3 === ???*33*)
+  ⚠️  nested operation
+- *33* ???*34*["tag"]
+  ⚠️  unknown object
+- *34* a
+  ⚠️  circular variable reference
+- *35* a
+  ⚠️  circular variable reference
+- *36* ???*37*["return"]
+  ⚠️  unknown object
+- *37* b
+  ⚠️  circular variable reference
 
 a#152 = (???*0* | ???*1*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#154 = ???*0*
 - *0* arguments[0]
@@ -2764,8 +2745,8 @@ a#159 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["entanglements"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#16 = ???*0*
 - *0* arguments[0]
@@ -2798,16 +2779,16 @@ a#168 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["eventTimes"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#169 = (???*0* | ???*1*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["expirationTimes"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#17 = ???*0*
 - *0* arguments[0]
@@ -2818,8 +2799,8 @@ a#171 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["entanglements"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#173 = (???*0* | ???*1*)
 - *0* arguments[0]
@@ -2834,11 +2815,11 @@ a#174 = ???*0*
 a#175 = (
   | ???*0*
   | {
-        "blockedOn": (???*1* | (???*2* ? null : (???*6* | ???*7*)) | ???*9* | [???*11*] | ???*12*),
-        "domEventName": ???*13*,
-        "eventSystemFlags": ???*14*,
-        "nativeEvent": ???*15*,
-        "targetContainers": [???*16*]
+        "blockedOn": (???*1* | (???*2* ? null : (???*6* | ???*7*)) | ???*9*),
+        "domEventName": ???*11*,
+        "eventSystemFlags": ???*12*,
+        "nativeEvent": ???*13*,
+        "targetContainers": [???*14*]
     }
 )
 - *0* arguments[0]
@@ -2861,19 +2842,15 @@ a#175 = (
   ⚠️  circular variable reference
 - *9* ???*10*["targetContainers"]
   ⚠️  unknown object
-- *10* arguments[0]
+- *10* a
+  ⚠️  circular variable reference
+- *11* arguments[2]
   ⚠️  function calls are not analysed yet
-- *11* arguments[4]
+- *12* arguments[3]
   ⚠️  function calls are not analysed yet
-- *12* unknown mutation
-  ⚠️  This value might have side effects
-- *13* arguments[2]
+- *13* arguments[5]
   ⚠️  function calls are not analysed yet
-- *14* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *15* arguments[5]
-  ⚠️  function calls are not analysed yet
-- *16* arguments[4]
+- *14* arguments[4]
   ⚠️  function calls are not analysed yet
 
 a#176 = ???*0*
@@ -2924,9 +2901,165 @@ a#20 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#203 = ???*0*
-- *0* max number of linking steps reached
+a#203 = (
+  | ???*0*
+  | (???*1* ? (???*6* | ???*8*) : (???*10* | ???*11* | ???*13*))
+  | ???*14*
+  | null[`__reactFiber$${???*20*}`]
+  | null["parentNode"][`__reactContainer$${???*25*}`]
+  | null[`__reactFiber$${???*30*}`][`__reactContainer$${???*35*}`]
+  | null["parentNode"][`__reactFiber$${???*40*}`]
+  | null[`__reactFiber$${???*45*}`][`__reactFiber$${???*50*}`]
+  | null["parentNode"]
+  | null[`__reactFiber$${???*55*}`]["alternate"]
+  | null
+  | (???*60* ? (???*63* | ???*64*) : null)["memoizedState"]["dehydrated"]
+)
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* (3 === (???*2* | ???*4*))
+  ⚠️  nested operation
+- *2* ???*3*["nodeType"]
+  ⚠️  unknown object
+- *3* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *4* ???*5*["nodeType"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
+- *5* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *6* ???*7*["parentNode"]
+  ⚠️  unknown object
+- *7* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *8* ???*9*["parentNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *9* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *10* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *11* ???*12*["target"]
+  ⚠️  unknown object
+- *12* a
+  ⚠️  circular variable reference
+- *13* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *14* ???*15*[`__reactFiber$${???*16*}`]
+  ⚠️  unknown object
+- *15* a
+  ⚠️  circular variable reference
+- *16* ???*17*["slice"](2)
+  ⚠️  unknown callee object
+- *17* ???*18*(36)
+  ⚠️  unknown callee
+- *18* ???*19*["toString"]
+  ⚠️  unknown object
+- *19* ???()
+  ⚠️  nested operation
+- *20* ???*21*["slice"](2)
+  ⚠️  unknown callee object
+- *21* ???*22*(36)
+  ⚠️  unknown callee
+- *22* ???*23*["toString"]
+  ⚠️  unknown object
+- *23* ???*24*()
+  ⚠️  nested operation
+- *24* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *25* ???*26*["slice"](2)
+  ⚠️  unknown callee object
+- *26* ???*27*(36)
+  ⚠️  unknown callee
+- *27* ???*28*["toString"]
+  ⚠️  unknown object
+- *28* ???*29*()
+  ⚠️  nested operation
+- *29* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *30* ???*31*["slice"](2)
+  ⚠️  unknown callee object
+- *31* ???*32*(36)
+  ⚠️  unknown callee
+- *32* ???*33*["toString"]
+  ⚠️  unknown object
+- *33* ???*34*()
+  ⚠️  nested operation
+- *34* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *35* ???*36*["slice"](2)
+  ⚠️  unknown callee object
+- *36* ???*37*(36)
+  ⚠️  unknown callee
+- *37* ???*38*["toString"]
+  ⚠️  unknown object
+- *38* ???*39*()
+  ⚠️  nested operation
+- *39* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *40* ???*41*["slice"](2)
+  ⚠️  unknown callee object
+- *41* ???*42*(36)
+  ⚠️  unknown callee
+- *42* ???*43*["toString"]
+  ⚠️  unknown object
+- *43* ???*44*()
+  ⚠️  nested operation
+- *44* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *45* ???*46*["slice"](2)
+  ⚠️  unknown callee object
+- *46* ???*47*(36)
+  ⚠️  unknown callee
+- *47* ???*48*["toString"]
+  ⚠️  unknown object
+- *48* ???*49*()
+  ⚠️  nested operation
+- *49* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *50* ???*51*["slice"](2)
+  ⚠️  unknown callee object
+- *51* ???*52*(36)
+  ⚠️  unknown callee
+- *52* ???*53*["toString"]
+  ⚠️  unknown object
+- *53* ???*54*()
+  ⚠️  nested operation
+- *54* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *55* ???*56*["slice"](2)
+  ⚠️  unknown callee object
+- *56* ???*57*(36)
+  ⚠️  unknown callee
+- *57* ???*58*["toString"]
+  ⚠️  unknown object
+- *58* ???*59*()
+  ⚠️  nested operation
+- *59* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *60* (3 === ???*61*)
+  ⚠️  nested operation
+- *61* ???*62*["tag"]
+  ⚠️  unknown object
+- *62* a
+  ⚠️  circular variable reference
+- *63* a
+  ⚠️  circular variable reference
+- *64* ???*65*["return"]
+  ⚠️  unknown object
+- *65* b
+  ⚠️  circular variable reference
 
 a#206 = ???*0*
 - *0* arguments[0]
@@ -2938,13 +3071,13 @@ a#207 = (???*0* | 0 | ???*1*)
 - *1* updated with update expression
   ⚠️  This value might have side effects
 
-a#208 = (???*0* | ???*1* | 13["charCode"] | 13 | 13["keyCode"])
+a#208 = (???*0* | ???*1* | 13)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["charCode"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#21 = ???*0*
 - *0* arguments[0]
@@ -2992,77 +3125,33 @@ a#220 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#221 = (???*0* | "altKey" | "ctrlKey" | "metaKey" | "shiftKey" | ???*1* | ???*3* | ???*4*)
+a#221 = (???*0* | "altKey" | "ctrlKey" | "metaKey" | "shiftKey" | ???*1*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* {}[???*2*]
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *3* FreeVar(undefined)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *4* unknown mutation
-  ⚠️  This value might have side effects
+- *2* a
+  ⚠️  circular variable reference
 
-a#223 = (
-  | ???*0*
-  | ((???*1* | ???*2*) ? (???*15* | ???*16* | ???*25* | 13) : 0)
-)
+a#223 = (???*0* | ((???*1* | ???*2*) ? (???*6* | ???*7* | 13) : 0))
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
-- *2* (13 === (???*3* | ???*4* | ???*13* | 13))
+- *2* (13 === (???*3* | ???*4* | 13))
   ⚠️  nested operation
-- *3* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *4* ((???*5* | ???*6*) ? (???*10* | ???*11* | 13) : 0)
-  ⚠️  nested operation
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* (13 === (???*7* | ???*8* | 13))
-  ⚠️  nested operation
-- *7* a
+- *3* a
   ⚠️  circular variable reference
-- *8* ???*9*["charCode"]
+- *4* ???*5*["charCode"]
   ⚠️  unknown object
-- *9* a
+- *5* a
   ⚠️  circular variable reference
-- *10* a
+- *6* a
   ⚠️  circular variable reference
-- *11* ???*12*["charCode"]
+- *7* ???*8*["charCode"]
   ⚠️  unknown object
-- *12* a
-  ⚠️  circular variable reference
-- *13* ???*14*["charCode"]
-  ⚠️  unknown object
-- *14* a
-  ⚠️  circular variable reference
-- *15* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *16* ((???*17* | ???*18*) ? (???*22* | ???*23* | 13) : 0)
-  ⚠️  nested operation
-- *17* unsupported expression
-  ⚠️  This value might have side effects
-- *18* (13 === (???*19* | ???*20* | 13))
-  ⚠️  nested operation
-- *19* a
-  ⚠️  circular variable reference
-- *20* ???*21*["charCode"]
-  ⚠️  unknown object
-- *21* a
-  ⚠️  circular variable reference
-- *22* a
-  ⚠️  circular variable reference
-- *23* ???*24*["charCode"]
-  ⚠️  unknown object
-- *24* a
-  ⚠️  circular variable reference
-- *25* ???*26*["charCode"]
-  ⚠️  unknown object
-- *26* a
+- *8* a
   ⚠️  circular variable reference
 
 a#225 = ???*0*
@@ -3098,8 +3187,8 @@ a#231 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["detail"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#232 = (???*0* | ???*1*)
 - *0* arguments[0]
@@ -3205,36 +3294,29 @@ a#253 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["firstChild"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
-a#254 = (
-  | ???*0*
-  | 0
-  | ???*1*
-  | ((???*2* | 0 | ???*3*) + (???*4* | 0["textContent"]["length"] | ???*7*))
-)
+a#254 = (???*0* | 0 | ???*1* | (???*2* + (???*3* | ???*6*)))
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* d
   ⚠️  pattern without value
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *3* d
+- *2* a
   ⚠️  circular variable reference
-- *4* ???*5*["length"]
+- *3* ???*4*["length"]
   ⚠️  unknown object
-- *5* ???*6*["textContent"]
+- *4* ???*5*["textContent"]
   ⚠️  unknown object
-- *6* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *7* ???*8*["length"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *8* ???*9*["textContent"]
+- *5* a
+  ⚠️  circular variable reference
+- *6* ???*7*["length"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *9* unsupported expression
+- *7* ???*8*["textContent"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *8* unsupported expression
   ⚠️  This value might have side effects
 
 a#26 = (???*0* | ???*1* | ???*3*)
@@ -3246,10 +3328,10 @@ a#26 = (???*0* | ???*1* | ???*3*)
 - *2* FreeVar(Symbol)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *3* ???*4*["@@iterator"]
+- *3* ???*4*[Ja]
   ⚠️  unknown object
-- *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *4* a
+  ⚠️  circular variable reference
 
 a#260 = ???*0*
 - *0* arguments[0]
@@ -3263,10 +3345,9 @@ a#261 = (
   | (???*4* ? ???*7* : ???*8*)["activeElement"]["contentWindow"]
   | (???*9* ? ???*12* : ???*13*)["body"]["contentWindow"]
   | (???*14* ? ???*17* : ???*18*)["body"]["contentWindow"]
-  | ???*19*
-  | (???*23* ? ???*26* : ???*27*)["activeElement"]["contentWindow"]
-  | (???*28* ? ???*31* : ???*32*)["body"]["contentWindow"]
-  | (???*33* ? ???*36* : ???*37*)["body"]["contentWindow"]
+  | (???*19* ? ???*22* : ???*23*)["activeElement"]["contentWindow"]
+  | (???*24* ? ???*27* : ???*28*)["body"]["contentWindow"]
+  | (???*29* ? ???*32* : ???*33*)["body"]["contentWindow"]
 )
 - *0* FreeVar(window)
   ⚠️  unknown global
@@ -3312,53 +3393,41 @@ a#261 = (
   ⚠️  This value might have side effects
 - *18* unsupported expression
   ⚠️  This value might have side effects
-- *19* ???*20*["contentWindow"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *20* ???*21*["activeElement"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *21* ???*22*["document"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *22* FreeVar(window)
+- *19* ("undefined" !== ???*20*)
+  ⚠️  nested operation
+- *20* typeof(???*21*)
+  ⚠️  nested operation
+- *21* FreeVar(document)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *23* ("undefined" !== ???*24*)
-  ⚠️  nested operation
-- *24* typeof(???*25*)
-  ⚠️  nested operation
-- *25* FreeVar(document)
+- *22* FreeVar(document)
   ⚠️  unknown global
   ⚠️  This value might have side effects
+- *23* unsupported expression
+  ⚠️  This value might have side effects
+- *24* ("undefined" !== ???*25*)
+  ⚠️  nested operation
+- *25* typeof(???*26*)
+  ⚠️  nested operation
 - *26* FreeVar(document)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *27* unsupported expression
-  ⚠️  This value might have side effects
-- *28* ("undefined" !== ???*29*)
-  ⚠️  nested operation
-- *29* typeof(???*30*)
-  ⚠️  nested operation
-- *30* FreeVar(document)
+- *27* FreeVar(document)
   ⚠️  unknown global
   ⚠️  This value might have side effects
+- *28* unsupported expression
+  ⚠️  This value might have side effects
+- *29* ("undefined" !== ???*30*)
+  ⚠️  nested operation
+- *30* typeof(???*31*)
+  ⚠️  nested operation
 - *31* FreeVar(document)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *32* unsupported expression
-  ⚠️  This value might have side effects
-- *33* ("undefined" !== ???*34*)
-  ⚠️  nested operation
-- *34* typeof(???*35*)
-  ⚠️  nested operation
-- *35* FreeVar(document)
+- *32* FreeVar(document)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *36* FreeVar(document)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *37* unsupported expression
+- *33* unsupported expression
   ⚠️  This value might have side effects
 
 a#265 = ???*0*
@@ -3421,23 +3490,15 @@ a#3 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#30 = (???*0* | ((???*1* | ???*2*) ? ???*6* : ""))
+a#30 = (???*0* | (???*1* ? ???*2* : ""))
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *2* (???*3* ? ???*4* : "")
-  ⚠️  nested operation
+- *1* a
+  ⚠️  circular variable reference
+- *2* ???*3*["displayName"]
+  ⚠️  unknown object
 - *3* a
   ⚠️  circular variable reference
-- *4* ???*5*["displayName"]
-  ⚠️  unknown object
-- *5* a
-  ⚠️  circular variable reference
-- *6* ???*7*["displayName"]
-  ⚠️  unknown object
-- *7* arguments[0]
-  ⚠️  function calls are not analysed yet
 
 a#307 = ???*0*
 - *0* arguments[0]
@@ -3448,16 +3509,16 @@ a#308 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#310 = (???*0* | ???*1*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#311 = ???*0*
 - *0* arguments[0]
@@ -3492,26 +3553,18 @@ a#324 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["nextSibling"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#327 = (???*0* | ???*1*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["previousSibling"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
-a#331 = (
-  | ???*0*
-  | ???*1*
-  | ???*2*
-  | null
-  | null["parentNode"]
-  | null[`__reactFiber$${???*4*}`]["alternate"]
-  | null[`__reactFiber$${???*9*}`]
-)
+a#331 = (???*0* | ???*1* | ???*2* | null)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* a
@@ -3520,44 +3573,14 @@ a#331 = (
   ⚠️  unknown object
 - *3* a
   ⚠️  circular variable reference
-- *4* ???*5*["slice"](2)
-  ⚠️  unknown callee object
-- *5* ???*6*(36)
-  ⚠️  unknown callee
-- *6* ???*7*["toString"]
-  ⚠️  unknown object
-- *7* ???*8*()
-  ⚠️  nested operation
-- *8* ???["random"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *9* ???*10*["slice"](2)
-  ⚠️  unknown callee object
-- *10* ???*11*(36)
-  ⚠️  unknown callee
-- *11* ???*12*["toString"]
-  ⚠️  unknown object
-- *12* ???*13*()
-  ⚠️  nested operation
-- *13* ???["random"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
 
 a#335 = (???*0* | ???*1*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* ???*2*[`__reactFiber$${???*3*}`]
+- *1* ???*2*[Of]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *3* ???*4*["slice"](2)
-  ⚠️  unknown callee object
-- *4* ???*5*(36)
-  ⚠️  unknown callee
-- *5* ???*6*["toString"]
-  ⚠️  unknown object
-- *6* ???()
-  ⚠️  nested operation
+- *2* a
+  ⚠️  circular variable reference
 
 a#336 = ???*0*
 - *0* arguments[0]
@@ -3584,16 +3607,16 @@ a#341 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#342 = (???*0* | ???*1*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["childContextTypes"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#344 = ???*0*
 - *0* arguments[0]
@@ -3603,32 +3626,22 @@ a#345 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#346 = (???*0* | ???*1* | ???*2* | ???*4* | ???*6* | ???*7* | {})
+a#346 = (???*0* | ???*1* | ???*2* | {})
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* ???*3*["__reactInternalMemoizedMergedChildContext"]
   ⚠️  unknown object
-- *3* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *4* ???*5*["__reactInternalMemoizedMergedChildContext"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *5* unsupported expression
-  ⚠️  This value might have side effects
-- *6* FreeVar(undefined)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *7* unknown mutation
-  ⚠️  This value might have side effects
+- *3* a
+  ⚠️  circular variable reference
 
 a#347 = (???*0* | {} | ???*1* | ???*2*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* unknown mutation
   ⚠️  This value might have side effects
-- *2* Object.assign*3*({}, ({} | ???*4*), (???*5* | ???*7* | ???*8* | ???*9* | ???*11*()))
+- *2* Object.assign*3*({}, ({} | ???*4*), (???*5* | ???*7*()))
   ⚠️  only const object assign is supported
   ⚠️  This value might have side effects
 - *3* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
@@ -3636,21 +3649,11 @@ a#347 = (???*0* | {} | ???*1* | ???*2*)
   ⚠️  This value might have side effects
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
-- *6* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *7* FreeVar(undefined)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *8* unknown mutation
-  ⚠️  This value might have side effects
-- *9* ???*10*["stateNode"]
+- *6* a
+  ⚠️  circular variable reference
+- *7* ???*8*["getChildContext"]
   ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *10* unknown mutation
-  ⚠️  This value might have side effects
-- *11* ???*12*["getChildContext"]
-  ⚠️  unknown object
-- *12* d
+- *8* d
   ⚠️  circular variable reference
 
 a#348 = ???*0*
@@ -3702,22 +3705,16 @@ a#369 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
-a#370 = (
-  | ???*0*
-  | ???*1*
-  | (???*3* ? ???*5* : null)["memoizedState"]
-  | (???*7* ? ???*16* : null)
-  | (???*18* ? ???*20* : null)["nextSibling"]
-)
+a#370 = (???*0* | ???*1* | (???*3* ? ???*5* : null))
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["memoizedState"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 - *3* (null !== ???*4*)
   ⚠️  nested operation
 - *4* a
@@ -3725,36 +3722,6 @@ a#370 = (
 - *5* ???*6*["dehydrated"]
   ⚠️  unknown object
 - *6* a
-  ⚠️  circular variable reference
-- *7* (null !== (???*8* | ???*9* | ???*11*))
-  ⚠️  nested operation
-- *8* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *9* ???*10*["memoizedState"]
-  ⚠️  unknown object
-- *10* a
-  ⚠️  circular variable reference
-- *11* (???*12* ? ???*14* : null)
-  ⚠️  nested operation
-- *12* (null !== ???*13*)
-  ⚠️  nested operation
-- *13* a
-  ⚠️  circular variable reference
-- *14* ???*15*["dehydrated"]
-  ⚠️  unknown object
-- *15* a
-  ⚠️  circular variable reference
-- *16* ???*17*["dehydrated"]
-  ⚠️  unknown object
-- *17* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *18* (null !== ???*19*)
-  ⚠️  nested operation
-- *19* a
-  ⚠️  circular variable reference
-- *20* ???*21*["dehydrated"]
-  ⚠️  unknown object
-- *21* a
   ⚠️  circular variable reference
 
 a#378 = ???*0*
@@ -3770,8 +3737,8 @@ a#381 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["defaultProps"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#384 = ???*0*
 - *0* arguments[0]
@@ -3782,47 +3749,29 @@ a#385 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#387 = (???*0* | ???*1*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["dependencies"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#388 = (
   | ???*0*
-  | {
-        "context": (
-          | ???*1*
-          | {"context": ???*2*, "memoizedValue": ???*3*, "next": null}
-        ),
-        "memoizedValue": (???*5* | ???*7* | ???*8*),
-        "next": null
-    }
+  | {"context": ???*1*, "memoizedValue": ???*2*, "next": null}
 )
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *2* a
+- *1* a
   ⚠️  circular variable reference
-- *3* ???*4*["_currentValue"]
+- *2* ???*3*["_currentValue"]
   ⚠️  unknown object
-- *4* a
+- *3* a
   ⚠️  circular variable reference
-- *5* ???*6*["_currentValue"]
-  ⚠️  unknown object
-- *6* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *7* FreeVar(undefined)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *8* unknown mutation
-  ⚠️  This value might have side effects
 
 a#390 = ???*0*
 - *0* arguments[0]
@@ -3837,8 +3786,8 @@ a#392 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#393 = ???*0*
 - *0* arguments[0]
@@ -3849,8 +3798,8 @@ a#394 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#395 = ???*0*
 - *0* arguments[0]
@@ -3889,8 +3838,8 @@ a#400 = (
   ⚠️  unknown object
 - *2* ???*3*["updateQueue"]
   ⚠️  unknown object
-- *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *3* a
+  ⚠️  circular variable reference
 - *4* ???*5*["eventTime"]
   ⚠️  unknown object
 - *5* c
@@ -3942,48 +3891,48 @@ a#416 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["_reactInternals"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#417 = (???*0* | ???*1*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["_reactInternals"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#418 = (???*0* | ???*1*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["_reactInternals"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#419 = (???*0* | ???*1*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["_reactInternals"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#420 = (???*0* | ???*1*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#421 = (???*0* | ???*1*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#422 = (???*0* | ???*1*)
 - *0* arguments[0]
@@ -4041,15 +3990,14 @@ a#435 = (???*0* | new ???*1*())
 a#436 = (
   | ???*0*
   | ???*1*
-  | new (...) => undefined(???*3*, (???*5* | ???*6*), ???*8*, ???*10*)["alternate"]
-  | new (...) => undefined(???*12*, (???*14* | ???*15*), ???*17*, ???*19*)
+  | new (...) => undefined(???*3*, (???*5* | ???*6*), ???*8*, ???*10*)
 )
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 - *3* ???*4*["tag"]
   ⚠️  unknown object
 - *4* a
@@ -4068,24 +4016,6 @@ a#436 = (
   ⚠️  unknown object
 - *11* a
   ⚠️  circular variable reference
-- *12* ???*13*["tag"]
-  ⚠️  unknown object
-- *13* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *14* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *15* ???*16*["dependencies"]
-  ⚠️  unknown object
-- *16* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *17* ???*18*["key"]
-  ⚠️  unknown object
-- *18* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *19* ???*20*["mode"]
-  ⚠️  unknown object
-- *20* arguments[0]
-  ⚠️  function calls are not analysed yet
 
 a#439 = ???*0*
 - *0* arguments[0]
@@ -4111,31 +4041,13 @@ a#445 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#447 = (???*0* | ???*1* | null["get"](???*4*) | null | null["get"](???*5*))
+a#447 = (???*0* | ???*1* | null)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* ???*2*["get"](???*3*)
+- *1* ???*2*["get"](c)
   ⚠️  unknown callee object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *3* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *4* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *5* (???*6* ? ???*9* : ???*10*)
-  ⚠️  nested operation
-- *6* (null === ???*7*)
-  ⚠️  nested operation
-- *7* ???*8*["key"]
-  ⚠️  unknown object
-- *8* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *9* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *10* ???*11*["key"]
-  ⚠️  unknown object
-- *11* arguments[3]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#453 = ???*0*
 - *0* arguments[0]
@@ -4153,9 +4065,83 @@ a#471 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#472 = ???*0*
-- *0* max number of linking steps reached
+a#472 = (
+  | ???*0*
+  | ???*1*
+  | (???*3* ? ???*4* : ???*6*)["nodeType"]
+  | null["nodeType"]
+  | (???*8* ? (
+      | undefined
+      | "http://www.w3.org/2000/svg"
+      | "http://www.w3.org/1998/Math/MathML"
+      | "http://www.w3.org/1999/xhtml"
+    ) : ???*10*)["nodeType"]
+  | (???*14* ? (???*16* | null["parentNode"]) : (???*18* | ???*19* | ???*25* | null))
+)
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* ???*2*["nodeType"]
+  ⚠️  unknown object
+- *2* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *3* unsupported expression
   ⚠️  This value might have side effects
+- *4* ???*5*["namespaceURI"]
+  ⚠️  unknown object
+- *5* b
+  ⚠️  circular variable reference
+- *6* ((???*7* | false) ? (
+      | undefined
+      | "http://www.w3.org/2000/svg"
+      | "http://www.w3.org/1998/Math/MathML"
+      | "http://www.w3.org/1999/xhtml"
+    ) : null)
+  ⚠️  nested operation
+- *7* (null == null)
+  ⚠️  nested operation
+- *8* (null == ???*9*)
+  ⚠️  nested operation
+- *9* b
+  ⚠️  circular variable reference
+- *10* (???*11* ? "http://www.w3.org/1999/xhtml" : ???*13*)
+  ⚠️  nested operation
+- *11* ("http://www.w3.org/2000/svg" === ???*12*)
+  ⚠️  nested operation
+- *12* b
+  ⚠️  circular variable reference
+- *13* b
+  ⚠️  circular variable reference
+- *14* (8 === ???*15*)
+  ⚠️  nested operation
+- *15* a
+  ⚠️  circular variable reference
+- *16* ???*17*["parentNode"]
+  ⚠️  unknown object
+- *17* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *18* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *19* (???*20* ? ???*21* : ???*23*)
+  ⚠️  nested operation
+- *20* unsupported expression
+  ⚠️  This value might have side effects
+- *21* ???*22*["namespaceURI"]
+  ⚠️  unknown object
+- *22* b
+  ⚠️  circular variable reference
+- *23* ((???*24* | false) ? (
+      | undefined
+      | "http://www.w3.org/2000/svg"
+      | "http://www.w3.org/1998/Math/MathML"
+      | "http://www.w3.org/1999/xhtml"
+    ) : null)
+  ⚠️  nested operation
+- *24* (null == null)
+  ⚠️  nested operation
+- *25* ???*26*["documentElement"]
+  ⚠️  unknown object
+- *26* b
+  ⚠️  circular variable reference
 
 a#474 = ???*0*
 - *0* arguments[0]
@@ -4191,20 +4177,234 @@ a#488 = (0 !== (0 | ???*0*))
 
 a#489 = {"memoizedState": null, "baseState": null, "baseQueue": null, "queue": null, "next": null}
 
-a#49 = ???*0*
-- *0* max number of linking steps reached
+a#49 = (
+  | ???*0*
+  | ""
+  | `
+${???*1*}`
+  | ???*6*
+  | (???*8* ? ???*9* : "")
+  | (???*25* ? ???*26* : "")
+  | (???*43* ? ???*44* : "")
+)
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* ???*2*["replace"](" at new ", " at ")
+  ⚠️  unknown callee object
+- *2* ???*3*[g]
+  ⚠️  unknown object
+- *3* ???*4*["split"]("\n")
+  ⚠️  unknown callee object
+- *4* ???*5*["stack"]
+  ⚠️  unknown object
+- *5* l
+  ⚠️  pattern without value
+- *6* ???*7*["replace"]("<anonymous>", a["displayName"])
+  ⚠️  unknown callee object
+- *7* k
+  ⚠️  circular variable reference
+- *8* unsupported expression
   ⚠️  This value might have side effects
+- *9* `
+${(???*10* | ???*11* | ???*15* | "")}${(???*19* | ???*21*)}`
+  ⚠️  nested operation
+- *10* La
+  ⚠️  pattern without value
+- *11* ???*12*(/\n( *(at )?)/)
+  ⚠️  unknown callee
+- *12* ???*13*["match"]
+  ⚠️  unknown object
+- *13* ???*14*()
+  ⚠️  nested operation
+- *14* ???["trim"]
+  ⚠️  unknown object
+- *15* ???*16*[1]
+  ⚠️  unknown object
+- *16* ???*17*(/\n( *(at )?)/)
+  ⚠️  unknown callee
+- *17* ???*18*["match"]
+  ⚠️  unknown object
+- *18* ???()
+  ⚠️  nested operation
+- *19* ???*20*["type"]
+  ⚠️  unknown object
+- *20* a
+  ⚠️  circular variable reference
+- *21* (???*22* ? ???*23* : "")
+  ⚠️  nested operation
+- *22* a
+  ⚠️  circular variable reference
+- *23* ???*24*["displayName"]
+  ⚠️  unknown object
+- *24* a
+  ⚠️  circular variable reference
+- *25* unsupported expression
+  ⚠️  This value might have side effects
+- *26* `
+${(???*27* | ???*28* | ???*32* | "")}${(???*36* | ???*39*)}`
+  ⚠️  nested operation
+- *27* La
+  ⚠️  pattern without value
+- *28* ???*29*(/\n( *(at )?)/)
+  ⚠️  unknown callee
+- *29* ???*30*["match"]
+  ⚠️  unknown object
+- *30* ???*31*()
+  ⚠️  nested operation
+- *31* ???["trim"]
+  ⚠️  unknown object
+- *32* ???*33*[1]
+  ⚠️  unknown object
+- *33* ???*34*(/\n( *(at )?)/)
+  ⚠️  unknown callee
+- *34* ???*35*["match"]
+  ⚠️  unknown object
+- *35* ???()
+  ⚠️  nested operation
+- *36* ???*37*["render"]
+  ⚠️  unknown object
+- *37* ???*38*["type"]
+  ⚠️  unknown object
+- *38* a
+  ⚠️  circular variable reference
+- *39* (???*40* ? ???*41* : "")
+  ⚠️  nested operation
+- *40* a
+  ⚠️  circular variable reference
+- *41* ???*42*["displayName"]
+  ⚠️  unknown object
+- *42* a
+  ⚠️  circular variable reference
+- *43* unsupported expression
+  ⚠️  This value might have side effects
+- *44* `
+${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
+  ⚠️  nested operation
+- *45* La
+  ⚠️  pattern without value
+- *46* ???*47*(/\n( *(at )?)/)
+  ⚠️  unknown callee
+- *47* ???*48*["match"]
+  ⚠️  unknown object
+- *48* ???*49*()
+  ⚠️  nested operation
+- *49* ???["trim"]
+  ⚠️  unknown object
+- *50* ???*51*[1]
+  ⚠️  unknown object
+- *51* ???*52*(/\n( *(at )?)/)
+  ⚠️  unknown callee
+- *52* ???*53*["match"]
+  ⚠️  unknown object
+- *53* ???()
+  ⚠️  nested operation
+- *54* ???*55*["type"]
+  ⚠️  unknown object
+- *55* a
+  ⚠️  circular variable reference
+- *56* (???*57* ? ???*58* : "")
+  ⚠️  nested operation
+- *57* a
+  ⚠️  circular variable reference
+- *58* ???*59*["displayName"]
+  ⚠️  unknown object
+- *59* a
+  ⚠️  circular variable reference
 
-a#490 = ???*0*
-- *0* max number of linking steps reached
+a#490 = (
+  | null["alternate"]
+  | ???*0*
+  | (null !== (null | ???*2* | ???*3*))["alternate"]
+  | (null !== (null["next"] | ???*4* | ???*6*))["alternate"]
+  | (???*8* ? ???*10* : null)
+  | null["next"]
+  | ???*12*
+  | {
+        "memoizedState": (null["memoizedState"] | ???*14* | ???*16*),
+        "baseState": (null["baseState"] | ???*18* | ???*20*),
+        "baseQueue": (null["baseQueue"] | ???*22* | ???*24*),
+        "queue": (null["queue"] | ???*26* | ???*28*),
+        "next": null
+    }
+)
+- *0* ???*1*["alternate"]
+  ⚠️  unknown object
+- *1* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *2* unsupported expression
   ⚠️  This value might have side effects
+- *3* a
+  ⚠️  circular variable reference
+- *4* ???*5*["next"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* unsupported expression
+  ⚠️  This value might have side effects
+- *6* ???*7*["next"]
+  ⚠️  unknown object
+- *7* a
+  ⚠️  circular variable reference
+- *8* (null !== ???*9*)
+  ⚠️  nested operation
+- *9* a
+  ⚠️  circular variable reference
+- *10* ???*11*["memoizedState"]
+  ⚠️  unknown object
+- *11* a
+  ⚠️  circular variable reference
+- *12* ???*13*["next"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *13* unsupported expression
+  ⚠️  This value might have side effects
+- *14* ???*15*["memoizedState"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *15* unsupported expression
+  ⚠️  This value might have side effects
+- *16* ???*17*["memoizedState"]
+  ⚠️  unknown object
+- *17* a
+  ⚠️  circular variable reference
+- *18* ???*19*["baseState"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *19* unsupported expression
+  ⚠️  This value might have side effects
+- *20* ???*21*["baseState"]
+  ⚠️  unknown object
+- *21* a
+  ⚠️  circular variable reference
+- *22* ???*23*["baseQueue"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *23* unsupported expression
+  ⚠️  This value might have side effects
+- *24* ???*25*["baseQueue"]
+  ⚠️  unknown object
+- *25* a
+  ⚠️  circular variable reference
+- *26* ???*27*["queue"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *27* unsupported expression
+  ⚠️  This value might have side effects
+- *28* ???*29*["queue"]
+  ⚠️  unknown object
+- *29* a
+  ⚠️  circular variable reference
 
 a#493 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#494 = ???*0*
-- *0* max number of linking steps reached
+a#494 = (???*0* | ???*1*)
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* ???*2*["interleaved"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *2* node limit reached
   ⚠️  This value might have side effects
 
 a#5 = (???*0* | 0 | ???*1*)
@@ -4213,9 +4413,21 @@ a#5 = (???*0* | 0 | ???*1*)
 - *1* updated with update expression
   ⚠️  This value might have side effects
 
-a#50 = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
+a#50 = (???*0* | ???*1* | null["displayName"] | null["name"] | "" | (???*3* ? ???*5* : "ForwardRef"))
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* ???*2*["displayName"]
+  ⚠️  unknown object
+- *2* a
+  ⚠️  circular variable reference
+- *3* ("" !== ???*4*)
+  ⚠️  nested operation
+- *4* a
+  ⚠️  circular variable reference
+- *5* `ForwardRef(${???*6*})`
+  ⚠️  nested operation
+- *6* a
+  ⚠️  circular variable reference
 
 a#501 = ???*0*
 - *0* arguments[0]
@@ -4225,8 +4437,157 @@ a#504 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#506 = ???*0*
-- *0* max number of linking steps reached
+a#506 = (
+  | ???*0*
+  | {
+        "getSnapshot": (
+          | ???*1*
+          | null["updateQueue"]
+          | ???*2*
+          | (null !== (
+              | null
+              | ???*4*
+              | ???*5*
+              | ???*7*
+              | {
+                    "memoizedState": ???*12*,
+                    "baseState": ???*14*,
+                    "baseQueue": ???*16*,
+                    "queue": ???*18*,
+                    "next": null
+                }
+            ))["updateQueue"]
+          | (null !== (null["next"] | ???*20* | ???*22* | null | ???*25*))["updateQueue"]
+          | {"lastEffect": null, "stores": null}
+        ),
+        "value": (
+          | ???*26*
+          | ???*27*
+          | null["updateQueue"]["stores"]
+          | (null !== (
+              | null
+              | ???*29*
+              | ???*30*
+              | ???*32*
+              | {
+                    "memoizedState": ???*37*,
+                    "baseState": ???*39*,
+                    "baseQueue": ???*41*,
+                    "queue": ???*43*,
+                    "next": null
+                }
+            ))["updateQueue"]["stores"]
+          | (null !== (null["next"] | ???*45* | ???*47* | null | ???*50*))["updateQueue"]["stores"]
+          | null
+          | ???*51*
+        )
+    }
+)
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *2* ???*3*["updateQueue"]
+  ⚠️  unknown object
+- *3* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *4* unsupported expression
+  ⚠️  This value might have side effects
+- *5* ???*6*["alternate"]
+  ⚠️  unknown object
+- *6* N
+  ⚠️  circular variable reference
+- *7* (???*8* ? ???*10* : null)
+  ⚠️  nested operation
+- *8* (null !== ???*9*)
+  ⚠️  nested operation
+- *9* a
+  ⚠️  circular variable reference
+- *10* ???*11*["memoizedState"]
+  ⚠️  unknown object
+- *11* a
+  ⚠️  circular variable reference
+- *12* ???*13*["memoizedState"]
+  ⚠️  unknown object
+- *13* O
+  ⚠️  circular variable reference
+- *14* ???*15*["baseState"]
+  ⚠️  unknown object
+- *15* O
+  ⚠️  circular variable reference
+- *16* ???*17*["baseQueue"]
+  ⚠️  unknown object
+- *17* O
+  ⚠️  circular variable reference
+- *18* ???*19*["queue"]
+  ⚠️  unknown object
+- *19* O
+  ⚠️  circular variable reference
+- *20* ???*21*["next"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *21* unsupported expression
+  ⚠️  This value might have side effects
+- *22* ???*23*["next"]
+  ⚠️  unknown object
+- *23* ???*24*["alternate"]
+  ⚠️  unknown object
+- *24* N
+  ⚠️  circular variable reference
+- *25* unknown mutation
+  ⚠️  This value might have side effects
+- *26* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *27* ???*28*["stores"]
+  ⚠️  unknown object
+- *28* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *29* unsupported expression
+  ⚠️  This value might have side effects
+- *30* ???*31*["alternate"]
+  ⚠️  unknown object
+- *31* N
+  ⚠️  circular variable reference
+- *32* (???*33* ? ???*35* : null)
+  ⚠️  nested operation
+- *33* (null !== ???*34*)
+  ⚠️  nested operation
+- *34* a
+  ⚠️  circular variable reference
+- *35* ???*36*["memoizedState"]
+  ⚠️  unknown object
+- *36* a
+  ⚠️  circular variable reference
+- *37* ???*38*["memoizedState"]
+  ⚠️  unknown object
+- *38* O
+  ⚠️  circular variable reference
+- *39* ???*40*["baseState"]
+  ⚠️  unknown object
+- *40* O
+  ⚠️  circular variable reference
+- *41* ???*42*["baseQueue"]
+  ⚠️  unknown object
+- *42* O
+  ⚠️  circular variable reference
+- *43* ???*44*["queue"]
+  ⚠️  unknown object
+- *44* O
+  ⚠️  circular variable reference
+- *45* ???*46*["next"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *46* unsupported expression
+  ⚠️  This value might have side effects
+- *47* ???*48*["next"]
+  ⚠️  unknown object
+- *48* ???*49*["alternate"]
+  ⚠️  unknown object
+- *49* N
+  ⚠️  circular variable reference
+- *50* unknown mutation
+  ⚠️  This value might have side effects
+- *51* unknown mutation
   ⚠️  This value might have side effects
 
 a#507 = ???*0*
@@ -4242,8 +4603,8 @@ a#510 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["value"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#513 = ???*0*
 - *0* arguments[0]
@@ -4252,65 +4613,29 @@ a#513 = ???*0*
 a#514 = (
   | ???*0*
   | ???*1*()
-  | ???*2*()
-  | {
-        "pending": null,
-        "interleaved": null,
-        "lanes": 0,
-        "dispatch": null,
-        "lastRenderedReducer": (...) => ???*4*,
-        "lastRenderedState": ???*5*
-    }()
-  | ???*6*()
   | {
         "pending": null,
         "interleaved": null,
         "lanes": 0,
         "dispatch": null,
         "lastRenderedReducer": (...) => (("function" === typeof(b)) ? b(a) : b),
-        "lastRenderedState": (
-          | ???*7*
-          | ???*8*()
-          | {
-                "pending": null,
-                "interleaved": null,
-                "lanes": 0,
-                "dispatch": null,
-                "lastRenderedReducer": (...) => (("function" === typeof(b)) ? b(a) : b),
-                "lastRenderedState": ???*9*
-            }
-          | ???*10*
-        )
+        "lastRenderedState": ???*2*
     }
-  | ???*11*
+  | ???*3*
 )
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *2* ???*3*()
-  ⚠️  nested operation
-- *3* a
+- *1* a
   ⚠️  circular variable reference
-- *4* (("function" === typeof(b)) ? b(a) : b)
-  ⚠️  nested operation
-- *5* a
+- *2* a
   ⚠️  circular variable reference
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *8* a
-  ⚠️  circular variable reference
-- *9* a
-  ⚠️  circular variable reference
-- *10* unsupported expression
-  ⚠️  This value might have side effects
-- *11* unsupported expression
+- *3* unsupported expression
   ⚠️  This value might have side effects
 
-a#515 = ???*0*
-- *0* max number of linking steps reached
+a#515 = (???*0* | ???*1*)
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* node limit reached
   ⚠️  This value might have side effects
 
 a#517 = ???*0*
@@ -4337,42 +4662,34 @@ a#524 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#525 = (???*0* | ???*1*() | ???*2*())
+a#525 = (???*0* | ???*1*())
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *2* ???*3*()
-  ⚠️  nested operation
-- *3* a
+- *1* a
   ⚠️  circular variable reference
 
 a#528 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#53 = (???*0* | ???*1* | ""["type"]["render"] | ""["displayName"] | ""["name"] | "")
+a#53 = (???*0* | ???*1* | "")
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["render"]
   ⚠️  unknown object
 - *2* ???*3*["type"]
   ⚠️  unknown object
-- *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *3* a
+  ⚠️  circular variable reference
 
 a#530 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#531 = (???*0* | ???*1*() | ???*2*())
+a#531 = (???*0* | ???*1*())
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *2* ???*3*()
-  ⚠️  nested operation
-- *3* a
+- *1* a
   ⚠️  circular variable reference
 
 a#532 = ???*0*
@@ -4416,8 +4733,8 @@ a#55 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["nodeName"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#550 = ???*0*
 - *0* arguments[0]
@@ -4431,14 +4748,10 @@ a#552 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#553 = (???*0* | ???*1*() | ???*2*())
+a#553 = (???*0* | ???*1*())
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *2* ???*3*()
-  ⚠️  nested operation
-- *3* a
+- *1* a
   ⚠️  circular variable reference
 
 a#554 = (
@@ -4448,76 +4761,73 @@ a#554 = (
         "interleaved": null,
         "lanes": 0,
         "dispatch": null,
-        "lastRenderedReducer": (
-          | ???*1*
-          | {
-                "pending": null,
-                "interleaved": null,
-                "lanes": 0,
-                "dispatch": null,
-                "lastRenderedReducer": ???*2*,
-                "lastRenderedState": (???*3* | (???*4* ? ???*7* : ???*9*))
-            }
-          | ???*10*
-        ),
-        "lastRenderedState": (???*11* | (???*12* ? ???*15* : ???*17*))
+        "lastRenderedReducer": ???*1*,
+        "lastRenderedState": (???*2* | (???*3* ? ???*6* : ???*8*))
     }
-  | ???*18*
+  | ???*9*
 )
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *2* a
+- *1* a
   ⚠️  circular variable reference
-- *3* arguments[1]
+- *2* arguments[1]
   ⚠️  function calls are not analysed yet
-- *4* (???*5* !== ???*6*)
+- *3* (???*4* !== ???*5*)
   ⚠️  nested operation
-- *5* unsupported expression
+- *4* unsupported expression
   ⚠️  This value might have side effects
-- *6* arguments[2]
+- *5* arguments[2]
   ⚠️  function calls are not analysed yet
-- *7* ???*8*(b)
+- *6* ???*7*(b)
   ⚠️  unknown callee
-- *8* arguments[2]
+- *7* arguments[2]
   ⚠️  function calls are not analysed yet
-- *9* b
+- *8* b
   ⚠️  circular variable reference
-- *10* unsupported expression
-  ⚠️  This value might have side effects
-- *11* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *12* (???*13* !== ???*14*)
-  ⚠️  nested operation
-- *13* unsupported expression
-  ⚠️  This value might have side effects
-- *14* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *15* ???*16*(b)
-  ⚠️  unknown callee
-- *16* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *17* b
-  ⚠️  circular variable reference
-- *18* unsupported expression
+- *9* unsupported expression
   ⚠️  This value might have side effects
 
-a#555 = (???*0* | {"current": (???*1* | {"current": ???*2*})})
+a#555 = (???*0* | {"current": ???*1*})
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *2* a
+- *1* a
   ⚠️  circular variable reference
 
 a#556 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#557 = ???*0*
-- *0* max number of linking steps reached
+a#557 = (
+  | [
+        ???*0*,
+        (
+          | false
+          | ???*1*()
+          | {
+                "pending": null,
+                "interleaved": null,
+                "lanes": 0,
+                "dispatch": null,
+                "lastRenderedReducer": (...) => (("function" === typeof(b)) ? b(a) : b),
+                "lastRenderedState": ???*2*
+            }
+          | ???*3*
+        )
+    ]
+  | (...) => undefined["bind"](null, ???*4*)
+)
+- *0* node limit reached
   ⚠️  This value might have side effects
+- *1* a
+  ⚠️  circular variable reference
+- *2* a
+  ⚠️  circular variable reference
+- *3* unsupported expression
+  ⚠️  This value might have side effects
+- *4* ???*5*[1]
+  ⚠️  unknown object
+- *5* a
+  ⚠️  circular variable reference
 
 a#559 = ???*0*
 - *0* arguments[0]
@@ -4666,23 +4976,15 @@ a#580 = ???*0*
 
 a#585 = (
   | ???*0*
-  | (...) => undefined["bind"](null, (???*1* | ???*2*), ???*6*, ???*7*)
+  | (...) => undefined["bind"](null, ???*1*, ???*2*, ???*3*)
 )
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *2* (...) => undefined["bind"](null, ???*3*, ???*4*, ???*5*)
-  ⚠️  nested operation
-- *3* a
+- *1* a
   ⚠️  circular variable reference
-- *4* arguments[1]
+- *2* arguments[1]
   ⚠️  function calls are not analysed yet
-- *5* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *6* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *7* arguments[2]
+- *3* arguments[2]
   ⚠️  function calls are not analysed yet
 
 a#587 = (???*0* | ???*1*)
@@ -4690,8 +4992,8 @@ a#587 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#589 = ???*0*
 - *0* arguments[0]
@@ -4709,40 +5011,135 @@ a#591 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#592 = ???*0*
-- *0* max number of linking steps reached
+a#592 = (
+  | ???*0*
+  | ???*1*
+  | new (...) => undefined(7, ???*3*, (null | ???*4*), (???*10* | ???*12*))
+  | ???*13*
+  | new (...) => undefined(22, ???*14*, (null | ???*15*), (???*21* | ???*23*))
+  | null
+  | new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*24*, ???*25*, (???*26* | ???*28*))
+  | (???*29* ? ???*31* : (...) => (???*32* | ???*33*))["type"]["alternate"]
+  | new (...) => undefined(???*34*, (???*37* | ???*38*), ???*41*, ???*44*)
+)
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* ???*2*["children"]
+  ⚠️  unknown object
+- *2* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *3* a
+  ⚠️  circular variable reference
+- *4* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*5*, ???*6*, (???*7* | ???*9*))
+  ⚠️  nested operation
+- *5* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *6* b
+  ⚠️  circular variable reference
+- *7* ???*8*["mode"]
+  ⚠️  unknown object
+- *8* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *9* unsupported assign operation
   ⚠️  This value might have side effects
+- *10* ???*11*["mode"]
+  ⚠️  unknown object
+- *11* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *12* unsupported assign operation
+  ⚠️  This value might have side effects
+- *13* a
+  ⚠️  sequence with side effects
+  ⚠️  This value might have side effects
+- *14* a
+  ⚠️  circular variable reference
+- *15* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*16*, ???*17*, (???*18* | ???*20*))
+  ⚠️  nested operation
+- *16* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *17* b
+  ⚠️  circular variable reference
+- *18* ???*19*["mode"]
+  ⚠️  unknown object
+- *19* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *20* unsupported assign operation
+  ⚠️  This value might have side effects
+- *21* ???*22*["mode"]
+  ⚠️  unknown object
+- *22* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *23* unsupported assign operation
+  ⚠️  This value might have side effects
+- *24* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *25* b
+  ⚠️  circular variable reference
+- *26* ???*27*["mode"]
+  ⚠️  unknown object
+- *27* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *28* unsupported assign operation
+  ⚠️  This value might have side effects
+- *29* (null !== ???*30*)
+  ⚠️  nested operation
+- *30* c
+  ⚠️  circular variable reference
+- *31* c
+  ⚠️  circular variable reference
+- *32* !(0)
+  ⚠️  nested operation
+- *33* !(1)
+  ⚠️  nested operation
+- *34* ???*35*["tag"]
+  ⚠️  unknown object
+- *35* ???*36*["type"]
+  ⚠️  unknown object
+- *36* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *37* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *38* ???*39*["dependencies"]
+  ⚠️  unknown object
+- *39* ???*40*["type"]
+  ⚠️  unknown object
+- *40* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *41* ???*42*["key"]
+  ⚠️  unknown object
+- *42* ???*43*["type"]
+  ⚠️  unknown object
+- *43* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *44* ???*45*["mode"]
+  ⚠️  unknown object
+- *45* ???*46*["type"]
+  ⚠️  unknown object
+- *46* arguments[2]
+  ⚠️  function calls are not analysed yet
 
 a#595 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#597 = (???*0* | (???*1* ? ???*11* : ???*12*))
+a#597 = (???*0* | (???*1* ? ???*7* : ???*8*))
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* (null !== ???*2*)
   ⚠️  nested operation
-- *2* (???*3* ? ???*9* : null)
+- *2* (???*3* ? ???*5* : null)
   ⚠️  nested operation
-- *3* (null !== (???*4* | ???*5*))
+- *3* (null !== ???*4*)
   ⚠️  nested operation
-- *4* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *5* (???*6* ? ???*7* : ???*8*)
-  ⚠️  nested operation
-- *6* (null !== ???)
-  ⚠️  nested operation
+- *4* a
+  ⚠️  circular variable reference
+- *5* ???*6*["memoizedState"]
+  ⚠️  unknown object
+- *6* a
+  ⚠️  circular variable reference
 - *7* unsupported expression
   ⚠️  This value might have side effects
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *9* ???*10*["memoizedState"]
-  ⚠️  unknown object
-- *10* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *11* unsupported expression
-  ⚠️  This value might have side effects
-- *12* arguments[2]
   ⚠️  function calls are not analysed yet
 
 a#599 = ???*0*
@@ -4807,8 +5204,30 @@ a#620 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#621 = ???*0*
-- *0* max number of linking steps reached
+a#621 = (
+  | ???*0*
+  | ???*1*
+  | 0["revealOrder"]["alternate"]
+  | ???*3*
+  | null["alternate"]
+  | null["sibling"]["alternate"]
+  | 0["revealOrder"]["sibling"]
+  | null["sibling"]
+  | null["sibling"]["sibling"]
+)
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* ???*2*["child"]
+  ⚠️  unknown object
+- *2* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *3* ???*4*["alternate"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *4* ???*5*["revealOrder"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* unknown mutation
   ⚠️  This value might have side effects
 
 a#628 = ???*0*
@@ -4858,18 +5277,18 @@ a#64 = (???*0* | "" | ((???*1* | ???*2*) ? ???*6* : ???*9*))
   ⚠️  nested operation
 - *4* ???*5*["toLowerCase"]
   ⚠️  unknown object
-- *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *5* a
+  ⚠️  circular variable reference
 - *6* (???*7* ? "true" : "false")
   ⚠️  nested operation
 - *7* ???*8*["checked"]
   ⚠️  unknown object
-- *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *8* a
+  ⚠️  circular variable reference
 - *9* ???*10*["value"]
   ⚠️  unknown object
-- *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *10* a
+  ⚠️  circular variable reference
 
 a#644 = ???*0*
 - *0* arguments[0]
@@ -4887,7 +5306,7 @@ a#647 = ???*0*
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-a#65 = (???*0* | ???*1* | (???*2* ? ???*5* : ???*6*) | (???*7* ? ???*10* : ???*11*))
+a#65 = (???*0* | ???*1* | (???*2* ? ???*5* : ???*6*))
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* a
@@ -4903,18 +5322,6 @@ a#65 = (???*0* | ???*1* | (???*2* ? ???*5* : ???*6*) | (???*7* ? ???*10* : ???*1
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* ("undefined" !== ???*8*)
-  ⚠️  nested operation
-- *8* typeof(???*9*)
-  ⚠️  nested operation
-- *9* FreeVar(document)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *10* FreeVar(document)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *11* unsupported expression
   ⚠️  This value might have side effects
 
 a#665 = (???*0* | ???*1*)
@@ -4958,8 +5365,8 @@ a#695 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#697 = ???*0*
 - *0* arguments[0]
@@ -4974,8 +5381,8 @@ a#699 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#7 = (???*0* | ???*1*)
 - *0* arguments[0]
@@ -4988,8 +5395,8 @@ a#7 = (???*0* | ???*1*)
   ⚠️  nested operation
 - *4* ???*5*["toLowerCase"]
   ⚠️  unknown object
-- *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *5* a
+  ⚠️  circular variable reference
 
 a#70 = ???*0*
 - *0* arguments[0]
@@ -5000,16 +5407,16 @@ a#703 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#704 = (???*0* | ???*1*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#705 = ???*0*
 - *0* arguments[0]
@@ -5064,8 +5471,8 @@ a#77 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["options"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#781 = ???*0*
 - *0* arguments[0]
@@ -5130,30 +5537,12 @@ a#801 = (
 - *18* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *19* (???*20* === (???*21* | 0 | 1 | ???*22* | 4 | ???*23* | ???*28*))
+- *19* (???*20* === ???*21*)
   ⚠️  nested operation
 - *20* unsupported expression
   ⚠️  This value might have side effects
-- *21* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *22* C
+- *21* a
   ⚠️  circular variable reference
-- *23* ((???*24* | ???*26*) ? ???*27* : 4)
-  ⚠️  nested operation
-- *24* (0 !== ???*25*)
-  ⚠️  nested operation
-- *25* C
-  ⚠️  circular variable reference
-- *26* unsupported expression
-  ⚠️  This value might have side effects
-- *27* C
-  ⚠️  circular variable reference
-- *28* ???*29*["event"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *29* FreeVar(window)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
 
 a#802 = ???*0*
 - *0* arguments[0]
@@ -5188,8 +5577,8 @@ a#827 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["expirationTimes"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#829 = ???*0*
 - *0* arguments[0]
@@ -5210,8 +5599,7 @@ a#834 = ???*0*
 a#838 = (
   | ???*0*
   | ???*1*
-  | new (...) => undefined(???*4*, (null | ???*7*), ???*10*, ???*13*)["current"]["alternate"]
-  | new (...) => undefined(???*16*, (null | ???*19*), ???*22*, ???*25*)
+  | new (...) => undefined(???*4*, (null | ???*7*), ???*10*, ???*13*)
 )
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
@@ -5219,8 +5607,8 @@ a#838 = (
   ⚠️  unknown object
 - *2* ???*3*["current"]
   ⚠️  unknown object
-- *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *3* a
+  ⚠️  circular variable reference
 - *4* ???*5*["tag"]
   ⚠️  unknown object
 - *5* ???*6*["current"]
@@ -5245,30 +5633,6 @@ a#838 = (
   ⚠️  unknown object
 - *15* a
   ⚠️  circular variable reference
-- *16* ???*17*["tag"]
-  ⚠️  unknown object
-- *17* ???*18*["current"]
-  ⚠️  unknown object
-- *18* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *19* ???*20*["dependencies"]
-  ⚠️  unknown object
-- *20* ???*21*["current"]
-  ⚠️  unknown object
-- *21* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *22* ???*23*["key"]
-  ⚠️  unknown object
-- *23* ???*24*["current"]
-  ⚠️  unknown object
-- *24* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *25* ???*26*["mode"]
-  ⚠️  unknown object
-- *26* ???*27*["current"]
-  ⚠️  unknown object
-- *27* arguments[0]
-  ⚠️  function calls are not analysed yet
 
 a#843 = ???*0*
 - *0* arguments[0]
@@ -5289,8 +5653,8 @@ a#869 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#87 = ???*0*
 - *0* arguments[0]
@@ -5367,14 +5731,14 @@ a#916 = (???*0* | (???*1* ? ???*5* : null))
   ⚠️  unknown object
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
-- *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *4* a
+  ⚠️  circular variable reference
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
-- *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *7* a
+  ⚠️  circular variable reference
 
 a#917 = ???*0*
 - *0* arguments[0]
@@ -5409,16 +5773,16 @@ a#943 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["prototype"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#944 = (???*0* | ???*1*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["$$typeof"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#946 = ???*0*
 - *0* arguments[0]
@@ -5485,63 +5849,32 @@ a#947 = (
 - *26* unsupported assign operation
   ⚠️  This value might have side effects
 
-a#948 = (
-  | ???*0*
-  | new (...) => undefined(7, (???*1* | ???*2*), ???*6*, ???*7*)
-)
+a#948 = (???*0* | new (...) => undefined(7, ???*1*, ???*2*, ???*3*))
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *2* new (...) => undefined(7, ???*3*, ???*4*, ???*5*)
-  ⚠️  nested operation
-- *3* a
+- *1* a
   ⚠️  circular variable reference
-- *4* arguments[3]
+- *2* arguments[3]
   ⚠️  function calls are not analysed yet
-- *5* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *6* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *7* arguments[1]
+- *3* arguments[1]
   ⚠️  function calls are not analysed yet
 
-a#949 = (
-  | ???*0*
-  | new (...) => undefined(22, (???*1* | ???*2*), ???*6*, ???*7*)
-)
+a#949 = (???*0* | new (...) => undefined(22, ???*1*, ???*2*, ???*3*))
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *2* new (...) => undefined(22, ???*3*, ???*4*, ???*5*)
-  ⚠️  nested operation
-- *3* a
+- *1* a
   ⚠️  circular variable reference
-- *4* arguments[3]
+- *2* arguments[3]
   ⚠️  function calls are not analysed yet
-- *5* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *6* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *7* arguments[1]
+- *3* arguments[1]
   ⚠️  function calls are not analysed yet
 
-a#950 = (
-  | ???*0*
-  | new (...) => undefined(6, (???*1* | ???*2*), null, ???*5*)
-)
+a#950 = (???*0* | new (...) => undefined(6, ???*1*, null, ???*2*))
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *2* new (...) => undefined(6, ???*3*, null, ???*4*)
-  ⚠️  nested operation
-- *3* a
+- *1* a
   ⚠️  circular variable reference
-- *4* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *5* arguments[1]
+- *2* arguments[1]
   ⚠️  function calls are not analysed yet
 
 a#951 = ???*0*
@@ -5554,35 +5887,21 @@ a#952 = ???*0*
 
 a#953 = (
   | ???*0*
-  | new (...) => undefined((???*1* | ???*2*), (???*9* | 1 | ???*10* | 0), ???*11*, ???*12*, ???*13*)
+  | new (...) => undefined(???*1*, (???*2* | 1 | ???*3* | 0), ???*4*, ???*5*, ???*6*)
 )
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *2* new (...) => undefined(???*3*, (???*4* | 1 | ???*5* | 0), ???*6*, ???*7*, ???*8*)
-  ⚠️  nested operation
-- *3* a
+- *1* a
   ⚠️  circular variable reference
-- *4* arguments[1]
+- *2* arguments[1]
   ⚠️  function calls are not analysed yet
-- *5* unsupported assign operation
+- *3* unsupported assign operation
   ⚠️  This value might have side effects
-- *6* arguments[2]
+- *4* arguments[2]
   ⚠️  function calls are not analysed yet
-- *7* arguments[7]
+- *5* arguments[7]
   ⚠️  function calls are not analysed yet
-- *8* arguments[8]
-  ⚠️  function calls are not analysed yet
-- *9* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *10* unsupported assign operation
-  ⚠️  This value might have side effects
-- *11* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *12* arguments[7]
-  ⚠️  function calls are not analysed yet
-- *13* arguments[8]
+- *6* arguments[8]
   ⚠️  function calls are not analysed yet
 
 a#954 = ???*0*
@@ -5594,15 +5913,17 @@ a#955 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["_reactInternals"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#96 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#960 = ???*0*
-- *0* max number of linking steps reached
+a#960 = (???*0* | ???*1*)
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* node limit reached
   ⚠️  This value might have side effects
 
 a#961 = ???*0*
@@ -5614,24 +5935,24 @@ a#962 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["current"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#963 = (???*0* | ???*1*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["memoizedState"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#965 = (???*0* | ???*1*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
 
 a#967 = ???*0*
 - *0* arguments[0]
@@ -5660,67 +5981,51 @@ a#974 = (
   | ???*0*
   | {
         "blockedOn": null,
-        "target": (
-          | ???*1*
-          | {
-                "blockedOn": null,
-                "target": ???*2*,
-                "priority": (
-                  | ???*3*()
-                  | 0
-                  | 1
-                  | ???*4*
-                  | 4
-                  | ((???*5* | ???*7*) ? ???*8* : 4)
-                  | (???*9* ? 16 : (???*10* | null | ???*16* | ???*17*))
-                  | ???*19*
-                )
-            }
-        ),
+        "target": ???*1*,
         "priority": (
-          | ???*20*()
+          | ???*2*()
           | 0
           | 1
-          | ???*21*
+          | ???*3*
           | 4
-          | ((???*22* | ???*24*) ? ???*25* : 4)
-          | (???*26* ? 16 : (???*27* | null | ???*34* | ???*35*))
-          | ???*37*
+          | ((???*4* | ???*6*) ? ???*7* : 4)
+          | (???*8* ? 16 : (???*9* | null | ???*16* | ???*17*))
+          | ???*19*
         )
     }
 )
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *2* a
+- *1* a
   ⚠️  circular variable reference
-- *3* Hc
+- *2* Hc
   ⚠️  pattern without value
-- *4* C
+- *3* C
   ⚠️  circular variable reference
-- *5* (0 !== ???*6*)
+- *4* (0 !== ???*5*)
   ⚠️  nested operation
-- *6* C
+- *5* C
   ⚠️  circular variable reference
-- *7* unsupported expression
+- *6* unsupported expression
   ⚠️  This value might have side effects
-- *8* C
+- *7* C
   ⚠️  circular variable reference
-- *9* unsupported expression
+- *8* unsupported expression
   ⚠️  This value might have side effects
-- *10* (???*11* ? ???*12* : 1)
+- *9* (???*10* ? ???*11* : 1)
   ⚠️  nested operation
-- *11* unsupported expression
+- *10* unsupported expression
   ⚠️  This value might have side effects
-- *12* (???*13* ? ???*14* : 4)
+- *11* (???*12* ? ???*13* : 4)
   ⚠️  nested operation
-- *13* unsupported expression
+- *12* unsupported expression
   ⚠️  This value might have side effects
-- *14* (???*15* ? 16 : 536870912)
+- *13* (???*14* ? 16 : 536870912)
   ⚠️  nested operation
-- *15* (... !== ...)
+- *14* (0 !== ???*15*)
   ⚠️  nested operation
+- *15* unsupported expression
+  ⚠️  This value might have side effects
 - *16* arguments[0]
   ⚠️  function calls are not analysed yet
 - *17* ???*18*["value"]
@@ -5728,42 +6033,6 @@ a#974 = (
 - *18* arguments[1]
   ⚠️  function calls are not analysed yet
 - *19* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *20* Hc
-  ⚠️  pattern without value
-- *21* C
-  ⚠️  circular variable reference
-- *22* (0 !== ???*23*)
-  ⚠️  nested operation
-- *23* C
-  ⚠️  circular variable reference
-- *24* unsupported expression
-  ⚠️  This value might have side effects
-- *25* C
-  ⚠️  circular variable reference
-- *26* unsupported expression
-  ⚠️  This value might have side effects
-- *27* (???*28* ? ???*29* : 1)
-  ⚠️  nested operation
-- *28* unsupported expression
-  ⚠️  This value might have side effects
-- *29* (???*30* ? ???*31* : 4)
-  ⚠️  nested operation
-- *30* unsupported expression
-  ⚠️  This value might have side effects
-- *31* (???*32* ? 16 : 536870912)
-  ⚠️  nested operation
-- *32* (0 !== ???*33*)
-  ⚠️  nested operation
-- *33* unsupported expression
-  ⚠️  This value might have side effects
-- *34* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *35* ???*36*["value"]
-  ⚠️  unknown object
-- *36* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *37* arguments[0]
   ⚠️  function calls are not analysed yet
 
 a#976 = ???*0*
@@ -5778,8 +6047,20 @@ a#979 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#982 = ???*0*
-- *0* max number of linking steps reached
+a#982 = (undefined | null | ???*0* | ???*3*)
+- *0* ???*1*["stateNode"]
+  ⚠️  unknown object
+- *1* ???*2*["child"]
+  ⚠️  unknown object
+- *2* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *3* ???*4*["stateNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *4* ???*5*["child"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* node limit reached
   ⚠️  This value might have side effects
 
 a#984 = (
@@ -5803,8 +6084,32 @@ a#986 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#989 = ???*0*
-- *0* max number of linking steps reached
+a#989 = (
+  | undefined
+  | null
+  | ???*0*
+  | ???*4*
+  | new (...) => undefined(???*7*, (0 | 1 | ???*8*), false, "", (...) => undefined)["child"]["stateNode"]
+)
+- *0* ???*1*["stateNode"]
+  ⚠️  unknown object
+- *1* ???*2*["child"]
+  ⚠️  unknown object
+- *2* ???*3*["_reactRootContainer"]
+  ⚠️  unknown object
+- *3* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *4* ???*5*["stateNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* ???*6*["child"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *6* node limit reached
+  ⚠️  This value might have side effects
+- *7* a
+  ⚠️  circular variable reference
+- *8* unsupported assign operation
   ⚠️  This value might have side effects
 
 a#99 = ???*0*
@@ -5887,38 +6192,22 @@ ak = (...) => undefined
 
 al = (...) => undefined
 
-b#100 = (???*0* | ((???*1* | ???*2*) + ???*10* + ???*14*))
+b#100 = (???*0* | (???*1* + ???*2* + ???*6*))
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *2* (???*3* + ???*4* + ???*8*)
-  ⚠️  nested operation
-- *3* b
+- *1* b
   ⚠️  circular variable reference
-- *4* ???*5*()
+- *2* ???*3*()
   ⚠️  nested operation
-- *5* ???*6*["toUpperCase"]
+- *3* ???*4*["toUpperCase"]
   ⚠️  unknown object
-- *6* ???*7*["charAt"](0)
+- *4* ???*5*["charAt"](0)
+  ⚠️  unknown callee object
+- *5* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *6* ???*7*["substring"](1)
   ⚠️  unknown callee object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *8* ???*9*["substring"](1)
-  ⚠️  unknown callee object
-- *9* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *10* ???*11*()
-  ⚠️  nested operation
-- *11* ???*12*["toUpperCase"]
-  ⚠️  unknown object
-- *12* ???*13*["charAt"](0)
-  ⚠️  unknown callee object
-- *13* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *14* ???*15*["substring"](1)
-  ⚠️  unknown callee object
-- *15* arguments[0]
   ⚠️  function calls are not analysed yet
 
 b#1001 = ???*0*
@@ -5965,8 +6254,8 @@ b#1013 = (
   ⚠️  This value might have side effects
 - *3* ???*4*["identifierPrefix"]
   ⚠️  unknown object
-- *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+- *4* b
+  ⚠️  circular variable reference
 - *5* (???*6* ? ???*9* : (...) => undefined)
   ⚠️  nested operation
 - *6* ("function" === ???*7*)
@@ -5981,8 +6270,8 @@ b#1013 = (
   ⚠️  This value might have side effects
 - *10* ???*11*["onRecoverableError"]
   ⚠️  unknown object
-- *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+- *11* b
+  ⚠️  circular variable reference
 
 b#1014 = ???*0*
 - *0* max number of linking steps reached
@@ -6016,13 +6305,7 @@ b#107 = ???*0*
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 
-b#109 = (
-  | ???*0*
-  | (???*2* ? null : (???*6* | ???*7*))["stateNode"]
-  | (???*9* ? null : (???*13* | ???*14*))["stateNode"][`__reactProps$${???*16*}`]
-  | null[`__reactProps$${???*21*}`]
-  | null
-)
+b#109 = (???*0* | (???*2* ? null : (???*6* | ???*7*))["stateNode"] | null)
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
@@ -6041,42 +6324,6 @@ b#109 = (
   ⚠️  unknown object
 - *8* a
   ⚠️  circular variable reference
-- *9* !((???*10* | ???*11*))
-  ⚠️  nested operation
-- *10* a
-  ⚠️  circular variable reference
-- *11* ???*12*[Of]
-  ⚠️  unknown object
-- *12* a
-  ⚠️  circular variable reference
-- *13* a
-  ⚠️  circular variable reference
-- *14* ???*15*[Of]
-  ⚠️  unknown object
-- *15* a
-  ⚠️  circular variable reference
-- *16* ???*17*["slice"](2)
-  ⚠️  unknown callee object
-- *17* ???*18*(36)
-  ⚠️  unknown callee
-- *18* ???*19*["toString"]
-  ⚠️  unknown object
-- *19* ???*20*()
-  ⚠️  nested operation
-- *20* ???["random"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *21* ???*22*["slice"](2)
-  ⚠️  unknown callee object
-- *22* ???*23*(36)
-  ⚠️  unknown callee
-- *23* ???*24*["toString"]
-  ⚠️  unknown object
-- *24* ???*25*()
-  ⚠️  nested operation
-- *25* ???["random"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
 
 b#11 = ???*0*
 - *0* ???*1*[0]
@@ -6117,7 +6364,7 @@ b#128 = ???*0*
 b#131 = (???*0* | ???*1* | ???*2*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* a
+- *1* b
   ⚠️  circular variable reference
 - *2* ???*3*["return"]
   ⚠️  unknown object
@@ -6157,14 +6404,7 @@ b#152 = (???*0* | ???*1* | ???*3* | null)
   ⚠️  unknown object
 - *2* a
   ⚠️  circular variable reference
-- *3* (...) => (a | b | null)((???*4* | ???*5*))
-  ⚠️  recursive function call
-  ⚠️  This value might have side effects
-- *4* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *5* ???*6*["child"]
-  ⚠️  unknown object
-- *6* a
+- *3* b
   ⚠️  circular variable reference
 
 b#156 = ???*0*
@@ -6213,17 +6453,175 @@ b#174 = ???*0*
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 
-b#175 = ???*0*
-- *0* max number of linking steps reached
+b#175 = (???*0* | (???*1* ? null : (???*5* | ???*6*)) | ???*8* | [???*10*] | ???*11*)
+- *0* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *1* !((???*2* | ???*3*))
+  ⚠️  nested operation
+- *2* b
+  ⚠️  circular variable reference
+- *3* ???*4*[Of]
+  ⚠️  unknown object
+- *4* a
+  ⚠️  circular variable reference
+- *5* b
+  ⚠️  circular variable reference
+- *6* ???*7*[Of]
+  ⚠️  unknown object
+- *7* a
+  ⚠️  circular variable reference
+- *8* ???*9*["targetContainers"]
+  ⚠️  unknown object
+- *9* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *10* arguments[4]
+  ⚠️  function calls are not analysed yet
+- *11* unknown mutation
   ⚠️  This value might have side effects
 
 b#176 = ???*0*
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 
-b#177 = ???*0*
-- *0* max number of linking steps reached
+b#177 = (
+  | ???*0*
+  | null[`__reactFiber$${???*7*}`]
+  | null["parentNode"][`__reactContainer$${???*12*}`]
+  | null[`__reactFiber$${???*17*}`][`__reactContainer$${???*22*}`]
+  | null["parentNode"][`__reactFiber$${???*27*}`]
+  | null[`__reactFiber$${???*32*}`][`__reactFiber$${???*37*}`]
+  | null["parentNode"]
+  | null[`__reactFiber$${???*42*}`]["alternate"]
+  | null
+  | (???*47* ? (???*50* | ???*51*) : null)["tag"]
+  | (???*53* ? (???*56* | ???*57*) : null)["memoizedState"]["dehydrated"]
+)
+- *0* ???*1*[`__reactFiber$${???*3*}`]
+  ⚠️  unknown object
+- *1* ???*2*["target"]
+  ⚠️  unknown object
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *3* ???*4*["slice"](2)
+  ⚠️  unknown callee object
+- *4* ???*5*(36)
+  ⚠️  unknown callee
+- *5* ???*6*["toString"]
+  ⚠️  unknown object
+- *6* ???()
+  ⚠️  nested operation
+- *7* ???*8*["slice"](2)
+  ⚠️  unknown callee object
+- *8* ???*9*(36)
+  ⚠️  unknown callee
+- *9* ???*10*["toString"]
+  ⚠️  unknown object
+- *10* ???*11*()
+  ⚠️  nested operation
+- *11* ???["random"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
+- *12* ???*13*["slice"](2)
+  ⚠️  unknown callee object
+- *13* ???*14*(36)
+  ⚠️  unknown callee
+- *14* ???*15*["toString"]
+  ⚠️  unknown object
+- *15* ???*16*()
+  ⚠️  nested operation
+- *16* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *17* ???*18*["slice"](2)
+  ⚠️  unknown callee object
+- *18* ???*19*(36)
+  ⚠️  unknown callee
+- *19* ???*20*["toString"]
+  ⚠️  unknown object
+- *20* ???*21*()
+  ⚠️  nested operation
+- *21* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *22* ???*23*["slice"](2)
+  ⚠️  unknown callee object
+- *23* ???*24*(36)
+  ⚠️  unknown callee
+- *24* ???*25*["toString"]
+  ⚠️  unknown object
+- *25* ???*26*()
+  ⚠️  nested operation
+- *26* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *27* ???*28*["slice"](2)
+  ⚠️  unknown callee object
+- *28* ???*29*(36)
+  ⚠️  unknown callee
+- *29* ???*30*["toString"]
+  ⚠️  unknown object
+- *30* ???*31*()
+  ⚠️  nested operation
+- *31* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *32* ???*33*["slice"](2)
+  ⚠️  unknown callee object
+- *33* ???*34*(36)
+  ⚠️  unknown callee
+- *34* ???*35*["toString"]
+  ⚠️  unknown object
+- *35* ???*36*()
+  ⚠️  nested operation
+- *36* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *37* ???*38*["slice"](2)
+  ⚠️  unknown callee object
+- *38* ???*39*(36)
+  ⚠️  unknown callee
+- *39* ???*40*["toString"]
+  ⚠️  unknown object
+- *40* ???*41*()
+  ⚠️  nested operation
+- *41* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *42* ???*43*["slice"](2)
+  ⚠️  unknown callee object
+- *43* ???*44*(36)
+  ⚠️  unknown callee
+- *44* ???*45*["toString"]
+  ⚠️  unknown object
+- *45* ???*46*()
+  ⚠️  nested operation
+- *46* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *47* (3 === ???*48*)
+  ⚠️  nested operation
+- *48* ???*49*["tag"]
+  ⚠️  unknown object
+- *49* b
+  ⚠️  circular variable reference
+- *50* b
+  ⚠️  circular variable reference
+- *51* ???*52*["return"]
+  ⚠️  unknown object
+- *52* b
+  ⚠️  circular variable reference
+- *53* (3 === ???*54*)
+  ⚠️  nested operation
+- *54* ???*55*["tag"]
+  ⚠️  unknown object
+- *55* b
+  ⚠️  circular variable reference
+- *56* b
+  ⚠️  circular variable reference
+- *57* ???*58*["return"]
+  ⚠️  unknown object
+- *58* b
+  ⚠️  circular variable reference
 
 b#183 = ???*0*
 - *0* max number of linking steps reached
@@ -6480,32 +6878,28 @@ b#249 = ???*0*
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 
-b#25 = (???*0* | (???*1* ? ???*7* : null)["attributeName"] | ???*9*)
+b#25 = (???*0* | (???*1* ? ???*5* : null)["attributeName"] | ???*7*)
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
-- *1* (???*2* | ???*3*)((???*4* | ???*5*))
+- *1* (???*2* | ???*3*)(???*4*)
   ⚠️  non-function callee
 - *2* FreeVar(undefined)
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *3* unknown mutation
   ⚠️  This value might have side effects
-- *4* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *5* ???*6*["attributeName"]
-  ⚠️  unknown object
-- *6* e
+- *4* b
   ⚠️  circular variable reference
-- *7* {}[???*8*]
+- *5* {}[???*6*]
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
-- *8* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *9* ???*10*["attributeName"]
+- *6* b
+  ⚠️  circular variable reference
+- *7* ???*8*["attributeName"]
   ⚠️  unknown object
-- *10* ???*11*["type"]
+- *8* ???*9*["type"]
   ⚠️  unknown object
-- *11* e
+- *9* e
   ⚠️  circular variable reference
 
 b#250 = ???*0*
@@ -6524,8 +6918,101 @@ b#260 = ???*0*
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 
-b#261 = ???*0*
-- *0* max number of linking steps reached
+b#261 = (
+  | undefined
+  | null
+  | ???*0*
+  | (???*2* ? ???*5* : ???*6*)["activeElement"]
+  | (???*7* ? ???*10* : ???*11*)["body"]
+  | (???*12* ? ???*15* : ???*16*)["body"]
+  | ???*17*
+  | (???*20* ? ???*23* : ???*24*)["activeElement"]
+  | (???*25* ? ???*28* : ???*29*)["body"]
+  | (???*30* ? ???*33* : ???*34*)["body"]
+)
+- *0* ???*1*["activeElement"]
+  ⚠️  unknown object
+- *1* unknown function argument (out of bounds)
+- *2* ("undefined" !== ???*3*)
+  ⚠️  nested operation
+- *3* typeof(???*4*)
+  ⚠️  nested operation
+- *4* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *5* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *6* unsupported expression
+  ⚠️  This value might have side effects
+- *7* ("undefined" !== ???*8*)
+  ⚠️  nested operation
+- *8* typeof(???*9*)
+  ⚠️  nested operation
+- *9* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *10* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *11* unsupported expression
+  ⚠️  This value might have side effects
+- *12* ("undefined" !== ???*13*)
+  ⚠️  nested operation
+- *13* typeof(???*14*)
+  ⚠️  nested operation
+- *14* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *15* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *16* unsupported expression
+  ⚠️  This value might have side effects
+- *17* ???*18*["activeElement"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *18* ???*19*["document"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *19* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *20* ("undefined" !== ???*21*)
+  ⚠️  nested operation
+- *21* typeof(???*22*)
+  ⚠️  nested operation
+- *22* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *23* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *24* unsupported expression
+  ⚠️  This value might have side effects
+- *25* ("undefined" !== ???*26*)
+  ⚠️  nested operation
+- *26* typeof(???*27*)
+  ⚠️  nested operation
+- *27* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *28* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *29* unsupported expression
+  ⚠️  This value might have side effects
+- *30* ("undefined" !== ???*31*)
+  ⚠️  nested operation
+- *31* typeof(???*32*)
+  ⚠️  nested operation
+- *32* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *33* FreeVar(document)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *34* unsupported expression
   ⚠️  This value might have side effects
 
 b#265 = (???*0* | ???*1* | ???*3*())
@@ -6548,23 +7035,15 @@ b#266 = ???*0*
 
 b#269 = (
   | ???*0*
-  | new (...) => ???*1*("onSelect", "select", null, (???*2* | ???*3*), ???*7*)
+  | new (...) => ???*1*("onSelect", "select", null, ???*2*, ???*3*)
 )
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
-- *2* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *3* new (...) => ???*4*("onSelect", "select", null, ???*5*, ???*6*)
-  ⚠️  nested operation
-- *4* unsupported expression
-  ⚠️  This value might have side effects
-- *5* b
+- *2* b
   ⚠️  circular variable reference
-- *6* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *7* arguments[2]
+- *3* arguments[2]
   ⚠️  function calls are not analysed yet
 
 b#27 = ???*0*
@@ -6640,18 +7119,16 @@ b#286 = ???*0*
 
 b#3 = (
   | `https://reactjs.org/docs/error-decoder.html?invariant=${???*0*}`
-  | `${???*1*}&args[]=${???*3*}`
+  | `${???*1*}&args[]=${???*2*}`
 )
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* `https://reactjs.org/docs/error-decoder.html?invariant=${???*2*}`
-  ⚠️  nested operation
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *3* ???*4*(FreeVar(arguments)[c])
+- *1* b
+  ⚠️  circular variable reference
+- *2* ???*3*(FreeVar(arguments)[c])
   ⚠️  unknown callee
   ⚠️  This value might have side effects
-- *4* FreeVar(encodeURIComponent)
+- *3* FreeVar(encodeURIComponent)
   ⚠️  unknown global
   ⚠️  This value might have side effects
 
@@ -6680,18 +7157,14 @@ b#314 = (???*0* | ???*1*)
   ⚠️  unknown callee
 - *3* ???*4*["replace"]
   ⚠️  unknown object
-- *4* (???*5* ? (???*6* | ???*7*) : (???*8* | ???*9*))
+- *4* (???*5* ? ???*6* : ???*7*)
   ⚠️  nested operation
 - *5* ("string" === ???)
   ⚠️  nested operation
-- *6* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *7* ???["replace"](yf, "")
-  ⚠️  unknown callee object
-- *8* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *9* ???["replace"](yf, "")
-  ⚠️  unknown callee object
+- *6* b
+  ⚠️  circular variable reference
+- *7* b
+  ⚠️  circular variable reference
 
 b#316 = ???*0*
 - *0* arguments[1]
@@ -6711,8 +7184,102 @@ b#327 = (0 | ???*0*)
 - *0* updated with update expression
   ⚠️  This value might have side effects
 
-b#331 = ???*0*
-- *0* max number of linking steps reached
+b#331 = (
+  | ???*0*
+  | null[`__reactFiber$${???*6*}`]
+  | null["parentNode"][`__reactContainer$${???*11*}`]
+  | null[`__reactFiber$${???*16*}`][`__reactContainer$${???*21*}`]
+  | null["parentNode"][`__reactFiber$${???*26*}`]
+  | null[`__reactFiber$${???*31*}`][`__reactFiber$${???*36*}`]
+)
+- *0* ???*1*[`__reactFiber$${???*2*}`]
+  ⚠️  unknown object
+- *1* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *2* ???*3*["slice"](2)
+  ⚠️  unknown callee object
+- *3* ???*4*(36)
+  ⚠️  unknown callee
+- *4* ???*5*["toString"]
+  ⚠️  unknown object
+- *5* ???()
+  ⚠️  nested operation
+- *6* ???*7*["slice"](2)
+  ⚠️  unknown callee object
+- *7* ???*8*(36)
+  ⚠️  unknown callee
+- *8* ???*9*["toString"]
+  ⚠️  unknown object
+- *9* ???*10*()
+  ⚠️  nested operation
+- *10* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *11* ???*12*["slice"](2)
+  ⚠️  unknown callee object
+- *12* ???*13*(36)
+  ⚠️  unknown callee
+- *13* ???*14*["toString"]
+  ⚠️  unknown object
+- *14* ???*15*()
+  ⚠️  nested operation
+- *15* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *16* ???*17*["slice"](2)
+  ⚠️  unknown callee object
+- *17* ???*18*(36)
+  ⚠️  unknown callee
+- *18* ???*19*["toString"]
+  ⚠️  unknown object
+- *19* ???*20*()
+  ⚠️  nested operation
+- *20* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *21* ???*22*["slice"](2)
+  ⚠️  unknown callee object
+- *22* ???*23*(36)
+  ⚠️  unknown callee
+- *23* ???*24*["toString"]
+  ⚠️  unknown object
+- *24* ???*25*()
+  ⚠️  nested operation
+- *25* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *26* ???*27*["slice"](2)
+  ⚠️  unknown callee object
+- *27* ???*28*(36)
+  ⚠️  unknown callee
+- *28* ???*29*["toString"]
+  ⚠️  unknown object
+- *29* ???*30*()
+  ⚠️  nested operation
+- *30* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *31* ???*32*["slice"](2)
+  ⚠️  unknown callee object
+- *32* ???*33*(36)
+  ⚠️  unknown callee
+- *33* ???*34*["toString"]
+  ⚠️  unknown object
+- *34* ???*35*()
+  ⚠️  nested operation
+- *35* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *36* ???*37*["slice"](2)
+  ⚠️  unknown callee object
+- *37* ???*38*(36)
+  ⚠️  unknown callee
+- *38* ???*39*["toString"]
+  ⚠️  unknown object
+- *39* ???*40*()
+  ⚠️  nested operation
+- *40* ???["random"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 
 b#340 = ???*0*
@@ -6732,8 +7299,8 @@ b#345 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["childContextTypes"]
   ⚠️  unknown object
-- *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+- *2* b
+  ⚠️  circular variable reference
 
 b#347 = ???*0*
 - *0* arguments[1]
@@ -6814,17 +7381,11 @@ b#370 = ???*0*
 b#381 = (???*0* | ???*1*)
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
-- *1* Object.assign*2*({}, (???*3* | ???*4*))
+- *1* Object.assign*2*({}, ???*3*)
   ⚠️  only const object assign is supported
   ⚠️  This value might have side effects
 - *2* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-- *3* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *4* Object.assign*5*({}, ???*6*)
-  ⚠️  only const object assign is supported
-  ⚠️  This value might have side effects
-- *5* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-- *6* b
+- *3* b
   ⚠️  circular variable reference
 
 b#384 = (null | ???*0*)
@@ -6875,8 +7436,8 @@ b#398 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
-- *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+- *2* b
+  ⚠️  circular variable reference
 
 b#4 = ???*0*
 - *0* arguments[1]
@@ -6972,57 +7533,32 @@ b#420 = ???*0*
 
 b#421 = (
   | ???*0*
-  | new (???*1* | ???*2*)(???*14*, (???*15* | ???*17* | ???*18* | ???*19*))
+  | new ???*1*(???*2*, (???*3* | ???*5* | ???*6* | ???*7*))
 )
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
-- *1* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *2* new ???*3*(???*4*, (???*5* | ???*7* | ???*8* | ???*9*))
-  ⚠️  nested operation
-- *3* b
+- *1* b
   ⚠️  circular variable reference
-- *4* arguments[2]
+- *2* arguments[2]
   ⚠️  function calls are not analysed yet
-- *5* ???*6*["contextType"]
+- *3* ???*4*["contextType"]
   ⚠️  unknown object
-- *6* b
+- *4* b
   ⚠️  circular variable reference
-- *7* FreeVar(undefined)
+- *5* FreeVar(undefined)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *8* unknown mutation
+- *6* unknown mutation
   ⚠️  This value might have side effects
-- *9* (???*10* ? ({} | ???*11*) : {})
+- *7* (???*8* ? ({} | ???*9*) : {})
   ⚠️  nested operation
-- *10* unsupported expression
+- *8* unsupported expression
   ⚠️  This value might have side effects
-- *11* ???*12*["__reactInternalMemoizedMaskedChildContext"]
+- *9* ???*10*["__reactInternalMemoizedMaskedChildContext"]
   ⚠️  unknown object
-- *12* ???*13*["stateNode"]
+- *10* ???*11*["stateNode"]
   ⚠️  unknown object
-- *13* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *14* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *15* ???*16*["contextType"]
-  ⚠️  unknown object
-- *16* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *17* FreeVar(undefined)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *18* unknown mutation
-  ⚠️  This value might have side effects
-- *19* (???*20* ? ({} | ???*21*) : {})
-  ⚠️  nested operation
-- *20* unsupported expression
-  ⚠️  This value might have side effects
-- *21* ???*22*["__reactInternalMemoizedMaskedChildContext"]
-  ⚠️  unknown object
-- *22* ???*23*["stateNode"]
-  ⚠️  unknown object
-- *23* arguments[0]
+- *11* arguments[0]
   ⚠️  function calls are not analysed yet
 
 b#422 = ???*0*
@@ -7074,8 +7610,8 @@ b#435 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["sibling"]
   ⚠️  unknown object
-- *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+- *2* b
+  ⚠️  circular variable reference
 
 b#436 = ???*0*
 - *0* arguments[1]
@@ -7225,9 +7761,52 @@ b#442 = (
 - *16* a
   ⚠️  circular variable reference
 
-b#443 = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
+b#443 = (
+  | ???*0*
+  | ???*1*
+  | new (...) => undefined(6, ???*2*, null, ???*3*)
+  | ???*5*
+  | new (...) => undefined(4, ???*7*, ???*13*, ???*15*)
+  | new (...) => undefined(7, ???*16*, null, ???*17*)
+)
+- *0* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *1* b
+  ⚠️  circular variable reference
+- *2* a
+  ⚠️  circular variable reference
+- *3* ???*4*["mode"]
+  ⚠️  unknown object
+- *4* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *5* ???*6*["mode"]
+  ⚠️  unknown object
+- *6* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *7* (???*8* ? ???*11* : [])
+  ⚠️  nested operation
+- *8* (null !== ???*9*)
+  ⚠️  nested operation
+- *9* ???*10*["children"]
+  ⚠️  unknown object
+- *10* b
+  ⚠️  circular variable reference
+- *11* ???*12*["children"]
+  ⚠️  unknown object
+- *12* b
+  ⚠️  circular variable reference
+- *13* ???*14*["key"]
+  ⚠️  unknown object
+- *14* b
+  ⚠️  circular variable reference
+- *15* b
+  ⚠️  circular variable reference
+- *16* a
+  ⚠️  circular variable reference
+- *17* ???*18*["mode"]
+  ⚠️  unknown object
+- *18* arguments[0]
+  ⚠️  function calls are not analysed yet
 
 b#445 = ???*0*
 - *0* arguments[1]
@@ -7237,9 +7816,62 @@ b#447 = ???*0*
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 
-b#472 = ???*0*
-- *0* max number of linking steps reached
+b#472 = (
+  | ???*0*
+  | (???*1* ? ???*2* : ???*4*)
+  | ???*6*
+  | (???*8* ? ???*10* : ???*12*)["namespaceURI"]
+  | null
+  | (???*13* ? (
+      | undefined
+      | "http://www.w3.org/2000/svg"
+      | "http://www.w3.org/1998/Math/MathML"
+      | "http://www.w3.org/1999/xhtml"
+    ) : ???*15*)
+)
+- *0* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *1* unsupported expression
   ⚠️  This value might have side effects
+- *2* ???*3*["namespaceURI"]
+  ⚠️  unknown object
+- *3* b
+  ⚠️  circular variable reference
+- *4* ((???*5* | false) ? (
+      | undefined
+      | "http://www.w3.org/2000/svg"
+      | "http://www.w3.org/1998/Math/MathML"
+      | "http://www.w3.org/1999/xhtml"
+    ) : null)
+  ⚠️  nested operation
+- *5* (null == null)
+  ⚠️  nested operation
+- *6* ???*7*["documentElement"]
+  ⚠️  unknown object
+- *7* b
+  ⚠️  circular variable reference
+- *8* (8 === ???*9*)
+  ⚠️  nested operation
+- *9* a
+  ⚠️  circular variable reference
+- *10* ???*11*["parentNode"]
+  ⚠️  unknown object
+- *11* b
+  ⚠️  circular variable reference
+- *12* b
+  ⚠️  circular variable reference
+- *13* (null == ???*14*)
+  ⚠️  nested operation
+- *14* b
+  ⚠️  circular variable reference
+- *15* (???*16* ? "http://www.w3.org/1999/xhtml" : ???*18*)
+  ⚠️  nested operation
+- *16* ("http://www.w3.org/2000/svg" === ???*17*)
+  ⚠️  nested operation
+- *17* b
+  ⚠️  circular variable reference
+- *18* b
+  ⚠️  circular variable reference
 
 b#474 = ({} | ???*0*)
 - *0* unknown mutation
@@ -7250,8 +7882,8 @@ b#476 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* b
+  ⚠️  circular variable reference
 
 b#484 = ???*0*
 - *0* arguments[1]
@@ -7281,8 +7913,8 @@ b#485 = (
   ⚠️  This value might have side effects
 - *2* ???*3*["alternate"]
   ⚠️  unknown object
-- *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+- *3* b
+  ⚠️  circular variable reference
 - *4* (???*5* ? ???*7* : null)
   ⚠️  nested operation
 - *5* (null !== ???*6*)
@@ -7318,13 +7950,13 @@ b#485 = (
   ⚠️  unknown object
 - *20* ???*21*["alternate"]
   ⚠️  unknown object
-- *21* arguments[1]
-  ⚠️  function calls are not analysed yet
+- *21* b
+  ⚠️  circular variable reference
 - *22* unknown mutation
   ⚠️  This value might have side effects
 
 b#490 = ???*0*
-- *0* max number of linking steps reached
+- *0* node limit reached
   ⚠️  This value might have side effects
 
 b#493 = ???*0*
@@ -7438,17 +8070,11 @@ b#5 = ???*0*
 
 b#50 = (
   | ???*0*
-  | null["displayName"]["render"]
-  | null["name"]["render"]
   | ""["render"]
   | (???*2* ? ???*4* : "ForwardRef")["render"]
-  | null["displayName"]["displayName"]
-  | null["name"]["displayName"]
   | ""["displayName"]
   | (???*6* ? ???*8* : "ForwardRef")["displayName"]
   | null
-  | null["displayName"]["_payload"]
-  | null["name"]["_payload"]
   | ""["_payload"]
   | (???*10* ? ???*12* : "ForwardRef")["_payload"]
 )
@@ -7899,68 +8525,28 @@ b#53 = (???*0* | ""["type"])
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
 
-b#530 = (???*0* | (???*1* ? null : (???*9* | ???*10*)))
+b#530 = (???*0* | (???*1* ? null : ???*4*))
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
-- *1* (???*2* === (???*3* | ???*4*))
+- *1* (???*2* === ???*3*)
   ⚠️  nested operation
 - *2* unsupported expression
   ⚠️  This value might have side effects
-- *3* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *4* (???*5* ? null : ???*8*)
-  ⚠️  nested operation
-- *5* (???*6* === ???*7*)
-  ⚠️  nested operation
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* b
+- *3* b
   ⚠️  circular variable reference
-- *8* b
-  ⚠️  circular variable reference
-- *9* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *10* (???*11* ? null : ???*14*)
-  ⚠️  nested operation
-- *11* (???*12* === ???*13*)
-  ⚠️  nested operation
-- *12* unsupported expression
-  ⚠️  This value might have side effects
-- *13* b
-  ⚠️  circular variable reference
-- *14* b
+- *4* b
   ⚠️  circular variable reference
 
-b#531 = (???*0* | (???*1* ? null : (???*9* | ???*10*)))
+b#531 = (???*0* | (???*1* ? null : ???*4*))
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
-- *1* (???*2* === (???*3* | ???*4*))
+- *1* (???*2* === ???*3*)
   ⚠️  nested operation
 - *2* unsupported expression
   ⚠️  This value might have side effects
-- *3* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *4* (???*5* ? null : ???*8*)
-  ⚠️  nested operation
-- *5* (???*6* === ???*7*)
-  ⚠️  nested operation
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* b
+- *3* b
   ⚠️  circular variable reference
-- *8* b
-  ⚠️  circular variable reference
-- *9* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *10* (???*11* ? null : ???*14*)
-  ⚠️  nested operation
-- *11* (???*12* === ???*13*)
-  ⚠️  nested operation
-- *12* unsupported expression
-  ⚠️  This value might have side effects
-- *13* b
-  ⚠️  circular variable reference
-- *14* b
+- *4* b
   ⚠️  circular variable reference
 
 b#532 = ???*0*
@@ -8015,39 +8601,19 @@ b#552 = ???*0*
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 
-b#553 = (???*0* | (???*1* ? null : (???*9* | ???*10*)))
+b#553 = (???*0* | (???*1* ? null : ???*4*))
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
-- *1* (???*2* === (???*3* | ???*4*))
+- *1* (???*2* === ???*3*)
   ⚠️  nested operation
 - *2* unsupported expression
   ⚠️  This value might have side effects
-- *3* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *4* (???*5* ? null : ???*8*)
-  ⚠️  nested operation
-- *5* (???*6* === ???*7*)
-  ⚠️  nested operation
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* b
+- *3* b
   ⚠️  circular variable reference
-- *8* b
-  ⚠️  circular variable reference
-- *9* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *10* (???*11* ? null : ???*14*)
-  ⚠️  nested operation
-- *11* (???*12* === ???*13*)
-  ⚠️  nested operation
-- *12* unsupported expression
-  ⚠️  This value might have side effects
-- *13* b
-  ⚠️  circular variable reference
-- *14* b
+- *4* b
   ⚠️  circular variable reference
 
-b#554 = (???*0* | (???*1* ? ???*4* : (???*6* | ???*7*)))
+b#554 = (???*0* | (???*1* ? ???*4* : ???*6*))
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 - *1* (???*2* !== ???*3*)
@@ -8060,21 +8626,7 @@ b#554 = (???*0* | (???*1* ? ???*4* : (???*6* | ???*7*)))
   ⚠️  unknown callee
 - *5* arguments[2]
   ⚠️  function calls are not analysed yet
-- *6* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *7* (???*8* ? ???*11* : ???*13*)
-  ⚠️  nested operation
-- *8* (???*9* !== ???*10*)
-  ⚠️  nested operation
-- *9* unsupported expression
-  ⚠️  This value might have side effects
-- *10* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *11* ???*12*(b)
-  ⚠️  unknown callee
-- *12* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *13* b
+- *6* b
   ⚠️  circular variable reference
 
 b#555 = (
@@ -8178,9 +8730,15 @@ b#555 = (
 - *36* a
   ⚠️  circular variable reference
 
-b#557 = ???*0*
-- *0* max number of linking steps reached
+b#557 = (???*0* | ???*1* | (...) => undefined["bind"](null, ???*2*)[0])
+- *0* node limit reached
   ⚠️  This value might have side effects
+- *1* unknown mutation
+  ⚠️  This value might have side effects
+- *2* ???*3*[1]
+  ⚠️  unknown object
+- *3* a
+  ⚠️  circular variable reference
 
 b#559 = ???*0*
 - *0* arguments[1]
@@ -8304,7 +8862,7 @@ b#565 = (
   ⚠️  circular variable reference
 
 b#566 = ???*0*
-- *0* max number of linking steps reached
+- *0* node limit reached
   ⚠️  This value might have side effects
 
 b#568 = (
@@ -8409,7 +8967,7 @@ b#568 = (
   ⚠️  circular variable reference
 
 b#569 = ???*0*
-- *0* max number of linking steps reached
+- *0* node limit reached
   ⚠️  This value might have side effects
 
 b#570 = ???*0*
@@ -8436,7 +8994,7 @@ b#585 = ???*0*
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 
-b#587 = (???*0* | (13 === ???*1*) | ???*3* | (???*5* ? ???*12* : true))
+b#587 = (???*0* | (13 === ???*1*) | ???*3* | (???*5* ? ???*7* : true))
 - *0* b
   ⚠️  pattern without value
 - *1* ???*2*["tag"]
@@ -8447,28 +9005,18 @@ b#587 = (???*0* | (13 === ???*1*) | ???*3* | (???*5* ? ???*12* : true))
   ⚠️  unknown object
 - *4* arguments[0]
   ⚠️  function calls are not analysed yet
-- *5* (null !== (???*6* | ???*7* | ???*10*))
+- *5* (null !== ???*6*)
   ⚠️  nested operation
 - *6* b
-  ⚠️  pattern without value
-- *7* (13 === ???*8*)
+  ⚠️  circular variable reference
+- *7* (???*8* ? true : false)
   ⚠️  nested operation
-- *8* ???*9*["tag"]
-  ⚠️  unknown object
-- *9* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *10* ???*11*["memoizedState"]
-  ⚠️  unknown object
-- *11* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *12* (???*13* ? true : false)
+- *8* (null !== ???*9*)
   ⚠️  nested operation
-- *13* (null !== ???*14*)
-  ⚠️  nested operation
-- *14* ???*15*["dehydrated"]
+- *9* ???*10*["dehydrated"]
   ⚠️  unknown object
-- *15* b
-  ⚠️  pattern without value
+- *10* b
+  ⚠️  circular variable reference
 
 b#589 = (
   | ???*0*
@@ -8531,33 +9079,18 @@ b#609 = ???*0*
 
 b#612 = (
   | ???*0*
-  | {
-        "mode": "visible",
-        "children": (
-          | ???*1*
-          | {"mode": "visible", "children": ???*2*}
-          | new (...) => undefined(22, ???*3*, null, ???*4*)
-        )
-    }
-  | new (...) => undefined(22, ???*6*, null, ???*7*)
+  | {"mode": "visible", "children": ???*1*}
+  | new (...) => undefined(22, ???*2*, null, ???*3*)
 )
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
-- *1* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *2* b
+- *1* b
   ⚠️  circular variable reference
-- *3* a
+- *2* a
   ⚠️  circular variable reference
-- *4* ???*5*["mode"]
+- *3* ???*4*["mode"]
   ⚠️  unknown object
-- *5* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *6* a
-  ⚠️  circular variable reference
-- *7* ???*8*["mode"]
-  ⚠️  unknown object
-- *8* arguments[0]
+- *4* arguments[0]
   ⚠️  function calls are not analysed yet
 
 b#613 = ???*0*
@@ -8694,19 +9227,13 @@ b#69 = ???*0*
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 
-b#691 = (
-  | ???*0*
-  | ???*1*
-  | (???*3* ? ???*5* : null)["updateQueue"]
-  | (???*7* ? ???*16* : null)
-  | (???*18* ? ???*20* : null)["next"]
-)
+b#691 = (???*0* | ???*1* | (???*3* ? ???*5* : null))
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
-- *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+- *2* b
+  ⚠️  circular variable reference
 - *3* (null !== ???*4*)
   ⚠️  nested operation
 - *4* b
@@ -8714,36 +9241,6 @@ b#691 = (
 - *5* ???*6*["lastEffect"]
   ⚠️  unknown object
 - *6* b
-  ⚠️  circular variable reference
-- *7* (null !== (???*8* | ???*9* | ???*11*))
-  ⚠️  nested operation
-- *8* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *9* ???*10*["updateQueue"]
-  ⚠️  unknown object
-- *10* b
-  ⚠️  circular variable reference
-- *11* (???*12* ? ???*14* : null)
-  ⚠️  nested operation
-- *12* (null !== ???*13*)
-  ⚠️  nested operation
-- *13* b
-  ⚠️  circular variable reference
-- *14* ???*15*["lastEffect"]
-  ⚠️  unknown object
-- *15* b
-  ⚠️  circular variable reference
-- *16* ???*17*["lastEffect"]
-  ⚠️  unknown object
-- *17* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *18* (null !== ???*19*)
-  ⚠️  nested operation
-- *19* b
-  ⚠️  circular variable reference
-- *20* ???*21*["lastEffect"]
-  ⚠️  unknown object
-- *21* b
   ⚠️  circular variable reference
 
 b#695 = ???*0*
@@ -8767,8 +9264,8 @@ b#70 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["checked"]
   ⚠️  unknown object
-- *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+- *2* b
+  ⚠️  circular variable reference
 
 b#703 = (???*0* | ???*1*)
 - *0* arguments[1]
@@ -8809,8 +9306,8 @@ b#716 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
-- *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+- *2* b
+  ⚠️  circular variable reference
 
 b#721 = ???*0*
 - *0* max number of linking steps reached
@@ -8851,69 +9348,16 @@ b#768 = ???*0*
 b#77 = (???*0* | {} | null | ???*1*)
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
-- *1* ???*2*[(0 | ???*3* | ???*4* | ???*12* | null["hasOwnProperty"](???*21*))]
+- *1* ???*2*[(0 | ???*3* | ???*4*)]
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* arguments[0]
   ⚠️  function calls are not analysed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
-- *4* ???*5*["hasOwnProperty"](`$${???*6*}`)
+- *4* ???*5*["hasOwnProperty"](`$${a[c]["value"]}`)
   ⚠️  unknown callee object
-  ⚠️  This value might have side effects
-- *5* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *6* ???*7*["value"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *7* ???*8*[(???*9* | 0 | ???*10* | undefined | ???*11* | "")]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *8* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *9* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *10* updated with update expression
-  ⚠️  This value might have side effects
-- *11* c
-  ⚠️  circular variable reference
-- *12* (???*13* | ???*14*)(`$${???*15*}`)
-  ⚠️  non-function callee
-  ⚠️  This value might have side effects
-- *13* FreeVar(undefined)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *14* unknown mutation
-  ⚠️  This value might have side effects
-- *15* ???*16*["value"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *16* ???*17*[(???*18* | 0 | ???*19* | undefined | ???*20* | "")]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *17* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *18* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *19* updated with update expression
-  ⚠️  This value might have side effects
-- *20* c
-  ⚠️  circular variable reference
-- *21* `$${???*22*}`
-  ⚠️  nested operation
-- *22* ???*23*["value"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *23* ???*24*[(???*25* | 0 | ???*26* | undefined | ???*27* | "")]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *24* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *25* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *26* updated with update expression
-  ⚠️  This value might have side effects
-- *27* c
+- *5* b
   ⚠️  circular variable reference
 
 b#781 = ???*0*
@@ -8951,8 +9395,8 @@ b#819 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
-- *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *2* b
+  ⚠️  circular variable reference
 
 b#82 = ???*0*
 - *0* arguments[1]
@@ -9005,14 +9449,14 @@ b#829 = (
 - *10* unsupported expression
   ⚠️  This value might have side effects
 
-b#83 = (???*0* | ???*1* | ""["defaultValue"] | ""["value"] | ""["children"] | ???*3* | "")
+b#83 = (???*0* | ???*1* | ???*3* | "")
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["defaultValue"]
   ⚠️  unknown object
-- *2* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *3* c
+- *2* b
+  ⚠️  circular variable reference
+- *3* b
   ⚠️  circular variable reference
 
 b#831 = ???*0*
@@ -9062,7 +9506,7 @@ b#869 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
-- *2* a
+- *2* b
   ⚠️  circular variable reference
 
 b#87 = ???*0*
@@ -9190,27 +9634,17 @@ b#946 = (???*0* | ???*1*)
 
 b#947 = (
   | ???*0*
-  | new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*1*, (???*2* | ???*3*), (???*8* | ???*9*))
+  | new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*1*, ???*2*, (???*3* | ???*4*))
 )
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 - *1* arguments[2]
   ⚠️  function calls are not analysed yet
-- *2* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *3* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*4*, ???*5*, (???*6* | ???*7*))
-  ⚠️  nested operation
-- *4* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *5* b
+- *2* b
   ⚠️  circular variable reference
-- *6* arguments[4]
+- *3* arguments[4]
   ⚠️  function calls are not analysed yet
-- *7* unsupported assign operation
-  ⚠️  This value might have side effects
-- *8* arguments[4]
-  ⚠️  function calls are not analysed yet
-- *9* unsupported assign operation
+- *4* unsupported assign operation
   ⚠️  This value might have side effects
 
 b#948 = ???*0*
@@ -9225,10 +9659,7 @@ b#950 = ???*0*
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 
-b#951 = (
-  | ???*0*
-  | new (...) => undefined(4, ???*1*, ???*7*, (???*9* | ???*10*))
-)
+b#951 = (???*0* | new (...) => undefined(4, ???*1*, ???*7*, ???*9*))
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 - *1* (???*2* ? ???*5* : [])
@@ -9247,27 +9678,7 @@ b#951 = (
   ⚠️  unknown object
 - *8* arguments[0]
   ⚠️  function calls are not analysed yet
-- *9* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *10* new (...) => undefined(4, ???*11*, ???*17*, ???*19*)
-  ⚠️  nested operation
-- *11* (???*12* ? ???*15* : [])
-  ⚠️  nested operation
-- *12* (null !== ???*13*)
-  ⚠️  nested operation
-- *13* ???*14*["children"]
-  ⚠️  unknown object
-- *14* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *15* ???*16*["children"]
-  ⚠️  unknown object
-- *16* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *17* ???*18*["key"]
-  ⚠️  unknown object
-- *18* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *19* b
+- *9* b
   ⚠️  circular variable reference
 
 b#952 = ???*0*
@@ -9309,16 +9720,14 @@ b#961 = (
           | ???*12*
           | ???*13*
           | ???*14*
-          | ???*16*
-          | ???*17*
           | 0
-          | ???*18*
+          | ???*16*
           | 4
-          | ((???*19* | ???*21*) ? ???*22* : 4)
-          | (???*23* ? 16 : (???*24* | null | ???*31* | ???*32*))
-          | ???*34*
-          | ???*35*
-          | (???*37* ? 16 : (undefined | 1 | 4 | 16 | 536870912))
+          | ((???*17* | ???*19*) ? ???*20* : 4)
+          | (???*21* ? 16 : (???*22* | null | ???*29* | ???*30*))
+          | ???*32*
+          | ???*33*
+          | (???*35* ? 16 : (undefined | 1 | 4 | 16 | 536870912))
         ),
         "tag": 0,
         "payload": null,
@@ -9357,58 +9766,53 @@ b#961 = (
   ⚠️  This value might have side effects
 - *14* ???*15*["current"]
   ⚠️  unknown object
-- *15* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *16* FreeVar(undefined)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *17* unknown mutation
-  ⚠️  This value might have side effects
+- *15* b
+  ⚠️  circular variable reference
+- *16* C
+  ⚠️  circular variable reference
+- *17* (0 !== ???*18*)
+  ⚠️  nested operation
 - *18* C
   ⚠️  circular variable reference
-- *19* (0 !== ???*20*)
-  ⚠️  nested operation
+- *19* unsupported expression
+  ⚠️  This value might have side effects
 - *20* C
   ⚠️  circular variable reference
 - *21* unsupported expression
   ⚠️  This value might have side effects
-- *22* C
-  ⚠️  circular variable reference
+- *22* (???*23* ? ???*24* : 1)
+  ⚠️  nested operation
 - *23* unsupported expression
   ⚠️  This value might have side effects
-- *24* (???*25* ? ???*26* : 1)
+- *24* (???*25* ? ???*26* : 4)
   ⚠️  nested operation
 - *25* unsupported expression
   ⚠️  This value might have side effects
-- *26* (???*27* ? ???*28* : 4)
+- *26* (???*27* ? 16 : 536870912)
   ⚠️  nested operation
-- *27* unsupported expression
+- *27* (0 !== ???*28*)
+  ⚠️  nested operation
+- *28* unsupported expression
   ⚠️  This value might have side effects
-- *28* (???*29* ? 16 : 536870912)
-  ⚠️  nested operation
-- *29* (0 !== ???*30*)
-  ⚠️  nested operation
-- *30* unsupported expression
-  ⚠️  This value might have side effects
-- *31* arguments[0]
+- *29* arguments[0]
   ⚠️  function calls are not analysed yet
-- *32* ???*33*["value"]
+- *30* ???*31*["value"]
   ⚠️  unknown object
-- *33* arguments[1]
+- *31* arguments[1]
   ⚠️  function calls are not analysed yet
-- *34* arguments[0]
+- *32* arguments[0]
   ⚠️  function calls are not analysed yet
-- *35* ???*36*["event"]
+- *33* ???*34*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *36* FreeVar(window)
+- *34* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *37* (???*38* === ???*39*)
+- *35* (???*36* === ???*37*)
   ⚠️  nested operation
-- *38* unsupported expression
+- *36* unsupported expression
   ⚠️  This value might have side effects
-- *39* a
+- *37* a
   ⚠️  circular variable reference
 
 b#963 = ???*0*
@@ -9599,98 +10003,49 @@ ba = (
   | "onCompositionEnd"
   | "onCompositionUpdate"
   | ???*0*
-  | new (...) => ???*1*(
-        ("onCompositionStart" | "onCompositionEnd" | "onCompositionUpdate" | ???*2* | ???*3*),
-        ???*22*,
-        null,
-        ???*23*,
-        ???*24*
-    )
+  | new (...) => ???*1*(???*2*, ???*3*, null, ???*4*, ???*5*)
 )
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* unsupported expression
   ⚠️  This value might have side effects
-- *2* unsupported expression
-  ⚠️  This value might have side effects
-- *3* new (...) => ???*4*(???*5*, ???*6*, null, ???*7*, ???*8*)
-  ⚠️  nested operation
-- *4* unsupported expression
-  ⚠️  This value might have side effects
-- *5* ba
+- *2* ba
   ⚠️  circular variable reference
-- *6* arguments[0]
+- *3* arguments[0]
   ⚠️  function calls are not analysed yet
-- *7* arguments[2]
+- *4* arguments[2]
   ⚠️  function calls are not analysed yet
-- *8* (???*9* ? (???*14* | ???*16*) : (???*18* | ???*19* | ???*21*))
+- *5* (???*6* ? (???*11* | ???*13*) : (???*15* | ???*16* | ???*18*))
   ⚠️  nested operation
-- *9* (3 === (???*10* | ???*12*))
+- *6* (3 === (???*7* | ???*9*))
   ⚠️  nested operation
-- *10* ???*11*["nodeType"]
+- *7* ???*8*["nodeType"]
   ⚠️  unknown object
-- *11* arguments[2]
+- *8* arguments[2]
   ⚠️  function calls are not analysed yet
-- *12* ???*13*["nodeType"]
+- *9* ???*10*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *13* FreeVar(window)
+- *10* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *14* ???*15*["parentNode"]
+- *11* ???*12*["parentNode"]
   ⚠️  unknown object
+- *12* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *13* ???*14*["parentNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *14* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
 - *15* arguments[2]
   ⚠️  function calls are not analysed yet
-- *16* ???*17*["parentNode"]
+- *16* ???*17*["target"]
   ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *17* FreeVar(window)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *18* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *19* ???*20*["target"]
-  ⚠️  unknown object
-- *20* a
+- *17* a
   ⚠️  circular variable reference
-- *21* FreeVar(window)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *22* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *23* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *24* (???*25* ? (???*30* | ???*32*) : (???*34* | ???*35* | ???*37*))
-  ⚠️  nested operation
-- *25* (3 === (???*26* | ???*28*))
-  ⚠️  nested operation
-- *26* ???*27*["nodeType"]
-  ⚠️  unknown object
-- *27* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *28* ???*29*["nodeType"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *29* FreeVar(window)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *30* ???*31*["parentNode"]
-  ⚠️  unknown object
-- *31* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *32* ???*33*["parentNode"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *33* FreeVar(window)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *34* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *35* ???*36*["target"]
-  ⚠️  unknown object
-- *36* a
-  ⚠️  circular variable reference
-- *37* FreeVar(window)
+- *18* FreeVar(window)
   ⚠️  unknown global
   ⚠️  This value might have side effects
 
@@ -9773,34 +10128,20 @@ c#1001 = (
 - *16* arguments[0]
   ⚠️  function calls are not analysed yet
 
-c#1004 = (???*0* | ???*1* | ???*3* | ???*6*)
+c#1004 = (???*0* | ???*1* | ???*3*)
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["parentNode"]
   ⚠️  unknown object
-- *2* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *3* ???*4*["parentNode"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *4* ???*5*["querySelectorAll"](
+- *2* c
+  ⚠️  circular variable reference
+- *3* ???*4*["querySelectorAll"](
         `input[name=${FreeVar(JSON)["stringify"](`${b}`)}][type="radio"]`
     )
   ⚠️  unknown callee object
   ⚠️  This value might have side effects
-- *5* c
+- *4* c
   ⚠️  circular variable reference
-- *6* ???*7*["querySelectorAll"](`input[name=${???*8*}][type="radio"]`)
-  ⚠️  unknown callee object
-  ⚠️  This value might have side effects
-- *7* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *8* ???*9*["stringify"](b)
-  ⚠️  unknown callee object
-  ⚠️  This value might have side effects
-- *9* FreeVar(JSON)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
 
 c#101 = ???*0*
 - *0* arguments[2]
@@ -9832,38 +10173,29 @@ c#1017 = ???*0*
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 
-c#1018 = (
-  | ???*0*
-  | (null != (???*1* | ???*2*))[(???*4* | 0 | ???*5*)]
-  | ???*6*
-  | null[(???*11* | 0 | ???*12*)]
-)
+c#1018 = (???*0* | (null != ???*1*)[(???*2* | 0 | ???*3*)] | ???*4* | null[(???*9* | 0 | ???*10*)])
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
-- *1* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *2* ???*3*[a]
-  ⚠️  unknown object
-- *3* d
+- *1* c
   ⚠️  circular variable reference
-- *4* arguments[0]
+- *2* arguments[0]
   ⚠️  function calls are not analysed yet
-- *5* updated with update expression
+- *3* updated with update expression
   ⚠️  This value might have side effects
-- *6* ???*7*[(???*9* | 0 | ???*10*)]
+- *4* ???*5*[(???*7* | 0 | ???*8*)]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *7* ???*8*["hydratedSources"]
+- *5* ???*6*["hydratedSources"]
   ⚠️  unknown object
-- *8* arguments[2]
+- *6* c
+  ⚠️  circular variable reference
+- *7* arguments[0]
   ⚠️  function calls are not analysed yet
+- *8* updated with update expression
+  ⚠️  This value might have side effects
 - *9* arguments[0]
   ⚠️  function calls are not analysed yet
 - *10* updated with update expression
-  ⚠️  This value might have side effects
-- *11* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *12* updated with update expression
   ⚠️  This value might have side effects
 
 c#1019 = ???*0*
@@ -9884,13 +10216,11 @@ c#116 = ???*0*
 
 c#119 = (
   | ???*0*
-  | !((???*2* | null | ???*5*))["stateNode"]
+  | !((???*2* | null | ???*4*))["stateNode"]
   | false["stateNode"]
-  | !(???*8*)["stateNode"][`__reactProps$${???*9*}`][???*14*]
-  | false["stateNode"][`__reactProps$${???*15*}`][???*20*]
-  | null[???*21*]
-  | !(???*22*)[???*24*]
-  | !(???*25*)[???*31*]
+  | null[???*7*]
+  | !(???*8*)[???*10*]
+  | !(???*11*)[???*17*]
 )
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
@@ -9898,65 +10228,35 @@ c#119 = (
   ⚠️  function calls are not analysed yet
 - *2* ???*3*[Pf]
   ⚠️  unknown object
-- *3* ???*4*["stateNode"]
-  ⚠️  unknown object
-- *4* a
+- *3* c
   ⚠️  circular variable reference
-- *5* !(???*6*)
+- *4* !(???*5*)
   ⚠️  nested operation
-- *6* ???*7*["disabled"]
+- *5* ???*6*["disabled"]
   ⚠️  unknown object
-- *7* d
+- *6* d
   ⚠️  circular variable reference
-- *8* d
-  ⚠️  circular variable reference
-- *9* ???*10*["slice"](2)
-  ⚠️  unknown callee object
-- *10* ???*11*(36)
-  ⚠️  unknown callee
-- *11* ???*12*["toString"]
+- *7* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *8* ???*9*["disabled"]
   ⚠️  unknown object
-- *12* ???*13*()
+- *9* d
+  ⚠️  circular variable reference
+- *10* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *11* ("button" === (???*12* | ???*13* | ???*15* | false))
   ⚠️  nested operation
-- *13* ???["random"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *14* arguments[1]
+- *12* arguments[0]
   ⚠️  function calls are not analysed yet
-- *15* ???*16*["slice"](2)
-  ⚠️  unknown callee object
-- *16* ???*17*(36)
-  ⚠️  unknown callee
-- *17* ???*18*["toString"]
+- *13* ???*14*["type"]
   ⚠️  unknown object
-- *18* ???*19*()
-  ⚠️  nested operation
-- *19* ???["random"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *20* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *21* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *22* ???*23*["disabled"]
-  ⚠️  unknown object
-- *23* d
+- *14* a
   ⚠️  circular variable reference
-- *24* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *25* ("button" === (???*26* | ???*27* | ???*29* | false))
+- *15* !(???*16*)
   ⚠️  nested operation
-- *26* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *27* ???*28*["type"]
-  ⚠️  unknown object
-- *28* a
+- *16* d
   ⚠️  circular variable reference
-- *29* !(???*30*)
-  ⚠️  nested operation
-- *30* d
-  ⚠️  circular variable reference
-- *31* arguments[1]
+- *17* arguments[1]
   ⚠️  function calls are not analysed yet
 
 c#123 = ???*0*
@@ -9981,9 +10281,27 @@ c#131 = (???*0* | ???*1* | ???*2*)
 - *3* b
   ⚠️  circular variable reference
 
-c#136 = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
+c#136 = (???*0* | ???*1* | (???*3* ? (???*6* | ???*7* | ???*8*) : null))
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* ???*2*["alternate"]
+  ⚠️  unknown object
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *3* (3 === ???*4*)
+  ⚠️  nested operation
+- *4* ???*5*["tag"]
+  ⚠️  unknown object
+- *5* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *6* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *7* a
+  ⚠️  circular variable reference
+- *8* ???*9*["return"]
+  ⚠️  unknown object
+- *9* b
+  ⚠️  circular variable reference
 
 c#159 = (???*0* | ???*2*)
 - *0* ???*1*["pendingLanes"]
@@ -10150,30 +10468,22 @@ c#212 = ???*0*
 
 c#236 = (
   | ???*0*
-  | new (...) => ???*1*("onChange", "change", null, (???*2* | ???*3*), ???*7*)
+  | new (...) => ???*1*("onChange", "change", null, ???*2*, ???*3*)
 )
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
-- *2* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *3* new (...) => ???*4*("onChange", "change", null, ???*5*, ???*6*)
-  ⚠️  nested operation
-- *4* unsupported expression
-  ⚠️  This value might have side effects
-- *5* c
+- *2* c
   ⚠️  circular variable reference
-- *6* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *7* arguments[3]
+- *3* arguments[3]
   ⚠️  function calls are not analysed yet
 
 c#246 = ???*0*
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 
-c#25 = (???*0* | null | (???*1* ? "" : (???*13* | null | ???*14*)))
+c#25 = (???*0* | null | (???*1* ? "" : ???*13*))
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 - *1* (3 === (???*2* | ???*11*))
@@ -10202,35 +10512,7 @@ c#25 = (???*0* | null | (???*1* ? "" : (???*13* | null | ???*14*)))
   ⚠️  unknown object
 - *12* e
   ⚠️  circular variable reference
-- *13* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *14* (???*15* ? "" : ???*26*)
-  ⚠️  nested operation
-- *15* (3 === (???*16* | ???*24*))
-  ⚠️  nested operation
-- *16* (???*17* ? ???*22* : null)
-  ⚠️  nested operation
-- *17* (???*18* | ???*19*)((???*20* | ???*21*))
-  ⚠️  non-function callee
-- *18* FreeVar(undefined)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *19* unknown mutation
-  ⚠️  This value might have side effects
-- *20* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *21* ???["attributeName"]
-  ⚠️  unknown object
-- *22* {}[???*23*]
-  ⚠️  unknown object prototype methods or values
-  ⚠️  This value might have side effects
-- *23* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *24* ???*25*["type"]
-  ⚠️  unknown object
-- *25* e
-  ⚠️  circular variable reference
-- *26* c
+- *13* c
   ⚠️  circular variable reference
 
 c#251 = ???*0*
@@ -10244,21 +10526,7 @@ c#251 = ???*0*
 - *3* arguments[0]
   ⚠️  function calls are not analysed yet
 
-c#254 = (
-  | ???*0*
-  | 0
-  | ???*1*
-  | (???*2* + (???*3* | ???*6*))
-  | ???*9*
-  | 0["nextSibling"]
-  | (???*11* + ???*12*)["nextSibling"]
-  | ???*15*
-  | 0["parentNode"]
-  | (???*17* + ???*18*)["parentNode"]
-  | ???*21*
-  | (???*22* + ???*23*)
-  | ???*26*
-)
+c#254 = (???*0* | 0 | ???*1* | (???*2* + ???*3*) | ???*6* | ???*8* | ???*9*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* d
@@ -10269,56 +10537,44 @@ c#254 = (
   ⚠️  unknown object
 - *4* ???*5*["textContent"]
   ⚠️  unknown object
-- *5* a
+- *5* c
   ⚠️  circular variable reference
-- *6* ???*7*["length"]
+- *6* ???*7*["firstChild"]
   ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *7* ???*8*["textContent"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
+- *7* a
+  ⚠️  circular variable reference
 - *8* unsupported expression
   ⚠️  This value might have side effects
-- *9* ???*10*["firstChild"]
-  ⚠️  unknown object
-- *10* a
-  ⚠️  circular variable reference
-- *11* a
-  ⚠️  circular variable reference
-- *12* ???*13*["length"]
-  ⚠️  unknown object
-- *13* ???*14*["textContent"]
-  ⚠️  unknown object
-- *14* c
-  ⚠️  circular variable reference
-- *15* ???*16*["nextSibling"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *16* unsupported expression
-  ⚠️  This value might have side effects
-- *17* a
-  ⚠️  circular variable reference
-- *18* ???*19*["length"]
-  ⚠️  unknown object
-- *19* ???*20*["textContent"]
-  ⚠️  unknown object
-- *20* c
-  ⚠️  circular variable reference
-- *21* unsupported expression
-  ⚠️  This value might have side effects
-- *22* a
-  ⚠️  circular variable reference
-- *23* ???*24*["length"]
-  ⚠️  unknown object
-- *24* ???*25*["textContent"]
-  ⚠️  unknown object
-- *25* c
-  ⚠️  circular variable reference
-- *26* c
+- *9* c
   ⚠️  circular variable reference
 
-c#261 = ???*0*
-- *0* max number of linking steps reached
+c#261 = (("string" === ???*0*) | false)
+- *0* typeof((
+      | undefined["contentWindow"]["location"]["href"]
+      | null["contentWindow"]["location"]["href"]
+      | ???*1*
+      | ???*5*
+    ))
+  ⚠️  nested operation
+- *1* ???*2*["href"]
+  ⚠️  unknown object
+- *2* ???*3*["location"]
+  ⚠️  unknown object
+- *3* ???*4*["contentWindow"]
+  ⚠️  unknown object
+- *4* ???["activeElement"]
+  ⚠️  unknown object
+- *5* ???*6*["href"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *6* ???*7*["location"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *7* ???*8*["contentWindow"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *8* ???["activeElement"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 
 c#266 = ???*0*
@@ -10357,105 +10613,34 @@ c#281 = ???*0*
 
 c#285 = (
   | ???*0*
-  | (...) => undefined["bind"](null, ???*1*, (???*2* | ???*3* | ???*7*), ???*12*)
-  | ???*13*
-  | true["bind"](null, ???*29*, (???*30* | ???*31* | ???*35*), ???*40*)
+  | (...) => undefined["bind"](null, ???*1*, ???*2*, ???*3*)
+  | ???*4*
+  | true["bind"](null, ???*9*, ???*10*, ???*11*)
 )
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 - *1* arguments[1]
   ⚠️  function calls are not analysed yet
-- *2* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *3* (...) => undefined["bind"](null, ???*4*, ???*5*, ???*6*)
-  ⚠️  nested operation
-- *4* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *5* c
+- *2* c
   ⚠️  circular variable reference
-- *6* arguments[0]
+- *3* arguments[0]
   ⚠️  function calls are not analysed yet
-- *7* ???*8*["bind"](null, ???*9*, ???*10*, ???*11*)
+- *4* ???*5*["bind"](null, ???*6*, ???*7*, ???*8*)
   ⚠️  unknown callee object
   ⚠️  This value might have side effects
-- *8* unsupported expression
+- *5* unsupported expression
   ⚠️  This value might have side effects
+- *6* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *7* c
+  ⚠️  circular variable reference
+- *8* arguments[0]
+  ⚠️  function calls are not analysed yet
 - *9* arguments[1]
   ⚠️  function calls are not analysed yet
 - *10* c
   ⚠️  circular variable reference
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *12* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *13* ???*14*["bind"](
-        null,
-        ???*15*,
-        (
-          | ???*16*
-          | (...) => undefined["bind"](null, ???*17*, ???*18*, ???*19*)
-          | ???*20*
-          | true["bind"](null, ???*25*, ???*26*, ???*27*)
-        ),
-        ???*28*
-    )
-  ⚠️  unknown callee object
-  ⚠️  This value might have side effects
-- *14* unsupported expression
-  ⚠️  This value might have side effects
-- *15* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *16* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *17* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *18* c
-  ⚠️  circular variable reference
-- *19* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *20* ???*21*["bind"](null, ???*22*, ???*23*, ???*24*)
-  ⚠️  unknown callee object
-  ⚠️  This value might have side effects
-- *21* unsupported expression
-  ⚠️  This value might have side effects
-- *22* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *23* c
-  ⚠️  circular variable reference
-- *24* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *25* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *26* c
-  ⚠️  circular variable reference
-- *27* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *28* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *29* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *30* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *31* (...) => undefined["bind"](null, ???*32*, ???*33*, ???*34*)
-  ⚠️  nested operation
-- *32* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *33* c
-  ⚠️  circular variable reference
-- *34* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *35* ???*36*["bind"](null, ???*37*, ???*38*, ???*39*)
-  ⚠️  unknown callee object
-  ⚠️  This value might have side effects
-- *36* unsupported expression
-  ⚠️  This value might have side effects
-- *37* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *38* c
-  ⚠️  circular variable reference
-- *39* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *40* arguments[0]
   ⚠️  function calls are not analysed yet
 
 c#286 = ???*0*
@@ -10491,8 +10676,8 @@ c#311 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
-- *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+- *2* c
+  ⚠️  circular variable reference
 
 c#314 = ???*0*
 - *0* arguments[2]
@@ -10505,8 +10690,8 @@ c#320 = (???*0* | ???*1*)
   ⚠️  unknown object
 - *2* ???*3*["nextSibling"]
   ⚠️  unknown object
-- *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+- *3* c
+  ⚠️  circular variable reference
 
 c#327 = ???*0*
 - *0* ???*1*["data"]
@@ -10514,8 +10699,37 @@ c#327 = ???*0*
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
 
-c#331 = ???*0*
-- *0* max number of linking steps reached
+c#331 = (
+  | ???*0*
+  | null["parentNode"]
+  | null[`__reactFiber$${???*2*}`]["alternate"]
+  | null[`__reactFiber$${???*7*}`]
+)
+- *0* ???*1*["parentNode"]
+  ⚠️  unknown object
+- *1* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *2* ???*3*["slice"](2)
+  ⚠️  unknown callee object
+- *3* ???*4*(36)
+  ⚠️  unknown callee
+- *4* ???*5*["toString"]
+  ⚠️  unknown object
+- *5* ???*6*()
+  ⚠️  nested operation
+- *6* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *7* ???*8*["slice"](2)
+  ⚠️  unknown callee object
+- *8* ???*9*(36)
+  ⚠️  unknown callee
+- *9* ???*10*["toString"]
+  ⚠️  unknown object
+- *10* ???*11*()
+  ⚠️  nested operation
+- *11* ???["random"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 
 c#341 = ???*0*
@@ -10546,14 +10760,10 @@ c#350 = (null | [???*0*] | ???*1*)
 - *2* eg
   ⚠️  circular variable reference
 
-c#357 = (???*0* | ((???*1* | ???*2*) + 1))
+c#357 = (???*0* | (???*1* + 1))
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
-- *1* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *2* (???*3* + 1)
-  ⚠️  nested operation
-- *3* c
+- *1* c
   ⚠️  circular variable reference
 
 c#361 = new (...) => undefined(5, null, null, 0)
@@ -10610,9 +10820,76 @@ c#398 = (???*0* | ???*1*)
 - *1* unsupported assign operation
   ⚠️  This value might have side effects
 
-c#400 = ???*0*
-- *0* max number of linking steps reached
+c#400 = (
+  | ???*0*
+  | {
+        "baseState": ???*2*,
+        "firstBaseUpdate": (null | ???*5*),
+        "lastBaseUpdate": (
+          | null
+          | {
+                "eventTime": ???*6*,
+                "lane": ???*8*,
+                "tag": ???*10*,
+                "payload": ???*12*,
+                "callback": ???*14*,
+                "next": null
+            }
+          | ???*16*
+          | ???*17*
+        ),
+        "shared": ???*18*,
+        "effects": ???*21*
+    }
+)
+- *0* ???*1*["updateQueue"]
+  ⚠️  unknown object
+- *1* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *2* ???*3*["baseState"]
+  ⚠️  unknown object
+- *3* ???*4*["alternate"]
+  ⚠️  unknown object
+- *4* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *5* unsupported expression
   ⚠️  This value might have side effects
+- *6* ???*7*["eventTime"]
+  ⚠️  unknown object
+- *7* c
+  ⚠️  circular variable reference
+- *8* ???*9*["lane"]
+  ⚠️  unknown object
+- *9* c
+  ⚠️  circular variable reference
+- *10* ???*11*["tag"]
+  ⚠️  unknown object
+- *11* c
+  ⚠️  circular variable reference
+- *12* ???*13*["payload"]
+  ⚠️  unknown object
+- *13* c
+  ⚠️  circular variable reference
+- *14* ???*15*["callback"]
+  ⚠️  unknown object
+- *15* c
+  ⚠️  circular variable reference
+- *16* unsupported expression
+  ⚠️  This value might have side effects
+- *17* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *18* ???*19*["shared"]
+  ⚠️  unknown object
+- *19* ???*20*["alternate"]
+  ⚠️  unknown object
+- *20* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *21* ???*22*["effects"]
+  ⚠️  unknown object
+- *22* ???*23*["alternate"]
+  ⚠️  unknown object
+- *23* arguments[0]
+  ⚠️  function calls are not analysed yet
 
 c#404 = ???*0*
 - *0* arguments[2]
@@ -10622,118 +10899,34 @@ c#412 = ???*0*
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 
-c#415 = (???*0* | ???*1* | (???*16* ? (???*32* | ???*33*) : ???*35*))
+c#415 = (???*0* | ???*1* | (???*3* ? (???*5* | ???*6*) : ???*8*))
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
-- *1* (???*2* | ???*3* | (???*5* ? (???*7* | ???*8*) : ???*10*))(d, b)
-  ⚠️  non-function callee
-- *2* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *3* ???*4*(d, b)
+- *1* ???*2*(d, b)
   ⚠️  unknown callee
+- *2* c
+  ⚠️  circular variable reference
+- *3* (null === ???*4*)
+  ⚠️  nested operation
 - *4* c
   ⚠️  circular variable reference
-- *5* (null === ???*6*)
-  ⚠️  nested operation
-- *6* c
-  ⚠️  circular variable reference
-- *7* arguments[1]
+- *5* arguments[1]
   ⚠️  function calls are not analysed yet
-- *8* ???*9*["memoizedState"]
+- *6* ???*7*["memoizedState"]
   ⚠️  unknown object
-- *9* arguments[0]
+- *7* arguments[0]
   ⚠️  function calls are not analysed yet
-- *10* Object.assign*11*({}, (???*12* | ???*13*), ???*15*)
+- *8* Object.assign*9*({}, (???*10* | ???*11*), ???*13*)
   ⚠️  only const object assign is supported
   ⚠️  This value might have side effects
-- *11* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-- *12* arguments[1]
+- *9* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+- *10* arguments[1]
   ⚠️  function calls are not analysed yet
-- *13* ???*14*["memoizedState"]
+- *11* ???*12*["memoizedState"]
   ⚠️  unknown object
-- *14* arguments[0]
+- *12* arguments[0]
   ⚠️  function calls are not analysed yet
-- *15* c
-  ⚠️  circular variable reference
-- *16* (null === (???*17* | ???*18* | ???*20*))
-  ⚠️  nested operation
-- *17* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *18* ???*19*(d, b)
-  ⚠️  unknown callee
-- *19* c
-  ⚠️  circular variable reference
-- *20* (???*21* ? (???*23* | ???*24*) : ???*26*)
-  ⚠️  nested operation
-- *21* (null === ???*22*)
-  ⚠️  nested operation
-- *22* c
-  ⚠️  circular variable reference
-- *23* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *24* ???*25*["memoizedState"]
-  ⚠️  unknown object
-- *25* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *26* Object.assign*27*({}, (???*28* | ???*29*), ???*31*)
-  ⚠️  only const object assign is supported
-  ⚠️  This value might have side effects
-- *27* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-- *28* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *29* ???*30*["memoizedState"]
-  ⚠️  unknown object
-- *30* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *31* c
-  ⚠️  circular variable reference
-- *32* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *33* ???*34*["memoizedState"]
-  ⚠️  unknown object
-- *34* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *35* Object.assign*36*(
-        {},
-        (???*37* | ???*38*),
-        (???*40* | ???*41* | (???*43* ? (???*45* | ???*46*) : ???*48*))
-    )
-  ⚠️  only const object assign is supported
-  ⚠️  This value might have side effects
-- *36* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-- *37* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *38* ???*39*["memoizedState"]
-  ⚠️  unknown object
-- *39* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *40* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *41* ???*42*(d, b)
-  ⚠️  unknown callee
-- *42* c
-  ⚠️  circular variable reference
-- *43* (null === ???*44*)
-  ⚠️  nested operation
-- *44* c
-  ⚠️  circular variable reference
-- *45* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *46* ???*47*["memoizedState"]
-  ⚠️  unknown object
-- *47* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *48* Object.assign*49*({}, (???*50* | ???*51*), ???*53*)
-  ⚠️  only const object assign is supported
-  ⚠️  This value might have side effects
-- *49* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-- *50* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *51* ???*52*["memoizedState"]
-  ⚠️  unknown object
-- *52* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *53* c
+- *13* c
   ⚠️  circular variable reference
 
 c#417 = ???*0*
@@ -10789,8 +10982,8 @@ c#424 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["_owner"]
   ⚠️  unknown object
-- *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+- *2* c
+  ⚠️  circular variable reference
 
 c#431 = (...) => null
 
@@ -10822,8 +11015,10 @@ c#442 = ???*0*
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 
-c#443 = ???*0*
-- *0* max number of linking steps reached
+c#443 = (???*0* | ???*1*)
+- *0* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *1* node limit reached
   ⚠️  This value might have side effects
 
 c#445 = ???*0*
@@ -10868,11 +11063,11 @@ c#485 = ???*0*
   ⚠️  function calls are not analysed yet
 
 c#494 = ???*0*
-- *0* max number of linking steps reached
+- *0* node limit reached
   ⚠️  This value might have side effects
 
 c#501 = ???*0*
-- *0* max number of linking steps reached
+- *0* node limit reached
   ⚠️  This value might have side effects
 
 c#504 = (
@@ -11117,45 +11312,17 @@ c#52 = ???*0*
 - *0* c
   ⚠️  pattern without value
 
-c#528 = (???*0* | (???*1* ? (???*8* | ???*11*) : null))
+c#528 = (???*0* | (???*1* ? ???*3* : null))
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
-- *1* (null !== (???*2* | ???*3*))
+- *1* (null !== ???*2*)
   ⚠️  nested operation
-- *2* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *3* (???*4* ? ???*6* : null)
-  ⚠️  nested operation
-- *4* (null !== ???*5*)
-  ⚠️  nested operation
-- *5* c
+- *2* c
   ⚠️  circular variable reference
-- *6* ???*7*["concat"]([a])
+- *3* ???*4*["concat"]([a])
   ⚠️  unknown callee object
-- *7* c
+- *4* c
   ⚠️  circular variable reference
-- *8* ???*9*["concat"]([???*10*])
-  ⚠️  unknown callee object
-- *9* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *10* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *11* ???*12*([???*18*])
-  ⚠️  unknown callee
-- *12* ???*13*["concat"]
-  ⚠️  unknown object
-- *13* (???*14* ? ???*16* : null)
-  ⚠️  nested operation
-- *14* (null !== ???*15*)
-  ⚠️  nested operation
-- *15* c
-  ⚠️  circular variable reference
-- *16* ???*17*["concat"]([a])
-  ⚠️  unknown callee object
-- *17* c
-  ⚠️  circular variable reference
-- *18* arguments[0]
-  ⚠️  function calls are not analysed yet
 
 c#530 = (
   | null
@@ -11378,11 +11545,11 @@ c#533 = (
   ⚠️  circular variable reference
 - *1* (0 !== ???*2*)
   ⚠️  nested operation
-- *2* C
+- *2* c
   ⚠️  circular variable reference
 - *3* unsupported expression
   ⚠️  This value might have side effects
-- *4* C
+- *4* c
   ⚠️  circular variable reference
 - *5* unsupported expression
   ⚠️  This value might have side effects
@@ -11409,13 +11576,116 @@ c#533 = (
 - *16* arguments[0]
   ⚠️  function calls are not analysed yet
 
-c#537 = ???*0*
-- *0* max number of linking steps reached
+c#537 = (
+  | ???*0*
+  | {
+        "lane": (
+          | 1
+          | ???*1*
+          | ???*2*
+          | ???*3*
+          | 0
+          | ???*4*
+          | 4
+          | ((???*5* | ???*7*) ? ???*8* : 4)
+          | (???*9* ? 16 : (???*10* | null | ???*17* | ???*18*))
+          | ???*20*
+          | (???*22* ? 16 : (undefined | 1 | 4 | 16 | 536870912))
+        ),
+        "action": ???*25*,
+        "hasEagerState": false,
+        "eagerState": null,
+        "next": null
+    }
+  | (???*26* ? ???*30* : null)
+)
+- *0* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *1* unsupported expression
   ⚠️  This value might have side effects
+- *2* Ck
+  ⚠️  sequence with side effects
+  ⚠️  This value might have side effects
+- *3* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *4* C
+  ⚠️  circular variable reference
+- *5* (0 !== ???*6*)
+  ⚠️  nested operation
+- *6* C
+  ⚠️  circular variable reference
+- *7* unsupported expression
+  ⚠️  This value might have side effects
+- *8* C
+  ⚠️  circular variable reference
+- *9* unsupported expression
+  ⚠️  This value might have side effects
+- *10* (???*11* ? ???*12* : 1)
+  ⚠️  nested operation
+- *11* unsupported expression
+  ⚠️  This value might have side effects
+- *12* (???*13* ? ???*14* : 4)
+  ⚠️  nested operation
+- *13* unsupported expression
+  ⚠️  This value might have side effects
+- *14* (???*15* ? 16 : 536870912)
+  ⚠️  nested operation
+- *15* (0 !== ???*16*)
+  ⚠️  nested operation
+- *16* unsupported expression
+  ⚠️  This value might have side effects
+- *17* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *18* ???*19*["value"]
+  ⚠️  unknown object
+- *19* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *20* ???*21*["event"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *21* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *22* (???*23* === ???*24*)
+  ⚠️  nested operation
+- *23* unsupported expression
+  ⚠️  This value might have side effects
+- *24* a
+  ⚠️  circular variable reference
+- *25* c
+  ⚠️  circular variable reference
+- *26* (3 === ???*27*)
+  ⚠️  nested operation
+- *27* ???*28*["tag"]
+  ⚠️  unknown object
+- *28* ???*29*["alternate"]
+  ⚠️  unknown object
+- *29* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *30* ???*31*["stateNode"]
+  ⚠️  unknown object
+- *31* ???*32*["alternate"]
+  ⚠️  unknown object
+- *32* arguments[0]
+  ⚠️  function calls are not analysed yet
 
-c#539 = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
+c#539 = (???*0* | (???*1* ? ???*5* : null))
+- *0* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *1* (3 === ???*2*)
+  ⚠️  nested operation
+- *2* ???*3*["tag"]
+  ⚠️  unknown object
+- *3* ???*4*["alternate"]
+  ⚠️  unknown object
+- *4* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *5* ???*6*["stateNode"]
+  ⚠️  unknown object
+- *6* ???*7*["alternate"]
+  ⚠️  unknown object
+- *7* arguments[0]
+  ⚠️  function calls are not analysed yet
 
 c#546 = ???*0*
 - *0* ???*1*["pending"]
@@ -11429,45 +11699,17 @@ c#547 = (???*0* | ???*1*)
 - *1* unsupported assign operation
   ⚠️  This value might have side effects
 
-c#550 = (???*0* | (???*1* ? (???*8* | ???*11*) : null))
+c#550 = (???*0* | (???*1* ? ???*3* : null))
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
-- *1* (null !== (???*2* | ???*3*))
+- *1* (null !== ???*2*)
   ⚠️  nested operation
-- *2* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *3* (???*4* ? ???*6* : null)
-  ⚠️  nested operation
-- *4* (null !== ???*5*)
-  ⚠️  nested operation
-- *5* c
+- *2* c
   ⚠️  circular variable reference
-- *6* ???*7*["concat"]([a])
+- *3* ???*4*["concat"]([a])
   ⚠️  unknown callee object
-- *7* c
+- *4* c
   ⚠️  circular variable reference
-- *8* ???*9*["concat"]([???*10*])
-  ⚠️  unknown callee object
-- *9* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *10* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *11* ???*12*([???*18*])
-  ⚠️  unknown callee
-- *12* ???*13*["concat"]
-  ⚠️  unknown object
-- *13* (???*14* ? ???*16* : null)
-  ⚠️  nested operation
-- *14* (null !== ???*15*)
-  ⚠️  nested operation
-- *15* c
-  ⚠️  circular variable reference
-- *16* ???*17*["concat"]([a])
-  ⚠️  unknown callee object
-- *17* c
-  ⚠️  circular variable reference
-- *18* arguments[0]
-  ⚠️  function calls are not analysed yet
 
 c#553 = (
   | null
@@ -11577,12 +11819,10 @@ c#554 = ???*0*
 c#559 = (???*0* | ???*1*() | ???*2*())
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
-- *1* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *2* ???*3*()
-  ⚠️  nested operation
-- *3* c
+- *1* c
   ⚠️  circular variable reference
+- *2* arguments[1]
+  ⚠️  function calls are not analysed yet
 
 c#56 = ???*0*
 - *0* ???*1*(???*3*, ((???*6* | ???*7*) ? "checked" : "value"))
@@ -11613,8 +11853,36 @@ c#562 = ???*0*
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-c#570 = ???*0*
-- *0* max number of linking steps reached
+c#570 = ("" | (???*0* + (undefined | ???*1* | ???*13* | "")))
+- *0* c
+  ⚠️  circular variable reference
+- *1* `
+${(???*2* | ???*3* | ???*7* | "")}${(???*11* | ""["type"])}`
+  ⚠️  nested operation
+- *2* La
+  ⚠️  pattern without value
+- *3* ???*4*(/\n( *(at )?)/)
+  ⚠️  unknown callee
+- *4* ???*5*["match"]
+  ⚠️  unknown object
+- *5* ???*6*()
+  ⚠️  nested operation
+- *6* ???["trim"]
+  ⚠️  unknown object
+- *7* ???*8*[1]
+  ⚠️  unknown object
+- *8* ???*9*(/\n( *(at )?)/)
+  ⚠️  unknown callee
+- *9* ???*10*["match"]
+  ⚠️  unknown object
+- *10* ???()
+  ⚠️  nested operation
+- *11* ???*12*["type"]
+  ⚠️  unknown object
+- *12* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *13* a
+  ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
 c#573 = ???*0*
@@ -11627,52 +11895,24 @@ c#576 = ???*0*
 
 c#578 = (
   | ???*0*
-  | {
-        "eventTime": ???*1*,
-        "lane": (
-          | ???*2*
-          | {"eventTime": ???*3*, "lane": ???*4*, "tag": 0, "payload": null, "callback": null, "next": null}
-        ),
-        "tag": 0,
-        "payload": null,
-        "callback": null,
-        "next": null
-    }
+  | {"eventTime": ???*1*, "lane": ???*2*, "tag": 0, "payload": null, "callback": null, "next": null}
 )
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
-- *2* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *3* unsupported expression
-  ⚠️  This value might have side effects
-- *4* c
+- *2* c
   ⚠️  circular variable reference
 
 c#580 = (
   | ???*0*
-  | {
-        "eventTime": ???*1*,
-        "lane": (
-          | ???*2*
-          | {"eventTime": ???*3*, "lane": ???*4*, "tag": 0, "payload": null, "callback": null, "next": null}
-        ),
-        "tag": 0,
-        "payload": null,
-        "callback": null,
-        "next": null
-    }
+  | {"eventTime": ???*1*, "lane": ???*2*, "tag": 0, "payload": null, "callback": null, "next": null}
 )
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
-- *2* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *3* unsupported expression
-  ⚠️  This value might have side effects
-- *4* c
+- *2* c
   ⚠️  circular variable reference
 
 c#584 = ???*0*
@@ -11693,30 +11933,23 @@ c#590 = ???*0*
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 
-c#591 = (???*0* | ???*1* | (0 !== (0 | ???*3*))["render"] | (0 !== (0 | ???*4*)))
+c#591 = (???*0* | ???*1* | (0 !== (0 | ???*3*)))
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["render"]
   ⚠️  unknown object
-- *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+- *2* c
+  ⚠️  circular variable reference
 - *3* updated with update expression
   ⚠️  This value might have side effects
-- *4* updated with update expression
-  ⚠️  This value might have side effects
 
-c#592 = (
-  | ???*0*
-  | ???*1*
-  | (???*3* ? ???*5* : (...) => (???*6* | ???*7*))["compare"]
-  | (???*8* ? (???*18* | ???*19* | ???*21*) : (...) => (???*27* | ???*28*))
-)
+c#592 = (???*0* | ???*1* | (???*3* ? ???*5* : (...) => (???*6* | ???*7*)))
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["compare"]
   ⚠️  unknown object
-- *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+- *2* c
+  ⚠️  circular variable reference
 - *3* (null !== ???*4*)
   ⚠️  nested operation
 - *4* c
@@ -11726,48 +11959,6 @@ c#592 = (
 - *6* !(0)
   ⚠️  nested operation
 - *7* !(1)
-  ⚠️  nested operation
-- *8* (null !== (???*9* | ???*10* | ???*12*))
-  ⚠️  nested operation
-- *9* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *10* ???*11*["compare"]
-  ⚠️  unknown object
-- *11* c
-  ⚠️  circular variable reference
-- *12* (???*13* ? ???*15* : (...) => (???*16* | ???*17*))
-  ⚠️  nested operation
-- *13* (null !== ???*14*)
-  ⚠️  nested operation
-- *14* c
-  ⚠️  circular variable reference
-- *15* c
-  ⚠️  circular variable reference
-- *16* !(0)
-  ⚠️  nested operation
-- *17* !(1)
-  ⚠️  nested operation
-- *18* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *19* ???*20*["compare"]
-  ⚠️  unknown object
-- *20* c
-  ⚠️  circular variable reference
-- *21* (???*22* ? ???*24* : (...) => (???*25* | ???*26*))
-  ⚠️  nested operation
-- *22* (null !== ???*23*)
-  ⚠️  nested operation
-- *23* c
-  ⚠️  circular variable reference
-- *24* c
-  ⚠️  circular variable reference
-- *25* !(0)
-  ⚠️  nested operation
-- *26* !(1)
-  ⚠️  nested operation
-- *27* !(0)
-  ⚠️  nested operation
-- *28* !(1)
   ⚠️  nested operation
 
 c#595 = ???*0*
@@ -11787,13 +11978,9 @@ c#599 = ???*0*
 c#600 = (???*0* | ???*1*)
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
-- *1* (???*2* | ???*3*)(d, e)
-  ⚠️  non-function callee
-- *2* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *3* ???*4*(d, e)
+- *1* ???*2*(d, e)
   ⚠️  unknown callee
-- *4* c
+- *2* c
   ⚠️  circular variable reference
 
 c#601 = ???*0*
@@ -11832,32 +12019,19 @@ c#620 = ???*0*
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 
-c#621 = (
-  | ???*0*
-  | ???*1*
-  | 0["revealOrder"]["sibling"]
-  | ???*3*
-  | null["sibling"]
-  | 0["revealOrder"]
-  | null
-  | ???*6*
-  | null["alternate"]
-)
+c#621 = (???*0* | ???*1* | 0["revealOrder"] | ???*3* | null | ???*5*)
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
   ⚠️  function calls are not analysed yet
-- *3* ???*4*["sibling"]
+- *3* ???*4*["revealOrder"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *4* ???*5*["revealOrder"]
-  ⚠️  unknown object
+- *4* unknown mutation
   ⚠️  This value might have side effects
-- *5* unknown mutation
-  ⚠️  This value might have side effects
-- *6* e
+- *5* c
   ⚠️  circular variable reference
 
 c#629 = (
@@ -11977,7 +12151,7 @@ c#644 = ???*0*
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 
-c#645 = (null | ???*0* | ???*1* | null["sibling"])
+c#645 = (null | ???*0* | ???*1*)
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["tail"]
@@ -12017,7 +12191,7 @@ c#687 = ???*0*
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 
-c#69 = ((???*0* ? "" : ???*3*) | undefined | (???*5* ? ???*8* : (???*10* | undefined | "")) | "")
+c#69 = ((???*0* ? "" : ???*3*) | undefined | (???*5* ? ???*8* : ???*10*) | "")
 - *0* (null == ???*1*)
   ⚠️  nested operation
 - *1* ???*2*["defaultValue"]
@@ -12038,32 +12212,15 @@ c#69 = ((???*0* ? "" : ???*3*) | undefined | (???*5* ? ???*8* : (???*10* | undef
   ⚠️  unknown object
 - *9* arguments[1]
   ⚠️  function calls are not analysed yet
-- *10* (???*11* ? "" : ???*14*)
-  ⚠️  nested operation
-- *11* (null == ???*12*)
-  ⚠️  nested operation
-- *12* ???*13*["defaultValue"]
-  ⚠️  unknown object
-- *13* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *14* ???*15*["defaultValue"]
-  ⚠️  unknown object
-- *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+- *10* c
+  ⚠️  circular variable reference
 
-c#691 = (???*0* | ???*1* | ???*3*)
+c#691 = (???*0* | ???*1*)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* ???*2*["next"]
   ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *2* unsupported expression
-  ⚠️  This value might have side effects
-- *3* ???*4*["next"]
-  ⚠️  unknown object
-- *4* ???*5*["next"]
-  ⚠️  unknown object
-- *5* c
+- *2* c
   ⚠️  circular variable reference
 
 c#695 = ???*0*
@@ -12081,8 +12238,8 @@ c#703 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["_reactRootContainer"]
   ⚠️  unknown object
-- *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+- *2* c
+  ⚠️  circular variable reference
 
 c#704 = ???*0*
 - *0* arguments[2]
@@ -12093,16 +12250,16 @@ c#705 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
-- *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+- *2* c
+  ⚠️  circular variable reference
 
 c#706 = (???*0* | ???*1*)
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
-- *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+- *2* c
+  ⚠️  circular variable reference
 
 c#71 = (undefined | ???*0* | "")
 - *0* ???*1*["value"]
@@ -12189,42 +12346,19 @@ c#803 = (
   | module<scheduler, {}>["unstable_UserBlockingPriority"]
   | module<scheduler, {}>["unstable_NormalPriority"]
   | module<scheduler, {}>["unstable_IdlePriority"]
-  | module<scheduler, {}>["unstable_scheduleCallback"](
-        (
-          | ???*2*
-          | null
-          | module<scheduler, {}>["unstable_ImmediatePriority"]
-          | module<scheduler, {}>["unstable_UserBlockingPriority"]
-          | module<scheduler, {}>["unstable_NormalPriority"]
-          | module<scheduler, {}>["unstable_IdlePriority"]
-          | ???*4*
-        ),
-        ???*9*
-    )
+  | module<scheduler, {}>["unstable_scheduleCallback"](???*2*, ???*3*)
 )
 - *0* ???*1*["callbackNode"]
   ⚠️  unknown object
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
-- *2* ???*3*["callbackNode"]
-  ⚠️  unknown object
-- *3* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *4* module<scheduler, {}>["unstable_scheduleCallback"](???*5*, ???*6*)
-  ⚠️  nested operation
-- *5* c
+- *2* c
   ⚠️  circular variable reference
-- *6* (...) => (null | ???*7*)["bind"](null, ???*8*)
+- *3* (...) => (null | ???*4*)["bind"](null, ???*5*)
   ⚠️  nested operation
-- *7* ((...[...] === c) ? Hk["bind"](null, a) : null)
+- *4* ((a["callbackNode"] === c) ? Hk["bind"](null, a) : null)
   ⚠️  nested operation
-- *8* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *9* (...) => (null | ???*10*)["bind"](null, ???*11*)
-  ⚠️  nested operation
-- *10* ((a["callbackNode"] === c) ? Hk["bind"](null, a) : null)
-  ⚠️  nested operation
-- *11* arguments[0]
+- *5* arguments[0]
   ⚠️  function calls are not analysed yet
 
 c#807 = ???*0*
@@ -12249,24 +12383,14 @@ c#829 = ???*0*
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-c#83 = (
-  | ???*0*
-  | ""["value"]
-  | ""["children"]
-  | ""["value"][0]
-  | ""["children"][0]
-  | ""[0]
-  | ???*2*
-  | ???*3*
-  | ""
-)
+c#83 = (???*0* | ""["value"] | ""["children"] | ???*2* | ???*3* | "")
 - *0* ???*1*["value"]
   ⚠️  unknown object
 - *1* arguments[1]
   ⚠️  function calls are not analysed yet
 - *2* arguments[1]
   ⚠️  function calls are not analysed yet
-- *3* b
+- *3* c
   ⚠️  circular variable reference
 
 c#831 = ???*0*
@@ -12500,9 +12624,51 @@ c#96 = ???*0*
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
 
-c#960 = ???*0*
-- *0* max number of linking steps reached
+c#960 = (
+  | ???*0*
+  | ???*1*
+  | new (...) => undefined(???*3*, (???*4* | ???*5* | 1 | ???*17* | 0), true, ???*18*, ???*19*)["current"]
+)
+- *0* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *1* ???*2*["current"]
+  ⚠️  unknown object
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *3* a
+  ⚠️  circular variable reference
+- *4* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *5* (???*6* ? ???*8* : ???*9*)
+  ⚠️  nested operation
+- *6* (0 !== ???*7*)
+  ⚠️  nested operation
+- *7* unsupported expression
   ⚠️  This value might have side effects
+- *8* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *9* (???*10* ? (???*14* | ???*15*) : ???*16*)
+  ⚠️  nested operation
+- *10* (???*11* !== (???*12* | ???*13*))
+  ⚠️  nested operation
+- *11* unsupported expression
+  ⚠️  This value might have side effects
+- *12* unsupported expression
+  ⚠️  This value might have side effects
+- *13* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *14* unsupported expression
+  ⚠️  This value might have side effects
+- *15* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *16* unsupported expression
+  ⚠️  This value might have side effects
+- *17* unsupported assign operation
+  ⚠️  This value might have side effects
+- *18* arguments[7]
+  ⚠️  function calls are not analysed yet
+- *19* arguments[8]
+  ⚠️  function calls are not analysed yet
 
 c#961 = (???*0* | {} | ???*1* | ???*2* | ???*4*)
 - *0* arguments[2]
@@ -12715,7 +12881,7 @@ d#1004 = ???*0*
 d#1013 = (
   | ""
   | ???*0*
-  | new (...) => undefined(???*2*, (1 | ???*3* | 0), false, ("" | ???*4*), (???*6* | ???*11*))["identifierPrefix"]
+  | new (...) => undefined(???*2*, (1 | ???*3* | 0), false, ???*4*, (???*5* | ???*10*))["identifierPrefix"]
 )
 - *0* ???*1*["identifierPrefix"]
   ⚠️  unknown object
@@ -12725,80 +12891,36 @@ d#1013 = (
   ⚠️  circular variable reference
 - *3* unsupported assign operation
   ⚠️  This value might have side effects
-- *4* ???*5*["identifierPrefix"]
-  ⚠️  unknown object
-- *5* b
+- *4* d
   ⚠️  circular variable reference
-- *6* (???*7* ? ???*10* : (...) => undefined)
+- *5* (???*6* ? ???*9* : (...) => undefined)
   ⚠️  nested operation
-- *7* ("function" === ???*8*)
+- *6* ("function" === ???*7*)
   ⚠️  nested operation
-- *8* typeof(???*9*)
+- *7* typeof(???*8*)
   ⚠️  nested operation
+- *8* FreeVar(reportError)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
 - *9* FreeVar(reportError)
   ⚠️  unknown global
   ⚠️  This value might have side effects
-- *10* FreeVar(reportError)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *11* ???*12*["onRecoverableError"]
+- *10* ???*11*["onRecoverableError"]
   ⚠️  unknown object
-- *12* b
+- *11* b
   ⚠️  circular variable reference
 
-d#1018 = (
-  | (null != (???*0* | ???*1* | null[(???*6* | 0 | ???*7*)]))
-  | ???*8*
-  | (null != ???*10*)[(???*11* | 0 | ???*12*)]["hydratedSources"]
-  | ???*13*
-  | null[(???*19* | 0 | ???*20*)]["hydratedSources"]
-  | null
-)
+d#1018 = ((null != (???*0* | ???*1*)) | ???*3* | null)
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
-- *1* ???*2*[(???*4* | 0 | ???*5*)]
+- *1* ???*2*[a]
   ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *2* (null != ???*3*)
-  ⚠️  nested operation
-- *3* c
+- *2* d
   ⚠️  circular variable reference
-- *4* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *5* updated with update expression
-  ⚠️  This value might have side effects
-- *6* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *7* updated with update expression
-  ⚠️  This value might have side effects
-- *8* ???*9*["hydratedSources"]
+- *3* ???*4*["hydratedSources"]
   ⚠️  unknown object
-- *9* arguments[2]
+- *4* arguments[2]
   ⚠️  function calls are not analysed yet
-- *10* c
-  ⚠️  circular variable reference
-- *11* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *12* updated with update expression
-  ⚠️  This value might have side effects
-- *13* ???*14*["hydratedSources"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *14* ???*15*[(???*17* | 0 | ???*18*)]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *15* ???*16*["hydratedSources"]
-  ⚠️  unknown object
-- *16* c
-  ⚠️  circular variable reference
-- *17* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *18* updated with update expression
-  ⚠️  This value might have side effects
-- *19* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *20* updated with update expression
-  ⚠️  This value might have side effects
 
 d#102 = (0 === (???*0* | ???*2*))
 - *0* ???*1*["indexOf"]("--")
@@ -12812,9 +12934,68 @@ d#1023 = ???*0*
 - *0* arguments[3]
   ⚠️  function calls are not analysed yet
 
-d#119 = ???*0*
-- *0* max number of linking steps reached
+d#119 = (
+  | ???*0*
+  | !(???*7*)["stateNode"][`__reactProps$${???*8*}`]
+  | false["stateNode"][`__reactProps$${???*13*}`]
+  | null
+  | !(???*18*)
+  | !(???*20*)
+)
+- *0* ???*1*[`__reactProps$${???*3*}`]
+  ⚠️  unknown object
+- *1* ???*2*["stateNode"]
+  ⚠️  unknown object
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *3* ???*4*["slice"](2)
+  ⚠️  unknown callee object
+- *4* ???*5*(36)
+  ⚠️  unknown callee
+- *5* ???*6*["toString"]
+  ⚠️  unknown object
+- *6* ???()
+  ⚠️  nested operation
+- *7* d
+  ⚠️  circular variable reference
+- *8* ???*9*["slice"](2)
+  ⚠️  unknown callee object
+- *9* ???*10*(36)
+  ⚠️  unknown callee
+- *10* ???*11*["toString"]
+  ⚠️  unknown object
+- *11* ???*12*()
+  ⚠️  nested operation
+- *12* ???["random"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
+- *13* ???*14*["slice"](2)
+  ⚠️  unknown callee object
+- *14* ???*15*(36)
+  ⚠️  unknown callee
+- *15* ???*16*["toString"]
+  ⚠️  unknown object
+- *16* ???*17*()
+  ⚠️  nested operation
+- *17* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *18* ???*19*["disabled"]
+  ⚠️  unknown object
+- *19* d
+  ⚠️  circular variable reference
+- *20* ("button" === (???*21* | ???*22* | ???*24* | false))
+  ⚠️  nested operation
+- *21* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *22* ???*23*["type"]
+  ⚠️  unknown object
+- *23* a
+  ⚠️  circular variable reference
+- *24* !(???*25*)
+  ⚠️  nested operation
+- *25* d
+  ⚠️  circular variable reference
 
 d#123 = ???*0*
 - *0* arguments[3]
@@ -12828,9 +13009,25 @@ d#128 = ???*0*
 - *0* arguments[3]
   ⚠️  function calls are not analysed yet
 
-d#136 = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
+d#136 = (???*0* | (???*2* ? (???*5* | ???*6* | ???*7*) : null))
+- *0* ???*1*["alternate"]
+  ⚠️  unknown object
+- *1* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *2* (3 === ???*3*)
+  ⚠️  nested operation
+- *3* ???*4*["tag"]
+  ⚠️  unknown object
+- *4* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *5* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *6* a
+  ⚠️  circular variable reference
+- *7* ???*8*["return"]
+  ⚠️  unknown object
+- *8* b
+  ⚠️  circular variable reference
 
 d#159 = (
   | 0
@@ -12967,45 +13164,27 @@ d#251 = (???*0* | 0 | ???*4*)
 
 d#254 = (
   | ???*0*
-  | ((???*1* | 0 | ???*2* | ???*3*) + (???*11* | 0["textContent"]["length"] | ???*14*))
+  | ((???*1* | 0 | ???*2*) + (???*3* | 0["textContent"]["length"] | ???*6*))
 )
 - *0* d
   ⚠️  pattern without value
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
 - *2* d
-  ⚠️  pattern without value
-- *3* (???*4* + (???*5* | ???*8*))
-  ⚠️  nested operation
-- *4* a
   ⚠️  circular variable reference
-- *5* ???*6*["length"]
+- *3* ???*4*["length"]
   ⚠️  unknown object
-- *6* ???*7*["textContent"]
+- *4* ???*5*["textContent"]
   ⚠️  unknown object
-- *7* a
-  ⚠️  circular variable reference
-- *8* ???*9*["length"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *9* ???*10*["textContent"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *10* unsupported expression
-  ⚠️  This value might have side effects
-- *11* ???*12*["length"]
-  ⚠️  unknown object
-- *12* ???*13*["textContent"]
-  ⚠️  unknown object
-- *13* arguments[0]
+- *5* arguments[0]
   ⚠️  function calls are not analysed yet
-- *14* ???*15*["length"]
+- *6* ???*7*["length"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *15* ???*16*["textContent"]
+- *7* ???*8*["textContent"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
-- *16* unsupported expression
+- *8* unsupported expression
   ⚠️  This value might have side effects
 
 d#264 = ???*0*
@@ -13026,7 +13205,7 @@ d#274 = (???*0* | "unknown-event"){truthy}
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
 
-d#275 = (???*0* | null[(0 | ???*3*)] | null[(0 | ???*4*)]["listeners"] | ???*5*)
+d#275 = (???*0* | null[(0 | ???*3*)] | ???*4*)
 - *0* ???*1*[(0 | ???*2*)]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -13036,13 +13215,9 @@ d#275 = (???*0* | null[(0 | ???*3*)] | null[(0 | ???*4*)]["listeners"] | ???*5*)
   ⚠️  This value might have side effects
 - *3* updated with update expression
   ⚠️  This value might have side effects
-- *4* updated with update expression
-  ⚠️  This value might have side effects
-- *5* ???*6*["listeners"]
+- *4* ???*5*["listeners"]
   ⚠️  unknown object
-- *6* ???*7*["listeners"]
-  ⚠️  unknown object
-- *7* d
+- *5* d
   ⚠️  circular variable reference
 
 d#280 = `${???*0*}__bubble`
@@ -13057,23 +13232,131 @@ d#285 = ???*0*
 - *0* arguments[3]
   ⚠️  function calls are not analysed yet
 
-d#286 = (???*0* | ???*1* | ???*2* | ???*4*)
+d#286 = (???*0* | ???*1* | ???*2*)
 - *0* arguments[3]
   ⚠️  function calls are not analysed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* ???*3*["return"]
   ⚠️  unknown object
-- *3* arguments[3]
+- *3* d
+  ⚠️  circular variable reference
+
+d#292 = (
+  | ???*0*
+  | ???*1*
+  | ???*2*
+  | ???*4*
+  | null[`__reactFiber$${???*6*}`]
+  | null["parentNode"][`__reactContainer$${???*11*}`]
+  | null[`__reactFiber$${???*16*}`][`__reactContainer$${???*21*}`]
+  | null["parentNode"][`__reactFiber$${???*26*}`]
+  | null[`__reactFiber$${???*31*}`][`__reactFiber$${???*36*}`]
+  | null["parentNode"]
+  | null[`__reactFiber$${???*41*}`]["alternate"]
+  | null
+  | []
+)
+- *0* arguments[3]
   ⚠️  function calls are not analysed yet
-- *4* ???*5*["return"]
+- *1* unsupported expression
+  ⚠️  This value might have side effects
+- *2* ???*3*["return"]
+  ⚠️  unknown object
+- *3* d
+  ⚠️  circular variable reference
+- *4* ???*5*["tag"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *5* unsupported expression
   ⚠️  This value might have side effects
-
-d#292 = ???*0*
-- *0* max number of linking steps reached
+- *6* ???*7*["slice"](2)
+  ⚠️  unknown callee object
+- *7* ???*8*(36)
+  ⚠️  unknown callee
+- *8* ???*9*["toString"]
+  ⚠️  unknown object
+- *9* ???*10*()
+  ⚠️  nested operation
+- *10* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *11* ???*12*["slice"](2)
+  ⚠️  unknown callee object
+- *12* ???*13*(36)
+  ⚠️  unknown callee
+- *13* ???*14*["toString"]
+  ⚠️  unknown object
+- *14* ???*15*()
+  ⚠️  nested operation
+- *15* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *16* ???*17*["slice"](2)
+  ⚠️  unknown callee object
+- *17* ???*18*(36)
+  ⚠️  unknown callee
+- *18* ???*19*["toString"]
+  ⚠️  unknown object
+- *19* ???*20*()
+  ⚠️  nested operation
+- *20* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *21* ???*22*["slice"](2)
+  ⚠️  unknown callee object
+- *22* ???*23*(36)
+  ⚠️  unknown callee
+- *23* ???*24*["toString"]
+  ⚠️  unknown object
+- *24* ???*25*()
+  ⚠️  nested operation
+- *25* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *26* ???*27*["slice"](2)
+  ⚠️  unknown callee object
+- *27* ???*28*(36)
+  ⚠️  unknown callee
+- *28* ???*29*["toString"]
+  ⚠️  unknown object
+- *29* ???*30*()
+  ⚠️  nested operation
+- *30* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *31* ???*32*["slice"](2)
+  ⚠️  unknown callee object
+- *32* ???*33*(36)
+  ⚠️  unknown callee
+- *33* ???*34*["toString"]
+  ⚠️  unknown object
+- *34* ???*35*()
+  ⚠️  nested operation
+- *35* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *36* ???*37*["slice"](2)
+  ⚠️  unknown callee object
+- *37* ???*38*(36)
+  ⚠️  unknown callee
+- *38* ???*39*["toString"]
+  ⚠️  unknown object
+- *39* ???*40*()
+  ⚠️  nested operation
+- *40* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *41* ???*42*["slice"](2)
+  ⚠️  unknown callee object
+- *42* ???*43*(36)
+  ⚠️  unknown callee
+- *43* ???*44*["toString"]
+  ⚠️  unknown object
+- *44* ???*45*()
+  ⚠️  nested operation
+- *45* ???["random"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 
 d#30 = ???*0*
@@ -13103,10 +13386,8 @@ d#345 = (???*0* | ???*2*())
   ⚠️  function calls are not analysed yet
 - *2* ???*3*["getChildContext"]
   ⚠️  unknown object
-- *3* ???*4*["stateNode"]
-  ⚠️  unknown object
-- *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *3* d
+  ⚠️  circular variable reference
 
 d#347 = (???*0* | ???*2* | ???*3* | ???*4*)
 - *0* ???*1*["stateNode"]
@@ -13144,30 +13425,9 @@ d#350 = (null[(0 | ???*0*)] | ???*1* | ???*2* | ???*3* | ???*5* | ???*9*)
   ⚠️  circular variable reference
 - *8* updated with update expression
   ⚠️  This value might have side effects
-- *9* (null[(0 | ???*10*)] | ???*11* | ???*12* | ???*13* | ???*15* | ???*19*)(!(0))
-  ⚠️  non-function callee
-- *10* updated with update expression
-  ⚠️  This value might have side effects
-- *11* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *12* unknown mutation
-  ⚠️  This value might have side effects
-- *13* [][???*14*]
-  ⚠️  unknown array prototype methods or values
-- *14* updated with update expression
-  ⚠️  This value might have side effects
-- *15* ???*16*[(0 | ???*18*)]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *16* ???*17*["slice"]((a + 1))
-  ⚠️  unknown callee object
-- *17* eg
-  ⚠️  circular variable reference
-- *18* updated with update expression
-  ⚠️  This value might have side effects
-- *19* ???*20*(!(0))
+- *9* ???*10*(!(0))
   ⚠️  unknown callee
-- *20* d
+- *10* d
   ⚠️  circular variable reference
 
 d#357 = ???*0*
@@ -13202,7 +13462,7 @@ d#398 = (???*0* | ???*2*)
 - *2* unsupported assign operation
   ⚠️  This value might have side effects
 
-d#400 = (???*0* | null["alternate"] | ???*2* | ???*3* | ???*4* | null["alternate"]["updateQueue"])
+d#400 = (???*0* | null["alternate"] | ???*2* | ???*3* | ???*4*)
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
@@ -13365,9 +13625,46 @@ d#420 = ???*0*
 - *0* arguments[3]
   ⚠️  function calls are not analysed yet
 
-d#421 = ???*0*
-- *0* max number of linking steps reached
+d#421 = (
+  | false
+  | ???*0*
+  | new ???*2*(???*3*, (???*4* | ???*6* | ???*7* | ???*8*))["contextTypes"]
+  | (null !== ???*13*)
+  | (???*14* !== ???*15*)
+)
+- *0* ???*1*["contextTypes"]
+  ⚠️  unknown object
+- *1* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *2* b
+  ⚠️  circular variable reference
+- *3* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *4* ???*5*["contextType"]
+  ⚠️  unknown object
+- *5* b
+  ⚠️  circular variable reference
+- *6* FreeVar(undefined)
+  ⚠️  unknown global
   ⚠️  This value might have side effects
+- *7* unknown mutation
+  ⚠️  This value might have side effects
+- *8* (???*9* ? ({} | ???*10*) : {})
+  ⚠️  nested operation
+- *9* unsupported expression
+  ⚠️  This value might have side effects
+- *10* ???*11*["__reactInternalMemoizedMaskedChildContext"]
+  ⚠️  unknown object
+- *11* ???*12*["stateNode"]
+  ⚠️  unknown object
+- *12* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *13* d
+  ⚠️  circular variable reference
+- *14* unsupported expression
+  ⚠️  This value might have side effects
+- *15* d
+  ⚠️  circular variable reference
 
 d#422 = ???*0*
 - *0* arguments[3]
@@ -13396,8 +13693,8 @@ d#434 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["sibling"]
   ⚠️  unknown object
-- *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+- *2* d
+  ⚠️  circular variable reference
 
 d#437 = (???*0* | ???*1*)
 - *0* arguments[2]
@@ -13518,9 +13815,46 @@ d#442 = ???*0*
 - *0* arguments[3]
   ⚠️  function calls are not analysed yet
 
-d#443 = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
+d#443 = (
+  | ???*0*
+  | new (...) => undefined(6, ???*2*, null, ???*3*)["_init"]
+  | new (...) => undefined(4, ???*5*, ???*11*, ???*13*)["_init"]
+  | new (...) => undefined(7, ???*14*, null, ???*15*)["_init"]
+)
+- *0* ???*1*["_init"]
+  ⚠️  unknown object
+- *1* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *2* a
+  ⚠️  circular variable reference
+- *3* ???*4*["mode"]
+  ⚠️  unknown object
+- *4* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *5* (???*6* ? ???*9* : [])
+  ⚠️  nested operation
+- *6* (null !== ???*7*)
+  ⚠️  nested operation
+- *7* ???*8*["children"]
+  ⚠️  unknown object
+- *8* b
+  ⚠️  circular variable reference
+- *9* ???*10*["children"]
+  ⚠️  unknown object
+- *10* b
+  ⚠️  circular variable reference
+- *11* ???*12*["key"]
+  ⚠️  unknown object
+- *12* b
+  ⚠️  circular variable reference
+- *13* b
+  ⚠️  circular variable reference
+- *14* a
+  ⚠️  circular variable reference
+- *15* ???*16*["mode"]
+  ⚠️  unknown object
+- *16* arguments[0]
+  ⚠️  function calls are not analysed yet
 
 d#445 = ???*0*
 - *0* arguments[3]
@@ -13543,12 +13877,112 @@ d#494 = ???*0*
   ⚠️  This value might have side effects
 
 d#501 = ???*0*
-- *0* max number of linking steps reached
+- *0* ???*1*["dispatch"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *1* node limit reached
   ⚠️  This value might have side effects
 
-d#504 = ???*0*
-- *0* max number of linking steps reached
+d#504 = (
+  | null
+  | ???*0*
+  | {"memoizedState": null, "baseState": null, "baseQueue": null, "queue": null, "next": null}
+  | (???*1* ? (null["memoizedState"] | ???*3*) : ???*5*)
+  | null["alternate"]
+  | ???*7*
+  | (null !== (null | ???*9* | ???*10*))["alternate"]
+  | (null !== (null["next"] | ???*11* | ???*13*))["alternate"]
+  | (???*15* ? ???*17* : null)
+  | null["next"]
+  | ???*19*
+  | {
+        "memoizedState": (null["memoizedState"] | ???*21* | ???*23*),
+        "baseState": (null["baseState"] | ???*25* | ???*27*),
+        "baseQueue": (null["baseQueue"] | ???*29* | ???*31*),
+        "queue": (null["queue"] | ???*33* | ???*35*),
+        "next": null
+    }
+)
+- *0* unsupported expression
   ⚠️  This value might have side effects
+- *1* (null === ???*2*)
+  ⚠️  nested operation
+- *2* P
+  ⚠️  circular variable reference
+- *3* ???*4*["memoizedState"]
+  ⚠️  unknown object
+- *4* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *5* ???*6*["next"]
+  ⚠️  unknown object
+- *6* P
+  ⚠️  circular variable reference
+- *7* ???*8*["alternate"]
+  ⚠️  unknown object
+- *8* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *9* unsupported expression
+  ⚠️  This value might have side effects
+- *10* a
+  ⚠️  circular variable reference
+- *11* ???*12*["next"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *12* unsupported expression
+  ⚠️  This value might have side effects
+- *13* ???*14*["next"]
+  ⚠️  unknown object
+- *14* a
+  ⚠️  circular variable reference
+- *15* (null !== ???*16*)
+  ⚠️  nested operation
+- *16* a
+  ⚠️  circular variable reference
+- *17* ???*18*["memoizedState"]
+  ⚠️  unknown object
+- *18* a
+  ⚠️  circular variable reference
+- *19* ???*20*["next"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *20* unsupported expression
+  ⚠️  This value might have side effects
+- *21* ???*22*["memoizedState"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *22* unsupported expression
+  ⚠️  This value might have side effects
+- *23* ???*24*["memoizedState"]
+  ⚠️  unknown object
+- *24* a
+  ⚠️  circular variable reference
+- *25* ???*26*["baseState"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *26* unsupported expression
+  ⚠️  This value might have side effects
+- *27* ???*28*["baseState"]
+  ⚠️  unknown object
+- *28* a
+  ⚠️  circular variable reference
+- *29* ???*30*["baseQueue"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *30* unsupported expression
+  ⚠️  This value might have side effects
+- *31* ???*32*["baseQueue"]
+  ⚠️  unknown object
+- *32* a
+  ⚠️  circular variable reference
+- *33* ???*34*["queue"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *34* unsupported expression
+  ⚠️  This value might have side effects
+- *35* ???*36*["queue"]
+  ⚠️  unknown object
+- *36* a
+  ⚠️  circular variable reference
 
 d#507 = ???*0*
 - *0* arguments[3]
@@ -13640,44 +14074,24 @@ d#517 = ???*0*
 - *0* arguments[3]
   ⚠️  function calls are not analysed yet
 
-d#518 = (???*0* | (???*1* ? null : (???*9* | ???*10*)))
+d#518 = (???*0* | (???*1* ? null : ???*4*))
 - *0* arguments[3]
   ⚠️  function calls are not analysed yet
-- *1* (???*2* === (???*3* | ???*4*))
+- *1* (???*2* === ???*3*)
   ⚠️  nested operation
 - *2* unsupported expression
   ⚠️  This value might have side effects
-- *3* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *4* (???*5* ? null : ???*8*)
-  ⚠️  nested operation
-- *5* (???*6* === ???*7*)
-  ⚠️  nested operation
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* d
+- *3* d
   ⚠️  circular variable reference
-- *8* d
-  ⚠️  circular variable reference
-- *9* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *10* (???*11* ? null : ???*14*)
-  ⚠️  nested operation
-- *11* (???*12* === ???*13*)
-  ⚠️  nested operation
-- *12* unsupported expression
-  ⚠️  This value might have side effects
-- *13* d
-  ⚠️  circular variable reference
-- *14* d
+- *4* d
   ⚠️  circular variable reference
 
 d#530 = ???*0*
-- *0* max number of linking steps reached
+- *0* node limit reached
   ⚠️  This value might have side effects
 
 d#531 = ???*0*
-- *0* max number of linking steps reached
+- *0* node limit reached
   ⚠️  This value might have side effects
 
 d#533 = module<react, {}>["__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED"]["ReactCurrentBatchConfig"]["transition"]
@@ -14004,8 +14418,8 @@ d#570 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
-- *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+- *2* d
+  ⚠️  circular variable reference
 
 d#578 = ???*0*
 - *0* ???*1*["value"]
@@ -14196,148 +14610,63 @@ d#639 = (???*0* | ???*1*)
   ⚠️  function calls are not analysed yet
 - *1* Object.assign*2*(
         {},
-        (???*3* | ???*4*),
+        ???*3*,
         {
-            "defaultChecked": ???*18*,
-            "defaultValue": ???*19*,
-            "value": ???*20*,
-            "checked": (???*21* ? (???*34* | ???*36*) : ???*49*)
+            "defaultChecked": ???*4*,
+            "defaultValue": ???*5*,
+            "value": ???*6*,
+            "checked": (???*7* ? ???*10* : ???*12*)
         }
     )
   ⚠️  only const object assign is supported
   ⚠️  This value might have side effects
 - *2* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-- *3* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *4* Object.assign*5*(
-        {},
-        ???*6*,
-        {
-            "defaultChecked": ???*7*,
-            "defaultValue": ???*8*,
-            "value": ???*9*,
-            "checked": (???*10* ? ???*13* : ???*15*)
-        }
-    )
-  ⚠️  only const object assign is supported
-  ⚠️  This value might have side effects
-- *5* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-- *6* d
+- *3* d
   ⚠️  circular variable reference
-- *7* unsupported expression
+- *4* unsupported expression
   ⚠️  This value might have side effects
-- *8* unsupported expression
+- *5* unsupported expression
   ⚠️  This value might have side effects
-- *9* unsupported expression
+- *6* unsupported expression
   ⚠️  This value might have side effects
-- *10* (null != ???*11*)
+- *7* (null != ???*8*)
   ⚠️  nested operation
-- *11* ???*12*["checked"]
+- *8* ???*9*["checked"]
   ⚠️  unknown object
-- *12* d
+- *9* d
   ⚠️  circular variable reference
-- *13* ???*14*["checked"]
+- *10* ???*11*["checked"]
   ⚠️  unknown object
-- *14* d
+- *11* d
   ⚠️  circular variable reference
-- *15* ???*16*["initialChecked"]
+- *12* ???*13*["initialChecked"]
   ⚠️  unknown object
-- *16* ???*17*["_wrapperState"]
+- *13* ???*14*["_wrapperState"]
   ⚠️  unknown object
-- *17* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *18* unsupported expression
-  ⚠️  This value might have side effects
-- *19* unsupported expression
-  ⚠️  This value might have side effects
-- *20* unsupported expression
-  ⚠️  This value might have side effects
-- *21* (null != (???*22* | ???*24*))
-  ⚠️  nested operation
-- *22* ???*23*["checked"]
-  ⚠️  unknown object
-- *23* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *24* ???*25*["checked"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *25* Object.assign*26*(
-        {},
-        ???*27*,
-        {
-            "defaultChecked": ???*28*,
-            "defaultValue": ???*29*,
-            "value": ???*30*,
-            "checked": (???*31* ? ???*32* : ???*33*)
-        }
-    )
-  ⚠️  only const object assign is supported
-  ⚠️  This value might have side effects
-- *26* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-- *27* d
-  ⚠️  circular variable reference
-- *28* unsupported expression
-  ⚠️  This value might have side effects
-- *29* unsupported expression
-  ⚠️  This value might have side effects
-- *30* unsupported expression
-  ⚠️  This value might have side effects
-- *31* (... != ...)
-  ⚠️  nested operation
-- *32* ...[...]
-  ⚠️  unknown object
-- *33* ...[...]
-  ⚠️  unknown object
-- *34* ???*35*["checked"]
-  ⚠️  unknown object
-- *35* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *36* ???*37*["checked"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *37* Object.assign*38*(
-        {},
-        ???*39*,
-        {
-            "defaultChecked": ???*40*,
-            "defaultValue": ???*41*,
-            "value": ???*42*,
-            "checked": (???*43* ? ???*45* : ???*47*)
-        }
-    )
-  ⚠️  only const object assign is supported
-  ⚠️  This value might have side effects
-- *38* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-- *39* d
-  ⚠️  circular variable reference
-- *40* unsupported expression
-  ⚠️  This value might have side effects
-- *41* unsupported expression
-  ⚠️  This value might have side effects
-- *42* unsupported expression
-  ⚠️  This value might have side effects
-- *43* (null != ???*44*)
-  ⚠️  nested operation
-- *44* ...[...]
-  ⚠️  unknown object
-- *45* ???*46*["checked"]
-  ⚠️  unknown object
-- *46* d
-  ⚠️  circular variable reference
-- *47* ???*48*["initialChecked"]
-  ⚠️  unknown object
-- *48* ...[...]
-  ⚠️  unknown object
-- *49* ???*50*["initialChecked"]
-  ⚠️  unknown object
-- *50* ???*51*["_wrapperState"]
-  ⚠️  unknown object
-- *51* arguments[0]
+- *14* arguments[0]
   ⚠️  function calls are not analysed yet
 
-d#64 = ???*0*
-- *0* max number of linking steps reached
+d#64 = ("" | ((???*0* | ???*1*) ? ???*5* : ???*8*))
+- *0* unsupported expression
   ⚠️  This value might have side effects
+- *1* ("input" === ???*2*)
+  ⚠️  nested operation
+- *2* ???*3*()
+  ⚠️  nested operation
+- *3* ???*4*["toLowerCase"]
+  ⚠️  unknown object
+- *4* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *5* (???*6* ? "true" : "false")
+  ⚠️  nested operation
+- *6* ???*7*["checked"]
+  ⚠️  unknown object
+- *7* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *8* ???*9*["value"]
+  ⚠️  unknown object
+- *9* arguments[0]
+  ⚠️  function calls are not analysed yet
 
 d#644 = ???*0*
 - *0* arguments[3]
@@ -14371,40 +14700,18 @@ d#673 = ???*0*
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-d#687 = (???*0* | (???*2* ? ???*10* : null) | (???*13* ? ???*15* : null)["next"])
+d#687 = (???*0* | (???*2* ? ???*4* : null))
 - *0* ???*1*["updateQueue"]
   ⚠️  unknown object
 - *1* arguments[1]
   ⚠️  function calls are not analysed yet
-- *2* (null !== (???*3* | ???*5*))
+- *2* (null !== ???*3*)
   ⚠️  nested operation
-- *3* ???*4*["updateQueue"]
-  ⚠️  unknown object
-- *4* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *5* (???*6* ? ???*8* : null)
-  ⚠️  nested operation
-- *6* (null !== ???*7*)
-  ⚠️  nested operation
-- *7* d
+- *3* d
   ⚠️  circular variable reference
-- *8* ???*9*["lastEffect"]
+- *4* ???*5*["lastEffect"]
   ⚠️  unknown object
-- *9* d
-  ⚠️  circular variable reference
-- *10* ???*11*["lastEffect"]
-  ⚠️  unknown object
-- *11* ???*12*["updateQueue"]
-  ⚠️  unknown object
-- *12* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *13* (null !== ???*14*)
-  ⚠️  nested operation
-- *14* d
-  ⚠️  circular variable reference
-- *15* ???*16*["lastEffect"]
-  ⚠️  unknown object
-- *16* d
+- *5* d
   ⚠️  circular variable reference
 
 d#69 = (???*0* ? ???*3* : ???*5*)
@@ -14672,21 +14979,6 @@ d#843 = (
         }
     ))["memoizedState"]
   | (null !== (null["next"] | ???*18* | ???*20* | null | ???*23*))["memoizedState"]
-  | null["memoizedState"]["next"]
-  | (null !== (
-      | null
-      | ???*24*
-      | ???*25*
-      | ???*27*
-      | {
-            "memoizedState": ???*32*,
-            "baseState": ???*34*,
-            "baseQueue": ???*36*,
-            "queue": ???*38*,
-            "next": null
-        }
-    ))["memoizedState"]["next"]
-  | (null !== (null["next"] | ???*40* | ???*42* | null | ???*45*))["memoizedState"]["next"]
 )
 - *0* ???*1*["memoizedState"]
   ⚠️  unknown object
@@ -14736,51 +15028,6 @@ d#843 = (
 - *22* N
   ⚠️  circular variable reference
 - *23* unknown mutation
-  ⚠️  This value might have side effects
-- *24* unsupported expression
-  ⚠️  This value might have side effects
-- *25* ???*26*["alternate"]
-  ⚠️  unknown object
-- *26* N
-  ⚠️  circular variable reference
-- *27* (???*28* ? ???*30* : null)
-  ⚠️  nested operation
-- *28* (null !== ???*29*)
-  ⚠️  nested operation
-- *29* a
-  ⚠️  circular variable reference
-- *30* ???*31*["memoizedState"]
-  ⚠️  unknown object
-- *31* a
-  ⚠️  circular variable reference
-- *32* ???*33*["memoizedState"]
-  ⚠️  unknown object
-- *33* O
-  ⚠️  circular variable reference
-- *34* ???*35*["baseState"]
-  ⚠️  unknown object
-- *35* O
-  ⚠️  circular variable reference
-- *36* ???*37*["baseQueue"]
-  ⚠️  unknown object
-- *37* O
-  ⚠️  circular variable reference
-- *38* ???*39*["queue"]
-  ⚠️  unknown object
-- *39* O
-  ⚠️  circular variable reference
-- *40* ???*41*["next"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *41* unsupported expression
-  ⚠️  This value might have side effects
-- *42* ???*43*["next"]
-  ⚠️  unknown object
-- *43* ???*44*["alternate"]
-  ⚠️  unknown object
-- *44* N
-  ⚠️  circular variable reference
-- *45* unknown mutation
   ⚠️  This value might have side effects
 
 d#863 = (???*0* ? {
@@ -15026,36 +15273,16 @@ d#960 = (???*0* | (???*1* ? ???*3* : ???*4*))
 - *11* unsupported expression
   ⚠️  This value might have side effects
 
-d#961 = (???*0* | (???*1* ? null : (???*9* | ???*10*)))
+d#961 = (???*0* | (???*1* ? null : ???*4*))
 - *0* arguments[3]
   ⚠️  function calls are not analysed yet
-- *1* (???*2* === (???*3* | ???*4*))
+- *1* (???*2* === ???*3*)
   ⚠️  nested operation
 - *2* unsupported expression
   ⚠️  This value might have side effects
-- *3* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *4* (???*5* ? null : ???*8*)
-  ⚠️  nested operation
-- *5* (???*6* === ???*7*)
-  ⚠️  nested operation
-- *6* unsupported expression
-  ⚠️  This value might have side effects
-- *7* d
+- *3* d
   ⚠️  circular variable reference
-- *8* d
-  ⚠️  circular variable reference
-- *9* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *10* (???*11* ? null : ???*14*)
-  ⚠️  nested operation
-- *11* (???*12* === ???*13*)
-  ⚠️  nested operation
-- *12* unsupported expression
-  ⚠️  This value might have side effects
-- *13* d
-  ⚠️  circular variable reference
-- *14* d
+- *4* d
   ⚠️  circular variable reference
 
 d#979 = (???*0* | (...) => undefined)
@@ -15100,13 +15327,9 @@ db = (...) => (undefined | FreeVar(undefined))
 dc = module<scheduler, {}>["unstable_requestPaint"]
 
 dd = (true | false | !(???*0*))
-- *0* !((null | true | false | ???*1*))
+- *0* !((null | ???*1*))
   ⚠️  nested operation
-- *1* !(???*2*)
-  ⚠️  nested operation
-- *2* !(???*3*)
-  ⚠️  nested operation
-- *3* Cf
+- *1* dd
   ⚠️  circular variable reference
 
 de = (!(???*0*) | !((???*3* | ???*7*)) | null | ???*8* | ???*10*)
@@ -15157,7 +15380,7 @@ dk = (...) => undefined
 
 dl = (...) => {
     "$$typeof": wa,
-    "key": ((null == d) ? null : d),
+    "key": ((null == d) ? null : `${d}`),
     "children": a,
     "containerInfo": b,
     "implementation": c
@@ -15194,7 +15417,7 @@ e#1004 = (???*0* | null)
 e#1013 = (
   | (???*0* ? ???*3* : (...) => undefined)
   | ???*4*
-  | new (...) => undefined(???*6*, (1 | ???*7* | 0), false, ("" | ???*8*), (???*10* | ???*15*))["onRecoverableError"]
+  | new (...) => undefined(???*6*, (1 | ???*7* | 0), false, ("" | ???*8*), ???*10*)["onRecoverableError"]
 )
 - *0* ("function" === ???*1*)
   ⚠️  nested operation
@@ -15218,21 +15441,7 @@ e#1013 = (
   ⚠️  unknown object
 - *9* b
   ⚠️  circular variable reference
-- *10* (???*11* ? ???*14* : (...) => undefined)
-  ⚠️  nested operation
-- *11* ("function" === ???*12*)
-  ⚠️  nested operation
-- *12* typeof(???*13*)
-  ⚠️  nested operation
-- *13* FreeVar(reportError)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *14* FreeVar(reportError)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *15* ???*16*["onRecoverableError"]
-  ⚠️  unknown object
-- *16* b
+- *10* e
   ⚠️  circular variable reference
 
 e#1018 = (
@@ -15272,52 +15481,53 @@ e#1018 = (
   ⚠️  function calls are not analysed yet
 - *12* updated with update expression
   ⚠️  This value might have side effects
-- *13* (
-      | false
-      | true
-      | ???*14*
-      | (null != ???*16*)[(???*17* | 0 | ???*18*)]["_getVersion"]
-      | ???*19*
-      | null[(???*25* | 0 | ???*26*)]["_getVersion"]
-      | ???*27*
-    )(c["_source"])
-  ⚠️  non-function callee
-- *14* ???*15*["_getVersion"]
-  ⚠️  unknown object
-- *15* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *16* c
-  ⚠️  circular variable reference
-- *17* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *18* updated with update expression
-  ⚠️  This value might have side effects
-- *19* ???*20*["_getVersion"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *20* ???*21*[(???*23* | 0 | ???*24*)]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *21* ???*22*["hydratedSources"]
-  ⚠️  unknown object
-- *22* c
-  ⚠️  circular variable reference
-- *23* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *24* updated with update expression
-  ⚠️  This value might have side effects
-- *25* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *26* updated with update expression
-  ⚠️  This value might have side effects
-- *27* ???*28*(c["_source"])
+- *13* ???*14*(c["_source"])
   ⚠️  unknown callee
-- *28* e
+- *14* e
   ⚠️  circular variable reference
 
-e#102 = ???*0*
-- *0* max number of linking steps reached
+e#102 = (???*0* ? "" : ???*3*)
+- *0* (null == ???*1*)
+  ⚠️  nested operation
+- *1* ???*2*[c]
+  ⚠️  unknown object
+- *2* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *3* ((???*4* | ???*8* | ???*12*) ? ???*13* : ???*17*)
+  ⚠️  nested operation
+- *4* (0 === (???*5* | ???*7*))
+  ⚠️  nested operation
+- *5* ???*6*["indexOf"]("--")
+  ⚠️  unknown callee object
+- *6* c
+  ⚠️  pattern without value
+- *7* "cssFloat"["indexOf"]("--")
+  ⚠️  nested operation
+- *8* (???*9* | ???*10*)((???*11* | "cssFloat"))
+  ⚠️  non-function callee
+- *9* FreeVar(undefined)
+  ⚠️  unknown global
   ⚠️  This value might have side effects
+- *10* unknown mutation
+  ⚠️  This value might have side effects
+- *11* c
+  ⚠️  pattern without value
+- *12* node limit reached
+  ⚠️  This value might have side effects
+- *13* ???*14*()
+  ⚠️  nested operation
+- *14* ???*15*["trim"]
+  ⚠️  unknown object
+- *15* ???*16*[c]
+  ⚠️  unknown object
+- *16* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *17* `${???*18*}px`
+  ⚠️  nested operation
+- *18* ???*19*[c]
+  ⚠️  unknown object
+- *19* arguments[1]
+  ⚠️  function calls are not analysed yet
 
 e#123 = ???*0*
 - *0* arguments[4]
@@ -15393,7 +15603,7 @@ e#193 = (
   | (???*5* ? 16 : (???*6* | null | ???*13* | ???*14*))
   | ???*16*
 )
-- *0* C
+- *0* e
   ⚠️  circular variable reference
 - *1* (0 !== ???*2*)
   ⚠️  nested operation
@@ -15554,12 +15764,9 @@ e#212 = ???*0*
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 
-e#25 = ((???*0* ? ???*13* : null) | (???*15* ? ???*21* : null)["type"] | ???*23*)
-- *0* (???*1* | ???*2*)(
-        (???*3* | (???*4* ? ???*8* : null)["attributeName"] | ???*10*)
-    )
+e#25 = ((???*0* ? ???*6* : null) | ???*8*)
+- *0* (???*1* | ???*2*)((???*3* | ???*4*))
   ⚠️  non-function callee
-  ⚠️  This value might have side effects
 - *1* FreeVar(undefined)
   ⚠️  unknown global
   ⚠️  This value might have side effects
@@ -15567,54 +15774,18 @@ e#25 = ((???*0* ? ???*13* : null) | (???*15* ? ???*21* : null)["type"] | ???*23*
   ⚠️  This value might have side effects
 - *3* arguments[1]
   ⚠️  function calls are not analysed yet
-- *4* (???*5* | ???*6*)(???*7*)
-  ⚠️  non-function callee
-- *5* FreeVar(undefined)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *6* unknown mutation
-  ⚠️  This value might have side effects
-- *7* b
+- *4* ???*5*["attributeName"]
+  ⚠️  unknown object
+- *5* e
   ⚠️  circular variable reference
-- *8* {}[???*9*]
+- *6* {}[???*7*]
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
-- *9* b
-  ⚠️  circular variable reference
-- *10* ???*11*["attributeName"]
-  ⚠️  unknown object
-- *11* ???*12*["type"]
-  ⚠️  unknown object
-- *12* e
-  ⚠️  circular variable reference
-- *13* {}[???*14*]
-  ⚠️  unknown object prototype methods or values
-  ⚠️  This value might have side effects
-- *14* arguments[1]
+- *7* arguments[1]
   ⚠️  function calls are not analysed yet
-- *15* (???*16* | ???*17*)((???*18* | ???*19*))
-  ⚠️  non-function callee
-- *16* FreeVar(undefined)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *17* unknown mutation
-  ⚠️  This value might have side effects
-- *18* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *19* ???*20*["attributeName"]
+- *8* ???*9*["type"]
   ⚠️  unknown object
-- *20* e
-  ⚠️  circular variable reference
-- *21* {}[???*22*]
-  ⚠️  unknown object prototype methods or values
-  ⚠️  This value might have side effects
-- *22* arguments[1]
-  ⚠️  function calls are not analysed yet
-- *23* ???*24*["type"]
-  ⚠️  unknown object
-- *24* ???*25*["type"]
-  ⚠️  unknown object
-- *25* e
+- *9* e
   ⚠️  circular variable reference
 
 e#251 = ???*0*
@@ -15702,39 +15873,8 @@ e#292 = (
   ⚠️  This value might have side effects
 - *14* arguments[2]
   ⚠️  function calls are not analysed yet
-- *15* (???*16* ? (???*21* | ???*23*) : (???*25* | ???*26* | ???*28*))
-  ⚠️  nested operation
-- *16* (3 === (???*17* | ???*19*))
-  ⚠️  nested operation
-- *17* ???*18*["nodeType"]
-  ⚠️  unknown object
-- *18* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *19* ???*20*["nodeType"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *20* FreeVar(window)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *21* ???*22*["parentNode"]
-  ⚠️  unknown object
-- *22* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *23* ???*24*["parentNode"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *24* FreeVar(window)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *25* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *26* ???*27*["target"]
-  ⚠️  unknown object
-- *27* a
+- *15* e
   ⚠️  circular variable reference
-- *28* FreeVar(window)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
 
 e#30 = ???*0*
 - *0* ???*1*["split"]("\n")
@@ -16231,9 +16371,16 @@ e#494 = ???*0*
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-e#501 = ???*0*
-- *0* max number of linking steps reached
+e#501 = (???*0* | ???*2*)
+- *0* ???*1*["pending"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
+- *1* node limit reached
+  ⚠️  This value might have side effects
+- *2* ???*3*["next"]
+  ⚠️  unknown object
+- *3* e
+  ⚠️  circular variable reference
 
 e#504 = ???*0*()
 - *0* arguments[1]
@@ -16465,8 +16612,116 @@ e#537 = (???*0* ? ???*2* : ???*3*)
 - *10* unsupported expression
   ⚠️  This value might have side effects
 
-e#539 = ???*0*
-- *0* max number of linking steps reached
+e#539 = (
+  | {
+        "lane": (
+          | 1
+          | ???*0*
+          | ???*1*
+          | ???*2*
+          | 0
+          | ???*3*
+          | 4
+          | ((???*4* | ???*6*) ? ???*7* : 4)
+          | (???*8* ? 16 : (???*9* | null | ???*16* | ???*17*))
+          | ???*19*
+          | (???*21* ? 16 : (undefined | 1 | 4 | 16 | 536870912))
+        ),
+        "action": (???*24* | (???*25* ? ???*29* : null)),
+        "hasEagerState": false,
+        "eagerState": null,
+        "next": null
+    }
+  | (???*32* ? ???*34* : ???*35*)
+)
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+- *1* Ck
+  ⚠️  sequence with side effects
+  ⚠️  This value might have side effects
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *3* C
+  ⚠️  circular variable reference
+- *4* (0 !== ???*5*)
+  ⚠️  nested operation
+- *5* C
+  ⚠️  circular variable reference
+- *6* unsupported expression
+  ⚠️  This value might have side effects
+- *7* C
+  ⚠️  circular variable reference
+- *8* unsupported expression
+  ⚠️  This value might have side effects
+- *9* (???*10* ? ???*11* : 1)
+  ⚠️  nested operation
+- *10* unsupported expression
+  ⚠️  This value might have side effects
+- *11* (???*12* ? ???*13* : 4)
+  ⚠️  nested operation
+- *12* unsupported expression
+  ⚠️  This value might have side effects
+- *13* (???*14* ? 16 : 536870912)
+  ⚠️  nested operation
+- *14* (0 !== ???*15*)
+  ⚠️  nested operation
+- *15* unsupported expression
+  ⚠️  This value might have side effects
+- *16* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *17* ???*18*["value"]
+  ⚠️  unknown object
+- *18* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *19* ???*20*["event"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *20* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *21* (???*22* === ???*23*)
+  ⚠️  nested operation
+- *22* unsupported expression
+  ⚠️  This value might have side effects
+- *23* a
+  ⚠️  circular variable reference
+- *24* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *25* (3 === ???*26*)
+  ⚠️  nested operation
+- *26* ???*27*["tag"]
+  ⚠️  unknown object
+- *27* ???*28*["alternate"]
+  ⚠️  unknown object
+- *28* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *29* ???*30*["stateNode"]
+  ⚠️  unknown object
+- *30* ???*31*["alternate"]
+  ⚠️  unknown object
+- *31* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *32* (0 !== ???*33*)
+  ⚠️  nested operation
+- *33* unsupported expression
+  ⚠️  This value might have side effects
+- *34* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *35* (???*36* ? (???*40* | ???*41*) : ???*42*)
+  ⚠️  nested operation
+- *36* (???*37* !== (???*38* | ???*39*))
+  ⚠️  nested operation
+- *37* unsupported expression
+  ⚠️  This value might have side effects
+- *38* unsupported expression
+  ⚠️  This value might have side effects
+- *39* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *40* unsupported expression
+  ⚠️  This value might have side effects
+- *41* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *42* unsupported expression
   ⚠️  This value might have side effects
 
 e#559 = (
@@ -16596,9 +16851,51 @@ e#56 = ???*0*
 - *10* ???["toLowerCase"]
   ⚠️  unknown object
 
-e#570 = ???*0*
-- *0* max number of linking steps reached
+e#570 = (
+  | ""
+  | (???*0* + (undefined | ???*1* | ???*13* | ""))
+  | `
+Error generating stack: ${???*14*}
+${???*16*}`
+)
+- *0* c
+  ⚠️  circular variable reference
+- *1* `
+${(???*2* | ???*3* | ???*7* | "")}${(???*11* | ""["type"])}`
+  ⚠️  nested operation
+- *2* La
+  ⚠️  pattern without value
+- *3* ???*4*(/\n( *(at )?)/)
+  ⚠️  unknown callee
+- *4* ???*5*["match"]
+  ⚠️  unknown object
+- *5* ???*6*()
+  ⚠️  nested operation
+- *6* ???["trim"]
+  ⚠️  unknown object
+- *7* ???*8*[1]
+  ⚠️  unknown object
+- *8* ???*9*(/\n( *(at )?)/)
+  ⚠️  unknown callee
+- *9* ???*10*["match"]
+  ⚠️  unknown object
+- *10* ???()
+  ⚠️  nested operation
+- *11* ???*12*["type"]
+  ⚠️  unknown object
+- *12* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *13* a
+  ⚠️  sequence with side effects
   ⚠️  This value might have side effects
+- *14* ???*15*["message"]
+  ⚠️  unknown object
+- *15* f
+  ⚠️  pattern without value
+- *16* ???*17*["stack"]
+  ⚠️  unknown object
+- *17* f
+  ⚠️  pattern without value
 
 e#580 = ???*0*
 - *0* ???*1*["value"]
@@ -16733,28 +17030,56 @@ e#609 = ???*0*
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-e#614 = ???*0*
-- *0* max number of linking steps reached
+e#614 = (
+  | ???*0*
+  | ???*1*
+  | (...) => undefined["bind"](
+        null,
+        (???*3* | ???*4* | ???*6* | null["fallback"]["treeContext"])
+    )["mode"]
+  | ???*8*
+  | 2
+  | 8
+  | 32
+  | 268435456
+  | 0
+  | (???*10* ? 0 : ???*12*)
+)
+- *0* arguments[4]
+  ⚠️  function calls are not analysed yet
+- *1* ???*2*["mode"]
+  ⚠️  unknown object
+- *2* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *3* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *4* ???*5*["treeContext"]
+  ⚠️  unknown object
+- *5* arguments[5]
+  ⚠️  function calls are not analysed yet
+- *6* ???*7*["treeContext"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
+- *7* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *8* ???*9*["mode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *9* unsupported expression
+  ⚠️  This value might have side effects
+- *10* (0 !== ???*11*)
+  ⚠️  nested operation
+- *11* unsupported expression
+  ⚠️  This value might have side effects
+- *12* e
+  ⚠️  circular variable reference
 
 e#620 = ???*0*
 - *0* arguments[4]
   ⚠️  function calls are not analysed yet
 
-e#621 = (
-  | ???*0*
-  | 0["revealOrder"]
-  | ???*3*
-  | null
-  | ???*5*
-  | ???*6*
-  | 0["revealOrder"]["sibling"]
-  | null["sibling"]
-  | 0["revealOrder"]["alternate"]
-  | null["alternate"]
-  | null["sibling"]["alternate"]
-  | null["sibling"]["sibling"]
-)
+e#621 = (???*0* | 0["revealOrder"] | ???*3* | null | ???*5* | ???*6* | null["sibling"] | null["alternate"])
 - *0* ???*1*["revealOrder"]
   ⚠️  unknown object
 - *1* ???*2*["pendingProps"]
@@ -16768,7 +17093,7 @@ e#621 = (
   ⚠️  This value might have side effects
 - *5* arguments[2]
   ⚠️  function calls are not analysed yet
-- *6* c
+- *6* e
   ⚠️  circular variable reference
 
 e#631 = ???*0*
@@ -16786,149 +17111,40 @@ e#639 = (???*0* | ???*2*)
   ⚠️  function calls are not analysed yet
 - *2* Object.assign*3*(
         {},
-        (???*4* | ???*6*),
+        ???*4*,
         {
-            "defaultChecked": ???*20*,
-            "defaultValue": ???*21*,
-            "value": ???*22*,
-            "checked": (???*23* ? (???*37* | ???*40*) : ???*53*)
+            "defaultChecked": ???*5*,
+            "defaultValue": ???*6*,
+            "value": ???*7*,
+            "checked": (???*8* ? ???*11* : ???*13*)
         }
     )
   ⚠️  only const object assign is supported
   ⚠️  This value might have side effects
 - *3* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-- *4* ???*5*["memoizedProps"]
-  ⚠️  unknown object
-- *5* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *6* Object.assign*7*(
-        {},
-        ???*8*,
-        {
-            "defaultChecked": ???*9*,
-            "defaultValue": ???*10*,
-            "value": ???*11*,
-            "checked": (???*12* ? ???*15* : ???*17*)
-        }
-    )
-  ⚠️  only const object assign is supported
-  ⚠️  This value might have side effects
-- *7* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-- *8* e
+- *4* e
   ⚠️  circular variable reference
-- *9* unsupported expression
+- *5* unsupported expression
   ⚠️  This value might have side effects
-- *10* unsupported expression
+- *6* unsupported expression
   ⚠️  This value might have side effects
-- *11* unsupported expression
+- *7* unsupported expression
   ⚠️  This value might have side effects
-- *12* (null != ???*13*)
+- *8* (null != ???*9*)
   ⚠️  nested operation
-- *13* ???*14*["checked"]
+- *9* ???*10*["checked"]
   ⚠️  unknown object
-- *14* e
+- *10* e
   ⚠️  circular variable reference
-- *15* ???*16*["checked"]
+- *11* ???*12*["checked"]
   ⚠️  unknown object
-- *16* e
+- *12* e
   ⚠️  circular variable reference
-- *17* ???*18*["initialChecked"]
+- *13* ???*14*["initialChecked"]
   ⚠️  unknown object
-- *18* ???*19*["_wrapperState"]
+- *14* ???*15*["_wrapperState"]
   ⚠️  unknown object
-- *19* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *20* unsupported expression
-  ⚠️  This value might have side effects
-- *21* unsupported expression
-  ⚠️  This value might have side effects
-- *22* unsupported expression
-  ⚠️  This value might have side effects
-- *23* (null != (???*24* | ???*27*))
-  ⚠️  nested operation
-- *24* ???*25*["checked"]
-  ⚠️  unknown object
-- *25* ???*26*["memoizedProps"]
-  ⚠️  unknown object
-- *26* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *27* ???*28*["checked"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *28* Object.assign*29*(
-        {},
-        ???*30*,
-        {
-            "defaultChecked": ???*31*,
-            "defaultValue": ???*32*,
-            "value": ???*33*,
-            "checked": (???*34* ? ???*35* : ???*36*)
-        }
-    )
-  ⚠️  only const object assign is supported
-  ⚠️  This value might have side effects
-- *29* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-- *30* e
-  ⚠️  circular variable reference
-- *31* unsupported expression
-  ⚠️  This value might have side effects
-- *32* unsupported expression
-  ⚠️  This value might have side effects
-- *33* unsupported expression
-  ⚠️  This value might have side effects
-- *34* (... != ...)
-  ⚠️  nested operation
-- *35* ...[...]
-  ⚠️  unknown object
-- *36* ...[...]
-  ⚠️  unknown object
-- *37* ???*38*["checked"]
-  ⚠️  unknown object
-- *38* ???*39*["memoizedProps"]
-  ⚠️  unknown object
-- *39* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *40* ???*41*["checked"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *41* Object.assign*42*(
-        {},
-        ???*43*,
-        {
-            "defaultChecked": ???*44*,
-            "defaultValue": ???*45*,
-            "value": ???*46*,
-            "checked": (???*47* ? ???*49* : ???*51*)
-        }
-    )
-  ⚠️  only const object assign is supported
-  ⚠️  This value might have side effects
-- *42* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-- *43* e
-  ⚠️  circular variable reference
-- *44* unsupported expression
-  ⚠️  This value might have side effects
-- *45* unsupported expression
-  ⚠️  This value might have side effects
-- *46* unsupported expression
-  ⚠️  This value might have side effects
-- *47* (null != ???*48*)
-  ⚠️  nested operation
-- *48* ...[...]
-  ⚠️  unknown object
-- *49* ???*50*["checked"]
-  ⚠️  unknown object
-- *50* e
-  ⚠️  circular variable reference
-- *51* ???*52*["initialChecked"]
-  ⚠️  unknown object
-- *52* ...[...]
-  ⚠️  unknown object
-- *53* ???*54*["initialChecked"]
-  ⚠️  unknown object
-- *54* ???*55*["_wrapperState"]
-  ⚠️  unknown object
-- *55* arguments[0]
+- *15* arguments[0]
   ⚠️  function calls are not analysed yet
 
 e#646 = ???*0*
@@ -16945,23 +17161,16 @@ e#673 = ???*0*
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-e#687 = (???*0* | ???*1* | ???*3*)
+e#687 = (???*0* | ???*1*)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* ???*2*["next"]
   ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *2* unsupported expression
-  ⚠️  This value might have side effects
-- *3* ???*4*["next"]
-  ⚠️  unknown object
-- *4* ???*5*["next"]
-  ⚠️  unknown object
-- *5* e
+- *2* e
   ⚠️  circular variable reference
 
-e#706 = (false | ???*0* | ???*1* | ???*2* | true | false["next"] | true["next"] | ???*4*)
-- *0* Yj
+e#706 = (false | ???*0* | true | ???*1* | ???*2*)
+- *0* e
   ⚠️  circular variable reference
 - *1* unsupported expression
   ⚠️  This value might have side effects
@@ -16969,11 +17178,6 @@ e#706 = (false | ???*0* | ???*1* | ???*2* | true | false["next"] | true["next"] 
   ⚠️  unknown object
 - *3* e
   ⚠️  circular variable reference
-- *4* ???*5*["next"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *5* unsupported expression
-  ⚠️  This value might have side effects
 
 e#716 = ???*0*
 - *0* ???*1*[d]
@@ -17209,9 +17413,110 @@ e#953 = ???*0*
 - *0* arguments[4]
   ⚠️  function calls are not analysed yet
 
-e#960 = ???*0*
-- *0* max number of linking steps reached
+e#960 = (
+  | ???*0*
+  | 1
+  | ???*1*
+  | ???*2*
+  | ???*3*
+  | new (...) => undefined(???*5*, (???*6* | ???*7* | 1 | ???*19* | 0), true, ???*20*, ???*21*)["current"]
+  | 0
+  | ???*22*
+  | 4
+  | ((???*23* | ???*25*) ? ???*26* : 4)
+  | (???*27* ? 16 : (???*28* | null | ???*35* | ???*36*))
+  | ???*38*
+  | (???*40* ? 16 : (undefined | 1 | 4 | 16 | 536870912))
+)
+- *0* arguments[4]
+  ⚠️  function calls are not analysed yet
+- *1* unsupported expression
   ⚠️  This value might have side effects
+- *2* Ck
+  ⚠️  sequence with side effects
+  ⚠️  This value might have side effects
+- *3* ???*4*["current"]
+  ⚠️  unknown object
+- *4* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *5* a
+  ⚠️  circular variable reference
+- *6* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *7* (???*8* ? ???*10* : ???*11*)
+  ⚠️  nested operation
+- *8* (0 !== ???*9*)
+  ⚠️  nested operation
+- *9* unsupported expression
+  ⚠️  This value might have side effects
+- *10* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *11* (???*12* ? (???*16* | ???*17*) : ???*18*)
+  ⚠️  nested operation
+- *12* (???*13* !== (???*14* | ???*15*))
+  ⚠️  nested operation
+- *13* unsupported expression
+  ⚠️  This value might have side effects
+- *14* unsupported expression
+  ⚠️  This value might have side effects
+- *15* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *16* unsupported expression
+  ⚠️  This value might have side effects
+- *17* module<scheduler, {}>["unstable_now"]()
+  ⚠️  nested operation
+- *18* unsupported expression
+  ⚠️  This value might have side effects
+- *19* unsupported assign operation
+  ⚠️  This value might have side effects
+- *20* arguments[7]
+  ⚠️  function calls are not analysed yet
+- *21* arguments[8]
+  ⚠️  function calls are not analysed yet
+- *22* C
+  ⚠️  circular variable reference
+- *23* (0 !== ???*24*)
+  ⚠️  nested operation
+- *24* C
+  ⚠️  circular variable reference
+- *25* unsupported expression
+  ⚠️  This value might have side effects
+- *26* C
+  ⚠️  circular variable reference
+- *27* unsupported expression
+  ⚠️  This value might have side effects
+- *28* (???*29* ? ???*30* : 1)
+  ⚠️  nested operation
+- *29* unsupported expression
+  ⚠️  This value might have side effects
+- *30* (???*31* ? ???*32* : 4)
+  ⚠️  nested operation
+- *31* unsupported expression
+  ⚠️  This value might have side effects
+- *32* (???*33* ? 16 : 536870912)
+  ⚠️  nested operation
+- *33* (0 !== ???*34*)
+  ⚠️  nested operation
+- *34* unsupported expression
+  ⚠️  This value might have side effects
+- *35* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *36* ???*37*["value"]
+  ⚠️  unknown object
+- *37* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *38* ???*39*["event"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *39* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *40* (???*41* === ???*42*)
+  ⚠️  nested operation
+- *41* unsupported expression
+  ⚠️  This value might have side effects
+- *42* a
+  ⚠️  circular variable reference
 
 e#961 = (???*0* | ???*2* | ???*3*)
 - *0* ???*1*["current"]
@@ -17260,31 +17565,13 @@ ee = ???*0*
 
 ef = "abort auxClick cancel canPlay canPlayThrough click close contextMenu copy cut drag dragEnd dragEnter dragExit dragLeave dragOver dragStart drop durationChange emptied encrypted ended error gotPointerCapture input invalid keyDown keyPress keyUp load loadedData loadedMetadata loadStart lostPointerCapture mouseDown mouseMove mouseOut mouseOver mouseUp paste pause play playing pointerCancel pointerDown pointerMove pointerOut pointerOver pointerUp progress rateChange reset resize seeked seeking stalled submit suspend timeUpdate touchCancel touchEnd touchStart volumeChange scroll toggle touchMove waiting wheel"["split"](" ")
 
-eg = (null | [???*0*] | null["slice"](???*1*) | ???*3* | ???*7*)
+eg = (null | [???*0*] | ???*1*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* ((0 | ???*2*) + 1)
-  ⚠️  nested operation
-- *2* updated with update expression
-  ⚠️  This value might have side effects
-- *3* ???*4*(((0 | ???*6*) + 1))
-  ⚠️  unknown callee
-  ⚠️  This value might have side effects
-- *4* [???*5*]["slice"]
-  ⚠️  non-num constant property on array
-- *5* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *6* updated with update expression
-  ⚠️  This value might have side effects
-- *7* ???*8*["slice"](((0 | ???*10*) + 1))
+- *1* ???*2*["slice"]((a + 1))
   ⚠️  unknown callee object
-  ⚠️  This value might have side effects
-- *8* ???*9*["slice"]((a + 1))
-  ⚠️  unknown callee object
-- *9* eg
+- *2* eg
   ⚠️  circular variable reference
-- *10* updated with update expression
-  ⚠️  This value might have side effects
 
 eh = (...) => undefined
 
@@ -17347,9 +17634,45 @@ f#128 = ???*0*
 - *0* arguments[5]
   ⚠️  function calls are not analysed yet
 
-f#136 = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
+f#136 = (
+  | ???*0*
+  | (???*3* ? (???*6* | ???*7* | ???*8*) : null)["return"]["alternate"]
+  | (???*10* ? (???*13* | ???*14* | ???*15*) : null)["return"]["child"]
+)
+- *0* ???*1*["alternate"]
+  ⚠️  unknown object
+- *1* ???*2*["return"]
+  ⚠️  unknown object
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *3* (3 === ???*4*)
+  ⚠️  nested operation
+- *4* ???*5*["tag"]
+  ⚠️  unknown object
+- *5* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *6* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *7* a
+  ⚠️  circular variable reference
+- *8* ???*9*["return"]
+  ⚠️  unknown object
+- *9* b
+  ⚠️  circular variable reference
+- *10* (3 === ???*11*)
+  ⚠️  nested operation
+- *11* ???*12*["tag"]
+  ⚠️  unknown object
+- *12* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *13* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *14* a
+  ⚠️  circular variable reference
+- *15* ???*16*["return"]
+  ⚠️  unknown object
+- *16* b
+  ⚠️  circular variable reference
 
 f#159 = (???*0* | ???*2* | ???*3*)
 - *0* ???*1*["pingedLanes"]
@@ -17511,8 +17834,120 @@ f#275 = (
 - *13* h
   ⚠️  circular variable reference
 
-f#286 = ???*0*
-- *0* max number of linking steps reached
+f#286 = (
+  | ???*0*
+  | ???*1*
+  | ???*2*
+  | ???*4*
+  | null[`__reactFiber$${???*6*}`]
+  | null["parentNode"][`__reactContainer$${???*11*}`]
+  | null[`__reactFiber$${???*16*}`][`__reactContainer$${???*21*}`]
+  | null["parentNode"][`__reactFiber$${???*26*}`]
+  | null[`__reactFiber$${???*31*}`][`__reactFiber$${???*36*}`]
+  | null["parentNode"]
+  | null[`__reactFiber$${???*41*}`]["alternate"]
+  | null
+)
+- *0* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *1* unsupported expression
+  ⚠️  This value might have side effects
+- *2* ???*3*["return"]
+  ⚠️  unknown object
+- *3* d
+  ⚠️  circular variable reference
+- *4* ???*5*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* unsupported expression
+  ⚠️  This value might have side effects
+- *6* ???*7*["slice"](2)
+  ⚠️  unknown callee object
+- *7* ???*8*(36)
+  ⚠️  unknown callee
+- *8* ???*9*["toString"]
+  ⚠️  unknown object
+- *9* ???*10*()
+  ⚠️  nested operation
+- *10* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *11* ???*12*["slice"](2)
+  ⚠️  unknown callee object
+- *12* ???*13*(36)
+  ⚠️  unknown callee
+- *13* ???*14*["toString"]
+  ⚠️  unknown object
+- *14* ???*15*()
+  ⚠️  nested operation
+- *15* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *16* ???*17*["slice"](2)
+  ⚠️  unknown callee object
+- *17* ???*18*(36)
+  ⚠️  unknown callee
+- *18* ???*19*["toString"]
+  ⚠️  unknown object
+- *19* ???*20*()
+  ⚠️  nested operation
+- *20* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *21* ???*22*["slice"](2)
+  ⚠️  unknown callee object
+- *22* ???*23*(36)
+  ⚠️  unknown callee
+- *23* ???*24*["toString"]
+  ⚠️  unknown object
+- *24* ???*25*()
+  ⚠️  nested operation
+- *25* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *26* ???*27*["slice"](2)
+  ⚠️  unknown callee object
+- *27* ???*28*(36)
+  ⚠️  unknown callee
+- *28* ???*29*["toString"]
+  ⚠️  unknown object
+- *29* ???*30*()
+  ⚠️  nested operation
+- *30* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *31* ???*32*["slice"](2)
+  ⚠️  unknown callee object
+- *32* ???*33*(36)
+  ⚠️  unknown callee
+- *33* ???*34*["toString"]
+  ⚠️  unknown object
+- *34* ???*35*()
+  ⚠️  nested operation
+- *35* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *36* ???*37*["slice"](2)
+  ⚠️  unknown callee object
+- *37* ???*38*(36)
+  ⚠️  unknown callee
+- *38* ???*39*["toString"]
+  ⚠️  unknown object
+- *39* ???*40*()
+  ⚠️  nested operation
+- *40* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *41* ???*42*["slice"](2)
+  ⚠️  unknown callee object
+- *42* ???*43*(36)
+  ⚠️  unknown callee
+- *43* ???*44*["toString"]
+  ⚠️  unknown object
+- *44* ???*45*()
+  ⚠️  nested operation
+- *45* ???["random"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 
 f#30 = ???*0*
@@ -17523,9 +17958,87 @@ f#30 = ???*0*
 - *2* l
   ⚠️  pattern without value
 
-f#308 = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
+f#308 = (
+  | ???*0*
+  | null
+  | !((???*2* | null | ???*4*))["stateNode"]
+  | false["stateNode"]
+  | null[`${???*7*}Capture`]
+  | !(???*8*)[`${???*10*}Capture`]
+  | !(???*11*)[`${???*17*}Capture`]
+  | !((???*18* | null | ???*20*))["stateNode"]
+  | null[???*23*]
+  | !(???*24*)[???*26*]
+  | !(???*27*)[???*33*]
+)
+- *0* ???*1*["stateNode"]
+  ⚠️  unknown object
+- *1* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *2* ???*3*[Pf]
+  ⚠️  unknown object
+- *3* c
+  ⚠️  circular variable reference
+- *4* !(???*5*)
+  ⚠️  nested operation
+- *5* ???*6*["disabled"]
+  ⚠️  unknown object
+- *6* d
+  ⚠️  circular variable reference
+- *7* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *8* ???*9*["disabled"]
+  ⚠️  unknown object
+- *9* d
+  ⚠️  circular variable reference
+- *10* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *11* ("button" === (???*12* | ???*13* | ???*15* | false))
+  ⚠️  nested operation
+- *12* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *13* ???*14*["return"]
+  ⚠️  unknown object
+- *14* a
+  ⚠️  circular variable reference
+- *15* !(???*16*)
+  ⚠️  nested operation
+- *16* d
+  ⚠️  circular variable reference
+- *17* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *18* ???*19*[Pf]
+  ⚠️  unknown object
+- *19* c
+  ⚠️  circular variable reference
+- *20* !(???*21*)
+  ⚠️  nested operation
+- *21* ???*22*["disabled"]
+  ⚠️  unknown object
+- *22* d
+  ⚠️  circular variable reference
+- *23* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *24* ???*25*["disabled"]
+  ⚠️  unknown object
+- *25* d
+  ⚠️  circular variable reference
+- *26* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *27* ("button" === (???*28* | ???*29* | ???*31* | false))
+  ⚠️  nested operation
+- *28* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *29* ???*30*["return"]
+  ⚠️  unknown object
+- *30* a
+  ⚠️  circular variable reference
+- *31* !(???*32*)
+  ⚠️  nested operation
+- *32* d
+  ⚠️  circular variable reference
+- *33* arguments[1]
+  ⚠️  function calls are not analysed yet
 
 f#311 = ???*0*
 - *0* ???*1*["_reactName"]
@@ -17550,9 +18063,78 @@ f#357 = ((???*0* + (???*1* | ???*2*)) | ???*3*)
 - *4* unsupported expression
   ⚠️  This value might have side effects
 
-f#400 = ???*0*
-- *0* max number of linking steps reached
+f#400 = (
+  | null
+  | {
+        "eventTime": (???*0* | ???*3* | ???*4*),
+        "lane": (???*5* | ???*8* | ???*9*),
+        "tag": (???*10* | ???*13* | ???*14*),
+        "payload": (???*15* | ???*18* | ???*19*),
+        "callback": (???*20* | ???*23* | ???*24*),
+        "next": null
+    }
+  | ???*25*
+  | ???*26*
+)
+- *0* ???*1*["eventTime"]
+  ⚠️  unknown object
+- *1* ???*2*["updateQueue"]
+  ⚠️  unknown object
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *3* FreeVar(undefined)
+  ⚠️  unknown global
   ⚠️  This value might have side effects
+- *4* unknown mutation
+  ⚠️  This value might have side effects
+- *5* ???*6*["lane"]
+  ⚠️  unknown object
+- *6* ???*7*["updateQueue"]
+  ⚠️  unknown object
+- *7* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *8* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *9* unknown mutation
+  ⚠️  This value might have side effects
+- *10* ???*11*["tag"]
+  ⚠️  unknown object
+- *11* ???*12*["updateQueue"]
+  ⚠️  unknown object
+- *12* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *13* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *14* unknown mutation
+  ⚠️  This value might have side effects
+- *15* ???*16*["payload"]
+  ⚠️  unknown object
+- *16* ???*17*["updateQueue"]
+  ⚠️  unknown object
+- *17* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *18* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *19* unknown mutation
+  ⚠️  This value might have side effects
+- *20* ???*21*["callback"]
+  ⚠️  unknown object
+- *21* ???*22*["updateQueue"]
+  ⚠️  unknown object
+- *22* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *23* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *24* unknown mutation
+  ⚠️  This value might have side effects
+- *25* unsupported expression
+  ⚠️  This value might have side effects
+- *26* arguments[1]
+  ⚠️  function calls are not analysed yet
 
 f#404 = ???*0*
 - *0* max number of linking steps reached
@@ -17760,9 +18342,36 @@ f#420 = ???*0*
 - *0* arguments[5]
   ⚠️  function calls are not analysed yet
 
-f#421 = ???*0*
-- *0* max number of linking steps reached
+f#421 = (
+  | ???*0*
+  | new ???*2*(???*3*, ???*4*)["contextType"]
+  | ???*5*
+  | ???*6*
+  | (???*7* ? ({} | ???*8*) : {})
+)
+- *0* ???*1*["contextType"]
+  ⚠️  unknown object
+- *1* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *2* b
+  ⚠️  circular variable reference
+- *3* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *4* f
+  ⚠️  circular variable reference
+- *5* FreeVar(undefined)
+  ⚠️  unknown global
   ⚠️  This value might have side effects
+- *6* unknown mutation
+  ⚠️  This value might have side effects
+- *7* unsupported expression
+  ⚠️  This value might have side effects
+- *8* ???*9*["__reactInternalMemoizedMaskedChildContext"]
+  ⚠️  unknown object
+- *9* ???*10*["stateNode"]
+  ⚠️  unknown object
+- *10* arguments[0]
+  ⚠️  function calls are not analysed yet
 
 f#423 = (???*0* | (???*2* ? ({} | ???*7*) : ({} | ???*8*)))
 - *0* ???*1*["contextType"]
@@ -17820,32 +18429,59 @@ f#459 = (???*0* | ???*1* | ???*4*)
   ⚠️  unknown object
 - *2* ???*3*["props"]
   ⚠️  unknown object
-- *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+- *3* f
+  ⚠️  circular variable reference
 - *4* f
   ⚠️  circular variable reference
 
-f#485 = (???*0* | 0 | ((???*1* | 0 | ???*2*) + 1))
+f#485 = (???*0* | 0 | (???*1* + 1))
 - *0* arguments[5]
   ⚠️  function calls are not analysed yet
-- *1* arguments[5]
-  ⚠️  function calls are not analysed yet
-- *2* (???*3* + 1)
-  ⚠️  nested operation
-- *3* f
+- *1* f
   ⚠️  circular variable reference
 
 f#494 = ???*0*
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-f#501 = ???*0*
-- *0* max number of linking steps reached
+f#501 = (???*0* | ???*1*)
+- *0* node limit reached
   ⚠️  This value might have side effects
+- *1* ???*2*(f, g["action"])
+  ⚠️  unknown callee
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
 
-f#504 = ???*0*
-- *0* max number of linking steps reached
+f#504 = !(???*0*)
+- *0* ???*1*(???*11*, ???*12*)
+  ⚠️  unknown callee
   ⚠️  This value might have side effects
+- *1* (???*2* ? ???*6* : (...) => ???*8*)
+  ⚠️  nested operation
+- *2* ("function" === ???*3*)
+  ⚠️  nested operation
+- *3* typeof(???*4*)
+  ⚠️  nested operation
+- *4* Object*5*["is"]
+  ⚠️  unsupported property on global Object
+  ⚠️  This value might have side effects
+- *5* Object: The global Object variable
+- *6* Object*7*["is"]
+  ⚠️  unsupported property on global Object
+  ⚠️  This value might have side effects
+- *7* Object: The global Object variable
+- *8* (((a === b) && ((0 !== a) || (???*9* === ???*10*))) || ((a !== a) && (b !== b)))
+  ⚠️  nested operation
+- *9* unsupported expression
+  ⚠️  This value might have side effects
+- *10* unsupported expression
+  ⚠️  This value might have side effects
+- *11* node limit reached
+  ⚠️  This value might have side effects
+- *12* ???*13*()
+  ⚠️  nested operation
+- *13* arguments[1]
+  ⚠️  function calls are not analysed yet
 
 f#518 = (
   | ???*0*
@@ -17956,8 +18592,7 @@ f#592 = (
   | new (...) => undefined(22, ???*19*, (null | ???*20*), (???*26* | ???*28*))["child"]
   | null["child"]
   | new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*29*, ???*30*, (???*31* | ???*33*))["child"]
-  | (???*34* ? ???*36* : (...) => (???*37* | ???*38*))["type"]["alternate"]["child"]
-  | new (...) => undefined(???*39*, (???*42* | ???*43*), ???*46*, ???*49*)["child"]
+  | new (...) => undefined(???*34*, (???*36* | ???*37*), ???*39*, ???*41*)["child"]
 )
 - *0* ???*1*["type"]
   ⚠️  unknown object
@@ -18029,42 +18664,24 @@ f#592 = (
   ⚠️  function calls are not analysed yet
 - *33* unsupported assign operation
   ⚠️  This value might have side effects
-- *34* (null !== ???*35*)
-  ⚠️  nested operation
-- *35* c
+- *34* ???*35*["tag"]
+  ⚠️  unknown object
+- *35* f
   ⚠️  circular variable reference
-- *36* c
+- *36* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *37* ???*38*["dependencies"]
+  ⚠️  unknown object
+- *38* f
   ⚠️  circular variable reference
-- *37* !(0)
-  ⚠️  nested operation
-- *38* !(1)
-  ⚠️  nested operation
-- *39* ???*40*["tag"]
+- *39* ???*40*["key"]
   ⚠️  unknown object
-- *40* ???*41*["type"]
+- *40* f
+  ⚠️  circular variable reference
+- *41* ???*42*["mode"]
   ⚠️  unknown object
-- *41* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *42* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *43* ???*44*["dependencies"]
-  ⚠️  unknown object
-- *44* ???*45*["type"]
-  ⚠️  unknown object
-- *45* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *46* ???*47*["key"]
-  ⚠️  unknown object
-- *47* ???*48*["type"]
-  ⚠️  unknown object
-- *48* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *49* ???*50*["mode"]
-  ⚠️  unknown object
-- *50* ???*51*["type"]
-  ⚠️  unknown object
-- *51* arguments[2]
-  ⚠️  function calls are not analysed yet
+- *42* f
+  ⚠️  circular variable reference
 
 f#595 = ???*0*
 - *0* ???*1*["memoizedProps"]
@@ -18072,28 +18689,24 @@ f#595 = ???*0*
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
 
-f#597 = (???*0* ? ???*9* : null)
+f#597 = (???*0* ? ???*7* : null)
 - *0* (null !== (???*1* | ???*2*))
   ⚠️  nested operation
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
-- *2* (???*3* ? ???*7* : ???*8*)
+- *2* (???*3* ? ???*5* : ???*6*)
   ⚠️  nested operation
 - *3* (null !== ???*4*)
   ⚠️  nested operation
-- *4* (???*5* ? ???*6* : null)
-  ⚠️  nested operation
-- *5* (null !== ???)
-  ⚠️  nested operation
-- *6* ???["memoizedState"]
-  ⚠️  unknown object
-- *7* unsupported expression
+- *4* f
+  ⚠️  circular variable reference
+- *5* unsupported expression
   ⚠️  This value might have side effects
-- *8* arguments[2]
+- *6* arguments[2]
   ⚠️  function calls are not analysed yet
-- *9* ???*10*["memoizedState"]
+- *7* ???*8*["memoizedState"]
   ⚠️  unknown object
-- *10* arguments[0]
+- *8* arguments[0]
   ⚠️  function calls are not analysed yet
 
 f#600 = ((???*0* ? ({} | ???*6*) : ({} | ???*7*)) | {} | ???*8*)
@@ -18178,7 +18791,7 @@ f#687 = (???*0* | ???*2*)
 - *4* e
   ⚠️  circular variable reference
 
-f#706 = (false | ???*0* | true | ???*1* | ???*2* | false["tag"] | true["tag"] | ???*4*)
+f#706 = (false | ???*0* | true | ???*1* | ???*2*)
 - *0* e
   ⚠️  circular variable reference
 - *1* unsupported expression
@@ -18187,11 +18800,6 @@ f#706 = (false | ???*0* | true | ???*1* | ???*2* | false["tag"] | true["tag"] | 
   ⚠️  unknown object
 - *3* e
   ⚠️  circular variable reference
-- *4* ???*5*["tag"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *5* unsupported expression
-  ⚠️  This value might have side effects
 
 f#716 = ???*0*
 - *0* arguments[0]
@@ -18632,8 +19240,114 @@ g#275 = (???*0* | ???*1* | 0)
 - *1* updated with update expression
   ⚠️  This value might have side effects
 
-g#286 = ???*0*
-- *0* max number of linking steps reached
+g#286 = (
+  | ???*0*
+  | ???*2*
+  | null[`__reactFiber$${???*4*}`]
+  | null["parentNode"][`__reactContainer$${???*9*}`]
+  | null[`__reactFiber$${???*14*}`][`__reactContainer$${???*19*}`]
+  | null["parentNode"][`__reactFiber$${???*24*}`]
+  | null[`__reactFiber$${???*29*}`][`__reactFiber$${???*34*}`]
+  | null["parentNode"]
+  | null[`__reactFiber$${???*39*}`]["alternate"]
+  | null
+)
+- *0* ???*1*["tag"]
+  ⚠️  unknown object
+- *1* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *2* ???*3*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *3* unsupported expression
+  ⚠️  This value might have side effects
+- *4* ???*5*["slice"](2)
+  ⚠️  unknown callee object
+- *5* ???*6*(36)
+  ⚠️  unknown callee
+- *6* ???*7*["toString"]
+  ⚠️  unknown object
+- *7* ???*8*()
+  ⚠️  nested operation
+- *8* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *9* ???*10*["slice"](2)
+  ⚠️  unknown callee object
+- *10* ???*11*(36)
+  ⚠️  unknown callee
+- *11* ???*12*["toString"]
+  ⚠️  unknown object
+- *12* ???*13*()
+  ⚠️  nested operation
+- *13* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *14* ???*15*["slice"](2)
+  ⚠️  unknown callee object
+- *15* ???*16*(36)
+  ⚠️  unknown callee
+- *16* ???*17*["toString"]
+  ⚠️  unknown object
+- *17* ???*18*()
+  ⚠️  nested operation
+- *18* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *19* ???*20*["slice"](2)
+  ⚠️  unknown callee object
+- *20* ???*21*(36)
+  ⚠️  unknown callee
+- *21* ???*22*["toString"]
+  ⚠️  unknown object
+- *22* ???*23*()
+  ⚠️  nested operation
+- *23* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *24* ???*25*["slice"](2)
+  ⚠️  unknown callee object
+- *25* ???*26*(36)
+  ⚠️  unknown callee
+- *26* ???*27*["toString"]
+  ⚠️  unknown object
+- *27* ???*28*()
+  ⚠️  nested operation
+- *28* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *29* ???*30*["slice"](2)
+  ⚠️  unknown callee object
+- *30* ???*31*(36)
+  ⚠️  unknown callee
+- *31* ???*32*["toString"]
+  ⚠️  unknown object
+- *32* ???*33*()
+  ⚠️  nested operation
+- *33* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *34* ???*35*["slice"](2)
+  ⚠️  unknown callee object
+- *35* ???*36*(36)
+  ⚠️  unknown callee
+- *36* ???*37*["toString"]
+  ⚠️  unknown object
+- *37* ???*38*()
+  ⚠️  nested operation
+- *38* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *39* ???*40*["slice"](2)
+  ⚠️  unknown callee object
+- *40* ???*41*(36)
+  ⚠️  unknown callee
+- *41* ???*42*["toString"]
+  ⚠️  unknown object
+- *42* ???*43*()
+  ⚠️  nested operation
+- *43* ???["random"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
 
 g#292 = []
@@ -18650,8 +19364,68 @@ g#357 = ???*0*
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-g#400 = ???*0*
-- *0* max number of linking steps reached
+g#400 = {
+    "eventTime": (???*0* | ???*3* | ???*4*),
+    "lane": (???*5* | ???*8* | ???*9*),
+    "tag": (???*10* | ???*13* | ???*14*),
+    "payload": (???*15* | ???*18* | ???*19*),
+    "callback": (???*20* | ???*23* | ???*24*),
+    "next": null
+}
+- *0* ???*1*["eventTime"]
+  ⚠️  unknown object
+- *1* ???*2*["updateQueue"]
+  ⚠️  unknown object
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *3* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *4* unknown mutation
+  ⚠️  This value might have side effects
+- *5* ???*6*["lane"]
+  ⚠️  unknown object
+- *6* ???*7*["updateQueue"]
+  ⚠️  unknown object
+- *7* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *8* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *9* unknown mutation
+  ⚠️  This value might have side effects
+- *10* ???*11*["tag"]
+  ⚠️  unknown object
+- *11* ???*12*["updateQueue"]
+  ⚠️  unknown object
+- *12* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *13* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *14* unknown mutation
+  ⚠️  This value might have side effects
+- *15* ???*16*["payload"]
+  ⚠️  unknown object
+- *16* ???*17*["updateQueue"]
+  ⚠️  unknown object
+- *17* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *18* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *19* unknown mutation
+  ⚠️  This value might have side effects
+- *20* ???*21*["callback"]
+  ⚠️  unknown object
+- *21* ???*22*["updateQueue"]
+  ⚠️  unknown object
+- *22* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *23* FreeVar(undefined)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *24* unknown mutation
   ⚠️  This value might have side effects
 
 g#404 = ???*0*
@@ -18676,19 +19450,12 @@ g#494 = ???*0*
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-g#501 = (???*0* | ???*1* | ???*3*)
+g#501 = (???*0* | ???*1*)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* ???*2*["next"]
   ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *2* unsupported expression
-  ⚠️  This value might have side effects
-- *3* ???*4*["next"]
-  ⚠️  unknown object
-- *4* ???*5*["next"]
-  ⚠️  unknown object
-- *5* g
+- *2* g
   ⚠️  circular variable reference
 
 g#518 = (
@@ -19073,18 +19840,39 @@ g#961 = (
 - *27* a
   ⚠️  circular variable reference
 
-g#979 = ???*0*
-- *0* max number of linking steps reached
+g#979 = (???*0* | ???*1*)
+- *0* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *1* node limit reached
   ⚠️  This value might have side effects
 
-g#986 = ???*0*
-- *0* max number of linking steps reached
+g#986 = (
+  | ???*0*
+  | ???*2*
+  | ???*3*
+  | new (...) => undefined(???*4*, (0 | 1 | ???*5*), false, "", (...) => undefined)
+)
+- *0* ???*1*["_reactRootContainer"]
+  ⚠️  unknown object
+- *1* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *2* arguments[1]
+  ⚠️  function calls are not analysed yet
+- *3* node limit reached
+  ⚠️  This value might have side effects
+- *4* a
+  ⚠️  circular variable reference
+- *5* unsupported assign operation
   ⚠️  This value might have side effects
 
 gb = (...) => A(
     {},
     b,
-    {"value": ???*0*, "defaultValue": ???*1*, "children": a["_wrapperState"]["initialValue"]}
+    {
+        "value": ???*0*,
+        "defaultValue": ???*1*,
+        "children": `${a["_wrapperState"]["initialValue"]}`
+    }
 )
 - *0* unsupported expression
   ⚠️  This value might have side effects
@@ -19135,9 +19923,60 @@ h#128 = ???*0*
 - *0* arguments[7]
   ⚠️  function calls are not analysed yet
 
-h#136 = ???*0*
-- *0* max number of linking steps reached
-  ⚠️  This value might have side effects
+h#136 = (
+  | ???*0*
+  | (???*3* ? (???*6* | ???*7* | ???*8*) : null)["return"]["child"]
+  | (???*10* ? (???*13* | ???*14* | ???*15*) : null)["return"]["alternate"]["child"]
+  | (???*17* ? (???*20* | ???*21* | ???*22*) : null)["return"]["child"]["child"]
+)
+- *0* ???*1*["child"]
+  ⚠️  unknown object
+- *1* ???*2*["return"]
+  ⚠️  unknown object
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *3* (3 === ???*4*)
+  ⚠️  nested operation
+- *4* ???*5*["tag"]
+  ⚠️  unknown object
+- *5* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *6* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *7* a
+  ⚠️  circular variable reference
+- *8* ???*9*["return"]
+  ⚠️  unknown object
+- *9* b
+  ⚠️  circular variable reference
+- *10* (3 === ???*11*)
+  ⚠️  nested operation
+- *11* ???*12*["tag"]
+  ⚠️  unknown object
+- *12* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *13* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *14* a
+  ⚠️  circular variable reference
+- *15* ???*16*["return"]
+  ⚠️  unknown object
+- *16* b
+  ⚠️  circular variable reference
+- *17* (3 === ???*18*)
+  ⚠️  nested operation
+- *18* ???*19*["tag"]
+  ⚠️  unknown object
+- *19* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *20* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *21* a
+  ⚠️  circular variable reference
+- *22* ???*23*["return"]
+  ⚠️  unknown object
+- *23* b
+  ⚠️  circular variable reference
 
 h#159 = ???*0*
 - *0* unsupported expression
@@ -19147,12 +19986,7 @@ h#162 = ???*0*
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-h#275 = (
-  | ???*0*
-  | null[(0 | ???*6*)][(???*7* | ???*8* | 0)]
-  | null[(0 | ???*9*)][(???*10* | ???*11* | 0)]["listener"]
-  | ???*12*
-)
+h#275 = (???*0* | null[(0 | ???*6*)][(???*7* | ???*8* | 0)] | ???*9*)
 - *0* ???*1*[(???*4* | ???*5* | 0)]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -19173,17 +20007,9 @@ h#275 = (
   ⚠️  This value might have side effects
 - *8* updated with update expression
   ⚠️  This value might have side effects
-- *9* updated with update expression
-  ⚠️  This value might have side effects
-- *10* unsupported expression
-  ⚠️  This value might have side effects
-- *11* updated with update expression
-  ⚠️  This value might have side effects
-- *12* ???*13*["listener"]
+- *9* ???*10*["listener"]
   ⚠️  unknown object
-- *13* ???*14*["listener"]
-  ⚠️  unknown object
-- *14* h
+- *10* h
   ⚠️  circular variable reference
 
 h#286 = (???*0* | ???*3*)
@@ -19277,8 +20103,167 @@ h#614 = ???*0*
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-h#639 = ???*0*
-- *0* max number of linking steps reached
+h#639 = (???*0* | ???*5* | (???*22* ? (???*39* | ???*44*) : ???*61*) | (???*62* ? ???*63* : ???*65*))
+- *0* ???*1*[(???*3* | null | [] | ???*4*)]
+  ⚠️  unknown object
+- *1* ???*2*["memoizedProps"]
+  ⚠️  unknown object
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *3* l
+  ⚠️  pattern without value
+- *4* f
+  ⚠️  circular variable reference
+- *5* ???*6*[(???*20* | null | [] | ???*21*)]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *6* Object.assign*7*(
+        {},
+        ???*8*,
+        {
+            "defaultChecked": ???*9*,
+            "defaultValue": ???*10*,
+            "value": ???*11*,
+            "checked": (???*12* ? ???*15* : ???*17*)
+        }
+    )
+  ⚠️  only const object assign is supported
+  ⚠️  This value might have side effects
+- *7* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+- *8* e
+  ⚠️  circular variable reference
+- *9* unsupported expression
+  ⚠️  This value might have side effects
+- *10* unsupported expression
+  ⚠️  This value might have side effects
+- *11* unsupported expression
+  ⚠️  This value might have side effects
+- *12* (null != ???*13*)
+  ⚠️  nested operation
+- *13* ???*14*["checked"]
+  ⚠️  unknown object
+- *14* e
+  ⚠️  circular variable reference
+- *15* ???*16*["checked"]
+  ⚠️  unknown object
+- *16* e
+  ⚠️  circular variable reference
+- *17* ???*18*["initialChecked"]
+  ⚠️  unknown object
+- *18* ???*19*["_wrapperState"]
+  ⚠️  unknown object
+- *19* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *20* l
+  ⚠️  pattern without value
+- *21* f
+  ⚠️  circular variable reference
+- *22* (null != (???*23* | ???*25*))
+  ⚠️  nested operation
+- *23* ???*24*["memoizedProps"]
+  ⚠️  unknown object
+- *24* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *25* Object.assign*26*(
+        {},
+        ???*27*,
+        {
+            "defaultChecked": ???*28*,
+            "defaultValue": ???*29*,
+            "value": ???*30*,
+            "checked": (???*31* ? ???*34* : ???*36*)
+        }
+    )
+  ⚠️  only const object assign is supported
+  ⚠️  This value might have side effects
+- *26* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+- *27* e
+  ⚠️  circular variable reference
+- *28* unsupported expression
+  ⚠️  This value might have side effects
+- *29* unsupported expression
+  ⚠️  This value might have side effects
+- *30* unsupported expression
+  ⚠️  This value might have side effects
+- *31* (null != ???*32*)
+  ⚠️  nested operation
+- *32* ???*33*["checked"]
+  ⚠️  unknown object
+- *33* e
+  ⚠️  circular variable reference
+- *34* ???*35*["checked"]
+  ⚠️  unknown object
+- *35* e
+  ⚠️  circular variable reference
+- *36* ???*37*["initialChecked"]
+  ⚠️  unknown object
+- *37* ???*38*["_wrapperState"]
+  ⚠️  unknown object
+- *38* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *39* ???*40*[(???*42* | null | [] | ???*43*)]
+  ⚠️  unknown object
+- *40* ???*41*["memoizedProps"]
+  ⚠️  unknown object
+- *41* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *42* l
+  ⚠️  pattern without value
+- *43* f
+  ⚠️  circular variable reference
+- *44* ???*45*[(???*59* | null | [] | ???*60*)]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *45* Object.assign*46*(
+        {},
+        ???*47*,
+        {
+            "defaultChecked": ???*48*,
+            "defaultValue": ???*49*,
+            "value": ???*50*,
+            "checked": (???*51* ? ???*54* : ???*56*)
+        }
+    )
+  ⚠️  only const object assign is supported
+  ⚠️  This value might have side effects
+- *46* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+- *47* e
+  ⚠️  circular variable reference
+- *48* unsupported expression
+  ⚠️  This value might have side effects
+- *49* unsupported expression
+  ⚠️  This value might have side effects
+- *50* unsupported expression
+  ⚠️  This value might have side effects
+- *51* (null != ???*52*)
+  ⚠️  nested operation
+- *52* ???*53*["checked"]
+  ⚠️  unknown object
+- *53* e
+  ⚠️  circular variable reference
+- *54* ???*55*["checked"]
+  ⚠️  unknown object
+- *55* e
+  ⚠️  circular variable reference
+- *56* ???*57*["initialChecked"]
+  ⚠️  unknown object
+- *57* ???*58*["_wrapperState"]
+  ⚠️  unknown object
+- *58* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *59* l
+  ⚠️  pattern without value
+- *60* f
+  ⚠️  circular variable reference
+- *61* unsupported expression
+  ⚠️  This value might have side effects
+- *62* h
+  ⚠️  circular variable reference
+- *63* ???*64*["__html"]
+  ⚠️  unknown object
+- *64* h
+  ⚠️  circular variable reference
+- *65* unsupported expression
   ⚠️  This value might have side effects
 
 h#647 = ???*0*
@@ -19413,9 +20398,165 @@ ib = (...) => undefined
 
 ic = module<scheduler, {}>["unstable_LowPriority"]
 
-id = ???*0*
-- *0* max number of linking steps reached
+id = (
+  | null
+  | ???*0*
+  | (???*1* ? (???*6* | ???*8*) : (???*10* | ???*11* | ???*13*))
+  | ???*14*
+  | null[`__reactFiber$${???*20*}`]
+  | null["parentNode"][`__reactContainer$${???*25*}`]
+  | null[`__reactFiber$${???*30*}`][`__reactContainer$${???*35*}`]
+  | null["parentNode"][`__reactFiber$${???*40*}`]
+  | null[`__reactFiber$${???*45*}`][`__reactFiber$${???*50*}`]
+  | null["parentNode"]
+  | null[`__reactFiber$${???*55*}`]["alternate"]
+  | (???*60* ? (???*63* | ???*64*) : null)["memoizedState"]["dehydrated"]
+)
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* (3 === (???*2* | ???*4*))
+  ⚠️  nested operation
+- *2* ???*3*["nodeType"]
+  ⚠️  unknown object
+- *3* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *4* ???*5*["nodeType"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
+- *5* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *6* ???*7*["parentNode"]
+  ⚠️  unknown object
+- *7* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *8* ???*9*["parentNode"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *9* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *10* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *11* ???*12*["target"]
+  ⚠️  unknown object
+- *12* a
+  ⚠️  circular variable reference
+- *13* FreeVar(window)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *14* ???*15*[`__reactFiber$${???*16*}`]
+  ⚠️  unknown object
+- *15* a
+  ⚠️  circular variable reference
+- *16* ???*17*["slice"](2)
+  ⚠️  unknown callee object
+- *17* ???*18*(36)
+  ⚠️  unknown callee
+- *18* ???*19*["toString"]
+  ⚠️  unknown object
+- *19* ???()
+  ⚠️  nested operation
+- *20* ???*21*["slice"](2)
+  ⚠️  unknown callee object
+- *21* ???*22*(36)
+  ⚠️  unknown callee
+- *22* ???*23*["toString"]
+  ⚠️  unknown object
+- *23* ???*24*()
+  ⚠️  nested operation
+- *24* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *25* ???*26*["slice"](2)
+  ⚠️  unknown callee object
+- *26* ???*27*(36)
+  ⚠️  unknown callee
+- *27* ???*28*["toString"]
+  ⚠️  unknown object
+- *28* ???*29*()
+  ⚠️  nested operation
+- *29* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *30* ???*31*["slice"](2)
+  ⚠️  unknown callee object
+- *31* ???*32*(36)
+  ⚠️  unknown callee
+- *32* ???*33*["toString"]
+  ⚠️  unknown object
+- *33* ???*34*()
+  ⚠️  nested operation
+- *34* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *35* ???*36*["slice"](2)
+  ⚠️  unknown callee object
+- *36* ???*37*(36)
+  ⚠️  unknown callee
+- *37* ???*38*["toString"]
+  ⚠️  unknown object
+- *38* ???*39*()
+  ⚠️  nested operation
+- *39* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *40* ???*41*["slice"](2)
+  ⚠️  unknown callee object
+- *41* ???*42*(36)
+  ⚠️  unknown callee
+- *42* ???*43*["toString"]
+  ⚠️  unknown object
+- *43* ???*44*()
+  ⚠️  nested operation
+- *44* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *45* ???*46*["slice"](2)
+  ⚠️  unknown callee object
+- *46* ???*47*(36)
+  ⚠️  unknown callee
+- *47* ???*48*["toString"]
+  ⚠️  unknown object
+- *48* ???*49*()
+  ⚠️  nested operation
+- *49* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *50* ???*51*["slice"](2)
+  ⚠️  unknown callee object
+- *51* ???*52*(36)
+  ⚠️  unknown callee
+- *52* ???*53*["toString"]
+  ⚠️  unknown object
+- *53* ???*54*()
+  ⚠️  nested operation
+- *54* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *55* ???*56*["slice"](2)
+  ⚠️  unknown callee object
+- *56* ???*57*(36)
+  ⚠️  unknown callee
+- *57* ???*58*["toString"]
+  ⚠️  unknown object
+- *58* ???*59*()
+  ⚠️  nested operation
+- *59* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *60* (3 === ???*61*)
+  ⚠️  nested operation
+- *61* ???*62*["tag"]
+  ⚠️  unknown object
+- *62* a
+  ⚠️  circular variable reference
+- *63* a
+  ⚠️  circular variable reference
+- *64* ???*65*["return"]
+  ⚠️  unknown object
+- *65* b
+  ⚠️  circular variable reference
 
 ie = (false | true)
 
@@ -19542,7 +20683,6 @@ k#30 = (
   | `
 ${???*0*}`
   | ???*5*
-  | ???*16*
 )
 - *0* ???*1*["replace"](" at new ", " at ")
   ⚠️  unknown callee object
@@ -19554,47 +20694,9 @@ ${???*0*}`
   ⚠️  unknown object
 - *4* l
   ⚠️  pattern without value
-- *5* ???*6*("<anonymous>", (???*10* | ???*12*["displayName"]))
-  ⚠️  unknown callee
-- *6* ???*7*["replace"]
-  ⚠️  unknown object
-- *7* `
-${???*8*}`
-  ⚠️  nested operation
-- *8* ???*9*["replace"](" at new ", " at ")
+- *5* ???*6*["replace"]("<anonymous>", a["displayName"])
   ⚠️  unknown callee object
-- *9* ???[g]
-  ⚠️  unknown object
-- *10* ???*11*["displayName"]
-  ⚠️  unknown object
-- *11* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *12* (???*13* ? ???*14* : "")
-  ⚠️  nested operation
-- *13* a
-  ⚠️  circular variable reference
-- *14* ???*15*["displayName"]
-  ⚠️  unknown object
-- *15* a
-  ⚠️  circular variable reference
-- *16* ???*17*["replace"](
-        "<anonymous>",
-        (???*19* | (???*21* ? ???*22* : "")["displayName"])
-    )
-  ⚠️  unknown callee object
-- *17* ???*18*["replace"]("<anonymous>", a["displayName"])
-  ⚠️  unknown callee object
-- *18* k
-  ⚠️  circular variable reference
-- *19* ???*20*["displayName"]
-  ⚠️  unknown object
-- *20* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *21* a
-  ⚠️  circular variable reference
-- *22* ???*23*["displayName"]
-  ⚠️  unknown object
-- *23* a
+- *6* k
   ⚠️  circular variable reference
 
 k#311 = (
@@ -19682,26 +20784,17 @@ k#539 = ???*0*
 - *1* arguments[1]
   ⚠️  function calls are not analysed yet
 
-k#601 = (
-  | ???*0*
-  | ???*3*
-  | (???*5* ? ({} | ???*9*) : ({} | ???*10*))["_currentValue"]
-  | ???*11*
-  | ???*12*
-  | (???*13* ? ({} | ???*17*) : ({} | ???*18*))
-  | {}
-)
+k#601 = (???*0* | ???*3* | ???*4* | (???*5* ? ({} | ???*9*) : ({} | ???*10*)) | {})
 - *0* ???*1*["context"]
   ⚠️  unknown object
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
   ⚠️  function calls are not analysed yet
-- *3* ???*4*["_currentValue"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *4* FreeVar(undefined)
+- *3* FreeVar(undefined)
   ⚠️  unknown global
+  ⚠️  This value might have side effects
+- *4* unknown mutation
   ⚠️  This value might have side effects
 - *5* (null !== (???*6* | ???*7*))
   ⚠️  nested operation
@@ -19715,33 +20808,12 @@ k#601 = (
   ⚠️  This value might have side effects
 - *10* unknown mutation
   ⚠️  This value might have side effects
-- *11* FreeVar(undefined)
-  ⚠️  unknown global
-  ⚠️  This value might have side effects
-- *12* unknown mutation
-  ⚠️  This value might have side effects
-- *13* (null !== (???*14* | ???*15*))
-  ⚠️  nested operation
-- *14* arguments[2]
-  ⚠️  function calls are not analysed yet
-- *15* ???*16*["childContextTypes"]
-  ⚠️  unknown object
-- *16* a
-  ⚠️  circular variable reference
-- *17* unknown mutation
-  ⚠️  This value might have side effects
-- *18* unknown mutation
-  ⚠️  This value might have side effects
 
 k#609 = ???*0*
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-k#639 = (
-  | ???*0*
-  | ???*4*
-  | ((???*21* | ???*25* | ???*42*) ? (???*47* | ???*52*) : ???*68*)
-)
+k#639 = (???*0* | ???*4* | (???*21* ? ???*22* : ???*24*))
 - *0* ???*1*[(???*2* | null | [] | ???*3*)]
   ⚠️  unknown object
 - *1* arguments[3]
@@ -19794,122 +20866,13 @@ k#639 = (
   ⚠️  pattern without value
 - *20* f
   ⚠️  circular variable reference
-- *21* ???*22*[(???*23* | null | [] | ???*24*)]
-  ⚠️  unknown object
-- *22* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *23* l
-  ⚠️  pattern without value
-- *24* f
+- *21* k
   ⚠️  circular variable reference
-- *25* ???*26*[(???*40* | null | [] | ???*41*)]
+- *22* ???*23*["__html"]
   ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *26* Object.assign*27*(
-        {},
-        ???*28*,
-        {
-            "defaultChecked": ???*29*,
-            "defaultValue": ???*30*,
-            "value": ???*31*,
-            "checked": (???*32* ? ???*35* : ???*37*)
-        }
-    )
-  ⚠️  only const object assign is supported
-  ⚠️  This value might have side effects
-- *27* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-- *28* d
+- *23* k
   ⚠️  circular variable reference
-- *29* unsupported expression
-  ⚠️  This value might have side effects
-- *30* unsupported expression
-  ⚠️  This value might have side effects
-- *31* unsupported expression
-  ⚠️  This value might have side effects
-- *32* (null != ???*33*)
-  ⚠️  nested operation
-- *33* ???*34*["checked"]
-  ⚠️  unknown object
-- *34* d
-  ⚠️  circular variable reference
-- *35* ???*36*["checked"]
-  ⚠️  unknown object
-- *36* d
-  ⚠️  circular variable reference
-- *37* ???*38*["initialChecked"]
-  ⚠️  unknown object
-- *38* ???*39*["_wrapperState"]
-  ⚠️  unknown object
-- *39* arguments[0]
-  ⚠️  function calls are not analysed yet
-- *40* l
-  ⚠️  pattern without value
-- *41* f
-  ⚠️  circular variable reference
-- *42* (???*43* ? ???*44* : ???*46*)
-  ⚠️  nested operation
-- *43* k
-  ⚠️  circular variable reference
-- *44* ???*45*["__html"]
-  ⚠️  unknown object
-- *45* k
-  ⚠️  circular variable reference
-- *46* unsupported expression
-  ⚠️  This value might have side effects
-- *47* ???*48*["__html"]
-  ⚠️  unknown object
-- *48* ???*49*[(???*50* | null | [] | ???*51*)]
-  ⚠️  unknown object
-- *49* arguments[3]
-  ⚠️  function calls are not analysed yet
-- *50* l
-  ⚠️  pattern without value
-- *51* f
-  ⚠️  circular variable reference
-- *52* ???*53*["__html"]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *53* ???*54*[(???*66* | null | [] | ???*67*)]
-  ⚠️  unknown object
-  ⚠️  This value might have side effects
-- *54* Object.assign*55*(
-        {},
-        ???*56*,
-        {
-            "defaultChecked": ???*57*,
-            "defaultValue": ???*58*,
-            "value": ???*59*,
-            "checked": (???*60* ? ???*62* : ???*64*)
-        }
-    )
-  ⚠️  only const object assign is supported
-  ⚠️  This value might have side effects
-- *55* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-- *56* d
-  ⚠️  circular variable reference
-- *57* unsupported expression
-  ⚠️  This value might have side effects
-- *58* unsupported expression
-  ⚠️  This value might have side effects
-- *59* unsupported expression
-  ⚠️  This value might have side effects
-- *60* (null != ???*61*)
-  ⚠️  nested operation
-- *61* ???["checked"]
-  ⚠️  unknown object
-- *62* ???*63*["checked"]
-  ⚠️  unknown object
-- *63* d
-  ⚠️  circular variable reference
-- *64* ???*65*["initialChecked"]
-  ⚠️  unknown object
-- *65* ???["_wrapperState"]
-  ⚠️  unknown object
-- *66* l
-  ⚠️  pattern without value
-- *67* f
-  ⚠️  circular variable reference
-- *68* unsupported expression
+- *24* unsupported expression
   ⚠️  This value might have side effects
 
 k#647 = ???*0*
@@ -20561,9 +21524,45 @@ n#292 = ???*0*
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-n#404 = ???*0*
-- *0* max number of linking steps reached
+n#404 = (
+  | ???*0*
+  | ???*1*
+  | ???*6*
+  | null["next"]["payload"]
+  | (???*9* ? ???*12* : ???*14*)["next"]["payload"]
+)
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *1* ???*2*["payload"]
+  ⚠️  unknown object
+- *2* ???*3*["pending"]
+  ⚠️  unknown object
+- *3* ???*4*["shared"]
+  ⚠️  unknown object
+- *4* ???*5*["updateQueue"]
+  ⚠️  unknown object
+- *5* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *6* ???*7*["payload"]
+  ⚠️  unknown object
   ⚠️  This value might have side effects
+- *7* ???*8*["lastBaseUpdate"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *8* unsupported expression
+  ⚠️  This value might have side effects
+- *9* ("function" === ???*10*)
+  ⚠️  nested operation
+- *10* typeof(???*11*)
+  ⚠️  nested operation
+- *11* n
+  ⚠️  circular variable reference
+- *12* ???*13*["call"](y, q, r)
+  ⚠️  unknown callee object
+- *13* n
+  ⚠️  circular variable reference
+- *14* n
+  ⚠️  circular variable reference
 
 n#431 = (...) => (???*0* | l)
 - *0* l
@@ -20607,17 +21606,9 @@ na#292 = (
   | (...) => (undefined | te(b))
   | ???*0*
 )
-- *0* (
-      | (...) => (undefined | b)
-      | (...) => (undefined | te(b))
-      | (...) => (undefined | te(qe))
-      | (...) => (undefined | te(b))
-      | ???*1*
-    )(a, d)
-  ⚠️  non-function callee
-- *1* ???*2*(a, d)
+- *0* ???*1*(a, d)
   ⚠️  unknown callee
-- *2* na
+- *1* na
   ⚠️  circular variable reference
 
 na#860 = ???*0*
@@ -20867,9 +21858,17 @@ q#673 = ???*0*
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-q#721 = ???*0*
-- *0* max number of linking steps reached
+q#721 = (???*0* | ???*3* | ???*4*)
+- *0* ???*1*[(g + 1)]
+  ⚠️  unknown object
+- *1* ???*2*["updateQueue"]
+  ⚠️  unknown object
+- *2* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *3* unsupported expression
   ⚠️  This value might have side effects
+- *4* arguments[0]
+  ⚠️  function calls are not analysed yet
 
 q#768 = ???*0*
 - *0* max number of linking steps reached
@@ -20928,7 +21927,7 @@ r#404 = ???*0*
   ⚠️  This value might have side effects
 
 r#431 = (...) => (
-  | ((null !== e) ? null : h(a, b, c, d))
+  | ((null !== e) ? null : h(a, b, `${c}`, d))
   | ((c["key"] === e) ? k(a, b, c, d) : null)
   | ((c["key"] === e) ? l(a, b, c, d) : null)
   | ???*0*
@@ -20967,7 +21966,7 @@ r#883 = ???*0*
 
 ra = /[\-:]([a-z])/g
 
-rb = (...) => (((null == b) || ("boolean" === typeof(b)) || ("" === b)) ? "" : ((c || ("number" !== typeof(b)) || (0 === b) || (pb["hasOwnProperty"](a) && pb[a])) ? b["trim"]() : `${b}px`))
+rb = (...) => (((null == b) || ("boolean" === typeof(b)) || ("" === b)) ? "" : ((c || ("number" !== typeof(b)) || (0 === b) || (pb["hasOwnProperty"](a) && pb[a])) ? `${b}`["trim"]() : `${b}px`))
 
 rc = (64 | ???*0*)
 - *0* unsupported assign operation
@@ -21325,8 +22324,127 @@ vl = {
 - *5* unknown mutation
   ⚠️  This value might have side effects
 
-w#292 = ???*0*
-- *0* max number of linking steps reached
+w#292 = (
+  | ???*0*
+  | ???*1*
+  | ???*2*
+  | ???*4*
+  | null[`__reactFiber$${???*6*}`]
+  | null["parentNode"][`__reactContainer$${???*11*}`]
+  | null[`__reactFiber$${???*16*}`][`__reactContainer$${???*21*}`]
+  | null["parentNode"][`__reactFiber$${???*26*}`]
+  | null[`__reactFiber$${???*31*}`][`__reactFiber$${???*36*}`]
+  | null["parentNode"]
+  | null[`__reactFiber$${???*41*}`]["alternate"]
+  | null
+  | []
+  | "mouse"
+  | "pointer"
+  | 0
+  | ???*46*
+)
+- *0* arguments[3]
+  ⚠️  function calls are not analysed yet
+- *1* unsupported expression
+  ⚠️  This value might have side effects
+- *2* ???*3*["return"]
+  ⚠️  unknown object
+- *3* d
+  ⚠️  circular variable reference
+- *4* ???*5*["tag"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *5* unsupported expression
+  ⚠️  This value might have side effects
+- *6* ???*7*["slice"](2)
+  ⚠️  unknown callee object
+- *7* ???*8*(36)
+  ⚠️  unknown callee
+- *8* ???*9*["toString"]
+  ⚠️  unknown object
+- *9* ???*10*()
+  ⚠️  nested operation
+- *10* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *11* ???*12*["slice"](2)
+  ⚠️  unknown callee object
+- *12* ???*13*(36)
+  ⚠️  unknown callee
+- *13* ???*14*["toString"]
+  ⚠️  unknown object
+- *14* ???*15*()
+  ⚠️  nested operation
+- *15* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *16* ???*17*["slice"](2)
+  ⚠️  unknown callee object
+- *17* ???*18*(36)
+  ⚠️  unknown callee
+- *18* ???*19*["toString"]
+  ⚠️  unknown object
+- *19* ???*20*()
+  ⚠️  nested operation
+- *20* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *21* ???*22*["slice"](2)
+  ⚠️  unknown callee object
+- *22* ???*23*(36)
+  ⚠️  unknown callee
+- *23* ???*24*["toString"]
+  ⚠️  unknown object
+- *24* ???*25*()
+  ⚠️  nested operation
+- *25* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *26* ???*27*["slice"](2)
+  ⚠️  unknown callee object
+- *27* ???*28*(36)
+  ⚠️  unknown callee
+- *28* ???*29*["toString"]
+  ⚠️  unknown object
+- *29* ???*30*()
+  ⚠️  nested operation
+- *30* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *31* ???*32*["slice"](2)
+  ⚠️  unknown callee object
+- *32* ???*33*(36)
+  ⚠️  unknown callee
+- *33* ???*34*["toString"]
+  ⚠️  unknown object
+- *34* ???*35*()
+  ⚠️  nested operation
+- *35* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *36* ???*37*["slice"](2)
+  ⚠️  unknown callee object
+- *37* ???*38*(36)
+  ⚠️  unknown callee
+- *38* ???*39*["toString"]
+  ⚠️  unknown object
+- *39* ???*40*()
+  ⚠️  nested operation
+- *40* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *41* ???*42*["slice"](2)
+  ⚠️  unknown callee object
+- *42* ???*43*(36)
+  ⚠️  unknown callee
+- *43* ???*44*["toString"]
+  ⚠️  unknown object
+- *44* ???*45*()
+  ⚠️  nested operation
+- *45* ???["random"]
+  ⚠️  unknown object
+  ⚠️  This value might have side effects
+- *46* updated with update expression
   ⚠️  This value might have side effects
 
 w#449 = (???*0* | ???*1*)
@@ -21618,7 +22736,7 @@ ze = ???*0*
   ⚠️  unknown global
   ⚠️  This value might have side effects
 
-zf = (...) => (("string" === typeof(a)) ? a : a)["replace"](xf, "\n")["replace"](yf, "")
+zf = (...) => (("string" === typeof(a)) ? a : `${a}`)["replace"](xf, "\n")["replace"](yf, "")
 
 zg = (null | [???*0*])
 - *0* arguments[0]


### PR DESCRIPTION
Maintain a cache of `VariableId -> JsValue` (per-module), so that we don't reevaluate variables (mostly, unless it's a local variable inside a function call) 

```
canary 82026906a6:
15,3gb
TURBO_ENGINE_READ_ONLY=1 NEXT_TURBOPACK_TRACING= TURBOPACK=1 TURBOPACK_BUILD=  501.72s user 108.30s system 760% cpu 1:20.26 total
TURBO_ENGINE_READ_ONLY=1 NEXT_TURBOPACK_TRACING= TURBOPACK=1 TURBOPACK_BUILD=  502.01s user 102.27s system 774% cpu 1:18.04 total

mischnic/analyzer-link-cache 66d7e1f00c:
15,3gb
TURBO_ENGINE_READ_ONLY=1 NEXT_TURBOPACK_TRACING= TURBOPACK=1 TURBOPACK_BUILD=  490.36s user 104.63s system 731% cpu 1:21.34 total
TURBO_ENGINE_READ_ONLY=1 NEXT_TURBOPACK_TRACING= TURBOPACK=1 TURBOPACK_BUILD=  489.22s user 106.89s system 780% cpu 1:16.39 total
```

Closes PACK-3899