### PR TITLE
Read and write rspack test manifests by name

### DIFF
--- a/.github/workflows/rspack-nextjs-build-integration-tests.yml
+++ b/.github/workflows/rspack-nextjs-build-integration-tests.yml
@@ -99,7 +99,7 @@ jobs:
           name: test-reports-start-${{ matrix.group }}
           if-no-files-found: 'error'
           path: |
-            test/turbopack-test-junit-report
+            test/rspack-test-junit-report
 
   test-integration-production:
     name: Next.js integration test (Integration)

--- a/.github/workflows/rspack-nextjs-dev-integration-tests.yml
+++ b/.github/workflows/rspack-nextjs-dev-integration-tests.yml
@@ -99,7 +99,7 @@ jobs:
           name: test-reports-dev-${{ matrix.group }}
           if-no-files-found: 'error'
           path: |
-            test/turbopack-test-junit-report
+            test/rspack-test-junit-report
 
   test-integration-development:
     name: Next.js integration test (Integration)
@@ -149,7 +149,7 @@ jobs:
           name: test-reports-dev-integration-${{ matrix.group }}
           if-no-files-found: 'error'
           path: |
-            test/turbopack-test-junit-report
+            test/rspack-test-junit-report
 
   # Collect integration test results from execute_tests,
   # Store it as github artifact for next step to consume.

--- a/.github/workflows/rspack-update-tests-manifest.yml
+++ b/.github/workflows/rspack-update-tests-manifest.yml
@@ -38,11 +38,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           BRANCH_NAME: rspack-manifest
-          SCRIPT: test/build-turbopack-dev-tests-manifest.js
+          SCRIPT: test/build-rspack-dev-tests-manifest.js
           PR_TITLE: Update Rspack development test manifest
           PR_BODY: This auto-generated PR updates the development integration test manifest used when testing Rspack.
   update_build_manifest:
-    name: Update and upload Turbopack production test manifest
+    name: Update and upload Rspack production test manifest
     if: github.repository_owner == 'vercel'
     runs-on: ubuntu-latest
     steps:
@@ -71,6 +71,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           BRANCH_NAME: rspack-manifest
-          SCRIPT: test/build-turbopack-build-tests-manifest.js
+          SCRIPT: test/build-rspack-build-tests-manifest.js
           PR_TITLE: Update Rspack production test manifest
           PR_BODY: This auto-generated PR updates the production integration test manifest used when testing Rspack.

--- a/jest.config.js
+++ b/jest.config.js
@@ -36,9 +36,14 @@ if (enableTestReport) {
     customJestConfig.reporters = ['default']
   }
 
-  const outputDirectory = process.env.TURBOPACK
-    ? '<rootDir>/turbopack-test-junit-report'
-    : '<rootDir>/test-junit-report'
+  let outputDirectory
+  if (process.env.TURBOPACK) {
+    outputDirectory = '<rootDir>/turbopack-test-junit-report'
+  } else if (process.env.NEXT_RSPACK) {
+    outputDirectory = '<rootDir>/rspack-test-junit-report'
+  } else {
+    outputDirectory = '<rootDir>/test-junit-report'
+  }
 
   customJestConfig.reporters.push([
     'jest-junit',

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -5,5 +5,6 @@ e2e/**/tsconfig.json
 production/**/tsconfig.json
 development/**/tsconfig.json
 
+rspack-test-junit-report/
 test-junit-report/
 turbopack-test-junit-report/


### PR DESCRIPTION
Previously, rspack test runs were writing to `test-junit-report`, but were expected to be found at `turbopack-test-junit-report`.

This renames both sides to be `rspack-test-junit-report`.


Closes PACK-3838