### PR TITLE
fix: `client-only` error message format

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -277,8 +277,8 @@ fn report_error(app_dir: &Option<PathBuf>, filepath: &str, error_kind: RSCErrorK
                 // If importing "react-dom/server", we should show a different error.
                 "react-dom/server" => "You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering".to_string(),
                 // If importing "next/router", we should tell them to use "next/navigation".
-                "next/router" => r#"You have a Server Component that imports next/router. Use next/navigation instead.\nLearn more: https://nextjs.org/docs/app/api-reference/functions/use-router"#.to_string(),
-                _ => format!(r#"You're importing a component that imports {source}. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering\n\n"#)
+                "next/router" => "You have a Server Component that imports next/router. Use next/navigation instead.\nLearn more: https://nextjs.org/docs/app/api-reference/functions/use-router".to_string(),
+                _ => format!("You're importing a component that imports {source}. It only works in a Client Component but none of its parents are marked with \"use client\", so they're Server Components by default.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering\n\n")
             };
 
             (msg, vec![span])

--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -278,7 +278,7 @@ fn report_error(app_dir: &Option<PathBuf>, filepath: &str, error_kind: RSCErrorK
                 "react-dom/server" => "You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering".to_string(),
                 // If importing "next/router", we should tell them to use "next/navigation".
                 "next/router" => "You have a Server Component that imports next/router. Use next/navigation instead.\nLearn more: https://nextjs.org/docs/app/api-reference/functions/use-router".to_string(),
-                _ => format!("You're importing a component that imports {source}. It only works in a Client Component but none of its parents are marked with \"use client\", so they're Server Components by default.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering\n\n")
+                _ => format!("You're importing a component that imports {source}. It only works in a Client Component but none of its parents are marked with \"use client\", so they're Server Components by default.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering")
             };
 
             (msg, vec![span])

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/client-only/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/client-only/output.stderr
@@ -1,5 +1,5 @@
-  x You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.\nLearn
-  | more: https://nextjs.org/docs/app/building-your-application/rendering\n\n
+  x You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.
+  | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
    ,-[input.js:9:1]
  8 | 
  9 | import 'client-only'

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/react-dom-server-client/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/react-dom-server-client/output.stderr
@@ -6,7 +6,7 @@
    : ^^^^^^^^^^^^^^^^^^^^^^^^^
    `----
   x You're importing a component that imports react-dom/client. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.
-  | \nLearn more: https://nextjs.org/docs/app/building-your-application/rendering\n\n
+  | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
     ,-[input.js:11:1]
  10 | 
  11 | import 'react-dom/client'

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -175,15 +175,16 @@ describe('Error overlay - RSC build errors', () => {
       // TODO: fix the issue ordering.
       // turbopack emits the resolve issue first instead of the transform issue.
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
-        "./app/server-with-errors/client-only-in-server/client-only-lib.js:1:1
-        Ecmascript file had an error
-        > 1 | import 'client-only'
-            | ^^^^^^^^^^^^^^^^^^^^
-          2 |
-          3 | export default function ClientOnlyLib() {
-          4 |   return 'client-only-lib'
+       "./app/server-with-errors/client-only-in-server/client-only-lib.js:1:1
+       Ecmascript file had an error
+       > 1 | import 'client-only'
+           | ^^^^^^^^^^^^^^^^^^^^
+         2 |
+         3 | export default function ClientOnlyLib() {
+         4 |   return 'client-only-lib'
 
-        You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.\\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering\\n\\n"
+       You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.
+       Learn more: https://nextjs.org/docs/app/building-your-application/rendering"
       `)
     } else {
       expect(await session.getRedboxSource()).toInclude(


### PR DESCRIPTION
Looking at the test file change should convince you that this fixes the formatting issue.

https://linear.app/vercel/issue/NDX-671/error-from-client-only-package-is-malformed