### PR TITLE
(fixes: #75439) Handle null or undefined href prop passed into componentt

### DIFF
--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -412,7 +412,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
     let children: React.ReactNode
 
     const {
-      href: hrefProp,
+      href: unfilteredHrefProp,
       as: asProp,
       children: childrenProp,
       prefetch: prefetchProp = null,
@@ -426,6 +426,8 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
       legacyBehavior = false,
       ...restProps
     } = props
+
+    const hrefProp = unfilteredHrefProp ?? ''
 
     children = childrenProp
 

--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -255,7 +255,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
     let children: React.ReactNode
 
     const {
-      href: hrefProp,
+      href: unfilteredHrefProp,
       as: asProp,
       children: childrenProp,
       prefetch: prefetchProp = null,
@@ -270,6 +270,8 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
       legacyBehavior = false,
       ...restProps
     } = props
+
+    const hrefProp = unfilteredHrefProp ?? ''
 
     children = childrenProp
 


### PR DESCRIPTION
This PR fixes #75439 by handling null or undefined href value that could be passed in despite type checks failing.