### PR TITLE
chore(github): update github labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -97,7 +97,7 @@ body:
         - 'Metadata'
         - 'Middleware'
         - 'Module Resolution'
-        - 'Output (export/standalone)'
+        - 'Output'
         - 'Package Managers'
         - 'Pages Router'
         - 'Parallel & Intercepting Routes'


### PR DESCRIPTION
## Why?

Rename `Output (export/standalone)` to `Output`. This keeps it separate from labels such as `Image (next/image)` (`export/standalone` is not an import).