### PR TITLE
[Turbopack] disable lifo slot to make all tasks stealable

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -17,10 +17,22 @@ rustdocflags = []
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld"
-rustflags = ["-C", "target-feature=+crt-static"]
+rustflags = [
+  "--cfg",
+  "tokio_unstable",
+  "-Zshare-generics=y",
+  "-C",
+  "target-feature=+crt-static"
+]
 
 [target.i686-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]
+rustflags = [
+  "--cfg",
+  "tokio_unstable",
+  "-Zshare-generics=y",
+  "-C",
+  "target-feature=+crt-static"
+]
 
 [target.aarch64-pc-windows-msvc]
 linker = "rust-lld"

--- a/turbopack/crates/turbopack-cli/src/main.rs
+++ b/turbopack/crates/turbopack-cli/src/main.rs
@@ -29,6 +29,7 @@ fn main() {
         .on_thread_stop(|| {
             TurboMalloc::thread_stop();
         })
+        .disable_lifo_slot()
         .build()
         .unwrap()
         .block_on(main_inner(args))


### PR DESCRIPTION
### What?

* pass rustflags to windows too
* disable lifo slot to make all tasks stealable

### Why?

Since we do a lot of CPU bound work in tokio tasks this can lead to future polling taking several seconds. With the lifo slot, one task is not stealable and need to wait for these several seconds to be executed. This delays that task and causes reduced parallelization of tasks.


Closes PACK-3836