### PR TITLE
[Turbopack] use Timestamp type, allow spans less than 1µs

### DIFF
--- a/turbopack/crates/turbopack-trace-server/src/lib.rs
+++ b/turbopack/crates/turbopack-trace-server/src/lib.rs
@@ -18,6 +18,7 @@ mod span_graph_ref;
 mod span_ref;
 mod store;
 mod store_container;
+mod timestamp;
 mod u64_empty_string;
 mod u64_string;
 mod viewer;

--- a/turbopack/crates/turbopack-trace-server/src/main.rs
+++ b/turbopack/crates/turbopack-trace-server/src/main.rs
@@ -19,6 +19,7 @@ mod span_graph_ref;
 mod span_ref;
 mod store;
 mod store_container;
+mod timestamp;
 mod u64_empty_string;
 mod u64_string;
 mod viewer;

--- a/turbopack/crates/turbopack-trace-server/src/reader/heaptrack.rs
+++ b/turbopack/crates/turbopack-trace-server/src/reader/heaptrack.rs
@@ -6,7 +6,7 @@ use rustc_demangle::demangle;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::TraceFormat;
-use crate::{span::SpanIndex, store_container::StoreContainer, FxIndexMap};
+use crate::{span::SpanIndex, store_container::StoreContainer, timestamp::Timestamp, FxIndexMap};
 
 #[derive(Debug, Clone, Copy)]
 struct TraceNode {
@@ -87,7 +87,7 @@ struct TraceData {
 pub struct HeaptrackFormat {
     store: Arc<StoreContainer>,
     version: u32,
-    last_timestamp: u64,
+    last_timestamp: Timestamp,
     strings: Vec<String>,
     traces: Vec<TraceData>,
     ip_parent_map: FxHashMap<(usize, SpanIndex), usize>,
@@ -109,7 +109,7 @@ impl HeaptrackFormat {
         Self {
             store,
             version: 0,
-            last_timestamp: 0,
+            last_timestamp: Timestamp::ZERO,
             strings: vec!["".to_string()],
             traces: vec![TraceData {
                 span_index: SpanIndex::new(usize::MAX).unwrap(),
@@ -411,7 +411,7 @@ impl TraceFormat for HeaptrackFormat {
                 b'c' => {
                     // timestamp
                     let timestamp = read_hex(&mut line)?;
-                    self.last_timestamp = timestamp;
+                    self.last_timestamp = Timestamp::from_micros(timestamp);
                 }
                 b'a' => {
                     // allocation info

--- a/turbopack/crates/turbopack-trace-server/src/reader/nextjs.rs
+++ b/turbopack/crates/turbopack-trace-server/src/reader/nextjs.rs
@@ -4,7 +4,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Deserialize;
 
 use super::TraceFormat;
-use crate::{span::SpanIndex, store_container::StoreContainer, FxIndexMap};
+use crate::{span::SpanIndex, store_container::StoreContainer, timestamp::Timestamp, FxIndexMap};
 
 pub struct NextJsFormat {
     store: Arc<StoreContainer>,
@@ -51,6 +51,8 @@ impl TraceFormat for NextJsFormat {
                     start_time: _,
                     trace_id: _,
                 } = span;
+                let timestamp = Timestamp::from_micros(timestamp);
+                let duration = Timestamp::from_micros(duration);
                 let (parent, queue_parent) = if let Some(parent) = parent_id {
                     if let Some(parent) = self.id_mapping.get(&parent) {
                         (Some(*parent), None)

--- a/turbopack/crates/turbopack-trace-server/src/server.rs
+++ b/turbopack/crates/turbopack-trace-server/src/server.rs
@@ -11,6 +11,7 @@ use tungstenite::{accept, Message};
 use crate::{
     store::SpanId,
     store_container::StoreContainer,
+    timestamp::Timestamp,
     u64_string,
     viewer::{Update, ViewLineUpdate, ViewMode, Viewer},
 };
@@ -32,10 +33,10 @@ pub enum ServerToClientMessage {
         #[serde(with = "u64_string")]
         id: SpanId,
         is_graph: bool,
-        start: u64,
-        end: u64,
-        duration: u64,
-        cpu: u64,
+        start: Timestamp,
+        end: Timestamp,
+        duration: Timestamp,
+        cpu: Timestamp,
         allocations: u64,
         deallocations: u64,
         allocation_count: u64,
@@ -74,8 +75,8 @@ pub enum ClientToServerMessage {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SpanViewEvent {
-    pub start: u64,
-    pub duration: u64,
+    pub start: Timestamp,
+    pub duration: Timestamp,
     pub name: String,
     pub id: Option<SpanId>,
 }
@@ -312,10 +313,10 @@ fn handle_connection(
                                 ServerToClientMessage::QueryResult {
                                     id,
                                     is_graph: false,
-                                    start: 0,
-                                    end: 0,
-                                    duration: 0,
-                                    cpu: 0,
+                                    start: Timestamp::ZERO,
+                                    end: Timestamp::ZERO,
+                                    duration: Timestamp::ZERO,
+                                    cpu: Timestamp::ZERO,
                                     allocations: 0,
                                     deallocations: 0,
                                     allocation_count: 0,

--- a/turbopack/crates/turbopack-trace-server/src/span.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span.rs
@@ -5,13 +5,15 @@ use std::{
 
 use rustc_hash::FxHashMap;
 
+use crate::timestamp::Timestamp;
+
 pub type SpanIndex = NonZeroUsize;
 
 pub struct Span {
     // These values won't change after creation:
     pub parent: Option<SpanIndex>,
     pub depth: u32,
-    pub start: u64,
+    pub start: Timestamp,
     pub category: String,
     pub name: String,
     pub args: Vec<(String, String)>,
@@ -46,16 +48,16 @@ pub struct SpanTimeData {
     pub ignore_self_time: bool,
 
     // This might change during writing:
-    pub self_end: u64,
+    pub self_end: Timestamp,
 
     // These values are computed automatically:
-    pub self_time: u64,
+    pub self_time: Timestamp,
 
     // These values are computed when accessed (and maybe deleted during writing):
-    pub end: OnceLock<u64>,
-    pub total_time: OnceLock<u64>,
-    pub corrected_self_time: OnceLock<u64>,
-    pub corrected_total_time: OnceLock<u64>,
+    pub end: OnceLock<Timestamp>,
+    pub total_time: OnceLock<Timestamp>,
+    pub corrected_self_time: OnceLock<Timestamp>,
+    pub corrected_total_time: OnceLock<Timestamp>,
 }
 
 #[derive(Default)]
@@ -99,7 +101,7 @@ impl Span {
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum SpanEvent {
-    SelfTime { start: u64, end: u64 },
+    SelfTime { start: Timestamp, end: Timestamp },
     Child { index: SpanIndex },
 }
 
@@ -108,7 +110,7 @@ pub enum SpanGraphEvent {
     // TODO(sokra) use events instead of children for visualizing span graphs
     #[allow(dead_code)]
     SelfTime {
-        duration: u64,
+        duration: Timestamp,
     },
     Child {
         child: Arc<SpanGraph>,
@@ -123,19 +125,19 @@ pub struct SpanGraph {
     // These values are computed when accessed:
     pub max_depth: OnceLock<u32>,
     pub events: OnceLock<Vec<SpanGraphEvent>>,
-    pub self_time: OnceLock<u64>,
+    pub self_time: OnceLock<Timestamp>,
     pub self_allocations: OnceLock<u64>,
     pub self_deallocations: OnceLock<u64>,
     pub self_persistent_allocations: OnceLock<u64>,
     pub self_allocation_count: OnceLock<u64>,
-    pub total_time: OnceLock<u64>,
+    pub total_time: OnceLock<Timestamp>,
     pub total_allocations: OnceLock<u64>,
     pub total_deallocations: OnceLock<u64>,
     pub total_persistent_allocations: OnceLock<u64>,
     pub total_allocation_count: OnceLock<u64>,
     pub total_span_count: OnceLock<u64>,
-    pub corrected_self_time: OnceLock<u64>,
-    pub corrected_total_time: OnceLock<u64>,
+    pub corrected_self_time: OnceLock<Timestamp>,
+    pub corrected_total_time: OnceLock<Timestamp>,
     pub bottom_up: OnceLock<Vec<Arc<SpanBottomUp>>>,
 }
 
@@ -148,8 +150,8 @@ pub struct SpanBottomUp {
     // These values are computed when accessed:
     pub max_depth: OnceLock<u32>,
     pub events: OnceLock<Vec<SpanGraphEvent>>,
-    pub self_time: OnceLock<u64>,
-    pub corrected_self_time: OnceLock<u64>,
+    pub self_time: OnceLock<Timestamp>,
+    pub corrected_self_time: OnceLock<Timestamp>,
     pub self_allocations: OnceLock<u64>,
     pub self_deallocations: OnceLock<u64>,
     pub self_persistent_allocations: OnceLock<u64>,

--- a/turbopack/crates/turbopack-trace-server/src/span_bottom_up_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_bottom_up_ref.rs
@@ -9,6 +9,7 @@ use crate::{
     span_graph_ref::{event_map_to_list, SpanGraphEventRef, SpanGraphRef},
     span_ref::SpanRef,
     store::{SpanId, Store},
+    timestamp::Timestamp,
     FxIndexMap,
 };
 
@@ -128,14 +129,14 @@ impl<'a> SpanBottomUpRef<'a> {
         })
     }
 
-    pub fn corrected_self_time(&self) -> u64 {
+    pub fn corrected_self_time(&self) -> Timestamp {
         *self
             .bottom_up
             .corrected_self_time
             .get_or_init(|| self.spans().map(|span| span.corrected_self_time()).sum())
     }
 
-    pub fn self_time(&self) -> u64 {
+    pub fn self_time(&self) -> Timestamp {
         *self
             .bottom_up
             .self_time

--- a/turbopack/crates/turbopack-trace-server/src/timestamp.rs
+++ b/turbopack/crates/turbopack-trace-server/src/timestamp.rs
@@ -1,0 +1,145 @@
+use std::{
+    fmt::{Debug, Display, Formatter},
+    iter::Sum,
+    ops::{Add, AddAssign, Deref, Div, DivAssign, Mul, MulAssign, Sub, SubAssign},
+};
+
+use serde::{Deserialize, Serialize};
+
+const DUR_VALUE_MICROSECOND: u64 = 100;
+
+#[derive(Clone, Copy, Default, Serialize, Deserialize)]
+pub struct Timestamp(u64);
+
+impl Timestamp {
+    pub const MAX: Self = Self(u64::MAX);
+    pub const ZERO: Self = Self(0);
+}
+
+impl Timestamp {
+    pub fn from_micros(micros: u64) -> Self {
+        Self(micros * DUR_VALUE_MICROSECOND)
+    }
+
+    pub fn is_zero(&self) -> bool {
+        self.0 == 0
+    }
+
+    pub fn from_value(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub fn saturating_sub(self, rhs: Self) -> Self {
+        Self(self.0.saturating_sub(rhs.0))
+    }
+}
+
+impl Debug for Timestamp {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "{:.2}μs", self.0 as f64 / DUR_VALUE_MICROSECOND as f64)
+    }
+}
+
+impl Display for Timestamp {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "{:.2}μs", self.0 as f64 / DUR_VALUE_MICROSECOND as f64)
+    }
+}
+
+impl Add for Timestamp {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        Self(self.0 + rhs.0)
+    }
+}
+
+impl AddAssign for Timestamp {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0;
+    }
+}
+
+impl Sub for Timestamp {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self {
+        Self(self.0 - rhs.0)
+    }
+}
+
+impl SubAssign for Timestamp {
+    fn sub_assign(&mut self, rhs: Self) {
+        self.0 -= rhs.0;
+    }
+}
+
+impl Div<u64> for Timestamp {
+    type Output = Self;
+
+    fn div(self, rhs: u64) -> Self {
+        Self(self.0 / rhs)
+    }
+}
+
+impl DivAssign<u64> for Timestamp {
+    fn div_assign(&mut self, rhs: u64) {
+        self.0 /= rhs;
+    }
+}
+
+impl Div for Timestamp {
+    type Output = u64;
+
+    fn div(self, rhs: Self) -> u64 {
+        self.0 / rhs.0
+    }
+}
+
+impl Mul<u64> for Timestamp {
+    type Output = Self;
+
+    fn mul(self, rhs: u64) -> Self {
+        Self(self.0 * rhs)
+    }
+}
+
+impl MulAssign<u64> for Timestamp {
+    fn mul_assign(&mut self, rhs: u64) {
+        self.0 *= rhs;
+    }
+}
+
+impl Sum for Timestamp {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Timestamp(0), |a, b| a + b)
+    }
+}
+
+impl PartialEq for Timestamp {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Eq for Timestamp {}
+
+impl Ord for Timestamp {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl PartialOrd for Timestamp {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Deref for Timestamp {
+    type Target = u64;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}


### PR DESCRIPTION
### What?

The minimum span size of 1µs was a bit limiting. This changes it to 0.01µs.

A trace viewer update is also needed: https://github.com/vercel/turbo-trace-viewer/pull/11

Closes PACK-3880