### PR TITLE
Turbopack: try to improve trace viewer

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -738,7 +738,9 @@ pub(crate) async fn analyse_ecmascript_module_internal(
     let handler = Handler::with_emitter(true, false, Box::new(emitter));
 
     let mut var_graph = {
-        let _span = tracing::info_span!("analyze variable values");
+        // This span messes with persistent caching because the resulting effects are freed in a
+        // different span
+        // let _span = tracing::info_span!("analyze variable values").entered();
         set_handler_and_globals(&handler, globals, || create_graph(program, eval_context))
     };
 

--- a/turbopack/crates/turbopack-trace-server/src/span_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_ref.rs
@@ -153,8 +153,17 @@ impl<'a> SpanRef<'a> {
     }
 
     pub fn self_persistent_allocations(&self) -> u64 {
-        self.self_allocations()
-            .saturating_sub(self.span.self_deallocations)
+        let expected_total = self
+            .total_allocations()
+            .saturating_sub(self.total_deallocations());
+
+        let child_total = self
+            .children()
+            .map(|child| child.total_persistent_allocations())
+            .reduce(|a, b| a + b)
+            .unwrap_or_default();
+
+        expected_total.saturating_sub(child_total)
     }
 
     pub fn self_allocation_count(&self) -> u64 {


### PR DESCRIPTION
Try to better graphically represent the situation where a child span allocates something which is then dropped in the parent/a sibling span. Theoretically this would require negative spans, which is obviously not possible

Not sure if this is better to be honest (when adding back that commented out span, it's still completely wrong). Happy to close this instead if we're not convinced