### PR TITLE
perf(turbopack/swc): Add icf to builds, reducing binary size

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,34 +5,22 @@ TURBO_PNPM_WORKSPACE_DIR = { value = "", relative = true }
 [alias]
 xtask = "run --package xtask --"
 
-[build]
+[target.'cfg(any(unix, not(unix)))']
+# Cargo will merge rustflags from `target` sections together, but `target`
+# sections are mutually exclusive with `build` sections. Define this in an
+# always-matched `target` section, so that we don't have to duplicate flags
+# everywhere.
+# https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags
 rustflags = [
-  "--cfg",
-  "tokio_unstable",
+  "--cfg=tokio_unstable",
   "-Zshare-generics=y", # make the current crate share its generic instantiations
   "-Zthreads=8", # parallel frontend https://blog.rust-lang.org/2023/11/09/parallel-rustc.html
   "-Csymbol-mangling-version=v0",
 ]
-rustdocflags = []
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld"
-rustflags = [
-  "--cfg",
-  "tokio_unstable",
-  "-Zshare-generics=y",
-  "-C",
-  "target-feature=+crt-static"
-]
-
-[target.i686-pc-windows-msvc]
-rustflags = [
-  "--cfg",
-  "tokio_unstable",
-  "-Zshare-generics=y",
-  "-C",
-  "target-feature=+crt-static"
-]
+rustflags = ["-Ctarget-feature=+crt-static"]
 
 [target.aarch64-pc-windows-msvc]
 linker = "rust-lld"
@@ -42,26 +30,10 @@ linker = "rust-lld"
 
 [target.'cfg(all(target_os = "linux", target_env = "gnu"))']
 rustflags = [
-  "--cfg",
-  "tokio_unstable",
-  "-Zshare-generics=y",
-  "-Zthreads=8",
   "-Zunstable-options",
-  "-Csymbol-mangling-version=v0",
   "-Clinker-flavor=gnu-lld-cc",
-  "-Clink-self-contained=+linker",
 ]
 
 [target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-musl-gcc"
-rustflags = [
-  "--cfg",
-  "tokio_unstable",
-  "-Zshare-generics=y",
-  "-Csymbol-mangling-version=v0",
-  "-Ctarget-feature=-crt-static",
-  "-Clink-arg=-lgcc",
-]
-
-[target.armv7-unknown-linux-gnueabihf]
-linker = "arm-linux-gnueabihf-gcc"
+rustflags = ["-Ctarget-feature=-crt-static", "-Clink-arg=-lgcc"]

--- a/.cargo/release-config.toml
+++ b/.cargo/release-config.toml
@@ -1,0 +1,12 @@
+# Overrides to `.cargo/config.toml` used by `pnpm build-native-release`/`pnpm
+# build-native-no-plugin-release` and the `build_and_deploy` GitHub actions
+# workflow.
+#
+# When using the napi CLI or the `pack-next` script, you can use
+# `--cargo-flags=--config=.cargo/release-config.toml` to enable this.
+#
+# cargo's merging logic combines rustflags in this file with those in the
+# relevant target sections of `.cargo/config.toml`
+
+[profile.release]
+strip = "symbols"

--- a/.cargo/release-config.toml
+++ b/.cargo/release-config.toml
@@ -2,6 +2,9 @@
 # build-native-no-plugin-release` and the `build_and_deploy` GitHub actions
 # workflow.
 #
+# These options potentially make builds slower and only have a small runtime
+# performance impact, so we only want to use them in CI.
+#
 # When using the napi CLI or the `pack-next` script, you can use
 # `--cargo-flags=--config=.cargo/release-config.toml` to enable this.
 #
@@ -10,3 +13,18 @@
 
 [profile.release]
 strip = "symbols"
+
+[target.'cfg(target_os = "macos")']
+# Enable Identical Code Folding (ICF), this is the same option that rustc uses.
+# MSVC (Windows) builds do this by default (without a flag).
+#
+# This reduces our stripped binary size:
+# - linux arm64: 134555288 -> 132508168 bytes (-1.5%)
+# - macos arm64: 132022352 -> 126647920 bytes (-4.1%)
+#
+# https://github.com/rust-lang/rust/blob/4a5f1cc52b7/src/bootstrap/src/core/build_steps/compile.rs#L1100
+rustflags = ["-Clink-arg=--icf=all"]
+
+[target.'cfg(all(target_os = "linux", target_env = "gnu"))']
+# We need to use `-Wl,` because `cc`/`gcc` is used as the linker
+rustflags = ["-Clink-arg=-Wl,--icf=all"]

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -140,9 +140,12 @@ jobs:
             # --env-mode loose is a breaking change required with turbo 2.x since Strict mode is now the default
             # TODO: we should add the relevant envs later to to switch to strict mode
             build: |
-              npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}" "turbo@${TURBO_VERSION}" && corepack enable
-              turbo run build-native-release -vvv --env-mode loose --remote-cache-timeout 90 --summarize -- --target x86_64-apple-darwin
-              strip -x packages/next-swc/native/next-swc.*.node
+              set -ex
+              npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}" "turbo@${TURBO_VERSION}"
+              corepack enable
+              turbo run build-native-release -vvv --env-mode loose \
+                --remote-cache-timeout 90 --summarize -- \
+                --target x86_64-apple-darwin
 
           - host:
               - 'self-hosted'
@@ -153,9 +156,12 @@ jobs:
             # --env-mode loose is a breaking change required with turbo 2.x since Strict mode is now the default
             # TODO: we should add the relevant envs later to to switch to strict mode
             build: |
-              npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}" "turbo@${TURBO_VERSION}" && corepack enable
-              turbo run build-native-release -vvv --env-mode loose --remote-cache-timeout 90 --summarize -- --target aarch64-apple-darwin
-              strip -x packages/next-swc/native/next-swc.*.node
+              set -ex
+              npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}" "turbo@${TURBO_VERSION}"
+              corepack enable
+              turbo run build-native-release -vvv --env-mode loose \
+                --remote-cache-timeout 90 --summarize -- \
+                --target aarch64-apple-darwin
 
           - host:
               - 'self-hosted'
@@ -165,9 +171,12 @@ jobs:
             # --env-mode loose is a breaking change required with turbo 2.x since Strict mode is now the default
             # TODO: we should add the relevant envs later to to switch to strict mode
             build: |
+              set -ex
               corepack enable
               npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}" "turbo@${TURBO_VERSION}"
-              turbo run build-native-release -vvv --env-mode loose --remote-cache-timeout 90 --summarize -- --target x86_64-pc-windows-msvc
+              turbo run build-native-release -vvv --env-mode loose \
+                --remote-cache-timeout 90 --summarize -- \
+                --target x86_64-pc-windows-msvc
             target: 'x86_64-pc-windows-msvc'
 
           - host:
@@ -179,9 +188,12 @@ jobs:
             # --env-mode loose is a breaking change required with turbo 2.x since Strict mode is now the default
             # TODO: we should add the relevant envs later to to switch to strict mode
             build: |
+              set -ex
               corepack enable
               npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}" "turbo@${TURBO_VERSION}"
-              turbo run build-native-no-plugin-release -vvv --env-mode loose --remote-cache-timeout 90 --summarize -- --target aarch64-pc-windows-msvc
+              turbo run build-native-no-plugin-release -vvv --env-mode loose \
+                --remote-cache-timeout 90 --summarize -- \
+                --target aarch64-pc-windows-msvc
 
           - host:
               - 'self-hosted'
@@ -198,16 +210,16 @@ jobs:
             # - zig linker with portable glibc is avoided as it has known issues with static tls + node.js + multi threaded
             #   environment.
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:stable-2023-09-17-x64
-            build: >-
-              set -ex &&
-              apt update &&
-              apt install -y pkg-config xz-utils dav1d libdav1d-dev &&
-              rustup show &&
-              rustup target add x86_64-unknown-linux-gnu &&
-              npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}" &&
-              unset CC_x86_64_unknown_linux_gnu && unset CC &&
-              cd packages/next-swc && npm run build-native-release -- --target x86_64-unknown-linux-gnu &&
-              strip native/next-swc.*.node &&
+            build: |
+              set -ex
+              apt update
+              apt install -y pkg-config xz-utils dav1d libdav1d-dev
+              rustup show
+              rustup target add x86_64-unknown-linux-gnu
+              npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}"
+              unset CC_x86_64_unknown_linux_gnu && unset CC
+              cd packages/next-swc && npm run build-native-release -- \
+                --target x86_64-unknown-linux-gnu
               objdump -T native/next-swc.*.node | grep GLIBC_
 
           - host:
@@ -218,15 +230,15 @@ jobs:
 
             target: 'x86_64-unknown-linux-musl'
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:stable-2023-09-17-alpine
-            build: >-
-              set -ex &&
-              apk update &&
-              apk add --no-cache libc6-compat pkgconfig dav1d libdav1d dav1d-dev clang-static llvm-dev &&
-              rustup show &&
-              rustup target add x86_64-unknown-linux-musl &&
-              npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}" &&
-              cd packages/next-swc && npm run build-native-release -- --target x86_64-unknown-linux-musl &&
-              strip native/next-swc.*.node
+            build: |
+              set -ex
+              apk update
+              apk add --no-cache libc6-compat pkgconfig dav1d libdav1d dav1d-dev clang-static llvm-dev
+              rustup show
+              rustup target add x86_64-unknown-linux-musl
+              npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}"
+              cd packages/next-swc
+              npm run build-native-release -- --target x86_64-unknown-linux-musl
 
           - host:
               - 'self-hosted'
@@ -236,18 +248,18 @@ jobs:
 
             target: 'aarch64-unknown-linux-gnu'
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:stable-2023-09-17-aarch64
-            build: >-
-              set -ex &&
-              apt update &&
-              apt install -y pkg-config xz-utils dav1d libdav1d-dev &&
-              export JEMALLOC_SYS_WITH_LG_PAGE=16 &&
-              rustup show &&
-              rustup target add aarch64-unknown-linux-gnu &&
-              npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}" &&
-              export CC_aarch64_unknown_linux_gnu=/usr/bin/clang &&
-              export CFLAGS_aarch64_unknown_linux_gnu=\"--target=aarch64-unknown-linux-gnu --sysroot=/usr/aarch64-unknown-linux-gnu\" &&
-              cd packages/next-swc && npm run build-native-release -- --target aarch64-unknown-linux-gnu &&
-              llvm-strip -x native/next-swc.*.node &&
+            build: |
+              set -ex
+              apt update
+              apt install -y pkg-config xz-utils dav1d libdav1d-dev
+              export JEMALLOC_SYS_WITH_LG_PAGE=16
+              rustup show
+              rustup target add aarch64-unknown-linux-gnu
+              npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}"
+              export CC_aarch64_unknown_linux_gnu=/usr/bin/clang
+              export CFLAGS_aarch64_unknown_linux_gnu=\"--target=aarch64-unknown-linux-gnu --sysroot=/usr/aarch64-unknown-linux-gnu\"
+              cd packages/next-swc
+              npm run build-native-release -- --target aarch64-unknown-linux-gnu
               objdump -T native/next-swc.*.node | grep GLIBC_
 
           - host:
@@ -258,16 +270,16 @@ jobs:
 
             target: 'aarch64-unknown-linux-musl'
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:stable-2023-09-17-alpine
-            build: >-
-              set -ex &&
-              apk update &&
-              apk add --no-cache libc6-compat pkgconfig dav1d libdav1d dav1d-dev clang-static llvm-dev &&
-              export JEMALLOC_SYS_WITH_LG_PAGE=16 &&
-              npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}" &&
-              rustup show &&
-              rustup target add aarch64-unknown-linux-musl &&
-              cd packages/next-swc && npm run build-native-release -- --target aarch64-unknown-linux-musl &&
-              llvm-strip -x native/next-swc.*.node
+            build: |
+              set -ex
+              apk update
+              apk add --no-cache libc6-compat pkgconfig dav1d libdav1d dav1d-dev clang-static llvm-dev
+              export JEMALLOC_SYS_WITH_LG_PAGE=16
+              npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}"
+              rustup show
+              rustup target add aarch64-unknown-linux-musl
+              cd packages/next-swc
+              npm run build-native-release -- --target aarch64-unknown-linux-musl
 
     name: stable - ${{ matrix.settings.target }} - node@16
     runs-on: ${{ matrix.settings.host }}

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "clean": "node ../../scripts/rm.mjs native",
     "build-native": "napi build --platform -p next-swc-napi --cargo-cwd ../../ --cargo-name next_swc_napi --features plugin,image-extended --js false native",
-    "build-native-release": "napi build --platform -p next-swc-napi --cargo-cwd ../../ --cargo-name next_swc_napi --release --features plugin,image-extended,tracing/release_max_level_info --js false native",
+    "build-native-release": "napi build --platform -p next-swc-napi --cargo-cwd ../../ --cargo-name next_swc_napi --release --cargo-flags=--config=.cargo/release-config.toml --features plugin,image-extended,tracing/release_max_level_info --js false native",
     "build-native-no-plugin": "napi build --platform -p next-swc-napi --cargo-cwd ../../ --cargo-name next_swc_napi --features image-webp --js false native",
-    "build-native-no-plugin-release": "napi build --platform -p next-swc-napi --cargo-cwd ../../ --cargo-name next_swc_napi --release --features image-webp,tracing/release_max_level_info --js false native",
+    "build-native-no-plugin-release": "napi build --platform -p next-swc-napi --cargo-cwd ../../ --cargo-name next_swc_napi --release --cargo-flags=--config=.cargo/release-config.toml --features image-webp,tracing/release_max_level_info --js false native",
     "build-native-wasi": "npx --package=@napi-rs/cli@3.0.0-alpha.45 napi build --platform --target wasm32-wasip1-threads -p next-swc-napi --cwd ../../ --output-dir packages/next-swc/native --no-default-features",
     "build-wasm": "wasm-pack build ../../crates/wasm --scope=next",
     "cache-build-native": "[ -d native ] && echo $(ls native)",


### PR DESCRIPTION
Decreases macos binary size by ~4.1%, and linux binary size by ~1.5% on arm64.

Unlike LTO, this does not appear to have any meaningful impact on build times.

Rustc reported some minor benefit to execution time (better code cache effects) when they enabled this, though I suspect it's too small to easily measure.

I'm only enabling this on the release builds used by CI. Release builds made with some other scripts, like `pack-next` will not do this.