### PR TITLE
[DevOverlay] fix total error count

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/use-error-hook.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/use-error-hook.ts
@@ -110,6 +110,6 @@ export function useErrorHook({
       ? rootLayoutMissingTags.length
       : !!buildError
         ? 1
-        : errors.length,
+        : readyErrors.length,
   }
 }


### PR DESCRIPTION
`readyErrors` seems to be the value that we're using to actually display the errors in the overlay, while `state.errors` seems to often contain duplicates. This causes a drift in the number of errors reported in the overlay vs the indicator. We should use the same source of truth for both. 