### PR TITLE
refactor(turbo-tasks): Remove default is_transient implementation

### DIFF
--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -20,15 +20,17 @@ pub trait TaskInput: Send + Sync + Clone + Debug + PartialEq + Eq + Hash {
     fn is_resolved(&self) -> bool {
         true
     }
-    fn is_transient(&self) -> bool {
-        false
-    }
+    fn is_transient(&self) -> bool;
 }
 
 macro_rules! impl_task_input {
     ($($t:ty),*) => {
         $(
-            impl TaskInput for $t {}
+            impl TaskInput for $t {
+                fn is_transient(&self) -> bool {
+                    false
+                }
+            }
         )*
     };
 }


### PR DESCRIPTION
This is intended to prevent mistakes like #75291 in the future.

Closes PACK-3865