### PR TITLE
perf(turbo-rcstr): Fix the fast codepath for RcStr::into_owned()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9072,6 +9072,7 @@ version = "0.1.0"
 name = "turbo-rcstr"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "new_debug_unreachable",
  "serde",
  "triomphe 0.1.12",

--- a/turbopack/crates/turbo-rcstr/Cargo.toml
+++ b/turbopack/crates/turbo-rcstr/Cargo.toml
@@ -14,5 +14,12 @@ turbo-tasks-hash = { workspace = true }
 serde = { workspace = true }
 new_debug_unreachable = "1.0.6"
 
+[dev-dependencies]
+criterion = { workspace = true }
+
 [lints]
 workspace = true
+
+[[bench]]
+name = "mod"
+harness = false

--- a/turbopack/crates/turbo-rcstr/benches/mod.rs
+++ b/turbopack/crates/turbo-rcstr/benches/mod.rs
@@ -1,0 +1,38 @@
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use turbo_rcstr::RcStr;
+
+// map has a fast-path if the Arc is uniquely owned
+fn bench_map(c: &mut Criterion) {
+    let long_string = "this is a long string that will take time to copy".repeat(1000);
+    for cloned in [false, true] {
+        c.bench_with_input(
+            BenchmarkId::new("RcStr::map", if cloned { "cloned" } else { "unique" }),
+            &cloned,
+            |b, cloned| {
+                b.iter_batched(
+                    || {
+                        let rc_str = RcStr::from(long_string.as_str());
+                        let maybe_cloned = if *cloned { Some(rc_str.clone()) } else { None };
+                        (rc_str, maybe_cloned)
+                    },
+                    |(mut rc_str, maybe_cloned)| {
+                        rc_str = rc_str.map(|mut s| {
+                            s.truncate(s.len() - 1);
+                            s
+                        });
+                        // don't drop these ourselves, let criterion do that later
+                        (rc_str, maybe_cloned)
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+}
+
+criterion_group!(
+  name = benches;
+  config = Criterion::default();
+  targets = bench_map,
+);
+criterion_main!(benches);

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -3,7 +3,7 @@ use std::{
     ffi::OsStr,
     fmt::{Debug, Display},
     hash::{Hash, Hasher},
-    mem::forget,
+    mem::{forget, ManuallyDrop},
     num::NonZeroU8,
     ops::Deref,
     path::{Path, PathBuf},
@@ -96,15 +96,11 @@ impl RcStr {
     pub fn into_owned(self) -> String {
         match self.tag() {
             DYNAMIC_TAG => {
-                let arc = unsafe { dynamic::restore_arc(self.unsafe_data) };
-
-                match Arc::try_unwrap(arc.clone()) {
+                // convert `self` into `arc`
+                let arc = unsafe { dynamic::restore_arc(ManuallyDrop::new(self).unsafe_data) };
+                match Arc::try_unwrap(arc) {
                     Ok(v) => v,
-                    Err(arc) => {
-                        let s = arc.to_string();
-                        forget(arc);
-                        s
-                    }
+                    Err(arc) => arc.to_string(),
                 }
             }
             INLINE_TAG => self.as_str().to_string(),
@@ -298,5 +294,35 @@ impl Drop for RcStr {
         if self.tag() == DYNAMIC_TAG {
             unsafe { drop(dynamic::restore_arc(self.unsafe_data)) }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem::ManuallyDrop;
+
+    use super::*;
+
+    #[test]
+    fn test_refcount() {
+        fn refcount(str: &RcStr) -> usize {
+            assert!(str.tag() == DYNAMIC_TAG);
+            let arc = ManuallyDrop::new(unsafe { dynamic::restore_arc(str.unsafe_data) });
+            triomphe::Arc::count(&arc)
+        }
+
+        let str = RcStr::from("this is a long string that won't be inlined");
+
+        assert_eq!(refcount(&str), 1);
+        assert_eq!(refcount(&str), 1); // refcount should not modify the refcount itself
+
+        let cloned_str = str.clone();
+        assert_eq!(refcount(&str), 2);
+
+        drop(cloned_str);
+        assert_eq!(refcount(&str), 1);
+
+        let _ = str.clone().into_owned();
+        assert_eq!(refcount(&str), 1);
     }
 }


### PR DESCRIPTION
If we uniquely own the only reference to an `RcStr`, `into_owned` should just unwrap the `Arc` and return the inner value instead of cloning it.

It seems this optimization was accidentally broken at some point. `Arc::try_unwrap(arc.clone())` is always going to return the non-unique `Err` value because the `arc.clone()` will always set the refcount >= 2.

This makes `RcStr::into_owned` significantly faster for large strings that we own a unique `Arc` for.

Includes a unit test and a benchmark to prevent regressing.


```
RcStr::map/unique       time:   [17.311 ns 17.539 ns 17.797 ns]
                        change: [-97.932% -97.855% -97.778%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

RcStr::map/cloned       time:   [1.0424 µs 1.0529 µs 1.0655 µs]
                        change: [-1.2209% +1.1551% +3.8229%] (p = 0.39 > 0.05)
                        No change in performance detected.
Found 22 outliers among 100 measurements (22.00%)
  9 (9.00%) low severe
  7 (7.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe
```

Closes PACK-3858