### PR TITLE
Add regression test for previously hanging compilation with Turbopack

### DIFF
--- a/test/development/app-dir/use-cache-hmr/use-cache-hmr.test.ts
+++ b/test/development/app-dir/use-cache-hmr/use-cache-hmr.test.ts
@@ -101,4 +101,29 @@ describe('use-cache-hmr', () => {
         })
     )
   })
+
+  it('should successfully finish compilation when "use cache" directive is added/removed', async () => {
+    await next.browser('/')
+    let cliOutputLength = next.cliOutput.length
+
+    // Disable "use cache" directive
+    await next.patchFile('app/page.tsx', (content) =>
+      content.replace(`'use cache'`, `// 'use cache'`)
+    )
+
+    await retry(async () => {
+      expect(next.cliOutput.slice(cliOutputLength)).toInclude('✓ Compiled')
+    }, 10_000)
+
+    cliOutputLength = next.cliOutput.length
+
+    // Re-enable "use cache" directive
+    await next.patchFile('app/page.tsx', (content) =>
+      content.replace(`// 'use cache'`, `'use cache'`)
+    )
+
+    await retry(async () => {
+      expect(next.cliOutput.slice(cliOutputLength)).toInclude('✓ Compiled')
+    }, 10_000)
+  })
 })


### PR DESCRIPTION
When adding or removing a `"use cache"` directive to a function or module, Turbopack was not able to finish the compilation and hung. This is now fixed, and we're adding the test to prevent regression.