### PR TITLE
Fix `Cannot read properties of null (reading 'textContent')` when `__NEXT_DATA__` element is missing

### DIFF
--- a/packages/next/src/client/index.tsx
+++ b/packages/next/src/client/index.tsx
@@ -195,9 +195,19 @@ export async function initialize(opts: { devClient?: any } = {}): Promise<{
     devClient = opts.devClient
   }
 
-  initialData = JSON.parse(
-    document.getElementById('__NEXT_DATA__')!.textContent!
-  )
+  let dataElement = document.getElementById('__NEXT_DATA__')
+
+  let iterations = 0
+  while (!dataElement && iterations < 10) {
+    await new Promise((resolve) => setTimeout(resolve, 5))
+    dataElement = document.getElementById('__NEXT_DATA__')
+    iterations += 1
+  }
+  if (!dataElement?.textContent) {
+    throw new Error('Could not find __NEXT_DATA__ element')
+  }
+
+  initialData = JSON.parse(dataElement.textContent)
   window.__NEXT_DATA__ = initialData
 
   defaultLocale = initialData.defaultLocale


### PR DESCRIPTION
When using `getServerSideProps` and streaming it can happen that the Next.js framework script runs before the `__NEXT_DATA__` script, if that happens the page becomes unresponsive and an error is thrown: `Cannot read properties of null (reading 'textContent')`

Fix https://github.com/vercel/next.js/pull/53423
Fix https://github.com/vercel/next.js/discussions/41299
Fix https://github.com/vercel/next.js/issues/47377
Fix https://github.com/nibtime/next-safe-middleware/issues/83

This PR waits for `__NEXT_DATA__` to be available if it's missing, it does not add any latency in case __NEXT_DATA__ is present which should be true for most cases