### PR TITLE
Fix console replaying and `React.cache` usage in `"use cache"` functions

### DIFF
--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -60,7 +60,7 @@ function generateCacheEntry(
   outerWorkUnitStore: WorkUnitStore | undefined,
   clientReferenceManifest: DeepReadonly<ClientReferenceManifestForRsc>,
   encodedArguments: FormData | string,
-  fn: any,
+  fn: (...args: unknown[]) => Promise<unknown>,
   timeoutError: UseCacheTimeoutError
 ): Promise<[ReadableStream, Promise<CacheEntry>]> {
   // We need to run this inside a clean AsyncLocalStorage snapshot so that the cache
@@ -84,7 +84,7 @@ function generateCacheEntryWithRestoredWorkStore(
   outerWorkUnitStore: WorkUnitStore | undefined,
   clientReferenceManifest: DeepReadonly<ClientReferenceManifestForRsc>,
   encodedArguments: FormData | string,
-  fn: any,
+  fn: (...args: unknown[]) => Promise<unknown>,
   timeoutError: UseCacheTimeoutError
 ) {
   // Since we cleared the AsyncLocalStorage we need to restore the workStore.
@@ -111,7 +111,7 @@ function generateCacheEntryWithCacheContext(
   outerWorkUnitStore: WorkUnitStore | undefined,
   clientReferenceManifest: DeepReadonly<ClientReferenceManifestForRsc>,
   encodedArguments: FormData | string,
-  fn: any,
+  fn: (...args: unknown[]) => Promise<unknown>,
   timeoutError: UseCacheTimeoutError
 ) {
   if (!workStore.cacheLifeProfiles) {
@@ -291,7 +291,7 @@ async function generateCacheEntryImpl(
   innerCacheStore: UseCacheStore,
   clientReferenceManifest: DeepReadonly<ClientReferenceManifestForRsc>,
   encodedArguments: FormData | string,
-  fn: any,
+  fn: (...args: unknown[]) => Promise<unknown>,
   timeoutError: UseCacheTimeoutError
 ): Promise<[ReadableStream, Promise<CacheEntry>]> {
   const temporaryReferences = createServerTemporaryReferenceSet()
@@ -335,24 +335,28 @@ async function generateCacheEntryImpl(
 
   // Track the timestamp when we started computing the result.
   const startTime = performance.timeOrigin + performance.now()
-  // Invoke the inner function to load a new result.
-  const result = fn.apply(null, args)
+
+  // Invoke the inner function to load a new result. We delay the invocation
+  // though, until React awaits the promise so that React's request store (ALS)
+  // is available when the function is invoked. This allows us, for example, to
+  // capture logs so that we can later replay them.
+  const resultPromise = createLazyPromise(() => fn.apply(null, args))
 
   let errors: Array<unknown> = []
 
   let timer = undefined
   const controller = new AbortController()
   if (outerWorkUnitStore?.type === 'prerender') {
-    // If we're prerendering, we give you 50 seconds to fill a cache entry. Otherwise
-    // we assume you stalled on hanging input and deopt. This needs to be lower than
-    // just the general timeout of 60 seconds.
+    // If we're prerendering, we give you 50 seconds to fill a cache entry.
+    // Otherwise we assume you stalled on hanging input and de-opt. This needs
+    // to be lower than just the general timeout of 60 seconds.
     timer = setTimeout(() => {
       controller.abort(timeoutError)
     }, 50000)
   }
 
   const stream = renderToReadableStream(
-    result,
+    resultPromise,
     clientReferenceManifest.clientModules,
     {
       environmentName: 'Cache',
@@ -488,7 +492,7 @@ export function cache(
   kind: string,
   id: string,
   boundArgsLength: number,
-  fn: any
+  fn: (...args: unknown[]) => Promise<unknown>
 ) {
   for (const [key, value] of Object.entries(
     cacheHandlerGlobal.__nextCacheHandlers || {}
@@ -818,4 +822,34 @@ export function cache(
     },
   }[name]
   return cachedFn
+}
+
+function createLazyPromise<TResult>(
+  fn: () => Promise<TResult>
+): Promise<TResult> {
+  let invoked = false
+  let resolveFn: (value: TResult) => void
+  let rejectFn: (reason?: unknown) => void
+
+  const promise = new Promise<TResult>((resolve, reject) => {
+    resolveFn = resolve
+    rejectFn = reject
+  })
+
+  return new Proxy(promise, {
+    get(target, prop, receiver) {
+      if (prop === 'then') {
+        return (...args: unknown[]) => {
+          if (!invoked) {
+            invoked = true
+            fn().then(resolveFn, rejectFn)
+          }
+
+          return Reflect.apply(target.then, target, args)
+        }
+      }
+
+      return Reflect.get(target, prop, receiver)
+    },
+  })
 }

--- a/test/e2e/app-dir/use-cache/app/(no-suspense)/logs/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(no-suspense)/logs/page.tsx
@@ -1,0 +1,18 @@
+async function Bar() {
+  'use cache'
+  const date = new Date().toLocaleTimeString()
+  console.log('deep inside', date)
+  return <p>{date}</p>
+}
+
+async function Foo() {
+  'use cache'
+  console.log('inside')
+  return <Bar />
+}
+
+export default async function Page() {
+  console.log('outside')
+
+  return <Foo />
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -513,7 +513,7 @@ const ignoredLogs = [
 ]
 
 async function getSanitizedLogs(browser: BrowserInterface): Promise<string[]> {
-  const logs = await browser.log()
+  const logs = await browser.log({ includeArgs: true })
 
   return logs
     .map(({ args }) =>

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -315,30 +315,33 @@ describe('use-cache', () => {
     })
   })
 
-  it('should be able to revalidate a page using unstable_expireTag', async () => {
-    const browser = await next.browser(`/form`)
-    const time1 = await browser.waitForElementByCss('#t').text()
+  // TODO(useCache): Re-activate for deploy tests when NAR-85 is resolved.
+  if (!isNextDeploy) {
+    it('should be able to revalidate a page using unstable_expireTag', async () => {
+      const browser = await next.browser(`/form`)
+      const time1 = await browser.waitForElementByCss('#t').text()
 
-    await browser.loadPage(new URL(`/form`, next.url).toString())
+      await browser.loadPage(new URL(`/form`, next.url).toString())
 
-    const time2 = await browser.waitForElementByCss('#t').text()
+      const time2 = await browser.waitForElementByCss('#t').text()
 
-    expect(time1).toBe(time2)
+      expect(time1).toBe(time2)
 
-    await browser.elementByCss('#refresh').click()
+      await browser.elementByCss('#refresh').click()
 
-    await waitFor(500)
+      await waitFor(500)
 
-    const time3 = await browser.waitForElementByCss('#t').text()
+      const time3 = await browser.waitForElementByCss('#t').text()
 
-    expect(time3).not.toBe(time2)
+      expect(time3).not.toBe(time2)
 
-    // Reloading again should ideally be the same value but because the Action seeds
-    // the cache with real params as the argument it has a different cache key.
-    // await browser.loadPage(new URL(`/form?c`, next.url).toString())
-    // const time4 = await browser.waitForElementByCss('#t').text()
-    // expect(time4).toBe(time3);
-  })
+      // Reloading again should ideally be the same value but because the Action seeds
+      // the cache with real params as the argument it has a different cache key.
+      // await browser.loadPage(new URL(`/form?c`, next.url).toString())
+      // const time4 = await browser.waitForElementByCss('#t').text()
+      // expect(time4).toBe(time3);
+    })
+  }
 
   it('should use revalidate config in fetch', async () => {
     const browser = await next.browser('/fetch-revalidate')

--- a/test/lib/browsers/base.ts
+++ b/test/lib/browsers/base.ts
@@ -119,8 +119,12 @@ export abstract class BrowserInterface<TCurrent = any> {
   abstract text(): Promise<string>
   abstract getComputedCss(prop: string): Promise<string>
   abstract hasElementByCssSelector(selector: string): Promise<boolean>
-  abstract log(): Promise<
-    { source: string; message: string; args: unknown[] }[]
+  abstract log<T extends boolean = false>(options?: {
+    includeArgs?: T
+  }): Promise<
+    T extends true
+      ? { source: string; message: string; args: unknown[] }[]
+      : { source: string; message: string }[]
   >
   abstract websocketFrames(): Promise<any[]>
   abstract url(): Promise<string>

--- a/test/lib/browsers/base.ts
+++ b/test/lib/browsers/base.ts
@@ -119,7 +119,9 @@ export abstract class BrowserInterface<TCurrent = any> {
   abstract text(): Promise<string>
   abstract getComputedCss(prop: string): Promise<string>
   abstract hasElementByCssSelector(selector: string): Promise<boolean>
-  abstract log(): Promise<{ source: string; message: string }[]>
+  abstract log(): Promise<
+    { source: string; message: string; args: unknown[] }[]
+  >
   abstract websocketFrames(): Promise<any[]>
   abstract url(): Promise<string>
   abstract waitForIdleNetwork(): Promise<void>

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -481,8 +481,26 @@ export class Playwright extends BrowserInterface {
     return page.evaluate<T>(fn).catch(() => null)
   }
 
-  async log() {
-    return this.chain(() => Promise.all(pageLogs))
+  async log<T extends boolean = false>(options?: {
+    includeArgs?: T
+  }): Promise<
+    T extends true
+      ? { source: string; message: string; args: unknown[] }[]
+      : { source: string; message: string }[]
+  > {
+    return this.chain(
+      () =>
+        options?.includeArgs
+          ? Promise.all(pageLogs)
+          : Promise.all(pageLogs).then((logs) =>
+              logs.map(({ source, message }) => ({ source, message }))
+            )
+      // TODO: Starting with TypeScript 5.8 we might not need this type cast.
+    ) as Promise<
+      T extends true
+        ? { source: string; message: string; args: unknown[] }[]
+        : { source: string; message: string }[]
+    >
   }
 
   async websocketFrames() {


### PR DESCRIPTION
Console logs in server components are replayed in the browser. For example, when you run `console.log('foo')`, the log will be replayed in the browser as `[Server] foo`. When the component is inside of a `"use cache"` scope, it's replayed as `[Cache] foo`.

However, when logging directly in the function body of a `"use cache"` function, we are currently not replaying the log in the browser.

The reason for that is that the function is called outside of React's rendering, before handing the result promise over to React for serialization. Since the function is called without React's request storage, no console chunks are emitted.

We can work around this by invoking the function lazily when React calls `.then()` on the promise. This ensures that the function is run inside of React's request storage and console chunks can be emitted.

In addition, this also unlocks that `React.cache` can be used in a `"use cache"` function to dedupe other function calls.

closes NAR-83