### PR TITLE
[dev-overlay] add a11y test

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "sweep": "node scripts/sweep.cjs",
     "check-error-codes": "node packages/next/check-error-codes.js",
     "storybook": "turbo run storybook",
-    "build-storybook": "turbo run build-storybook"
+    "build-storybook": "turbo run build-storybook",
+    "test-storybook": "turbo run test-storybook"
   },
   "devDependencies": {
     "@actions/core": "1.10.1",

--- a/packages/next/.storybook/main.ts
+++ b/packages/next/.storybook/main.ts
@@ -19,6 +19,7 @@ const config: StorybookConfig = {
     getAbsolutePath('@storybook/addon-webpack5-compiler-swc'),
     getAbsolutePath('@storybook/addon-essentials'),
     getAbsolutePath('@storybook/addon-interactions'),
+    getAbsolutePath('@storybook/addon-a11y'),
   ],
   framework: {
     name: getAbsolutePath('@storybook/react-webpack5'),

--- a/packages/next/.storybook/preview.ts
+++ b/packages/next/.storybook/preview.ts
@@ -2,6 +2,9 @@ import type { Preview } from '@storybook/react'
 
 const preview: Preview = {
   parameters: {
+    a11y: {
+      element: 'nextjs-portal',
+    },
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/packages/next/.storybook/preview.ts
+++ b/packages/next/.storybook/preview.ts
@@ -22,6 +22,12 @@ const preview: Preview = {
       default: 'backdrop',
     },
   },
+  globals: {
+    a11y: {
+      // Optional flag to prevent the automatic check
+      manual: true,
+    },
+  },
 }
 
 export default preview

--- a/packages/next/.storybook/test-runner.ts
+++ b/packages/next/.storybook/test-runner.ts
@@ -1,0 +1,22 @@
+import type { TestRunnerConfig } from '@storybook/test-runner'
+import { injectAxe, checkA11y } from 'axe-playwright'
+
+/*
+ * See https://storybook.js.org/docs/writing-tests/test-runner#test-hook-api
+ * to learn more about the test-runner hooks API.
+ */
+const config: TestRunnerConfig = {
+  async preVisit(page) {
+    await injectAxe(page)
+  },
+  async postVisit(page) {
+    await checkA11y(page, 'nextjs-portal', {
+      detailedReport: true,
+      detailedReportOptions: {
+        html: true,
+      },
+    })
+  },
+}
+
+export default config

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -88,7 +88,8 @@
     "typescript": "tsec --noEmit",
     "ncc-compiled": "taskr ncc",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "test-storybook": "test-storybook"
   },
   "taskr": {
     "requires": [

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -227,6 +227,7 @@
     "assert": "2.0.0",
     "async-retry": "1.2.3",
     "async-sema": "3.0.0",
+    "axe-playwright": "2.0.3",
     "babel-plugin-react-compiler": "19.0.0-beta-e552027-20250112",
     "babel-plugin-transform-define": "2.0.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",

--- a/packages/next/test-runner-jest.config.js
+++ b/packages/next/test-runner-jest.config.js
@@ -1,0 +1,18 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { getJestConfig } = require('@storybook/test-runner')
+
+// The default Jest configuration comes from @storybook/test-runner
+const testRunnerConfig = getJestConfig()
+
+/**
+ * @type {import('@jest/types').Config.InitialOptions}
+ */
+module.exports = {
+  ...testRunnerConfig,
+  /** Add your own overrides below, and make sure
+   *  to merge testRunnerConfig properties with your own
+   * @see https://jestjs.io/docs/configuration
+   */
+  rootDir: '<rootDir>/../src/client/components/react-dev-overlay/',
+  testMatch: ['**/*.stories.tsx', '**/*.test.tsx'],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1173,6 +1173,9 @@ importers:
       async-sema:
         specifier: 3.0.0
         version: 3.0.0
+      axe-playwright:
+        specifier: 2.0.3
+        version: 2.0.3(playwright@1.48.0)
       babel-plugin-react-compiler:
         specifier: 19.0.0-beta-e552027-20250112
         version: 19.0.0-beta-e552027-20250112
@@ -5848,6 +5851,9 @@ packages:
   '@types/jsonwebtoken@9.0.0':
     resolution: {integrity: sha512-mM4TkDpA9oixqg1Fv2vVpOFyIVLJjm5x4k0V+K/rEsizfjD7Tk7LKk3GTtbB7KCfP0FEHQtsZqFxYA0+sijNVg==}
 
+  '@types/junit-report-builder@3.0.2':
+    resolution: {integrity: sha512-R5M+SYhMbwBeQcNXYWNCZkl09vkVfAtcPIaCGdzIkkbeaTrVbGQ7HVgi4s+EmM/M1K4ZuWQH0jGcvMvNePfxYA==}
+
   '@types/keyv@3.1.1':
     resolution: {integrity: sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==}
 
@@ -6805,6 +6811,17 @@ packages:
   axe-core@4.10.0:
     resolution: {integrity: sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==}
     engines: {node: '>=4'}
+
+  axe-html-reporter@2.2.11:
+    resolution: {integrity: sha512-WlF+xlNVgNVWiM6IdVrsh+N0Cw7qupe5HT9N6Uyi+aN7f6SSi92RDomiP1noW8OWIV85V6x404m5oKMeqRV3tQ==}
+    engines: {node: '>=8.9.0'}
+    peerDependencies:
+      axe-core: '>=3'
+
+  axe-playwright@2.0.3:
+    resolution: {integrity: sha512-s7iI2okyHHsD3XZK4RMJtTy2UASkNWLQtnzLuaHiK3AWkERf+cqZJqkxb7O4b56fnbib9YnZVRByTl92ME3o6g==}
+    peerDependencies:
+      playwright: '>1.0.0'
 
   axios@1.7.9:
     resolution: {integrity: sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==}
@@ -11121,6 +11138,10 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  junit-report-builder@5.1.1:
+    resolution: {integrity: sha512-ZNOIIGMzqCGcHQEA2Q4rIQQ3Df6gSIfne+X9Rly9Bc2y55KxAZu8iGv+n2pP0bLf0XAOctJZgeloC54hWzCahQ==}
+    engines: {node: '>=16'}
+
   junk@1.0.3:
     resolution: {integrity: sha512-3KF80UaaSSxo8jVnRYtMKNGFOoVPBdkkVPsw+Ad0y4oxKXPduS6G6iHkrf69yJVff/VAaYXkV42rtZ7daJxU3w==}
     engines: {node: '>=0.10.0'}
@@ -12129,6 +12150,10 @@ packages:
   multimatch@5.0.0:
     resolution: {integrity: sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==}
     engines: {node: '>=10'}
+
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
 
   mute-stream@0.0.7:
     resolution: {integrity: sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==}
@@ -16632,6 +16657,10 @@ packages:
   xml@1.0.1:
     resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
 
+  xmlbuilder@15.1.1:
+    resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
+    engines: {node: '>=8.0'}
+
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
@@ -17106,7 +17135,7 @@ snapshots:
 
   '@babel/helper-function-name@7.24.7':
     dependencies:
-      '@babel/template': 7.24.7
+      '@babel/template': 7.25.7
       '@babel/types': 7.22.5
 
   '@babel/helper-hoist-variables@7.22.5':
@@ -17352,7 +17381,7 @@ snapshots:
   '@babel/helper-wrap-function@7.22.20':
     dependencies:
       '@babel/helper-function-name': 7.24.7
-      '@babel/template': 7.24.7
+      '@babel/template': 7.25.7
       '@babel/types': 7.22.5
 
   '@babel/helper-wrap-function@7.25.7':
@@ -21610,7 +21639,7 @@ snapshots:
       '@types/aria-query': 5.0.1
       aria-query: 5.3.0
       chalk: 4.1.2
-      dom-accessibility-api: 0.5.13
+      dom-accessibility-api: 0.5.16
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
@@ -21903,6 +21932,8 @@ snapshots:
   '@types/jsonwebtoken@9.0.0':
     dependencies:
       '@types/node': 20.17.6
+
+  '@types/junit-report-builder@3.0.2': {}
 
   '@types/keyv@3.1.1':
     dependencies:
@@ -23020,6 +23051,20 @@ snapshots:
   aws4@1.9.0: {}
 
   axe-core@4.10.0: {}
+
+  axe-html-reporter@2.2.11(axe-core@4.10.0):
+    dependencies:
+      axe-core: 4.10.0
+      mustache: 4.2.0
+
+  axe-playwright@2.0.3(playwright@1.48.0):
+    dependencies:
+      '@types/junit-report-builder': 3.0.2
+      axe-core: 4.10.0
+      axe-html-reporter: 2.2.11(axe-core@4.10.0)
+      junit-report-builder: 5.1.1
+      picocolors: 1.1.1
+      playwright: 1.48.0
 
   axios@1.7.9(debug@4.1.1):
     dependencies:
@@ -27916,7 +27961,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.22.5
       '@babel/parser': 7.22.5
-      '@istanbuljs/schema': 0.1.2
+      '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 7.6.3
     transitivePeerDependencies:
@@ -28674,6 +28719,12 @@ snapshots:
       array.prototype.flat: 1.3.2
       object.assign: 4.1.5
       object.values: 1.2.0
+
+  junit-report-builder@5.1.1:
+    dependencies:
+      lodash: 4.17.21
+      make-dir: 3.1.0
+      xmlbuilder: 15.1.1
 
   junk@1.0.3: {}
 
@@ -30227,6 +30278,8 @@ snapshots:
       array-union: 2.1.0
       arrify: 2.0.1
       minimatch: 3.0.4
+
+  mustache@4.2.0: {}
 
   mute-stream@0.0.7: {}
 
@@ -35518,6 +35571,8 @@ snapshots:
   xml-name-validator@4.0.0: {}
 
   xml@1.0.1: {}
+
+  xmlbuilder@15.1.1: {}
 
   xmlchars@2.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,7 +140,7 @@ importers:
         version: 1.1.0
       '@testing-library/jest-dom':
         specifier: 6.1.2
-        version: 6.1.2(@jest/globals@29.7.0)(@types/jest@29.5.5)(jest@29.7.0(@types/node@20.17.6))(vitest@3.0.4(@types/node@20.17.6)(sass@1.54.0))
+        version: 6.1.2(@jest/globals@29.7.0)(@types/jest@29.5.5)(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(vitest@3.0.4(@types/node@20.17.6)(sass@1.54.0))
       '@testing-library/react':
         specifier: ^15.0.5
         version: 15.0.7(@types/react@19.0.8)(react-dom@19.1.0-canary-37906d4d-20250127(react@19.1.0-canary-37906d4d-20250127))(react@19.1.0-canary-37906d4d-20250127)
@@ -278,7 +278,7 @@ importers:
         version: 2.31.0(@typescript-eslint/parser@8.0.0(eslint@9.12.0)(typescript@5.7.2))(eslint@9.12.0)
       eslint-plugin-jest:
         specifier: 27.6.3
-        version: 27.6.3(@typescript-eslint/eslint-plugin@8.0.0(@typescript-eslint/parser@8.0.0(eslint@9.12.0)(typescript@5.7.2))(eslint@9.12.0)(typescript@5.7.2))(eslint@9.12.0)(jest@29.7.0(@types/node@20.17.6))(typescript@5.7.2)
+        version: 27.6.3(@typescript-eslint/eslint-plugin@8.0.0(@typescript-eslint/parser@8.0.0(eslint@9.12.0)(typescript@5.7.2))(eslint@9.12.0)(typescript@5.7.2))(eslint@9.12.0)(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.7.2)
       eslint-plugin-jsdoc:
         specifier: 48.0.4
         version: 48.0.4(eslint@9.12.0)
@@ -365,7 +365,7 @@ importers:
         version: 29.7.0
       jest-extended:
         specifier: 4.0.2
-        version: 4.0.2(jest@29.7.0(@types/node@20.17.6))
+        version: 4.0.2(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -21614,7 +21614,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.1.2(@jest/globals@29.7.0)(@types/jest@29.5.5)(jest@29.7.0(@types/node@20.17.6))(vitest@3.0.4(@types/node@20.17.6)(sass@1.54.0))':
+  '@testing-library/jest-dom@6.1.2(@jest/globals@29.7.0)(@types/jest@29.5.5)(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(vitest@3.0.4(@types/node@20.17.6)(sass@1.54.0))':
     dependencies:
       '@adobe/css-tools': 4.3.1
       '@babel/runtime': 7.22.5
@@ -25642,7 +25642,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@27.6.3(@typescript-eslint/eslint-plugin@8.0.0(@typescript-eslint/parser@8.0.0(eslint@9.12.0)(typescript@5.7.2))(eslint@9.12.0)(typescript@5.7.2))(eslint@9.12.0)(jest@29.7.0(@types/node@20.17.6))(typescript@5.7.2):
+  eslint-plugin-jest@27.6.3(@typescript-eslint/eslint-plugin@8.0.0(@typescript-eslint/parser@8.0.0(eslint@9.12.0)(typescript@5.7.2))(eslint@9.12.0)(typescript@5.7.2))(eslint@9.12.0)(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.7.2):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@9.12.0)(typescript@5.7.2)
       eslint: 9.12.0
@@ -28142,7 +28142,7 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-extended@4.0.2(jest@29.7.0(@types/node@20.17.6)):
+  jest-extended@4.0.2(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0)):
     dependencies:
       jest-diff: 29.7.0
       jest-get-type: 29.6.3

--- a/turbo.json
+++ b/turbo.json
@@ -15,6 +15,9 @@
       "dependsOn": ["^build-storybook"],
       "outputs": ["storybook-static/**"]
     },
+    "test-storybook": {
+      "dependsOn": ["^test-storybook"]
+    },
     "typescript": {},
     "//#typescript": {},
     "//#get-test-timings": {


### PR DESCRIPTION
Added a11y test, but haven't enabled for the CI. Will follow up to resolve the test result.

![CleanShot 2025-02-01 at 03 20 54](https://github.com/user-attachments/assets/7315d740-dec1-4327-977b-8a8f3b06e95e)

You can manually test a11y at the storybook portal:

https://github.com/user-attachments/assets/72929e65-bd70-481e-ac2f-1b518c344373

Closes https://linear.app/vercel/issue/NDX-584/add-a11y-tests