### PR TITLE
chore(turbopack): Remove unmaintained fxhash crate, use rustc-hash instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2540,15 +2540,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "generator"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4531,7 +4522,6 @@ dependencies = [
  "dashmap 6.1.0",
  "easy-error",
  "either",
- "fxhash",
  "hex",
  "indexmap 2.7.1",
  "indoc",
@@ -4568,7 +4558,6 @@ dependencies = [
  "console-subscriber",
  "dashmap 6.1.0",
  "dhat",
- "fxhash",
  "getrandom",
  "iana-time-zone",
  "indexmap 2.7.1",
@@ -4584,6 +4573,7 @@ dependencies = [
  "once_cell",
  "owo-colors 3.5.0",
  "rand",
+ "rustc-hash 1.1.0",
  "serde",
  "serde_json",
  "shadow-rs",

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -47,7 +47,6 @@ workspace = true
 anyhow = "1.0.66"
 backtrace = "0.3"
 console-subscriber = { workspace = true, optional = true }
-fxhash = "0.2.1"
 dhat = { workspace = true, optional = true }
 indexmap = { workspace = true }
 owo-colors = { workspace = true }
@@ -64,6 +63,7 @@ napi = { version = "2", default-features = false, features = [
 napi-derive = "2"
 next-custom-transforms = { workspace = true }
 rand = { workspace = true }
+rustc-hash = { workspace = true }
 serde = "1"
 serde_json = "1"
 shadow-rs = { workspace = true }

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -41,8 +41,8 @@ use std::{
 
 use backtrace::Backtrace;
 use dashmap::DashMap;
-use fxhash::FxHashSet;
 use napi::bindgen_prelude::*;
+use rustc_hash::FxHashSet;
 use swc_core::{
     base::{Compiler, TransformOutput},
     common::{FilePathMapping, SourceMap},

--- a/crates/napi/src/minify.rs
+++ b/crates/napi/src/minify.rs
@@ -27,8 +27,8 @@ DEALINGS IN THE SOFTWARE.
 */
 use std::sync::Arc;
 
-use fxhash::FxHashMap;
 use napi::bindgen_prelude::*;
+use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use swc_core::{
     base::{config::JsMinifyOptions, try_with_handler, BoolOrDataConfig, TransformOutput},

--- a/crates/napi/src/transform.rs
+++ b/crates/napi/src/transform.rs
@@ -36,10 +36,10 @@ use std::{
 
 use anyhow::{anyhow, bail, Context as _};
 use dashmap::DashMap;
-use fxhash::FxHashSet;
 use napi::bindgen_prelude::*;
 use next_custom_transforms::chain_transforms::{custom_before_pass, TransformOptions};
 use once_cell::sync::Lazy;
+use rustc_hash::FxHashSet;
 use swc_core::{
     base::{try_with_handler, Compiler, TransformOutput},
     common::{comments::SingleThreadedComments, errors::ColorConfig, FileName, Mark, GLOBALS},
@@ -87,7 +87,7 @@ impl Task for TransformTask {
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
         GLOBALS.set(&Default::default(), || {
-            let eliminated_packages: Rc<RefCell<fxhash::FxHashSet<String>>> = Default::default();
+            let eliminated_packages: Rc<RefCell<FxHashSet<String>>> = Default::default();
             let use_cache_telemetry_tracker: Rc<DashMap<String, usize>> = Default::default();
 
             let res = catch_unwind(AssertUnwindSafe(|| {

--- a/crates/next-custom-transforms/Cargo.toml
+++ b/crates/next-custom-transforms/Cargo.toml
@@ -17,7 +17,6 @@ workspace = true
 chrono = "0.4"
 easy-error = "1.0.0"
 either = "1"
-fxhash = "0.2.1"
 hex = "0.4.3"
 indexmap = { workspace = true }
 indoc = { workspace = true }

--- a/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/crates/next-custom-transforms/src/chain_transforms.rs
@@ -2,9 +2,9 @@ use std::{cell::RefCell, path::PathBuf, rc::Rc, sync::Arc};
 
 use dashmap::DashMap;
 use either::Either;
-use fxhash::FxHashSet;
 use modularize_imports;
 use preset_env_base::query::targets_to_versions;
+use rustc_hash::FxHashSet;
 use serde::Deserialize;
 use swc_core::{
     common::{

--- a/crates/next-custom-transforms/src/transforms/next_ssg.rs
+++ b/crates/next-custom-transforms/src/transforms/next_ssg.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, mem::take, rc::Rc};
 
 use easy_error::{bail, Error};
-use fxhash::FxHashSet;
+use rustc_hash::FxHashSet;
 use swc_core::{
     common::{
         errors::HANDLER,

--- a/crates/next-custom-transforms/tests/telemetry.rs
+++ b/crates/next-custom-transforms/tests/telemetry.rs
@@ -1,8 +1,8 @@
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
-use fxhash::FxHashSet;
 use next_custom_transforms::transforms::next_ssg::next_ssg;
 use once_cell::sync::Lazy;
+use rustc_hash::FxHashSet;
 use swc_core::{
     base::{try_with_handler, Compiler},
     common::{comments::SingleThreadedComments, FileName, FilePathMapping, SourceMap, GLOBALS},

--- a/crates/next-custom-transforms/tests/telemetry.rs
+++ b/crates/next-custom-transforms/tests/telemetry.rs
@@ -53,11 +53,11 @@ export function getServerSideProps() {
         })
         .is_ok()
     );
-    assert_eq!(
-        eliminated_packages
-            .borrow()
-            .iter()
-            .collect::<Vec<&String>>(),
-        vec!["@napi-rs/bcrypt", "http"]
-    );
+    let mut eliminated_packages_vec = Rc::into_inner(eliminated_packages)
+        .expect("we should have the only remaining reference to `eliminated_packages`")
+        .into_inner()
+        .into_iter()
+        .collect::<Vec<String>>();
+    eliminated_packages_vec.sort_unstable(); // HashSet order is random/arbitrary
+    assert_eq!(eliminated_packages_vec, vec!["@napi-rs/bcrypt", "http"]);
 }


### PR DESCRIPTION
The fxhash crate hasn't been updated in 7 years, the rust-hash crate is actively maintained.

We were using an awkward mix of both, unify on just using rustc-hash.

Closes PACK-3864