### PR TITLE
perf(next-custom-transforms): Replace non-`Sync` `Rc<DashMap<_, _>>` usage with `Rc<RefCell<FxHashMap<_, _>>>`

### DIFF
--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -40,9 +40,8 @@ use std::{
 };
 
 use backtrace::Backtrace;
-use dashmap::DashMap;
 use napi::bindgen_prelude::*;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::{
     base::{Compiler, TransformOutput},
     common::{FilePathMapping, SourceMap},
@@ -108,7 +107,7 @@ pub fn complete_output(
     env: &Env,
     output: TransformOutput,
     eliminated_packages: FxHashSet<String>,
-    use_cache_telemetry_tracker: DashMap<String, usize>,
+    use_cache_telemetry_tracker: FxHashMap<String, usize>,
 ) -> napi::Result<Object> {
     let mut js_output = env.create_object()?;
     js_output.set_named_property("code", env.create_string_from_std(output.code)?)?;
@@ -127,7 +126,7 @@ pub fn complete_output(
             env.create_string_from_std(serde_json::to_string(
                 &use_cache_telemetry_tracker
                     .iter()
-                    .map(|entry| (entry.key().clone(), *entry.value()))
+                    .map(|(k, v)| (k.clone(), *v))
                     .collect::<Vec<_>>(),
             )?)?,
         )?;

--- a/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/crates/next-custom-transforms/src/chain_transforms.rs
@@ -1,10 +1,9 @@
 use std::{cell::RefCell, path::PathBuf, rc::Rc, sync::Arc};
 
-use dashmap::DashMap;
 use either::Either;
 use modularize_imports;
 use preset_env_base::query::targets_to_versions;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Deserialize;
 use swc_core::{
     common::{
@@ -126,7 +125,7 @@ pub fn custom_before_pass<'a, C>(
     comments: C,
     eliminated_packages: Rc<RefCell<FxHashSet<String>>>,
     unresolved_mark: Mark,
-    use_cache_telemetry_tracker: Rc<DashMap<String, usize>>,
+    use_cache_telemetry_tracker: Rc<RefCell<FxHashMap<String, usize>>>,
 ) -> impl Pass + 'a
 where
     C: Clone + Comments + 'a,

--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -1,14 +1,14 @@
 use std::{
-    collections::{BTreeMap, HashSet},
+    cell::RefCell,
+    collections::{hash_map, BTreeMap, HashSet},
     convert::{TryFrom, TryInto},
     mem::{replace, take},
     rc::Rc,
 };
 
-use dashmap::DashMap;
 use hex::encode as hex_encode;
 use indoc::formatdoc;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Deserialize;
 use sha1::{Digest, Sha1};
 use swc_core::{
@@ -123,7 +123,7 @@ pub fn server_actions<C: Comments>(
     file_name: &FileName,
     config: Config,
     comments: C,
-    use_cache_telemetry_tracker: Rc<DashMap<String, usize>>,
+    use_cache_telemetry_tracker: Rc<RefCell<FxHashMap<String, usize>>>,
 ) -> impl Pass {
     visit_mut_pass(ServerActions {
         config,
@@ -220,7 +220,7 @@ struct ServerActions<C: Comments> {
     arrow_or_fn_expr_ident: Option<Ident>,
     exported_local_ids: HashSet<Id>,
 
-    use_cache_telemetry_tracker: Rc<DashMap<String, usize>>,
+    use_cache_telemetry_tracker: Rc<RefCell<FxHashMap<String, usize>>>,
 }
 
 impl<C: Comments> ServerActions<C> {
@@ -2618,7 +2618,7 @@ struct DirectiveVisitor<'a> {
     directive: Option<Directive>,
     has_file_directive: bool,
     is_allowed_position: bool,
-    use_cache_telemetry_tracker: Rc<DashMap<String, usize>>,
+    use_cache_telemetry_tracker: Rc<RefCell<FxHashMap<String, usize>>>,
 }
 
 impl DirectiveVisitor<'_> {
@@ -2779,14 +2779,13 @@ impl DirectiveVisitor<'_> {
 
     // Increment telemetry counter tracking usage of "use cache" directives
     fn increment_cache_usage_counter(&mut self, cache_kind: &str) {
-        let entry = self
-            .use_cache_telemetry_tracker
-            .entry(cache_kind.to_string());
+        let mut tracker_map = RefCell::borrow_mut(&self.use_cache_telemetry_tracker);
+        let entry = tracker_map.entry(cache_kind.to_string());
         match entry {
-            dashmap::mapref::entry::Entry::Occupied(mut occupied) => {
+            hash_map::Entry::Occupied(mut occupied) => {
                 *occupied.get_mut() += 1;
             }
-            dashmap::mapref::entry::Entry::Vacant(vacant) => {
+            hash_map::Entry::Vacant(vacant) => {
                 vacant.insert(1);
             }
         }


### PR DESCRIPTION
This is a follow-up to https://github.com/vercel/next.js/pull/75007

`DashMap` is needed for situations where you have many threads (or tokio tasks) modifying the same data at the same time. It introduces a lot of memory and CPU overhead to create individually lockable `RwLock` shards. This type of data structure implements `Sync`, indicating that it can be shared between threads.

`Rc` is not `Sync` (`Arc` is `Sync`), so wrapping `DashMap` in `Rc` doesn't make a lot of sense: You're paying a pretty high overhead for the ability to share data between threads, and wrapping it in something that does not support sharing data between threads.

This visitor code is entirely single-threaded, so just use `Rc<RefCell<FxHashMap>>` instead. `RefCell` is a very cheap single-threaded version of a `Mutex`. `FxHashMap` is just a `HashMap` with the faster `FxHash` algorithm used.

Closes PACK-3871