### PR TITLE
Turbopack: codegen modules without whitespace

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -2140,7 +2140,8 @@ async fn emit_content(
         let comments = comments.consumable();
 
         let mut emitter = Emitter {
-            cfg: swc_core::ecma::codegen::Config::default(),
+            cfg: swc_core::ecma::codegen::Config::default()
+                .with_minify(matches!(minify, MinifyType::Minify { .. })),
             cm: source_map.clone(),
             comments: Some(&comments as &dyn Comments),
             wr,


### PR DESCRIPTION
When minification is enabled, codegen modules without inserting whitespace. This should make for less data in general and in particular also help the chunking heuristics because the module sizes are more accurate.


```
testing against 0293c96cf32

find .next -regex '.*\.js$' | wc -l 


canary b6f8743ecd
13,75 GB 
TURBO_ENGINE_READ_ONLY=1 NEXT_TURBOPACK_TRACING= TURBOPACK=1 TURBOPACK_BUILD=  507.86s user 77.80s system 847% cpu 1:09.11 total
TURBO_ENGINE_READ_ONLY=1 NEXT_TURBOPACK_TRACING= TURBOPACK=1 TURBOPACK_BUILD=  503.13s user 77.86s system 855% cpu 1:07.90 total

Generated 8588 JS chunks in .next


mischnic/codegen-modules-without-whitespace 16e0ae2af0
13,75 GB
TURBO_ENGINE_READ_ONLY=1 NEXT_TURBOPACK_TRACING= TURBOPACK=1 TURBOPACK_BUILD=  514.79s user 75.63s system 859% cpu 1:08.72 total
TURBO_ENGINE_READ_ONLY=1 NEXT_TURBOPACK_TRACING= TURBOPACK=1 TURBOPACK_BUILD=  505.92s user 80.44s system 855% cpu 1:08.57 total

Generated 8059 JS chunks in .next
```