### PR TITLE
refactor(turbopack): Define and use an FxDashMap alias everywhere

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -19,7 +19,6 @@ use std::{
 
 use anyhow::{bail, Result};
 use auto_hash_map::{AutoMap, AutoSet};
-use dashmap::DashMap;
 use parking_lot::{Condvar, Mutex};
 use rustc_hash::FxHasher;
 use smallvec::smallvec;
@@ -33,7 +32,7 @@ use turbo_tasks::{
     registry,
     task_statistics::TaskStatisticsApi,
     util::IdFactoryWithReuse,
-    CellId, FunctionId, RawVc, ReadConsistency, SessionId, TaskId, TraitTypeId,
+    CellId, FunctionId, FxDashMap, RawVc, ReadConsistency, SessionId, TaskId, TraitTypeId,
     TurboTasksBackendApi, ValueTypeId, TRANSIENT_TASK_BIT,
 };
 
@@ -152,7 +151,7 @@ struct TurboTasksBackendInner<B: BackingStorage> {
 
     persisted_task_cache_log: Option<TaskCacheLog>,
     task_cache: BiMap<Arc<CachedTaskType>, TaskId>,
-    transient_tasks: DashMap<TaskId, Arc<TransientTask>, BuildHasherDefault<FxHasher>>,
+    transient_tasks: FxDashMap<TaskId, Arc<TransientTask>>,
 
     persisted_storage_data_log: Option<PersistedStorageLog>,
     persisted_storage_meta_log: Option<PersistedStorageLog>,
@@ -214,7 +213,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             ),
             persisted_task_cache_log: need_log.then(|| Sharded::new(shard_amount)),
             task_cache: BiMap::new(),
-            transient_tasks: DashMap::default(),
+            transient_tasks: FxDashMap::default(),
             persisted_storage_data_log: need_log.then(|| PersistedStorageLog::new(shard_amount)),
             persisted_storage_meta_log: need_log.then(|| PersistedStorageLog::new(shard_amount)),
             storage: Storage::new(),

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -1,12 +1,10 @@
 use std::{
-    hash::{BuildHasherDefault, Hash},
+    hash::Hash,
     ops::{Deref, DerefMut},
     thread::available_parallelism,
 };
 
-use dashmap::DashMap;
-use rustc_hash::FxHasher;
-use turbo_tasks::TaskId;
+use turbo_tasks::{FxDashMap, TaskId};
 
 use crate::{
     backend::dynamic_storage::DynamicStorage,
@@ -502,7 +500,7 @@ impl InnerStorage {
 }
 
 pub struct Storage {
-    map: DashMap<TaskId, Box<InnerStorage>, BuildHasherDefault<FxHasher>>,
+    map: FxDashMap<TaskId, Box<InnerStorage>>,
 }
 
 impl Storage {
@@ -510,7 +508,7 @@ impl Storage {
         let shard_amount =
             (available_parallelism().map_or(4, |v| v.get()) * 64).next_power_of_two();
         Self {
-            map: DashMap::with_capacity_and_hasher_and_shard_amount(
+            map: FxDashMap::with_capacity_and_hasher_and_shard_amount(
                 1024 * 1024,
                 Default::default(),
                 shard_amount,

--- a/turbopack/crates/turbo-tasks-backend/src/database/startup_cache.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/startup_cache.rs
@@ -10,8 +10,8 @@ use std::{
 
 use anyhow::{Ok, Result};
 use byteorder::WriteBytesExt;
-use dashmap::DashMap;
 use rustc_hash::{FxHashMap, FxHasher};
+use turbo_tasks::FxDashMap;
 
 use crate::database::{
     by_key_space::ByKeySpace,
@@ -39,7 +39,7 @@ impl<T: KeyValueDatabase> Borrow<[u8]> for ValueBuffer<'_, T> {
     }
 }
 
-type Cache = ByKeySpace<DashMap<Vec<u8>, Option<Vec<u8>>, BuildHasherDefault<FxHasher>>>;
+type Cache = ByKeySpace<FxDashMap<Vec<u8>, Option<Vec<u8>>>>;
 
 pub struct StartupCacheLayer<T: KeyValueDatabase> {
     database: T,
@@ -81,7 +81,7 @@ impl<T: KeyValueDatabase> StartupCacheLayer<T> {
             fresh_db,
             cache_size: AtomicUsize::new(0),
             cache: ByKeySpace::new(|key_space| {
-                DashMap::with_capacity_and_hasher(
+                FxDashMap::with_capacity_and_hasher(
                     match key_space {
                         KeySpace::Infra => 8,
                         KeySpace::TaskMeta => 1024 * 1024,

--- a/turbopack/crates/turbo-tasks-backend/src/utils/bi_map.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/utils/bi_map.rs
@@ -1,18 +1,15 @@
-use std::{
-    borrow::Borrow,
-    hash::{BuildHasherDefault, Hash},
-};
+use std::{borrow::Borrow, hash::Hash};
 
-use dashmap::{mapref::entry::Entry, DashMap};
-use rustc_hash::FxHasher;
+use dashmap::mapref::entry::Entry;
+use turbo_tasks::FxDashMap;
 
-/// A bidirectional [`DashMap`] that allows lookup by key or value.
+/// A bidirectional [`FxDashMap`] that allows lookup by key or value.
 ///
 /// As keys and values are stored twice, they should be small types, such as
 /// [`Arc`][`std::sync::Arc`].
 pub struct BiMap<K, V> {
-    forward: DashMap<K, V, BuildHasherDefault<FxHasher>>,
-    reverse: DashMap<V, K, BuildHasherDefault<FxHasher>>,
+    forward: FxDashMap<K, V>,
+    reverse: FxDashMap<V, K>,
 }
 
 impl<K, V> BiMap<K, V>
@@ -22,8 +19,8 @@ where
 {
     pub fn new() -> Self {
         Self {
-            forward: DashMap::default(),
-            reverse: DashMap::default(),
+            forward: FxDashMap::default(),
+            reverse: FxDashMap::default(),
         }
     }
 

--- a/turbopack/crates/turbo-tasks-backend/src/utils/dash_map_multi.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/utils/dash_map_multi.rs
@@ -202,6 +202,7 @@ mod tests {
     use std::thread::scope;
 
     use rand::prelude::SliceRandom;
+    use turbo_tasks::FxDashMap;
 
     use super::*;
 
@@ -210,7 +211,7 @@ mod tests {
         const N: usize = 100000;
         const THREADS: usize = 20;
 
-        let map = DashMap::with_shard_amount(4);
+        let map = FxDashMap::with_hasher_and_shard_amount(Default::default(), 4);
         let indicies = (0..THREADS)
             .map(|_| {
                 let mut vec = (0..N).collect::<Vec<_>>();

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -131,6 +131,7 @@ pub use vc::{
 
 pub type FxIndexSet<T> = indexmap::IndexSet<T, BuildHasherDefault<FxHasher>>;
 pub type FxIndexMap<K, V> = indexmap::IndexMap<K, V, BuildHasherDefault<FxHasher>>;
+pub type FxDashMap<K, V> = dashmap::DashMap<K, V, BuildHasherDefault<FxHasher>>;
 
 // Copied from indexmap! and indexset!
 #[macro_export]

--- a/turbopack/crates/turbo-tasks/src/once_map.rs
+++ b/turbopack/crates/turbo-tasks/src/once_map.rs
@@ -3,10 +3,12 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use dashmap::{mapref::entry::Entry, DashMap};
+use dashmap::mapref::entry::Entry;
+
+use crate::FxDashMap;
 
 pub struct OnceConcurrentlyMap<K: Hash + Eq + Ord + Send + Sync + 'static, V: Clone + Send + Sync> {
-    inner: DashMap<&'static K, Arc<Mutex<Option<V>>>>,
+    inner: FxDashMap<&'static K, Arc<Mutex<Option<V>>>>,
 }
 
 impl<K: Hash + Eq + Ord + Send + Sync, V: Clone + Send + Sync> Default
@@ -20,7 +22,7 @@ impl<K: Hash + Eq + Ord + Send + Sync, V: Clone + Send + Sync> Default
 impl<K: Hash + Eq + Ord + Send + Sync, V: Clone + Send + Sync> OnceConcurrentlyMap<K, V> {
     pub fn new() -> Self {
         Self {
-            inner: DashMap::new(),
+            inner: FxDashMap::default(),
         }
     }
 
@@ -48,7 +50,7 @@ impl<K: Hash + Eq + Ord + Send + Sync, V: Clone + Send + Sync> OnceConcurrentlyM
 }
 
 struct TemporarilyInserted<'a, K: 'static + Hash + Eq + Ord + Send + Sync, V: Send + Sync> {
-    inner: &'a DashMap<&'static K, V>,
+    inner: &'a FxDashMap<&'static K, V>,
     key: &'a K,
 }
 
@@ -71,7 +73,7 @@ pub struct SafeOnceConcurrentlyMap<
     K: Clone + Hash + Eq + Ord + Send + Sync + 'static,
     V: Clone + Send + Sync,
 > {
-    inner: DashMap<K, Arc<Mutex<Option<V>>>>,
+    inner: FxDashMap<K, Arc<Mutex<Option<V>>>>,
 }
 
 impl<K: Clone + Hash + Eq + Ord + Send + Sync, V: Clone + Send + Sync> Default
@@ -87,7 +89,7 @@ impl<K: Clone + Hash + Eq + Ord + Send + Sync, V: Clone + Send + Sync>
 {
     pub fn new() -> Self {
         Self {
-            inner: DashMap::new(),
+            inner: FxDashMap::default(),
         }
     }
 
@@ -119,7 +121,7 @@ struct SafeTemporarilyInserted<
     K: 'static + Clone + Hash + Eq + Ord + Send + Sync,
     V: Send + Sync,
 > {
-    inner: &'a DashMap<K, V>,
+    inner: &'a FxDashMap<K, V>,
     key: &'a K,
 }
 

--- a/turbopack/crates/turbo-tasks/src/registry.rs
+++ b/turbopack/crates/turbo-tasks/src/registry.rs
@@ -1,43 +1,35 @@
-use std::{
-    fmt::Debug,
-    hash::{BuildHasherDefault, Hash},
-    num::NonZeroU64,
-    ops::Deref,
-};
+use std::{fmt::Debug, hash::Hash, num::NonZeroU64, ops::Deref};
 
-use dashmap::{mapref::entry::Entry, DashMap};
+use dashmap::mapref::entry::Entry;
 use once_cell::sync::Lazy;
-use rustc_hash::FxHasher;
 
 use crate::{
     id::{FunctionId, TraitTypeId, ValueTypeId},
     id_factory::IdFactory,
     native_function::NativeFunction,
     no_move_vec::NoMoveVec,
-    TraitType, ValueType,
+    FxDashMap, TraitType, ValueType,
 };
 
-type FxDashMap<K, V> = DashMap<K, V, BuildHasherDefault<FxHasher>>;
-
 static FUNCTION_ID_FACTORY: IdFactory<FunctionId> = IdFactory::new(1, u32::MAX as u64);
-static FUNCTIONS_BY_NAME: Lazy<FxDashMap<&'static str, FunctionId>> = Lazy::new(DashMap::default);
+static FUNCTIONS_BY_NAME: Lazy<FxDashMap<&'static str, FunctionId>> = Lazy::new(FxDashMap::default);
 static FUNCTIONS_BY_VALUE: Lazy<FxDashMap<&'static NativeFunction, FunctionId>> =
-    Lazy::new(DashMap::default);
+    Lazy::new(FxDashMap::default);
 static FUNCTIONS: Lazy<NoMoveVec<(&'static NativeFunction, &'static str)>> =
     Lazy::new(NoMoveVec::new);
 
 static VALUE_TYPE_ID_FACTORY: IdFactory<ValueTypeId> = IdFactory::new(1, u32::MAX as u64);
 static VALUE_TYPES_BY_NAME: Lazy<FxDashMap<&'static str, ValueTypeId>> =
-    Lazy::new(DashMap::default);
+    Lazy::new(FxDashMap::default);
 static VALUE_TYPES_BY_VALUE: Lazy<FxDashMap<&'static ValueType, ValueTypeId>> =
-    Lazy::new(DashMap::default);
+    Lazy::new(FxDashMap::default);
 static VALUE_TYPES: Lazy<NoMoveVec<(&'static ValueType, &'static str)>> = Lazy::new(NoMoveVec::new);
 
 static TRAIT_TYPE_ID_FACTORY: IdFactory<TraitTypeId> = IdFactory::new(1, u32::MAX as u64);
 static TRAIT_TYPES_BY_NAME: Lazy<FxDashMap<&'static str, TraitTypeId>> =
-    Lazy::new(DashMap::default);
+    Lazy::new(FxDashMap::default);
 static TRAIT_TYPES_BY_VALUE: Lazy<FxDashMap<&'static TraitType, TraitTypeId>> =
-    Lazy::new(DashMap::default);
+    Lazy::new(FxDashMap::default);
 static TRAIT_TYPES: Lazy<NoMoveVec<(&'static TraitType, &'static str)>> = Lazy::new(NoMoveVec::new);
 
 fn register_thing<

--- a/turbopack/crates/turbo-tasks/src/task_statistics.rs
+++ b/turbopack/crates/turbo-tasks/src/task_statistics.rs
@@ -1,13 +1,8 @@
-use std::{
-    hash::BuildHasherDefault,
-    sync::{Arc, OnceLock},
-};
+use std::sync::{Arc, OnceLock};
 
-use dashmap::DashMap;
-use rustc_hash::FxHasher;
 use serde::{ser::SerializeMap, Serialize, Serializer};
 
-use crate::{registry, FunctionId};
+use crate::{registry, FunctionId, FxDashMap};
 
 /// An API for optionally enabling, updating, and reading aggregated statistics.
 #[derive(Default)]
@@ -19,7 +14,7 @@ impl TaskStatisticsApi {
     pub fn enable(&self) -> &Arc<TaskStatistics> {
         self.inner.get_or_init(|| {
             Arc::new(TaskStatistics {
-                inner: DashMap::with_hasher(Default::default()),
+                inner: FxDashMap::with_hasher(Default::default()),
             })
         })
     }
@@ -43,7 +38,7 @@ impl TaskStatisticsApi {
 
 /// A type representing the enabled state of [`TaskStatisticsApi`]. Implements [`serde::Serialize`].
 pub struct TaskStatistics {
-    inner: DashMap<FunctionId, TaskFunctionStatistics, BuildHasherDefault<FxHasher>>,
+    inner: FxDashMap<FunctionId, TaskFunctionStatistics>,
 }
 
 impl TaskStatistics {


### PR DESCRIPTION
This is similar to the `FxHashMap`/`FxHashSet`/`FxIndexMap`/`FxIndexSet` aliases we use everywhere.

Closes PACK-3872