### PR TITLE
[Turbopack] await shutdown before ending pool

### DIFF
--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -304,6 +304,7 @@ export async function turbopackBuild(): Promise<{
   }
 }
 
+let shutdownPromise: Promise<void> | undefined
 export async function workerMain(workerData: {
   buildContext: typeof NextBuildContext
 }): Promise<Awaited<ReturnType<typeof turbopackBuild>>> {
@@ -330,5 +331,12 @@ export async function workerMain(workerData: {
   setGlobal('telemetry', telemetry)
 
   const result = await turbopackBuild()
+  shutdownPromise = result.shutdownPromise
   return result
+}
+
+export async function waitForShutdown(): Promise<void> {
+  if (shutdownPromise) {
+    await shutdownPromise
+  }
 }


### PR DESCRIPTION
### What?

Make sure to gracefully shutdown the Turbopack process, by waiting for shutdown before killing the process.

This makes sure Persistent Caching will have time to store the cache, before it's killed. That should happen in background while doing SSG. (Maybe we need to change that in future for memory reasons, but it will work for now.)

Closes PACK-3887