### PR TITLE
refactor(turbo-tasks): Codemod/migrate all ResolvedVc casting callsites to use the new synchronous APIs

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1634,8 +1634,7 @@ impl AppEndpoint {
                     .edge_rsc_runtime_entries()
                     .await?
                     .clone_value();
-                let evaluatable = ResolvedVc::try_sidecast(app_entry.rsc_entry)
-                    .await?
+                let evaluatable = ResolvedVc::try_sidecast_sync(app_entry.rsc_entry)
                     .context("Entry module must be evaluatable")?;
                 evaluatable_assets.push(evaluatable);
                 evaluatable_assets.push(server_action_manifest_loader);
@@ -1676,9 +1675,10 @@ impl AppEndpoint {
                             .server_utils
                             .iter()
                             .map(|m| async move {
-                                Ok(*ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(*m)
-                                    .await?
-                                    .context("Expected server utils to be chunkable")?)
+                                Ok(
+                                    *ResolvedVc::try_downcast_sync::<Box<dyn ChunkableModule>>(*m)
+                                        .context("Expected server utils to be chunkable")?,
+                                )
                             })
                             .try_join()
                             .await?;

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1634,7 +1634,7 @@ impl AppEndpoint {
                     .edge_rsc_runtime_entries()
                     .await?
                     .clone_value();
-                let evaluatable = ResolvedVc::try_sidecast_sync(app_entry.rsc_entry)
+                let evaluatable = ResolvedVc::try_sidecast(app_entry.rsc_entry)
                     .context("Entry module must be evaluatable")?;
                 evaluatable_assets.push(evaluatable);
                 evaluatable_assets.push(server_action_manifest_loader);
@@ -1675,10 +1675,8 @@ impl AppEndpoint {
                             .server_utils
                             .iter()
                             .map(|m| async move {
-                                Ok(
-                                    *ResolvedVc::try_downcast_sync::<Box<dyn ChunkableModule>>(*m)
-                                        .context("Expected server utils to be chunkable")?,
-                                )
+                                Ok(*ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(*m)
+                                    .context("Expected server utils to be chunkable")?)
                             })
                             .try_join()
                             .await?;

--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -39,7 +39,7 @@ pub async fn map_client_references(
             let module = node.module;
 
             if let Some(client_reference_module) =
-                ResolvedVc::try_downcast_type_sync::<EcmascriptClientReferenceModule>(module)
+                ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(module)
             {
                 Ok(Some((
                     module,
@@ -49,7 +49,7 @@ pub async fn map_client_references(
                     },
                 )))
             } else if let Some(client_reference_module) =
-                ResolvedVc::try_downcast_type_sync::<CssClientReferenceModule>(module)
+                ResolvedVc::try_downcast_type::<CssClientReferenceModule>(module)
             {
                 Ok(Some((
                     module,
@@ -58,7 +58,7 @@ pub async fn map_client_references(
                     )),
                 )))
             } else if let Some(server_component) =
-                ResolvedVc::try_downcast_type_sync::<NextServerComponentModule>(module)
+                ResolvedVc::try_downcast_type::<NextServerComponentModule>(module)
             {
                 Ok(Some((
                     module,

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -132,7 +132,7 @@ pub async fn map_next_dynamic(graph: Vc<SingleModuleGraph>) -> Result<Vc<Dynamic
                 .is_some_and(|layer| &**layer == "app-client" || &**layer == "client")
             {
                 if let Some(dynamic_entry_module) =
-                    ResolvedVc::try_downcast_type::<NextDynamicEntryModule>(*module).await?
+                    ResolvedVc::try_downcast_type_sync::<NextDynamicEntryModule>(*module)
                 {
                     return Ok(Some((
                         *module,
@@ -143,7 +143,7 @@ pub async fn map_next_dynamic(graph: Vc<SingleModuleGraph>) -> Result<Vc<Dynamic
             // TODO add this check once these modules have the correct layer
             // if layer.is_some_and(|layer| &**layer == "app-rsc") {
             if let Some(client_reference_module) =
-                ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(*module).await?
+                ResolvedVc::try_downcast_type_sync::<EcmascriptClientReferenceModule>(*module)
             {
                 return Ok(Some((
                     *module,

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -132,7 +132,7 @@ pub async fn map_next_dynamic(graph: Vc<SingleModuleGraph>) -> Result<Vc<Dynamic
                 .is_some_and(|layer| &**layer == "app-client" || &**layer == "client")
             {
                 if let Some(dynamic_entry_module) =
-                    ResolvedVc::try_downcast_type_sync::<NextDynamicEntryModule>(*module)
+                    ResolvedVc::try_downcast_type::<NextDynamicEntryModule>(*module)
                 {
                     return Ok(Some((
                         *module,
@@ -143,7 +143,7 @@ pub async fn map_next_dynamic(graph: Vc<SingleModuleGraph>) -> Result<Vc<Dynamic
             // TODO add this check once these modules have the correct layer
             // if layer.is_some_and(|layer| &**layer == "app-rsc") {
             if let Some(client_reference_module) =
-                ResolvedVc::try_downcast_type_sync::<EcmascriptClientReferenceModule>(*module)
+                ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(*module)
             {
                 return Ok(Some((
                     *module,

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -124,12 +124,12 @@ impl InstrumentationEndpoint {
         .clone_value();
 
         let Some(module) =
-            ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(module).await?
+            ResolvedVc::try_downcast_sync::<Box<dyn EcmascriptChunkPlaceable>>(module)
         else {
             bail!("Entry module must be evaluatable");
         };
 
-        let Some(evaluatable) = ResolvedVc::try_sidecast(module).await? else {
+        let Some(evaluatable) = ResolvedVc::try_sidecast_sync(module) else {
             bail!("Entry module must be evaluatable");
         };
         evaluatable_assets.push(evaluatable);
@@ -155,7 +155,7 @@ impl InstrumentationEndpoint {
         let userland_module = self.core_modules().await?.userland_module;
         let module_graph = this.project.module_graph(*userland_module);
 
-        let Some(module) = ResolvedVc::try_downcast(userland_module).await? else {
+        let Some(module) = ResolvedVc::try_downcast_sync(userland_module) else {
             bail!("Entry module must be evaluatable");
         };
 

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -123,13 +123,12 @@ impl InstrumentationEndpoint {
         .await?
         .clone_value();
 
-        let Some(module) =
-            ResolvedVc::try_downcast_sync::<Box<dyn EcmascriptChunkPlaceable>>(module)
+        let Some(module) = ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(module)
         else {
             bail!("Entry module must be evaluatable");
         };
 
-        let Some(evaluatable) = ResolvedVc::try_sidecast_sync(module) else {
+        let Some(evaluatable) = ResolvedVc::try_sidecast(module) else {
             bail!("Entry module must be evaluatable");
         };
         evaluatable_assets.push(evaluatable);
@@ -155,7 +154,7 @@ impl InstrumentationEndpoint {
         let userland_module = self.core_modules().await?.userland_module;
         let module_graph = this.project.module_graph(*userland_module);
 
-        let Some(module) = ResolvedVc::try_downcast_sync(userland_module) else {
+        let Some(module) = ResolvedVc::try_downcast(userland_module) else {
             bail!("Entry module must be evaluatable");
         };
 

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -960,7 +960,7 @@ impl PageEndpoint {
             let is_edge = matches!(runtime, NextRuntime::Edge);
             if is_edge {
                 let mut evaluatable_assets = edge_runtime_entries.await?.clone_value();
-                let evaluatable = ResolvedVc::try_sidecast_sync(ssr_module)
+                let evaluatable = ResolvedVc::try_sidecast(ssr_module)
                     .context("could not process page loader entry module")?;
                 evaluatable_assets.push(evaluatable);
 

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -960,8 +960,7 @@ impl PageEndpoint {
             let is_edge = matches!(runtime, NextRuntime::Edge);
             if is_edge {
                 let mut evaluatable_assets = edge_runtime_entries.await?.clone_value();
-                let evaluatable = ResolvedVc::try_sidecast(ssr_module)
-                    .await?
+                let evaluatable = ResolvedVc::try_sidecast_sync(ssr_module)
                     .context("could not process page loader entry module")?;
                 evaluatable_assets.push(evaluatable);
 

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -196,7 +196,7 @@ impl VersionedContentMap {
         };
 
         if let Some(generate_source_map) =
-            ResolvedVc::try_sidecast_sync::<Box<dyn GenerateSourceMap>>(*asset)
+            ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(*asset)
         {
             Ok(if let Some(section) = section {
                 generate_source_map.by_section(section)

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -196,7 +196,7 @@ impl VersionedContentMap {
         };
 
         if let Some(generate_source_map) =
-            ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(*asset).await?
+            ResolvedVc::try_sidecast_sync::<Box<dyn GenerateSourceMap>>(*asset)
         {
             Ok(if let Some(section) = section {
                 generate_source_map.by_section(section)

--- a/crates/next-api/src/webpack_stats.rs
+++ b/crates/next-api/src/webpack_stats.rs
@@ -27,7 +27,7 @@ where
             continue;
         };
 
-        if let Some(chunk) = ResolvedVc::try_downcast_type::<EcmascriptDevChunk>(*asset).await? {
+        if let Some(chunk) = ResolvedVc::try_downcast_type_sync::<EcmascriptDevChunk>(*asset) {
             let chunk_ident = normalize_client_path(&chunk.ident().path().await?.path);
             chunks.push(WebpackStatsChunk {
                 size: asset_len,

--- a/crates/next-api/src/webpack_stats.rs
+++ b/crates/next-api/src/webpack_stats.rs
@@ -27,7 +27,7 @@ where
             continue;
         };
 
-        if let Some(chunk) = ResolvedVc::try_downcast_type_sync::<EcmascriptDevChunk>(*asset) {
+        if let Some(chunk) = ResolvedVc::try_downcast_type::<EcmascriptDevChunk>(*asset) {
             let chunk_ident = normalize_client_path(&chunk.ident().path().await?.path);
             chunks.push(WebpackStatsChunk {
                 size: asset_len,

--- a/crates/next-core/src/bootstrap.rs
+++ b/crates/next-core/src/bootstrap.rs
@@ -110,8 +110,7 @@ pub async fn bootstrap(
         .to_resolved()
         .await?;
 
-    let asset = ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(asset)
-        .await?
+    let asset = ResolvedVc::try_sidecast_sync::<Box<dyn EvaluatableAsset>>(asset)
         .context("internal module must be evaluatable")?;
 
     Ok(*asset)

--- a/crates/next-core/src/bootstrap.rs
+++ b/crates/next-core/src/bootstrap.rs
@@ -110,7 +110,7 @@ pub async fn bootstrap(
         .to_resolved()
         .await?;
 
-    let asset = ResolvedVc::try_sidecast_sync::<Box<dyn EvaluatableAsset>>(asset)
+    let asset = ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(asset)
         .context("internal module must be evaluatable")?;
 
     Ok(*asset)

--- a/crates/next-core/src/next_client/runtime_entry.rs
+++ b/crates/next-core/src/next_client/runtime_entry.rs
@@ -45,8 +45,7 @@ impl RuntimeEntry {
 
         let mut runtime_entries = Vec::with_capacity(modules.len());
         for &module in &modules {
-            if let Some(entry) =
-                ResolvedVc::try_downcast::<Box<dyn EvaluatableAsset>>(module).await?
+            if let Some(entry) = ResolvedVc::try_downcast_sync::<Box<dyn EvaluatableAsset>>(module)
             {
                 runtime_entries.push(entry);
             } else {

--- a/crates/next-core/src/next_client/runtime_entry.rs
+++ b/crates/next-core/src/next_client/runtime_entry.rs
@@ -45,8 +45,7 @@ impl RuntimeEntry {
 
         let mut runtime_entries = Vec::with_capacity(modules.len());
         for &module in &modules {
-            if let Some(entry) = ResolvedVc::try_downcast_sync::<Box<dyn EvaluatableAsset>>(module)
-            {
+            if let Some(entry) = ResolvedVc::try_downcast::<Box<dyn EvaluatableAsset>>(module) {
                 runtime_entries.push(entry);
             } else {
                 bail!(

--- a/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_transition.rs
+++ b/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_transition.rs
@@ -36,7 +36,7 @@ impl Transition for NextCssClientReferenceTransition {
             return Ok(ProcessResult::Ignore.cell());
         };
 
-        let client_module = ResolvedVc::try_sidecast_sync::<Box<dyn CssChunkPlaceable>>(module)
+        let client_module = ResolvedVc::try_sidecast::<Box<dyn CssChunkPlaceable>>(module)
             .context("css client asset is not css chunk placeable")?;
 
         Ok(ProcessResult::Module(ResolvedVc::upcast(

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
@@ -99,13 +99,13 @@ impl Transition for NextEcmascriptClientReferenceTransition {
         };
 
         let Some(client_module) =
-            ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(client_module).await?
+            ResolvedVc::try_sidecast_sync::<Box<dyn EcmascriptChunkPlaceable>>(client_module)
         else {
             bail!("client asset is not ecmascript chunk placeable");
         };
 
         let Some(ssr_module) =
-            ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(ssr_module).await?
+            ResolvedVc::try_sidecast_sync::<Box<dyn EcmascriptChunkPlaceable>>(ssr_module)
         else {
             bail!("SSR asset is not ecmascript chunk placeable");
         };

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
@@ -99,13 +99,13 @@ impl Transition for NextEcmascriptClientReferenceTransition {
         };
 
         let Some(client_module) =
-            ResolvedVc::try_sidecast_sync::<Box<dyn EcmascriptChunkPlaceable>>(client_module)
+            ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(client_module)
         else {
             bail!("client asset is not ecmascript chunk placeable");
         };
 
         let Some(ssr_module) =
-            ResolvedVc::try_sidecast_sync::<Box<dyn EcmascriptChunkPlaceable>>(ssr_module)
+            ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(ssr_module)
         else {
             bail!("SSR asset is not ecmascript chunk placeable");
         };

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -166,9 +166,8 @@ pub async fn client_reference_graph(
                     .map(|module| async move {
                         Ok(VisitClientReferenceNode {
                             state: if let Some(server_component) =
-                                ResolvedVc::try_downcast_type_sync::<NextServerComponentModule>(
-                                    module,
-                                ) {
+                                ResolvedVc::try_downcast_type::<NextServerComponentModule>(module)
+                            {
                                 VisitClientReferenceNodeState::InServerComponent {
                                     server_component,
                                 }
@@ -414,9 +413,8 @@ impl Visit<VisitClientReferenceNode> for VisitClientReference {
                 })
                 .flatten()
                 .map(|module| async move {
-                    if let Some(client_reference_module) = ResolvedVc::try_downcast_type_sync::<
-                        EcmascriptClientReferenceModule,
-                    >(*module)
+                    if let Some(client_reference_module) =
+                        ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(*module)
                     {
                         return Ok(VisitClientReferenceNode {
                             state: node.state,
@@ -433,7 +431,7 @@ impl Visit<VisitClientReferenceNode> for VisitClientReference {
                     }
 
                     if let Some(client_reference_module) =
-                        ResolvedVc::try_downcast_type_sync::<CssClientReferenceModule>(*module)
+                        ResolvedVc::try_downcast_type::<CssClientReferenceModule>(*module)
                     {
                         return Ok(VisitClientReferenceNode {
                             state: node.state,
@@ -450,7 +448,7 @@ impl Visit<VisitClientReferenceNode> for VisitClientReference {
                     }
 
                     if let Some(server_component_asset) =
-                        ResolvedVc::try_downcast_type_sync::<NextServerComponentModule>(*module)
+                        ResolvedVc::try_downcast_type::<NextServerComponentModule>(*module)
                     {
                         return Ok(VisitClientReferenceNode {
                             state: VisitClientReferenceNodeState::InServerComponent {
@@ -463,9 +461,7 @@ impl Visit<VisitClientReferenceNode> for VisitClientReference {
                         });
                     }
 
-                    if ResolvedVc::try_downcast_type_sync::<NextServerUtilityModule>(*module)
-                        .is_some()
-                    {
+                    if ResolvedVc::try_downcast_type::<NextServerUtilityModule>(*module).is_some() {
                         return Ok(VisitClientReferenceNode {
                             state: VisitClientReferenceNodeState::InServerUtil,
                             ty: VisitClientReferenceNodeType::ServerUtilEntry(

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -166,9 +166,9 @@ pub async fn client_reference_graph(
                     .map(|module| async move {
                         Ok(VisitClientReferenceNode {
                             state: if let Some(server_component) =
-                                ResolvedVc::try_downcast_type::<NextServerComponentModule>(module)
-                                    .await?
-                            {
+                                ResolvedVc::try_downcast_type_sync::<NextServerComponentModule>(
+                                    module,
+                                ) {
                                 VisitClientReferenceNodeState::InServerComponent {
                                     server_component,
                                 }
@@ -414,9 +414,9 @@ impl Visit<VisitClientReferenceNode> for VisitClientReference {
                 })
                 .flatten()
                 .map(|module| async move {
-                    if let Some(client_reference_module) =
-                        ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(*module)
-                            .await?
+                    if let Some(client_reference_module) = ResolvedVc::try_downcast_type_sync::<
+                        EcmascriptClientReferenceModule,
+                    >(*module)
                     {
                         return Ok(VisitClientReferenceNode {
                             state: node.state,
@@ -433,7 +433,7 @@ impl Visit<VisitClientReferenceNode> for VisitClientReference {
                     }
 
                     if let Some(client_reference_module) =
-                        ResolvedVc::try_downcast_type::<CssClientReferenceModule>(*module).await?
+                        ResolvedVc::try_downcast_type_sync::<CssClientReferenceModule>(*module)
                     {
                         return Ok(VisitClientReferenceNode {
                             state: node.state,
@@ -450,7 +450,7 @@ impl Visit<VisitClientReferenceNode> for VisitClientReference {
                     }
 
                     if let Some(server_component_asset) =
-                        ResolvedVc::try_downcast_type::<NextServerComponentModule>(*module).await?
+                        ResolvedVc::try_downcast_type_sync::<NextServerComponentModule>(*module)
                     {
                         return Ok(VisitClientReferenceNode {
                             state: VisitClientReferenceNodeState::InServerComponent {
@@ -463,8 +463,7 @@ impl Visit<VisitClientReferenceNode> for VisitClientReference {
                         });
                     }
 
-                    if ResolvedVc::try_downcast_type::<NextServerUtilityModule>(*module)
-                        .await?
+                    if ResolvedVc::try_downcast_type_sync::<NextServerUtilityModule>(*module)
                         .is_some()
                     {
                         return Ok(VisitClientReferenceNode {

--- a/crates/next-core/src/next_dynamic/dynamic_transition.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_transition.rs
@@ -69,10 +69,9 @@ impl Transition for NextDynamicTransition {
 
         Ok(match &*module.try_into_module().await? {
             Some(client_module) => {
-                let Some(client_module) =
-                    ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(*client_module)
-                        .await?
-                else {
+                let Some(client_module) = ResolvedVc::try_sidecast_sync::<
+                    Box<dyn EcmascriptChunkPlaceable>,
+                >(*client_module) else {
                     bail!("not an ecmascript client_module");
                 };
 

--- a/crates/next-core/src/next_dynamic/dynamic_transition.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_transition.rs
@@ -69,9 +69,9 @@ impl Transition for NextDynamicTransition {
 
         Ok(match &*module.try_into_module().await? {
             Some(client_module) => {
-                let Some(client_module) = ResolvedVc::try_sidecast_sync::<
-                    Box<dyn EcmascriptChunkPlaceable>,
-                >(*client_module) else {
+                let Some(client_module) =
+                    ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(*client_module)
+                else {
                     bail!("not an ecmascript client_module");
                 };
 

--- a/crates/next-core/src/next_dynamic/visit_dynamic.rs
+++ b/crates/next-core/src/next_dynamic/visit_dynamic.rs
@@ -94,7 +94,7 @@ impl Visit<VisitDynamicNode> for VisitDynamic {
 
             let referenced_modules = referenced_modules.iter().map(|module| async move {
                 if let Some(next_dynamic_module) =
-                    ResolvedVc::try_downcast_type_sync::<NextDynamicEntryModule>(*module)
+                    ResolvedVc::try_downcast_type::<NextDynamicEntryModule>(*module)
                 {
                     return Ok(VisitDynamicNode::Dynamic(
                         next_dynamic_module,

--- a/crates/next-core/src/next_dynamic/visit_dynamic.rs
+++ b/crates/next-core/src/next_dynamic/visit_dynamic.rs
@@ -94,7 +94,7 @@ impl Visit<VisitDynamicNode> for VisitDynamic {
 
             let referenced_modules = referenced_modules.iter().map(|module| async move {
                 if let Some(next_dynamic_module) =
-                    ResolvedVc::try_downcast_type::<NextDynamicEntryModule>(*module).await?
+                    ResolvedVc::try_downcast_type_sync::<NextDynamicEntryModule>(*module)
                 {
                     return Ok(VisitDynamicNode::Dynamic(
                         next_dynamic_module,

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -428,8 +428,7 @@ async fn parse_route_matcher_from_js_value(
 pub async fn parse_config_from_source(
     module: ResolvedVc<Box<dyn Module>>,
 ) -> Result<Vc<NextSourceConfig>> {
-    if let Some(ecmascript_asset) =
-        ResolvedVc::try_sidecast_sync::<Box<dyn EcmascriptParsable>>(module)
+    if let Some(ecmascript_asset) = ResolvedVc::try_sidecast::<Box<dyn EcmascriptParsable>>(module)
     {
         if let ParseResult::Ok {
             program: Program::Module(module_ast),

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -429,7 +429,7 @@ pub async fn parse_config_from_source(
     module: ResolvedVc<Box<dyn Module>>,
 ) -> Result<Vc<NextSourceConfig>> {
     if let Some(ecmascript_asset) =
-        ResolvedVc::try_sidecast::<Box<dyn EcmascriptParsable>>(module).await?
+        ResolvedVc::try_sidecast_sync::<Box<dyn EcmascriptParsable>>(module)
     {
         if let ParseResult::Ok {
             program: Program::Module(module_ast),

--- a/turbopack/crates/turbo-tasks-testing/tests/resolved_vc.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/resolved_vc.rs
@@ -83,9 +83,9 @@ async fn test_sidecast() -> Result<()> {
     run(&REGISTRATION, || async {
         let concrete_value = ImplementsAandB.resolved_cell();
         let as_a = ResolvedVc::upcast::<Box<dyn TraitA>>(concrete_value);
-        let as_b = ResolvedVc::try_sidecast_sync::<Box<dyn TraitB>>(as_a);
+        let as_b = ResolvedVc::try_sidecast::<Box<dyn TraitB>>(as_a);
         assert!(as_b.is_some());
-        let as_c = ResolvedVc::try_sidecast_sync::<Box<dyn TraitC>>(as_a);
+        let as_c = ResolvedVc::try_sidecast::<Box<dyn TraitC>>(as_a);
         assert!(as_c.is_none());
         Ok(())
     })

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -14,7 +14,7 @@ use crate::{
     debug::{ValueDebug, ValueDebugFormat, ValueDebugFormatString},
     trace::{TraceRawVcs, TraceRawVcsContext},
     vc::Vc,
-    ResolveTypeError, Upcast, VcRead, VcTransparentRead, VcValueTrait, VcValueType,
+    Upcast, VcRead, VcTransparentRead, VcValueTrait, VcValueType,
 };
 
 /// A "subtype" (via [`Deref`]) of [`Vc`] that represents a specific [`Vc::cell`]/`.cell()` or
@@ -211,23 +211,6 @@ impl<T> ResolvedVc<T>
 where
     T: VcValueTrait + ?Sized,
 {
-    /// Attempts to sidecast the given `Vc<Box<dyn T>>` to a `Vc<Box<dyn K>>`.
-    ///
-    /// Returns `None` if the underlying value type does not implement `K`.
-    ///
-    /// **Note:** if the trait `T` is required to implement `K`, use [`ResolvedVc::upcast`] instead.
-    /// This provides stronger guarantees, removing the need for a [`Result`] return type.
-    ///
-    /// See also: [`Vc::try_resolve_sidecast`].
-    pub async fn try_sidecast<K>(this: Self) -> Result<Option<ResolvedVc<K>>, ResolveTypeError>
-    where
-        K: VcValueTrait + ?Sized,
-    {
-        // TODO: Expose a synchronous API instead of this async one that returns `Result<Option<_>>`
-        Ok(Self::try_sidecast_sync(this))
-    }
-
-    /// Attempts to sidecast the given `ResolvedVc<Box<dyn T>>` to a `ResolvedVc<Box<dyn K>>`.
     ///
     /// Returns `None` if the underlying value type does not implement `K`.
     ///
@@ -258,39 +241,12 @@ where
     /// Returns `None` if the underlying value type is not a `K`.
     ///
     /// See also: [`Vc::try_resolve_downcast`].
-    pub async fn try_downcast<K>(this: Self) -> Result<Option<ResolvedVc<K>>, ResolveTypeError>
-    where
-        K: Upcast<T> + VcValueTrait + ?Sized,
-    {
-        // TODO: Expose a synchronous API instead of this async one that returns `Result<Option<_>>`
-        Ok(Self::try_downcast_sync(this))
-    }
-
-    /// Attempts to downcast the given `ResolvedVc<Box<dyn T>>` to a `ResolvedVc<K>`, where `K`
-    /// is of the form `Box<dyn L>`, and `L` is a value trait.
-    ///
-    /// Returns `None` if the underlying value type is not a `K`.
-    ///
-    /// See also: [`Vc::try_resolve_downcast`].
     pub fn try_downcast_sync<K>(this: Self) -> Option<ResolvedVc<K>>
     where
         K: Upcast<T> + VcValueTrait + ?Sized,
     {
         // this is just a more type-safe version of a sidecast
         Self::try_sidecast_sync(this)
-    }
-
-    /// Attempts to downcast the given `Vc<Box<dyn T>>` to a `Vc<K>`, where `K` is a value type.
-    ///
-    /// Returns `None` if the underlying value type is not a `K`.
-    ///
-    /// See also: [`Vc::try_resolve_downcast_type`].
-    pub async fn try_downcast_type<K>(this: Self) -> Result<Option<ResolvedVc<K>>, ResolveTypeError>
-    where
-        K: Upcast<T> + VcValueType,
-    {
-        // TODO: Expose a synchronous API instead of this async one that returns `Result<Option<_>>`
-        Ok(Self::try_downcast_type_sync(this))
     }
 
     /// Attempts to downcast the given `Vc<Box<dyn T>>` to a `Vc<K>`, where `K` is a value type.

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -211,14 +211,13 @@ impl<T> ResolvedVc<T>
 where
     T: VcValueTrait + ?Sized,
 {
-    ///
     /// Returns `None` if the underlying value type does not implement `K`.
     ///
     /// **Note:** if the trait `T` is required to implement `K`, use [`ResolvedVc::upcast`] instead.
     /// This provides stronger guarantees, removing the need for a [`Result`] return type.
     ///
     /// See also: [`Vc::try_resolve_sidecast`].
-    pub fn try_sidecast_sync<K>(this: Self) -> Option<ResolvedVc<K>>
+    pub fn try_sidecast<K>(this: Self) -> Option<ResolvedVc<K>>
     where
         K: VcValueTrait + ?Sized,
     {
@@ -241,12 +240,12 @@ where
     /// Returns `None` if the underlying value type is not a `K`.
     ///
     /// See also: [`Vc::try_resolve_downcast`].
-    pub fn try_downcast_sync<K>(this: Self) -> Option<ResolvedVc<K>>
+    pub fn try_downcast<K>(this: Self) -> Option<ResolvedVc<K>>
     where
         K: Upcast<T> + VcValueTrait + ?Sized,
     {
         // this is just a more type-safe version of a sidecast
-        Self::try_sidecast_sync(this)
+        Self::try_sidecast(this)
     }
 
     /// Attempts to downcast the given `Vc<Box<dyn T>>` to a `Vc<K>`, where `K` is a value type.
@@ -254,7 +253,7 @@ where
     /// Returns `None` if the underlying value type is not a `K`.
     ///
     /// See also: [`Vc::try_resolve_downcast_type`].
-    pub fn try_downcast_type_sync<K>(this: Self) -> Option<ResolvedVc<K>>
+    pub fn try_downcast_type<K>(this: Self) -> Option<ResolvedVc<K>>
     where
         K: Upcast<T> + VcValueType,
     {

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -107,7 +107,7 @@ impl EcmascriptDevEvaluateChunk {
                 let module_graph = this.module_graph;
                 move |entry| async move {
                     if let Some(placeable) =
-                        ResolvedVc::try_sidecast_sync::<Box<dyn EcmascriptChunkPlaceable>>(*entry)
+                        ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(*entry)
                     {
                         Ok(Some(
                             placeable

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -107,8 +107,7 @@ impl EcmascriptDevEvaluateChunk {
                 let module_graph = this.module_graph;
                 move |entry| async move {
                     if let Some(placeable) =
-                        ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(*entry)
-                            .await?
+                        ResolvedVc::try_sidecast_sync::<Box<dyn EcmascriptChunkPlaceable>>(*entry)
                     {
                         Ok(Some(
                             placeable

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
@@ -75,7 +75,7 @@ impl EcmascriptDevChunkListContent {
 
         for (chunk_path, chunk_content) in &self.chunks_contents {
             if let Some(mergeable) =
-                ResolvedVc::try_sidecast_sync::<Box<dyn MergeableVersionedContent>>(*chunk_content)
+                ResolvedVc::try_sidecast::<Box<dyn MergeableVersionedContent>>(*chunk_content)
             {
                 let merger = mergeable.get_merger().resolve().await?;
                 by_merger.entry(merger).or_default().push(*chunk_content);

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
@@ -75,8 +75,7 @@ impl EcmascriptDevChunkListContent {
 
         for (chunk_path, chunk_content) in &self.chunks_contents {
             if let Some(mergeable) =
-                ResolvedVc::try_sidecast::<Box<dyn MergeableVersionedContent>>(*chunk_content)
-                    .await?
+                ResolvedVc::try_sidecast_sync::<Box<dyn MergeableVersionedContent>>(*chunk_content)
             {
                 let merger = mergeable.get_merger().resolve().await?;
                 by_merger.entry(merger).or_default().push(*chunk_content);

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/update.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/update.rs
@@ -91,7 +91,7 @@ pub(super) async fn update_chunk_list(
 
     for (chunk_path, chunk_content) in &content.chunks_contents {
         if let Some(mergeable) =
-            ResolvedVc::try_sidecast::<Box<dyn MergeableVersionedContent>>(*chunk_content).await?
+            ResolvedVc::try_sidecast_sync::<Box<dyn MergeableVersionedContent>>(*chunk_content)
         {
             let merger = mergeable.get_merger().to_resolved().await?;
             by_merger.entry(merger).or_default().push(*chunk_content);

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/update.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/update.rs
@@ -91,7 +91,7 @@ pub(super) async fn update_chunk_list(
 
     for (chunk_path, chunk_content) in &content.chunks_contents {
         if let Some(mergeable) =
-            ResolvedVc::try_sidecast_sync::<Box<dyn MergeableVersionedContent>>(*chunk_content)
+            ResolvedVc::try_sidecast::<Box<dyn MergeableVersionedContent>>(*chunk_content)
         {
             let merger = mergeable.get_merger().to_resolved().await?;
             by_merger.entry(merger).or_default().push(*chunk_content);

--- a/turbopack/crates/turbopack-browser/src/ecmascript/merged/merger.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/merged/merger.rs
@@ -31,7 +31,7 @@ impl VersionedContentMerger for EcmascriptDevChunkContentMerger {
             .iter()
             .map(|content| async move {
                 if let Some(content) =
-                    ResolvedVc::try_downcast_type_sync::<EcmascriptDevChunkContent>(*content)
+                    ResolvedVc::try_downcast_type::<EcmascriptDevChunkContent>(*content)
                 {
                     Ok(content)
                 } else {

--- a/turbopack/crates/turbopack-browser/src/ecmascript/merged/merger.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/merged/merger.rs
@@ -31,7 +31,7 @@ impl VersionedContentMerger for EcmascriptDevChunkContentMerger {
             .iter()
             .map(|content| async move {
                 if let Some(content) =
-                    ResolvedVc::try_downcast_type::<EcmascriptDevChunkContent>(*content).await?
+                    ResolvedVc::try_downcast_type_sync::<EcmascriptDevChunkContent>(*content)
                 {
                     Ok(content)
                 } else {

--- a/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
@@ -45,8 +45,7 @@ impl RuntimeEntry {
 
         let mut runtime_entries = Vec::with_capacity(modules.len());
         for &module in &modules {
-            if let Some(entry) =
-                ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(module).await?
+            if let Some(entry) = ResolvedVc::try_sidecast_sync::<Box<dyn EvaluatableAsset>>(module)
             {
                 runtime_entries.push(entry);
             } else {

--- a/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
@@ -45,8 +45,7 @@ impl RuntimeEntry {
 
         let mut runtime_entries = Vec::with_capacity(modules.len());
         for &module in &modules {
-            if let Some(entry) = ResolvedVc::try_sidecast_sync::<Box<dyn EvaluatableAsset>>(module)
-            {
+            if let Some(entry) = ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(module) {
                 runtime_entries.push(entry);
             } else {
                 bail!(

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -375,7 +375,7 @@ async fn build_internal(
         .map(|entry_module| async move {
             Ok(
                 if let Some(ecmascript) =
-                    ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(entry_module).await?
+                    ResolvedVc::try_sidecast_sync::<Box<dyn EvaluatableAsset>>(entry_module)
                 {
                     match target {
                         Target::Browser => {

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -375,7 +375,7 @@ async fn build_internal(
         .map(|entry_module| async move {
             Ok(
                 if let Some(ecmascript) =
-                    ResolvedVc::try_sidecast_sync::<Box<dyn EvaluatableAsset>>(entry_module)
+                    ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(entry_module)
                 {
                     match target {
                         Target::Browser => {

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -163,8 +163,8 @@ pub async fn create_web_entry_source(
         .into_iter()
         .map(|module| async move {
             if let (Some(chunkable_module), Some(entry)) = (
-                ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(module).await?,
-                ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(module).await?,
+                ResolvedVc::try_sidecast_sync::<Box<dyn ChunkableModule>>(module),
+                ResolvedVc::try_sidecast_sync::<Box<dyn EvaluatableAsset>>(module),
             ) {
                 Ok(DevHtmlEntry {
                     chunkable_module,
@@ -173,7 +173,7 @@ pub async fn create_web_entry_source(
                     runtime_entries: Some(runtime_entries.with_entry(*entry).to_resolved().await?),
                 })
             } else if let Some(chunkable_module) =
-                ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(module).await?
+                ResolvedVc::try_sidecast_sync::<Box<dyn ChunkableModule>>(module)
             {
                 // TODO this is missing runtime code, so it's probably broken and we should also
                 // add an ecmascript chunk with the runtime code

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -163,8 +163,8 @@ pub async fn create_web_entry_source(
         .into_iter()
         .map(|module| async move {
             if let (Some(chunkable_module), Some(entry)) = (
-                ResolvedVc::try_sidecast_sync::<Box<dyn ChunkableModule>>(module),
-                ResolvedVc::try_sidecast_sync::<Box<dyn EvaluatableAsset>>(module),
+                ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(module),
+                ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(module),
             ) {
                 Ok(DevHtmlEntry {
                     chunkable_module,
@@ -173,7 +173,7 @@ pub async fn create_web_entry_source(
                     runtime_entries: Some(runtime_entries.with_entry(*entry).to_resolved().await?),
                 })
             } else if let Some(chunkable_module) =
-                ResolvedVc::try_sidecast_sync::<Box<dyn ChunkableModule>>(module)
+                ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(module)
             {
                 // TODO this is missing runtime code, so it's probably broken and we should also
                 // add an ecmascript chunk with the runtime code

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -312,7 +312,7 @@ pub async fn chunk_group_content(
                 }
 
                 let Some(chunkable_module) =
-                    ResolvedVc::try_sidecast_sync::<Box<dyn ChunkableModule>>(node.module)
+                    ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(node.module)
                 else {
                     return Ok(GraphTraversalAction::Skip);
                 };
@@ -331,7 +331,7 @@ pub async fn chunk_group_content(
                 };
 
                 let parent_module =
-                    ResolvedVc::try_sidecast_sync::<Box<dyn ChunkableModule>>(parent_node.module)
+                    ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(parent_node.module)
                         .context("Expected parent module to be chunkable")?;
 
                 Ok(match edge {

--- a/turbopack/crates/turbopack-core/src/introspect/module.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/module.rs
@@ -15,9 +15,10 @@ pub struct IntrospectableModule(ResolvedVc<Box<dyn Module>>);
 impl IntrospectableModule {
     #[turbo_tasks::function]
     pub async fn new(asset: ResolvedVc<Box<dyn Module>>) -> Result<Vc<Box<dyn Introspectable>>> {
-        Ok(*ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(asset)
-            .await?
-            .unwrap_or_else(|| ResolvedVc::upcast(IntrospectableModule(asset).resolved_cell())))
+        Ok(
+            *ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(asset)
+                .unwrap_or_else(|| ResolvedVc::upcast(IntrospectableModule(asset).resolved_cell())),
+        )
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/introspect/module.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/module.rs
@@ -15,10 +15,8 @@ pub struct IntrospectableModule(ResolvedVc<Box<dyn Module>>);
 impl IntrospectableModule {
     #[turbo_tasks::function]
     pub async fn new(asset: ResolvedVc<Box<dyn Module>>) -> Result<Vc<Box<dyn Introspectable>>> {
-        Ok(
-            *ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(asset)
-                .unwrap_or_else(|| ResolvedVc::upcast(IntrospectableModule(asset).resolved_cell())),
-        )
+        Ok(*ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(asset)
+            .unwrap_or_else(|| ResolvedVc::upcast(IntrospectableModule(asset).resolved_cell())))
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/introspect/output_asset.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/output_asset.rs
@@ -18,7 +18,7 @@ impl IntrospectableOutputAsset {
         asset: ResolvedVc<Box<dyn OutputAsset>>,
     ) -> Result<Vc<Box<dyn Introspectable>>> {
         Ok(
-            *ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(asset).unwrap_or_else(|| {
+            *ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(asset).unwrap_or_else(|| {
                 ResolvedVc::upcast(IntrospectableOutputAsset(asset).resolved_cell())
             }),
         )

--- a/turbopack/crates/turbopack-core/src/introspect/output_asset.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/output_asset.rs
@@ -17,11 +17,11 @@ impl IntrospectableOutputAsset {
     pub async fn new(
         asset: ResolvedVc<Box<dyn OutputAsset>>,
     ) -> Result<Vc<Box<dyn Introspectable>>> {
-        Ok(*ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(asset)
-            .await?
-            .unwrap_or_else(|| {
+        Ok(
+            *ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(asset).unwrap_or_else(|| {
                 ResolvedVc::upcast(IntrospectableOutputAsset(asset).resolved_cell())
-            }))
+            }),
+        )
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/introspect/source.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/source.rs
@@ -12,10 +12,8 @@ pub struct IntrospectableSource(ResolvedVc<Box<dyn Source>>);
 impl IntrospectableSource {
     #[turbo_tasks::function]
     pub async fn new(asset: ResolvedVc<Box<dyn Source>>) -> Result<Vc<Box<dyn Introspectable>>> {
-        Ok(
-            *ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(asset)
-                .unwrap_or_else(|| ResolvedVc::upcast(IntrospectableSource(asset).resolved_cell())),
-        )
+        Ok(*ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(asset)
+            .unwrap_or_else(|| ResolvedVc::upcast(IntrospectableSource(asset).resolved_cell())))
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/introspect/source.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/source.rs
@@ -12,9 +12,10 @@ pub struct IntrospectableSource(ResolvedVc<Box<dyn Source>>);
 impl IntrospectableSource {
     #[turbo_tasks::function]
     pub async fn new(asset: ResolvedVc<Box<dyn Source>>) -> Result<Vc<Box<dyn Introspectable>>> {
-        Ok(*ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(asset)
-            .await?
-            .unwrap_or_else(|| ResolvedVc::upcast(IntrospectableSource(asset).resolved_cell())))
+        Ok(
+            *ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(asset)
+                .unwrap_or_else(|| ResolvedVc::upcast(IntrospectableSource(asset).resolved_cell())),
+        )
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/introspect/utils.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/utils.rs
@@ -77,7 +77,7 @@ pub async fn children_from_module_references(
     for &reference in &*references {
         let mut key = key;
         if let Some(chunkable) =
-            ResolvedVc::try_downcast_sync::<Box<dyn ChunkableModuleReference>>(reference)
+            ResolvedVc::try_downcast::<Box<dyn ChunkableModuleReference>>(reference)
         {
             match &*chunkable.chunking_type().await? {
                 None => {}

--- a/turbopack/crates/turbopack-core/src/introspect/utils.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/utils.rs
@@ -77,7 +77,7 @@ pub async fn children_from_module_references(
     for &reference in &*references {
         let mut key = key;
         if let Some(chunkable) =
-            ResolvedVc::try_downcast::<Box<dyn ChunkableModuleReference>>(reference).await?
+            ResolvedVc::try_downcast_sync::<Box<dyn ChunkableModuleReference>>(reference)
         {
             match &*chunkable.chunking_type().await? {
                 None => {}

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -598,8 +598,7 @@ async fn source_pos(
     start: SourcePos,
     end: SourcePos,
 ) -> Result<Option<(ResolvedVc<Box<dyn Source>>, SourcePos, SourcePos)>> {
-    let Some(generator) = ResolvedVc::try_sidecast_sync::<Box<dyn GenerateSourceMap>>(source)
-    else {
+    let Some(generator) = ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(source) else {
         return Ok(None);
     };
 

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -598,7 +598,7 @@ async fn source_pos(
     start: SourcePos,
     end: SourcePos,
 ) -> Result<Option<(ResolvedVc<Box<dyn Source>>, SourcePos, SourcePos)>> {
-    let Some(generator) = ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(source).await?
+    let Some(generator) = ResolvedVc::try_sidecast_sync::<Box<dyn GenerateSourceMap>>(source)
     else {
         return Ok(None);
     };

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -289,7 +289,7 @@ pub async fn primary_chunkable_referenced_modules(
         .iter()
         .map(|reference| async {
             if let Some(reference) =
-                ResolvedVc::try_downcast::<Box<dyn ChunkableModuleReference>>(*reference).await?
+                ResolvedVc::try_downcast_sync::<Box<dyn ChunkableModuleReference>>(*reference)
             {
                 if let Some(chunking_type) = &*reference.chunking_type().await? {
                     let resolved = reference

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -289,7 +289,7 @@ pub async fn primary_chunkable_referenced_modules(
         .iter()
         .map(|reference| async {
             if let Some(reference) =
-                ResolvedVc::try_downcast_sync::<Box<dyn ChunkableModuleReference>>(*reference)
+                ResolvedVc::try_downcast::<Box<dyn ChunkableModuleReference>>(*reference)
             {
                 if let Some(chunking_type) = &*reference.chunking_type().await? {
                     let resolved = reference

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -40,7 +40,7 @@ impl Asset for SourceMapAsset {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<AssetContent>> {
         let Some(generate_source_map) =
-            ResolvedVc::try_sidecast_sync::<Box<dyn GenerateSourceMap>>(self.asset)
+            ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(self.asset)
         else {
             bail!("asset does not support generating source maps")
         };
@@ -84,7 +84,7 @@ impl Introspectable for SourceMapAsset {
     #[turbo_tasks::function]
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         let mut children = FxIndexSet::default();
-        if let Some(asset) = ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(self.asset) {
+        if let Some(asset) = ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.asset) {
             children.insert((ResolvedVc::cell("asset".into()), asset));
         }
         Ok(Vc::cell(children))

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -40,7 +40,7 @@ impl Asset for SourceMapAsset {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<AssetContent>> {
         let Some(generate_source_map) =
-            ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(self.asset).await?
+            ResolvedVc::try_sidecast_sync::<Box<dyn GenerateSourceMap>>(self.asset)
         else {
             bail!("asset does not support generating source maps")
         };
@@ -84,8 +84,7 @@ impl Introspectable for SourceMapAsset {
     #[turbo_tasks::function]
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         let mut children = FxIndexSet::default();
-        if let Some(asset) = ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.asset).await?
-        {
+        if let Some(asset) = ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(self.asset) {
             children.insert((ResolvedVc::cell("asset".into()), asset));
         }
         Ok(Vc::cell(children))

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -215,7 +215,7 @@ impl CssChunkItem for CssModuleChunkItem {
 
         for reference in references.iter() {
             if let Some(import_ref) =
-                ResolvedVc::try_downcast_type::<ImportAssetReference>(*reference).await?
+                ResolvedVc::try_downcast_type_sync::<ImportAssetReference>(*reference)
             {
                 for &module in import_ref
                     .resolve_reference()
@@ -226,7 +226,7 @@ impl CssChunkItem for CssModuleChunkItem {
                     .iter()
                 {
                     if let Some(placeable) =
-                        ResolvedVc::try_downcast::<Box<dyn CssChunkPlaceable>>(module).await?
+                        ResolvedVc::try_downcast_sync::<Box<dyn CssChunkPlaceable>>(module)
                     {
                         let item = placeable.as_chunk_item(*self.module_graph, *chunking_context);
                         if let Some(css_item) =
@@ -240,7 +240,7 @@ impl CssChunkItem for CssModuleChunkItem {
                     }
                 }
             } else if let Some(compose_ref) =
-                ResolvedVc::try_downcast_type::<CssModuleComposeReference>(*reference).await?
+                ResolvedVc::try_downcast_type_sync::<CssModuleComposeReference>(*reference)
             {
                 for &module in compose_ref
                     .resolve_reference()
@@ -251,7 +251,7 @@ impl CssChunkItem for CssModuleChunkItem {
                     .iter()
                 {
                     if let Some(placeable) =
-                        ResolvedVc::try_downcast::<Box<dyn CssChunkPlaceable>>(module).await?
+                        ResolvedVc::try_downcast_sync::<Box<dyn CssChunkPlaceable>>(module)
                     {
                         let item = placeable.as_chunk_item(*self.module_graph, *chunking_context);
                         if let Some(css_item) =
@@ -266,9 +266,7 @@ impl CssChunkItem for CssModuleChunkItem {
 
         let mut code_gens = Vec::new();
         for r in references.iter() {
-            if let Some(code_gen) =
-                ResolvedVc::try_sidecast::<Box<dyn CodeGenerateable>>(*r).await?
-            {
+            if let Some(code_gen) = ResolvedVc::try_sidecast_sync::<Box<dyn CodeGenerateable>>(*r) {
                 code_gens.push(code_gen.code_generation(*chunking_context));
             }
         }

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -215,7 +215,7 @@ impl CssChunkItem for CssModuleChunkItem {
 
         for reference in references.iter() {
             if let Some(import_ref) =
-                ResolvedVc::try_downcast_type_sync::<ImportAssetReference>(*reference)
+                ResolvedVc::try_downcast_type::<ImportAssetReference>(*reference)
             {
                 for &module in import_ref
                     .resolve_reference()
@@ -226,7 +226,7 @@ impl CssChunkItem for CssModuleChunkItem {
                     .iter()
                 {
                     if let Some(placeable) =
-                        ResolvedVc::try_downcast_sync::<Box<dyn CssChunkPlaceable>>(module)
+                        ResolvedVc::try_downcast::<Box<dyn CssChunkPlaceable>>(module)
                     {
                         let item = placeable.as_chunk_item(*self.module_graph, *chunking_context);
                         if let Some(css_item) =
@@ -240,7 +240,7 @@ impl CssChunkItem for CssModuleChunkItem {
                     }
                 }
             } else if let Some(compose_ref) =
-                ResolvedVc::try_downcast_type_sync::<CssModuleComposeReference>(*reference)
+                ResolvedVc::try_downcast_type::<CssModuleComposeReference>(*reference)
             {
                 for &module in compose_ref
                     .resolve_reference()
@@ -251,7 +251,7 @@ impl CssChunkItem for CssModuleChunkItem {
                     .iter()
                 {
                     if let Some(placeable) =
-                        ResolvedVc::try_downcast_sync::<Box<dyn CssChunkPlaceable>>(module)
+                        ResolvedVc::try_downcast::<Box<dyn CssChunkPlaceable>>(module)
                     {
                         let item = placeable.as_chunk_item(*self.module_graph, *chunking_context);
                         if let Some(css_item) =
@@ -266,7 +266,7 @@ impl CssChunkItem for CssModuleChunkItem {
 
         let mut code_gens = Vec::new();
         for r in references.iter() {
-            if let Some(code_gen) = ResolvedVc::try_sidecast_sync::<Box<dyn CodeGenerateable>>(*r) {
+            if let Some(code_gen) = ResolvedVc::try_sidecast::<Box<dyn CodeGenerateable>>(*r) {
                 code_gens.push(code_gen.code_generation(*chunking_context));
             }
         }

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -200,7 +200,7 @@ impl OutputChunk for CssChunk {
             .iter()
             .map(|&chunk_item| async move {
                 let Some(css_item) =
-                    ResolvedVc::try_downcast::<Box<dyn CssChunkItem>>(chunk_item).await?
+                    ResolvedVc::try_downcast_sync::<Box<dyn CssChunkItem>>(chunk_item)
                 else {
                     return Ok(vec![]);
                 };
@@ -505,7 +505,7 @@ impl ChunkType for CssChunkType {
                 .iter()
                 .map(async |ChunkItemWithAsyncModuleInfo { chunk_item, .. }| {
                     let Some(chunk_item) =
-                        ResolvedVc::try_downcast::<Box<dyn CssChunkItem>>(*chunk_item).await?
+                        ResolvedVc::try_downcast_sync::<Box<dyn CssChunkItem>>(*chunk_item)
                     else {
                         bail!("Chunk item is not an css chunk item but reporting chunk type css");
                     };

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -199,8 +199,7 @@ impl OutputChunk for CssChunk {
         let imports_chunk_items: Vec<_> = entries_chunk_items
             .iter()
             .map(|&chunk_item| async move {
-                let Some(css_item) =
-                    ResolvedVc::try_downcast_sync::<Box<dyn CssChunkItem>>(chunk_item)
+                let Some(css_item) = ResolvedVc::try_downcast::<Box<dyn CssChunkItem>>(chunk_item)
                 else {
                     return Ok(vec![]);
                 };
@@ -505,7 +504,7 @@ impl ChunkType for CssChunkType {
                 .iter()
                 .map(async |ChunkItemWithAsyncModuleInfo { chunk_item, .. }| {
                     let Some(chunk_item) =
-                        ResolvedVc::try_downcast_sync::<Box<dyn CssChunkItem>>(*chunk_item)
+                        ResolvedVc::try_downcast::<Box<dyn CssChunkItem>>(*chunk_item)
                     else {
                         bail!("Chunk item is not an css chunk item but reporting chunk type css");
                     };

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -355,7 +355,7 @@ impl EcmascriptChunkItem for ModuleChunkItem {
                         };
 
                         let Some(css_module) =
-                            ResolvedVc::try_downcast_type_sync::<ModuleCssAsset>(*resolved_module)
+                            ResolvedVc::try_downcast_type::<ModuleCssAsset>(*resolved_module)
                         else {
                             CssModuleComposesIssue {
                                 severity: IssueSeverity::Error.resolved_cell(),

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -355,8 +355,7 @@ impl EcmascriptChunkItem for ModuleChunkItem {
                         };
 
                         let Some(css_module) =
-                            ResolvedVc::try_downcast_type::<ModuleCssAsset>(*resolved_module)
-                                .await?
+                            ResolvedVc::try_downcast_type_sync::<ModuleCssAsset>(*resolved_module)
                         else {
                             CssModuleComposesIssue {
                                 severity: IssueSeverity::Error.resolved_cell(),

--- a/turbopack/crates/turbopack-css/src/references/url.rs
+++ b/turbopack/crates/turbopack-css/src/references/url.rs
@@ -61,7 +61,7 @@ impl UrlAssetReference {
     ) -> Result<Vc<ReferencedAsset>> {
         if let Some(module) = *self.resolve_reference().first_module().await? {
             if let Some(chunkable) =
-                ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(module).await?
+                ResolvedVc::try_downcast_sync::<Box<dyn ChunkableModule>>(module)
             {
                 let chunk_item = chunkable.as_chunk_item(module_graph, chunking_context);
                 if let Some(embeddable) =

--- a/turbopack/crates/turbopack-css/src/references/url.rs
+++ b/turbopack/crates/turbopack-css/src/references/url.rs
@@ -60,9 +60,7 @@ impl UrlAssetReference {
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<ReferencedAsset>> {
         if let Some(module) = *self.resolve_reference().first_module().await? {
-            if let Some(chunkable) =
-                ResolvedVc::try_downcast_sync::<Box<dyn ChunkableModule>>(module)
-            {
+            if let Some(chunkable) = ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(module) {
                 let chunk_item = chunkable.as_chunk_item(module_graph, chunking_context);
                 if let Some(embeddable) =
                     Vc::try_resolve_downcast::<Box<dyn CssEmbed>>(chunk_item).await?

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -146,16 +146,15 @@ impl DevHtmlAsset {
                 } = entry;
 
                 let assets = if let Some(runtime_entries) = runtime_entries {
-                    let runtime_entries = if let Some(evaluatable) =
-                        ResolvedVc::try_downcast_sync(chunkable_module)
-                    {
-                        runtime_entries
-                            .with_entry(*evaluatable)
-                            .to_resolved()
-                            .await?
-                    } else {
-                        runtime_entries
-                    };
+                    let runtime_entries =
+                        if let Some(evaluatable) = ResolvedVc::try_downcast(chunkable_module) {
+                            runtime_entries
+                                .with_entry(*evaluatable)
+                                .to_resolved()
+                                .await?
+                        } else {
+                            runtime_entries
+                        };
                     chunking_context.evaluated_chunk_group_assets(
                         chunkable_module.ident(),
                         *runtime_entries,

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -147,7 +147,7 @@ impl DevHtmlAsset {
 
                 let assets = if let Some(runtime_entries) = runtime_entries {
                     let runtime_entries = if let Some(evaluatable) =
-                        ResolvedVc::try_downcast(chunkable_module).await?
+                        ResolvedVc::try_downcast_sync(chunkable_module)
                     {
                         runtime_entries
                             .with_entry(*evaluatable)

--- a/turbopack/crates/turbopack-dev-server/src/source/combined.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/combined.rs
@@ -58,7 +58,7 @@ impl Introspectable for CombinedContentSource {
             .map(|&source| async move {
                 Ok(
                     if let Some(source) =
-                        ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(source).await?
+                        ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(source)
                     {
                         Some(source.title().await?)
                     } else {
@@ -86,19 +86,21 @@ impl Introspectable for CombinedContentSource {
     #[turbo_tasks::function]
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         let source = ResolvedVc::cell("source".into());
-        Ok(Vc::cell(
-            self.sources
-                .iter()
-                .copied()
-                .map(|s| async move {
-                    Ok(ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(s).await?)
-                })
-                .try_join()
-                .await?
-                .into_iter()
-                .flatten()
-                .map(|i| (source, i))
-                .collect(),
-        ))
+        Ok(
+            Vc::cell(
+                self.sources
+                    .iter()
+                    .copied()
+                    .map(|s| async move {
+                        Ok(ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(s))
+                    })
+                    .try_join()
+                    .await?
+                    .into_iter()
+                    .flatten()
+                    .map(|i| (source, i))
+                    .collect(),
+            ),
+        )
     }
 }

--- a/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
@@ -126,8 +126,7 @@ impl Introspectable for ConditionalContentSource {
 
     #[turbo_tasks::function]
     async fn title(&self) -> Result<Vc<RcStr>> {
-        if let Some(activator) =
-            ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(self.activator)
+        if let Some(activator) = ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.activator)
         {
             Ok(activator.title())
         } else {
@@ -139,9 +138,9 @@ impl Introspectable for ConditionalContentSource {
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         Ok(Vc::cell(
             [
-                ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(self.activator)
+                ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.activator)
                     .map(|i| (activator_key(), i)),
-                ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(self.action)
+                ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.action)
                     .map(|i| (action_key(), i)),
             ]
             .into_iter()

--- a/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
@@ -127,7 +127,7 @@ impl Introspectable for ConditionalContentSource {
     #[turbo_tasks::function]
     async fn title(&self) -> Result<Vc<RcStr>> {
         if let Some(activator) =
-            ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.activator).await?
+            ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(self.activator)
         {
             Ok(activator.title())
         } else {
@@ -139,11 +139,9 @@ impl Introspectable for ConditionalContentSource {
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         Ok(Vc::cell(
             [
-                ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.activator)
-                    .await?
+                ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(self.activator)
                     .map(|i| (activator_key(), i)),
-                ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.action)
-                    .await?
+                ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(self.action)
                     .map(|i| (action_key(), i)),
             ]
             .into_iter()

--- a/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
@@ -153,9 +153,7 @@ impl Introspectable for IssueFilePathContentSource {
     #[turbo_tasks::function]
     async fn ty(&self) -> Result<Vc<RcStr>> {
         Ok(
-            if let Some(source) =
-                ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(self.source)
-            {
+            if let Some(source) = ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.source) {
                 source.ty()
             } else {
                 Vc::cell("IssueContextContentSource".into())
@@ -166,9 +164,7 @@ impl Introspectable for IssueFilePathContentSource {
     #[turbo_tasks::function]
     async fn title(&self) -> Result<Vc<RcStr>> {
         Ok(
-            if let Some(source) =
-                ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(self.source)
-            {
+            if let Some(source) = ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.source) {
                 let title = source.title().await?;
                 Vc::cell(format!("{}: {}", self.description, title).into())
             } else {
@@ -180,9 +176,7 @@ impl Introspectable for IssueFilePathContentSource {
     #[turbo_tasks::function]
     async fn details(&self) -> Result<Vc<RcStr>> {
         Ok(
-            if let Some(source) =
-                ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(self.source)
-            {
+            if let Some(source) = ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.source) {
                 source.details()
             } else {
                 Vc::cell(RcStr::default())
@@ -193,9 +187,7 @@ impl Introspectable for IssueFilePathContentSource {
     #[turbo_tasks::function]
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         Ok(
-            if let Some(source) =
-                ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(self.source)
-            {
+            if let Some(source) = ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.source) {
                 source.children()
             } else {
                 Vc::cell(Default::default())

--- a/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
@@ -154,7 +154,7 @@ impl Introspectable for IssueFilePathContentSource {
     async fn ty(&self) -> Result<Vc<RcStr>> {
         Ok(
             if let Some(source) =
-                ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.source).await?
+                ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(self.source)
             {
                 source.ty()
             } else {
@@ -167,7 +167,7 @@ impl Introspectable for IssueFilePathContentSource {
     async fn title(&self) -> Result<Vc<RcStr>> {
         Ok(
             if let Some(source) =
-                ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.source).await?
+                ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(self.source)
             {
                 let title = source.title().await?;
                 Vc::cell(format!("{}: {}", self.description, title).into())
@@ -181,7 +181,7 @@ impl Introspectable for IssueFilePathContentSource {
     async fn details(&self) -> Result<Vc<RcStr>> {
         Ok(
             if let Some(source) =
-                ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.source).await?
+                ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(self.source)
             {
                 source.details()
             } else {
@@ -194,7 +194,7 @@ impl Introspectable for IssueFilePathContentSource {
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         Ok(
             if let Some(source) =
-                ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.source).await?
+                ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(self.source)
             {
                 source.children()
             } else {

--- a/turbopack/crates/turbopack-dev-server/src/source/lazy_instantiated.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/lazy_instantiated.rs
@@ -48,7 +48,7 @@ impl Introspectable for LazyInstantiatedContentSource {
     #[turbo_tasks::function]
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         Ok(Vc::cell(
-            [ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(
+            [ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(
                 self.get_source.content_source().to_resolved().await?,
             )
             .map(|i| (source_key(), i))]

--- a/turbopack/crates/turbopack-dev-server/src/source/lazy_instantiated.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/lazy_instantiated.rs
@@ -48,10 +48,9 @@ impl Introspectable for LazyInstantiatedContentSource {
     #[turbo_tasks::function]
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         Ok(Vc::cell(
-            [ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(
+            [ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(
                 self.get_source.content_source().to_resolved().await?,
             )
-            .await?
             .map(|i| (source_key(), i))]
             .into_iter()
             .flatten()

--- a/turbopack/crates/turbopack-dev-server/src/source/router.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/router.rs
@@ -64,9 +64,10 @@ async fn get_introspection_children(
             .cloned()
             .chain(std::iter::once((RcStr::default(), *fallback)))
             .map(|(path, source)| async move {
-                Ok(ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(source)
-                    .await?
-                    .map(|i| (ResolvedVc::cell(path), i)))
+                Ok(
+                    ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(source)
+                        .map(|i| (ResolvedVc::cell(path), i)),
+                )
             })
             .try_join()
             .await?

--- a/turbopack/crates/turbopack-dev-server/src/source/router.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/router.rs
@@ -64,10 +64,8 @@ async fn get_introspection_children(
             .cloned()
             .chain(std::iter::once((RcStr::default(), *fallback)))
             .map(|(path, source)| async move {
-                Ok(
-                    ResolvedVc::try_sidecast_sync::<Box<dyn Introspectable>>(source)
-                        .map(|i| (ResolvedVc::cell(path), i)),
-                )
+                Ok(ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(source)
+                    .map(|i| (ResolvedVc::cell(path), i)))
             })
             .try_join()
             .await?

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
@@ -55,10 +55,9 @@ impl ChunkType for EcmascriptChunkType {
                                module: _,
                                async_info,
                            }| {
-                        let Some(chunk_item) =
-                            ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkItem>>(*chunk_item)
-                                .await?
-                        else {
+                        let Some(chunk_item) = ResolvedVc::try_downcast_sync::<
+                            Box<dyn EcmascriptChunkItem>,
+                        >(*chunk_item) else {
                             bail!(
                                 "Chunk item is not an ecmascript chunk item but reporting chunk \
                                  type ecmascript"

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
@@ -55,9 +55,9 @@ impl ChunkType for EcmascriptChunkType {
                                module: _,
                                async_info,
                            }| {
-                        let Some(chunk_item) = ResolvedVc::try_downcast_sync::<
-                            Box<dyn EcmascriptChunkItem>,
-                        >(*chunk_item) else {
+                        let Some(chunk_item) =
+                            ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkItem>>(*chunk_item)
+                        else {
                             bail!(
                                 "Chunk item is not an ecmascript chunk item but reporting chunk \
                                  type ecmascript"

--- a/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
@@ -142,7 +142,7 @@ impl ChunkGroupFilesChunkItem {
     async fn chunks(&self) -> Result<Vc<OutputAssets>> {
         let inner = self.inner.await?;
         let chunks = if let Some(ecma) =
-            ResolvedVc::try_sidecast_sync::<Box<dyn EvaluatableAsset>>(inner.module)
+            ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(inner.module)
         {
             inner.chunking_context.evaluated_chunk_group_assets(
                 inner.module.ident(),

--- a/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
@@ -142,7 +142,7 @@ impl ChunkGroupFilesChunkItem {
     async fn chunks(&self) -> Result<Vc<OutputAssets>> {
         let inner = self.inner.await?;
         let chunks = if let Some(ecma) =
-            ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(inner.module).await?
+            ResolvedVc::try_sidecast_sync::<Box<dyn EvaluatableAsset>>(inner.module)
         {
             inner.chunking_context.evaluated_chunk_group_assets(
                 inner.module.ident(),

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -767,15 +767,14 @@ impl EcmascriptModuleContent {
         for r in references.await?.iter() {
             let r = r.resolve().await?;
             if let Some(code_gen) =
-                ResolvedVc::try_sidecast_sync::<Box<dyn CodeGenerateableWithAsyncModuleInfo>>(r)
+                ResolvedVc::try_sidecast::<Box<dyn CodeGenerateableWithAsyncModuleInfo>>(r)
             {
                 code_gens.push(code_gen.code_generation(
                     module_graph,
                     chunking_context,
                     async_module_info,
                 ));
-            } else if let Some(code_gen) =
-                ResolvedVc::try_sidecast_sync::<Box<dyn CodeGenerateable>>(r)
+            } else if let Some(code_gen) = ResolvedVc::try_sidecast::<Box<dyn CodeGenerateable>>(r)
             {
                 code_gens.push(code_gen.code_generation(module_graph, chunking_context));
             }

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -767,7 +767,7 @@ impl EcmascriptModuleContent {
         for r in references.await?.iter() {
             let r = r.resolve().await?;
             if let Some(code_gen) =
-                ResolvedVc::try_sidecast::<Box<dyn CodeGenerateableWithAsyncModuleInfo>>(r).await?
+                ResolvedVc::try_sidecast_sync::<Box<dyn CodeGenerateableWithAsyncModuleInfo>>(r)
             {
                 code_gens.push(code_gen.code_generation(
                     module_graph,
@@ -775,7 +775,7 @@ impl EcmascriptModuleContent {
                     async_module_info,
                 ));
             } else if let Some(code_gen) =
-                ResolvedVc::try_sidecast::<Box<dyn CodeGenerateable>>(r).await?
+                ResolvedVc::try_sidecast_sync::<Box<dyn CodeGenerateable>>(r)
             {
                 code_gens.push(code_gen.code_generation(module_graph, chunking_context));
             }

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
@@ -161,8 +161,7 @@ impl EcmascriptChunkItem for ManifestLoaderChunkItem {
         // Finally, we need the id of the module that we're actually trying to
         // dynamically import.
         let placeable =
-            ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(manifest.inner)
-                .await?
+            ResolvedVc::try_downcast_sync::<Box<dyn EcmascriptChunkPlaceable>>(manifest.inner)
                 .ok_or_else(|| anyhow!("asset is not placeable in ecmascript chunk"))?;
         let dynamic_id = &*placeable
             .as_chunk_item(

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
@@ -161,7 +161,7 @@ impl EcmascriptChunkItem for ManifestLoaderChunkItem {
         // Finally, we need the id of the module that we're actually trying to
         // dynamically import.
         let placeable =
-            ResolvedVc::try_downcast_sync::<Box<dyn EcmascriptChunkPlaceable>>(manifest.inner)
+            ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(manifest.inner)
                 .ok_or_else(|| anyhow!("asset is not placeable in ecmascript chunk"))?;
         let dynamic_id = &*placeable
             .as_chunk_item(

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -96,8 +96,7 @@ impl ReferencedAsset {
                 }
                 &ModuleResolveResultItem::Module(module) => {
                     if let Some(placeable) =
-                        ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(module)
-                            .await?
+                        ResolvedVc::try_downcast_sync::<Box<dyn EcmascriptChunkPlaceable>>(module)
                     {
                         return Ok(ReferencedAsset::Some(placeable).cell());
                     }
@@ -175,8 +174,7 @@ impl ModuleReference for EsmAssetReference {
             if module == TURBOPACK_PART_IMPORT_SOURCE {
                 if let Some(part) = self.export_name {
                     let module: ResolvedVc<crate::EcmascriptModuleAsset> =
-                        ResolvedVc::try_downcast_type(self.origin)
-                            .await?
+                        ResolvedVc::try_downcast_type_sync(self.origin)
                             .expect("EsmAssetReference origin should be a EcmascriptModuleAsset");
 
                     return Ok(ModuleResolveResult::module(
@@ -204,7 +202,7 @@ impl ModuleReference for EsmAssetReference {
             let part = part.await?;
             if let &ModulePart::Export(export_name) = &*part {
                 for &module in result.primary_modules().await? {
-                    if let Some(module) = ResolvedVc::try_downcast(module).await? {
+                    if let Some(module) = ResolvedVc::try_downcast_sync(module) {
                         let export = export_name.await?;
                         if *is_export_missing(*module, export.clone_value()).await? {
                             InvalidExport {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -96,7 +96,7 @@ impl ReferencedAsset {
                 }
                 &ModuleResolveResultItem::Module(module) => {
                     if let Some(placeable) =
-                        ResolvedVc::try_downcast_sync::<Box<dyn EcmascriptChunkPlaceable>>(module)
+                        ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(module)
                     {
                         return Ok(ReferencedAsset::Some(placeable).cell());
                     }
@@ -174,7 +174,7 @@ impl ModuleReference for EsmAssetReference {
             if module == TURBOPACK_PART_IMPORT_SOURCE {
                 if let Some(part) = self.export_name {
                     let module: ResolvedVc<crate::EcmascriptModuleAsset> =
-                        ResolvedVc::try_downcast_type_sync(self.origin)
+                        ResolvedVc::try_downcast_type(self.origin)
                             .expect("EsmAssetReference origin should be a EcmascriptModuleAsset");
 
                     return Ok(ModuleResolveResult::module(
@@ -202,7 +202,7 @@ impl ModuleReference for EsmAssetReference {
             let part = part.await?;
             if let &ModulePart::Export(export_name) = &*part {
                 for &module in result.primary_modules().await? {
-                    if let Some(module) = ResolvedVc::try_downcast_sync(module) {
+                    if let Some(module) = ResolvedVc::try_downcast(module) {
                         let export = export_name.await?;
                         if *is_export_missing(*module, export.clone_value()).await? {
                             InvalidExport {

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -604,7 +604,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
             }
             if !source_map_from_comment {
                 if let Some(generate_source_map) =
-                    ResolvedVc::try_sidecast_sync::<Box<dyn GenerateSourceMap>>(source)
+                    ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(source)
                 {
                     let source_map_origin = source.ident().path();
                     analysis.set_source_map(

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -604,7 +604,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
             }
             if !source_map_from_comment {
                 if let Some(generate_source_map) =
-                    ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(source).await?
+                    ResolvedVc::try_sidecast_sync::<Box<dyn GenerateSourceMap>>(source)
                 {
                     let source_map_origin = source.ident().path();
                     analysis.set_source_map(

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -346,7 +346,7 @@ async fn to_single_pattern_mapping(
             return Ok(SinglePatternMapping::Invalid);
         }
     };
-    if let Some(chunkable) = ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(module).await? {
+    if let Some(chunkable) = ResolvedVc::try_downcast_sync::<Box<dyn ChunkableModule>>(module) {
         match resolve_type {
             ResolveType::AsyncChunkLoader => {
                 let loader_id = chunking_context.async_loader_chunk_item_id(*chunkable);

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -346,7 +346,7 @@ async fn to_single_pattern_mapping(
             return Ok(SinglePatternMapping::Invalid);
         }
     };
-    if let Some(chunkable) = ResolvedVc::try_downcast_sync::<Box<dyn ChunkableModule>>(module) {
+    if let Some(chunkable) = ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(module) {
         match resolve_type {
             ResolveType::AsyncChunkLoader => {
                 let loader_id = chunking_context.async_loader_chunk_item_id(*chunkable);

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -69,8 +69,7 @@ impl WorkerAssetReference {
         let Some(module) = *module.first_module().await? else {
             return Ok(None);
         };
-        let Some(chunkable) = ResolvedVc::try_downcast_sync::<Box<dyn ChunkableModule>>(module)
-        else {
+        let Some(chunkable) = ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(module) else {
             CodeGenerationIssue {
                 severity: IssueSeverity::Bug.resolved_cell(),
                 title: StyledString::Text("non-ecmascript placeable asset".into()).resolved_cell(),

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -69,7 +69,7 @@ impl WorkerAssetReference {
         let Some(module) = *module.first_module().await? else {
             return Ok(None);
         };
-        let Some(chunkable) = ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(module).await?
+        let Some(chunkable) = ResolvedVc::try_downcast_sync::<Box<dyn ChunkableModule>>(module)
         else {
             CodeGenerationIssue {
                 severity: IssueSeverity::Bug.resolved_cell(),

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
@@ -72,15 +72,14 @@ impl EcmascriptChunkItem for EcmascriptModuleFacadeChunkItem {
         let mut code_gens = Vec::with_capacity(references_ref.len() + 2);
         for r in &references_ref {
             if let Some(code_gen) =
-                ResolvedVc::try_sidecast_sync::<Box<dyn CodeGenerateableWithAsyncModuleInfo>>(*r)
+                ResolvedVc::try_sidecast::<Box<dyn CodeGenerateableWithAsyncModuleInfo>>(*r)
             {
                 code_gens.push(code_gen.code_generation(
                     *self.module_graph,
                     *chunking_context,
                     async_module_info,
                 ));
-            } else if let Some(code_gen) =
-                ResolvedVc::try_sidecast_sync::<Box<dyn CodeGenerateable>>(*r)
+            } else if let Some(code_gen) = ResolvedVc::try_sidecast::<Box<dyn CodeGenerateable>>(*r)
             {
                 code_gens.push(code_gen.code_generation(*self.module_graph, *chunking_context));
             }

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -76,7 +76,7 @@ impl Module for EcmascriptModuleFacadeModule {
         let references = match &*self.ty.await? {
             ModulePart::Evaluation => {
                 let Some(module) =
-                    ResolvedVc::try_sidecast_sync::<Box<dyn EcmascriptAnalyzable>>(self.module)
+                    ResolvedVc::try_sidecast::<Box<dyn EcmascriptAnalyzable>>(self.module)
                 else {
                     bail!(
                         "Expected EcmascriptModuleAsset for a EcmascriptModuleFacadeModule with \
@@ -95,7 +95,7 @@ impl Module for EcmascriptModuleFacadeModule {
             }
             ModulePart::Exports => {
                 let Some(module) =
-                    ResolvedVc::try_sidecast_sync::<Box<dyn EcmascriptAnalyzable>>(self.module)
+                    ResolvedVc::try_sidecast::<Box<dyn EcmascriptAnalyzable>>(self.module)
                 else {
                     bail!(
                         "Expected EcmascriptModuleAsset for a EcmascriptModuleFacadeModule with \

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -76,7 +76,7 @@ impl Module for EcmascriptModuleFacadeModule {
         let references = match &*self.ty.await? {
             ModulePart::Evaluation => {
                 let Some(module) =
-                    ResolvedVc::try_sidecast::<Box<dyn EcmascriptAnalyzable>>(self.module).await?
+                    ResolvedVc::try_sidecast_sync::<Box<dyn EcmascriptAnalyzable>>(self.module)
                 else {
                     bail!(
                         "Expected EcmascriptModuleAsset for a EcmascriptModuleFacadeModule with \
@@ -95,7 +95,7 @@ impl Module for EcmascriptModuleFacadeModule {
             }
             ModulePart::Exports => {
                 let Some(module) =
-                    ResolvedVc::try_sidecast::<Box<dyn EcmascriptAnalyzable>>(self.module).await?
+                    ResolvedVc::try_sidecast_sync::<Box<dyn EcmascriptAnalyzable>>(self.module)
                 else {
                     bail!(
                         "Expected EcmascriptModuleAsset for a EcmascriptModuleFacadeModule with \

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
@@ -67,7 +67,7 @@ impl ModuleReference for EcmascriptModulePartReference {
         let module = if let Some(part) = self.part {
             match *part.await? {
                 ModulePart::Locals => {
-                    let Some(module) = ResolvedVc::try_downcast_type(self.module).await? else {
+                    let Some(module) = ResolvedVc::try_downcast_type_sync(self.module) else {
                         bail!(
                             "Expected EcmascriptModuleAsset for a EcmascriptModulePartReference \
                              with ModulePart::Locals"

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
@@ -67,7 +67,7 @@ impl ModuleReference for EcmascriptModulePartReference {
         let module = if let Some(part) = self.part {
             match *part.await? {
                 ModulePart::Locals => {
-                    let Some(module) = ResolvedVc::try_downcast_type_sync(self.module) else {
+                    let Some(module) = ResolvedVc::try_downcast_type(self.module) else {
                         bail!(
                             "Expected EcmascriptModuleAsset for a EcmascriptModulePartReference \
                              with ModulePart::Locals"

--- a/turbopack/crates/turbopack-ecmascript/src/static_code.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/static_code.rs
@@ -38,7 +38,7 @@ impl StaticEcmascriptCode {
             .module()
             .to_resolved()
             .await?;
-        let Some(asset) = ResolvedVc::try_sidecast::<Box<dyn EcmascriptAnalyzable>>(module).await?
+        let Some(asset) = ResolvedVc::try_sidecast_sync::<Box<dyn EcmascriptAnalyzable>>(module)
         else {
             bail!("asset is not an Ecmascript module")
         };

--- a/turbopack/crates/turbopack-ecmascript/src/static_code.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/static_code.rs
@@ -38,8 +38,7 @@ impl StaticEcmascriptCode {
             .module()
             .to_resolved()
             .await?;
-        let Some(asset) = ResolvedVc::try_sidecast_sync::<Box<dyn EcmascriptAnalyzable>>(module)
-        else {
+        let Some(asset) = ResolvedVc::try_sidecast::<Box<dyn EcmascriptAnalyzable>>(module) else {
             bail!("asset is not an Ecmascript module")
         };
         Ok(Self::cell(StaticEcmascriptCode {

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -41,7 +41,7 @@ impl WorkerLoaderChunkItem {
         let module = self.module.await?;
 
         let Some(evaluatable) =
-            ResolvedVc::try_downcast::<Box<dyn EvaluatableAsset>>(module.inner).await?
+            ResolvedVc::try_downcast_sync::<Box<dyn EvaluatableAsset>>(module.inner)
         else {
             bail!(
                 "{} is not evaluatable for Worker loader module",

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -40,8 +40,7 @@ impl WorkerLoaderChunkItem {
     async fn chunks(&self) -> Result<Vc<OutputAssets>> {
         let module = self.module.await?;
 
-        let Some(evaluatable) =
-            ResolvedVc::try_downcast_sync::<Box<dyn EvaluatableAsset>>(module.inner)
+        let Some(evaluatable) = ResolvedVc::try_downcast::<Box<dyn EvaluatableAsset>>(module.inner)
         else {
             bail!(
                 "{} is not evaluatable for Worker loader module",

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -94,7 +94,7 @@ async fn internal_assets_for_source_mapping(
     let mut internal_assets_for_source_mapping = HashMap::new();
     for asset in internal_assets.iter() {
         if let Some(generate_source_map) =
-            ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(*asset).await?
+            ResolvedVc::try_sidecast_sync::<Box<dyn GenerateSourceMap>>(*asset)
         {
             if let Some(path) = intermediate_output_path.get_path_to(&*asset.ident().path().await?)
             {

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -94,7 +94,7 @@ async fn internal_assets_for_source_mapping(
     let mut internal_assets_for_source_mapping = HashMap::new();
     for asset in internal_assets.iter() {
         if let Some(generate_source_map) =
-            ResolvedVc::try_sidecast_sync::<Box<dyn GenerateSourceMap>>(*asset)
+            ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(*asset)
         {
             if let Some(path) = intermediate_output_path.get_path_to(&*asset.ident().path().await?)
             {

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -434,7 +434,7 @@ impl ChunkingContext for NodeJsChunkingContext {
             )
             .collect();
 
-        let Some(module) = ResolvedVc::try_downcast_sync(module) else {
+        let Some(module) = ResolvedVc::try_downcast(module) else {
             bail!("module must be placeable in an ecmascript chunk");
         };
 

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -434,7 +434,7 @@ impl ChunkingContext for NodeJsChunkingContext {
             )
             .collect();
 
-        let Some(module) = ResolvedVc::try_downcast(module).await? else {
+        let Some(module) = ResolvedVc::try_downcast_sync(module) else {
             bail!("module must be placeable in an ecmascript chunk");
         };
 

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -112,9 +112,8 @@ impl EcmascriptBuildNodeEntryChunk {
 
         let evaluatable_assets = this.evaluatable_assets.await?;
         for evaluatable_asset in &*evaluatable_assets {
-            if let Some(placeable) = ResolvedVc::try_sidecast_sync::<
-                Box<dyn EcmascriptChunkPlaceable>,
-            >(*evaluatable_asset)
+            if let Some(placeable) =
+                ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(*evaluatable_asset)
             {
                 let runtime_module_id = placeable
                     .as_chunk_item(*this.module_graph, Vc::upcast(*this.chunking_context))

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -112,9 +112,9 @@ impl EcmascriptBuildNodeEntryChunk {
 
         let evaluatable_assets = this.evaluatable_assets.await?;
         for evaluatable_asset in &*evaluatable_assets {
-            if let Some(placeable) =
-                ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(*evaluatable_asset)
-                    .await?
+            if let Some(placeable) = ResolvedVc::try_sidecast_sync::<
+                Box<dyn EcmascriptChunkPlaceable>,
+            >(*evaluatable_asset)
             {
                 let runtime_module_id = placeable
                     .as_chunk_item(*this.module_graph, Vc::upcast(*this.chunking_context))

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -499,7 +499,7 @@ async fn walk_asset(
             .iter()
             .copied()
             .map(|asset| async move {
-                Ok(ResolvedVc::try_downcast::<Box<dyn OutputAsset>>(asset).await?)
+                Ok(ResolvedVc::try_downcast_sync::<Box<dyn OutputAsset>>(asset))
             })
             .try_join()
             .await?

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -498,9 +498,7 @@ async fn walk_asset(
             .await?
             .iter()
             .copied()
-            .map(|asset| async move {
-                Ok(ResolvedVc::try_downcast_sync::<Box<dyn OutputAsset>>(asset))
-            })
+            .map(|asset| async move { Ok(ResolvedVc::try_downcast::<Box<dyn OutputAsset>>(asset)) })
             .try_join()
             .await?
             .into_iter()

--- a/turbopack/crates/turbopack/src/global_module_ids.rs
+++ b/turbopack/crates/turbopack/src/global_module_ids.rs
@@ -34,7 +34,7 @@ pub async fn get_global_module_id_strategy(
             .traverse_all_edges_unordered(|parent, current| {
                 if let (_, &ChunkingType::Async) = parent {
                     let module =
-                        ResolvedVc::try_sidecast_sync::<Box<dyn ChunkableModule>>(current.module)
+                        ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(current.module)
                             .context("expected chunkable module for async reference")?;
                     async_idents.push(AsyncLoaderModule::asset_ident_for(*module));
                 }

--- a/turbopack/crates/turbopack/src/module_options/rule_condition.rs
+++ b/turbopack/crates/turbopack/src/module_options/rule_condition.rs
@@ -96,9 +96,7 @@ impl RuleCondition {
             }
             RuleCondition::ReferenceType(condition_ty) => condition_ty.includes(reference_type),
             RuleCondition::ResourceIsVirtualSource => {
-                ResolvedVc::try_downcast_type::<VirtualSource>(source)
-                    .await?
-                    .is_some()
+                ResolvedVc::try_downcast_type_sync::<VirtualSource>(source).is_some()
             }
             RuleCondition::ResourcePathGlob { glob, base } => {
                 if let Some(path) = base.get_relative_path_to(path) {

--- a/turbopack/crates/turbopack/src/module_options/rule_condition.rs
+++ b/turbopack/crates/turbopack/src/module_options/rule_condition.rs
@@ -96,7 +96,7 @@ impl RuleCondition {
             }
             RuleCondition::ReferenceType(condition_ty) => condition_ty.includes(reference_type),
             RuleCondition::ResourceIsVirtualSource => {
-                ResolvedVc::try_downcast_type_sync::<VirtualSource>(source).is_some()
+                ResolvedVc::try_downcast_type::<VirtualSource>(source).is_some()
             }
             RuleCondition::ResourcePathGlob { glob, base } => {
                 if let Some(path) = base.get_relative_path_to(path) {


### PR DESCRIPTION
This is a follow-up to https://github.com/vercel/next.js/pull/75055.

After #75055, the async methods are just facades around the synchronous versions, to avoid breaking the API.

I made this PR using:

```
sg run -p 'ResolvedVc::try_sidecast::<$$$TY>($$$ARGS).await?' -r 'ResolvedVc::try_sidecast_sync::<$$$TY>($$$ARGS)' -U
sg run -p 'ResolvedVc::try_sidecast($$$ARGS).await?' -r 'ResolvedVc::try_sidecast_sync($$$ARGS)' -U
sg run -p 'ResolvedVc::try_downcast::<$$$TY>($$$ARGS).await?' -r 'ResolvedVc::try_downcast_sync::<$$$TY>($$$ARGS)' -U
sg run -p 'ResolvedVc::try_downcast($$$ARGS).await?' -r 'ResolvedVc::try_downcast_sync($$$ARGS)' -U
sg run -p 'ResolvedVc::try_downcast_type::<$$$TY>($$$ARGS).await?' -r 'ResolvedVc::try_downcast_type_sync::<$$$TY>($$$ARGS)' -U
sg run -p 'ResolvedVc::try_downcast_type($$$ARGS).await?' -r 'ResolvedVc::try_downcast_type_sync($$$ARGS)' -U
```

Delete the implementation of the non-sync methods, and then:

```
sg run -p 'ResolvedVc::try_sidecast_sync' -r 'ResolvedVc::try_sidecast' -U
sg run -p 'ResolvedVc::try_downcast_sync' -r 'ResolvedVc::try_downcast' -U
sg run -p 'ResolvedVc::try_downcast_type_sync' -r 'ResolvedVc::try_downcast_type' -U
```

Then rename the methods implementations in `resolved.rs` to match.

Closes PACK-3861