### PR TITLE
Clean-up: remove unused errorMessage param in stack frames

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/get-error-by-type.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/get-error-by-type.ts
@@ -31,8 +31,7 @@ export async function getErrorByType(
         frames: await getOriginalStackFrames(
           event.frames,
           getErrorSource(event.reason),
-          isAppDir,
-          event.reason.toString()
+          isAppDir
         ),
       }
       if (event.type === ACTION_UNHANDLED_ERROR) {

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
@@ -15,15 +15,14 @@ export interface OriginalStackFrame extends OriginalStackFrameResponse {
 function getOriginalStackFrame(
   source: StackFrame,
   type: 'server' | 'edge-server' | null,
-  isAppDir: boolean,
-  errorMessage: string
+  isAppDir: boolean
 ): Promise<OriginalStackFrame> {
   async function _getOriginalStackFrame(): Promise<OriginalStackFrame> {
     const params = new URLSearchParams()
     params.append('isServer', String(type === 'server'))
     params.append('isEdgeServer', String(type === 'edge-server'))
     params.append('isAppDirectory', String(isAppDir))
-    params.append('errorMessage', errorMessage)
+
     for (const key in source) {
       params.append(key, ((source as any)[key] ?? '').toString())
     }
@@ -86,13 +85,10 @@ function getOriginalStackFrame(
 export function getOriginalStackFrames(
   frames: StackFrame[],
   type: 'server' | 'edge-server' | null,
-  isAppDir: boolean,
-  errorMessage: string
+  isAppDir: boolean
 ) {
   return Promise.all(
-    frames.map((frame) =>
-      getOriginalStackFrame(frame, type, isAppDir, errorMessage)
-    )
+    frames.map((frame) => getOriginalStackFrame(frame, type, isAppDir))
   )
 }
 


### PR DESCRIPTION
`errorMessage` is passed to endpoint but never actually used, so thought it was safe to delete. This also simplifies request batching.