### PR TITLE
DX: Reduce devtools clutter by batching stack frame requests

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
@@ -1,5 +1,9 @@
 import type { StackFrame } from 'next/dist/compiled/stacktrace-parser'
-import type { OriginalStackFrameResponse } from '../../server/shared'
+import type {
+  OriginalStackFrameResponse,
+  OriginalStackFrameResponseResult,
+  OriginalStackFramesRequest,
+} from '../../server/shared'
 import {
   isWebpackInternalResource,
   formatFrameSourceFile,
@@ -14,36 +18,15 @@ export interface OriginalStackFrame extends OriginalStackFrameResponse {
 
 function getOriginalStackFrame(
   source: StackFrame,
-  type: 'server' | 'edge-server' | null,
-  isAppDir: boolean
+  response: OriginalStackFrameResponseResult
 ): Promise<OriginalStackFrame> {
   async function _getOriginalStackFrame(): Promise<OriginalStackFrame> {
-    const params = new URLSearchParams()
-    params.append('isServer', String(type === 'server'))
-    params.append('isEdgeServer', String(type === 'edge-server'))
-    params.append('isAppDirectory', String(isAppDir))
-
-    for (const key in source) {
-      params.append(key, ((source as any)[key] ?? '').toString())
+    if (response.status === 'rejected') {
+      return Promise.reject(new Error(response.reason))
     }
 
-    const controller = new AbortController()
-    const tm = setTimeout(() => controller.abort(), 3000)
-    const res = await self
-      .fetch(
-        `${
-          process.env.__NEXT_ROUTER_BASEPATH || ''
-        }/__nextjs_original-stack-frame?${params.toString()}`,
-        { signal: controller.signal }
-      )
-      .finally(() => {
-        clearTimeout(tm)
-      })
-    if (!res.ok || res.status === 204) {
-      return Promise.reject(new Error(await res.text()))
-    }
+    const body: OriginalStackFrameResponse = response.value
 
-    const body: OriginalStackFrameResponse = await res.json()
     return {
       error: false,
       reason: null,
@@ -82,13 +65,24 @@ function getOriginalStackFrame(
   }))
 }
 
-export function getOriginalStackFrames(
+export async function getOriginalStackFrames(
   frames: StackFrame[],
   type: 'server' | 'edge-server' | null,
   isAppDir: boolean
-) {
+): Promise<OriginalStackFrame[]> {
+  const req: OriginalStackFramesRequest = {
+    frames,
+    isServer: type === 'server',
+    isEdgeServer: type === 'edge-server',
+    isAppDirectory: isAppDir,
+  }
+  const res = await fetch('/__nextjs_original-stack-frames', {
+    method: 'POST',
+    body: JSON.stringify(req),
+  })
+  const data = await res.json()
   return Promise.all(
-    frames.map((frame) => getOriginalStackFrame(frame, type, isAppDir))
+    frames.map((frame, index) => getOriginalStackFrame(frame, data[index]))
   )
 }
 

--- a/packages/next/src/client/components/react-dev-overlay/server/shared.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/shared.ts
@@ -9,6 +9,18 @@ import isInternal, {
 
 export type SourcePackage = 'react' | 'next'
 
+export interface OriginalStackFramesRequest {
+  frames: StackFrame[]
+  isServer: boolean
+  isEdgeServer: boolean
+  isAppDirectory: boolean
+}
+
+export type OriginalStackFramesResponse = OriginalStackFrameResponseResult[]
+
+export type OriginalStackFrameResponseResult =
+  PromiseSettledResult<OriginalStackFrameResponse>
+
 export interface OriginalStackFrameResponse {
   originalStackFrame?: (StackFrame & { ignored: boolean }) | null
   originalCodeFrame?: string | null


### PR DESCRIPTION
## What?  
Minimizes unnecessary network requests in the development overlay by batching stack frame resolutions.

## Why?  
Instead of sending individual HTTP requests for each stack frame, this change consolidates them into a single POST request. This helps declutter the network tab in browser devtools, especially in cases where multiple failed requests occur due to server-side errors.

## How?  
- Introduces a new endpoint `/__nextjs_original-stack-frames` to handle batched stack frame requests  
- Updates Webpack and Turbopack middlewares to support batched resolutions  
- Refactors stack frame processing to work with batched responses

Closes NDX-500