### PR TITLE
add additional x-middleware-set-cookie filtering

### DIFF
--- a/packages/next/src/server/send-response.ts
+++ b/packages/next/src/server/send-response.ts
@@ -36,6 +36,11 @@ export async function sendResponse(
 
     // Copy over the response headers.
     response.headers?.forEach((value, name) => {
+      // `x-middleware-set-cookie` is an internal header not needed for the response
+      if (name.toLowerCase() === 'x-middleware-set-cookie') {
+        return
+      }
+
       // The append handling is special cased for `set-cookie`.
       if (name.toLowerCase() === 'set-cookie') {
         // TODO: (wyattjoh) replace with native response iteration when we can upgrade undici

--- a/test/e2e/app-dir/app-middleware/app-middleware.test.ts
+++ b/test/e2e/app-dir/app-middleware/app-middleware.test.ts
@@ -198,6 +198,12 @@ describe('app-dir with middleware', () => {
     const response = await next.fetch('/rsc-cookies/cookie-options')
     expect(response.status).toBe(200)
     expect(response.headers.get('x-middleware-set-cookie')).toBeNull()
+
+    const response2 = await next.fetch('/cookies/api')
+    expect(response2.status).toBe(200)
+    expect(response2.headers.get('x-middleware-set-cookie')).toBeNull()
+    expect(response2.headers.get('set-cookie')).toBeDefined()
+    expect(response2.headers.get('set-cookie')).toContain('example')
   })
 
   it('should ignore x-middleware-set-cookie as a request header', async () => {

--- a/test/e2e/app-dir/app-middleware/app/cookies/api/route.js
+++ b/test/e2e/app-dir/app-middleware/app/cookies/api/route.js
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+
+export function GET() {
+  const response = new NextResponse()
+  response.cookies.set({
+    name: 'example',
+    value: 'example',
+  })
+
+  return response
+}


### PR DESCRIPTION
Previously when we removed this from the response we only did so for requests that flowed through middleware and static handlers.  We should ensure it's filtered in `sendResponse` as well. The header is only needed internally.