### PR TITLE
[metadata] Simplify the html insertion html stream handling for ppr

### DIFF
--- a/test/production/app-dir/ppr-use-server-inserted-html/app/layout.tsx
+++ b/test/production/app-dir/ppr-use-server-inserted-html/app/layout.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export default async function Root({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/ppr-use-server-inserted-html/app/partial-resume/client.tsx
+++ b/test/production/app-dir/ppr-use-server-inserted-html/app/partial-resume/client.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { useRef } from 'react'
+import { useServerInsertedHTML } from 'next/navigation'
+
+export function InsertHtml({ id, data }: { id: string; data: string }) {
+  const insertRef = useRef(false)
+  useServerInsertedHTML(() => {
+    // only insert the style tag once
+    if (insertRef.current) {
+      return
+    }
+    insertRef.current = true
+    const value = (
+      <style
+        data-test-id={id}
+      >{`[data-inserted-${data}] { content: ${data} }`}</style>
+    )
+    console.log(`testing-log-insertion:${data}`)
+    return value
+  })
+
+  return <div>Loaded: {data}</div>
+}

--- a/test/production/app-dir/ppr-use-server-inserted-html/app/partial-resume/page.tsx
+++ b/test/production/app-dir/ppr-use-server-inserted-html/app/partial-resume/page.tsx
@@ -1,0 +1,22 @@
+import React, { Suspense } from 'react'
+import { headers } from 'next/headers'
+import { InsertHtml } from './client'
+
+async function Dynamic() {
+  await headers()
+
+  return (
+    <div>
+      <h3>dynamic</h3>
+      <InsertHtml id={'inserted-html'} data={'dynamic-data'} />
+    </div>
+  )
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Dynamic />
+    </Suspense>
+  )
+}

--- a/test/production/app-dir/ppr-use-server-inserted-html/next.config.js
+++ b/test/production/app-dir/ppr-use-server-inserted-html/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    ppr: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/production/app-dir/ppr-use-server-inserted-html/ppr-use-server-inserted-html.test.ts
+++ b/test/production/app-dir/ppr-use-server-inserted-html/ppr-use-server-inserted-html.test.ts
@@ -1,0 +1,32 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('ppr-use-server-inserted-html', () => {
+  const { next, isNextStart } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextStart) {
+    it('should mark the route as ppr rendered', async () => {
+      const prerenderManifest = JSON.parse(
+        await next.readFile('.next/prerender-manifest.json')
+      )
+      expect(prerenderManifest.routes['/partial-resume'].renderingMode).toBe(
+        'PARTIALLY_STATIC'
+      )
+    })
+  }
+
+  it('should not log insertion in build', async () => {
+    const output = next.cliOutput
+    expect(output).not.toContain('testing-log-insertion:')
+  })
+
+  it('should insert the html insertion into html body', async () => {
+    const $ = await next.render$('/partial-resume')
+    const output = next.cliOutput
+    expect(output).toContain('testing-log-insertion:dynamic-data')
+
+    expect($('head [data-test-id]').length).toBe(0)
+    expect($('body [data-test-id]').length).toBe(1)
+  })
+})


### PR DESCRIPTION
### What

* Remove the `freezing` logic in the server html insertion stream helper.
* Add the branch of dealing with `</head>` not found case in server html insertion, it's for PPR resume case.

### Why

The current form of streaming logic for server html insertion is bit complex that can be simplified. 

* There's a `freezing` condition to wait for React's chunk flushing and then insert the server html content. This one is not required anymore as in all the cases there the large initial chunk is sent, there's no need to keep the condition to do the duplicate work of waiting for the chunk.
* There's a case when partial dynamic rendering resumed in PPR, the `<head>` was already flushed in prerender during build time. So in the resume rendering, the `</head>` won't be located, we need to add the handling for that case.


Closes NDX-749