### PR TITLE
Fix: Add missing 'keys' property to PushSubscription interface

### DIFF
--- a/docs/01-app/03-building-your-application/07-configuring/16-progressive-web-apps.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/16-progressive-web-apps.mdx
@@ -414,6 +414,15 @@ webpush.setVapidDetails(
   process.env.VAPID_PRIVATE_KEY!
 )
 
+// PushSubscription interface definition
+interface PushSubscription {
+  endpoint: string;
+  keys: {
+    auth: string;
+    p256dh: string;
+  };
+}
+
 let subscription: PushSubscription | null = null
 
 export async function subscribeUser(sub: PushSubscription) {


### PR DESCRIPTION
The 'PushSubscription' interface was missing the required 'keys' property, which caused errors when trying to send push notifications using the 'web-push' library. The 'keys' property, which includes 'auth' and 'p256dh', is necessary for the subscription to work correctly.

This change adds the missing 'keys' property to the interface, ensuring that the  subscription data complies with the expected format for 'web-push' notifications.

Before The Fix: 
Error Message
![Screenshot (125)](https://github.com/user-attachments/assets/33f8f9f1-026b-4ab9-9492-46e53d8684a2)

After The Fix:
Error Resolved
![Screenshot (127)](https://github.com/user-attachments/assets/01e6a044-7170-4c3c-a15b-a380813185bb)

