### PR TITLE
perf: Make `next-page-static-info` use `Atom` instead of `String`

### DIFF
--- a/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
+++ b/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
@@ -4,7 +4,7 @@ use next_custom_transforms::transforms::page_static_info::{
     collect_exports, extract_exported_const_values, Const,
 };
 use serde_json::Value;
-use swc_core::ecma::ast::Program;
+use swc_core::{atoms::atom, ecma::ast::Program};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
@@ -51,7 +51,7 @@ impl CustomTransformer for NextPageStaticInfo {
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         if let Some(collected_exports) = collect_exports(program)? {
             let mut properties_to_extract = collected_exports.extra_properties.clone();
-            properties_to_extract.insert("config".to_string());
+            properties_to_extract.insert(atom!("config"));
 
             let extracted = extract_exported_const_values(program, properties_to_extract);
 
@@ -82,7 +82,8 @@ impl CustomTransformer for NextPageStaticInfo {
             }
 
             if is_app_page {
-                if let Some(Some(Const::Value(Value::Object(config_obj)))) = extracted.get("config")
+                if let Some(Some(Const::Value(Value::Object(config_obj)))) =
+                    extracted.get(&atom!("config"))
                 {
                     let mut messages = vec![format!(
                         "Page config in {} is deprecated. Replace `export const config=…` with \
@@ -110,7 +111,7 @@ impl CustomTransformer for NextPageStaticInfo {
                 }
             }
 
-            if collected_exports.directives.contains("client")
+            if collected_exports.directives.contains(&atom!("client"))
                 && collected_exports.generate_static_params
                 && is_app_page
             {

--- a/crates/next-custom-transforms/src/transforms/page_static_info/collect_exported_const_visitor.rs
+++ b/crates/next-custom-transforms/src/transforms/page_static_info/collect_exported_const_visitor.rs
@@ -1,7 +1,7 @@
-use std::collections::{HashMap, HashSet};
-
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde_json::{Map, Number, Value};
 use swc_core::{
+    atoms::Atom,
     common::{Mark, SyntaxContext},
     ecma::{
         ast::{
@@ -22,12 +22,12 @@ pub enum Const {
 }
 
 pub(crate) struct CollectExportedConstVisitor {
-    pub properties: HashMap<String, Option<Const>>,
+    pub properties: FxHashMap<Atom, Option<Const>>,
     expr_ctx: ExprCtx,
 }
 
 impl CollectExportedConstVisitor {
-    pub fn new(properties_to_extract: HashSet<String>) -> Self {
+    pub fn new(properties_to_extract: FxHashSet<Atom>) -> Self {
         Self {
             properties: properties_to_extract
                 .into_iter()
@@ -60,7 +60,7 @@ impl Visit for CollectExportedConstVisitor {
                             ..
                         } = decl
                         {
-                            let id = id.sym.as_ref();
+                            let id = &id.sym;
                             if let Some(prop) = self.properties.get_mut(id) {
                                 *prop = extract_value(self.expr_ctx, init, id.to_string());
                             };


### PR DESCRIPTION
### What?

Use `swc_atoms::Atom` instead of `String` in `next-swc`. 

### Why?

`Atom` does not allocate if another instance has the same value, meaning that `clone()` is a single atomic operation. But `String` allocates regardless of any other occurrence. 


Closes PACK-3860