### PR TITLE
perf: Make `cjs_optimizer` use `Atom` instead of `String`

### DIFF
--- a/crates/next-core/src/next_shared/transforms/next_cjs_optimizer.rs
+++ b/crates/next-core/src/next_shared/transforms/next_cjs_optimizer.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use next_custom_transforms::transforms::cjs_optimizer::{cjs_optimizer, Config, PackageConfig};
 use rustc_hash::FxHashMap;
 use swc_core::{
+    atoms::atom,
     common::SyntaxContext,
     ecma::{ast::*, visit::VisitMutWith},
 };
@@ -18,30 +19,30 @@ pub fn get_next_cjs_optimizer_rule(enable_mdx_rs: bool) -> ModuleRule {
     // build it internally without accepting customization.
     let config = Config {
         packages: FxHashMap::from_iter([(
-            "next/server".to_string(),
+            atom!("next/server"),
             PackageConfig {
                 transforms: FxHashMap::from_iter([
                     (
-                        "NextRequest".into(),
-                        "next/dist/server/web/spec-extension/request".into(),
+                        atom!("NextRequest"),
+                        atom!("next/dist/server/web/spec-extension/request"),
                     ),
                     (
-                        "NextResponse".into(),
-                        "next/dist/server/web/spec-extension/response".into(),
+                        atom!("NextResponse"),
+                        atom!("next/dist/server/web/spec-extension/response"),
                     ),
                     (
-                        "ImageResponse".into(),
-                        "next/dist/server/web/spec-extension/image-response".into(),
+                        atom!("ImageResponse"),
+                        atom!("next/dist/server/web/spec-extension/image-response"),
                     ),
                     (
-                        "userAgentFromString".into(),
-                        "next/dist/server/web/spec-extension/user-agent".into(),
+                        atom!("userAgentFromString"),
+                        atom!("next/dist/server/web/spec-extension/user-agent"),
                     ),
                     (
-                        "userAgent".into(),
-                        "next/dist/server/web/spec-extension/user-agent".into(),
+                        atom!("userAgent"),
+                        atom!("next/dist/server/web/spec-extension/user-agent"),
                     ),
-                    ("after".into(), "next/dist/server/after".into()),
+                    (atom!("after"), atom!("next/dist/server/after")),
                 ]),
             },
         )]),

--- a/crates/next-custom-transforms/src/transforms/cjs_optimizer.rs
+++ b/crates/next-custom-transforms/src/transforms/cjs_optimizer.rs
@@ -7,7 +7,7 @@ use swc_core::{
             CallExpr, Callee, Decl, Expr, Id, Ident, IdentName, Lit, MemberExpr, MemberProp,
             Module, ModuleItem, Pat, Script, Stmt, VarDecl, VarDeclKind, VarDeclarator,
         },
-        atoms::{Atom, JsWord},
+        atoms::Atom,
         utils::{prepend_stmts, private_ident, ExprFactory, IdentRenamer},
         visit::{noop_visit_mut_type, noop_visit_type, Visit, VisitMut, VisitMutWith, VisitWith},
     },
@@ -23,18 +23,18 @@ pub fn cjs_optimizer(config: Config, unresolved_ctxt: SyntaxContext) -> CjsOptim
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Config {
-    pub packages: FxHashMap<String, PackageConfig>,
+    pub packages: FxHashMap<Atom, PackageConfig>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PackageConfig {
-    pub transforms: FxHashMap<JsWord, JsWord>,
+    pub transforms: FxHashMap<Atom, Atom>,
 }
 
 pub struct CjsOptimizer {
     data: State,
-    packages: FxHashMap<String, PackageConfig>,
+    packages: FxHashMap<Atom, PackageConfig>,
     unresolved_ctxt: SyntaxContext,
 }
 
@@ -46,7 +46,7 @@ struct State {
     imports: FxHashMap<Id, ImportRecord>,
 
     /// `(module_specifier, property): (identifier)`
-    replaced: FxHashMap<(Atom, JsWord), Id>,
+    replaced: FxHashMap<(Atom, Atom), Id>,
 
     extra_stmts: Vec<Stmt>,
 
@@ -64,7 +64,7 @@ struct ImportRecord {
 }
 
 impl CjsOptimizer {
-    fn should_rewrite(&self, module_specifier: &str) -> Option<&FxHashMap<JsWord, JsWord>> {
+    fn should_rewrite(&self, module_specifier: &Atom) -> Option<&FxHashMap<Atom, Atom>> {
         self.packages.get(module_specifier).map(|v| &v.transforms)
     }
 }


### PR DESCRIPTION
### What?

### Why?

`swc_atoms::Atom` is better for repeatedly used strings.

Closes PACK-3862