### PR TITLE
perf: Make `next/dynamic` handler  use `Atom` instead of `String`

### DIFF
--- a/crates/next-core/src/next_shared/transforms/next_dynamic.rs
+++ b/crates/next-core/src/next_shared/transforms/next_dynamic.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::dynamic::{next_dynamic, NextDynamicMode};
-use swc_core::{common::FileName, ecma::ast::Program};
+use swc_core::{atoms::atom, common::FileName, ecma::ast::Program};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
@@ -51,8 +51,8 @@ impl CustomTransformer for NextJsDynamic {
             self.is_react_server_layer,
             self.is_app_dir,
             NextDynamicMode::Turbopack {
-                dynamic_client_transition_name: "next-dynamic-client".to_string(),
-                dynamic_transition_name: "next-dynamic".to_string(),
+                dynamic_client_transition_name: atom!("next-dynamic-client"),
+                dynamic_transition_name: atom!("next-dynamic"),
             },
             FileName::Real(ctx.file_path_str.into()).into(),
             None,

--- a/crates/next-custom-transforms/src/transforms/dynamic.rs
+++ b/crates/next-custom-transforms/src/transforms/dynamic.rs
@@ -76,8 +76,8 @@ pub enum NextDynamicMode {
     /// * the ident of the client module (via `dynamic_client_transition_name`) is added to the
     ///   metadata
     Turbopack {
-        dynamic_client_transition_name: String,
-        dynamic_transition_name: String,
+        dynamic_client_transition_name: Atom,
+        dynamic_transition_name: Atom,
     },
 }
 
@@ -102,8 +102,8 @@ enum NextDynamicPatcherState {
     /// the given transition under a particular ident.
     #[allow(unused)]
     Turbopack {
-        dynamic_client_transition_name: String,
-        dynamic_transition_name: String,
+        dynamic_client_transition_name: Atom,
+        dynamic_transition_name: Atom,
         imports: Vec<TurbopackImport>,
     },
 }

--- a/crates/next-custom-transforms/tests/fixture.rs
+++ b/crates/next-custom-transforms/tests/fixture.rs
@@ -26,6 +26,7 @@ use next_custom_transforms::transforms::{
 use rustc_hash::FxHashSet;
 use serde::de::DeserializeOwned;
 use swc_core::{
+    atoms::atom,
     common::{comments::SingleThreadedComments, FileName, Mark, SyntaxContext},
     ecma::{
         ast::Pass,
@@ -130,8 +131,8 @@ fn next_dynamic_fixture(input: PathBuf) {
                 false,
                 false,
                 NextDynamicMode::Turbopack {
-                    dynamic_client_transition_name: "next-client-dynamic".to_string(),
-                    dynamic_transition_name: "next-dynamic".to_string(),
+                    dynamic_client_transition_name: atom!("next-client-dynamic"),
+                    dynamic_transition_name: atom!("next-dynamic"),
                 },
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")).into(),
                 Some("/some-project/src".into()),
@@ -150,8 +151,8 @@ fn next_dynamic_fixture(input: PathBuf) {
                 false,
                 false,
                 NextDynamicMode::Turbopack {
-                    dynamic_client_transition_name: "next-client-dynamic".to_string(),
-                    dynamic_transition_name: "next-dynamic".to_string(),
+                    dynamic_client_transition_name: atom!("next-client-dynamic"),
+                    dynamic_transition_name: atom!("next-dynamic"),
                 },
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")).into(),
                 Some("/some-project/src".into()),
@@ -170,8 +171,8 @@ fn next_dynamic_fixture(input: PathBuf) {
                 false,
                 false,
                 NextDynamicMode::Turbopack {
-                    dynamic_client_transition_name: "next-client-dynamic".to_string(),
-                    dynamic_transition_name: "next-dynamic".to_string(),
+                    dynamic_client_transition_name: atom!("next-client-dynamic"),
+                    dynamic_transition_name: atom!("next-dynamic"),
                 },
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")).into(),
                 Some("/some-project/src".into()),
@@ -276,8 +277,8 @@ fn app_dir_next_dynamic_fixture(input: PathBuf) {
                 true,
                 false,
                 NextDynamicMode::Turbopack {
-                    dynamic_client_transition_name: "next-client-dynamic".to_string(),
-                    dynamic_transition_name: "next-dynamic".to_string(),
+                    dynamic_client_transition_name: atom!("next-client-dynamic"),
+                    dynamic_transition_name: atom!("next-dynamic"),
                 },
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")).into(),
                 Some("/some-project/src".into()),
@@ -296,8 +297,8 @@ fn app_dir_next_dynamic_fixture(input: PathBuf) {
                 true,
                 false,
                 NextDynamicMode::Turbopack {
-                    dynamic_client_transition_name: "next-client-dynamic".to_string(),
-                    dynamic_transition_name: "next-dynamic".to_string(),
+                    dynamic_client_transition_name: atom!("next-client-dynamic"),
+                    dynamic_transition_name: atom!("next-dynamic"),
                 },
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")).into(),
                 Some("/some-project/src".into()),
@@ -316,8 +317,8 @@ fn app_dir_next_dynamic_fixture(input: PathBuf) {
                 true,
                 false,
                 NextDynamicMode::Turbopack {
-                    dynamic_client_transition_name: "next-client-dynamic".to_string(),
-                    dynamic_transition_name: "next-dynamic".to_string(),
+                    dynamic_client_transition_name: atom!("next-client-dynamic"),
+                    dynamic_transition_name: atom!("next-dynamic"),
                 },
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")).into(),
                 Some("/some-project/src".into()),
@@ -336,8 +337,8 @@ fn app_dir_next_dynamic_fixture(input: PathBuf) {
                 false,
                 false,
                 NextDynamicMode::Turbopack {
-                    dynamic_client_transition_name: "next-client-dynamic".to_string(),
-                    dynamic_transition_name: "next-dynamic".to_string(),
+                    dynamic_client_transition_name: atom!("next-client-dynamic"),
+                    dynamic_transition_name: atom!("next-dynamic"),
                 },
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")).into(),
                 Some("/some-project/src".into()),


### PR DESCRIPTION
### What?

### Why?


`swc_atoms::Atom` is better for repeatedly used strings.

Closes PACK-3869