### PR TITLE
perf: Make `next_ssg`  use `Atom` instead of `String`

### DIFF
--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -43,6 +43,7 @@ use backtrace::Backtrace;
 use napi::bindgen_prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::{
+    atoms::Atom,
     base::{Compiler, TransformOutput},
     common::{FilePathMapping, SourceMap},
 };

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -107,7 +107,7 @@ fn get_compiler() -> Arc<Compiler> {
 pub fn complete_output(
     env: &Env,
     output: TransformOutput,
-    eliminated_packages: FxHashSet<String>,
+    eliminated_packages: FxHashSet<Atom>,
     use_cache_telemetry_tracker: FxHashMap<String, usize>,
 ) -> napi::Result<Object> {
     let mut js_output = env.create_object()?;

--- a/crates/napi/src/transform.rs
+++ b/crates/napi/src/transform.rs
@@ -40,6 +40,7 @@ use next_custom_transforms::chain_transforms::{custom_before_pass, TransformOpti
 use once_cell::sync::Lazy;
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::{
+    atoms::Atom,
     base::{try_with_handler, Compiler, TransformOutput},
     common::{comments::SingleThreadedComments, errors::ColorConfig, FileName, Mark, GLOBALS},
     ecma::ast::noop_pass,
@@ -81,12 +82,12 @@ fn skip_filename() -> bool {
 }
 
 impl Task for TransformTask {
-    type Output = (TransformOutput, FxHashSet<String>, FxHashMap<String, usize>);
+    type Output = (TransformOutput, FxHashSet<Atom>, FxHashMap<String, usize>);
     type JsValue = Object;
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
         GLOBALS.set(&Default::default(), || {
-            let eliminated_packages: Rc<RefCell<FxHashSet<String>>> = Default::default();
+            let eliminated_packages: Rc<RefCell<FxHashSet<Atom>>> = Default::default();
             let use_cache_telemetry_tracker: Rc<RefCell<FxHashMap<String, usize>>> =
                 Default::default();
 

--- a/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/crates/next-custom-transforms/src/chain_transforms.rs
@@ -6,6 +6,7 @@ use preset_env_base::query::targets_to_versions;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Deserialize;
 use swc_core::{
+    atoms::Atom,
     common::{
         comments::{Comments, NoopComments},
         pass::Optional,
@@ -123,7 +124,7 @@ pub fn custom_before_pass<'a, C>(
     file: Arc<SourceFile>,
     opts: &'a TransformOptions,
     comments: C,
-    eliminated_packages: Rc<RefCell<FxHashSet<String>>>,
+    eliminated_packages: Rc<RefCell<FxHashSet<Atom>>>,
     unresolved_mark: Mark,
     use_cache_telemetry_tracker: Rc<RefCell<FxHashMap<String, usize>>>,
 ) -> impl Pass + 'a

--- a/crates/next-custom-transforms/src/transforms/next_ssg.rs
+++ b/crates/next-custom-transforms/src/transforms/next_ssg.rs
@@ -3,6 +3,7 @@ use std::{cell::RefCell, mem::take, rc::Rc};
 use easy_error::{bail, Error};
 use rustc_hash::FxHashSet;
 use swc_core::{
+    atoms::Atom,
     common::{
         errors::HANDLER,
         pass::{Repeat, Repeated},
@@ -17,7 +18,7 @@ use swc_core::{
 static SSG_EXPORTS: &[&str; 3] = &["getStaticProps", "getStaticPaths", "getServerSideProps"];
 
 /// Note: This paths requires running `resolver` **before** running this.
-pub fn next_ssg(eliminated_packages: Rc<RefCell<FxHashSet<String>>>) -> impl Pass {
+pub fn next_ssg(eliminated_packages: Rc<RefCell<FxHashSet<Atom>>>) -> impl Pass {
     fold_pass(Repeat::new(NextSsg {
         state: State {
             eliminated_packages,
@@ -52,7 +53,7 @@ struct State {
 
     /// Track the import packages which are eliminated in the
     /// `getServerSideProps`
-    pub eliminated_packages: Rc<RefCell<FxHashSet<String>>>,
+    pub eliminated_packages: Rc<RefCell<FxHashSet<Atom>>>,
 }
 
 impl State {
@@ -387,7 +388,7 @@ impl Fold for NextSsg {
                         self.state
                             .eliminated_packages
                             .borrow_mut()
-                            .insert(import_src.to_string());
+                            .insert(import_src.clone());
                     }
                     tracing::trace!(
                         "Dropping import `{}{:?}` because it should be removed",

--- a/crates/next-custom-transforms/tests/telemetry.rs
+++ b/crates/next-custom-transforms/tests/telemetry.rs
@@ -4,7 +4,7 @@ use next_custom_transforms::transforms::next_ssg::next_ssg;
 use once_cell::sync::Lazy;
 use rustc_hash::FxHashSet;
 use swc_core::{
-    atoms::{atom, Atom},
+    atoms::Atom,
     base::{try_with_handler, Compiler},
     common::{comments::SingleThreadedComments, FileName, FilePathMapping, SourceMap, GLOBALS},
     ecma::ast::noop_pass,

--- a/crates/next-custom-transforms/tests/telemetry.rs
+++ b/crates/next-custom-transforms/tests/telemetry.rs
@@ -4,6 +4,7 @@ use next_custom_transforms::transforms::next_ssg::next_ssg;
 use once_cell::sync::Lazy;
 use rustc_hash::FxHashSet;
 use swc_core::{
+    atoms::{atom, Atom},
     base::{try_with_handler, Compiler},
     common::{comments::SingleThreadedComments, FileName, FilePathMapping, SourceMap, GLOBALS},
     ecma::ast::noop_pass,
@@ -17,7 +18,7 @@ static COMPILER: Lazy<Arc<Compiler>> = Lazy::new(|| {
 
 #[test]
 fn should_collect_estimated_third_part_packages() {
-    let eliminated_packages: Rc<RefCell<FxHashSet<String>>> = Default::default();
+    let eliminated_packages: Rc<RefCell<FxHashSet<Atom>>> = Default::default();
     let fm = COMPILER.cm.new_source_file(
         FileName::Real("fixture.js".into()).into(),
         r#"import http from 'http'
@@ -57,7 +58,7 @@ export function getServerSideProps() {
         .expect("we should have the only remaining reference to `eliminated_packages`")
         .into_inner()
         .into_iter()
-        .collect::<Vec<String>>();
+        .collect::<Vec<Atom>>();
     eliminated_packages_vec.sort_unstable(); // HashSet order is random/arbitrary
     assert_eq!(eliminated_packages_vec, vec!["@napi-rs/bcrypt", "http"]);
 }


### PR DESCRIPTION
### What?

### Why?


`swc_atoms::Atom` is better for repeatedly used strings.

Closes PACK-3875