### PR TITLE
perf: Make server action pass  use `Atom` instead of `String`

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -11,6 +11,7 @@ use regex::Regex;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use swc_core::{
+    atoms::{atom, Atom},
     common::{
         comments::{Comment, CommentKind, Comments},
         errors::HANDLER,
@@ -19,7 +20,6 @@ use swc_core::{
     },
     ecma::{
         ast::*,
-        atoms::{js_word, JsWord},
         utils::{prepend_stmts, quote_ident, quote_str, ExprFactory},
         visit::{
             noop_visit_mut_type, noop_visit_type, visit_mut_pass, Visit, VisitMut, VisitMutWith,
@@ -66,13 +66,13 @@ struct ReactServerComponents<C: Comments> {
     filepath: String,
     app_dir: Option<PathBuf>,
     comments: C,
-    directive_import_collection: Option<(bool, bool, RcVec<ModuleImports>, RcVec<String>)>,
+    directive_import_collection: Option<(bool, bool, RcVec<ModuleImports>, RcVec<Atom>)>,
 }
 
 #[derive(Clone, Debug)]
 struct ModuleImports {
-    source: (JsWord, Span),
-    specifiers: Vec<(JsWord, Span)>,
+    source: (Atom, Span),
+    specifiers: Vec<(Atom, Span)>,
 }
 
 enum RSCErrorKind {
@@ -248,13 +248,21 @@ impl<C: Comments> ReactServerComponents<C> {
                 kind: CommentKind::Block,
                 text: format!(
                     " __next_internal_client_entry_do_not_use__ {} {} ",
-                    export_names.join(","),
+                    join_atoms(export_names),
                     if is_cjs { "cjs" } else { "auto" }
                 )
                 .into(),
             },
         );
     }
+}
+
+fn join_atoms(atoms: &[Atom]) -> String {
+    atoms
+        .iter()
+        .map(|atom| atom.as_ref())
+        .collect::<Vec<_>>()
+        .join(",")
 }
 
 /// Consolidated place to parse, generate error messages for the RSC parsing
@@ -357,7 +365,7 @@ fn collect_top_level_directives_and_imports(
     app_dir: &Option<PathBuf>,
     filepath: &str,
     module: &Module,
-) -> (bool, bool, Vec<ModuleImports>, Vec<String>) {
+) -> (bool, bool, Vec<ModuleImports>, Vec<Atom>) {
     let mut imports: Vec<ModuleImports> = vec![];
     let mut finished_directives = false;
     let mut is_client_entry = false;
@@ -460,8 +468,8 @@ fn collect_top_level_directives_and_imports(
                             },
                             None => (named.local.to_id().0, named.local.span),
                         },
-                        ImportSpecifier::Default(d) => (js_word!(""), d.span),
-                        ImportSpecifier::Namespace(n) => ("*".into(), n.span),
+                        ImportSpecifier::Default(d) => (atom!(""), d.span),
+                        ImportSpecifier::Namespace(n) => (atom!("*"), n.span),
                     })
                     .collect();
 
@@ -476,16 +484,16 @@ fn collect_top_level_directives_and_imports(
             ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(e)) => {
                 for specifier in &e.specifiers {
                     export_names.push(match specifier {
-                        ExportSpecifier::Default(_) => "default".to_string(),
-                        ExportSpecifier::Namespace(_) => "*".to_string(),
+                        ExportSpecifier::Default(_) => atom!("default"),
+                        ExportSpecifier::Namespace(_) => atom!("*"),
                         ExportSpecifier::Named(named) => match &named.exported {
                             Some(exported) => match &exported {
-                                ModuleExportName::Ident(i) => i.sym.to_string(),
-                                ModuleExportName::Str(s) => s.value.to_string(),
+                                ModuleExportName::Ident(i) => i.sym.clone(),
+                                ModuleExportName::Str(s) => s.value.clone(),
                             },
                             _ => match &named.orig {
-                                ModuleExportName::Ident(i) => i.sym.to_string(),
-                                ModuleExportName::Str(s) => s.value.to_string(),
+                                ModuleExportName::Ident(i) => i.sym.clone(),
+                                ModuleExportName::Str(s) => s.value.clone(),
                             },
                         },
                     })
@@ -495,15 +503,15 @@ fn collect_top_level_directives_and_imports(
             ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl { decl, .. })) => {
                 match decl {
                     Decl::Class(ClassDecl { ident, .. }) => {
-                        export_names.push(ident.sym.to_string());
+                        export_names.push(ident.sym.clone());
                     }
                     Decl::Fn(FnDecl { ident, .. }) => {
-                        export_names.push(ident.sym.to_string());
+                        export_names.push(ident.sym.clone());
                     }
                     Decl::Var(var) => {
                         for decl in &var.decls {
                             if let Pat::Ident(ident) = &decl.name {
-                                export_names.push(ident.id.sym.to_string());
+                                export_names.push(ident.id.sym.clone());
                             }
                         }
                     }
@@ -515,18 +523,18 @@ fn collect_top_level_directives_and_imports(
                 decl: _,
                 ..
             })) => {
-                export_names.push("default".to_string());
+                export_names.push(atom!("default"));
                 finished_directives = true;
             }
             ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(ExportDefaultExpr {
                 expr: _,
                 ..
             })) => {
-                export_names.push("default".to_string());
+                export_names.push(atom!("default"));
                 finished_directives = true;
             }
             ModuleItem::ModuleDecl(ModuleDecl::ExportAll(_)) => {
-                export_names.push("*".to_string());
+                export_names.push(atom!("*"));
             }
             _ => {
                 finished_directives = true;
@@ -544,12 +552,12 @@ struct ReactServerComponentValidator {
     use_cache_enabled: bool,
     filepath: String,
     app_dir: Option<PathBuf>,
-    invalid_server_imports: Vec<JsWord>,
+    invalid_server_imports: Vec<Atom>,
     invalid_server_lib_apis_mapping: FxHashMap<&'static str, Vec<&'static str>>,
     deprecated_apis_mapping: FxHashMap<&'static str, Vec<&'static str>>,
-    invalid_client_imports: Vec<JsWord>,
+    invalid_client_imports: Vec<Atom>,
     invalid_client_lib_apis_mapping: FxHashMap<&'static str, Vec<&'static str>>,
-    pub directive_import_collection: Option<(bool, bool, RcVec<ModuleImports>, RcVec<String>)>,
+    pub directive_import_collection: Option<(bool, bool, RcVec<ModuleImports>, RcVec<Atom>)>,
     imports: ImportMap,
 }
 
@@ -623,13 +631,13 @@ impl ReactServerComponentValidator {
             deprecated_apis_mapping: FxHashMap::from_iter([("next/server", vec!["ImageResponse"])]),
 
             invalid_server_imports: vec![
-                JsWord::from("client-only"),
-                JsWord::from("react-dom/client"),
-                JsWord::from("react-dom/server"),
-                JsWord::from("next/router"),
+                Atom::from("client-only"),
+                Atom::from("react-dom/client"),
+                Atom::from("react-dom/server"),
+                Atom::from("next/router"),
             ],
 
-            invalid_client_imports: vec![JsWord::from("server-only"), JsWord::from("next/headers")],
+            invalid_client_imports: vec![Atom::from("server-only"), Atom::from("next/headers")],
 
             invalid_client_lib_apis_mapping: FxHashMap::from_iter([("next/server", vec!["after"])]),
             imports: ImportMap::default(),
@@ -781,25 +789,23 @@ impl ReactServerComponentValidator {
         let is_layout_or_page = RE.is_match(&self.filepath);
 
         if is_layout_or_page {
-            let mut possibly_invalid_exports: FxIndexMap<String, (InvalidExportKind, Span)> =
+            let mut possibly_invalid_exports: FxIndexMap<Atom, (InvalidExportKind, Span)> =
                 FxIndexMap::default();
 
             let mut collect_possibly_invalid_exports =
-                |export_name: &str, span: &Span| match export_name {
+                |export_name: &Atom, span: &Span| match &**export_name {
                     "getServerSideProps" | "getStaticProps" => {
                         possibly_invalid_exports
-                            .insert(export_name.to_string(), (InvalidExportKind::General, *span));
+                            .insert(export_name.clone(), (InvalidExportKind::General, *span));
                     }
                     "generateMetadata" | "metadata" => {
-                        possibly_invalid_exports.insert(
-                            export_name.to_string(),
-                            (InvalidExportKind::Metadata, *span),
-                        );
+                        possibly_invalid_exports
+                            .insert(export_name.clone(), (InvalidExportKind::Metadata, *span));
                     }
                     "runtime" => {
                         if self.dynamic_io_enabled {
                             possibly_invalid_exports.insert(
-                                export_name.to_string(),
+                                export_name.clone(),
                                 (
                                     InvalidExportKind::RouteSegmentConfig(
                                         NextConfigProperty::DynamicIo,
@@ -809,7 +815,7 @@ impl ReactServerComponentValidator {
                             );
                         } else if self.use_cache_enabled {
                             possibly_invalid_exports.insert(
-                                export_name.to_string(),
+                                export_name.clone(),
                                 (
                                     InvalidExportKind::RouteSegmentConfig(
                                         NextConfigProperty::UseCache,
@@ -822,7 +828,7 @@ impl ReactServerComponentValidator {
                     "dynamicParams" | "dynamic" | "fetchCache" | "revalidate" => {
                         if self.dynamic_io_enabled {
                             possibly_invalid_exports.insert(
-                                export_name.to_string(),
+                                export_name.clone(),
                                 (
                                     InvalidExportKind::RouteSegmentConfig(
                                         NextConfigProperty::DynamicIo,
@@ -876,7 +882,7 @@ impl ReactServerComponentValidator {
                             &self.filepath,
                             RSCErrorKind::NextRscErrIncompatibleRouteSegmentConfig(
                                 *span,
-                                export_name.clone(),
+                                export_name.to_string(),
                                 *property,
                             ),
                         );
@@ -890,7 +896,7 @@ impl ReactServerComponentValidator {
                                 &self.app_dir,
                                 &self.filepath,
                                 RSCErrorKind::NextRscErrClientMetadataExport((
-                                    export_name.clone(),
+                                    export_name.to_string(),
                                     *span,
                                 )),
                             );
@@ -902,7 +908,7 @@ impl ReactServerComponentValidator {
                         report_error(
                             &self.app_dir,
                             &self.filepath,
-                            RSCErrorKind::NextRscErrInvalidApi((export_name.clone(), *span)),
+                            RSCErrorKind::NextRscErrInvalidApi((export_name.to_string(), *span)),
                         );
                     }
                 }
@@ -910,8 +916,8 @@ impl ReactServerComponentValidator {
 
             // Server entry can't export `generateMetadata` and `metadata` together.
             if !is_client_entry {
-                let export1 = possibly_invalid_exports.get("generateMetadata");
-                let export2 = possibly_invalid_exports.get("metadata");
+                let export1 = possibly_invalid_exports.get(&atom!("generateMetadata"));
+                let export2 = possibly_invalid_exports.get(&atom!("metadata"));
 
                 if let (Some((_, span1)), Some((_, span2))) = (export1, export2) {
                     report_error(

--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -12,6 +12,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Deserialize;
 use sha1::{Digest, Sha1};
 use swc_core::{
+    atoms::Atom,
     common::{
         comments::{Comment, CommentKind, Comments},
         errors::HANDLER,
@@ -20,7 +21,6 @@ use swc_core::{
     },
     ecma::{
         ast::*,
-        atoms::JsWord,
         utils::{private_ident, quote_ident, ExprFactory},
         visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith},
     },
@@ -116,7 +116,7 @@ enum ServerActionsErrorKind {
 
 /// A mapping of hashed action id to the action's exported function name.
 // Using BTreeMap to ensure the order of the actions is deterministic.
-pub type ActionsMap = BTreeMap<String, String>;
+pub type ActionsMap = BTreeMap<Atom, Atom>;
 
 #[tracing::instrument(level = tracing::Level::TRACE, skip_all)]
 pub fn server_actions<C: Comments>(
@@ -206,14 +206,14 @@ struct ServerActions<C: Comments> {
 
     exported_idents: Vec<(
         /* ident */ Ident,
-        /* name */ String,
-        /* id */ String,
+        /* name */ Atom,
+        /* id */ Atom,
     )>,
 
     annotations: Vec<Stmt>,
     extra_items: Vec<ModuleItem>,
     hoisted_extra_items: Vec<ModuleItem>,
-    export_actions: Vec<(/* name */ String, /* id */ String)>,
+    export_actions: Vec<(/* name */ Atom, /* id */ Atom)>,
 
     private_ctxt: SyntaxContext,
 
@@ -229,7 +229,7 @@ impl<C: Comments> ServerActions<C> {
         export_name: &str,
         is_cache: bool,
         params: Option<&Vec<Param>>,
-    ) -> String {
+    ) -> Atom {
         // Attach a checksum to the action using sha1:
         // $$id = special_byte + sha1('hash_salt' + 'file_name' + ':' + 'export_name');
         // Currently encoded as hex.
@@ -304,23 +304,23 @@ impl<C: Comments> ServerActions<C> {
         result.push((type_bit << 7) | (arg_mask << 1) | rest_args);
         result.rotate_right(1);
 
-        hex_encode(result)
+        Atom::from(hex_encode(result))
     }
 
-    fn gen_action_ident(&mut self) -> JsWord {
-        let id: JsWord = format!("$$RSC_SERVER_ACTION_{0}", self.reference_index).into();
+    fn gen_action_ident(&mut self) -> Atom {
+        let id: Atom = format!("$$RSC_SERVER_ACTION_{0}", self.reference_index).into();
         self.reference_index += 1;
         id
     }
 
-    fn gen_cache_ident(&mut self) -> JsWord {
-        let id: JsWord = format!("$$RSC_SERVER_CACHE_{0}", self.reference_index).into();
+    fn gen_cache_ident(&mut self) -> Atom {
+        let id: Atom = format!("$$RSC_SERVER_CACHE_{0}", self.reference_index).into();
         self.reference_index += 1;
         id
     }
 
-    fn gen_ref_ident(&mut self) -> JsWord {
-        let id: JsWord = format!("$$RSC_SERVER_REF_{0}", self.reference_index).into();
+    fn gen_ref_ident(&mut self) -> Atom {
+        let id: Atom = format!("$$RSC_SERVER_REF_{0}", self.reference_index).into();
         self.reference_index += 1;
         id
     }
@@ -426,13 +426,13 @@ impl<C: Comments> ServerActions<C> {
             new_params.push(Param::from(p.clone()));
         }
 
-        let action_name = self.gen_action_ident().to_string();
-        let action_ident = Ident::new(action_name.clone().into(), arrow.span, self.private_ctxt);
+        let action_name = self.gen_action_ident();
+        let action_ident = Ident::new(action_name.clone(), arrow.span, self.private_ctxt);
         let action_id = self.generate_server_reference_id(&action_name, false, Some(&new_params));
 
         self.has_action = true;
         self.export_actions
-            .push((action_name.to_string(), action_id.clone()));
+            .push((action_name.clone(), action_id.clone()));
 
         let register_action_expr = bind_args_to_ref_expr(
             annotate_ident_as_server_reference(
@@ -569,13 +569,13 @@ impl<C: Comments> ServerActions<C> {
 
         new_params.append(&mut function.params);
 
-        let action_name: JsWord = self.gen_action_ident();
+        let action_name: Atom = self.gen_action_ident();
         let action_ident = Ident::new(action_name.clone(), function.span, self.private_ctxt);
         let action_id = self.generate_server_reference_id(&action_name, false, Some(&new_params));
 
         self.has_action = true;
         self.export_actions
-            .push((action_name.to_string(), action_id.clone()));
+            .push((action_name.clone(), action_id.clone()));
 
         let register_action_expr = bind_args_to_ref_expr(
             annotate_ident_as_server_reference(
@@ -690,15 +690,15 @@ impl<C: Comments> ServerActions<C> {
             new_params.push(Param::from(p.clone()));
         }
 
-        let cache_name: JsWord = self.gen_cache_ident();
+        let cache_name: Atom = self.gen_cache_ident();
         let cache_ident = private_ident!(cache_name.clone());
-        let export_name: JsWord = cache_name;
+        let export_name: Atom = cache_name;
 
         let reference_id = self.generate_server_reference_id(&export_name, true, Some(&new_params));
 
         self.has_cache = true;
         self.export_actions
-            .push((export_name.to_string(), reference_id.clone()));
+            .push((export_name.clone(), reference_id.clone()));
 
         if let BlockStmtOrExpr::BlockStmt(block) = &mut *arrow.body {
             block.visit_mut_with(&mut ClosureReplacer {
@@ -825,14 +825,14 @@ impl<C: Comments> ServerActions<C> {
             new_params.push(p.clone());
         }
 
-        let cache_name: JsWord = self.gen_cache_ident();
+        let cache_name: Atom = self.gen_cache_ident();
         let cache_ident = private_ident!(cache_name.clone());
 
         let reference_id = self.generate_server_reference_id(&cache_name, true, Some(&new_params));
 
         self.has_cache = true;
         self.export_actions
-            .push((cache_name.to_string(), reference_id.clone()));
+            .push((cache_name.clone(), reference_id.clone()));
 
         let register_action_expr = annotate_ident_as_server_reference(
             cache_ident.clone(),
@@ -1475,7 +1475,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                                 if !(is_cache_fn && self.config.is_react_server_layer) {
                                     self.exported_idents.push((
                                         f.ident.clone(),
-                                        f.ident.sym.to_string(),
+                                        f.ident.sym.clone(),
                                         self.generate_server_reference_id(
                                             f.ident.sym.as_ref(),
                                             ref_id,
@@ -1492,7 +1492,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                                 for ident in &idents {
                                     self.exported_idents.push((
                                         ident.clone(),
-                                        ident.sym.to_string(),
+                                        ident.sym.clone(),
                                         self.generate_server_reference_id(
                                             ident.sym.as_ref(),
                                             in_cache_file,
@@ -1533,7 +1533,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                                             // export { foo as bar }
                                             self.exported_idents.push((
                                                 ident.clone(),
-                                                sym.to_string(),
+                                                sym.clone(),
                                                 self.generate_server_reference_id(
                                                     sym.as_ref(),
                                                     in_cache_file,
@@ -1544,7 +1544,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                                             // export { foo as "bar" }
                                             self.exported_idents.push((
                                                 ident.clone(),
-                                                str.value.to_string(),
+                                                str.value.clone(),
                                                 self.generate_server_reference_id(
                                                     str.value.as_ref(),
                                                     in_cache_file,
@@ -1556,7 +1556,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                                         // export { foo }
                                         self.exported_idents.push((
                                             ident.clone(),
-                                            ident.sym.to_string(),
+                                            ident.sym.clone(),
                                             self.generate_server_reference_id(
                                                 ident.sym.as_ref(),
                                                 in_cache_file,
@@ -1887,8 +1887,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                                     decls: vec![VarDeclarator {
                                         span: DUMMY_SP,
                                         name: Pat::Ident(
-                                            IdentName::new(export_name.clone().into(), ident.span)
-                                                .into(),
+                                            IdentName::new(export_name.clone(), ident.span).into(),
                                         ),
                                         init: Some(Box::new(Expr::Call(CallExpr {
                                             span: call_expr_span,
@@ -1916,7 +1915,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                         span: DUMMY_SP,
                         expr: Box::new(annotate_ident_as_server_reference(
                             ident.clone(),
-                            ref_id.to_string(),
+                            ref_id.clone(),
                             ident.span,
                             &self.comments,
                         )),
@@ -2336,7 +2335,7 @@ fn assign_arrow_expr(ident: &Ident, expr: Expr) -> Expr {
 
 fn annotate_ident_as_server_reference(
     ident: Ident,
-    action_id: String,
+    action_id: Atom,
     original_span: Span,
     comments: &dyn Comments,
 ) -> Expr {
@@ -2373,7 +2372,7 @@ fn annotate_ident_as_server_reference(
     })
 }
 
-fn bind_args_to_ref_expr(expr: Expr, bound: Vec<Option<ExprOrSpread>>, action_id: String) -> Expr {
+fn bind_args_to_ref_expr(expr: Expr, bound: Vec<Option<ExprOrSpread>>, action_id: Atom) -> Expr {
     if bound.is_empty() {
         expr
     } else {
@@ -2842,7 +2841,7 @@ impl VisitMut for ClosureReplacer<'_> {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct NamePart {
-    prop: JsWord,
+    prop: Atom,
     is_member: bool,
     optional: bool,
 }


### PR DESCRIPTION
### What?

Use `swc_atoms::Atom` instead of `String` in `next-swc`. 

### Why?

`Atom` does not allocate if another instance has the same value, meaning that `clone()` is a single atomic operation. But `String` allocates regardless of any other occurrence. 


Closes PACK-3886