### PR TITLE
fix rustflags for musl targets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -54,6 +54,7 @@ rustflags = [
 
 [target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-musl-gcc"
+# Config need to be mirrowed to .github/workflows/build_and_deploy.yml
 rustflags = [
   "--cfg",
   "tokio_unstable",
@@ -61,6 +62,17 @@ rustflags = [
   "-Csymbol-mangling-version=v0",
   "-Ctarget-feature=-crt-static",
   "-Clink-arg=-lgcc",
+]
+
+[target.x86_64-unknown-linux-musl]
+# Config need to be mirrowed to .github/workflows/build_and_deploy.yml
+rustflags = [
+  "--cfg",
+  "tokio_unstable",
+  "-Zshare-generics=y",
+  "-Zthreads=8",
+  "-Csymbol-mangling-version=v0",
+  "-Ctarget-feature=-crt-static",
 ]
 
 [target.armv7-unknown-linux-gnueabihf]

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -225,6 +225,7 @@ jobs:
               rustup show &&
               rustup target add x86_64-unknown-linux-musl &&
               npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}" &&
+              export RUSTFLAGS="--cfg tokio_unstable -Zshare-generics=y -Zthreads=8 -Csymbol-mangling-version=v0 -Ctarget-feature=-crt-static" &&
               cd packages/next-swc && npm run build-native-release -- --target x86_64-unknown-linux-musl &&
               strip native/next-swc.*.node
 
@@ -266,6 +267,7 @@ jobs:
               npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}" &&
               rustup show &&
               rustup target add aarch64-unknown-linux-musl &&
+              export RUSTFLAGS="--cfg tokio_unstable -Zshare-generics=y -Zthreads=8 -Zunstable-options -Csymbol-mangling-version=v0 -Clinker-flavor=gnu-lld-cc -Clink-self-contained=+linker" &&
               cd packages/next-swc && npm run build-native-release -- --target aarch64-unknown-linux-musl &&
               llvm-strip -x native/next-swc.*.node
 


### PR DESCRIPTION
### What?

napi sets the RUSTFLAGS env var for musl targets: https://github.com/napi-rs/napi-rs/blob/2d8e19d7c626405287b73a52dc91731c3b89c8df/cli/src/api/build.ts#L467-L485
this means our .cargo/config.toml rustflags are not applied.
This fixes that by adding the RUSTFLAGS env var to the build script


Closes PACK-3844