### PR TITLE
Fix corepack keys

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,4 +28,5 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 # RUN su node -c "npm install -g <your-package-list-here>"
 
 # Enable pnpm
+RUN npm i -g corepack@latest
 RUN corepack enable pnpm

--- a/.github/actions/next-stats-action/Dockerfile
+++ b/.github/actions/next-stats-action/Dockerfile
@@ -12,6 +12,7 @@ RUN apt install unzip wget curl nano htop screen build-essential pkg-config libs
 RUN ln $(which python3) /usr/bin/python
 
 RUN curl -sfLS https://install-node.vercel.app/v18.18.2 | bash -s -- -f
+RUN npm i -g corepack@0.31
 RUN corepack enable
 
 WORKDIR /next-stats

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -29,7 +29,10 @@ jobs:
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
-      - run: corepack enable
+      - name: Setup corepack
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
       - name: Determine deploy target
         # 'force-preview' performs a full preview build but only if acknowledged i.e. workflow_dispatch
         # 'automated-preview' for pushes on branches other than 'canary' for integration testing.
@@ -70,7 +73,10 @@ jobs:
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
-      - run: corepack enable
+      - name: Setup corepack
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
 
       - uses: actions/checkout@v4
         with:
@@ -458,7 +464,10 @@ jobs:
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
-      - run: corepack enable
+      - name: Setup corepack
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
 
       # https://github.com/actions/virtual-environments/issues/1187
       - name: tune linux network
@@ -518,7 +527,10 @@ jobs:
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
-      - run: corepack enable
+      - name: Setup corepack
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
 
       # https://github.com/actions/virtual-environments/issues/1187
       - name: tune linux network
@@ -576,7 +588,10 @@ jobs:
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
-      - run: corepack enable
+      - name: Setup corepack
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
 
       - uses: ./.github/actions/setup-rust
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -108,7 +108,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-      - run: corepack enable
+      - name: Setup corepack
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
       - name: 'Run link checker'
         run: node ./.github/actions/validate-docs-links/dist/index.js
         env:

--- a/.github/workflows/code_freeze.yml
+++ b/.github/workflows/code_freeze.yml
@@ -31,7 +31,10 @@ jobs:
         with:
           node-version: 18
           check-latest: true
-      - run: corepack enable
+      - name: Setup corepack
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
 
       - run: git clone https://github.com/vercel/next.js.git --depth=1 .
 

--- a/.github/workflows/issue_wrong_template.yml
+++ b/.github/workflows/issue_wrong_template.yml
@@ -11,7 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-      - run: corepack enable
+      - name: Setup corepack
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
       - name: 'Close issues using the wrong issue template'
         run: node ./.github/actions/next-repo-actions/dist/wrong-issue-template/index.js
         env:

--- a/.github/workflows/popular.yml
+++ b/.github/workflows/popular.yml
@@ -12,7 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-      - run: corepack enable
+      - name: Setup corepack
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
       - name: 'Issues: Send notification to Slack'
         run: node ./.github/actions/next-repo-actions/dist/issues/index.mjs
         continue-on-error: true

--- a/.github/workflows/rspack-update-tests-manifest.yml
+++ b/.github/workflows/rspack-update-tests-manifest.yml
@@ -26,7 +26,10 @@ jobs:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
 
-      - run: corepack enable
+      - name: Setup corepack
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
 
       - name: Install dependencies
         shell: bash
@@ -59,7 +62,10 @@ jobs:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
 
-      - run: corepack enable
+      - name: Setup corepack
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/setup-nextjs-build.yml
+++ b/.github/workflows/setup-nextjs-build.yml
@@ -82,6 +82,7 @@ jobs:
         run: |
           wget https://github.com/sharkdp/hyperfine/releases/download/v1.16.1/hyperfine_1.16.1_amd64.deb
           sudo dpkg -i hyperfine_1.16.1_amd64.deb
+          npm i -g corepack@0.31
           corepack enable
           pnpm install --loglevel error
 

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -25,7 +25,9 @@ jobs:
           check-latest: true
 
       - name: Setup pnpm
-        run: corepack enable
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -39,7 +39,10 @@ jobs:
         with:
           node-version: 18
           check-latest: true
-      - run: corepack enable
+      - name: Setup corepack
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
 
       - run: pnpm install
       - run: pnpm build

--- a/.github/workflows/triage_with_ai.yml
+++ b/.github/workflows/triage_with_ai.yml
@@ -10,7 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-      - run: corepack enable
+      - name: Setup corepack
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
       - name: 'Send report to Slack (AI-powered)'
         run: node ./.github/actions/next-repo-actions/dist/triage-issues-with-ai/index.js
     env:

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -82,7 +82,11 @@ jobs:
       - name: tune linux network
         run: sudo ethtool -K eth0 tx off rx off
 
-      - run: corepack enable && pnpm --version
+      - name: Setup corepack
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
+          pnpm --version
 
       - id: get-store-path
         run: echo STORE_PATH=$(pnpm store path) >> $GITHUB_OUTPUT

--- a/.github/workflows/turbopack-update-tests-manifest.yml
+++ b/.github/workflows/turbopack-update-tests-manifest.yml
@@ -26,7 +26,10 @@ jobs:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
 
-      - run: corepack enable
+      - name: Setup corepack
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/turbopack-upload-tests-manifest.yml
+++ b/.github/workflows/turbopack-upload-tests-manifest.yml
@@ -27,7 +27,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - run: corepack enable
+      - name: Setup corepack
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/update_fonts_data.yml
+++ b/.github/workflows/update_fonts_data.yml
@@ -28,7 +28,10 @@ jobs:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
 
-      - run: corepack enable
+      - name: Setup corepack
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/update_react.yml
+++ b/.github/workflows/update_react.yml
@@ -39,7 +39,10 @@ jobs:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
 
-      - run: corepack enable
+      - name: Setup corepack
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
 
       - name: Install dependencies
         shell: bash


### PR DESCRIPTION
Works around https://github.com/nodejs/corepack/issues/612

Only affects GH runners. I scanned all `corepack enable` and ensured that we install the fixed version if a GH runner is used.

`echo "COREPACK_INTEGRITY_KEYS='$(curl https://registry.npmjs.org/-/npm/v1/keys | jq -c '{npm: .keys}')'" >> $GITHUB_ENV` is the more light-weight fix. I couldn't get this to work though because single vs double quotes is too hard for me. `npm i -g corepack@` only takes 3s which is negligible for a temporary fix.
