### PR TITLE
perf: Remove needless `Arc`

### DIFF
--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -98,10 +98,10 @@ fn init() {
 }
 
 #[inline]
-fn get_compiler() -> Arc<Compiler> {
+fn get_compiler() -> Compiler {
     let cm = Arc::new(SourceMap::new(FilePathMapping::empty()));
 
-    Arc::new(Compiler::new(cm))
+    Compiler::new(cm)
 }
 
 pub fn complete_output(
@@ -135,8 +135,6 @@ pub fn complete_output(
 
     Ok(js_output)
 }
-
-pub type ArcCompiler = Arc<Compiler>;
 
 static REGISTER_ONCE: Once = Once::new();
 

--- a/crates/napi/src/minify.rs
+++ b/crates/napi/src/minify.rs
@@ -25,7 +25,6 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 */
-use std::sync::Arc;
 
 use napi::bindgen_prelude::*;
 use rustc_hash::FxHashMap;
@@ -42,7 +41,7 @@ use swc_core::{
 use crate::{get_compiler, util::MapErr};
 
 pub struct MinifyTask {
-    c: Arc<swc_core::base::Compiler>,
+    c: swc_core::base::Compiler,
     code: MinifyTarget,
     opts: swc_core::base::config::JsMinifyOptions,
 }

--- a/crates/napi/src/transform.rs
+++ b/crates/napi/src/transform.rs
@@ -31,7 +31,6 @@ use std::{
     fs::read_to_string,
     panic::{catch_unwind, AssertUnwindSafe},
     rc::Rc,
-    sync::Arc,
 };
 
 use anyhow::{anyhow, bail, Context as _};
@@ -58,7 +57,7 @@ pub enum Input {
 }
 
 pub struct TransformTask {
-    pub c: Arc<Compiler>,
+    pub c: Compiler,
     pub input: Input,
     pub options: Buffer,
 }


### PR DESCRIPTION
### What?

Remove one allocation per `transform()` and `minify()`.

### Why?

We don't need to allocate `Compiler` in an `Arc`, because we don't share it.

Closes PACK-3894