### PR TITLE
Only reference published `@types/react-dom` versions

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -208,7 +208,7 @@
     "@types/picomatch": "2.3.3",
     "@types/platform": "1.3.4",
     "@types/react": "19.0.8",
-    "@types/react-dom": "19.0.8",
+    "@types/react-dom": "19.0.3",
     "@types/react-is": "18.2.4",
     "@types/semver": "7.3.1",
     "@types/send": "0.14.4",


### PR DESCRIPTION
Only affects installs without a lockfile. Otherwise it used the one we have specified in `resolutions`. I almost want to keep it to flush out installs without lockfiles but still: referencing non-existing versions is confusing.