### PR TITLE
Don't warn about Turbopack config if disabled

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1316,6 +1316,11 @@ export function getConfiguredExperimentalFeatures(
     ) as (keyof ExperimentalConfig)[]) {
       const value = userNextConfigExperimental[name]
 
+      if (name === 'turbo' && !process.env.TURBOPACK) {
+        // Ignore any Turbopack config if Turbopack is not enabled
+        continue
+      }
+
       if (
         name in defaultConfig.experimental &&
         value !== defaultConfig.experimental[name]


### PR DESCRIPTION
This is confusing users: https://github.com/vercel/next.js/issues/54708#issuecomment-2629468562

![Image](https://github.com/user-attachments/assets/e40e1a43-97e7-4e4c-86cb-68fa94f7328b)

Closes PACK-3857