### PR TITLE
Fix corepack keys in deploy e2e tests

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -135,6 +135,10 @@ jobs:
       - run: fnm use --install-if-missing ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
       - run: fnm default ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
       - run: node -v
+      - name: Prepare corepack
+        if: ${{ contains('ubuntu-latest', fromJson(inputs.runs_on_labels)) }}
+        run: |
+          npm i -g corepack@0.31
       - run: corepack enable
       - run: pwd
 


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/75600

I missed that we actually call `build_reusable` with `ubuntu-latest` (e.g. in deploy e2e tests).