### PR TITLE
Fix source map for dev overlay for turbopack

### DIFF
--- a/test/development/app-dir/source-mapping-with-css-module/app/layout.js
+++ b/test/development/app-dir/source-mapping-with-css-module/app/layout.js
@@ -1,0 +1,3 @@
+export default function Layout({ children }) {
+  return <div>{children}</div>
+}

--- a/test/development/app-dir/source-mapping-with-css-module/app/with-css-module/page.js
+++ b/test/development/app-dir/source-mapping-with-css-module/app/with-css-module/page.js
@@ -1,0 +1,12 @@
+import styles from './page.module.css'
+
+export default function Page() {
+  throw new Error('boom')
+
+  // eslint-disable-next-line
+  return (
+    <div className={styles.page}>
+      <h1>Hello</h1>
+    </div>
+  )
+}

--- a/test/development/app-dir/source-mapping-with-css-module/app/with-css-module/page.module.css
+++ b/test/development/app-dir/source-mapping-with-css-module/app/with-css-module/page.module.css
@@ -1,0 +1,168 @@
+.page {
+  --gray-rgb: 0, 0, 0;
+  --gray-alpha-200: rgba(var(--gray-rgb), 0.08);
+  --gray-alpha-100: rgba(var(--gray-rgb), 0.05);
+
+  --button-primary-hover: #383838;
+  --button-secondary-hover: #f2f2f2;
+
+  display: grid;
+  grid-template-rows: 20px 1fr 20px;
+  align-items: center;
+  justify-items: center;
+  min-height: 100svh;
+  padding: 80px;
+  gap: 64px;
+  font-family: var(--font-geist-sans);
+}
+
+@media (prefers-color-scheme: dark) {
+  .page {
+    --gray-rgb: 255, 255, 255;
+    --gray-alpha-200: rgba(var(--gray-rgb), 0.145);
+    --gray-alpha-100: rgba(var(--gray-rgb), 0.06);
+
+    --button-primary-hover: #ccc;
+    --button-secondary-hover: #1a1a1a;
+  }
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  grid-row-start: 2;
+}
+
+.main ol {
+  font-family: var(--font-geist-mono);
+  padding-left: 0;
+  margin: 0;
+  font-size: 14px;
+  line-height: 24px;
+  letter-spacing: -0.01em;
+  list-style-position: inside;
+}
+
+.main li:not(:last-of-type) {
+  margin-bottom: 8px;
+}
+
+.main code {
+  font-family: inherit;
+  background: var(--gray-alpha-100);
+  padding: 2px 4px;
+  border-radius: 4px;
+  font-weight: 600;
+}
+
+.ctas {
+  display: flex;
+  gap: 16px;
+}
+
+.ctas a {
+  appearance: none;
+  border-radius: 128px;
+  height: 48px;
+  padding: 0 20px;
+  border: none;
+  border: 1px solid transparent;
+  transition:
+    background 0.2s,
+    color 0.2s,
+    border-color 0.2s;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  line-height: 20px;
+  font-weight: 500;
+}
+
+a.primary {
+  background: var(--foreground);
+  color: var(--background);
+  gap: 8px;
+}
+
+a.secondary {
+  border-color: var(--gray-alpha-200);
+  min-width: 180px;
+}
+
+.footer {
+  grid-row-start: 3;
+  display: flex;
+  gap: 24px;
+}
+
+.footer a {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.footer img {
+  flex-shrink: 0;
+}
+
+/* Enable hover only on non-touch devices */
+@media (hover: hover) and (pointer: fine) {
+  a.primary:hover {
+    background: var(--button-primary-hover);
+    border-color: transparent;
+  }
+
+  a.secondary:hover {
+    background: var(--button-secondary-hover);
+    border-color: transparent;
+  }
+
+  .footer a:hover {
+    text-decoration: underline;
+    text-underline-offset: 4px;
+  }
+}
+
+@media (max-width: 600px) {
+  .page {
+    padding: 32px;
+    padding-bottom: 80px;
+  }
+
+  .main {
+    align-items: center;
+  }
+
+  .main ol {
+    text-align: center;
+  }
+
+  .ctas {
+    flex-direction: column;
+  }
+
+  .ctas a {
+    font-size: 14px;
+    height: 40px;
+    padding: 0 16px;
+  }
+
+  a.secondary {
+    min-width: auto;
+  }
+
+  .footer {
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .logo {
+    filter: invert();
+  }
+}

--- a/test/development/app-dir/source-mapping-with-css-module/app/without-css-module/page.js
+++ b/test/development/app-dir/source-mapping-with-css-module/app/without-css-module/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  throw new Error('boom')
+}

--- a/test/development/app-dir/source-mapping-with-css-module/source-mapping-with-css-module.test.ts
+++ b/test/development/app-dir/source-mapping-with-css-module/source-mapping-with-css-module.test.ts
@@ -1,0 +1,21 @@
+import { nextTestSetup } from 'e2e-utils'
+import { getRedboxSource } from 'next-test-utils'
+
+describe('source-mapping-with-css-module', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('works with css module', async () => {
+    const browser = await next.browser('/with-css-module')
+
+    const source = await getRedboxSource(browser)
+    expect(source).toContain('app/with-css-module/page.js')
+  })
+
+  it('works without css module', async () => {
+    const browser = await next.browser('/without-css-module')
+    const source = await getRedboxSource(browser)
+    expect(source).toContain('app/without-css-module/page.js')
+  })
+})


### PR DESCRIPTION
### What?

The dev overlay source map did not work when the RSC file uses CSS module.

### Why?

`nativeTraceSource` errors when resolving path like `[project]/app/page.module.css [app-rsc] (css module)` from the Turbopack sourcemap.

### How?

Fixed by wrapping the native source tracing with a `try-catch` block.

Closes NDX-767