### PR TITLE
Add nodejs runtime support for middleware

### DIFF
--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -614,12 +614,7 @@ export async function getPagesPageStaticInfo({
   const config = parsePagesSegmentConfig(exportedConfig, route)
   const isAnAPIRoute = isAPIRoute(route)
 
-  const resolvedRuntime =
-    isEdgeRuntime(config.runtime ?? config.config?.runtime) ||
-    getServerSideProps ||
-    getStaticProps
-      ? config.runtime ?? config.config?.runtime
-      : undefined
+  const resolvedRuntime = config.runtime ?? config.config?.runtime
 
   if (resolvedRuntime === SERVER_RUNTIME.experimentalEdge) {
     warnAboutExperimentalEdge(isAnAPIRoute ? page! : null)

--- a/packages/next/src/build/webpack/plugins/build-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/build-manifest-plugin.ts
@@ -44,7 +44,9 @@ function createEdgeRuntimeManifest(originAssetMap: BuildManifest): string {
     lowPriorityFiles: [],
   }
 
-  const manifestDefCode = `self.__BUILD_MANIFEST = ${JSON.stringify(
+  // we use globalThis here because middleware can be node
+  // which doesn't have "self"
+  const manifestDefCode = `globalThis.__BUILD_MANIFEST = ${JSON.stringify(
     assetMap,
     null,
     2
@@ -52,7 +54,7 @@ function createEdgeRuntimeManifest(originAssetMap: BuildManifest): string {
   // edge lowPriorityFiles item: '"/static/" + process.env.__NEXT_BUILD_ID + "/low-priority.js"'.
   // Since lowPriorityFiles is not fixed and relying on `process.env.__NEXT_BUILD_ID`, we'll produce code creating it dynamically.
   const lowPriorityFilesCode =
-    `self.__BUILD_MANIFEST.lowPriorityFiles = [\n` +
+    `globalThis.__BUILD_MANIFEST.lowPriorityFiles = [\n` +
     manifestFilenames
       .map((filename) => {
         return `"/static/" + process.env.__NEXT_BUILD_ID + "/${filename}",\n`

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -252,6 +252,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
     excludeDefaultMomentLocales: z.boolean().optional(),
     experimental: z
       .strictObject({
+        nodeMiddleware: z.boolean().optional(),
         after: z.boolean().optional(),
         appDocumentPreloading: z.boolean().optional(),
         appIsrStatus: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -259,6 +259,7 @@ export interface LoggingConfig {
 }
 
 export interface ExperimentalConfig {
+  nodeMiddleware?: boolean
   cacheHandlers?: {
     default?: string
     remote?: string
@@ -1129,6 +1130,7 @@ export const defaultConfig: NextConfig = {
   modularizeImports: undefined,
   outputFileTracingRoot: process.env.NEXT_PRIVATE_OUTPUT_TRACE_ROOT || '',
   experimental: {
+    nodeMiddleware: false,
     cacheLife: {
       default: {
         stale: undefined, // defaults to staleTimes.static

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -802,9 +802,15 @@ export function onDemandEntryHandler({
       const isServerComponent =
         isInsideAppDir && staticInfo.rsc !== RSC_MODULE_TYPES.client
 
+      let pageRuntime = staticInfo.runtime
+
+      if (isMiddlewareFile(page) && !nextConfig.experimental.nodeMiddleware) {
+        pageRuntime = 'edge'
+      }
+
       runDependingOnPageType({
         page: route.page,
-        pageRuntime: staticInfo.runtime,
+        pageRuntime,
         pageType: pageBundleType,
         onClient: () => {
           // Skip adding the client entry for app / Server Components.

--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -1,4 +1,5 @@
 import type {
+  FunctionsConfigManifest,
   ManifestRoute,
   PrerenderManifest,
   RoutesManifest,
@@ -30,6 +31,7 @@ import { getMiddlewareRouteMatcher } from '../../../shared/lib/router/utils/midd
 import {
   APP_PATH_ROUTES_MANIFEST,
   BUILD_ID_FILE,
+  FUNCTIONS_CONFIG_MANIFEST,
   MIDDLEWARE_MANIFEST,
   PAGES_MANIFEST,
   PRERENDER_MANIFEST,
@@ -201,6 +203,11 @@ export async function setupFsCheck(opts: {
       'server',
       MIDDLEWARE_MANIFEST
     )
+    const functionsConfigManifestPath = path.join(
+      distDir,
+      'server',
+      FUNCTIONS_CONFIG_MANIFEST
+    )
     const pagesManifestPath = path.join(distDir, 'server', PAGES_MANIFEST)
     const appRoutesManifestPath = path.join(distDir, APP_PATH_ROUTES_MANIFEST)
 
@@ -215,6 +222,10 @@ export async function setupFsCheck(opts: {
     const middlewareManifest = JSON.parse(
       await fs.readFile(middlewareManifestPath, 'utf8').catch(() => '{}')
     ) as MiddlewareManifest
+
+    const functionsConfigManifest = JSON.parse(
+      await fs.readFile(functionsConfigManifestPath, 'utf8').catch(() => '{}')
+    ) as FunctionsConfigManifest
 
     const pagesManifest = JSON.parse(
       await fs.readFile(pagesManifestPath, 'utf8')
@@ -273,6 +284,12 @@ export async function setupFsCheck(opts: {
     if (middlewareManifest.middleware?.['/']?.matchers) {
       middlewareMatcher = getMiddlewareRouteMatcher(
         middlewareManifest.middleware?.['/']?.matchers
+      )
+    } else if (functionsConfigManifest?.functions['/_middleware']) {
+      middlewareMatcher = getMiddlewareRouteMatcher(
+        functionsConfigManifest.functions['/_middleware'].matchers ?? [
+          { regexp: '.*', originalSource: '/:path*' },
+        ]
       )
     }
 

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -41,6 +41,7 @@ import {
   NEXT_FONT_MANIFEST,
   PHASE_PRODUCTION_BUILD,
   UNDERSCORE_NOT_FOUND_ROUTE_ENTRY,
+  FUNCTIONS_CONFIG_MANIFEST,
 } from '../shared/lib/constants'
 import { findDir } from '../lib/find-pages-dir'
 import { NodeNextRequest, NodeNextResponse } from './base-http/node'
@@ -110,6 +111,7 @@ import { AwaiterOnce } from './after/awaiter'
 import { AsyncCallbackSet } from './lib/async-callback-set'
 import DefaultCacheHandler from './lib/cache-handlers/default'
 import { cacheHandlerGlobal, cacheHandlersSymbol } from './use-cache/constants'
+import type { UnwrapPromise } from '../lib/coalesced-function'
 
 export * from './base-server'
 
@@ -1343,6 +1345,19 @@ export default class NextNodeServer extends BaseServer<
     const manifest = this.getMiddlewareManifest()
     const middleware = manifest?.middleware?.['/']
     if (!middleware) {
+      const middlewareModule = this.loadNodeMiddleware()
+
+      if (middlewareModule) {
+        return {
+          match: getMiddlewareRouteMatcher(
+            middlewareModule.config?.matchers || [
+              { regexp: '.*', originalSource: '/:path*' },
+            ]
+          ),
+          page: '/',
+        }
+      }
+
       return
     }
 
@@ -1420,6 +1435,30 @@ export default class NextNodeServer extends BaseServer<
     }
   }
 
+  private loadNodeMiddleware() {
+    if (!this.nextConfig.experimental.nodeMiddleware) {
+      return
+    }
+
+    try {
+      const functionsConfig = this.renderOpts.dev
+        ? {}
+        : require(join(this.distDir, 'server', FUNCTIONS_CONFIG_MANIFEST))
+
+      if (this.renderOpts.dev || functionsConfig?.functions?.['/_middleware']) {
+        return require(join(this.distDir, 'server', 'middleware.js'))
+      }
+    } catch (err) {
+      if (
+        isError(err) &&
+        err.code !== 'ENOENT' &&
+        err.code !== 'MODULE_NOT_FOUND'
+      ) {
+        throw err
+      }
+    }
+  }
+
   /**
    * Checks if a middleware exists. This method is useful for the development
    * server where we need to check the filesystem. Here we just check the
@@ -1427,6 +1466,10 @@ export default class NextNodeServer extends BaseServer<
    */
   protected async hasMiddleware(pathname: string): Promise<boolean> {
     const info = this.getEdgeFunctionInfo({ page: pathname, middleware: true })
+
+    if (!info && this.loadNodeMiddleware()) {
+      return true
+    }
     return Boolean(info && info.paths.length > 0)
   }
 
@@ -1512,36 +1555,63 @@ export default class NextNodeServer extends BaseServer<
       middleware: true,
     })
 
-    if (!middlewareInfo) {
-      throw new MiddlewareNotFoundError()
-    }
-
     const method = (params.request.method || 'GET').toUpperCase()
-    const { run } = require('./web/sandbox') as typeof import('./web/sandbox')
-
-    const result = await run({
-      distDir: this.distDir,
-      name: middlewareInfo.name,
-      paths: middlewareInfo.paths,
-      edgeFunctionEntry: middlewareInfo,
-      request: {
-        headers: params.request.headers,
-        method,
-        nextConfig: {
-          basePath: this.nextConfig.basePath,
-          i18n: this.nextConfig.i18n,
-          trailingSlash: this.nextConfig.trailingSlash,
-          experimental: this.nextConfig.experimental,
-        },
-        url: url,
-        page,
-        body: getRequestMeta(params.request, 'clonableBody'),
-        signal: signalFromNodeResponse(params.response.originalResponse),
-        waitUntil: this.getWaitUntil(),
+    const requestData = {
+      headers: params.request.headers,
+      method,
+      nextConfig: {
+        basePath: this.nextConfig.basePath,
+        i18n: this.nextConfig.i18n,
+        trailingSlash: this.nextConfig.trailingSlash,
+        experimental: this.nextConfig.experimental,
       },
-      useCache: true,
-      onWarning: params.onWarning,
-    })
+      url: url,
+      page,
+      body:
+        method !== 'GET' && method !== 'HEAD'
+          ? (getRequestMeta(params.request, 'clonableBody') as any)
+          : undefined,
+
+      signal: signalFromNodeResponse(params.response.originalResponse),
+      waitUntil: this.getWaitUntil(),
+    }
+    let result:
+      | UnwrapPromise<ReturnType<typeof import('./web/sandbox').run>>
+      | undefined
+
+    // if no middleware info check for Node.js middleware
+    // this is not in the middleware-manifest as that historically
+    // has only included edge-functions, we need to do a breaking
+    // version bump for that manifest to write this info there if
+    // we decide we want to
+    if (!middlewareInfo) {
+      let middlewareModule
+      middlewareModule = this.loadNodeMiddleware()
+
+      if (!middlewareModule) {
+        throw new MiddlewareNotFoundError()
+      }
+      const adapterFn: typeof import('./web/adapter').adapter =
+        middlewareModule.default || middlewareModule
+
+      result = await adapterFn({
+        handler: middlewareModule.middleware || middlewareModule,
+        request: requestData,
+        page: 'middleware',
+      })
+    } else {
+      const { run } = require('./web/sandbox') as typeof import('./web/sandbox')
+
+      result = await run({
+        distDir: this.distDir,
+        name: middlewareInfo.name,
+        paths: middlewareInfo.paths,
+        edgeFunctionEntry: middlewareInfo,
+        request: requestData,
+        useCache: true,
+        onWarning: params.onWarning,
+      })
+    }
 
     if (!this.renderOpts.dev) {
       result.waitUntil.catch((error) => {

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -103,7 +103,8 @@ export async function adapter(
   await ensureInstrumentationRegistered()
 
   // TODO-APP: use explicit marker for this
-  const isEdgeRendering = typeof self.__BUILD_MANIFEST !== 'undefined'
+  const isEdgeRendering =
+    typeof (globalThis as any).__BUILD_MANIFEST !== 'undefined'
 
   params.request.url = normalizeRscURL(params.request.url)
 

--- a/packages/next/src/server/web/globals.ts
+++ b/packages/next/src/server/web/globals.ts
@@ -82,6 +82,10 @@ function __import_unsupported(moduleName: string) {
 }
 
 function enhanceGlobals() {
+  if (process.env.NEXT_RUNTIME !== 'edge') {
+    return
+  }
+
   // The condition is true when the "process" module is provided
   if (process !== global.process) {
     // prefer local process but global.process has correct "env"

--- a/packages/next/src/shared/lib/turbopack/manifest-loader.ts
+++ b/packages/next/src/shared/lib/turbopack/manifest-loader.ts
@@ -423,7 +423,9 @@ export class TurbopackManifestLoader {
     )
     await writeFileAtomic(
       middlewareBuildManifestPath,
-      `self.__BUILD_MANIFEST=${JSON.stringify(buildManifest)};`
+      // we use globalThis here because middleware can be node
+      // which doesn't have "self"
+      `globalThis.__BUILD_MANIFEST=${JSON.stringify(buildManifest)};`
     )
 
     const interceptionRewrites = JSON.stringify(

--- a/test/e2e/middleware-general/test/node-runtime.test.ts
+++ b/test/e2e/middleware-general/test/node-runtime.test.ts
@@ -1,0 +1,7 @@
+process.env.TEST_NODE_MIDDLEWARE = 'true'
+
+if (process.env.TURBOPACK) {
+  it('should skip', () => {})
+} else {
+  require('./index.test')
+}

--- a/test/unit/parse-page-static-info.test.ts
+++ b/test/unit/parse-page-static-info.test.ts
@@ -30,7 +30,7 @@ describe('parse page static info', () => {
         nextConfig: createNextConfig(),
         pageType: PAGE_TYPES.PAGES,
       })
-    expect(runtime).toBe(undefined)
+    expect(runtime).toBe('nodejs')
     expect(getServerSideProps).toBe(false)
     expect(getStaticProps).toBe(false)
   })


### PR DESCRIPTION
This allows setting `runtime: 'nodejs'` in middleware, which removes the constraint of only using edge runtime APIs for middleware. This doesn't change the signature of middleware and it still receives `(req: NextRequest, event: NextFetchEvent) => Response`. 

x-ref: https://github.com/vercel/next.js/discussions/71727
x-ref: https://github.com/vercel/next.js/discussions/46722