### PR TITLE
chore(github): update stale bot

### DIFF
--- a/.github/workflows/issue_stale.yml
+++ b/.github/workflows/issue_stale.yml
@@ -17,7 +17,7 @@ jobs:
           repo-token: ${{ secrets.STALE_TOKEN }}
           ascending: true
           days-before-issue-close: 7
-          days-before-issue-stale: 730 # issues with no activity in over two years
+          days-before-issue-stale: 545 # issues with no activity in over ~1.5 years
           days-before-pr-close: -1
           days-before-pr-stale: -1
           remove-issue-stale-when-updated: true


### PR DESCRIPTION
## Why?

A `days-before-issue-stale` period of two years has so far been successful. We can now move this to ~1.5 years (545 days).