### PR TITLE
Disable `rewrite-headers` tests that are dependent on Vercel site config

### DIFF
--- a/test/e2e/app-dir/rewrite-headers/rewrite-headers.test.ts
+++ b/test/e2e/app-dir/rewrite-headers/rewrite-headers.test.ts
@@ -308,31 +308,34 @@ const cases: {
       'x-nextjs-rewritten-query': null,
     },
   },
-  {
-    name: 'middleware rewrite external RSC',
-    pathname: '/hello/vercel',
-    headers: {
-      RSC: '1',
-    },
-    expected: {
-      // Vercel matches `/` to `/home`
-      'x-nextjs-rewritten-path': '/home',
-      'x-nextjs-rewritten-query': null,
-    },
-  },
-  {
-    name: 'middleware rewrite external Prefetch RSC',
-    pathname: '/hello/vercel',
-    headers: {
-      RSC: '1',
-      'Next-Router-Prefetch': '1',
-    },
-    expected: {
-      // Vercel matches `/` to `/home`
-      'x-nextjs-rewritten-path': '/home',
-      'x-nextjs-rewritten-query': null,
-    },
-  },
+  // TODO: These next two scenarios are dependent on how the Vercel site has
+  // configured its rewrites, and thus are prone to be flaky. Figure out what
+  // Next.js logic this is supposed to test.
+  // {
+  //   name: 'middleware rewrite external RSC',
+  //   pathname: '/hello/vercel',
+  //   headers: {
+  //     RSC: '1',
+  //   },
+  //   expected: {
+  //     // Vercel matches `/` to `/home`
+  //     'x-nextjs-rewritten-path': '/home',
+  //     'x-nextjs-rewritten-query': null,
+  //   },
+  // },
+  // {
+  //   name: 'middleware rewrite external Prefetch RSC',
+  //   pathname: '/hello/vercel',
+  //   headers: {
+  //     RSC: '1',
+  //     'Next-Router-Prefetch': '1',
+  //   },
+  //   expected: {
+  //     // Vercel matches `/` to `/home`
+  //     'x-nextjs-rewritten-path': '/home',
+  //     'x-nextjs-rewritten-query': null,
+  //   },
+  // },
   {
     name: 'next.config.js rewrites with query HTML',
     pathname: '/hello/fred',


### PR DESCRIPTION
The two scenarios that test rewrite headers for vercel.com are dependent on how the Vercel site has currently configured its rewrites, and thus are prone to be flaky. Until we've figured out what Next.js logic this is supposed to test, and how we can decouple it from this external source, we are disabling them to unblock other PRs.

An attempt to fix the expectation was done yesterday in #75602, but in the meantime the returned `x-nextjs-rewritten-path` header has changed again (`/home/eyJhbGciOiJIUzI1NiJ9.AP0.7cQg-Q2tj1BAyHFfT32HLI3JRdEfYCiANjbtqRiDfLs`).