### PR TITLE
fix(docs): update incorrect API route docs link

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -34,7 +34,7 @@
   "33": "Turbopack build failed with %s issues:\\n%s",
   "34": "source-map information is not available at url() declaration %s",
   "35": "To use middleware you must provide a `hostname` and `port` to the Next.js Server",
-  "36": "API route returned a Response object in the Node.js runtime, this is not supported. Please use `runtime: \"edge\"` instead: https://nextjs.org/docs/api-routes/edge-api-routes",
+  "36": "API route returned a Response object in the Node.js runtime, this is not supported. Please use `runtime: \"edge\"` instead: https://nextjs.org/docs/pages/building-your-application/routing/api-routes#edge-api-routes",
   "37": "\\`%s\\` cannot be called inside \"use cache\". Call it outside and pass an argument instead. Read more: https://nextjs.org/docs/messages/next-request-in-use-cache",
   "38": "Extra keys returned from getStaticPaths in %s (%s) %s",
   "39": "Specified basePath should not end with /, found \"%s\"",

--- a/packages/next/src/server/api-utils/node/api-resolver.ts
+++ b/packages/next/src/server/api-utils/node/api-resolver.ts
@@ -423,7 +423,7 @@ export async function apiResolver(
       if (typeof apiRouteResult !== 'undefined') {
         if (apiRouteResult instanceof Response) {
           throw new Error(
-            'API route returned a Response object in the Node.js runtime, this is not supported. Please use `runtime: "edge"` instead: https://nextjs.org/docs/api-routes/edge-api-routes'
+            'API route returned a Response object in the Node.js runtime, this is not supported. Please use `runtime: "edge"` instead: https://nextjs.org/docs/pages/building-your-application/routing/api-routes#edge-api-routes'
           )
         }
         console.warn(


### PR DESCRIPTION
Updated the incorrect API route documentation link in the error message.

## What changed?
- Replaced outdated link: `https://nextjs.org/docs/api-routes/edge-api-routes`
- Added the correct link: `https://nextjs.org/docs/pages/building-your-application/routing/api-routes#edge-api-routes`

## Why?
The previous link was outdated and led to incorrect documentation. This update ensures users are directed to the correct resource.
