### PR TITLE
Turbopack: `OutputAsset::path()`

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1157,7 +1157,7 @@ impl AppEndpoint {
         for chunk in client_shared_chunk_group.assets.await?.iter().copied() {
             client_assets.insert(chunk);
 
-            let chunk_path = chunk.ident().path().await?;
+            let chunk_path = chunk.path().await?;
             if chunk_path.extension_ref() == Some("js") {
                 client_shared_chunks.push(chunk);
             }
@@ -1534,7 +1534,7 @@ impl AppEndpoint {
                         &app_entry.original_name,
                         server_path
                             .await?
-                            .get_path_to(&*rsc_chunk.ident().path().await?)
+                            .get_path_to(&*rsc_chunk.path().await?)
                             .context(
                                 "RSC chunk path should be within app paths manifest directory",
                             )?
@@ -1847,7 +1847,7 @@ impl Endpoint for AppEndpoint {
             let written_endpoint = match *output {
                 AppEndpointOutput::NodeJs { rsc_chunk, .. } => EndpointOutputPaths::NodeJs {
                     server_entry_path: node_root_ref
-                        .get_path_to(&*rsc_chunk.ident().path().await?)
+                        .get_path_to(&*rsc_chunk.path().await?)
                         .context("Node.js chunk entry path must be inside the node root")?
                         .to_string(),
                     server_paths,

--- a/crates/next-api/src/loadable_manifest.rs
+++ b/crates/next-api/src/loadable_manifest.rs
@@ -36,7 +36,7 @@ pub async fn create_react_loadable_manifest(
                 let client_relative_path_value = client_relative_path_value.clone();
                 async move {
                     Ok(client_relative_path_value
-                        .get_path_to(&*file.ident().path().await?)
+                        .get_path_to(&*file.path().await?)
                         .map(|path| path.into()))
                 }
             })

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -7,7 +7,6 @@ use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{File, FileSystem, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    ident::AssetIdent,
     output::OutputAsset,
     reference::all_assets_from_entries,
 };
@@ -60,13 +59,12 @@ impl NftJsonAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for NftJsonAsset {
     #[turbo_tasks::function]
-    async fn ident(&self) -> Result<Vc<AssetIdent>> {
-        let path = self.chunk.ident().path().await?;
-        Ok(AssetIdent::from_path(
-            path.fs
-                .root()
-                .join(format!("{}.nft.json", path.path).into()),
-        ))
+    async fn path(&self) -> Result<Vc<FileSystemPath>> {
+        let path = self.chunk.path().await?;
+        Ok(path
+            .fs
+            .root()
+            .join(format!("{}.nft.json", path.path).into()))
     }
 }
 
@@ -121,7 +119,7 @@ impl Asset for NftJsonAsset {
         let client_root_ref = client_root.await?;
         let dist_dir = self.dist_dir().await?;
 
-        let ident_folder = self.ident().path().parent().await?;
+        let ident_folder = self.path().parent().await?;
         let ident_folder_in_project_fs = this
             .project
             .project_path()
@@ -141,7 +139,7 @@ impl Asset for NftJsonAsset {
                 continue;
             }
 
-            let referenced_chunk_path = referenced_chunk.ident().path().await?;
+            let referenced_chunk_path = referenced_chunk.path().await?;
             if referenced_chunk_path.extension_ref() == Some("map") {
                 continue;
             }

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1098,7 +1098,7 @@ impl PageEndpoint {
         entry_chunk: Vc<Box<dyn OutputAsset>>,
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
         let node_root = self.pages_project.project().node_root();
-        let chunk_path = entry_chunk.ident().path().await?;
+        let chunk_path = entry_chunk.path().await?;
 
         let asset_path = node_root
             .join("server".into())
@@ -1424,7 +1424,7 @@ impl Endpoint for PageEndpoint {
             let written_endpoint = match *output {
                 PageEndpointOutput::NodeJs { entry_chunk, .. } => EndpointOutputPaths::NodeJs {
                     server_entry_path: node_root
-                        .get_path_to(&*entry_chunk.ident().path().await?)
+                        .get_path_to(&*entry_chunk.path().await?)
                         .context("ssr chunk entry path must be inside the node root")?
                         .to_string(),
                     server_paths,

--- a/crates/next-api/src/paths.rs
+++ b/crates/next-api/src/paths.rs
@@ -39,7 +39,7 @@ pub async fn all_server_paths(
                 .iter()
                 .map(|&asset| async move {
                     Ok(
-                        if let Some(path) = node_root.get_path_to(&*asset.ident().path().await?) {
+                        if let Some(path) = node_root.get_path_to(&*asset.path().await?) {
                             let content_hash = match *asset.content().await? {
                                 AssetContent::File(file) => *file.hash().await?,
                                 AssetContent::Redirect { .. } => 0,
@@ -84,7 +84,7 @@ pub(crate) async fn get_paths_from_root(
     output_assets
         .iter()
         .map(move |&file| async move {
-            let path = &*file.ident().path().await?;
+            let path = &*file.path().await?;
             let Some(relative) = root.get_path_to(path) else {
                 return Ok(None);
             };

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1649,7 +1649,7 @@ async fn any_output_changed(
         .into_inner()
         .into_reverse_topological()
         .map(|m| async move {
-            let asset_path = m.ident().path().await?;
+            let asset_path = m.path().await?;
             if !asset_path.path.ends_with(".map")
                 && (!server || !asset_path.path.ends_with(".css"))
                 && asset_path.is_inside_ref(path)

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -128,7 +128,7 @@ impl VersionedContentMap {
             let entries = assets_ref
                 .iter()
                 .map(|&asset| async move {
-                    let path = asset.ident().path().to_resolved().await?;
+                    let path = asset.path().to_resolved().await?;
                     Ok((path, asset))
                 })
                 .try_join()

--- a/crates/next-api/src/webpack_stats.rs
+++ b/crates/next-api/src/webpack_stats.rs
@@ -21,14 +21,14 @@ where
         FxIndexMap::default();
     let mut modules = vec![];
     for asset in entry_assets {
-        let path = normalize_client_path(&asset.ident().path().await?.path);
+        let path = normalize_client_path(&asset.path().await?.path);
 
         let Some(asset_len) = *asset.size_bytes().await? else {
             continue;
         };
 
         if let Some(chunk) = ResolvedVc::try_downcast_type::<EcmascriptDevChunk>(*asset) {
-            let chunk_ident = normalize_client_path(&chunk.ident().path().await?.path);
+            let chunk_ident = normalize_client_path(&chunk.path().await?.path);
             chunks.push(WebpackStatsChunk {
                 size: asset_len,
                 files: vec![chunk_ident.clone().into()],

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -50,7 +50,7 @@ pub async fn emit_assets(
         .iter()
         .copied()
         .map(|asset| async move {
-            let path = asset.ident().path();
+            let path = asset.path();
             let span = tracing::info_span!("emit asset", name = %path.to_string().await?);
             async move {
                 let path = path.await?;
@@ -79,11 +79,7 @@ pub async fn emit_assets(
 
 #[turbo_tasks::function]
 async fn emit(asset: Vc<Box<dyn OutputAsset>>) -> Result<()> {
-    let _ = asset
-        .content()
-        .write(asset.ident().path())
-        .resolve()
-        .await?;
+    let _ = asset.content().write(asset.path()).resolve().await?;
     Ok(())
 }
 
@@ -93,7 +89,7 @@ async fn emit_rebase(
     from: Vc<FileSystemPath>,
     to: Vc<FileSystemPath>,
 ) -> Result<()> {
-    let path = rebase(asset.ident().path(), from, to);
+    let path = rebase(asset.path(), from, to);
     let content = asset.content();
     let _ = content
         .resolve()

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -109,7 +109,7 @@ impl ClientReferenceManifest {
                         Ok(if let Some(path) = path {
                             (chunk, Either::Left(path))
                         } else {
-                            (chunk, Either::Right(chunk.ident().path().await?))
+                            (chunk, Either::Right(chunk.path().await?))
                         })
                     })
                     .try_join()

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -63,7 +63,7 @@ impl BuildManifest {
                         .iter()
                         .copied()
                         .map(|chunk| async move {
-                            let chunk_path = chunk.ident().path().await?;
+                            let chunk_path = chunk.path().await?;
                             Ok(client_relative_path_ref
                                 .get_path_to(&chunk_path)
                                 .context("client chunk entry path must be inside the client root")?
@@ -81,7 +81,7 @@ impl BuildManifest {
             .iter()
             .copied()
             .map(|chunk| async move {
-                let chunk_path = chunk.ident().path().await?;
+                let chunk_path = chunk.path().await?;
                 Ok(client_relative_path_ref
                     .get_path_to(&chunk_path)
                     .context("failed to resolve client-relative path to polyfill")?
@@ -95,7 +95,7 @@ impl BuildManifest {
             .iter()
             .copied()
             .map(|chunk| async move {
-                let chunk_path = chunk.ident().path().await?;
+                let chunk_path = chunk.path().await?;
                 Ok(client_relative_path_ref
                     .get_path_to(&chunk_path)
                     .context("failed to resolve client-relative path to root_main_file")?
@@ -448,7 +448,7 @@ impl AppBuildManifest {
                         .iter()
                         .copied()
                         .map(|chunk| async move {
-                            let chunk_path = chunk.ident().path().await?;
+                            let chunk_path = chunk.path().await?;
                             Ok(client_relative_path_ref
                                 .get_path_to(&chunk_path)
                                 .context("client chunk entry path must be inside the client root")?

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -10,7 +10,6 @@ use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkData, ChunksData},
     context::AssetContext,
-    ident::AssetIdent,
     module::Module,
     output::{OutputAsset, OutputAssets},
     proxied_asset::ProxiedAsset,
@@ -113,7 +112,7 @@ impl PageLoaderAsset {
                 .map(|&chunk| {
                     Vc::upcast::<Box<dyn OutputAsset>>(ProxiedAsset::new(
                         *chunk,
-                        FileSystemPath::rebase(chunk.ident().path(), **rebase_path, root_path),
+                        FileSystemPath::rebase(chunk.path(), **rebase_path, root_path),
                     ))
                     .to_resolved()
                 })
@@ -134,19 +133,17 @@ fn page_loader_chunk_reference_description() -> Vc<RcStr> {
 #[turbo_tasks::value_impl]
 impl OutputAsset for PageLoaderAsset {
     #[turbo_tasks::function]
-    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+    async fn path(&self) -> Result<Vc<FileSystemPath>> {
         let root = self
             .rebase_prefix_path
             .await?
             .map_or(*self.server_root, |path| *path);
-        Ok(AssetIdent::from_path(
-            root.join(
-                format!(
-                    "static/chunks/pages{}",
-                    get_asset_path_from_pathname(&self.pathname.await?, ".js")
-                )
-                .into(),
-            ),
+        Ok(root.join(
+            format!(
+                "static/chunks/pages{}",
+                get_asset_path_from_pathname(&self.pathname.await?, ".js")
+            )
+            .into(),
         ))
     }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1301,7 +1301,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         drop(task);
 
         {
-            // let _span = tracing::trace_span!("CleanupOldEdgesOperation").entered();
+            let _span = tracing::trace_span!("CleanupOldEdgesOperation").entered();
             // Remove outdated edges first, before removing in_progress+dirty flag.
             // We need to make sure all outdated edges are removed before the task can potentially
             // be scheduled and executed again

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1301,7 +1301,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         drop(task);
 
         {
-            let _span = tracing::trace_span!("CleanupOldEdgesOperation").entered();
+            // let _span = tracing::trace_span!("CleanupOldEdgesOperation").entered();
             // Remove outdated edges first, before removing in_progress+dirty flag.
             // We need to make sure all outdated edges are removed before the task can potentially
             // be scheduled and executed again

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -326,17 +326,16 @@ impl ChunkingContext for BrowserChunkingContext {
     }
 
     #[turbo_tasks::function]
-    async fn asset_url(self: Vc<Self>, ident: Vc<AssetIdent>) -> Result<Vc<RcStr>> {
-        let this = self.await?;
-        let asset_path = ident.path().await?.to_string();
+    async fn asset_url(&self, ident: Vc<FileSystemPath>) -> Result<Vc<RcStr>> {
+        let asset_path = ident.await?.to_string();
         let asset_path = asset_path
-            .strip_prefix(&format!("{}/", this.client_root.await?.path))
+            .strip_prefix(&format!("{}/", self.client_root.await?.path))
             .context("expected asset_path to contain client_root")?;
 
         Ok(Vc::cell(
             format!(
                 "{}{}",
-                this.asset_base_path
+                self.asset_base_path
                     .await?
                     .as_ref()
                     .map(|s| s.as_str())

--- a/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexSet, ResolvedVc, ValueToString, Vc};
+use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{Chunk, ChunkingContext, OutputChunk, OutputChunkRuntimeInfo},
-    ident::AssetIdent,
     introspect::{Introspectable, IntrospectableChildren},
     output::{OutputAsset, OutputAssets},
     source_map::{GenerateSourceMap, OptionSourceMap, SourceMapAsset},
@@ -83,9 +83,9 @@ impl EcmascriptDevChunk {
 #[turbo_tasks::value_impl]
 impl OutputAsset for EcmascriptDevChunk {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
+    fn path(&self) -> Vc<FileSystemPath> {
         let ident = self.chunk.ident().with_modifier(modifier());
-        AssetIdent::from_path(self.chunking_context.chunk_path(ident, ".js".into()))
+        self.chunking_context.chunk_path(ident, ".js".into())
     }
 
     #[turbo_tasks::function]
@@ -161,7 +161,7 @@ impl Introspectable for EcmascriptDevChunk {
 
     #[turbo_tasks::function]
     fn title(self: Vc<Self>) -> Vc<RcStr> {
-        self.ident().to_string()
+        self.path().to_string()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -59,7 +59,7 @@ impl EcmascriptDevChunkContent {
     pub(crate) fn own_version(&self) -> Vc<EcmascriptDevChunkVersion> {
         EcmascriptDevChunkVersion::new(
             self.chunking_context.output_root(),
-            self.chunk.ident().path(),
+            self.chunk.path(),
             *self.entries,
         )
     }
@@ -71,7 +71,7 @@ impl EcmascriptDevChunkContent {
         let source_maps = this
             .chunking_context
             .reference_chunk_source_maps(*ResolvedVc::upcast(this.chunk));
-        let chunk_path_vc = this.chunk.ident().path();
+        let chunk_path_vc = this.chunk.path();
         let chunk_path = chunk_path_vc.await?;
         let chunk_server_path = if let Some(path) = output_root.get_path_to(&chunk_path) {
             path

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
+use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkingContext, EvaluatableAssets},
@@ -90,7 +91,7 @@ fn chunk_key() -> Vc<RcStr> {
 #[turbo_tasks::value_impl]
 impl OutputAsset for EcmascriptDevChunkList {
     #[turbo_tasks::function]
-    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+    async fn path(&self) -> Result<Vc<FileSystemPath>> {
         let mut ident = self.ident.await?.clone_value();
         ident.add_modifier(modifier().to_resolved().await?);
 
@@ -106,9 +107,7 @@ impl OutputAsset for EcmascriptDevChunkList {
         // removed from the list.
 
         let ident = AssetIdent::new(Value::new(ident));
-        Ok(AssetIdent::from_path(
-            self.chunking_context.chunk_path(ident, ".js".into()),
-        ))
+        Ok(self.chunking_context.chunk_path(ident, ".js".into()))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
@@ -39,7 +39,7 @@ impl EcmascriptDevChunkListContent {
         let output_root = chunk_list_ref.chunking_context.output_root().await?;
         Ok(EcmascriptDevChunkListContent {
             chunk_list_path: output_root
-                .get_path_to(&*chunk_list.ident().path().await?)
+                .get_path_to(&*chunk_list.path().await?)
                 .context("chunk list path not in output root")?
                 .to_string(),
             chunks_contents: chunk_list_ref
@@ -51,7 +51,7 @@ impl EcmascriptDevChunkListContent {
                     async move {
                         Ok((
                             output_root
-                                .get_path_to(&*chunk.ident().path().await?)
+                                .get_path_to(&*chunk.path().await?)
                                 .map(|path| path.to_string()),
                             chunk.versioned_content().to_resolved().await?,
                         ))

--- a/turbopack/crates/turbopack-browser/src/ecmascript/merged/update.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/merged/update.rs
@@ -180,7 +180,7 @@ pub(super) async fn update_ecmascript_merged_chunk(
         .map(|content| async move {
             let content_ref = content.await?;
             let output_root = content_ref.chunking_context.output_root().await?;
-            let path = content_ref.chunk.ident().path().await?;
+            let path = content_ref.chunk.path().await?;
             Ok((*content, content_ref, output_root, path))
         })
         .try_join()

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -445,7 +445,7 @@ async fn build_internal(
 
     chunks
         .iter()
-        .map(|c| c.content().write(c.ident().path()))
+        .map(|c| c.content().write(c.path()))
         .try_join()
         .await?;
 

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -145,7 +145,7 @@ pub trait ChunkingContext {
 
     /// Returns a URL (relative or absolute, depending on the asset prefix) to
     /// the static asset based on its `ident`.
-    fn asset_url(self: Vc<Self>, ident: Vc<AssetIdent>) -> Result<Vc<RcStr>>;
+    fn asset_url(self: Vc<Self>, ident: Vc<FileSystemPath>) -> Result<Vc<RcStr>>;
 
     fn asset_path(
         self: Vc<Self>,

--- a/turbopack/crates/turbopack-core/src/chunk/data.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/data.rs
@@ -40,7 +40,7 @@ impl ChunkData {
         chunk: Vc<Box<dyn OutputAsset>>,
     ) -> Result<Vc<ChunkDataOption>> {
         let output_root = output_root.await?;
-        let path = chunk.ident().path().await?;
+        let path = chunk.path().await?;
         // The "path" in this case is the chunk's path, not the chunk item's path.
         // The difference is a chunk is a file served by the dev server, and an
         // item is one of several that are contained in that chunk file.
@@ -91,7 +91,7 @@ impl ChunkData {
                     let output_root = output_root.clone();
 
                     async move {
-                        let chunk_path = chunk.ident().path().await?;
+                        let chunk_path = chunk.path().await?;
                         Ok(output_root
                             .get_path_to(&chunk_path)
                             .map(|path| (path.to_owned(), chunk)))

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -19,7 +19,6 @@ use turbo_tasks::{
     debug::ValueDebugFormat, trace::TraceRawVcs, FxIndexMap, FxIndexSet, NonLocalValue, ResolvedVc,
     TaskInput, Upcast, ValueToString, Vc,
 };
-use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::DeterministicHash;
 
 pub use self::{
@@ -107,19 +106,16 @@ impl Chunks {
     }
 }
 
-/// A chunk is one type of asset.
+/// A [Chunk] group chunk items together into something that will become an [OutputAsset].
 /// It usually contains multiple chunk items.
+// TODO This could be simplified to and merged with [OutputChunk]
 #[turbo_tasks::value_trait]
-pub trait Chunk: Asset {
+pub trait Chunk {
     fn ident(self: Vc<Self>) -> Vc<AssetIdent>;
     fn chunking_context(self: Vc<Self>) -> Vc<Box<dyn ChunkingContext>>;
-    // TODO Once output assets have their own trait, this path() method will move
-    // into that trait and ident() will be removed from that. Assets on the
-    // output-level only have a path and no complex ident.
-    /// The path of the chunk.
-    fn path(self: Vc<Self>) -> Vc<FileSystemPath> {
-        self.ident().path()
-    }
+    // fn path(self: Vc<Self>) -> Vc<FileSystemPath> {
+    //     self.ident().path()
+    // }
 
     /// Other [OutputAsset]s referenced from this [Chunk].
     fn references(self: Vc<Self>) -> Vc<OutputAssets> {

--- a/turbopack/crates/turbopack-core/src/introspect/output_asset.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/output_asset.rs
@@ -39,7 +39,7 @@ impl Introspectable for IntrospectableOutputAsset {
 
     #[turbo_tasks::function]
     fn title(&self) -> Vc<RcStr> {
-        self.0.ident().to_string()
+        self.0.path().to_string()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/output.rs
+++ b/turbopack/crates/turbopack-core/src/output.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 use turbo_tasks::{FxIndexSet, ResolvedVc, Vc};
+use turbo_tasks_fs::FileSystemPath;
 
-use crate::{asset::Asset, ident::AssetIdent};
+use crate::asset::Asset;
 
 #[turbo_tasks::value(transparent)]
 pub struct OptionOutputAsset(Option<ResolvedVc<Box<dyn OutputAsset>>>);
@@ -10,10 +11,9 @@ pub struct OptionOutputAsset(Option<ResolvedVc<Box<dyn OutputAsset>>>);
 /// server.
 #[turbo_tasks::value_trait]
 pub trait OutputAsset: Asset {
-    // TODO change this to path() -> Vc<FileSystemPath>
     /// The identifier of the [OutputAsset]. It's expected to be unique and
-    /// capture all properties of the [OutputAsset]. Only path must be used.
-    fn ident(&self) -> Vc<AssetIdent>;
+    /// capture all properties of the [OutputAsset].
+    fn path(&self) -> Vc<FileSystemPath>;
 
     /// Other references [OutputAsset]s from this [OutputAsset].
     fn references(self: Vc<Self>) -> Vc<OutputAssets> {

--- a/turbopack/crates/turbopack-core/src/proxied_asset.rs
+++ b/turbopack/crates/turbopack-core/src/proxied_asset.rs
@@ -3,7 +3,6 @@ use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
     asset::{Asset, AssetContent},
-    ident::AssetIdent,
     output::{OutputAsset, OutputAssets},
     version::VersionedContent,
 };
@@ -34,8 +33,8 @@ impl ProxiedAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for ProxiedAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(*self.path)
+    fn path(&self) -> Vc<FileSystemPath> {
+        *self.path
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/raw_output.rs
+++ b/turbopack/crates/turbopack-core/src/raw_output.rs
@@ -3,7 +3,6 @@ use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
     asset::{Asset, AssetContent},
-    ident::AssetIdent,
     output::OutputAsset,
     source::Source,
 };
@@ -19,8 +18,8 @@ pub struct RawOutput {
 #[turbo_tasks::value_impl]
 impl OutputAsset for RawOutput {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(*self.path)
+    fn path(&self) -> Vc<FileSystemPath> {
+        *self.path
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/rebase.rs
+++ b/turbopack/crates/turbopack-core/src/rebase.rs
@@ -6,7 +6,6 @@ use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
     asset::{Asset, AssetContent},
-    ident::AssetIdent,
     module::Module,
     output::{OutputAsset, OutputAssets},
     reference::referenced_modules_and_affecting_sources,
@@ -41,12 +40,12 @@ impl RebasedAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for RebasedAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(FileSystemPath::rebase(
+    fn path(&self) -> Vc<FileSystemPath> {
+        FileSystemPath::rebase(
             self.module.ident().path(),
             *self.input_dir,
             *self.output_dir,
-        ))
+        )
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -1,11 +1,10 @@
 use anyhow::{bail, Result};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexSet, ResolvedVc, ValueToString, Vc};
-use turbo_tasks_fs::File;
+use turbo_tasks_fs::{File, FileSystemPath};
 
 use crate::{
     asset::{Asset, AssetContent},
-    ident::AssetIdent,
     introspect::{Introspectable, IntrospectableChildren},
     output::OutputAsset,
     source_map::{GenerateSourceMap, SourceMap},
@@ -28,10 +27,10 @@ impl SourceMapAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for SourceMapAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
+    fn path(&self) -> Vc<FileSystemPath> {
         // NOTE(alexkirsz) We used to include the asset's version id in the path,
         // but this caused `all_assets_map` to be recomputed on every change.
-        AssetIdent::from_path(self.asset.ident().path().append(".map".into()))
+        self.asset.path().append(".map".into())
     }
 }
 
@@ -73,7 +72,7 @@ impl Introspectable for SourceMapAsset {
 
     #[turbo_tasks::function]
     fn title(self: Vc<Self>) -> Vc<RcStr> {
-        self.ident().to_string()
+        self.path().to_string()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/traced_asset.rs
+++ b/turbopack/crates/turbopack-core/src/traced_asset.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
+use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
     asset::{Asset, AssetContent},
-    ident::AssetIdent,
     module::Module,
     output::{OutputAsset, OutputAssets},
     reference::referenced_modules_and_affecting_sources,
@@ -26,8 +26,8 @@ impl TracedAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for TracedAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(self.module.ident().path())
+    fn path(&self) -> Vc<FileSystemPath> {
+        self.module.ident().path()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/virtual_output.rs
+++ b/turbopack/crates/turbopack-core/src/virtual_output.rs
@@ -3,7 +3,6 @@ use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
     asset::{Asset, AssetContent},
-    ident::AssetIdent,
     output::{OutputAsset, OutputAssets},
 };
 
@@ -46,8 +45,8 @@ impl VirtualOutputAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for VirtualOutputAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(*self.path)
+    fn path(&self) -> Vc<FileSystemPath> {
+        *self.path
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
-use turbo_tasks_fs::File;
+use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{Chunk, ChunkItem, ChunkingContext},
@@ -87,7 +87,7 @@ impl Chunk for SingleItemCssChunk {
     #[turbo_tasks::function]
     fn ident(self: Vc<Self>) -> Vc<AssetIdent> {
         let self_as_output_asset: Vc<Box<dyn OutputAsset>> = Vc::upcast(self);
-        self_as_output_asset.ident()
+        AssetIdent::from_path(self_as_output_asset.path())
     }
 
     #[turbo_tasks::function]
@@ -104,14 +104,12 @@ fn single_item_modifier() -> Vc<RcStr> {
 #[turbo_tasks::value_impl]
 impl OutputAsset for SingleItemCssChunk {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(
-            self.chunking_context.chunk_path(
-                self.item
-                    .asset_ident()
-                    .with_modifier(single_item_modifier()),
-                ".css".into(),
-            ),
+    fn path(&self) -> Vc<FileSystemPath> {
+        self.chunking_context.chunk_path(
+            self.item
+                .asset_ident()
+                .with_modifier(single_item_modifier()),
+            ".css".into(),
         )
     }
 

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
@@ -1,10 +1,8 @@
 use anyhow::Result;
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::File;
+use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::Chunk,
-    ident::AssetIdent,
     output::OutputAsset,
     source_map::{GenerateSourceMap, SourceMap},
 };
@@ -28,8 +26,8 @@ impl SingleItemCssChunkSourceMapAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for SingleItemCssChunkSourceMapAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(self.chunk.path().append(".map".into()))
+    fn path(&self) -> Vc<FileSystemPath> {
+        self.chunk.path().append(".map".into())
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/source_map.rs
@@ -1,10 +1,8 @@
 use anyhow::Result;
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::File;
+use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::Chunk,
-    ident::AssetIdent,
     output::OutputAsset,
     source_map::{GenerateSourceMap, SourceMap},
 };
@@ -28,8 +26,8 @@ impl CssChunkSourceMapAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for CssChunkSourceMapAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(self.chunk.path().append(".map".into()))
+    fn path(&self) -> Vc<FileSystemPath> {
+        self.chunk.path().append(".map".into())
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/references/url.rs
+++ b/turbopack/crates/turbopack-css/src/references/url.rs
@@ -136,7 +136,7 @@ pub async fn resolve_url_reference(
     {
         // TODO(WEB-662) This is not the correct way to get the path of the asset.
         // `asset` is on module-level, but we need the output-level asset instead.
-        let path = asset.ident().path().await?;
+        let path = asset.path().await?;
         let relative_path = context_path
             .get_relative_path_to(&path)
             .unwrap_or_else(|| format!("/{}", path.path).into());

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -13,7 +13,6 @@ use turbopack_core::{
         availability_info::AvailabilityInfo, ChunkableModule, ChunkingContext, ChunkingContextExt,
         EvaluatableAssets,
     },
-    ident::AssetIdent,
     module::Module,
     module_graph::ModuleGraph,
     output::{OutputAsset, OutputAssets},
@@ -49,8 +48,8 @@ fn dev_html_chunk_reference_description() -> Vc<RcStr> {
 #[turbo_tasks::value_impl]
 impl OutputAsset for DevHtmlAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(*self.path)
+    fn path(&self) -> Vc<FileSystemPath> {
+        *self.path
     }
 
     #[turbo_tasks::function]
@@ -123,7 +122,7 @@ impl DevHtmlAsset {
         let context_path = this.path.parent().await?;
         let mut chunk_paths = vec![];
         for chunk in &*self.chunks().await? {
-            let chunk_path = &*chunk.ident().path().await?;
+            let chunk_path = &*chunk.path().await?;
             if let Some(relative_path) = context_path.get_path_to(chunk_path) {
                 chunk_paths.push(format!("/{relative_path}").into());
             }

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -113,7 +113,7 @@ async fn expand(
     let root_assets_with_path = root_assets
         .iter()
         .map(|&asset| async move {
-            let path = asset.ident().path().await?;
+            let path = asset.path().await?;
             Ok((path, asset))
         })
         .try_join()
@@ -153,7 +153,7 @@ async fn expand(
     while let Some(references) = queue.pop_front() {
         for asset in references.await?.iter() {
             if assets_set.insert(*asset) {
-                let path = asset.ident().path().await?;
+                let path = asset.path().await?;
                 if let Some(sub_path) = root_path.get_path_to(&path) {
                     let (sub_paths_buffer, sub_paths) = get_sub_paths(sub_path);
                     let expanded = if let Some(expanded) = &expanded {

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -6,18 +6,16 @@ pub(crate) mod placeable;
 
 use std::fmt::Write;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Value, ValueToString, Vc};
 use turbo_tasks_fs::FileSystem;
 use turbopack_core::{
-    asset::{Asset, AssetContent},
     chunk::{Chunk, ChunkItem, ChunkItems, ChunkingContext, ModuleIds},
     ident::AssetIdent,
     introspect::{
-        module::IntrospectableModule,
-        utils::{children_from_output_assets, content_to_details},
-        Introspectable, IntrospectableChildren,
+        module::IntrospectableModule, utils::children_from_output_assets, Introspectable,
+        IntrospectableChildren,
     },
     output::{OutputAsset, OutputAssets},
     server_fs::ServerFileSystem,
@@ -182,14 +180,6 @@ impl EcmascriptChunk {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl Asset for EcmascriptChunk {
-    #[turbo_tasks::function]
-    fn content(self: Vc<Self>) -> Result<Vc<AssetContent>> {
-        bail!("EcmascriptChunk::content() is not implemented")
-    }
-}
-
 #[turbo_tasks::function]
 fn introspectable_type() -> Vc<RcStr> {
     Vc::cell("ecmascript chunk".into())
@@ -209,20 +199,17 @@ impl Introspectable for EcmascriptChunk {
 
     #[turbo_tasks::function]
     fn title(self: Vc<Self>) -> Vc<RcStr> {
-        self.path().to_string()
+        self.ident().to_string()
     }
 
     #[turbo_tasks::function]
     async fn details(self: Vc<Self>) -> Result<Vc<RcStr>> {
-        let content = content_to_details(self.content());
         let mut details = String::new();
         let this = self.await?;
         details += "Chunk items:\n\n";
         for chunk_item in this.content.included_chunk_items().await? {
             writeln!(details, "- {}", chunk_item.asset_ident().to_string().await?)?;
         }
-        details += "\nContent:\n\n";
-        write!(details, "{}", content.await?)?;
         Ok(Vc::cell(details.into()))
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
@@ -180,7 +180,7 @@ impl EcmascriptChunkItem for ChunkGroupFilesChunkItem {
         let chunks_paths = chunks
             .await?
             .iter()
-            .map(|chunk| chunk.ident().path())
+            .map(|chunk| chunk.path())
             .try_join()
             .await?;
         let chunks_paths: Vec<_> = chunks_paths

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -46,11 +46,7 @@ async fn emit(
     intermediate_output_path: Vc<FileSystemPath>,
 ) -> Result<()> {
     for asset in internal_assets(intermediate_asset, intermediate_output_path).await? {
-        let _ = asset
-            .content()
-            .write(asset.ident().path())
-            .resolve()
-            .await?;
+        let _ = asset.content().write(asset.path()).resolve().await?;
     }
     Ok(())
 }
@@ -97,8 +93,7 @@ async fn internal_assets_for_source_mapping(
         if let Some(generate_source_map) =
             ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(*asset)
         {
-            if let Some(path) = intermediate_output_path.get_path_to(&*asset.ident().path().await?)
-            {
+            if let Some(path) = intermediate_output_path.get_path_to(&*asset.path().await?) {
                 internal_assets_for_source_mapping.insert(path.to_string(), generate_source_map);
             }
         }
@@ -152,12 +147,7 @@ async fn separate_assets_operation(
                 // others as "external". We follow references on "internal" assets, but do not
                 // look into references of "external" assets, since there are no "internal"
                 // assets behind "externals"
-                if asset
-                    .ident()
-                    .path()
-                    .await?
-                    .is_inside_ref(intermediate_output_path)
-                {
+                if asset.path().await?.is_inside_ref(intermediate_output_path) {
                     Ok(Type::Internal(*asset))
                 } else {
                     Ok(Type::External(*asset))
@@ -225,7 +215,7 @@ pub async fn get_renderer_pool_operation(
     let assets_for_source_mapping =
         internal_assets_for_source_mapping(*intermediate_asset, *output_root);
 
-    let entrypoint = intermediate_asset.ident().path();
+    let entrypoint = intermediate_asset.path();
 
     let Some(cwd) = to_sys_path(*cwd).await? else {
         bail!(

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -249,17 +249,16 @@ impl ChunkingContext for NodeJsChunkingContext {
     }
 
     #[turbo_tasks::function]
-    async fn asset_url(self: Vc<Self>, ident: Vc<AssetIdent>) -> Result<Vc<RcStr>> {
-        let this = self.await?;
-        let asset_path = ident.path().await?.to_string();
+    async fn asset_url(&self, ident: Vc<FileSystemPath>) -> Result<Vc<RcStr>> {
+        let asset_path = ident.await?.to_string();
         let asset_path = asset_path
-            .strip_prefix(&format!("{}/", this.client_root.await?.path))
+            .strip_prefix(&format!("{}/", self.client_root.await?.path))
             .context("expected client root to contain asset path")?;
 
         Ok(Vc::cell(
             format!(
                 "{}{}",
-                this.asset_prefix
+                self.asset_prefix
                     .await?
                     .as_ref()
                     .map(|s| s.clone())

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexSet, ResolvedVc, ValueToString, Vc};
+use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{Chunk, ChunkingContext},
-    ident::AssetIdent,
     introspect::{Introspectable, IntrospectableChildren},
     output::{OutputAsset, OutputAssets},
     source_map::{GenerateSourceMap, OptionSourceMap, SourceMapAsset},
@@ -67,9 +67,9 @@ impl EcmascriptBuildNodeChunk {
 #[turbo_tasks::value_impl]
 impl OutputAsset for EcmascriptBuildNodeChunk {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
+    fn path(&self) -> Vc<FileSystemPath> {
         let ident = self.chunk.ident().with_modifier(modifier());
-        AssetIdent::from_path(self.chunking_context.chunk_path(ident, ".js".into()))
+        self.chunking_context.chunk_path(ident, ".js".into())
     }
 
     #[turbo_tasks::function]
@@ -137,7 +137,7 @@ impl Introspectable for EcmascriptBuildNodeChunk {
 
     #[turbo_tasks::function]
     fn title(self: Vc<Self>) -> Vc<RcStr> {
-        self.ident().to_string()
+        self.path().to_string()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -76,7 +76,7 @@ impl EcmascriptBuildNodeChunkContent {
         let source_maps = this
             .chunking_context
             .reference_chunk_source_maps(*ResolvedVc::upcast(this.chunk));
-        let chunk_path_vc = this.chunk.ident().path();
+        let chunk_path_vc = this.chunk.path();
         let chunk_path = chunk_path_vc.await?;
 
         let mut code = CodeBuilder::default();
@@ -121,7 +121,7 @@ impl EcmascriptBuildNodeChunkContent {
     pub(crate) async fn own_version(&self) -> Result<Vc<EcmascriptBuildNodeChunkVersion>> {
         Ok(EcmascriptBuildNodeChunkVersion::new(
             self.chunking_context.output_root(),
-            self.chunk.ident().path(),
+            self.chunk.path(),
             *self.content,
             self.chunking_context.await?.minify_type(),
         ))

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -9,7 +9,6 @@ use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkItemExt, ChunkableModule, ChunkingContext, EvaluatableAssets},
     code_builder::{Code, CodeBuilder},
-    ident::AssetIdent,
     module_graph::ModuleGraph,
     output::{OutputAsset, OutputAssets},
     source_map::{GenerateSourceMap, OptionSourceMap, SourceMapAsset},
@@ -59,9 +58,9 @@ impl EcmascriptBuildNodeEntryChunk {
         let this = self.await?;
 
         let output_root = this.chunking_context.output_root().await?;
-        let chunk_path = self.ident().path().await?;
-        let chunk_directory = self.ident().path().parent().await?;
-        let runtime_path = self.runtime_chunk().ident().path().await?;
+        let chunk_path = self.path().await?;
+        let chunk_directory = self.path().parent().await?;
+        let runtime_path = self.runtime_chunk().path().await?;
         let runtime_relative_path =
             if let Some(path) = chunk_directory.get_relative_path_to(&runtime_path) {
                 path
@@ -96,7 +95,7 @@ impl EcmascriptBuildNodeEntryChunk {
 
         let other_chunks = this.other_chunks.await?;
         for other_chunk in &*other_chunks {
-            let other_chunk_path = &*other_chunk.ident().path().await?;
+            let other_chunk_path = &*other_chunk.path().await?;
             if let Some(other_chunk_public_path) = output_root.get_path_to(other_chunk_path) {
                 writedoc!(
                     code,
@@ -174,8 +173,8 @@ fn chunk_reference_description() -> Vc<RcStr> {
 #[turbo_tasks::value_impl]
 impl OutputAsset for EcmascriptBuildNodeEntryChunk {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(*self.path)
+    fn path(&self) -> Vc<FileSystemPath> {
+        *self.path
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Result};
 use indoc::writedoc;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
-use turbo_tasks_fs::{File, FileSystem};
+use turbo_tasks_fs::{File, FileSystem, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::ChunkingContext,
@@ -41,7 +41,7 @@ impl EcmascriptBuildNodeRuntimeChunk {
         let generate_source_map = this
             .chunking_context
             .reference_chunk_source_maps(Vc::upcast(self));
-        let runtime_path = self.ident().path().await?;
+        let runtime_path = self.path().await?;
         let runtime_public_path = if let Some(path) = output_root.get_path_to(&runtime_path) {
             path
         } else {
@@ -105,14 +105,14 @@ impl ValueToString for EcmascriptBuildNodeRuntimeChunk {
 #[turbo_tasks::value_impl]
 impl OutputAsset for EcmascriptBuildNodeRuntimeChunk {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
+    fn path(&self) -> Vc<FileSystemPath> {
         let ident = AssetIdent::from_path(
             turbopack_ecmascript_runtime::embed_fs()
                 .root()
                 .join("runtime.js".into()),
         );
 
-        AssetIdent::from_path(self.chunking_context.chunk_path(ident, ".js".into()))
+        self.chunking_context.chunk_path(ident, ".js".into())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-static/src/fixed.rs
+++ b/turbopack/crates/turbopack-static/src/fixed.rs
@@ -2,7 +2,6 @@ use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    ident::AssetIdent,
     output::OutputAsset,
     source::Source,
 };
@@ -33,8 +32,8 @@ impl FixedStaticAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for FixedStaticAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(*self.output_path)
+    fn path(&self) -> Vc<FileSystemPath> {
+        *self.output_path
     }
 }
 

--- a/turbopack/crates/turbopack-static/src/lib.rs
+++ b/turbopack/crates/turbopack-static/src/lib.rs
@@ -171,7 +171,7 @@ impl EcmascriptChunkItem for ModuleChunkItem {
                 path = StringifyJs(
                     &self
                         .chunking_context
-                        .asset_url(self.static_asset.ident())
+                        .asset_url(self.static_asset.path())
                         .await?
                 )
             )

--- a/turbopack/crates/turbopack-static/src/output_asset.rs
+++ b/turbopack/crates/turbopack-static/src/output_asset.rs
@@ -1,10 +1,9 @@
 use anyhow::Result;
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::FileContent;
+use turbo_tasks_fs::{FileContent, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::ChunkingContext,
-    ident::AssetIdent,
     output::OutputAsset,
     source::Source,
 };
@@ -31,7 +30,7 @@ impl StaticAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for StaticAsset {
     #[turbo_tasks::function]
-    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+    async fn path(&self) -> Result<Vc<FileSystemPath>> {
         let content = self.source.content();
         let content_hash = if let AssetContent::File(file) = &*content.await? {
             if let FileContent::Content(file) = &*file.await? {
@@ -43,10 +42,9 @@ impl OutputAsset for StaticAsset {
             anyhow::bail!("StaticAsset::path: unsupported file content")
         };
         let content_hash_b16 = turbo_tasks_hash::encode_hex(content_hash);
-        let asset_path = self
+        Ok(self
             .chunking_context
-            .asset_path(content_hash_b16.into(), self.source.ident());
-        Ok(AssetIdent::from_path(asset_path))
+            .asset_path(content_hash_b16.into(), self.source.ident()))
     }
 }
 

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -457,11 +457,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             .await
             .context(format!(
                 "Failed to walk asset {}",
-                asset
-                    .ident()
-                    .to_string()
-                    .await
-                    .context("to_string failed")?
+                asset.path().to_string().await.context("to_string failed")?
             ))?;
     }
 
@@ -478,7 +474,7 @@ async fn walk_asset(
     seen: &mut FxHashSet<Vc<FileSystemPath>>,
     queue: &mut VecDeque<ResolvedVc<Box<dyn OutputAsset>>>,
 ) -> Result<()> {
-    let path = asset.ident().path().resolve().await?;
+    let path = asset.path().resolve().await?;
 
     if !seen.insert(path) {
         return Ok(());

--- a/turbopack/crates/turbopack-wasm/src/output_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/output_asset.rs
@@ -1,9 +1,9 @@
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::ChunkingContext,
-    ident::AssetIdent,
     output::OutputAsset,
     source::Source,
 };
@@ -40,12 +40,9 @@ impl WebAssemblyAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for WebAssemblyAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
+    fn path(&self) -> Vc<FileSystemPath> {
         let ident = self.source.ident().with_modifier(modifier());
-
-        let asset_path = self.chunking_context.chunk_path(ident, ".wasm".into());
-
-        AssetIdent::from_path(asset_path)
+        self.chunking_context.chunk_path(ident, ".wasm".into())
     }
 }
 

--- a/turbopack/crates/turbopack-wasm/src/raw.rs
+++ b/turbopack/crates/turbopack-wasm/src/raw.rs
@@ -148,7 +148,7 @@ impl EcmascriptChunkItem for RawModuleChunkItem {
 
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<EcmascriptChunkItemContent>> {
-        let path = self.wasm_asset.ident().path().await?;
+        let path = self.wasm_asset.path().await?;
         let output_root = self.chunking_context.output_root().await?;
 
         let Some(path) = output_root.get_path_to(&path) else {

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -963,7 +963,7 @@ async fn emit_aggregated_assets(
 
 #[turbo_tasks::function]
 pub fn emit_asset(asset: Vc<Box<dyn OutputAsset>>) {
-    let _ = asset.content().write(asset.ident().path());
+    let _ = asset.content().write(asset.path());
 }
 
 #[turbo_tasks::function]
@@ -972,7 +972,7 @@ pub async fn emit_asset_into_dir(
     output_dir: Vc<FileSystemPath>,
 ) -> Result<()> {
     let dir = &*output_dir.await?;
-    if asset.ident().path().await?.is_inside_ref(dir) {
+    if asset.path().await?.is_inside_ref(dir) {
         let _ = emit_asset(asset);
     }
     Ok(())

--- a/turbopack/crates/turbopack/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack/tests/node-file-trace.rs
@@ -462,7 +462,7 @@ fn node_file_trace<B: Backend + 'static>(
                     .await?;
 
                 #[cfg(not(feature = "bench_against_node_nft"))]
-                let output_path = rebased.ident().path();
+                let output_path = rebased.path();
 
                 print_graph(ResolvedVc::upcast(rebased)).await?;
 
@@ -774,11 +774,11 @@ async fn print_graph(asset: ResolvedVc<Box<dyn OutputAsset>>) -> Result<()> {
             for &asset in references.iter().rev() {
                 queue.push((depth + 1, asset));
             }
-            println!("{}{}", indent, asset.ident().to_string().await?);
+            println!("{}{}", indent, asset.path().to_string().await?);
         } else if references.is_empty() {
-            println!("{}{} *", indent, asset.ident().to_string().await?);
+            println!("{}{} *", indent, asset.path().to_string().await?);
         } else {
-            println!("{}{} *...", indent, asset.ident().to_string().await?);
+            println!("{}{} *...", indent, asset.path().to_string().await?);
         }
     }
     Ok(())


### PR DESCRIPTION
This was planned anyway. Might produce fewer tasks and cells

- Make `Chunk` not a subtrait of `Asset` anymore
- Remove `Chunk::path()`
- Replace `OutputAsset::ident(&self) -> Vc<AssetIdent>;` with `fn path(&self) -> Vc<FileSystemPath>;`


```
testing against 0293c96cf32

canary dd676ccbdd:
14,7 GB
TURBO_ENGINE_READ_ONLY=1 NEXT_TURBOPACK_TRACING= TURBOPACK=1 TURBOPACK_BUILD=  533.84s user 84.44s system 834% cpu 1:14.10 total
TURBO_ENGINE_READ_ONLY=1 NEXT_TURBOPACK_TRACING= TURBOPACK=1 TURBOPACK_BUILD=  526.68s user 86.15s system 834% cpu 1:13.48 total

OutputAsset::path 680161d408
14,7 GB
TURBO_ENGINE_READ_ONLY=1 NEXT_TURBOPACK_TRACING= TURBOPACK=1 TURBOPACK_BUILD=  517.76s user 85.71s system 826% cpu 1:13.04 total
TURBO_ENGINE_READ_ONLY=1 NEXT_TURBOPACK_TRACING= TURBOPACK=1 TURBOPACK_BUILD=  519.98s user 87.23s system 827% cpu 1:13.35 total
```

Closes PACK-3879