### PR TITLE
Turbopack: disambiguate `TaskInput::resolve`

### DIFF
--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_input_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_input_macro.rs
@@ -112,7 +112,7 @@ pub fn derive_task_input(input: TokenStream) -> TokenStream {
                 quote! {
                     {
                         #(
-                            let #fields = turbo_tasks::TaskInput::resolve(#fields).await?;
+                            let #fields = turbo_tasks::TaskInput::resolve_input(#fields).await?;
                         )*
                         Ok(#ident { #(#fields),* })
                     }
@@ -126,7 +126,7 @@ pub fn derive_task_input(input: TokenStream) -> TokenStream {
                 quote! {
                     {
                         #(
-                            let #fields = turbo_tasks::TaskInput::resolve(#fields).await?;
+                            let #fields = turbo_tasks::TaskInput::resolve_input(#fields).await?;
                         )*
                         Ok(#ident(#(#fields),*))
                     }
@@ -169,7 +169,7 @@ pub fn derive_task_input(input: TokenStream) -> TokenStream {
             #[allow(non_snake_case)]
             #[allow(unreachable_code)] // This can occur for enums with no variants.
             #[allow(clippy::manual_async_fn)] // some impls need the manual return type to work :(
-            fn resolve(
+            fn resolve_input(
                 &self,
             ) -> impl
                 ::std::future::Future<Output = turbo_tasks::Result<Self>> +

--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -518,7 +518,7 @@ impl TurboFn<'_> {
                                 let (#(#exposed_input_idents,)*) = turbo_tasks::macro_helpers
                                     ::downcast_args_ref::<(#(#exposed_input_types,)*)>(magic_any);
                                 let resolved = (#(
-                                    <_ as turbo_tasks::TaskInput>::resolve(
+                                    <_ as turbo_tasks::TaskInput>::resolve_input(
                                         #inline_input_idents
                                     ).await?,
                                 )*);

--- a/turbopack/crates/turbo-tasks/src/native_function.rs
+++ b/turbopack/crates/turbo-tasks/src/native_function.rs
@@ -97,7 +97,7 @@ impl ArgMeta {
 fn resolve_functor_impl<T: MagicAny + TaskInput>(value: &dyn MagicAny) -> ResolveFuture<'_> {
     Box::pin(async {
         let value = downcast_args_ref::<T>(value);
-        let resolved = value.resolve().await?;
+        let resolved = value.resolve_input().await?;
         Ok(Box::new(resolved) as Box<dyn MagicAny>)
     })
 }


### PR DESCRIPTION
Disambiguate `TaskInput::resolve` from `Vc::resolve` and `ResolvedVc::resolve`.

Turns out there was only a single instance where `resolve()` turned out to be the wrong function anyway...

Closes PACK-3900