### PR TITLE
Unflake `cookies/headers/draftMode in "use cache"` test

### DIFF
--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -101,17 +101,21 @@ describe('use-cache', () => {
 
   it('should error when cookies/headers/draftMode is used inside "use cache"', async () => {
     const browser = await next.browser('/errors')
-    expect(await browser.waitForElementByCss('#cookies').text()).toContain(
-      isNextDev
-        ? 'Route /errors used "cookies" inside "use cache".'
-        : GENERIC_RSC_ERROR
-    )
-    expect(await browser.waitForElementByCss('#headers').text()).toContain(
-      isNextDev
-        ? 'Route /errors used "headers" inside "use cache".'
-        : GENERIC_RSC_ERROR
-    )
-    expect(await browser.waitForElementByCss('#draft-mode').text()).toContain(
+
+    await retry(async () => {
+      expect(await browser.elementById('cookies').text()).toContain(
+        isNextDev
+          ? 'Route /errors used "cookies" inside "use cache".'
+          : GENERIC_RSC_ERROR
+      )
+      expect(await browser.elementById('headers').text()).toContain(
+        isNextDev
+          ? 'Route /errors used "headers" inside "use cache".'
+          : GENERIC_RSC_ERROR
+      )
+    })
+
+    expect(await browser.elementById('draft-mode').text()).toContain(
       'Editing: false'
     )
 


### PR DESCRIPTION
[flakiness metric](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20env%3Aci%20%40git.repository.id%3Agithub.com%2Fvercel%2Fnext.js%20%40test.service%3Anextjs%20%40test.status%3Afail%20%40test.name%3A%22use-cache%20should%20error%20when%20cookies%2Fheaders%2FdraftMode%20is%20used%20inside%20%5C%22use%20cache%5C%22%22&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&graphType=flamegraph&index=citest&start=1730967696059&end=1738743696059&paused=false)

The error chunks are streaming in while the page is loaded, so `waitForElementByCss` is not sufficient because the error boundary is initially rendered without content, before React replaces it with the expected error messages.


https://github.com/user-attachments/assets/adb24a85-d7ac-4bcc-841d-d8f3e0644389

