### PR TITLE
perf: Do not run react compiler needlessly

### DIFF
--- a/packages/next/src/build/babel/loader/get-config.ts
+++ b/packages/next/src/build/babel/loader/get-config.ts
@@ -273,10 +273,7 @@ function getFreshConfig(
       return false
     }
 
-    if (
-      filename.includes('/node_modules/') ||
-      filename.includes('\\node_modules\\')
-    ) {
+    if (/[/\\]node_modules[/\\]/.test(filename)) {
       return false
     }
 

--- a/packages/next/src/build/babel/loader/get-config.ts
+++ b/packages/next/src/build/babel/loader/get-config.ts
@@ -329,6 +329,10 @@ function getFreshConfig(
   }
 
   if (loaderOptions.transformMode === 'standalone') {
+    if (!reactCompilerPluginsIfEnabled.length) {
+      return null
+    }
+
     options.plugins = [jsx, ...reactCompilerPluginsIfEnabled]
     options.presets = [
       [
@@ -462,6 +466,9 @@ export default function getConfig(
   const cacheKey = getCacheKey(cacheCharacteristics)
   if (configCache.has(cacheKey)) {
     const cachedConfig = configCache.get(cacheKey)
+    if (!cachedConfig) {
+      return null
+    }
 
     return {
       ...cachedConfig,

--- a/packages/next/src/build/babel/loader/get-config.ts
+++ b/packages/next/src/build/babel/loader/get-config.ts
@@ -273,7 +273,10 @@ function getFreshConfig(
       return false
     }
 
-    if (filename.includes('node_modules')) {
+    if (
+      filename.includes('/node_modules/') ||
+      filename.includes('\\node_modules\\')
+    ) {
       return false
     }
 

--- a/packages/next/src/build/babel/loader/get-config.ts
+++ b/packages/next/src/build/babel/loader/get-config.ts
@@ -273,6 +273,10 @@ function getFreshConfig(
       return false
     }
 
+    if (filename.includes('node_modules')) {
+      return false
+    }
+
     if (
       loaderOptions.reactCompilerExclude &&
       loaderOptions.reactCompilerExclude(filename)

--- a/packages/next/src/build/babel/loader/transform.ts
+++ b/packages/next/src/build/babel/loader/transform.ts
@@ -86,6 +86,9 @@ export default function transform(
     target,
     filename,
   })
+  if (!babelConfig) {
+    return { code: source, map: inputSourceMap }
+  }
   getConfigSpan.stop()
 
   const normalizeSpan = parentSpan.traceChild('babel-turbo-normalize-file')


### PR DESCRIPTION
### What?

 - Do not run react compiler for files in `node_modules`.
 - When the react compiler is not enabled, just disable babel.

### Why?

We were stripping TypeScript and JSX using babel when the React Compiler is enabled. We don't have to, and we should not.

Closes PACK-3976