### PR TITLE
docs(errors): add failed-to-find-server-action error page

### DIFF
--- a/errors/failed-to-find-server-action.mdx
+++ b/errors/failed-to-find-server-action.mdx
@@ -12,6 +12,8 @@ When self-hosting your Next.js application across multiple servers, each server 
 
 To mitigate this, you can overwrite the encryption key using the `process.env.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` environment variable. Specifying this variable ensures that your encryption keys are persistent across builds, and all server instances use the same key. This variable **must** be AES-GCM encrypted.
 
+In a non-self-hosted environment, you can use a feature such as [Skew Protection](https://vercel.com/docs/deployments/skew-protection) to ensure assets and functions from the previous version are still available, even after a new version is deployed.
+
 ## Useful Links
 
 - [Server Actions - Security](/docs/app/building-your-application/data-fetching/server-actions-and-mutations#security)

--- a/errors/failed-to-find-server-action.mdx
+++ b/errors/failed-to-find-server-action.mdx
@@ -1,0 +1,18 @@
+---
+title: Failed to find Server Action
+---
+
+## Why This Message Occurred
+
+For security purposes, Next.js creates encrypted, non-deterministic keys (IDs) to allow for the client to reference and call the [Server Action](/docs/app/building-your-application/data-fetching/server-actions-and-mutations). These keys are periodically recalculated between builds for enhanced security.
+
+When self-hosting your Next.js application across multiple servers, each server instance may end up with a different encryption key, leading to potential inconsistencies.
+
+## Possible Ways to Fix It
+
+To mitigate this, you can overwrite the encryption key using the `process.env.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` environment variable. Specifying this variable ensures that your encryption keys are persistent across builds, and all server instances use the same key. This variable **must** be AES-GCM encrypted.
+
+## Useful Links
+
+- [Server Actions - Security](/docs/app/building-your-application/data-fetching/server-actions-and-mutations#security)
+- [Overwriting encryption keys (advanced)](/docs/app/building-your-application/data-fetching/server-actions-and-mutations#overwriting-encryption-keys-advanced)

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -262,7 +262,7 @@
   "261": "Route %s used %s without first calling \\`await connection()\\`. See more info here: https://nextjs.org/docs/messages/next-prerender-sync-request",
   "262": "%s %s",
   "263": "Invariant: static generation store missing in %s",
-  "264": "Failed to find Server Action \"%s\". This request might be from an older or newer deployment. %s",
+  "264": "Failed to find Server Action \"%s\". This request might be from an older or newer deployment. %s\\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
   "265": "Farm is ended, no more calls can be done to it",
   "266": "Multiple children were passed to <Link> with \\`href\\` of \\`%s\\` but only one child is supported https://nextjs.org/docs/messages/link-multiple-children%s",
   "267": "Dynamic href \\`%s\\` found in <Link> while using the \\`/app\\` router, this is not supported. Read more: https://nextjs.org/docs/messages/app-dir-dynamic-href",

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -1085,7 +1085,7 @@ function getActionModIdOrError(
     throw new Error(
       `Failed to find Server Action "${actionId}". This request might be from an older or newer deployment. ${
         err instanceof Error ? `Original error: ${err.message}` : ''
-      }`
+      }\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action`
     )
   }
 }


### PR DESCRIPTION
## Why?

We should also have an error page when somebody gets this error → https://github.com/vercel/next.js/blob/d70cac3eb4dee1d1361629d1b4c765365f184e26/packages/next/src/server/app-render/action-handler.ts#L1086.