### PR TITLE
Turbopack: don't watch output FS

### DIFF
--- a/turbopack/crates/turbopack-cli/src/util.rs
+++ b/turbopack/crates/turbopack-cli/src/util.rs
@@ -67,6 +67,5 @@ pub async fn project_fs(project_dir: RcStr) -> Result<Vc<Box<dyn FileSystem>>> {
 #[turbo_tasks::function]
 pub async fn output_fs(project_dir: RcStr) -> Result<Vc<Box<dyn FileSystem>>> {
     let disk_fs = DiskFileSystem::new("output".into(), project_dir, vec![]);
-    disk_fs.await?.start_watching(None).await?;
     Ok(Vc::upcast(disk_fs))
 }


### PR DESCRIPTION
AFAICT, Next.js doesn't do this either
and this seems to solve this error
```
thread '<unnamed>' panicked at turbopack/crates/turbo-tasks-backend/src/backend/mod.rs:949:13:
Dependency tracking is disabled so invalidation is not allowed

thread 'tokio-runtime-worker' panicked at turbopack/crates/turbo-tasks-fs/src/lib.rs:265:63:
called `Result::unwrap()` on an `Err` value: PoisonError { .. }
```

Closes PACK-3897