### PR TITLE
Turbopack: uncell RequireContextValue

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known.rs
@@ -1,7 +1,7 @@
 use std::mem::take;
 
 use anyhow::Result;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbopack_core::compile_time_info::CompileTimeInfo;
 use url::Url;
 
@@ -354,10 +354,7 @@ pub fn require(args: Vec<JsValue>) -> JsValue {
 }
 
 /// (try to) statically evaluate `require.context(...)()`
-async fn require_context_require(
-    val: ResolvedVc<RequireContextValue>,
-    args: Vec<JsValue>,
-) -> Result<JsValue> {
+async fn require_context_require(val: RequireContextValue, args: Vec<JsValue>) -> Result<JsValue> {
     if args.is_empty() {
         return Ok(JsValue::unknown(
             JsValue::call(
@@ -384,8 +381,7 @@ async fn require_context_require(
         ));
     };
 
-    let map = val.await?;
-    let Some(m) = map.get(s) else {
+    let Some(m) = val.0.get(s) else {
         return Ok(JsValue::unknown(
             JsValue::call(
                 Box::new(JsValue::WellKnownFunction(
@@ -407,12 +403,11 @@ async fn require_context_require(
 
 /// (try to) statically evaluate `require.context(...).keys()`
 async fn require_context_require_keys(
-    val: ResolvedVc<RequireContextValue>,
+    val: RequireContextValue,
     args: Vec<JsValue>,
 ) -> Result<JsValue> {
     Ok(if args.is_empty() {
-        let map = val.await?;
-        JsValue::array(map.keys().cloned().map(|k| k.into()).collect())
+        JsValue::array(val.0.keys().cloned().map(|k| k.into()).collect())
     } else {
         JsValue::unknown(
             JsValue::call(
@@ -429,7 +424,7 @@ async fn require_context_require_keys(
 
 /// (try to) statically evaluate `require.context(...).resolve()`
 async fn require_context_require_resolve(
-    val: ResolvedVc<RequireContextValue>,
+    val: RequireContextValue,
     args: Vec<JsValue>,
 ) -> Result<JsValue> {
     if args.len() != 1 {
@@ -458,8 +453,7 @@ async fn require_context_require_resolve(
         ));
     };
 
-    let map = val.await?;
-    let Some(m) = map.get(s) else {
+    let Some(m) = val.0.get(s) else {
         return Ok(JsValue::unknown(
             JsValue::call(
                 Box::new(JsValue::WellKnownFunction(

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2880,9 +2880,7 @@ async fn require_context_visitor(
 
     Ok(JsValue::WellKnownFunction(
         WellKnownFunctionKind::RequireContextRequire(
-            RequireContextValue::from_context_map(map)
-                .to_resolved()
-                .await?,
+            RequireContextValue::from_context_map(map).await?,
         ),
     ))
 }


### PR DESCRIPTION
This might make a difference if the `RequireContextMap` is huge and used across many files

More importantly, this seems to solve this failure in the testing backend on https://github.com/vercel/next.js/pull/75440:

```
called 'Result::unwrap()' on an 'Err' value: Cell is empty
Stack backtrace:
0: <anyhow::Error>::msg::<&str>
1: <turbo_tasks::backend::TypedCellContent>::cast::<turbopack_emascript::analyzer::RequireContextValue>
2: <turbo_tasks::vc::read::ReadVcFuture<turbopack_ecmascript::analyzer::RequireContextValue> as core::future::future::Future>::poll
3: turbopack_ecmascript::analyzer::well_known::replace_well_known::{closure#0}
4: turbopack_ecmascript::analyzer::linker::visit::<mod::analyzer::bench_link::{closure#0}::{closure#0}::{closure#0}::{closure#0}, turbopack_emascript: analyzer: it {closure#0}>::{closure#0}
```

Closes PACK-3898