### PR TITLE
test: fix eslint plugin test

### DIFF
--- a/test/production/eslint-plugin-deps/index.test.ts
+++ b/test/production/eslint-plugin-deps/index.test.ts
@@ -84,6 +84,44 @@ describe('eslint plugin deps', () => {
   }
 }
         `,
+        'tsconfig.json': `{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "strictNullChecks": true,
+    "noEmit": true,
+    ${/* The rule @typescript-eslint/no-unnecessary-boolean-literal-compare requires the `strictNullChecks` compiler option to be turned on to function correctly. */ ''}
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules",
+  ]
+}
+        `,
       },
       dependencies: {
         // Manually installed @typescript-eslint/eslint-plugin, expect to be deduped

--- a/test/production/eslint-plugin-deps/index.test.ts
+++ b/test/production/eslint-plugin-deps/index.test.ts
@@ -95,9 +95,9 @@ describe('eslint plugin deps', () => {
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
+    // The rule @typescript-eslint/no-unnecessary-boolean-literal-compare requires the \`strictNullChecks\` compiler option to be turned on to function correctly.
     "strictNullChecks": true,
     "noEmit": true,
-    ${/* The rule @typescript-eslint/no-unnecessary-boolean-literal-compare requires the `strictNullChecks` compiler option to be turned on to function correctly. */ ''}
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,


### PR DESCRIPTION
x-ref: https://github.com/vercel/next.js/actions/runs/13157829411/job/36719272526?pr=75669

Add `tsconfig.json` fixture in output to power the eslint rule working properly