### PR TITLE
remove code for url-encoded actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "build-turbopack-cli": "cargo build -p turbopack-cli --release",
     "sweep": "node scripts/sweep.cjs",
     "check-error-codes": "node packages/next/check-error-codes.js",
+    "update-error-codes": "cd packages/next && pnpm taskr compile check_error_codes",
     "storybook": "turbo run storybook",
     "build-storybook": "turbo run build-storybook",
     "test-storybook": "turbo run test-storybook"

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -631,5 +631,6 @@
   "630": "Invariant (SlowModuleDetectionPlugin): Module is recorded after the report is generated. This is a Next.js internal bug.",
   "631": "Invariant (SlowModuleDetectionPlugin): Circular dependency detected in module graph. This is a Next.js internal bug.",
   "632": "Invariant (SlowModuleDetectionPlugin): Module is missing a required debugId. This is a Next.js internal bug.",
-  "633": "Dynamic route not found"
+  "633": "Dynamic route not found",
+  "634": "Server actions must use the multipart/form-data content-type"
 }

--- a/packages/next/src/server/lib/server-action-request-meta.ts
+++ b/packages/next/src/server/lib/server-action-request-meta.ts
@@ -7,7 +7,6 @@ export function getServerActionRequestMetadata(
   req: IncomingMessage | BaseNextRequest | NextRequest
 ): {
   actionId: string | null
-  isURLEncodedAction: boolean
   isMultipartAction: boolean
   isFetchAction: boolean
   isServerAction: boolean
@@ -23,9 +22,6 @@ export function getServerActionRequestMetadata(
     contentType = req.headers['content-type'] ?? null
   }
 
-  const isURLEncodedAction = Boolean(
-    req.method === 'POST' && contentType === 'application/x-www-form-urlencoded'
-  )
   const isMultipartAction = Boolean(
     req.method === 'POST' && contentType?.startsWith('multipart/form-data')
   )
@@ -35,13 +31,10 @@ export function getServerActionRequestMetadata(
       req.method === 'POST'
   )
 
-  const isServerAction = Boolean(
-    isFetchAction || isURLEncodedAction || isMultipartAction
-  )
+  const isServerAction = Boolean(isFetchAction || isMultipartAction)
 
   return {
     actionId,
-    isURLEncodedAction,
     isMultipartAction,
     isFetchAction,
     isServerAction,


### PR DESCRIPTION
we don't use them anyway so these codepaths are never tested. if we need them we can bring them back