### PR TITLE
refactor(actions): untangle action-handler

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -659,5 +659,9 @@
   "658": "Pass `Infinity` instead of `false` if you want to cache on the server forever without checking with the origin.",
   "659": "SSG should not return an image cache value",
   "660": "Rspack support is only available in Next.js canary.",
-  "661": "Build failed because of %s errors"
+  "661": "Build failed because of %s errors",
+  "662": "Failed to find Server Action \"%s\". This request might be from an older or newer deployment.",
+  "663": "Failed to find Server Action \"%s\". This request might be from an older or newer deployment.%s",
+  "664": "Expected no-js actions to return from handler early.",
+  "665": "Expected actionId to be defined for a fetch action"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -663,5 +663,7 @@
   "662": "Failed to find Server Action \"%s\". This request might be from an older or newer deployment.",
   "663": "Failed to find Server Action \"%s\". This request might be from an older or newer deployment.%s",
   "664": "Expected no-js actions to return from handler early.",
-  "665": "Expected actionId to be defined for a fetch action"
+  "665": "Expected actionId to be defined for a fetch action",
+  "666": "Action handler not found in action module",
+  "667": "This function cannot be used in the edge runtime"
 }

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -453,15 +453,22 @@ type ServerActionsConfig = {
 
 type HandleActionResult =
   | {
+      /** We either didn't find the actionId, or we did but it threw notFound(). */
       type: 'not-found'
     }
   | {
+      /** The request turned out to not be an action. */
       type: 'not-an-action'
     }
   | {
+      /** We decoded a FormState, but haven't rendered anything yet. */
+      type: 'needs-render'
+      formState: any
+    }
+  | {
+      /** A finished result. */
       type: 'done'
-      result: RenderResult | undefined
-      formState?: any
+      result: RenderResult
     }
 
 export async function handleAction({
@@ -691,8 +698,7 @@ export async function handleAction({
               requestStore.phase = 'render'
 
               return {
-                type: 'done',
-                result: undefined,
+                type: 'needs-render',
                 formState,
               }
             } else {
@@ -739,8 +745,7 @@ export async function handleAction({
               requestStore.phase = 'render'
 
               return {
-                type: 'done',
-                result: undefined,
+                type: 'needs-render',
                 formState,
               }
             } else {
@@ -933,7 +938,6 @@ export async function handleAction({
         return {
           type: 'done',
           result: actionResult,
-          formState: undefined,
         }
       }
     )

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -870,12 +870,6 @@ export async function handleAction({
           console.error(err)
           return { type: 'not-found' }
         }
-        if (actionId === null) {
-          // `getActionModIdOrError` checks this, but typescript doesn't know that.
-          throw new InvariantError(
-            'Expected actionId to be defined for a fetch action'
-          )
-        }
 
         // The temporary reference set is used for parsing the arguments and in the catch handler,
         // so we want to create it before any of the decoding logic has a chance to throw.

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -482,7 +482,7 @@ export async function handleAction({
   requestStore: RequestStore
   serverActions?: ServerActionsConfig
   ctx: AppRenderContext
-}): Promise<undefined | HandleActionResult> {
+}): Promise<HandleActionResult> {
   const contentType = req.headers['content-type']
   const { serverActionsManifest, page } = ctx.renderOpts
 
@@ -498,7 +498,7 @@ export async function handleAction({
   // Note that this can be a false positive -- any multipart/urlencoded POST can get us here,
   // But won't know if it's a no-js action or not until we call `decodeAction` below.
   if (!isPotentialServerAction) {
-    return
+    return { type: 'not-an-action' }
   }
 
   if (workStore.isStaticGeneration) {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1535,14 +1535,16 @@ async function renderToHTMLOrFlightImpl(
 
         return new RenderResult(stream, { metadata })
       } else if (actionRequestResult.type === 'done') {
-        if (actionRequestResult.result) {
-          actionRequestResult.result.assignMetadata(metadata)
-          return actionRequestResult.result
-        } else if (actionRequestResult.formState) {
-          formState = actionRequestResult.formState
-        }
+        // We ran the action, and have a flight result. Nothing more to do here.
+        actionRequestResult.result.assignMetadata(metadata)
+        return actionRequestResult.result
+      } else if (actionRequestResult.type === 'needs-render') {
+        // We ran the action, but haven't rendered anything yet, so continue below.
+        formState = actionRequestResult.formState
       } else if (actionRequestResult.type === 'not-an-action') {
-        // nothing to do here.
+        // This is likely a POST request targetting a page. We partially support this, so continue rendering.
+      } else {
+        actionRequestResult satisfies never
       }
     }
 

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1519,33 +1519,30 @@ async function renderToHTMLOrFlightImpl(
         ctx,
       })
 
-      if (actionRequestResult) {
-        if (actionRequestResult.type === 'not-found') {
-          const notFoundLoaderTree = createNotFoundLoaderTree(loaderTree)
-          res.statusCode = 404
-          const stream = await renderToStreamWithTracing(
-            requestStore,
-            req,
-            res,
-            ctx,
-            workStore,
-            notFoundLoaderTree,
-            formState,
-            postponedState
-          )
+      if (actionRequestResult.type === 'not-found') {
+        const notFoundLoaderTree = createNotFoundLoaderTree(loaderTree)
+        res.statusCode = 404
+        const stream = await renderToStreamWithTracing(
+          requestStore,
+          req,
+          res,
+          ctx,
+          workStore,
+          notFoundLoaderTree,
+          formState,
+          postponedState
+        )
 
-          return new RenderResult(stream, { metadata })
-        } else if (actionRequestResult.type === 'done') {
-          if (actionRequestResult.result) {
-            actionRequestResult.result.assignMetadata(metadata)
-            return actionRequestResult.result
-          } else if (actionRequestResult.formState) {
-            formState = actionRequestResult.formState
-          }
-        } else if (actionRequestResult.type === 'not-an-action') {
-          // TODO: previously, these would be a 'done' with no `result` and no `formState`,
-          // so they'd fall through the branch above. Why does that work?
+        return new RenderResult(stream, { metadata })
+      } else if (actionRequestResult.type === 'done') {
+        if (actionRequestResult.result) {
+          actionRequestResult.result.assignMetadata(metadata)
+          return actionRequestResult.result
+        } else if (actionRequestResult.formState) {
+          formState = actionRequestResult.formState
         }
+      } else if (actionRequestResult.type === 'not-an-action') {
+        // nothing to do here.
       }
     }
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -152,7 +152,7 @@ import {
 } from './route-modules/checks'
 import { PrefetchRSCPathnameNormalizer } from './normalizers/request/prefetch-rsc'
 import { NextDataPathnameNormalizer } from './normalizers/request/next-data'
-import { getIsServerAction } from './lib/server-action-request-meta'
+import { getIsPotentialServerAction } from './lib/server-action-request-meta'
 import { isInterceptionRouteAppPath } from '../shared/lib/router/utils/interception-routes'
 import { toRoute } from './lib/to-route'
 import type { DeepReadonly } from '../shared/lib/deep-readonly'
@@ -2012,7 +2012,7 @@ export default abstract class Server<
 
     const hasServerProps = !!components.getServerSideProps
     let hasGetStaticPaths = !!components.getStaticPaths
-    const isServerAction = getIsServerAction(req)
+    const isPotentialServerAction = getIsPotentialServerAction(req)
     const hasGetInitialProps = !!components.Component?.getInitialProps
     let isSSG = !!components.getStaticProps
 
@@ -2235,7 +2235,7 @@ export default abstract class Server<
 
     if (
       // Server actions can use non-GET/HEAD methods.
-      !isServerAction &&
+      !isPotentialServerAction &&
       // Resume can use non-GET/HEAD methods.
       !minimalPostponed &&
       !is404Page &&
@@ -2375,7 +2375,7 @@ export default abstract class Server<
       !isPreviewMode &&
       isSSG &&
       !opts.supportsDynamicResponse &&
-      !isServerAction &&
+      !isPotentialServerAction &&
       !minimalPostponed &&
       !isDynamicRSCRequest
     ) {
@@ -2521,7 +2521,7 @@ export default abstract class Server<
         shouldWaitOnAllReady,
         isOnDemandRevalidate,
         isDraftMode: isPreviewMode,
-        isServerAction,
+        isServerAction: isPotentialServerAction,
         postponed,
         waitUntil: this.getWaitUntil(),
         onClose: res.onClose.bind(res),
@@ -2761,7 +2761,7 @@ export default abstract class Server<
               this.nextConfig.experimental.dynamicIO &&
               this.renderOpts.dev &&
               !isPrefetchRSCRequest &&
-              !isServerAction
+              !isPotentialServerAction
             ) {
               const warmup = await module.warmup(req, res, context)
 

--- a/packages/next/src/server/lib/server-action-request-meta.ts
+++ b/packages/next/src/server/lib/server-action-request-meta.ts
@@ -10,7 +10,7 @@ export function getServerActionRequestMetadata(
   isURLEncodedAction: boolean
   isMultipartAction: boolean
   isFetchAction: boolean
-  isServerAction: boolean
+  isPotentialServerAction: boolean
 } {
   let actionId: string | null
   let contentType: string | null
@@ -35,7 +35,7 @@ export function getServerActionRequestMetadata(
       req.method === 'POST'
   )
 
-  const isServerAction = Boolean(
+  const isPotentialServerAction = Boolean(
     isFetchAction || isURLEncodedAction || isMultipartAction
   )
 
@@ -44,12 +44,12 @@ export function getServerActionRequestMetadata(
     isURLEncodedAction,
     isMultipartAction,
     isFetchAction,
-    isServerAction,
+    isPotentialServerAction,
   }
 }
 
-export function getIsServerAction(
+export function getIsPotentialServerAction(
   req: IncomingMessage | BaseNextRequest | NextRequest
 ): boolean {
-  return getServerActionRequestMetadata(req).isServerAction
+  return getServerActionRequestMetadata(req).isPotentialServerAction
 }

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -51,7 +51,7 @@ import {
   type ActionStore,
 } from '../../app-render/action-async-storage.external'
 import * as sharedModules from './shared-modules'
-import { getIsServerAction } from '../../lib/server-action-request-meta'
+import { getIsPotentialServerAction } from '../../lib/server-action-request-meta'
 import { RequestCookies } from 'next/dist/compiled/@edge-runtime/cookies'
 import { cleanURL } from './helpers/clean-url'
 import { StaticGenBailoutError } from '../../../client/components/static-generation-bailout'
@@ -662,7 +662,7 @@ export class AppRouteRouteModule extends RouteModule<
 
     const actionStore: ActionStore = {
       isAppRoute: true,
-      isAction: getIsServerAction(req),
+      isAction: getIsPotentialServerAction(req),
     }
 
     const implicitTags = getImplicitTags(

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1760,7 +1760,7 @@ describe('app-dir action handling', () => {
     })
 
     it.each(['307', '308'])(
-      `redirects properly when server action handler redirects with a %s status code`,
+      `redirects properly when route handler redirects with a %s status code`,
       async (statusCode) => {
         const postRequests = []
         const responseCodes = []
@@ -1791,7 +1791,7 @@ describe('app-dir action handling', () => {
         })
         expect(await browser.elementById('redirect-page')).toBeTruthy()
 
-        // since a 307/308 status code follows the redirect, the POST request should be made to both the action handler and the redirect target
+        // since a 307/308 status code follows the redirect, the POST request should be made to both the route handler and the redirect target
         expect(postRequests).toEqual([
           `/redirects/api-redirect-${statusCode}`,
           `/redirects?success=true`,


### PR DESCRIPTION
This is an attempt at breaking `handleAction` up into more manageable chunks. It should have no functional changes, just moving existing code around.

- hoisted all logic related to no-js (non-fetch) actions and non-action requests out into `handleNonFetchAction`, because it's basically a completely separate codepath, and having it mixed in with the others made things hard to follow
- pulled argument parsing (with `decodeReply`) out into a `parseFetchActionArguments` helpers
- moved some longer node-specific transformations out into helpers (`getSizeLimitedRequestBodyNode`, `parseBodyAsFormDataNode`)