### PR TITLE
add script for quickly updating error codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "build-turbopack-cli": "cargo build -p turbopack-cli --release",
     "sweep": "node scripts/sweep.cjs",
     "check-error-codes": "node packages/next/check-error-codes.js",
+    "update-error-codes": "cd packages/next && pnpm taskr compile check_error_codes",
     "storybook": "turbo run storybook",
     "build-storybook": "turbo run build-storybook",
     "test-storybook": "turbo run test-storybook"

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -2723,7 +2723,7 @@ export async function check_error_codes(task, opts) {
   } catch (err) {
     if (process.env.CI) {
       await execa.command(
-        'echo check_error_codes FAILED: There are new errors introduced but no corresponding error codes are found in errors.json file, so make sure you run `pnpm build` and then commit the change in errors.json.',
+        'echo check_error_codes FAILED: There are new errors introduced but no corresponding error codes are found in errors.json file, so make sure you run `pnpm build` or `pnpm update-error-codes` and then commit the change in errors.json.',
         {
           stdio: 'inherit',
         }


### PR DESCRIPTION
When CI fails because `errors.json` got out of sync, i want something to quickly update them. `pnpm update-error-codes` runs the minimal amount of things needed to do that, so it's faster than running a full `pnpm build`.