### PR TITLE
Turbopack: uncell AstPath

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
@@ -109,7 +109,8 @@ pub trait CodeGenerateable {
 
 #[derive(PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue)]
 pub enum CodeGen {
-    AmdDefineWithDependenciesCodeGen(AmdDefineWithDependenciesCodeGen),
+    // AMD occurs very rarely and makes the enum more than 2x bigger
+    AmdDefineWithDependenciesCodeGen(Box<AmdDefineWithDependenciesCodeGen>),
     CjsRequireCacheAccess(CjsRequireCacheAccess),
     ConstantConditionCodeGen(ConstantConditionCodeGen),
     ConstantValueCodeGen(ConstantValueCodeGen),

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -215,7 +215,7 @@ impl AmdDefineWithDependenciesCodeGen {
 
 impl From<AmdDefineWithDependenciesCodeGen> for CodeGen {
     fn from(val: AmdDefineWithDependenciesCodeGen) -> Self {
-        CodeGen::AmdDefineWithDependenciesCodeGen(val)
+        CodeGen::AmdDefineWithDependenciesCodeGen(Box::new(val))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -86,7 +86,7 @@ impl ChunkableModuleReference for CjsAssetReference {}
 pub struct CjsRequireAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,
-    pub path: ResolvedVc<AstPath>,
+    pub path: AstPath,
     pub issue_source: IssueSource,
     pub in_try: bool,
 }
@@ -97,7 +97,7 @@ impl CjsRequireAssetReference {
     pub fn new(
         origin: ResolvedVc<Box<dyn ResolveOrigin>>,
         request: ResolvedVc<Request>,
-        path: ResolvedVc<AstPath>,
+        path: AstPath,
         issue_source: IssueSource,
         in_try: bool,
     ) -> Vc<Self> {
@@ -161,8 +161,7 @@ impl CodeGenerateable for CjsRequireAssetReference {
         .await?;
         let mut visitors = Vec::new();
 
-        let path = &self.path.await?;
-        visitors.push(create_visitor!(path, visit_mut_expr(expr: &mut Expr) {
+        visitors.push(create_visitor!(self.path, visit_mut_expr(expr: &mut Expr) {
             let old_expr = expr.take();
             let message = if let Expr::Call(CallExpr { args, ..}) = old_expr {
                 match args.into_iter().next() {
@@ -195,7 +194,7 @@ impl CodeGenerateable for CjsRequireAssetReference {
 pub struct CjsRequireResolveAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,
-    pub path: ResolvedVc<AstPath>,
+    pub path: AstPath,
     pub issue_source: IssueSource,
     pub in_try: bool,
 }
@@ -206,7 +205,7 @@ impl CjsRequireResolveAssetReference {
     pub fn new(
         origin: ResolvedVc<Box<dyn ResolveOrigin>>,
         request: ResolvedVc<Request>,
-        path: ResolvedVc<AstPath>,
+        path: AstPath,
         issue_source: IssueSource,
         in_try: bool,
     ) -> Vc<Self> {
@@ -270,9 +269,8 @@ impl CodeGenerateable for CjsRequireResolveAssetReference {
         .await?;
         let mut visitors = Vec::new();
 
-        let path = &self.path.await?;
         // Inline the result of the `require.resolve` call as a literal.
-        visitors.push(create_visitor!(path, visit_mut_expr(expr: &mut Expr) {
+        visitors.push(create_visitor!(self.path, visit_mut_expr(expr: &mut Expr) {
             if let Expr::Call(call_expr) = expr {
                 let args = std::mem::take(&mut call_expr.args);
                 *expr = match args.into_iter().next() {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -34,7 +34,7 @@ use crate::{
 pub struct EsmAsyncAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,
-    pub path: ResolvedVc<AstPath>,
+    pub path: AstPath,
     pub annotations: ImportAnnotations,
     pub issue_source: IssueSource,
     pub in_try: bool,
@@ -57,7 +57,7 @@ impl EsmAsyncAssetReference {
     pub fn new(
         origin: ResolvedVc<Box<dyn ResolveOrigin>>,
         request: ResolvedVc<Request>,
-        path: ResolvedVc<AstPath>,
+        path: AstPath,
         issue_source: IssueSource,
         annotations: Value<ImportAnnotations>,
         in_try: bool,
@@ -140,10 +140,9 @@ impl CodeGenerateable for EsmAsyncAssetReference {
         )
         .await?;
 
-        let path = &self.path.await?;
         let import_externals = self.import_externals;
 
-        let visitor = create_visitor!(path, visit_mut_expr(expr: &mut Expr) {
+        let visitor = create_visitor!(self.path, visit_mut_expr(expr: &mut Expr) {
             let old_expr = expr.take();
             let message = if let Expr::Call(CallExpr { args, ..}) = old_expr {
                 match args.into_iter().next() {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
@@ -24,13 +24,13 @@ use crate::{
 #[derive(Hash, Debug)]
 pub struct EsmModuleIdAssetReference {
     inner: ResolvedVc<EsmAssetReference>,
-    ast_path: ResolvedVc<AstPath>,
+    ast_path: AstPath,
 }
 
 #[turbo_tasks::value_impl]
 impl EsmModuleIdAssetReference {
     #[turbo_tasks::function]
-    pub fn new(inner: ResolvedVc<EsmAssetReference>, ast_path: ResolvedVc<AstPath>) -> Vc<Self> {
+    pub fn new(inner: ResolvedVc<EsmAssetReference>, ast_path: AstPath) -> Vc<Self> {
         Self::cell(EsmModuleIdAssetReference { inner, ast_path })
     }
 }
@@ -78,7 +78,7 @@ impl CodeGenerateable for EsmModuleIdAssetReference {
                 .await?;
             let id = module_id_to_lit(&id);
             visitors.push(
-                create_visitor!(self.ast_path.await?, visit_mut_expr(expr: &mut Expr) {
+                create_visitor!(self.ast_path, visit_mut_expr(expr: &mut Expr) {
                     *expr = id.clone()
                 }),
             );
@@ -87,7 +87,7 @@ impl CodeGenerateable for EsmModuleIdAssetReference {
             // This can happen if the referenced asset is an external, or doesn't resolve
             // to anything.
             visitors.push(
-                create_visitor!(self.ast_path.await?, visit_mut_expr(expr: &mut Expr) {
+                create_visitor!(self.ast_path, visit_mut_expr(expr: &mut Expr) {
                     *expr = quote!("null" as Expr);
                 }),
             );

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -262,7 +262,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
 
     /// Builds the final analysis result. Resolves internal Vcs.
     pub async fn build(
-        self,
+        mut self,
         track_reexport_references: bool,
     ) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
         let references = self.references.into_iter().collect();
@@ -287,6 +287,8 @@ impl AnalyzeEcmascriptModuleResultBuilder {
         } else {
             OptionSourceMap::none().to_resolved().await?
         };
+
+        self.code_gens.shrink_to_fit();
         Ok(AnalyzeEcmascriptModuleResult::cell(
             AnalyzeEcmascriptModuleResult {
                 references: ResolvedVc::cell(references),

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -212,7 +212,7 @@ pub struct RequireContextAssetReference {
     pub dir: RcStr,
     pub include_subdirs: bool,
 
-    pub path: ResolvedVc<AstPath>,
+    pub path: AstPath,
     pub issue_source: Option<IssueSource>,
     pub in_try: bool,
 }
@@ -226,7 +226,7 @@ impl RequireContextAssetReference {
         dir: RcStr,
         include_subdirs: bool,
         filter: Vc<Regex>,
-        path: ResolvedVc<AstPath>,
+        path: AstPath,
         issue_source: Option<IssueSource>,
         in_try: bool,
     ) -> Result<Vc<Self>> {
@@ -302,8 +302,7 @@ impl CodeGenerateable for RequireContextAssetReference {
 
         let mut visitors = Vec::new();
 
-        let path = &self.path.await?;
-        visitors.push(create_visitor!(path, visit_mut_expr(expr: &mut Expr) {
+        visitors.push(create_visitor!(self.path, visit_mut_expr(expr: &mut Expr) {
             if let Expr::Call(_) = expr {
                 *expr = quote!(
                     "$turbopack_module_context($turbopack_require($id))" as Expr,

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -29,7 +29,7 @@ use crate::{
 pub struct WorkerAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,
-    pub path: ResolvedVc<AstPath>,
+    pub path: AstPath,
     pub issue_source: IssueSource,
     pub in_try: bool,
 }
@@ -40,7 +40,7 @@ impl WorkerAssetReference {
     pub fn new(
         origin: ResolvedVc<Box<dyn ResolveOrigin>>,
         request: ResolvedVc<Request>,
-        path: ResolvedVc<AstPath>,
+        path: AstPath,
         issue_source: IssueSource,
         in_try: bool,
     ) -> Vc<Self> {
@@ -131,9 +131,7 @@ impl CodeGenerateable for WorkerAssetReference {
             .chunk_item_id_from_ident(loader.ident())
             .await?;
 
-        let path = &self.path.await?;
-
-        let visitor = create_visitor!(path, visit_mut_expr(expr: &mut Expr) {
+        let visitor = create_visitor!(self.path, visit_mut_expr(expr: &mut Expr) {
             let message = if let Expr::New(NewExpr { args, ..}) = expr {
                 if let Some(args) = args {
                     match args.first_mut() {


### PR DESCRIPTION
- Remove the last remaining `AstPath` cells
- Also box a rare `CodeGen` enum variant (brings down enum size from 128 bytes to 48 bytes)
- `code_gens.shrink_to_fit()`

Might help memory slightly, but it's bordering on measurement noise:
```
testing against 0293c96cf32

canary b6f8743ecd
13,75 GB 
TURBO_ENGINE_READ_ONLY=1 NEXT_TURBOPACK_TRACING= TURBOPACK=1 TURBOPACK_BUILD=  507.86s user 77.80s system 847% cpu 1:09.11 total
TURBO_ENGINE_READ_ONLY=1 NEXT_TURBOPACK_TRACING= TURBOPACK=1 TURBOPACK_BUILD=  503.13s user 77.86s system 855% cpu 1:07.90 total


uncell AstPath 3ec676fea5
13,7 GB 
TURBO_ENGINE_READ_ONLY=1 NEXT_TURBOPACK_TRACING= TURBOPACK=1 TURBOPACK_BUILD=  505.04s user 83.92s system 853% cpu 1:09.00 total
TURBO_ENGINE_READ_ONLY=1 NEXT_TURBOPACK_TRACING= TURBOPACK=1 TURBOPACK_BUILD=  509.03s user 84.26s system 829% cpu 1:11.53 total
```

Closes PACK-3913