### PR TITLE
Fix lint for cacheTag doc

### DIFF
--- a/docs/01-app/04-api-reference/04-functions/cacheTag.mdx
+++ b/docs/01-app/04-api-reference/04-functions/cacheTag.mdx
@@ -94,7 +94,7 @@ export default async function submit() {
 - **Multiple Tags**: You can assign multiple tags to a single cache entry by passing an array to `cacheTag`.
 
 ```tsx
-cacheTag(['tag-one', 'tag-two']);
+cacheTag(['tag-one', 'tag-two'])
 ```
 
 ## Examples


### PR DESCRIPTION
Seems this was failing in https://github.com/vercel/next.js/pull/75693