### PR TITLE
[Turbopack] disable dependency tracking for next build

### DIFF
--- a/crates/napi/src/next_api/utils.rs
+++ b/crates/napi/src/next_api/utils.rs
@@ -170,6 +170,7 @@ pub fn create_turbo_tasks(
             turbo_tasks_backend::TurboTasksBackend::new(
                 turbo_tasks_backend::BackendOptions {
                     storage_mode: None,
+                    dependency_tracking,
                     ..Default::default()
                 },
                 noop_backing_storage(),


### PR DESCRIPTION
### What?

fix a previous PR that disables dependency tracking when not needed.

Closes PACK-3905