### PR TITLE
Invalidator: don’t call invalidate at all if there’s nothing to invalidate

### DIFF
--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -306,7 +306,10 @@ class Invalidator {
         this.rebuildAgain.delete(key)
       }
     }
-    this.invalidate(rebuild)
+
+    if (rebuild.length > 0) {
+      this.invalidate(rebuild)
+    }
   }
 
   public willRebuild(compilerKey: keyof typeof COMPILER_INDEXES) {


### PR DESCRIPTION
No behavior changes in this PR, just a small adjustment since while debugging it was surprising that `invalidate` was called even though it was a no-op with an empty array.

Previously, `invalidate` would unconditionally get called after building, even if no work was queued.

Test Plan: CI


Closes PACK-3907