### PR TITLE
chore(next-swc-napi): Remove unused(?) rlib target

### DIFF
--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [features]
 # Instead of enabling all the plugin-related functionality by default, make it


### PR DESCRIPTION
napi-rs only uses the cdylib version: https://github.com/napi-rs/napi-rs/blob/688a266f132f947b8002e892b78decd660d8a6ec/crates/napi/README.md#building

This might(?) slightly improve compile times for certain invocations of `cargo`.

Closes PACK-3906