### PR TITLE
Handle invalid sourcemaps

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -632,5 +632,6 @@
   "631": "Invariant (SlowModuleDetectionPlugin): Circular dependency detected in module graph. This is a Next.js internal bug.",
   "632": "Invariant (SlowModuleDetectionPlugin): Module is missing a required debugId. This is a Next.js internal bug.",
   "633": "Dynamic route not found",
-  "634": "Route %s used \"searchParams\" inside \"use cache\". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \"searchParams\" outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache"
+  "634": "Route %s used \"searchParams\" inside \"use cache\". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \"searchParams\" outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
+  "635": "%s: Invalid source map. Only conformant source maps can be used to find the original code."
 }

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
@@ -16,7 +16,11 @@ import path from 'path'
 import url from 'url'
 import { launchEditor } from '../internal/helpers/launchEditor'
 import type { StackFrame } from 'next/dist/compiled/stacktrace-parser'
-import { SourceMapConsumer } from 'next/dist/compiled/source-map08'
+import {
+  SourceMapConsumer,
+  type BasicSourceMapConsumer,
+  type NullableMappedPosition,
+} from 'next/dist/compiled/source-map08'
 import type { Project, TurbopackStackFrame } from '../../../../build/swc/types'
 import { getSourceMapFromFile } from '../internal/helpers/get-source-map-from-file'
 import { findSourceMap, type SourceMapPayload } from 'node:module'
@@ -230,39 +234,58 @@ function findApplicableSourceMapPayload(
 async function nativeTraceSource(
   frame: TurbopackStackFrame
 ): Promise<{ frame: IgnorableStackFrame; source: string | null } | undefined> {
-  const sourceMap = findSourceMap(
-    // TODO(veil): Why are the frames sent encoded?
+  const sourceURL = // TODO(veil): Why are the frames sent encoded?
     decodeURIComponent(frame.file)
-  )
-  if (sourceMap !== undefined) {
-    const traced = await SourceMapConsumer.with(
-      sourceMap.payload,
-      null,
-      async (consumer) => {
-        const originalPosition = consumer.originalPositionFor({
-          line: frame.line ?? 1,
-          column: frame.column ?? 1,
-        })
+  let sourceMapPayload: ModernSourceMapPayload | undefined
+  try {
+    sourceMapPayload = findSourceMap(sourceURL)?.payload
+  } catch (cause) {
+    throw new Error(
+      `${sourceURL}: Invalid source map. Only conformant source maps can be used to find the original code.`,
+      { cause }
+    )
+  }
 
-        if (originalPosition.source === null) {
-          return null
-        }
+  if (sourceMapPayload !== undefined) {
+    let consumer: BasicSourceMapConsumer
+    try {
+      consumer = await new SourceMapConsumer(sourceMapPayload)
+    } catch (cause) {
+      throw new Error(
+        `${sourceURL}: Invalid source map. Only conformant source maps can be used to find the original code.`,
+        { cause }
+      )
+    }
+    let traced: {
+      originalPosition: NullableMappedPosition
+      sourceContent: string | null
+    } | null
+    try {
+      const originalPosition = consumer.originalPositionFor({
+        line: frame.line ?? 1,
+        column: frame.column ?? 1,
+      })
 
+      if (originalPosition.source === null) {
+        traced = null
+      } else {
         const sourceContent: string | null =
           consumer.sourceContentFor(
             originalPosition.source,
             /* returnNullOnMissing */ true
           ) ?? null
 
-        return { originalPosition, sourceContent }
+        traced = { originalPosition, sourceContent }
       }
-    )
+    } finally {
+      consumer.destroy()
+    }
 
     if (traced !== null) {
       const { originalPosition, sourceContent } = traced
       const applicableSourceMap = findApplicableSourceMapPayload(
         frame,
-        sourceMap.payload
+        sourceMapPayload
       )
 
       // TODO(veil): Upstream a method to sourcemap consumer that immediately says if a frame is ignored or not.

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-webpack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-webpack.ts
@@ -1,7 +1,10 @@
 import { constants as FS, promises as fs } from 'fs'
 import path from 'path'
 import url from 'url'
-import { SourceMapConsumer } from 'next/dist/compiled/source-map08'
+import {
+  SourceMapConsumer,
+  type BasicSourceMapConsumer,
+} from 'next/dist/compiled/source-map08'
 import type { StackFrame } from 'next/dist/compiled/stacktrace-parser'
 import { getSourceMapFromFile } from '../internal/helpers/get-source-map-from-file'
 import { launchEditor } from '../internal/helpers/launchEditor'
@@ -86,7 +89,16 @@ async function findOriginalSourcePositionAndContent(
   sourceMap: RawSourceMap,
   position: { line: number; column: number | null }
 ): Promise<SourceAttributes | null> {
-  const consumer = await new SourceMapConsumer(sourceMap)
+  let consumer: BasicSourceMapConsumer
+  try {
+    consumer = await new SourceMapConsumer(sourceMap)
+  } catch (cause) {
+    throw new Error(
+      `${sourceMap.file}: Invalid source map. Only conformant source maps can be used to find the original code.`,
+      { cause }
+    )
+  }
+
   try {
     const sourcePosition = consumer.originalPositionFor({
       line: position.line,
@@ -533,8 +545,8 @@ export function getOverlayMiddleware(options: {
             rootDirectory,
           })
         )
-      } catch (error) {
-        return internalServerError(res, error)
+      } catch (err) {
+        return badRequest(res)
       }
     } else if (pathname === '/__nextjs_launch-editor') {
       const frame = {

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/app/bad-sourcemap/page.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/app/bad-sourcemap/page.js
@@ -1,0 +1,10 @@
+// Compile with pnpm tsc test/e2e/app-dir/server-source-maps/fixtures/default/bad-sourcemap/page.js --allowJs --sourceMap --target esnext --outDir test/e2e/app-dir/server-source-maps/fixtures/default/app/bad-sourcemap
+// Then change the `sources` entry in the sourcemap to `["custom://[badhost]/app/bad-sourcemap/page.js"]`
+// tsc compile errors can be ignored
+import { connection } from 'next/server'
+export default async function Page() {
+  await connection()
+  console.error(new Error('Boom!'))
+  return <p>Hello, Dave!</p>
+}
+//# sourceMappingURL=page.js.map

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/app/bad-sourcemap/page.js.map
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/app/bad-sourcemap/page.js.map
@@ -1,0 +1,10 @@
+{
+  "version": 3,
+  "file": "page.js",
+  "sourceRoot": "",
+  "sources": [
+    "custom://[badhost]/app/bad-sourcemap/page.js"
+  ],
+  "names": [],
+  "mappings": "AAAA,yNAAyN;AACzN,yGAAyG;AACzG,oCAAoC;AAEpC,OAAO,EAAE,UAAU,EAAE,MAAM,aAAa,CAAA;AAExC,MAAM,CAAC,OAAO,CAAC,KAAK,UAAU,IAAI;IAChC,MAAM,UAAU,EAAE,CAAA;IAClB,OAAO,CAAC,KAAK,CAAC,IAAI,KAAK,CAAC,OAAO,CAAC,CAAC,CAAA;IACjC,OAAO,CAAC,CAAC,CAAC,YAAY,EAAE,CAAC,CAAC,CAAA;AAC5B,CAAC"
+}

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/bad-sourcemap/page.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/bad-sourcemap/page.js
@@ -1,0 +1,11 @@
+// Compile with pnpm tsc test/e2e/app-dir/server-source-maps/fixtures/default/bad-sourcemap/page.js --allowJs --sourceMap --target esnext --outDir test/e2e/app-dir/server-source-maps/fixtures/default/app/bad-sourcemap
+// Then change the `sources` entry in the sourcemap to `["custom://[badhost]/app/bad-sourcemap/page.js"]`
+// tsc compile errors can be ignored
+
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+  console.error(new Error('Boom!'))
+  return <p>Hello, Dave!</p>
+}


### PR DESCRIPTION
Sourcemaps can be user generated content (e.g. when modules are externals) so they need to be treated as untrusted. There are two places where an invalid sourcemap triggers errors:
1. Node.js' `findSourceMap` throws on invalid sourcemaps with "TypeError [ERR_INVALID_ARG_TYPE]: The "payload" argument must be of type object. Received null"
2. `source-map` throws when constructing the sourcemap consumer

Source map consumers are in large parts free to not abort parsing and just continue but Node.js and `source-map` are stricter in that regard. Chrome is more forgiving as far as I can tell. This strictness might also just be from a time where the spec wasn't finalized or didn't [explicitly allow this level of lenience](https://tc39.es/ecma426/#optionally-report-an-error).

Closes https://linear.app/vercel/issue/NDX-505/