### PR TITLE
Only disable Prettier for original Turbopack source

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -53,15 +53,15 @@ test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.j
 test/e2e/async-modules/amp-validator-wasm.js
 
 # turbopack crates
-turbopack/crates/*/js/src/compiled
-turbopack/crates/turbopack/bench.json
-turbopack/crates/turbopack/tests
-turbopack/crates/turbopack-ecmascript/tests/analyzer/graph
-turbopack/crates/turbopack-ecmascript/tests/tree-shaker
-turbopack/crates/next-transform-strip-page-exports/tests
-turbopack/crates/next-transform-dynamic/tests
-turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/input/broken.js
-turbopack/crates/turbopack-tests/tests/**/output*
+/turbopack/crates/*/js/src/compiled
+/turbopack/crates/turbopack/bench.json
+/turbopack/crates/turbopack/tests
+/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph
+/turbopack/crates/turbopack-ecmascript/tests/tree-shaker
+/turbopack/crates/next-transform-strip-page-exports/tests
+/turbopack/crates/next-transform-dynamic/tests
+/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/input/broken.js
+/turbopack/crates/turbopack-tests/tests/**/output*
 
 # temporarily disable prettier for the turbopack directory
-turbopack/
+/turbopack/

--- a/packages/next/src/shared/lib/turbopack/manifest-loader.ts
+++ b/packages/next/src/shared/lib/turbopack/manifest-loader.ts
@@ -2,15 +2,20 @@ import type {
   EdgeFunctionDefinition,
   MiddlewareManifest,
 } from '../../../build/webpack/plugins/middleware-plugin'
-import type { StatsAsset, StatsChunk, StatsChunkGroup, StatsModule, StatsCompilation as WebpackStats } from 'webpack'
+import type {
+  StatsAsset,
+  StatsChunk,
+  StatsChunkGroup,
+  StatsModule,
+  StatsCompilation as WebpackStats,
+} from 'webpack'
 import type { BuildManifest } from '../../../server/get-page-files'
 import type { AppBuildManifest } from '../../../build/webpack/plugins/app-build-manifest-plugin'
 import type { PagesManifest } from '../../../build/webpack/plugins/pages-manifest-plugin'
 import { pathToRegexp } from 'next/dist/compiled/path-to-regexp'
 import type { ActionManifest } from '../../../build/webpack/plugins/flight-client-entry-plugin'
 import type { NextFontManifest } from '../../../build/webpack/plugins/next-font-manifest-plugin'
-import type {
-  REACT_LOADABLE_MANIFEST} from '../constants';
+import type { REACT_LOADABLE_MANIFEST } from '../constants'
 import {
   APP_BUILD_MANIFEST,
   APP_PATHS_MANIFEST,
@@ -41,7 +46,11 @@ import { getEntryKey, type EntryKey } from './entry-key'
 import type { CustomRoutes } from '../../../lib/load-custom-routes'
 import { getSortedRoutes } from '../router/utils'
 import { existsSync } from 'fs'
-import { addMetadataIdToRoute, addRouteSuffix, removeRouteSuffix } from '../../../server/dev/turbopack-utils'
+import {
+  addMetadataIdToRoute,
+  addRouteSuffix,
+  removeRouteSuffix,
+} from '../../../server/dev/turbopack-utils'
 import { tryToParsePath } from '../../../lib/try-to-parse-path'
 import type { Entrypoints } from '../../../build/swc/types'
 
@@ -54,7 +63,12 @@ type TurbopackMiddlewareManifest = MiddlewareManifest & {
   instrumentation?: InstrumentationDefinition
 }
 
-const getManifestPath = (page: string, distDir: string, name: string, type: string) => {
+const getManifestPath = (
+  page: string,
+  distDir: string,
+  name: string,
+  type: string
+) => {
   let manifestPath = posix.join(
     distDir,
     `server`,
@@ -90,12 +104,19 @@ async function readPartialManifest<T>(
 
   // Check the ambiguity of /sitemap and /sitemap.xml
   if (isSitemapRoute && !existsSync(manifestPath)) {
-    manifestPath = getManifestPath(pageName.replace(/\/sitemap\/route$/, '/sitemap.xml/route'), distDir, name, type)
+    manifestPath = getManifestPath(
+      pageName.replace(/\/sitemap\/route$/, '/sitemap.xml/route'),
+      distDir,
+      name,
+      type
+    )
   }
   // existsSync is faster than using the async version
-  if(!existsSync(manifestPath) && page.endsWith('/route')) {
+  if (!existsSync(manifestPath) && page.endsWith('/route')) {
     // TODO: Improve implementation of metadata routes, currently it requires this extra check for the variants of the files that can be written.
-    let metadataPage = addRouteSuffix(addMetadataIdToRoute(removeRouteSuffix(page)))
+    let metadataPage = addRouteSuffix(
+      addMetadataIdToRoute(removeRouteSuffix(page))
+    )
     manifestPath = getManifestPath(metadataPage, distDir, name, type)
   }
   return JSON.parse(await readFile(posix.join(manifestPath), 'utf-8')) as T
@@ -270,19 +291,10 @@ export class TurbopackManifestLoader {
   }
 
   private async writeWebpackStats(): Promise<void> {
-    const webpackStats = this.mergeWebpackStats(
-      this.webpackStats.values()
-    )
-    const path = join(
-      this.distDir,
-      'server',
-      WEBPACK_STATS
-    )
+    const webpackStats = this.mergeWebpackStats(this.webpackStats.values())
+    const path = join(this.distDir, 'server', WEBPACK_STATS)
     deleteCache(path)
-    await writeFileAtomic(
-      path,
-      JSON.stringify(webpackStats, null, 2)
-    )
+    await writeFileAtomic(path, JSON.stringify(webpackStats, null, 2))
   }
 
   async loadBuildManifest(
@@ -306,16 +318,14 @@ export class TurbopackManifestLoader {
   }
 
   private mergeWebpackStats(statsFiles: Iterable<WebpackStats>): WebpackStats {
-    const entrypoints: Record<string, StatsChunkGroup> = {};
+    const entrypoints: Record<string, StatsChunkGroup> = {}
     const assets: Map<string, StatsAsset> = new Map()
     const chunks: Map<string, StatsChunk> = new Map()
     const modules: Map<string | number, StatsModule> = new Map()
 
     for (const statsFile of statsFiles) {
       if (statsFile.entrypoints) {
-        for (const [k, v] of Object.entries(
-          statsFile.entrypoints
-        )) {
+        for (const [k, v] of Object.entries(statsFile.entrypoints)) {
           if (!entrypoints[k]) {
             entrypoints[k] = v
           }
@@ -340,10 +350,10 @@ export class TurbopackManifestLoader {
 
       if (statsFile.modules) {
         for (const module of statsFile.modules) {
-          const id = module.id;
+          const id = module.id
           if (id != null) {
             // Merge the chunk list for the module. This can vary across endpoints.
-            const existing = modules.get(id);
+            const existing = modules.get(id)
             if (existing == null) {
               modules.set(id, module)
             } else if (module.chunks != null && existing.chunks != null) {

--- a/packages/next/src/shared/lib/turbopack/utils.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.ts
@@ -1,7 +1,14 @@
-import type { Issue, StyledString, TurbopackResult } from '../../../build/swc/types'
+import type {
+  Issue,
+  StyledString,
+  TurbopackResult,
+} from '../../../build/swc/types'
 import { bold, green, magenta, red } from '../../../lib/picocolors'
 import isInternal from '../is-internal'
-import { decodeMagicIdentifier, MAGIC_IDENTIFIER_REGEX } from '../magic-identifier'
+import {
+  decodeMagicIdentifier,
+  MAGIC_IDENTIFIER_REGEX,
+} from '../magic-identifier'
 import type { EntryKey } from './entry-key'
 import * as Log from '../../../build/output/log'
 import type { NextConfigComplete } from '../../../server/config-shared'
@@ -60,7 +67,6 @@ export async function getTurbopackJsConfig(
   const { jsConfig } = await loadJsConfig(dir, nextConfig)
   return jsConfig ?? { compilerOptions: {} }
 }
-
 
 export function processIssues(
   currentEntryIssues: EntryIssuesMap,


### PR DESCRIPTION
`turbopack` matches any folder named `turbopack` e.g. `packages/turbopack` when it's really just about the root one.