### PR TITLE
[errors] dedupe replied console error

### DIFF
--- a/packages/next/src/client/components/errors/enqueue-client-error.ts
+++ b/packages/next/src/client/components/errors/enqueue-client-error.ts
@@ -1,4 +1,6 @@
 import { isHydrationError } from '../is-hydration-error'
+import { isUnhandledConsoleOrRejection } from './console-error'
+import { getStackBeforeReactBottomFrame } from './stitched-error'
 
 // Dedupe the two consecutive errors: If the previous one is same as current one, ignore the current one.
 export function enqueueConsecutiveDedupedError(
@@ -8,8 +10,23 @@ export function enqueueConsecutiveDedupedError(
   const isFront = isHydrationError(error)
   const previousError = isFront ? queue[0] : queue[queue.length - 1]
   // Compare the error stack to dedupe the consecutive errors
-  if (previousError && previousError.stack === error.stack) {
-    return
+  if (previousError) {
+    // React strict mode double invocation will result in the slightly different error stack.
+    // After react-stack-bottom-frame, the error stack is different.
+    // original one will has `renderWithHooks` in stack;
+    // replied one will has `renderWithHooksAgain` in stack;
+    // So we striped the stack after `react-stack-bottom-frame` then to compare the error stack.
+    if (
+      isUnhandledConsoleOrRejection(previousError) &&
+      isUnhandledConsoleOrRejection(error) &&
+      // Check if the error stack starts with the previous error stack
+      getStackBeforeReactBottomFrame(error.stack || '') ===
+        getStackBeforeReactBottomFrame(previousError.stack || '')
+    ) {
+      return
+    } else if (previousError.stack === error.stack) {
+      return
+    }
   }
   // TODO: change all to push error into errorQueue,
   // currently there's a async api error is always erroring while hydration error showing up.

--- a/packages/next/src/client/components/errors/stitched-error.ts
+++ b/packages/next/src/client/components/errors/stitched-error.ts
@@ -6,6 +6,14 @@ const REACT_ERROR_STACK_BOTTOM_FRAME_REGEX = new RegExp(
   `(at ${REACT_ERROR_STACK_BOTTOM_FRAME} )|(${REACT_ERROR_STACK_BOTTOM_FRAME}\\@)`
 )
 
+export function getStackBeforeReactBottomFrame(stack: string): string {
+  const stackLines = stack.split('\n')
+  const indexOfSplit = stackLines.findIndex((line) =>
+    REACT_ERROR_STACK_BOTTOM_FRAME_REGEX.test(line)
+  )
+  return stackLines.slice(0, indexOfSplit).join('\n')
+}
+
 export function getReactStitchedError<T = unknown>(err: T): Error | T {
   if (!process.env.__NEXT_REACT_OWNER_STACK) {
     return err

--- a/test/development/app-dir/capture-console-error/capture-console-error.test.ts
+++ b/test/development/app-dir/capture-console-error/capture-console-error.test.ts
@@ -102,7 +102,7 @@ describe('app-dir - capture-console-error', () => {
        {
          "callStacks": "Page
        app/browser/render/page.js (4:11)",
-         "count": 2,
+         "count": 1,
          "description": "trigger an console.error in render",
          "source": "app/browser/render/page.js (4:11) @ Page
 
@@ -121,7 +121,7 @@ describe('app-dir - capture-console-error', () => {
        {
          "callStacks": "Page
        app/browser/render/page.js (4:11)",
-         "count": 2,
+         "count": 1,
          "description": "trigger an console.error in render",
          "source": "app/browser/render/page.js (4:11) @ Page
 
@@ -150,7 +150,7 @@ describe('app-dir - capture-console-error', () => {
        {
          "callStacks": "Page
        app/browser/render/page.js (4:11)",
-         "count": 2,
+         "count": 1,
          "description": "trigger an console.error in render",
          "source": "app/browser/render/page.js (4:11) @ Page
 
@@ -169,7 +169,7 @@ describe('app-dir - capture-console-error', () => {
        {
          "callStacks": "Page
        app/browser/render/page.js (4:11)",
-         "count": 2,
+         "count": 1,
          "description": "trigger an console.error in render",
          "source": "app/browser/render/page.js (4:11) @ Page
 
@@ -198,7 +198,7 @@ describe('app-dir - capture-console-error', () => {
        {
          "callStacks": "Page
        app/ssr/page.js (4:11)",
-         "count": 2,
+         "count": 1,
          "description": "ssr console error:client",
          "source": "app/ssr/page.js (4:11) @ Page
 
@@ -217,7 +217,7 @@ describe('app-dir - capture-console-error', () => {
        {
          "callStacks": "Page
        app/ssr/page.js (4:11)",
-         "count": 2,
+         "count": 1,
          "description": "ssr console error:client",
          "source": "app/ssr/page.js (4:11) @ Page
 
@@ -246,7 +246,7 @@ describe('app-dir - capture-console-error', () => {
        {
          "callStacks": "Page
        app/ssr-error-instance/page.js (4:17)",
-         "count": 2,
+         "count": 1,
          "description": "Error: page error",
          "source": "app/ssr-error-instance/page.js (4:17) @ Page
 
@@ -265,7 +265,7 @@ describe('app-dir - capture-console-error', () => {
        {
          "callStacks": "Page
        app/ssr-error-instance/page.js (4:17)",
-         "count": 2,
+         "count": 1,
          "description": "Error: page error",
          "source": "app/ssr-error-instance/page.js (4:17) @ Page
 


### PR DESCRIPTION
### What

When we replay the effects, and during the interception of `console.error` calls. The error will have two different stacks. But we only need one error since it's only logged once. Here we strippped the call stack before `react-stack-bottom-frame` are actually same. We can compare the stack before that for console errors, this will help dedupe the continous same errors.

![image](https://github.com/user-attachments/assets/5a1418a3-f60a-4550-b1a0-d3590d28ea85)


Closes NDX-756
