### PR TITLE
chore(github): add labels-to-add-when-unstale label -> not stale

### DIFF
--- a/.github/workflows/issue_stale.yml
+++ b/.github/workflows/issue_stale.yml
@@ -22,6 +22,7 @@ jobs:
           days-before-pr-stale: -1
           remove-issue-stale-when-updated: true
           stale-issue-label: 'stale'
+          labels-to-add-when-unstale: 'not stale'
           stale-issue-message: 'This issue has been automatically marked as stale due to two years of inactivity. It will be closed in 7 days unless there’s further input. If you believe this issue is still relevant, please leave a comment or provide updated details. Thank you.'
           close-issue-message: 'This issue has been automatically closed due to two years of inactivity. If you’re still experiencing a similar problem or have additional details to share, please open a new issue following our current issue template. Your updated report helps us investigate and address concerns more efficiently. Thank you for your understanding!'
           operations-per-run: 300 # 1 operation per 100 issues, the rest is to label/comment/close
@@ -36,6 +37,9 @@ jobs:
           days-before-issue-stale: 1
           days-before-pr-close: -1
           days-before-pr-stale: -1
+          remove-issue-stale-when-updated: true
+          stale-issue-label: 'stale'
+          labels-to-add-when-unstale: 'not stale'
           operations-per-run: 300 # 1 operation per 100 issues, the rest is to label/comment/close
       - uses: actions/stale@v9
         id: stale-simple-repro
@@ -48,6 +52,9 @@ jobs:
           days-before-issue-stale: 1
           days-before-pr-close: -1
           days-before-pr-stale: -1
+          remove-issue-stale-when-updated: true
+          stale-issue-label: 'stale'
+          labels-to-add-when-unstale: 'not stale'
           operations-per-run: 300 # 1 operation per 100 issues, the rest is to label/comment/close
       - uses: actions/stale@v9
         id: stale-no-canary
@@ -60,4 +67,7 @@ jobs:
           days-before-issue-stale: 1
           days-before-pr-close: -1
           days-before-pr-stale: -1
+          remove-issue-stale-when-updated: true
+          stale-issue-label: 'stale'
+          labels-to-add-when-unstale: 'not stale'
           operations-per-run: 300 # 1 operation per 100 issues, the rest is to label/comment/close


### PR DESCRIPTION
## Why?

To track issues that are marked "not stale," we need to explicitly add a not stale label. https://github.com/actions/stale does not use this label by default.