### PR TITLE
docs: Update README for experimental testmode

### DIFF
--- a/packages/next/src/experimental/testmode/playwright/README.md
+++ b/packages/next/src/experimental/testmode/playwright/README.md
@@ -35,7 +35,7 @@ import { defineConfig } from 'next/experimental/testmode/playwright'
 
 export default defineConfig({
   webServer: {
-    command: 'npm dev',
+    command: 'npm run dev',
     url: 'http://localhost:3000',
   },
 })
@@ -44,10 +44,17 @@ export default defineConfig({
 ### Use the `next/experimental/testmode/playwright` to create tests
 
 ```javascript
+// Place this file in the `app` directory and name it with `.spec.ts`.
+// To customize where to put tests, add `testMatch` to `playwright.config.ts`.
+
 import { test, expect } from 'next/experimental/testmode/playwright'
 
 test('/product/shoe', async ({ page, next }) => {
   next.onFetch((request) => {
+    // `next.onFetch` only intercepts external fetch requests (for both client and server).
+    // For example, if you `fetch` a relative URL (e.g. `/api/hello`) from the client
+    // that's handled by a Next.js route handler (e.g. `app/api/hello/route.ts`),
+    // it won't be intercepted.
     if (request.url === 'http://my-db/product/shoe') {
       return new Response(
         JSON.stringify({

--- a/packages/next/src/experimental/testmode/playwright/README.md
+++ b/packages/next/src/experimental/testmode/playwright/README.md
@@ -50,11 +50,11 @@ export default defineConfig({
 import { test, expect } from 'next/experimental/testmode/playwright'
 
 test('/product/shoe', async ({ page, next }) => {
+  // NOTE: `next.onFetch` only intercepts external `fetch` requests (for both client and server).
+  // For example, if you `fetch` a relative URL (e.g. `/api/hello`) from the client
+  // that's handled by a Next.js route handler (e.g. `app/api/hello/route.ts`),
+  // it won't be intercepted.
   next.onFetch((request) => {
-    // `next.onFetch` only intercepts external fetch requests (for both client and server).
-    // For example, if you `fetch` a relative URL (e.g. `/api/hello`) from the client
-    // that's handled by a Next.js route handler (e.g. `app/api/hello/route.ts`),
-    // it won't be intercepted.
     if (request.url === 'http://my-db/product/shoe') {
       return new Response(
         JSON.stringify({


### PR DESCRIPTION
- Fix the `npm` command
- Make it clear where to place test files
  - Was reported here: https://github.com/vercel/next.js/issues/71773
  - Relevant Next.js code:

https://github.com/vercel/next.js/blob/ae5026a0fa8cd67f434cf63cc1db7d7ee696c047/packages/next/src/experimental/testmode/playwright/default-config.ts#L13

- Make it clear that `next.onFetch` only works for external requests.
  - Relevant Next.js code:

https://github.com/vercel/next.js/blob/d2711d22fb719131d63cbce05a6306917f3626ea/packages/next/src/experimental/testmode/playwright/page-route.ts#L34-L40