### PR TITLE
chore(turbopack): Remove legacy next.js HMR compat code

### DIFF
--- a/turbopack/crates/turbopack-cli/js/src/entry/client.ts
+++ b/turbopack/crates/turbopack-cli/js/src/entry/client.ts
@@ -3,7 +3,7 @@ import {
   connectHMR,
   addMessageListener,
   sendMessage,
-} from "@vercel/turbopack-ecmascript-runtime/browser/dev/hmr-client/websocket";
+} from "./websocket";
 
 export function initializeHMR(options: { assetPrefix: string }) {
   connect({

--- a/turbopack/crates/turbopack-cli/js/src/entry/websocket.ts
+++ b/turbopack/crates/turbopack-cli/js/src/entry/websocket.ts
@@ -1,5 +1,7 @@
 // Adapted from https://github.com/vercel/next.js/blob/canary/packages/next/src/client/dev/error-overlay/websocket.ts
 
+import type { WebSocketMessage } from "@vercel/turbopack-ecmascript-runtime/browser/dev/hmr-client/hmr-client";
+
 let source: WebSocket;
 const eventCallbacks: ((msg: WebSocketMessage) => void)[] = [];
 
@@ -17,15 +19,6 @@ function getSocketProtocol(assetPrefix: string): string {
   return protocol === "http:" ? "ws" : "wss";
 }
 
-export type WebSocketMessage =
-  | {
-      type: "turbopack-connected";
-    }
-  | {
-      type: "turbopack-message";
-      data: Record<string, any>;
-    };
-
 export function addMessageListener(cb: (msg: WebSocketMessage) => void) {
   eventCallbacks.push(cb);
 }
@@ -42,6 +35,7 @@ export type HMROptions = {
   log?: boolean;
 };
 
+// This is not used by Next.js, but it is used by the standalone turbopack-cli
 export function connectHMR(options: HMROptions) {
   const { timeout = 5 * 1000 } = options;
 

--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/dev/hmr-client/hmr-client.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/dev/hmr-client/hmr-client.ts
@@ -3,25 +3,26 @@
 /// <reference path="../../runtime/base/dev-protocol.d.ts" />
 /// <reference path="../../runtime/base/dev-extensions.ts" />
 
-import {
-  addMessageListener as turboSocketAddMessageListener,
-  sendMessage as turboSocketSendMessage,
-} from "./websocket";
-type SendMessage = typeof import("./websocket").sendMessage;
+type SendMessage = (msg: any) => void;
+export type WebSocketMessage =
+  | {
+      type: "turbopack-connected";
+    }
+  | {
+      type: "turbopack-message";
+      data: Record<string, any>;
+    };
+
 
 export type ClientOptions = {
-  addMessageListener: typeof import("./websocket").addMessageListener;
+  addMessageListener: (cb: (msg: WebSocketMessage) => void) => void;
   sendMessage: SendMessage;
   onUpdateError: (err: unknown) => void;
 };
 
 export function connect({
-  // TODO(WEB-1465) Remove this backwards compat fallback once
-  // vercel/next.js#54586 is merged.
-  addMessageListener = turboSocketAddMessageListener,
-  // TODO(WEB-1465) Remove this backwards compat fallback once
-  // vercel/next.js#54586 is merged.
-  sendMessage = turboSocketSendMessage,
+  addMessageListener,
+  sendMessage,
   onUpdateError = console.error,
 }: ClientOptions) {
   addMessageListener((msg) => {
@@ -547,13 +548,6 @@ export function subscribeToUpdate(
   sendMessage: SendMessage,
   callback: UpdateCallback
 ) {
-  // TODO(WEB-1465) Remove this backwards compat fallback once
-  // vercel/next.js#54586 is merged.
-  if (callback === undefined) {
-    callback = sendMessage;
-    sendMessage = turboSocketSendMessage;
-  }
-
   const key = resourceKey(resource);
   let callbackSet: UpdateCallbackSet;
   const existingCallbackSet = updateCallbackSets.get(key);

--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/dev/hmr-client/index.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/dev/hmr-client/index.ts
@@ -1,2 +1,1 @@
 export * from "./hmr-client";
-export * from "./websocket";


### PR DESCRIPTION
These TODOs are very old. Clean them up!

Closes PACK-3916