### PR TITLE
fix(turbopack): Always console.log the "done in" message after receiving a BUILT event

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
@@ -63,6 +63,8 @@ let mostRecentCompilationHash: any = null
 let __nextDevClientId = Math.round(Math.random() * 100 + Date.now())
 let reloading = false
 let startLatency: number | null = null
+let turbopackLastUpdateLatency: number | null = null
+let turbopackUpdatedModules: Set<string> = new Set()
 
 let pendingHotUpdateWebpack = Promise.resolve()
 let resolvePendingHotUpdateWebpack: () => void = () => {}
@@ -104,7 +106,9 @@ function reportHmrLatency(
   updatedModules: ReadonlyArray<string>
 ) {
   if (!startLatency) return
-  let endLatency = Date.now()
+  // turbopack has a debounce for the "built" event which we don't want to
+  // incorrectly show in this number, use the last TURBOPACK_MESSAGE time
+  let endLatency = turbopackLastUpdateLatency ?? Date.now()
   const latency = endLatency - startLatency
   console.log(`[Fast Refresh] done in ${latency}ms`)
   sendMessage(
@@ -314,6 +318,7 @@ function processMessage(
   function handleHotUpdate() {
     if (process.env.TURBOPACK) {
       dispatcher.onBuildOk()
+      reportHmrLatency(sendMessage, [...turbopackUpdatedModules])
     } else {
       tryApplyUpdates(
         function onBeforeHotUpdate(hasUpdates: boolean) {
@@ -375,6 +380,8 @@ function processMessage(
     }
     case HMR_ACTIONS_SENT_TO_BROWSER.BUILDING: {
       startLatency = Date.now()
+      turbopackLastUpdateLatency = null
+      turbopackUpdatedModules.clear()
       if (!process.env.TURBOPACK) {
         setPendingHotUpdateWebpack()
       }
@@ -461,7 +468,6 @@ function processMessage(
       break
     }
     case HMR_ACTIONS_SENT_TO_BROWSER.TURBOPACK_MESSAGE: {
-      const updatedModules = extractModulesFromTurbopackMessage(obj.data)
       dispatcher.onBeforeRefresh()
       processTurbopackMessage({
         type: HMR_ACTIONS_SENT_TO_BROWSER.TURBOPACK_MESSAGE,
@@ -472,7 +478,10 @@ function processMessage(
         console.warn(REACT_REFRESH_FULL_RELOAD_FROM_ERROR)
         performFullReload(null, sendMessage)
       }
-      reportHmrLatency(sendMessage, updatedModules)
+      for (const module of extractModulesFromTurbopackMessage(obj.data)) {
+        turbopackUpdatedModules.add(module)
+      }
+      turbopackLastUpdateLatency = Date.now()
       break
     }
     // TODO-APP: make server component change more granular

--- a/packages/next/src/server/dev/extract-modules-from-turbopack-message.ts
+++ b/packages/next/src/server/dev/extract-modules-from-turbopack-message.ts
@@ -2,7 +2,7 @@ import type { Update as TurbopackUpdate } from '../../build/swc/types'
 
 export function extractModulesFromTurbopackMessage(
   data: TurbopackUpdate | TurbopackUpdate[]
-) {
+): Set<string> {
   const updatedModules: Set<string> = new Set()
 
   const updates = Array.isArray(data) ? data : [data]
@@ -31,5 +31,5 @@ export function extractModulesFromTurbopackMessage(
     }
   }
 
-  return [...updatedModules]
+  return updatedModules
 }

--- a/test/development/app-hmr/hmr.test.ts
+++ b/test/development/app-hmr/hmr.test.ts
@@ -78,24 +78,13 @@ describe(`app-dir-hmr`, () => {
             const fastRefreshLogs = logs.filter((log) => {
               return log.message.startsWith('[Fast Refresh]')
             })
-            // FIXME:  3+ "rebuilding" but no "done" is confusing.
-            // There may actually be more "rebuilding" but not reliably.
-            // To ignore this flakiness, we just assert on subset matches.
-            // Once the  bug is fixed, each "rebuilding" should be paired with a "done in" exactly.
             expect(fastRefreshLogs).toEqual(
               expect.arrayContaining([
                 { source: 'log', message: '[Fast Refresh] rebuilding' },
-                { source: 'log', message: '[Fast Refresh] rebuilding' },
-                { source: 'log', message: '[Fast Refresh] rebuilding' },
-              ])
-            )
-            // FIXME: Turbopack should have matching "done in" for each "rebuilding"
-            expect(logs).not.toEqual(
-              expect.arrayContaining([
-                expect.objectContaining({
-                  message: expect.stringContaining('[Fast Refresh] done in'),
+                {
                   source: 'log',
-                }),
+                  message: expect.stringContaining('[Fast Refresh] done in'),
+                },
               ])
             )
           })
@@ -172,26 +161,14 @@ describe(`app-dir-hmr`, () => {
             expect(await browser.elementByCss('p').text()).toBe('ipad')
           })
 
-          if (process.env.TURBOPACK) {
-            // FIXME: Turbopack should have matching "done in" for each "rebuilding"
-            expect(logs).not.toEqual(
-              expect.arrayContaining([
-                expect.objectContaining({
-                  message: expect.stringContaining('[Fast Refresh] done in'),
-                  source: 'log',
-                }),
-              ])
-            )
-          } else {
-            expect(logs).toEqual(
-              expect.arrayContaining([
-                expect.objectContaining({
-                  message: expect.stringContaining('[Fast Refresh] done in'),
-                  source: 'log',
-                }),
-              ])
-            )
-          }
+          expect(logs).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                message: expect.stringContaining('[Fast Refresh] done in'),
+                source: 'log',
+              }),
+            ])
+          )
         })
 
         // ensure it's restored back to "mac" before the next test
@@ -221,54 +198,25 @@ describe(`app-dir-hmr`, () => {
 
       const logs = await browser.log()
       // TODO: Should assert on all logs but these are cluttered with logs from our test utils (e.g. playwright tracing or webdriver)
-      if (process.env.TURBOPACK) {
-        // FIXME: logging "rebuilding" multiple times instead of closing it of with "done in"
-        // Should just not branch here and have the same logs as Webpack.
-        expect(logs).toEqual(
-          expect.arrayContaining([
-            {
-              message: '[Fast Refresh] rebuilding',
-              source: 'log',
-            },
-            {
-              message: '[Fast Refresh] rebuilding',
-              source: 'log',
-            },
-            {
-              message: '[Fast Refresh] rebuilding',
-              source: 'log',
-            },
-          ])
-        )
-        expect(logs).not.toEqual(
-          expect.arrayContaining([
-            {
-              message: expect.stringContaining('[Fast Refresh] done in'),
-              source: 'log',
-            },
-          ])
-        )
-      } else {
-        expect(logs).toEqual(
-          expect.arrayContaining([
-            {
-              message: '[Fast Refresh] rebuilding',
-              source: 'log',
-            },
-            {
-              message: expect.stringContaining('[Fast Refresh] done in'),
-              source: 'log',
-            },
-          ])
-        )
-        expect(logs).not.toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              source: 'error',
-            }),
-          ])
-        )
-      }
+      expect(logs).toEqual(
+        expect.arrayContaining([
+          {
+            message: '[Fast Refresh] rebuilding',
+            source: 'log',
+          },
+          {
+            message: expect.stringContaining('[Fast Refresh] done in'),
+            source: 'log',
+          },
+        ])
+      )
+      expect(logs).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            source: 'error',
+          }),
+        ])
+      )
       // No MPA navigation triggered
       expect(await browser.eval('window.__TEST_NO_RELOAD')).toEqual(true)
     })


### PR DESCRIPTION
Previously, when making a change that doesn't actually cause any modules to update, you could see a:

```
[Fast Refresh] rebuilding
```

that is never followed by a

```
[Fast Refresh] done in 90ms
```

message. This PR attempts to more closely emulate webpack's behavior.

I've seen people observe this before and wrongly believe that Turbopack is hanging.

Doing this right is a little tricky: Turbopack emits the `BUILT` event separately using a debounce (currently 30ms) after the actual HMR updates.

I don't think the Turbopack HMR APIs are particularly great overall, but the way Turbopack is handing this sort-of makes sense. A file could be updated multiple times in quick succession (i.e. as the editor is in the middle of writing it), or somebody could save changes to multiple files at once, and there's no way to atomically synchronize all of the potential filesystem/editor interactions.

Closes PACK-3925