### PR TITLE
[dev-overlay] Introduce motion to surface new errors

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -92,7 +92,16 @@ function DevToolsPopover({
   useFocusTrap(menuRef, triggerRef, isMenuOpen)
   useClickOutside(menuRef, triggerRef, isMenuOpen, closeMenu)
 
-  function select(index: number | 'last') {
+  function select(index: number | 'first' | 'last') {
+    if (index === 'first') {
+      const all = menuRef.current?.querySelectorAll('[role="menuitem"]')
+      if (all) {
+        const firstIndex = all[0].getAttribute('data-index')
+        select(Number(firstIndex))
+      }
+      return
+    }
+
     if (index === 'last') {
       const all = menuRef.current?.querySelectorAll('[role="menuitem"]')
       if (all) {
@@ -124,7 +133,7 @@ function DevToolsPopover({
         select(prev)
         break
       case 'Home':
-        select(0)
+        select('first')
         break
       case 'End':
         select('last')
@@ -144,7 +153,7 @@ function DevToolsPopover({
       setIsMenuOpen(true)
       // Run on next tick because querying DOM after state change
       setTimeout(() => {
-        select(0)
+        select('first')
       })
     }
 
@@ -186,7 +195,6 @@ function DevToolsPopover({
     >
       <NextLogo
         ref={triggerRef}
-        key={issueCount}
         aria-haspopup="menu"
         aria-expanded={isMenuOpen}
         aria-controls="nextjs-dev-tools-menu"
@@ -227,12 +235,14 @@ function DevToolsPopover({
             }}
           >
             <div className="inner">
-              <MenuItem
-                index={0}
-                label="Issues"
-                value={<IssueCount>{issueCount}</IssueCount>}
-                onClick={openErrorOverlay}
-              />
+              {issueCount > 0 && (
+                <MenuItem
+                  index={0}
+                  label="Issues"
+                  value={<IssueCount>{issueCount}</IssueCount>}
+                  onClick={openErrorOverlay}
+                />
+              )}
               <MenuItem
                 label="Route"
                 value={isStaticRoute ? 'Static' : 'Dynamic'}

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -465,14 +465,13 @@ function useMeasureWidth(ref: React.RefObject<HTMLDivElement | null>) {
 
     const observer = new ResizeObserver(() => {
       const { width: w } = el.getBoundingClientRect()
-      if (w !== width) {
-        setWidth(w)
-      }
+      setWidth(w)
     })
 
     observer.observe(el)
     return () => observer.disconnect()
-  }, [ref, width])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return width
 }

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -371,11 +371,11 @@ export const NextLogo = forwardRef(function NextLogo(
             }
           }
 
-          @media (prefers-reduced-motion: reduce) {
+          @media (prefers-reduced-motion) {
             [data-issues-count-exit],
             [data-issues-count-enter],
             [data-issues-count-plural] {
-              animation-duration: 0ms;
+              animation-duration: 0ms !important;
             }
           }
         `}

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -16,7 +16,7 @@ const SHORT_DURATION_MS = 150
 
 export const NextLogo = forwardRef(function NextLogo(
   {
-    issueCount,
+    issueCount: issueCountProp,
     isDevBuilding,
     isDevRendering,
     onTriggerClick,
@@ -25,13 +25,13 @@ export const NextLogo = forwardRef(function NextLogo(
   }: Props,
   propRef: React.Ref<HTMLButtonElement>
 ) {
+  const [issueCount, setIssueCount] = useState(issueCountProp)
   const hasError = issueCount > 0
-  const [newErrorDetected, setNewErrorDetected] = useState(false)
   const [isErrorExpanded, setIsErrorExpanded] = useState(hasError)
+  const [newErrorDetected, setNewErrorDetected] = useState(false)
 
   const triggerRef = useRef<HTMLButtonElement | null>(null)
   const ref = useRef<HTMLDivElement | null>(null)
-  const prevIssueCountRef = useRef(issueCount)
   const width = useMeasureWidth(ref)
 
   const isLoading = useMinimumLoadingTimeMultiple(
@@ -39,23 +39,31 @@ export const NextLogo = forwardRef(function NextLogo(
   )
 
   useEffect(() => {
-    setIsErrorExpanded(hasError)
-
-    if (hasError && prevIssueCountRef.current !== issueCount) {
-      setNewErrorDetected(true)
-      // It is important to use a CSS transitioned state, not a CSS keyframed animation
-      // because if the issue count increases faster than the animation duration, it
-      // will abruptly stop and not transition smoothly back to its original state.
-      const timeoutId = window.setTimeout(() => {
-        setNewErrorDetected(false)
-      }, SHORT_DURATION_MS)
-
-      return () => {
-        clearTimeout(timeoutId)
-        prevIssueCountRef.current = issueCount
-      }
+    if (hasError) {
+      setIsErrorExpanded(true)
+    } else {
+      setIsErrorExpanded(false)
     }
-  }, [hasError, issueCount])
+
+    let timeoutId: number
+
+    // Bounce the entire element subtly to draw attention to the new error
+    setIssueCount((prevIssueCount: number) => {
+      // Check for 0, we don't want to animate on the first error surfacing
+      // because the badge will already expand to draw attention to it
+      if (prevIssueCount !== 0 && prevIssueCount !== issueCountProp) {
+        setNewErrorDetected(true)
+        // It is important to use a CSS transitioned state, not a CSS keyframed animation
+        // because if the issue count increases faster than the animation duration, it
+        // will abruptly stop and not transition smoothly back to its original state.
+        timeoutId = window.setTimeout(() => {
+          setNewErrorDetected(false)
+          clearTimeout(timeoutId)
+        }, SHORT_DURATION_MS)
+      }
+      return issueCountProp
+    })
+  }, [issueCountProp, issueCount, hasError])
 
   return (
     <div

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -442,7 +442,7 @@ function AnimateCount({
   animate: boolean
 }) {
   return (
-    <div {...props} key={String(count)} data-animate={animate}>
+    <div {...props} key={`${count}-${Date.now()}`} data-animate={animate}>
       <div aria-hidden data-issues-count-exit>
         {count - 1}
       </div>

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -406,7 +406,7 @@ export const NextLogo = forwardRef(function NextLogo(
                 aria-label="Open issues overlay"
                 onClick={openErrorOverlay}
               >
-                <AnimateCount animate={newErrorDetected} data-issues-count>
+                <AnimateCount animate={newErrorDetected}>
                   {issueCount}
                 </AnimateCount>{' '}
                 <div>
@@ -441,7 +441,6 @@ export const NextLogo = forwardRef(function NextLogo(
 function AnimateCount({
   children: propChildren,
   animate = true,
-  ...props
 }: {
   children: number
   animate: boolean
@@ -456,11 +455,13 @@ function AnimateCount({
   }, [propChildren])
 
   return (
-    <div {...props} key={String(enter)} data-animate={animate}>
+    <div key={String(enter)} data-animate={animate}>
       <div aria-hidden data-issues-count-exit>
         {exit}
       </div>
-      <div data-issues-count-enter>{enter}</div>
+      <div data-issues-count-enter data-issues-count>
+        {enter}
+      </div>
     </div>
   )
 }

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -399,6 +399,8 @@ export const NextLogo = forwardRef(function NextLogo(
                 onClick={openErrorOverlay}
               >
                 <AnimateCount
+                  // Used the key to force a re-render when the count changes.
+                  key={issueCount}
                   animate={newErrorDetected}
                   data-issues-count-animation
                 >
@@ -442,11 +444,11 @@ function AnimateCount({
   animate: boolean
 }) {
   return (
-    <div {...props} key={`animate-${count}`} data-animate={animate}>
-      <div aria-hidden data-issues-count-exit key={`exit-${count}`}>
+    <div {...props} data-animate={animate}>
+      <div aria-hidden data-issues-count-exit>
         {count - 1}
       </div>
-      <div data-issues-count data-issues-count-enter key={`enter-${count}`}>
+      <div data-issues-count data-issues-count-enter>
         {count}
       </div>
     </div>

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -442,11 +442,11 @@ function AnimateCount({
   animate: boolean
 }) {
   return (
-    <div {...props} key={`${count}-${Date.now()}`} data-animate={animate}>
-      <div aria-hidden data-issues-count-exit>
+    <div {...props} key={`animate-${count}`} data-animate={animate}>
+      <div aria-hidden data-issues-count-exit key={`exit-${count}`}>
         {count - 1}
       </div>
-      <div data-issues-count data-issues-count-enter>
+      <div data-issues-count data-issues-count-enter key={`enter-${count}`}>
         {count}
       </div>
     </div>

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -12,7 +12,7 @@ interface Props extends React.ComponentProps<'button'> {
 }
 
 const SIZE = 36
-const SHORE_DURATION_MS = 150
+const SHORT_DURATION_MS = 150
 
 export const NextLogo = forwardRef(function NextLogo(
   {
@@ -48,7 +48,7 @@ export const NextLogo = forwardRef(function NextLogo(
       // will abruptly stop and not transition smoothly back to its original state.
       const timeoutId = window.setTimeout(() => {
         setNewErrorDetected(false)
-      }, SHORE_DURATION_MS)
+      }, SHORT_DURATION_MS)
 
       return () => {
         clearTimeout(timeoutId)
@@ -63,7 +63,7 @@ export const NextLogo = forwardRef(function NextLogo(
       style={
         {
           '--size': `${SIZE}px`,
-          '--duration-short': `${SHORE_DURATION_MS}ms`,
+          '--duration-short': `${SHORT_DURATION_MS}ms`,
         } as React.CSSProperties
       }
     >

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -373,7 +373,8 @@ export const NextLogo = forwardRef(function NextLogo(
 
           @media (prefers-reduced-motion: reduce) {
             [data-issues-count-exit],
-            [data-issues-count-enter] {
+            [data-issues-count-enter],
+            [data-issues-count-plural] {
               animation-duration: 0ms;
             }
           }

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -82,6 +82,10 @@ export const NextLogo = forwardRef(function NextLogo(
     isDevBuilding || isDevRendering
   )
 
+  useEffect(() => {
+    setIsErrorExpanded(hasError)
+  }, [hasError])
+
   return (
     <div
       data-next-badge-root

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -442,29 +442,20 @@ export const NextLogo = forwardRef(function NextLogo(
 })
 
 function AnimateCount({
-  children: propChildren,
+  children: count,
   animate = true,
   ...props
 }: {
   children: number
   animate: boolean
 }) {
-  const [exit, setExit] = useState(propChildren)
-  const [enter, setEnter] = useState(propChildren)
-
-  useEffect(() => {
-    setExit(enter)
-    setEnter(propChildren)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [propChildren])
-
   return (
-    <div {...props} key={String(enter)} data-animate={animate}>
+    <div {...props} key={String(count)} data-animate={animate}>
       <div aria-hidden data-issues-count-exit>
-        {exit}
+        {count - 1}
       </div>
       <div data-issues-count data-issues-count-enter>
-        {enter}
+        {count}
       </div>
     </div>
   )

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -11,8 +11,8 @@ interface Props extends React.ComponentProps<'button'> {
   openErrorOverlay: () => void
 }
 
-const size = 36
-const shortDurationMs = 150
+const SIZE = 36
+const SHORE_DURATION_MS = 150
 
 export const NextLogo = forwardRef(function NextLogo(
   {
@@ -41,14 +41,14 @@ export const NextLogo = forwardRef(function NextLogo(
   useEffect(() => {
     setIsErrorExpanded(hasError)
 
-    if (hasError && prevIssueCountRef.current < issueCount) {
+    if (hasError && prevIssueCountRef.current !== issueCount) {
       setNewErrorDetected(true)
       // It is important to use a CSS transitioned state, not a CSS keyframed animation
       // because if the issue count increases faster than the animation duration, it
       // will abruptly stop and not transition smoothly back to its original state.
       const timeoutId = window.setTimeout(() => {
         setNewErrorDetected(false)
-      }, shortDurationMs)
+      }, SHORE_DURATION_MS)
 
       return () => {
         clearTimeout(timeoutId)
@@ -62,8 +62,8 @@ export const NextLogo = forwardRef(function NextLogo(
       data-next-badge-root
       style={
         {
-          '--size': `${size}px`,
-          '--duration-short': `${shortDurationMs}ms`,
+          '--size': `${SIZE}px`,
+          '--duration-short': `${SHORE_DURATION_MS}ms`,
         } as React.CSSProperties
       }
     >
@@ -378,7 +378,7 @@ export const NextLogo = forwardRef(function NextLogo(
         data-error-expanded={isErrorExpanded}
         data-animate={newErrorDetected}
         style={{
-          width: hasError && width > size ? width : size,
+          width: hasError && width > SIZE ? width : SIZE,
         }}
       >
         <div ref={ref}>

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -39,11 +39,7 @@ export const NextLogo = forwardRef(function NextLogo(
   )
 
   useEffect(() => {
-    if (hasError) {
-      setIsErrorExpanded(true)
-    } else {
-      setIsErrorExpanded(false)
-    }
+    setIsErrorExpanded(hasError)
 
     let timeoutId: number
 
@@ -58,11 +54,14 @@ export const NextLogo = forwardRef(function NextLogo(
         // will abruptly stop and not transition smoothly back to its original state.
         timeoutId = window.setTimeout(() => {
           setNewErrorDetected(false)
-          clearTimeout(timeoutId)
         }, SHORT_DURATION_MS)
       }
       return issueCountProp
     })
+
+    return () => {
+      clearTimeout(timeoutId)
+    }
   }, [issueCountProp, issueCount, hasError])
 
   return (

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -16,7 +16,7 @@ const shortDurationMs = 150
 
 export const NextLogo = forwardRef(function NextLogo(
   {
-    issueCount: propIssueCount,
+    issueCount: issueCountProp,
     isDevBuilding,
     isDevRendering,
     onTriggerClick,
@@ -25,7 +25,7 @@ export const NextLogo = forwardRef(function NextLogo(
   }: Props,
   propRef: React.Ref<HTMLButtonElement>
 ) {
-  const [issueCount, setIssueCount] = useState(propIssueCount)
+  const [issueCount, setIssueCount] = useState(issueCountProp)
   const hasError = issueCount > 0
   const [isErrorExpanded, setIsErrorExpanded] = useState(hasError)
   const [newErrorDetected, setNewErrorDetected] = useState(false)
@@ -51,7 +51,7 @@ export const NextLogo = forwardRef(function NextLogo(
     setIssueCount((prevIssueCount: number) => {
       // Check for 0, we don't want to animate on the first error surfacing
       // because the badge will already expand to draw attention to it
-      if (prevIssueCount !== 0 && prevIssueCount !== propIssueCount) {
+      if (prevIssueCount !== 0 && prevIssueCount !== issueCountProp) {
         setNewErrorDetected(true)
         // It is important to use a CSS transitioned state, not a CSS keyframed animation
         // because if the issue count increases faster than the animation duration, it
@@ -61,9 +61,9 @@ export const NextLogo = forwardRef(function NextLogo(
           clearTimeout(timeoutId)
         }, shortDurationMs)
       }
-      return propIssueCount
+      return issueCountProp
     })
-  }, [propIssueCount, issueCount, hasError])
+  }, [issueCountProp, issueCount, hasError])
 
   return (
     <div

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -264,7 +264,7 @@ export const NextLogo = forwardRef(function NextLogo(
             }
           }
 
-          [data-issues-count] {
+          [data-issues-count-animation] {
             display: grid;
             place-items: center center;
             font-variant-numeric: tabular-nums;
@@ -406,7 +406,10 @@ export const NextLogo = forwardRef(function NextLogo(
                 aria-label="Open issues overlay"
                 onClick={openErrorOverlay}
               >
-                <AnimateCount animate={newErrorDetected}>
+                <AnimateCount
+                  animate={newErrorDetected}
+                  data-issues-count-animation
+                >
                   {issueCount}
                 </AnimateCount>{' '}
                 <div>
@@ -441,6 +444,7 @@ export const NextLogo = forwardRef(function NextLogo(
 function AnimateCount({
   children: propChildren,
   animate = true,
+  ...props
 }: {
   children: number
   animate: boolean
@@ -455,11 +459,11 @@ function AnimateCount({
   }, [propChildren])
 
   return (
-    <div key={String(enter)} data-animate={animate}>
+    <div {...props} key={String(enter)} data-animate={animate}>
       <div aria-hidden data-issues-count-exit>
         {exit}
       </div>
-      <div data-issues-count-enter data-issues-count>
+      <div data-issues-count data-issues-count-enter>
         {enter}
       </div>
     </div>


### PR DESCRIPTION
This PR for the most part introduces an animation to subtly draw attention to new errors appearing on the Next.js Dev Tools badge. In addition, there are a few quality-of-life improvements made on the go:

- More robust keyboard navigation when determining the index to select
- Issue count is now hidden in the dropdown menu when there are no issues
- Increased hover state contrast for actions on the Badge `Error` state

> The animation respects `prefers: reduced-motion`. Because _reduced motion_ does not necessarily mean _no motion_, the Badge will only subtly bounce instead of translating the issue count and its plural suffix (`s`). 

https://github.com/user-attachments/assets/fad57ada-1dbd-4b27-a7c4-295781f09d40

---
- Closes [NDX-752](https://linear.app/vercel/issue/NDX-752/hide-issues-item-in-menu-when-count-is-zero)
- Closes [NDX-753](https://linear.app/vercel/issue/NDX-753/add-hover-state-to-floating-next-buttonball)
- Closes [NDX-766](https://linear.app/vercel/issue/NDX-766/tweak-color-contrast-on-pill-hover-state)
- Closes [NDX-755](https://linear.app/vercel/issue/NDX-755/fix-bug-prevent-error-reanimation-on-new-error-detection)
- Closes NDX-779
