### PR TITLE
[dev-overlay] fix: color contrast for terminal

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/styles/colors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/styles/colors.tsx
@@ -6,6 +6,17 @@ export function Colors() {
     <style>
       {css`
         :host {
+          ${
+            // CAUTION: THIS IS A WORKAROUND!
+            // For now, we use @babel/code-frame to parse the code frame which does not support option to change the color.
+            // x-ref: https://github.com/babel/babel/blob/efa52324ff835b794c48080f14877b6caf32cd15/packages/babel-code-frame/src/defs.ts#L40-L54
+            // So, we do a workaround mapping to change the color matching the theme.
+
+            // For example, in @babel/code-frame, the `keyword` is mapped to ANSI "cyan".
+            // We want the `keyword` to use the `syntax-keyword` color in the theme.
+            // So, we map the "cyan" to the `syntax-keyword` in the theme.
+            ''
+          }
           /* cyan: keyword */
           --color-ansi-cyan: var(--color-syntax-keyword);
           /* yellow: capitalized, jsxIdentifier, punctuation */

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/styles/colors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/styles/colors.tsx
@@ -6,6 +6,17 @@ export function Colors() {
     <style>
       {css`
         :host {
+          /* cyan: keyword */
+          --color-ansi-cyan: var(--color-syntax-keyword);
+          /* yellow: capitalized, jsxIdentifier, punctuation */
+          --color-ansi-yellow: var(--color-syntax-punctuation);
+          /* magenta: number, regex */
+          --color-ansi-magenta: var(--color-syntax-number);
+          /* green: string */
+          --color-ansi-green: var(--color-syntax-string);
+          /* gray (bright black): comment, gutter */
+          --color-ansi-bright-black: var(--color-syntax-comment);
+
           /* Ansi - Temporary */
           --color-ansi-selection: var(--color-gray-alpha-300);
           --color-ansi-bg: var(--color-background-200);
@@ -14,13 +25,8 @@ export function Colors() {
           --color-ansi-white: var(--color-gray-700);
           --color-ansi-black: var(--color-gray-200);
           --color-ansi-blue: var(--color-blue-700);
-          --color-ansi-cyan: var(--color-blue-700);
-          --color-ansi-green: var(--color-green-700);
-          --color-ansi-magenta: var(--color-blue-700);
           --color-ansi-red: var(--color-red-700);
-          --color-ansi-yellow: var(--color-amber-800);
           --color-ansi-bright-white: var(--color-gray-1000);
-          --color-ansi-bright-black: var(--color-gray-700);
           --color-ansi-bright-blue: var(--color-blue-800);
           --color-ansi-bright-cyan: var(--color-blue-800);
           --color-ansi-bright-green: var(--color-green-800);


### PR DESCRIPTION
### Why?

The color contrast of the terminal violated the WCAG standard.

Example:

| Yellow | Blue |
|--------|--------|
| ![CleanShot 2025-02-06 at 20 01 40](https://github.com/user-attachments/assets/f4e6407a-adea-471f-8a8f-4c2c3623845c) | ![CleanShot 2025-02-06 at 20 01 23](https://github.com/user-attachments/assets/d90fe606-45eb-418d-9c90-106a24075ca4) | 

### Before

#### Light

![CleanShot 2025-02-06 at 19 55 06](https://github.com/user-attachments/assets/045fc670-ddeb-418a-9dfc-ba3afe3d7d37)

![CleanShot 2025-02-06 at 19 56 01](https://github.com/user-attachments/assets/c3e6b440-364f-49e3-960a-7969fb591a99)

#### Dark

![CleanShot 2025-02-06 at 19 55 21](https://github.com/user-attachments/assets/8dcf756f-372d-4cae-98fe-6fcb47563e3b)

### After

#### Light

![CleanShot 2025-02-06 at 19 54 57](https://github.com/user-attachments/assets/26c96f3c-9e6a-4836-a800-dd1f2a6973c7)

![CleanShot 2025-02-06 at 19 56 48](https://github.com/user-attachments/assets/0de5b190-2209-4002-a36e-d087075b7c02)

#### Dark

![CleanShot 2025-02-06 at 19 55 16](https://github.com/user-attachments/assets/6c098ebb-5fc3-48ed-ab69-f9fe433ae032)

Closes https://linear.app/vercel/issue/NDX-657/fix-code-frame-color-contrast