### PR TITLE
[dev-overlay] fix: proceed to get runtime error when fails to fetch original stack frames

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
@@ -76,14 +76,18 @@ export async function getOriginalStackFrames(
     isEdgeServer: type === 'edge-server',
     isAppDirectory: isAppDir,
   }
-  const res = await fetch('/__nextjs_original-stack-frames', {
-    method: 'POST',
-    body: JSON.stringify(req),
-  })
-  const data = await res.json()
-  return Promise.all(
-    frames.map((frame, index) => getOriginalStackFrame(frame, data[index]))
-  )
+  try {
+    const res = await fetch('/__nextjs_original-stack-frames', {
+      method: 'POST',
+      body: JSON.stringify(req),
+    })
+    const data = await res.json()
+    return Promise.all(
+      frames.map((frame, index) => getOriginalStackFrame(frame, data[index]))
+    )
+  } catch {
+    return []
+  }
 }
 
 export function getFrameSource(frame: StackFrame): string {

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
@@ -76,24 +76,16 @@ export async function getOriginalStackFrames(
     isEdgeServer: type === 'edge-server',
     isAppDirectory: isAppDir,
   }
-  try {
-    const res = await fetch('/__nextjs_original-stack-frames', {
-      method: 'POST',
-      body: JSON.stringify(req),
-    })
 
-    if (!res.ok) {
-      return []
-    }
+  const res = await fetch('/__nextjs_original-stack-frames', {
+    method: 'POST',
+    body: JSON.stringify(req),
+  })
 
-    const data = await res.json()
-    return Promise.all(
-      frames.map((frame, index) => getOriginalStackFrame(frame, data[index]))
-    )
-  } catch (error) {
-    console.error(error)
-    return []
-  }
+  const data = await res.json()
+  return Promise.all(
+    frames.map((frame, index) => getOriginalStackFrame(frame, data[index]))
+  )
 }
 
 export function getFrameSource(frame: StackFrame): string {

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
@@ -85,7 +85,8 @@ export async function getOriginalStackFrames(
     return Promise.all(
       frames.map((frame, index) => getOriginalStackFrame(frame, data[index]))
     )
-  } catch {
+  } catch (error) {
+    console.error(error)
     return []
   }
 }

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
@@ -81,6 +81,11 @@ export async function getOriginalStackFrames(
       method: 'POST',
       body: JSON.stringify(req),
     })
+
+    if (!res.ok) {
+      return []
+    }
+
     const data = await res.json()
     return Promise.all(
       frames.map((frame, index) => getOriginalStackFrame(frame, data[index]))

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
@@ -82,6 +82,18 @@ export async function getOriginalStackFrames(
     body: JSON.stringify(req),
   })
 
+  if (!res.ok || res.status === 204) {
+    const reason = await res.text()
+    return Promise.all(
+      frames.map((frame) =>
+        getOriginalStackFrame(frame, {
+          status: 'rejected',
+          reason: `Failed to fetch the original stack frames: ${reason}`,
+        })
+      )
+    )
+  }
+
   const data = await res.json()
   return Promise.all(
     frames.map((frame, index) => getOriginalStackFrame(frame, data[index]))

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
@@ -82,6 +82,9 @@ export async function getOriginalStackFrames(
     body: JSON.stringify(req),
   })
 
+  // When fails to fetch the original stack frames, we reject here to be
+  // caught at `_getOriginalStackFrame()` and return the stack frames so
+  // that the error overlay can render.
   if (!res.ok || res.status === 204) {
     const reason = await res.text()
     return Promise.all(


### PR DESCRIPTION
### Why?

When fetch fails to get the original stack frames, the process to get the Runtime Errors fails.
The fetch will likely fail on Storybook stories.

| Before | After |
|--------|--------|
| ![CleanShot 2025-02-06 at 21 21 19](https://github.com/user-attachments/assets/7e136a02-8b1f-4ec0-8430-e02d919610c3) | ![CleanShot 2025-02-06 at 21 21 33](https://github.com/user-attachments/assets/5ce9f95f-f5a2-4738-b8c5-5152733aeab7) | 

### How?

Correctly reject when request fails so that it may be caught at `_getOriginalStackFrame()` and return the stack frame.