### PR TITLE
Return `null` if Redbox has no component stack

### DIFF
--- a/test/lib/development-sandbox.ts
+++ b/test/lib/development-sandbox.ts
@@ -148,6 +148,9 @@ export async function createSandbox(
           }
           return source
         },
+        /**
+         * @returns `null` if there are no frames
+         */
         async getRedboxComponentStack() {
           return getRedboxComponentStack(browser)
         },

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1285,17 +1285,20 @@ export function getSnapshotTestDescribe(variant: TestVariants) {
   return shouldSkip ? describe.skip : describe
 }
 
+/**
+ * @returns `null` if there are no frames
+ */
 export async function getRedboxComponentStack(
   browser: BrowserInterface
-): Promise<string> {
-  await browser.waitForElementByCss(
-    '[data-nextjs-container-errors-pseudo-html] code',
-    30000
-  )
+): Promise<string | null> {
   // TODO: the type for elementsByCss is incorrect
   const componentStackFrameElements: any = await browser.elementsByCss(
     '[data-nextjs-container-errors-pseudo-html] code'
   )
+  if (componentStackFrameElements.length === 0) {
+    return null
+  }
+
   const componentStackFrameTexts = await Promise.all(
     componentStackFrameElements.map((f) => f.innerText())
   )


### PR DESCRIPTION
... and stop waiting for it. The util is supposed to be called after `assertHasRedbox` (hence the "get" prefix). Waiting just makes failing tests slower.