### PR TITLE
Revert "chore(next-swc-napi): Remove unused(?) rlib target"

### DIFF
--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [features]
 # Instead of enabling all the plugin-related functionality by default, make it


### PR DESCRIPTION
Reverts vercel/next.js#75707

canary builds timed out

Closes PACK-3910