### PR TITLE
fix: enable new overlay properly when env var is set

### DIFF
--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -288,11 +288,7 @@ export function getDefineEnv({
         }
       : undefined),
     'process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY':
-      // When `__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY` is set on CI,
-      // we need to pass it here so it can be enabled.
-      process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ||
-      config.experimental.newDevOverlay ||
-      false,
+      config.experimental.newDevOverlay || false,
     'process.env.__NEXT_REACT_OWNER_STACK':
       config.experimental.reactOwnerStack ?? false,
   }

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -440,13 +440,6 @@ function assignDefaults(
     }
   }
 
-  // TODO(jiwon): remove once we've made new UI default
-  // Enable reactOwnerStack when newDevOverlay is enabled to have
-  // better call stack output in the new UI.
-  if (result.experimental?.newDevOverlay) {
-    result.experimental.reactOwnerStack = true
-  }
-
   warnCustomizedOption(
     result,
     'experimental.esmExternals',
@@ -926,6 +919,17 @@ function assignDefaults(
   if (!result.experimental) {
     result.experimental = {}
   }
+
+  // TODO(jiwon): remove once we've made new UI default
+  // Enable reactOwnerStack when newDevOverlay is enabled to have
+  // better call stack output in the new UI.
+  if (process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true') {
+    result.experimental.newDevOverlay = true
+  }
+  if (result.experimental.newDevOverlay) {
+    result.experimental.reactOwnerStack = true
+  }
+
   result.experimental.optimizePackageImports = [
     ...new Set([
       ...userProvidedOptimizePackageImports,


### PR DESCRIPTION
### What

When you pass `__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY` in cli it should also enable the react owner stack. Currently only setting the experimental flag in next.config.js will enable react owner stack. It's not consistent. This PR fixes the issue