### PR TITLE
Fix cms-plasmic example

### DIFF
--- a/examples/cms-plasmic/package.json
+++ b/examples/cms-plasmic/package.json
@@ -8,8 +8,8 @@
   "dependencies": {
     "@plasmicapp/loader-nextjs": "1.0.363",
     "next": "latest",
-    "react": "18.1.0",
-    "react-dom": "18.1.0"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@types/node": "17.0.41",

--- a/examples/cms-plasmic/tsconfig.json
+++ b/examples/cms-plasmic/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -12,8 +16,15 @@
     "module": "esnext",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "moduleResolution": "node"
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
This pull request includes updates to dependencies in the `examples/cms-plasmic` example. Since the example uses `next@latest`, react and react-dom 18.1.0 does not meet the peer dependencies of next.

