### PR TITLE
[DevOverlay] fix style regression

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/dialog/styles.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/dialog/styles.ts
@@ -51,6 +51,7 @@ const styles = css`
     height: 100%;
     display: flex;
     flex-direction: column;
+    position: relative;
   }
 
   /* Account for the footer height, when present */


### PR DESCRIPTION
Lifts the style fix from #75718 into a separate PR.

Fixes the feedback bar clipping the content:
![410278234-8a7d9d9e-b483-4019-bc8a-524e755b3dd7](https://github.com/user-attachments/assets/3dd90148-6835-4954-9341-ae10c3c14679)
