### PR TITLE
[dev-overlay] fix: do not display toggle button on hydration diff when untoggleable

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.tsx
@@ -184,7 +184,6 @@ export function Errors({
       (activeError.componentStackFrames?.length ||
         !!errorDetails.reactOutputComponentDiff) ? (
         <PseudoHtmlDiff
-          className="nextjs__container_errors__component-stack"
           hydrationMismatchType={hydrationErrorType}
           componentStackFrames={activeError.componentStackFrames || []}
           firstContent={serverContent}

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/component-stack-pseudo-html.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/component-stack-pseudo-html.stories.tsx
@@ -15,7 +15,7 @@ type Story = StoryObj<typeof PseudoHtmlDiff>
 
 const sampleComponentStack = [
   {
-    component: 'div',
+    component: 'section',
     canOpenInEditor: false,
   },
   {
@@ -32,9 +32,23 @@ const sampleComponentStack = [
   },
 ]
 
+const div = {
+  component: 'div',
+  canOpenInEditor: false,
+}
+
 export const TextMismatch: Story = {
   args: {
     componentStackFrames: sampleComponentStack,
+    firstContent: 'Server rendered content',
+    secondContent: 'Client rendered content',
+    hydrationMismatchType: 'text',
+    reactOutputComponentDiff: undefined,
+  },
+}
+export const TextMismatchExpandable: Story = {
+  args: {
+    componentStackFrames: sampleComponentStack.concat(div),
     firstContent: 'Server rendered content',
     secondContent: 'Client rendered content',
     hydrationMismatchType: 'text',
@@ -51,15 +65,38 @@ export const TextInTagMismatch: Story = {
     reactOutputComponentDiff: undefined,
   },
 }
+export const TextInTagMismatchExpandable: Story = {
+  args: {
+    componentStackFrames: sampleComponentStack.concat(div),
+    firstContent: 'Mismatched content',
+    secondContent: 'p',
+    hydrationMismatchType: 'text-in-tag',
+    reactOutputComponentDiff: undefined,
+  },
+}
 
 export const ReactUnifiedMismatch: Story = {
   args: {
     componentStackFrames: sampleComponentStack,
     hydrationMismatchType: 'tag',
     reactOutputComponentDiff: `<Page>
-  <Layout>
-    <div>
+<Layout>
+  <Home>
+    <main>
 -     <p>Server content</p>
 +     <p>Client content</p>`,
+  },
+}
+export const ReactUnifiedMismatchExpandable: Story = {
+  args: {
+    componentStackFrames: sampleComponentStack.concat(div),
+    hydrationMismatchType: 'tag',
+    reactOutputComponentDiff: `<Page>
+<Layout>
+  <Home>
+    <main>
+      <article>
+-       <p>Server content</p>
++       <p>Client content</p>`,
   },
 }

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/component-stack-pseudo-html.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/component-stack-pseudo-html.tsx
@@ -74,6 +74,13 @@ export function PseudoHtmlDiff({
 
   // For text mismatch, mismatched text will take 2 rows, so we display 4 rows of component stack
   const MAX_NON_COLLAPSED_FRAMES = isHtmlTagsWarning ? 6 : 4
+
+  const hasCollapsableFrames =
+    (isReactHydrationDiff
+      ? reactOutputComponentDiff?.split('\n')
+      : componentStackFrames
+    ).length > MAX_NON_COLLAPSED_FRAMES
+
   const [isHtmlCollapsed, toggleCollapseHtml] = useState(true)
 
   const htmlComponents = useMemo(() => {
@@ -124,7 +131,7 @@ export function PseudoHtmlDiff({
                 {'\n'}
               </span>
             )
-          } else if (!isHtmlCollapsed) {
+          } else if (!isHtmlCollapsed || !hasCollapsableFrames) {
             componentStacks.push(
               <span
                 data-nextjs-container-errors-pseudo-html-line
@@ -197,7 +204,7 @@ export function PseudoHtmlDiff({
         Math.abs(index - matchedIndex[1]) <= 1
 
       const isLastFewFrames =
-        !isHtmlTagsWarning && index >= componentList.length - 6
+        !isHtmlTagsWarning && index >= componentList.length - 4
 
       const adjProps = getAdjacentProps(isAdjacentTag)
 
@@ -318,18 +325,21 @@ export function PseudoHtmlDiff({
     MAX_NON_COLLAPSED_FRAMES,
     isReactHydrationDiff,
     reactOutputComponentDiff,
+    hasCollapsableFrames,
   ])
 
   return (
     <div data-nextjs-container-errors-pseudo-html>
-      <button
-        tabIndex={10} // match CallStackFrame
-        data-nextjs-container-errors-pseudo-html-collapse
-        onClick={() => toggleCollapseHtml(!isHtmlCollapsed)}
-      >
-        <CollapseIcon collapsed={isHtmlCollapsed} />
-      </button>
-      <pre {...props}>
+      {hasCollapsableFrames && (
+        <button
+          tabIndex={10} // match CallStackFrame
+          data-nextjs-container-errors-pseudo-html-collapse
+          onClick={() => toggleCollapseHtml(!isHtmlCollapsed)}
+        >
+          <CollapseIcon collapsed={isHtmlCollapsed} />
+        </button>
+      )}
+      <pre className="nextjs__container_errors__component-stack" {...props}>
         <code>{htmlComponents}</code>
       </pre>
     </div>


### PR DESCRIPTION
### Why?

Even if the hydration diff is untoggleable, the toggle button was displayed.

https://github.com/user-attachments/assets/796b6f25-30dd-4c69-bbf0-8164ccefc3ea

### How?

Synced to not display the toggle button and show full stacks when there are six or fewer stacks.

https://github.com/user-attachments/assets/1eb6b30f-e9df-42aa-9575-95c0aaeac78e

Closes NDX-771