### PR TITLE
Ensure node middleware is handled with standalone

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1467,6 +1467,7 @@ export async function copyTracedFiles(
   tracingRoot: string,
   serverConfig: NextConfigComplete,
   middlewareManifest: MiddlewareManifest,
+  hasNodeMiddleware: boolean,
   hasInstrumentationHook: boolean,
   staticPages: Set<string>
 ) {
@@ -1579,6 +1580,12 @@ export async function copyTracedFiles(
         Log.warn(`Failed to copy traced files for ${pageFile}`, err)
       }
     })
+  }
+
+  if (hasNodeMiddleware) {
+    const middlewareFile = path.join(distDir, 'server', 'middleware.js')
+    const middlewareTrace = `${middlewareFile}.nft.json`
+    await handleTraceFiles(middlewareTrace)
   }
 
   if (appPageKeys) {

--- a/test/production/standalone-mode/required-server-files/middleware-node.js
+++ b/test/production/standalone-mode/required-server-files/middleware-node.js
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server'
+import { ImageResponse } from 'next/og'
+import fs from 'fs'
+import path from 'path'
+
+export const config = {
+  runtime: 'nodejs',
+}
+
+export async function middleware(req) {
+  console.log('middleware', req.url)
+  console.log(
+    'env',
+    await fs.promises.readFile(path.join(process.cwd(), '.env'))
+  )
+
+  if (req.nextUrl.pathname === '/a-non-existent-page/to-test-with-middleware') {
+    return new ImageResponse(<div>Hello world</div>, {
+      width: 1200,
+      height: 600,
+    })
+  }
+  return NextResponse.next()
+}

--- a/test/production/standalone-mode/required-server-files/required-server-files-node-middleware.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-node-middleware.test.ts
@@ -1,0 +1,3 @@
+process.env.TEST_NODE_MIDDLEWARE = '1'
+
+require('./required-server-files.test')

--- a/test/production/standalone-mode/required-server-files/required-server-files-node-middleware.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-node-middleware.test.ts
@@ -1,3 +1,7 @@
 process.env.TEST_NODE_MIDDLEWARE = '1'
 
-require('./required-server-files.test')
+if (process.env.TURBOPACK) {
+  it('should skip for now', () => {})
+} else {
+  require('./required-server-files.test')
+}

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -36,7 +36,14 @@ describe('required server files', () => {
       files: {
         pages: new FileRef(join(__dirname, 'pages')),
         lib: new FileRef(join(__dirname, 'lib')),
-        'middleware.js': new FileRef(join(__dirname, 'middleware.js')),
+        'middleware.js': new FileRef(
+          join(
+            __dirname,
+            process.env.TEST_NODE_MIDDLEWARE
+              ? 'middleware-node.js'
+              : 'middleware.js'
+          )
+        ),
         'cache-handler.js': new FileRef(join(__dirname, 'cache-handler.js')),
         'data.txt': new FileRef(join(__dirname, 'data.txt')),
         '.env': new FileRef(join(__dirname, '.env')),
@@ -48,6 +55,9 @@ describe('required server files', () => {
         cacheMaxMemorySize: 0,
         eslint: {
           ignoreDuringBuilds: true,
+        },
+        experimental: {
+          nodeMiddleware: Boolean(process.env.TEST_NODE_MIDDLEWARE),
         },
         output: 'standalone',
         async rewrites() {
@@ -1367,14 +1377,16 @@ describe('required server files', () => {
       expect(res.status).toBe(200)
       expect(await res.text()).toContain('index page')
 
-      if (process.env.TURBOPACK) {
-        expect(
-          fs.existsSync(join(standaloneDir, '.next/server/edge/chunks'))
-        ).toBe(true)
-      } else {
-        expect(
-          fs.existsSync(join(standaloneDir, '.next/server/edge-chunks'))
-        ).toBe(true)
+      if (!process.env.TEST_NODE_MIDDLEWARE) {
+        if (process.env.TURBOPACK) {
+          expect(
+            fs.existsSync(join(standaloneDir, '.next/server/edge/chunks'))
+          ).toBe(true)
+        } else {
+          expect(
+            fs.existsSync(join(standaloneDir, '.next/server/edge-chunks'))
+          ).toBe(true)
+        }
       }
 
       const resImageResponse = await fetchViaHTTP(

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -387,12 +387,17 @@ describe('required server files', () => {
   ;(process.env.TURBOPACK ? it.skip : it)(
     'should output middleware correctly',
     async () => {
-      // eslint-disable-next-line jest/no-standalone-expect
-      expect(
-        await fs.pathExists(
-          join(next.testDir, 'standalone/.next/server/edge-runtime-webpack.js')
-        )
-      ).toBe(true)
+      if (!process.env.TEST_NODE_MIDDLEWARE) {
+        // eslint-disable-next-line jest/no-standalone-expect
+        expect(
+          await fs.pathExists(
+            join(
+              next.testDir,
+              'standalone/.next/server/edge-runtime-webpack.js'
+            )
+          )
+        ).toBe(true)
+      }
       // eslint-disable-next-line jest/no-standalone-expect
       expect(
         await fs.pathExists(


### PR DESCRIPTION
This makes sure we properly copy the necessary files in standalone mode and node middleware is configured also adds regression test for this. 