### PR TITLE
fix: ensure lint worker errors aren't silenced

### DIFF
--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -164,7 +164,7 @@ export async function verifyTypeScriptSetup({
      */
 
     // we are in a worker, print the error message and exit the process
-    if (process.env.JEST_WORKER_ID) {
+    if (process.env.IS_NEXT_WORKER) {
       if (err instanceof Error) {
         console.error(err.message)
       } else {

--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -50,6 +50,7 @@ export class Worker {
           env: {
             ...((farmOptions.forkOptions?.env || {}) as any),
             ...process.env,
+            IS_NEXT_WORKER: 'true',
           } as any,
         },
         maxRetries: 0,
@@ -75,7 +76,7 @@ export class Worker {
           worker._child?.on('exit', (code, signal) => {
             if ((code || (signal && signal !== 'SIGINT')) && this._worker) {
               logger.error(
-                `Static worker exited with code: ${code} and signal: ${signal}`
+                `Next.js build worker exited with code: ${code} and signal: ${signal}`
               )
 
               // if a child process doesn't exit gracefully, we want to bubble up the exit code to the parent process

--- a/test/production/app-dir/build-output/index.test.ts
+++ b/test/production/app-dir/build-output/index.test.ts
@@ -42,7 +42,7 @@ describe('production - app dir - build output', () => {
 
   it('should log errors not caught by the worker without terminating the process', async () => {
     expect(output).toContain('Error: Boom')
-    expect(output).not.toContain('Static worker exited with code: 78')
+    expect(output).not.toContain('Next.js build worker exited with code: 78')
 
     const $ = await next.render$('/uncaught-error')
     expect($('#sentinel').text()).toEqual('at buildtime')
@@ -66,7 +66,7 @@ describe('production - app dir - build output', () => {
     const { cliOutput } = await next.build()
     await next.deleteFile('app/out-of-band-dynamic-api/page.tsx')
 
-    expect(cliOutput).toContain('Static worker exited with code: 78')
+    expect(cliOutput).toContain('Next.js build worker exited with code: 78')
   })
 
   it('should fail the build if you use a dynamic API outside of a render context - headers', async () => {
@@ -87,7 +87,7 @@ describe('production - app dir - build output', () => {
     const { cliOutput } = await next.build()
     await next.deleteFile('app/out-of-band-dynamic-api/page.tsx')
 
-    expect(cliOutput).toContain('Static worker exited with code: 78')
+    expect(cliOutput).toContain('Next.js build worker exited with code: 78')
   })
 
   it('should fail the build if you use a dynamic API outside of a render context - searchParams', async () => {
@@ -106,7 +106,7 @@ describe('production - app dir - build output', () => {
     const { cliOutput } = await next.build()
     await next.deleteFile('app/out-of-band-dynamic-api/page.tsx')
 
-    expect(cliOutput).toContain('Static worker exited with code: 78')
+    expect(cliOutput).toContain('Next.js build worker exited with code: 78')
   })
 
   it('should fail the build if you use a dynamic API outside of a render context - redirect', async () => {
@@ -127,7 +127,7 @@ describe('production - app dir - build output', () => {
     const { cliOutput } = await next.build()
     await next.deleteFile('app/out-of-band-dynamic-api/page.tsx')
 
-    expect(cliOutput).toContain('Static worker exited with code: 78')
+    expect(cliOutput).toContain('Next.js build worker exited with code: 78')
   })
 
   it('should fail the build if you use a dynamic API outside of a render context - notFound', async () => {
@@ -148,6 +148,6 @@ describe('production - app dir - build output', () => {
     const { cliOutput } = await next.build()
     await next.deleteFile('app/out-of-band-dynamic-api/page.tsx')
 
-    expect(cliOutput).toContain('Static worker exited with code: 78')
+    expect(cliOutput).toContain('Next.js build worker exited with code: 78')
   })
 })

--- a/test/production/app-dir/worker-restart/worker-restart.test.ts
+++ b/test/production/app-dir/worker-restart/worker-restart.test.ts
@@ -56,7 +56,7 @@ describe('worker-restart', () => {
 
     const output = stdout + stderr
     expect(output).toContain(
-      'Static worker exited with code: null and signal: SIGKILL'
+      'Next.js build worker exited with code: null and signal: SIGKILL'
     )
   })
 })


### PR DESCRIPTION
Errors thrown by the lint worker would only surface the error if `JEST_WORKER_ID` is present. This check was not reliably truthy in all cases (eg, when run with the vercel CLI, `JEST_WORKER_ID` wasn't present) which meant the build would fail with no helpful error message. Outside of that, it was a brittle check because if jest-worker ever changed or removed this env, or we replaced the underlying worker library, this would start failing. 

This updates the check to be a more explicit env variable that we control.

There's an [existing test](https://github.com/vercel/next.js/blob/canary/test/production/ci-missing-typescript-deps/index.test.ts#L28-L30) for this but unfortunately it didn't repro in the test environment.

Test plan:
- `CI=1 npx next build`
- Ensure it errors

Fixes NEXT-3994