### PR TITLE
[dev-overlay] style: version info staleness click text to learn more

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/version-staleness-info/version-staleness-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/version-staleness-info/version-staleness-info.tsx
@@ -1,4 +1,5 @@
 import type { VersionInfo } from '../../../../../../../server/dev/parse-version-info'
+import { cx } from '../../helpers/cx'
 import { noop as css } from '../../helpers/noop-template'
 
 export function VersionStalenessInfo({
@@ -11,23 +12,24 @@ export function VersionStalenessInfo({
   const { staleness } = versionInfo
   let { text, indicatorClass, title } = getStaleness(versionInfo)
 
+  const shouldBeLink = staleness.startsWith('stale')
+  const InfoText = shouldBeLink ? 'a' : 'span'
+
   return (
     <span className="nextjs-container-build-error-version-status dialog-exclude-closing-from-outside-click">
-      <Eclipse className={`version-staleness-indicator ${indicatorClass}`} />
-      <span data-nextjs-version-checker title={title}>
+      <Eclipse className={cx('version-staleness-indicator', indicatorClass)} />
+      <InfoText
+        data-nextjs-version-checker
+        className={cx('version-staleness-info-text', indicatorClass)}
+        title={title}
+        {...(shouldBeLink && {
+          target: '_blank',
+          rel: 'noopener noreferrer',
+          href: 'https://nextjs.org/docs/messages/version-staleness',
+        })}
+      >
         {text}
-      </span>{' '}
-      {staleness === 'fresh' ||
-      staleness === 'newer-than-npm' ||
-      staleness === 'unknown' ? null : (
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://nextjs.org/docs/messages/version-staleness"
-        >
-          (learn more)
-        </a>
-      )}
+      </InfoText>
       {isTurbopack && <span className="turbopack-text">Turbopack</span>}
     </span>
   )
@@ -92,6 +94,15 @@ export const styles = css`
     font-size: 12px;
     font-weight: 500;
     line-height: var(--size-4);
+  }
+
+  .version-staleness-info-text.stale {
+    color: var(--color-amber-900);
+    text-decoration: underline;
+  }
+  .version-staleness-info-text.outdated {
+    color: var(--color-red-900);
+    text-decoration: underline;
   }
 
   .version-staleness-indicator.fresh {

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/version-staleness-info/version-staleness-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/version-staleness-info/version-staleness-info.tsx
@@ -13,23 +13,35 @@ export function VersionStalenessInfo({
   let { text, indicatorClass, title } = getStaleness(versionInfo)
 
   const shouldBeLink = staleness.startsWith('stale')
-  const InfoText = shouldBeLink ? 'a' : 'span'
+  if (shouldBeLink) {
+    return (
+      <a
+        className={cx(
+          'nextjs-container-build-error-version-status',
+          'dialog-exclude-closing-from-outside-click',
+          isTurbopack && 'turbopack-border'
+        )}
+        target="_blank"
+        rel="noopener noreferrer"
+        href="https://nextjs.org/docs/messages/version-staleness"
+      >
+        <Eclipse
+          className={cx('version-staleness-indicator', indicatorClass)}
+        />
+        <span data-nextjs-version-checker title={title}>
+          {text}
+        </span>
+        {isTurbopack && <span className="turbopack-text">Turbopack</span>}
+      </a>
+    )
+  }
 
   return (
     <span className="nextjs-container-build-error-version-status dialog-exclude-closing-from-outside-click">
       <Eclipse className={cx('version-staleness-indicator', indicatorClass)} />
-      <InfoText
-        data-nextjs-version-checker
-        className={cx('version-staleness-info-text', indicatorClass)}
-        title={title}
-        {...(shouldBeLink && {
-          target: '_blank',
-          rel: 'noopener noreferrer',
-          href: 'https://nextjs.org/docs/messages/version-staleness',
-        })}
-      >
+      <span data-nextjs-version-checker title={title}>
         {text}
-      </InfoText>
+      </span>
       {isTurbopack && <span className="turbopack-text">Turbopack</span>}
     </span>
   )
@@ -96,13 +108,17 @@ export const styles = css`
     line-height: var(--size-4);
   }
 
-  .version-staleness-info-text.stale {
-    color: var(--color-amber-900);
-    text-decoration: underline;
-  }
-  .version-staleness-info-text.outdated {
-    color: var(--color-red-900);
-    text-decoration: underline;
+  a.nextjs-container-build-error-version-status {
+    text-decoration: none;
+    color: var(--color-gray-900);
+
+    &:hover {
+      background: var(--color-gray-100);
+    }
+
+    &:focus {
+      outline: var(--focus-ring);
+    }
   }
 
   .version-staleness-indicator.fresh {

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.stories.tsx
@@ -153,8 +153,8 @@ export const Default: Story = {
   args: {
     readyErrors,
     versionInfo: {
-      installed: '14.0.0',
-      staleness: 'stale-minor',
+      installed: '15.0.0',
+      staleness: 'fresh',
     },
     debugInfo: { devtoolsFrontendUrl: undefined },
     isTurbopack: false,

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.stories.tsx
@@ -153,8 +153,8 @@ export const Default: Story = {
   args: {
     readyErrors,
     versionInfo: {
-      installed: '15.0.0',
-      staleness: 'fresh',
+      installed: '14.0.0',
+      staleness: 'stale-minor',
     },
     debugInfo: { devtoolsFrontendUrl: undefined },
     isTurbopack: false,


### PR DESCRIPTION
When the Next.js version is stale and revealing the docs for the version staleness, remove `(learn more)` and modify the info text to be clickable.

### Light

https://github.com/user-attachments/assets/cec6c6a1-a788-4c4d-ab20-416217b42c20

### Dark

https://github.com/user-attachments/assets/02e53d84-146b-4508-b877-586a7fb0195e

Closes NDX-637