### PR TITLE
test: Exclude `turbo-tasks-macro` from `test-cargo-unit`

### DIFF
--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -14,7 +14,7 @@
     "rust-check-fmt": "cd ../..; cargo fmt -- --check",
     "rust-check-clippy": "cargo clippy --workspace --all-targets -- -D warnings -A deprecated",
     "rust-check-napi": "cargo check -p next-swc-napi",
-    "test-cargo-unit": "cargo nextest run --workspace --exclude next-swc-napi --release --no-fail-fast"
+    "test-cargo-unit": "cargo nextest run --workspace --exclude next-swc-napi --exclude turbo-tasks-macros --release --no-fail-fast"
   },
   "napi": {
     "name": "next-swc",


### PR DESCRIPTION
### What?

Make `pnpm turbo run test-cargo-unit` work.

### Why?

Because the turbo command crashes with an error.

Closes PACK-3920