### PR TITLE
[backport v14] fix: ensure lint worker errors aren't silenced (#75766)

### DIFF
--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -164,7 +164,7 @@ export async function verifyTypeScriptSetup({
      */
 
     // we are in a worker, print the error message and exit the process
-    if (process.env.JEST_WORKER_ID) {
+    if (process.env.IS_NEXT_WORKER) {
       if (err instanceof Error) {
         console.error(err.message)
       } else {

--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -97,7 +97,7 @@ export class Worker {
       if (!worker) return
       const resolve = resolveRestartPromise
       logger.warn(
-        `Sending SIGTERM signal to static worker due to timeout${
+        `Sending SIGTERM signal to Next.js build worker due to timeout${
           timeout ? ` of ${timeout / 1000} seconds` : ''
         }. Subsequent errors may be a result of the worker exiting.`
       )

--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -48,6 +48,7 @@ export class Worker {
           env: {
             ...((farmOptions.forkOptions?.env || {}) as any),
             ...process.env,
+            IS_NEXT_WORKER: 'true',
           } as any,
         },
       }) as JestWorker
@@ -73,7 +74,7 @@ export class Worker {
           worker._child?.on('exit', (code, signal) => {
             if ((code || (signal && signal !== 'SIGINT')) && this._worker) {
               logger.error(
-                `Static worker exited with code: ${code} and signal: ${signal}`
+                `Next.js build worker exited with code: ${code} and signal: ${signal}`
               )
 
               // We're restarting the worker, so we don't want to exit the parent process

--- a/test/production/app-dir/worker-restart/worker-restart.test.ts
+++ b/test/production/app-dir/worker-restart/worker-restart.test.ts
@@ -13,10 +13,10 @@ describe('worker-restart', () => {
 
     const output = stdout + stderr
     expect(output).toContain(
-      'Sending SIGTERM signal to static worker due to timeout of 10 seconds. Subsequent errors may be a result of the worker exiting.'
+      'Sending SIGTERM signal to Next.js build worker due to timeout of 10 seconds. Subsequent errors may be a result of the worker exiting.'
     )
     expect(output).toContain(
-      'Static worker exited with code: null and signal: SIGTERM'
+      'Next.js build worker exited with code: null and signal: SIGTERM'
     )
     expect(output).toContain(
       'Restarted static page generation for /bad-page because it took more than 10 seconds'

--- a/test/production/app-dir/worker-restart/worker-restart.test.ts
+++ b/test/production/app-dir/worker-restart/worker-restart.test.ts
@@ -41,7 +41,7 @@ describe('worker-restart', () => {
 
     const output = stdout + stderr
     expect(output).toContain(
-      'Static worker exited with code: null and signal: SIGKILL'
+      'Next.js build worker exited with code: null and signal: SIGKILL'
     )
   })
 })


### PR DESCRIPTION
Backports:
- #75766