### PR TITLE
Dedupe cached data from `"use cache"` functions in RSC payload

### DIFF
--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -2376,7 +2376,7 @@ fn bind_args_to_ref_expr(expr: Expr, bound: Vec<Option<ExprOrSpread>>, action_id
     if bound.is_empty() {
         expr
     } else {
-        // expr.bind(null, [encryptActionBoundArgs("id", [arg1, ...])])
+        // expr.bind(null, [encryptActionBoundArgs("id", arg1, arg2, ...)])
         Expr::Call(CallExpr {
             span: DUMMY_SP,
             callee: Expr::Member(MemberExpr {
@@ -2395,19 +2395,12 @@ fn bind_args_to_ref_expr(expr: Expr, bound: Vec<Option<ExprOrSpread>>, action_id
                     expr: Box::new(Expr::Call(CallExpr {
                         span: DUMMY_SP,
                         callee: quote_ident!("encryptActionBoundArgs").as_callee(),
-                        args: vec![
-                            ExprOrSpread {
-                                spread: None,
-                                expr: Box::new(action_id.into()),
-                            },
-                            ExprOrSpread {
-                                spread: None,
-                                expr: Box::new(Expr::Array(ArrayLit {
-                                    span: DUMMY_SP,
-                                    elems: bound,
-                                })),
-                            },
-                        ],
+                        args: std::iter::once(ExprOrSpread {
+                            spread: None,
+                            expr: Box::new(action_id.into()),
+                        })
+                        .chain(bound.into_iter().flatten())
+                        .collect(),
                         ..Default::default()
                     })),
                 },

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/1/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/1/output.js
@@ -7,10 +7,7 @@ export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_0 = a
     await deleteFromDb($$ACTION_ARG_1);
 };
 export function Item({ id1, id2 }) {
-    var deleteItem = registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
-        id1,
-        id2
-    ]));
+    var deleteItem = registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", id1, id2));
     return <Button action={deleteItem}>Delete</Button>;
 }
 export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_1 = async function action($$ACTION_CLOSURE_BOUND) {
@@ -23,9 +20,6 @@ export default function Home() {
         name: 'John',
         test: 'test'
     };
-    const action = registerServerReference($$RSC_SERVER_ACTION_1, "4090b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("4090b5db271335765a4b0eab01f044b381b5ebd5cd", [
-        info.name,
-        info.test
-    ]));
+    const action = registerServerReference($$RSC_SERVER_ACTION_1, "4090b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("4090b5db271335765a4b0eab01f044b381b5ebd5cd", info.name, info.test));
     return null;
 }

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/16/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/16/output.js
@@ -10,10 +10,7 @@ export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_0 = a
 };
 export function Item({ id1, id2 }) {
     const v2 = id2;
-    const deleteItem = registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
-        id1,
-        v2
-    ]));
+    const deleteItem = registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", id1, v2));
     return <Button action={deleteItem}>Delete</Button>;
 }
 export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_1 = async function g($$ACTION_CLOSURE_BOUND, y, ...z) {
@@ -21,16 +18,12 @@ export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_1 = a
     return $$ACTION_ARG_0 + y + z[0];
 };
 const f = (x)=>{
-    var g = registerServerReference($$RSC_SERVER_ACTION_1, "7f90b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("7f90b5db271335765a4b0eab01f044b381b5ebd5cd", [
-        x
-    ]));
+    var g = registerServerReference($$RSC_SERVER_ACTION_1, "7f90b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("7f90b5db271335765a4b0eab01f044b381b5ebd5cd", x));
 };
 export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_2 = async function f($$ACTION_CLOSURE_BOUND, y, ...z) {
     var [$$ACTION_ARG_0] = await decryptActionBoundArgs("7f1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", $$ACTION_CLOSURE_BOUND);
     return $$ACTION_ARG_0 + y + z[0];
 };
 const g = (x)=>{
-    f = registerServerReference($$RSC_SERVER_ACTION_2, "7f1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null).bind(null, encryptActionBoundArgs("7f1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", [
-        x
-    ]));
+    f = registerServerReference($$RSC_SERVER_ACTION_2, "7f1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null).bind(null, encryptActionBoundArgs("7f1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", x));
 };

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/18/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/18/output.js
@@ -17,16 +17,10 @@ export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_1 = a
 export function Item({ id1, id2 }) {
     const v2 = id2;
     return <>
-      <Button action={registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
-        id1,
-        v2
-    ]))}>
+      <Button action={registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", id1, v2))}>
         Delete
       </Button>
-      <Button action={registerServerReference($$RSC_SERVER_ACTION_1, "4090b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("4090b5db271335765a4b0eab01f044b381b5ebd5cd", [
-        id1,
-        v2
-    ]))}>
+      <Button action={registerServerReference($$RSC_SERVER_ACTION_1, "4090b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("4090b5db271335765a4b0eab01f044b381b5ebd5cd", id1, v2))}>
         Delete
       </Button>
     </>;

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/19/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/19/output.js
@@ -6,9 +6,7 @@ export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_0 = a
 };
 export function Item({ value }) {
     return <>
-      <Button action={registerServerReference($$RSC_SERVER_ACTION_0, "606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
-        value
-    ]))}>
+      <Button action={registerServerReference($$RSC_SERVER_ACTION_0, "606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", value))}>
         Multiple
       </Button>
     </>;

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/21/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/21/output.js
@@ -9,9 +9,7 @@ export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_0 = a
 export default function Page() {
     const y = 1;
     return <Foo // TODO: should use `action` as function name?
-    action={validator(registerServerReference($$RSC_SERVER_ACTION_0, "606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
-        y
-    ])))}/>;
+    action={validator(registerServerReference($$RSC_SERVER_ACTION_0, "606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", y)))}/>;
 }
 export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_1 = async function() {};
 validator(registerServerReference($$RSC_SERVER_ACTION_1, "0090b5db271335765a4b0eab01f044b381b5ebd5cd", null));

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/23/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/23/output.js
@@ -9,12 +9,8 @@ export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_1 = a
     console.log(a, b, $$ACTION_ARG_0, c, d);
 };
 export default function Page({ foo, x, y }) {
-    var action = registerServerReference($$RSC_SERVER_ACTION_0, "7c6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("7c6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
-        x
-    ]));
+    var action = registerServerReference($$RSC_SERVER_ACTION_0, "7c6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("7c6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", x));
     action.bind(null, foo[0], foo[1], foo.x, foo[y]);
-    const action2 = registerServerReference($$RSC_SERVER_ACTION_1, "7c90b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("7c90b5db271335765a4b0eab01f044b381b5ebd5cd", [
-        x
-    ]));
+    const action2 = registerServerReference($$RSC_SERVER_ACTION_1, "7c90b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("7c90b5db271335765a4b0eab01f044b381b5ebd5cd", x));
     action2.bind(null, foo[0], foo[1], foo.x, foo[y]);
 }

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/24/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/24/output.js
@@ -5,7 +5,5 @@ export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_0 = a
     console.log(a, b, $$ACTION_ARG_0, d);
 };
 export default function Page({ foo, x, y }) {
-    var action = registerServerReference($$RSC_SERVER_ACTION_0, "7c6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("7c6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
-        foo
-    ]));
+    var action = registerServerReference($$RSC_SERVER_ACTION_0, "7c6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("7c6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", foo));
 }

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/25/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/25/output.js
@@ -12,10 +12,7 @@ export function Item({ id1, id2 }) {
         id1++;
         return <Button action={deleteItem}>Delete</Button>;
     })();
-    var deleteItem = registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
-        id1,
-        id2
-    ]));
+    var deleteItem = registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", id1, id2));
 }
 export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_1 = async function deleteItem($$ACTION_CLOSURE_BOUND) {
     var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("4090b5db271335765a4b0eab01f044b381b5ebd5cd", $$ACTION_CLOSURE_BOUND);
@@ -31,8 +28,5 @@ export function Item2({ id1, id2 }) {
     id1++;
     temp.push(<Button action={deleteItem}>Delete</Button>);
     return temp;
-    var deleteItem = registerServerReference($$RSC_SERVER_ACTION_1, "4090b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("4090b5db271335765a4b0eab01f044b381b5ebd5cd", [
-        id1,
-        id2
-    ]));
+    var deleteItem = registerServerReference($$RSC_SERVER_ACTION_1, "4090b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("4090b5db271335765a4b0eab01f044b381b5ebd5cd", id1, id2));
 }

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/28/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/28/output.js
@@ -17,25 +17,12 @@ export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_2 = a
         window
     });
     console.log(a, $$ACTION_ARG_0, action2);
-    var action2 = registerServerReference($$RSC_SERVER_ACTION_0, "606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
-        $$ACTION_ARG_1,
-        d,
-        f,
-        $$ACTION_ARG_2
-    ]));
+    var action2 = registerServerReference($$RSC_SERVER_ACTION_0, "606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$ACTION_ARG_1, d, f, $$ACTION_ARG_2));
     return [
         action2,
-        registerServerReference($$RSC_SERVER_ACTION_1, "6090b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("6090b5db271335765a4b0eab01f044b381b5ebd5cd", [
-            action2,
-            $$ACTION_ARG_1,
-            d
-        ]))
+        registerServerReference($$RSC_SERVER_ACTION_1, "6090b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("6090b5db271335765a4b0eab01f044b381b5ebd5cd", action2, $$ACTION_ARG_1, d))
     ];
 };
 function Comp(b, c, ...g) {
-    return registerServerReference($$RSC_SERVER_ACTION_2, "601c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null).bind(null, encryptActionBoundArgs("601c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", [
-        b,
-        c,
-        g
-    ]));
+    return registerServerReference($$RSC_SERVER_ACTION_2, "601c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null).bind(null, encryptActionBoundArgs("601c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", b, c, g));
 }

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/30/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/30/output.js
@@ -17,27 +17,14 @@ export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_2 = a
         window
     });
     console.log(a, $$ACTION_ARG_0, action2);
-    var action2 = registerServerReference($$RSC_SERVER_ACTION_0, "606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
-        $$ACTION_ARG_1,
-        d,
-        f,
-        $$ACTION_ARG_2
-    ]));
+    var action2 = registerServerReference($$RSC_SERVER_ACTION_0, "606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$ACTION_ARG_1, d, f, $$ACTION_ARG_2));
     return [
         action2,
-        registerServerReference($$RSC_SERVER_ACTION_1, "6090b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("6090b5db271335765a4b0eab01f044b381b5ebd5cd", [
-            action2,
-            $$ACTION_ARG_1,
-            d
-        ]))
+        registerServerReference($$RSC_SERVER_ACTION_1, "6090b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("6090b5db271335765a4b0eab01f044b381b5ebd5cd", action2, $$ACTION_ARG_1, d))
     ];
 };
 export async function /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ action0(b, c, ...g) {
-    return registerServerReference($$RSC_SERVER_ACTION_2, "601c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null).bind(null, encryptActionBoundArgs("601c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", [
-        b,
-        c,
-        g
-    ]));
+    return registerServerReference($$RSC_SERVER_ACTION_2, "601c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null).bind(null, encryptActionBoundArgs("601c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", b, c, g));
 }
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/32/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/32/output.js
@@ -21,10 +21,6 @@ export function Component() {
             current: 1
         }
     };
-    var action = registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
-        data,
-        baz.value,
-        foo
-    ]));
+    var action = registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", data, baz.value, foo));
     return <form action={action}/>;
 }

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/39/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/39/output.js
@@ -13,10 +13,7 @@ Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
 });
 async function Component({ foo }) {
     const a = 123;
-    var fn = $$RSC_SERVER_REF_1.bind(null, encryptActionBoundArgs("c03128060c414d59f8552e4788b846c0d2b7f74743", [
-        a,
-        foo
-    ]));
+    var fn = $$RSC_SERVER_REF_1.bind(null, encryptActionBoundArgs("c03128060c414d59f8552e4788b846c0d2b7f74743", a, foo));
     const data = await fn();
     return <div>{data}</div>;
 }

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/40/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/40/output.js
@@ -17,18 +17,12 @@ Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
 export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_2 = async function action($$ACTION_CLOSURE_BOUND, c) {
     var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("601c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", $$ACTION_CLOSURE_BOUND);
     const d = $$ACTION_ARG_0 + $$ACTION_ARG_1 + c;
-    var cache = $$RSC_SERVER_REF_1.bind(null, encryptActionBoundArgs("e03128060c414d59f8552e4788b846c0d2b7f74743", [
-        d,
-        $$ACTION_ARG_0
-    ]));
+    var cache = $$RSC_SERVER_REF_1.bind(null, encryptActionBoundArgs("e03128060c414d59f8552e4788b846c0d2b7f74743", d, $$ACTION_ARG_0));
     return cache(d);
 };
 async function Component({ a }) {
     const b = 1;
-    var action = registerServerReference($$RSC_SERVER_ACTION_2, "601c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null).bind(null, encryptActionBoundArgs("601c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", [
-        a,
-        b
-    ]));
+    var action = registerServerReference($$RSC_SERVER_ACTION_2, "601c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null).bind(null, encryptActionBoundArgs("601c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", a, b));
     return <form action={action}>
       <button>Submit</button>
     </form>;

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/41/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/41/output.js
@@ -10,10 +10,7 @@ export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_0 = a
 };
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_1 = $$cache__("default", "c0951c375b4a6a6e89d67b743ec5808127cfde405d", 0, async function Component({ foo }) {
     const a = 123;
-    var fn = registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
-        a,
-        foo
-    ]));
+    var fn = registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", a, foo));
     const data = await fn();
     return <div>{data}</div>;
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/42/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/42/output.js
@@ -13,10 +13,7 @@ Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
 });
 async function Component({ foo }) {
     const a = 123;
-    const fn = $$RSC_SERVER_REF_1.bind(null, encryptActionBoundArgs("c03128060c414d59f8552e4788b846c0d2b7f74743", [
-        a,
-        foo
-    ]));
+    const fn = $$RSC_SERVER_REF_1.bind(null, encryptActionBoundArgs("c03128060c414d59f8552e4788b846c0d2b7f74743", a, foo));
     const data = await fn();
     return <div>{data}</div>;
 }

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/43/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/43/output.js
@@ -11,9 +11,7 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_1 = $$ca
     return {
         x,
         y: Math.random(),
-        z: <Foo action={registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
-            x
-        ]))}/>,
+        z: <Foo action={registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", x))}/>,
         r: children
     };
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/5/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/5/output.js
@@ -14,11 +14,6 @@ export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_0 = a
 };
 export function Item({ id1, id2, id3, id4 }) {
     const v2 = id2;
-    var deleteItem = registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
-        id1,
-        v2,
-        id3,
-        id4.x
-    ]));
+    var deleteItem = registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", id1, v2, id3, id4.x));
     return <Button action={deleteItem}>Delete</Button>;
 }

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/52/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/52/output.js
@@ -33,19 +33,7 @@ export async function Component(a) {
     const b = 1;
     return <Client // Should be 1 110000 0, which is "e0" in hex (counts as two params,
     // because of the encrypted bound args param)
-    fn1={$$RSC_SERVER_REF_1.bind(null, encryptActionBoundArgs("e03128060c414d59f8552e4788b846c0d2b7f74743", [
-        a,
-        b
-    ]))} fn2={$$RSC_SERVER_REF_3.bind(null, encryptActionBoundArgs("c069348c79fce073bae2f70f139565a2fda1c74c74", [
-        a,
-        b
-    ]))} fn3={registerServerReference($$RSC_SERVER_ACTION_4, "60a9b2939c1f39073a6bed227fd20233064c8b7869", null).bind(null, encryptActionBoundArgs("60a9b2939c1f39073a6bed227fd20233064c8b7869", [
-        a,
-        b
-    ]))} fn4={registerServerReference($$RSC_SERVER_ACTION_5, "409651a98a9dccd7ffbe72ff5cf0f38546ca1252ab", null).bind(null, encryptActionBoundArgs("409651a98a9dccd7ffbe72ff5cf0f38546ca1252ab", [
-        a,
-        b
-    ]))}/>;
+    fn1={$$RSC_SERVER_REF_1.bind(null, encryptActionBoundArgs("e03128060c414d59f8552e4788b846c0d2b7f74743", a, b))} fn2={$$RSC_SERVER_REF_3.bind(null, encryptActionBoundArgs("c069348c79fce073bae2f70f139565a2fda1c74c74", a, b))} fn3={registerServerReference($$RSC_SERVER_ACTION_4, "60a9b2939c1f39073a6bed227fd20233064c8b7869", null).bind(null, encryptActionBoundArgs("60a9b2939c1f39073a6bed227fd20233064c8b7869", a, b))} fn4={registerServerReference($$RSC_SERVER_ACTION_5, "409651a98a9dccd7ffbe72ff5cf0f38546ca1252ab", null).bind(null, encryptActionBoundArgs("409651a98a9dccd7ffbe72ff5cf0f38546ca1252ab", a, b))}/>;
 }
 var $$RSC_SERVER_REF_1 = registerServerReference($$RSC_SERVER_CACHE_0, "e03128060c414d59f8552e4788b846c0d2b7f74743", null);
 var $$RSC_SERVER_REF_3 = registerServerReference($$RSC_SERVER_CACHE_2, "c069348c79fce073bae2f70f139565a2fda1c74c74", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/54/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/54/output.js
@@ -15,13 +15,8 @@ export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_2 = a
 function createObj(n) {
     const m = n + 1;
     return {
-        foo: $$RSC_SERVER_REF_1.bind(null, encryptActionBoundArgs("c03128060c414d59f8552e4788b846c0d2b7f74743", [
-            n,
-            m
-        ])),
-        bar: registerServerReference($$RSC_SERVER_ACTION_2, "401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null).bind(null, encryptActionBoundArgs("401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", [
-            m
-        ]))
+        foo: $$RSC_SERVER_REF_1.bind(null, encryptActionBoundArgs("c03128060c414d59f8552e4788b846c0d2b7f74743", n, m)),
+        bar: registerServerReference($$RSC_SERVER_ACTION_2, "401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null).bind(null, encryptActionBoundArgs("401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", m))
     };
 }
 var $$RSC_SERVER_REF_1 = registerServerReference($$RSC_SERVER_CACHE_0, "c03128060c414d59f8552e4788b846c0d2b7f74743", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/58/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/58/output.js
@@ -8,9 +8,7 @@ function createCachedFn(start) {
     function fn() {
         return start + Math.random();
     }
-    return $$RSC_SERVER_REF_1.bind(null, encryptActionBoundArgs("c03128060c414d59f8552e4788b846c0d2b7f74743", [
-        fn
-    ]));
+    return $$RSC_SERVER_REF_1.bind(null, encryptActionBoundArgs("c03128060c414d59f8552e4788b846c0d2b7f74743", fn));
 }
 var $$RSC_SERVER_REF_1 = registerServerReference($$RSC_SERVER_CACHE_0, "c03128060c414d59f8552e4788b846c0d2b7f74743", null);
 export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_2 = async function($$ACTION_CLOSURE_BOUND) {
@@ -21,7 +19,5 @@ function createServerAction(start) {
     function fn() {
         return start + Math.random();
     }
-    return registerServerReference($$RSC_SERVER_ACTION_2, "401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null).bind(null, encryptActionBoundArgs("401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", [
-        fn
-    ]));
+    return registerServerReference($$RSC_SERVER_ACTION_2, "401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null).bind(null, encryptActionBoundArgs("401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", fn));
 }

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/6/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/6/output.js
@@ -28,13 +28,6 @@ export function y(p, [p1, { p2 }], ...p3) {
     if (true) {
         const f8 = 1;
     }
-    var action = registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
-        f2,
-        f11,
-        p,
-        p1,
-        p2,
-        p3
-    ]));
+    var action = registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", f2, f11, p, p1, p2, p3));
     return <Button action={action}>Delete</Button>;
 }

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/7/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/7/output.js
@@ -6,11 +6,7 @@ export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_0 = a
     await deleteFromDb($$ACTION_ARG_0.id, $$ACTION_ARG_0?.foo, $$ACTION_ARG_0.bar.baz, $$ACTION_ARG_0[$$ACTION_ARG_1, $$ACTION_ARG_2]);
 };
 export function Item1(product, foo, bar) {
-    const a = registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
-        product,
-        foo,
-        bar
-    ]));
+    const a = registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", product, foo, bar));
     return <Button action={a}>Delete</Button>;
 }
 export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_1 = async function deleteItem2($$ACTION_CLOSURE_BOUND) {
@@ -18,11 +14,7 @@ export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_1 = a
     await deleteFromDb($$ACTION_ARG_0.id, $$ACTION_ARG_0?.foo, $$ACTION_ARG_0.bar.baz, $$ACTION_ARG_0[$$ACTION_ARG_1, $$ACTION_ARG_2]);
 };
 export function Item2(product, foo, bar) {
-    var deleteItem2 = registerServerReference($$RSC_SERVER_ACTION_1, "4090b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("4090b5db271335765a4b0eab01f044b381b5ebd5cd", [
-        product,
-        foo,
-        bar
-    ]));
+    var deleteItem2 = registerServerReference($$RSC_SERVER_ACTION_1, "4090b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("4090b5db271335765a4b0eab01f044b381b5ebd5cd", product, foo, bar));
     return <Button action={deleteItem2}>Delete</Button>;
 }
 export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_2 = async function deleteItem3($$ACTION_CLOSURE_BOUND) {
@@ -30,11 +22,7 @@ export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_2 = a
     await deleteFromDb($$ACTION_ARG_0.id, $$ACTION_ARG_0?.foo, $$ACTION_ARG_0.bar.baz, $$ACTION_ARG_0[$$ACTION_ARG_1, $$ACTION_ARG_2]);
 };
 export function Item3(product, foo, bar) {
-    const deleteItem3 = registerServerReference($$RSC_SERVER_ACTION_2, "401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null).bind(null, encryptActionBoundArgs("401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", [
-        product,
-        foo,
-        bar
-    ]));
+    const deleteItem3 = registerServerReference($$RSC_SERVER_ACTION_2, "401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null).bind(null, encryptActionBoundArgs("401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", product, foo, bar));
     return <Button action={deleteItem3}>Delete</Button>;
 }
 export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_3 = async function deleteItem4($$ACTION_CLOSURE_BOUND) {
@@ -42,10 +30,6 @@ export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_3 = a
     await deleteFromDb($$ACTION_ARG_0.id, $$ACTION_ARG_0?.foo, $$ACTION_ARG_0.bar.baz, $$ACTION_ARG_0[$$ACTION_ARG_1, $$ACTION_ARG_2]);
 };
 export function Item4(product, foo, bar) {
-    const deleteItem4 = registerServerReference($$RSC_SERVER_ACTION_3, "409ed0cc47abc4e1c64320cf42b74ae60b58c40f00", null).bind(null, encryptActionBoundArgs("409ed0cc47abc4e1c64320cf42b74ae60b58c40f00", [
-        product,
-        foo,
-        bar
-    ]));
+    const deleteItem4 = registerServerReference($$RSC_SERVER_ACTION_3, "409ed0cc47abc4e1c64320cf42b74ae60b58c40f00", null).bind(null, encryptActionBoundArgs("409ed0cc47abc4e1c64320cf42b74ae60b58c40f00", product, foo, bar));
     return <Button action={deleteItem4}>Delete</Button>;
 }

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -48,6 +48,7 @@ import {
   type SearchParams,
 } from '../request/search-params'
 import type { Params } from '../request/params'
+import React from 'react'
 
 type CacheKeyParts = [
   buildId: string,
@@ -861,7 +862,8 @@ export function cache(
       })
     },
   }[name]
-  return cachedFn
+
+  return React.cache(cachedFn)
 }
 
 /**

--- a/test/e2e/app-dir/use-cache/app/referential-equality/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/referential-equality/page.tsx
@@ -1,0 +1,61 @@
+/* eslint-disable no-self-compare */
+
+async function getObject(arg: unknown) {
+  'use cache'
+
+  return { arg }
+}
+
+async function getObjectWithBoundArgs(arg: unknown) {
+  async function getCachedObject() {
+    'use cache'
+
+    return { arg }
+  }
+
+  return getCachedObject()
+}
+
+export default async function Page() {
+  return (
+    <>
+      <h2>With normal args</h2>
+      <p>
+        Two <span style={{ whiteSpace: 'pre' }}>"use cache"</span> invocations
+        with the same arg return the same result:{' '}
+        <strong id="same-arg">
+          {String((await getObject(1)) === (await getObject(1)))}
+        </strong>
+      </p>
+      <p>
+        Two <span style={{ whiteSpace: 'pre' }}>"use cache"</span> invocations
+        with different args return different results:{' '}
+        <strong id="different-args">
+          {String((await getObject(1)) !== (await getObject(2)))}
+        </strong>
+      </p>
+
+      <h2>With bound args</h2>
+      <p>
+        Two <span style={{ whiteSpace: 'pre' }}>"use cache"</span> invocations
+        with the same bound arg return the same result:{' '}
+        <strong id="same-bound-arg">
+          {String(
+            (await getObjectWithBoundArgs(1)) ===
+              (await getObjectWithBoundArgs(1))
+          )}
+        </strong>
+      </p>
+      <p>
+        Two <span style={{ whiteSpace: 'pre' }}>"use cache"</span> invocations
+        with different bound args return different results:{' '}
+        <strong id="different-bound-args">
+          {String(
+            (await getObjectWithBoundArgs(1)) !==
+              (await getObjectWithBoundArgs(2))
+          )}
+        </strong>
+      </p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-cache/app/rsc-payload/client.tsx
+++ b/test/e2e/app-dir/use-cache/app/rsc-payload/client.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+export function ClientComponent({ children, data }) {
+  console.log(data)
+
+  return children
+}

--- a/test/e2e/app-dir/use-cache/app/rsc-payload/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/rsc-payload/page.tsx
@@ -1,0 +1,20 @@
+import { ClientComponent } from './client'
+
+async function getLargeObject() {
+  'use cache'
+
+  return { hello: 'world' }
+}
+
+export default async function Page() {
+  return (
+    <>
+      <ClientComponent data={await getLargeObject()}>
+        <p>foo</p>
+      </ClientComponent>
+      <ClientComponent data={await getLargeObject()}>
+        <p>bar</p>
+      </ClientComponent>
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -99,6 +99,29 @@ describe('use-cache', () => {
     expect(a).toBe(b)
   })
 
+  it('should return the same object reference for multiple invocations', async () => {
+    const browser = await next.browser('/referential-equality')
+    expect(await browser.elementById('same-arg').text()).toBe('true')
+    expect(await browser.elementById('different-args').text()).toBe('true')
+    expect(await browser.elementById('same-bound-arg').text()).toBe('true')
+    expect(await browser.elementById('different-bound-args').text()).toBe(
+      'true'
+    )
+  })
+
+  it('should dedupe cached data in the RSC payload', async () => {
+    const text = await next
+      .fetch('/rsc-payload')
+      .then((response) => response.text())
+
+    // The cached data is passed to two client components, but should appear
+    // only once in the RSC payload that's included in the HTML document.
+    expect(text).toIncludeRepeated(
+      '{\\\\"data\\\\":{\\\\"hello\\\\":\\\\"world\\\\"}',
+      1
+    )
+  })
+
   it('should error when cookies/headers/draftMode is used inside "use cache"', async () => {
     const browser = await next.browser('/errors')
 
@@ -311,6 +334,8 @@ describe('use-cache', () => {
         '/not-found',
         '/passed-to-client',
         '/react-cache',
+        '/referential-equality',
+        '/rsc-payload',
         '/static-class-method',
         '/use-action-state',
         '/with-server-action',


### PR DESCRIPTION
By leveraging `React.cache` internally, we can ensure that multiple invocations of the same `"use cache"` function return the same object reference. This also allows React to dedupe cached data that's included in the RSC payload, e.g. because it's passed to client components, which will reduce the response sizes for the HTML and RSC requests.

closes NAR-53

> [!NOTE]  
> This PR is best reviewed with hidden whitespace changes.
