### PR TITLE
[dev-overlay] fix: pagination focus ring was invisible

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-floating-header/error-overlay-floating-header.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-floating-header/error-overlay-floating-header.tsx
@@ -21,7 +21,7 @@ export function ErrorOverlayFloatingHeader({
   isTurbopack,
 }: ErrorOverlayFloatingHeaderProps) {
   return (
-    <div className="error-overlay-floating-header">
+    <div className="error-overlay-floating-header" tabIndex={1}>
       {/* TODO: better passing data instead of nullish coalescing */}
       <ErrorOverlayPagination
         readyErrors={readyErrors ?? []}

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-floating-header/error-overlay-floating-header.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-floating-header/error-overlay-floating-header.tsx
@@ -21,7 +21,7 @@ export function ErrorOverlayFloatingHeader({
   isTurbopack,
 }: ErrorOverlayFloatingHeaderProps) {
   return (
-    <div className="error-overlay-floating-header" tabIndex={1}>
+    <div className="error-overlay-floating-header">
       {/* TODO: better passing data instead of nullish coalescing */}
       <ErrorOverlayPagination
         readyErrors={readyErrors ?? []}

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-pagination/error-overlay-pagination.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-pagination/error-overlay-pagination.tsx
@@ -180,10 +180,6 @@ export const styles = css`
     border: none;
     border-radius: var(--rounded-full);
 
-    &:focus {
-      outline: none;
-    }
-
     &:not(:disabled):active {
       background: var(--color-gray-500);
     }


### PR DESCRIPTION
### Why?

The focus outline was none, so it was unable to tell if it was focused.

### Before

https://github.com/user-attachments/assets/5284fb54-cf84-4da5-a047-8d76b3f05eba

### After

https://github.com/user-attachments/assets/d2f66880-cb2a-41ce-a620-67f6efed4684

Closes NDX-793