### PR TITLE
Turbopack: store serialized sourcemaps instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9695,6 +9695,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "criterion",
+ "data-encoding",
  "either",
  "indexmap 2.7.1",
  "indoc",

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -39,7 +39,7 @@ use turbopack_core::{
     diagnostics::PlainDiagnostic,
     error::PrettyPrintError,
     issue::PlainIssue,
-    source_map::{OptionSourceMap, OptionStringifiedSourceMap, SourceMap, Token},
+    source_map::{SourceMap, Token},
     version::{PartialUpdate, TotalUpdate, Update, VersionState},
     SOURCE_MAP_PREFIX,
 };

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -56,7 +56,7 @@ use turbopack_core::{
     module_graph::{ModuleGraph, SingleModuleGraph, VisitedModules},
     output::{OutputAsset, OutputAssets},
     resolve::{find_context_file, FindContextFileResult},
-    source_map::{OptionSourceMap, OptionStringifiedSourceMap},
+    source_map::OptionStringifiedSourceMap,
     version::{
         NotFoundVersion, OptionVersionedContent, Update, Version, VersionState, VersionedContent,
     },

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -56,7 +56,7 @@ use turbopack_core::{
     module_graph::{ModuleGraph, SingleModuleGraph, VisitedModules},
     output::{OutputAsset, OutputAssets},
     resolve::{find_context_file, FindContextFileResult},
-    source_map::OptionSourceMap,
+    source_map::{OptionSourceMap, OptionStringifiedSourceMap},
     version::{
         NotFoundVersion, OptionVersionedContent, Update, Version, VersionState, VersionedContent,
     },
@@ -493,11 +493,11 @@ impl ProjectContainer {
         &self,
         file_path: Vc<FileSystemPath>,
         section: Option<RcStr>,
-    ) -> Vc<OptionSourceMap> {
+    ) -> Vc<OptionStringifiedSourceMap> {
         if let Some(map) = self.versioned_content_map {
             map.get_source_map(file_path, section)
         } else {
-            OptionSourceMap::none()
+            OptionStringifiedSourceMap::none()
         }
     }
 }

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -12,7 +12,7 @@ use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::Asset,
     output::{OptionOutputAsset, OutputAsset, OutputAssets},
-    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap},
+    source_map::{GenerateSourceMap, OptionStringifiedSourceMap},
     version::OptionVersionedContent,
 };
 

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -12,7 +12,7 @@ use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::Asset,
     output::{OptionOutputAsset, OutputAsset, OutputAssets},
-    source_map::{GenerateSourceMap, OptionSourceMap},
+    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap},
     version::OptionVersionedContent,
 };
 
@@ -189,7 +189,7 @@ impl VersionedContentMap {
         self: Vc<Self>,
         path: Vc<FileSystemPath>,
         section: Option<RcStr>,
-    ) -> Result<Vc<OptionSourceMap>> {
+    ) -> Result<Vc<OptionStringifiedSourceMap>> {
         let Some(asset) = &*self.get_asset(path).await? else {
             return Ok(Vc::cell(None));
         };

--- a/crates/next-core/src/app_segment_config.rs
+++ b/crates/next-core/src/app_segment_config.rs
@@ -247,10 +247,7 @@ impl Issue for NextSegmentConfigParsingIssue {
     #[turbo_tasks::function]
     async fn source(&self) -> Result<Vc<OptionIssueSource>> {
         Ok(Vc::cell(Some(
-            self.source
-                .resolve_source_map(self.ident.path())
-                .await?
-                .into_owned(),
+            self.source.resolve_source_map().await?.into_owned(),
         )))
     }
 }

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -217,9 +217,7 @@ describe('app-dir - server source maps', () => {
           // Node.js is fine with invalid URLs in index maps apparently.
           '' +
             '\nError: Boom!' +
-            // TODO(veil): Turbopack's sourcemap loader generates a wrong source entry here
-            // Should not be sourcemapped or "custom://[badhost]/app/bad-sourcemap/page.js"
-            '\n    at Page (app/bad-sourcemap/custom:/[badhost]/app/bad-sourcemap/page.js:9:15)' +
+            '\n    at Page (custom://[badhost]/app/bad-sourcemap/page.js:9:15)' +
             // TODO: Remove blank line
             '\n'
         )

--- a/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
@@ -7,7 +7,7 @@ use turbopack_core::{
     chunk::{Chunk, ChunkingContext, OutputChunk, OutputChunkRuntimeInfo},
     introspect::{Introspectable, IntrospectableChildren},
     output::{OutputAsset, OutputAssets},
-    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap, SourceMapAsset},
+    source_map::{GenerateSourceMap, OptionStringifiedSourceMap, SourceMapAsset},
     version::VersionedContent,
 };
 use turbopack_ecmascript::chunk::EcmascriptChunk;

--- a/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
@@ -7,7 +7,7 @@ use turbopack_core::{
     chunk::{Chunk, ChunkingContext, OutputChunk, OutputChunkRuntimeInfo},
     introspect::{Introspectable, IntrospectableChildren},
     output::{OutputAsset, OutputAssets},
-    source_map::{GenerateSourceMap, OptionSourceMap, SourceMapAsset},
+    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap, SourceMapAsset},
     version::VersionedContent,
 };
 use turbopack_ecmascript::chunk::EcmascriptChunk;
@@ -132,12 +132,12 @@ impl Asset for EcmascriptDevChunk {
 #[turbo_tasks::value_impl]
 impl GenerateSourceMap for EcmascriptDevChunk {
     #[turbo_tasks::function]
-    fn generate_source_map(self: Vc<Self>) -> Vc<OptionSourceMap> {
+    fn generate_source_map(self: Vc<Self>) -> Vc<OptionStringifiedSourceMap> {
         self.own_content().generate_source_map()
     }
 
     #[turbo_tasks::function]
-    fn by_section(self: Vc<Self>, section: RcStr) -> Vc<OptionSourceMap> {
+    fn by_section(self: Vc<Self>, section: RcStr) -> Vc<OptionStringifiedSourceMap> {
         self.own_content().by_section(section)
     }
 }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -10,7 +10,7 @@ use turbopack_core::{
     chunk::{ChunkingContext, MinifyType, ModuleId},
     code_builder::{Code, CodeBuilder},
     output::OutputAsset,
-    source_map::{GenerateSourceMap, OptionSourceMap},
+    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap},
     version::{MergeableVersionedContent, Version, VersionedContent, VersionedContentMerger},
 };
 use turbopack_ecmascript::{chunk::EcmascriptChunkContent, minify::minify, utils::StringifyJs};
@@ -157,12 +157,12 @@ impl MergeableVersionedContent for EcmascriptDevChunkContent {
 #[turbo_tasks::value_impl]
 impl GenerateSourceMap for EcmascriptDevChunkContent {
     #[turbo_tasks::function]
-    fn generate_source_map(self: Vc<Self>) -> Vc<OptionSourceMap> {
+    fn generate_source_map(self: Vc<Self>) -> Vc<OptionStringifiedSourceMap> {
         self.code().generate_source_map()
     }
 
     #[turbo_tasks::function]
-    async fn by_section(&self, section: RcStr) -> Result<Vc<OptionSourceMap>> {
+    async fn by_section(&self, section: RcStr) -> Result<Vc<OptionStringifiedSourceMap>> {
         // Weirdly, the ContentSource will have already URL decoded the ModuleId, and we
         // can't reparse that via serde.
         if let Ok(id) = ModuleId::parse(&section) {

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -10,7 +10,7 @@ use turbopack_core::{
     chunk::{ChunkingContext, MinifyType, ModuleId},
     code_builder::{Code, CodeBuilder},
     output::OutputAsset,
-    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap},
+    source_map::{GenerateSourceMap, OptionStringifiedSourceMap},
     version::{MergeableVersionedContent, Version, VersionedContent, VersionedContentMerger},
 };
 use turbopack_ecmascript::{chunk::EcmascriptChunkContent, minify::minify, utils::StringifyJs};

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -17,7 +17,7 @@ use turbopack_core::{
     module::Module,
     module_graph::ModuleGraph,
     output::{OutputAsset, OutputAssets},
-    source_map::{GenerateSourceMap, OptionSourceMap, SourceMapAsset},
+    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap, SourceMapAsset},
 };
 use turbopack_ecmascript::{
     chunk::{EcmascriptChunkData, EcmascriptChunkPlaceable},
@@ -281,7 +281,7 @@ impl Asset for EcmascriptDevEvaluateChunk {
 #[turbo_tasks::value_impl]
 impl GenerateSourceMap for EcmascriptDevEvaluateChunk {
     #[turbo_tasks::function]
-    fn generate_source_map(self: Vc<Self>) -> Vc<OptionSourceMap> {
+    fn generate_source_map(self: Vc<Self>) -> Vc<OptionStringifiedSourceMap> {
         self.code().generate_source_map()
     }
 }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -17,7 +17,7 @@ use turbopack_core::{
     module::Module,
     module_graph::ModuleGraph,
     output::{OutputAsset, OutputAssets},
-    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap, SourceMapAsset},
+    source_map::{GenerateSourceMap, OptionStringifiedSourceMap, SourceMapAsset},
 };
 use turbopack_ecmascript::{
     chunk::{EcmascriptChunkData, EcmascriptChunkPlaceable},

--- a/turbopack/crates/turbopack-browser/src/ecmascript/merged/update.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/merged/update.rs
@@ -83,15 +83,8 @@ struct EcmascriptModuleEntry {
 
 impl EcmascriptModuleEntry {
     async fn from_code(id: &ModuleId, code: Vc<Code>, chunk_path: &str) -> Result<Self> {
-        let map = match &*code.generate_source_map().await? {
-            Some(map) => {
-                // Cloning a rope is cheap.
-                Some(map.to_rope().owned().await?)
-            }
-            None => None,
-        };
-
-        Ok(Self::new(id, code.await?, map, chunk_path))
+        let map = &*code.generate_source_map().await?;
+        Ok(Self::new(id, code.await?, map.clone(), chunk_path))
     }
 
     fn new(id: &ModuleId, code: ReadRef<Code>, map: Option<Rope>, chunk_path: &str) -> Self {

--- a/turbopack/crates/turbopack-core/src/code_builder.rs
+++ b/turbopack/crates/turbopack-core/src/code_builder.rs
@@ -229,11 +229,11 @@ pub async fn fileify_source_map(
         version: u32,
         file: Option<String>,
         source_root: Option<String>,
-        sources: Vec<String>,
-        sources_content: Vec<Option<String>>,
+        sources: Vec<Option<String>>,
+        sources_content: Option<Vec<Option<String>>>,
         names: Vec<String>,
         mappings: String,
-        ignore_list: Vec<u32>,
+        ignore_list: Option<Vec<u32>>,
         sections: Option<Vec<SourceMapSectionJson>>,
     }
 
@@ -252,9 +252,11 @@ pub async fn fileify_source_map(
     // (apart from `sources`) and just keep storing them as strings.
     let mut map: SourceMapJson = serde_json::from_reader(map.read())?;
 
-    let transform_source = async |src: &mut String| {
-        if let Some(src_rest) = src.strip_prefix(&prefix) {
-            *src = uri_from_file(context_path, Some(src_rest)).await?;
+    let transform_source = async |src: &mut Option<String>| {
+        if let Some(src) = src {
+            if let Some(src_rest) = src.strip_prefix(&prefix) {
+                *src = uri_from_file(context_path, Some(src_rest)).await?;
+            }
         }
         anyhow::Ok(())
     };

--- a/turbopack/crates/turbopack-core/src/code_builder.rs
+++ b/turbopack/crates/turbopack-core/src/code_builder.rs
@@ -10,7 +10,7 @@ use turbo_tasks_fs::rope::{Rope, RopeBuilder};
 use turbo_tasks_hash::hash_xxh3_hash64;
 
 use crate::{
-    source_map::{GenerateSourceMap, OptionStringifiedSourceMap, SourceMap, SourceMapSection},
+    source_map::{GenerateSourceMap, OptionStringifiedSourceMap, SourceMap},
     source_pos::SourcePos,
 };
 
@@ -170,18 +170,10 @@ impl GenerateSourceMap for Code {
             }
             last_byte_pos = *byte_pos;
 
-            let encoded = match map {
-                None => SourceMap::empty_uncelled(),
-                Some(map) => match SourceMap::new_from_rope(map)? {
-                    None => SourceMap::empty_uncelled(),
-                    Some(map) => map,
-                },
-            };
-
-            sections.push(SourceMapSection::new(pos, encoded))
+            sections.push((pos, map.clone().unwrap_or_else(SourceMap::empty_rope)))
         }
 
-        let source_map = SourceMap::new_sectioned(sections).to_rope().await?;
+        let source_map = SourceMap::sections_to_rope(sections)?;
         Ok(Vc::cell(Some(source_map)))
     }
 }

--- a/turbopack/crates/turbopack-core/src/code_builder.rs
+++ b/turbopack/crates/turbopack-core/src/code_builder.rs
@@ -4,20 +4,14 @@ use std::{
     ops,
 };
 
-use anyhow::{Context, Result};
-use serde::{Deserialize, Serialize};
+use anyhow::Result;
 use turbo_tasks::Vc;
-use turbo_tasks_fs::{
-    rope::{Rope, RopeBuilder},
-    util::uri_from_file,
-    DiskFileSystem, FileSystemPath,
-};
+use turbo_tasks_fs::rope::{Rope, RopeBuilder};
 use turbo_tasks_hash::hash_xxh3_hash64;
 
 use crate::{
     source_map::{GenerateSourceMap, OptionStringifiedSourceMap, SourceMap, SourceMapSection},
     source_pos::SourcePos,
-    SOURCE_MAP_PREFIX,
 };
 
 /// A mapping of byte-offset in the code string to an associated source map.
@@ -205,72 +199,4 @@ impl Code {
         let hash = hash_xxh3_hash64(code.source_code());
         Vc::cell(hash)
     }
-}
-
-/// Turns `turbopack://[project]`` references in sourcemap sources into absolute
-/// `file://` uris. This is useful for debugging environments.
-pub async fn fileify_source_map(
-    map: Option<&Rope>,
-    context_path: Vc<FileSystemPath>,
-) -> Result<Option<Rope>> {
-    #[derive(Serialize, Deserialize)]
-    struct SourceMapSectionOffsetJson {
-        line: u32,
-        offset: u32,
-    }
-    #[derive(Serialize, Deserialize)]
-    struct SourceMapSectionJson {
-        offset: SourceMapSectionOffsetJson,
-        map: SourceMapJson,
-    }
-    #[derive(Serialize, Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    struct SourceMapJson {
-        version: u32,
-        file: Option<String>,
-        source_root: Option<String>,
-        sources: Vec<Option<String>>,
-        sources_content: Option<Vec<Option<String>>>,
-        names: Vec<String>,
-        mappings: String,
-        ignore_list: Option<Vec<u32>>,
-        sections: Option<Vec<SourceMapSectionJson>>,
-    }
-
-    let Some(map) = map else {
-        return Ok(None);
-    };
-
-    let context_fs = context_path.fs();
-    let context_fs = &*Vc::try_resolve_downcast_type::<DiskFileSystem>(context_fs)
-        .await?
-        .context("Expected the chunking context to have a DiskFileSystem")?
-        .await?;
-    let prefix = format!("{}[{}]/", SOURCE_MAP_PREFIX, context_fs.name());
-
-    // TODO this could be made (much) more efficient by not even de- and serializing other fields
-    // (apart from `sources`) and just keep storing them as strings.
-    let mut map: SourceMapJson = serde_json::from_reader(map.read())?;
-
-    let transform_source = async |src: &mut Option<String>| {
-        if let Some(src) = src {
-            if let Some(src_rest) = src.strip_prefix(&prefix) {
-                *src = uri_from_file(context_path, Some(src_rest)).await?;
-            }
-        }
-        anyhow::Ok(())
-    };
-
-    for src in map.sources.iter_mut() {
-        transform_source(src).await?;
-    }
-    for section in map.sections.iter_mut().flatten() {
-        for src in section.map.sources.iter_mut() {
-            transform_source(src).await?;
-        }
-    }
-
-    let map = Rope::from(serde_json::to_vec(&map)?);
-
-    Ok(Some(map))
 }

--- a/turbopack/crates/turbopack-core/src/code_builder.rs
+++ b/turbopack/crates/turbopack-core/src/code_builder.rs
@@ -181,12 +181,8 @@ impl GenerateSourceMap for Code {
             sections.push(SourceMapSection::new(pos, encoded))
         }
 
-        let mut result = vec![];
-        SourceMap::new_sectioned(sections)
-            .to_source_map()
-            .await?
-            .to_writer(&mut result)?;
-        Ok(Vc::cell(Some(Rope::from(result))))
+        let source_map = SourceMap::new_sectioned(sections).to_rope().await?;
+        Ok(Vc::cell(Some(source_map)))
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/code_builder.rs
+++ b/turbopack/crates/turbopack-core/src/code_builder.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use indexmap::IndexMap;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::{
     rope::{Rope, RopeBuilder},
     util::uri_from_file,
@@ -22,12 +22,15 @@ use crate::{
     SOURCE_MAP_PREFIX,
 };
 
+/// A mapping of byte-offset in the code string to an associated source map.
+pub type Mapping = (usize, Option<Rope>);
+
 /// Code stores combined output code and the source map of that output code.
 #[turbo_tasks::value(shared)]
 #[derive(Debug, Clone)]
 pub struct Code {
     code: Rope,
-    source_map: Option<Rope>,
+    mappings: Vec<Mapping>,
 }
 
 impl Code {
@@ -37,12 +40,9 @@ impl Code {
 
     /// Tests if any code in this Code contains an associated source map.
     pub fn has_source_map(&self) -> bool {
-        self.source_map.is_some()
+        !self.mappings.is_empty()
     }
 }
-
-/// A mapping of byte-offset in the code string to an associated source map.
-pub type Mapping = (usize, Option<ResolvedVc<Box<dyn GenerateSourceMap>>>);
 
 /// CodeBuilder provides a mutable container to append source code.
 #[derive(Default)]
@@ -63,11 +63,7 @@ impl CodeBuilder {
     /// Pushes original user code with an optional source map if one is
     /// available. If it's not, this is no different than pushing Synthetic
     /// code.
-    pub fn push_source(
-        &mut self,
-        code: &Rope,
-        map: Option<ResolvedVc<Box<dyn GenerateSourceMap>>>,
-    ) {
+    pub fn push_source(&mut self, code: &Rope, map: Option<Rope>) {
         self.push_map(map);
         self.code += code;
     }
@@ -88,7 +84,7 @@ impl CodeBuilder {
                 prebuilt
                     .mappings
                     .iter()
-                    .map(|(index, map)| (index + len, *map)),
+                    .map(|(index, map)| (index + len, map.clone())),
             );
         } else {
             self.push_map(None);
@@ -102,7 +98,7 @@ impl CodeBuilder {
     /// original code section. By inserting an empty source map when reaching a
     /// synthetic section directly after an original section, we tell Chrome
     /// that the previous map ended at this point.
-    fn push_map(&mut self, map: Option<ResolvedVc<Box<dyn GenerateSourceMap>>>) {
+    fn push_map(&mut self, map: Option<Rope>) {
         if map.is_none() && matches!(self.mappings.last(), None | Some((_, None))) {
             // No reason to push an empty map directly after an empty map
             return;
@@ -126,43 +122,6 @@ impl CodeBuilder {
             mappings: self.mappings,
         }
     }
-}
-
-async fn generate_source_map(code: &Rope, mappings: Vec<Mapping>) -> Rope {
-    let mut pos = SourcePos::new();
-    let mut last_byte_pos = 0;
-
-    let mut sections = Vec::with_capacity(mappings.len());
-    let mut read = code.read();
-    for (byte_pos, map) in &mappings {
-        let mut want = byte_pos - last_byte_pos;
-        while want > 0 {
-            let buf = read.fill_buf()?;
-            debug_assert!(!buf.is_empty());
-
-            let end = min(want, buf.len());
-            pos.update(&buf[0..end]);
-
-            read.consume(end);
-            want -= end;
-        }
-        last_byte_pos = *byte_pos;
-
-        let encoded = match map {
-            None => SourceMap::empty().to_resolved().await?,
-            Some(map) => match *map.generate_source_map().await? {
-                None => SourceMap::empty().to_resolved().await?,
-                Some(map) => map,
-            },
-        };
-
-        sections.push(SourceMapSection::new(pos, encoded))
-    }
-
-    SourceMap::new_sectioned(sections)
-        .to_source_map()
-        .await?
-        .to_writer(w)
 }
 
 impl ops::AddAssign<&'static str> for CodeBuilder {
@@ -199,7 +158,44 @@ impl GenerateSourceMap for Code {
     /// far the simplest way to concatenate the source maps of the multiple
     /// chunk items into a single map file.
     #[turbo_tasks::function]
-    pub async fn generate_source_map(&self) -> Result<Vc<OptionStringifiedSourceMap>> {}
+    pub async fn generate_source_map(&self) -> Result<Vc<OptionStringifiedSourceMap>> {
+        let mut pos = SourcePos::new();
+        let mut last_byte_pos = 0;
+
+        let mut sections = Vec::with_capacity(self.mappings.len());
+        let mut read = self.code.read();
+        for (byte_pos, map) in &self.mappings {
+            let mut want = byte_pos - last_byte_pos;
+            while want > 0 {
+                let buf = read.fill_buf()?;
+                debug_assert!(!buf.is_empty());
+
+                let end = min(want, buf.len());
+                pos.update(&buf[0..end]);
+
+                read.consume(end);
+                want -= end;
+            }
+            last_byte_pos = *byte_pos;
+
+            let encoded = match map {
+                None => SourceMap::empty_uncelled(),
+                Some(map) => match SourceMap::new_from_rope(map)? {
+                    None => SourceMap::empty_uncelled(),
+                    Some(map) => map,
+                },
+            };
+
+            sections.push(SourceMapSection::new(pos, encoded))
+        }
+
+        let mut result = vec![];
+        SourceMap::new_sectioned(sections)
+            .to_source_map()
+            .await?
+            .to_writer(&mut result)?;
+        Ok(Vc::cell(Some(Rope::from(result))))
+    }
 }
 
 #[turbo_tasks::value_impl]
@@ -215,46 +211,47 @@ impl Code {
 
 /// Turns `turbopack://[project]`` references in sourcemap sources into absolute
 /// `file://` uris. This is useful for debugging environments.
-#[turbo_tasks::function]
 pub async fn fileify_source_map(
-    map: Vc<OptionSourceMap>,
-    context_path: Vc<FileSystemPath>,
-) -> Result<Vc<OptionSourceMap>> {
-    let Some(map) = &*map.await? else {
-        return Ok(OptionSourceMap::none());
-    };
+    map: Option<&Rope>,
+    _context_path: Vc<FileSystemPath>,
+) -> Result<Option<Rope>> {
+    Ok(map.cloned())
 
-    let flattened = map.await?.to_source_map().await?;
-    let flattened = flattened.as_regular_source_map();
+    // let Some(map) = &*map.await? else {
+    //     return Ok(OptionSourceMap::none());
+    // };
 
-    let Some(flattened) = flattened else {
-        return Ok(OptionSourceMap::none());
-    };
+    // let flattened = map.to_source_map().await?;
+    // let flattened = flattened.as_regular_source_map();
 
-    let context_fs = context_path.fs();
-    let context_fs = &*Vc::try_resolve_downcast_type::<DiskFileSystem>(context_fs)
-        .await?
-        .context("Expected the chunking context to have a DiskFileSystem")?
-        .await?;
-    let prefix = format!("{}[{}]/", SOURCE_MAP_PREFIX, context_fs.name());
+    // let Some(flattened) = flattened else {
+    //     return Ok(OptionSourceMap::none());
+    // };
 
-    let mut transformed = flattened.into_owned();
-    let mut updates = IndexMap::new();
-    for (src_id, src) in transformed.sources().enumerate() {
-        let src = {
-            match src.strip_prefix(&prefix) {
-                Some(src) => uri_from_file(context_path, Some(src)).await?,
-                None => src.to_string(),
-            }
-        };
-        updates.insert(src_id, src);
-    }
+    // let context_fs = context_path.fs();
+    // let context_fs = &*Vc::try_resolve_downcast_type::<DiskFileSystem>(context_fs)
+    //     .await?
+    //     .context("Expected the chunking context to have a DiskFileSystem")?
+    //     .await?;
+    // let prefix = format!("{}[{}]/", SOURCE_MAP_PREFIX, context_fs.name());
 
-    for (src_id, src) in updates {
-        transformed.set_source(src_id as _, &src);
-    }
+    // let mut transformed = flattened.into_owned();
+    // let mut updates = IndexMap::new();
+    // for (src_id, src) in transformed.sources().enumerate() {
+    //     let src = {
+    //         match src.strip_prefix(&prefix) {
+    //             Some(src) => uri_from_file(context_path, Some(src)).await?,
+    //             None => src.to_string(),
+    //         }
+    //     };
+    //     updates.insert(src_id, src);
+    // }
 
-    Ok(Vc::cell(Some(
-        SourceMap::new_decoded(sourcemap::DecodedMap::Regular(transformed)).resolved_cell(),
-    )))
+    // for (src_id, src) in updates {
+    //     transformed.set_source(src_id as _, &src);
+    // }
+
+    // Ok(Vc::cell(Some(SourceMap::new_decoded(
+    //     sourcemap::DecodedMap::Regular(transformed),
+    // ))))
 }

--- a/turbopack/crates/turbopack-core/src/issue/analyze.rs
+++ b/turbopack/crates/turbopack-core/src/issue/analyze.rs
@@ -82,12 +82,7 @@ impl Issue for AnalyzeIssue {
     #[turbo_tasks::function]
     async fn source(&self) -> Result<Vc<OptionIssueSource>> {
         Ok(Vc::cell(match &self.source {
-            Some(source) => Some(
-                source
-                    .resolve_source_map(self.source_ident.path())
-                    .await?
-                    .into_owned(),
-            ),
+            Some(source) => Some(source.resolve_source_map().await?.into_owned()),
             None => None,
         }))
     }

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -586,12 +586,8 @@ async fn source_pos(
         return Ok(None);
     };
 
-    let srcmap = generator.generate_source_map().await?;
-    let Some(srcmap) = srcmap.as_ref() else {
-        return Ok(None);
-    };
-
-    let Some(srcmap) = SourceMap::new_from_rope(srcmap)? else {
+    let srcmap = generator.generate_source_map();
+    let Some(srcmap) = &*SourceMap::new_from_rope_cached(srcmap).await? else {
         return Ok(None);
     };
 

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -25,7 +25,7 @@ use turbo_tasks_hash::{DeterministicHash, Xxh3Hash64Hasher};
 use crate::{
     asset::{Asset, AssetContent},
     source::Source,
-    source_map::{convert_to_turbopack_source_map, GenerateSourceMap, SourceMap, TokenWithSource},
+    source_map::{GenerateSourceMap, SourceMap, TokenWithSource},
     source_pos::SourcePos,
 };
 
@@ -587,16 +587,15 @@ async fn source_pos(
         return Ok(None);
     };
 
-    let srcmap = generator.generate_source_map();
-
-    let Some(srcmap) = convert_to_turbopack_source_map(srcmap, origin).await? else {
+    let srcmap = generator.generate_source_map().await?;
+    let Some(srcmap) = srcmap.as_ref() else {
         return Ok(None);
     };
 
-    let Some(srcmap) = SourceMap::new_from_rope(&srcmap)? else {
+    let Some(srcmap) = SourceMap::new_from_rope(srcmap)? else {
         return Ok(None);
     };
-    let srcmap = &srcmap;
+    let srcmap = &srcmap.with_resolved_sources(origin).await?;
 
     let find = |line: u32, col: u32| async move {
         let TokenWithSource {

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -595,9 +595,8 @@ async fn source_pos(
     let Some(srcmap) = SourceMap::new_from_rope(srcmap)? else {
         return Ok(None);
     };
-    let srcmap = &srcmap.with_resolved_sources(origin).await?;
 
-    let find = |line: u32, col: u32| async move {
+    let find = async |line: u32, col: u32| {
         let TokenWithSource {
             token,
             source_content,

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -475,7 +475,7 @@ impl IssueSource {
         }
     }
 
-    pub async fn resolve_source_map(&self, origin: Vc<FileSystemPath>) -> Result<Cow<'_, Self>> {
+    pub async fn resolve_source_map(&self) -> Result<Cow<'_, Self>> {
         if let Some(range) = &self.range {
             let (start, end) = match range {
                 SourceRange::LineColumn(start, end) => (*start, *end),
@@ -491,7 +491,7 @@ impl IssueSource {
             };
 
             // If we have a source map, map the line/column to the original source.
-            let mapped = source_pos(self.source, origin, start, end).await?;
+            let mapped = source_pos(self.source, start, end).await?;
 
             if let Some((source, start, end)) = mapped {
                 return Ok(Cow::Owned(IssueSource {
@@ -579,7 +579,6 @@ impl IssueSource {
 
 async fn source_pos(
     source: ResolvedVc<Box<dyn Source>>,
-    origin: Vc<FileSystemPath>,
     start: SourcePos,
     end: SourcePos,
 ) -> Result<Option<(ResolvedVc<Box<dyn Source>>, SourcePos, SourcePos)>> {

--- a/turbopack/crates/turbopack-core/src/issue/resolve.rs
+++ b/turbopack/crates/turbopack-core/src/issue/resolve.rs
@@ -118,12 +118,7 @@ impl Issue for ResolvingIssue {
     #[turbo_tasks::function]
     async fn source(&self) -> Result<Vc<OptionIssueSource>> {
         Ok(Vc::cell(match &self.source {
-            Some(source) => Some(
-                source
-                    .resolve_source_map(*self.file_path)
-                    .await?
-                    .into_owned(),
-            ),
+            Some(source) => Some(source.resolve_source_map().await?.into_owned()),
             None => None,
         }))
     }

--- a/turbopack/crates/turbopack-core/src/reference/source_map.rs
+++ b/turbopack/crates/turbopack-core/src/reference/source_map.rs
@@ -8,7 +8,7 @@ use crate::{
     file_source::FileSource,
     raw_module::RawModule,
     resolve::ModuleResolveResult,
-    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap, SourceMap},
+    source_map::{GenerateSourceMap, OptionStringifiedSourceMap},
 };
 
 #[turbo_tasks::value]
@@ -60,11 +60,7 @@ impl GenerateSourceMap for SourceMapReference {
         let Some(file) = self.get_file().await else {
             return Ok(Vc::cell(None));
         };
-        let source_map = file
-            .read()
-            .await?
-            .as_content()
-            .map(|m| m.content().clone().resolved_cell());
+        let source_map = file.read().await?.as_content().map(|m| m.content().clone());
         Ok(Vc::cell(source_map))
     }
 }

--- a/turbopack/crates/turbopack-core/src/reference/source_map.rs
+++ b/turbopack/crates/turbopack-core/src/reference/source_map.rs
@@ -8,7 +8,7 @@ use crate::{
     file_source::FileSource,
     raw_module::RawModule,
     resolve::ModuleResolveResult,
-    source_map::{GenerateSourceMap, OptionSourceMap, SourceMap},
+    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap, SourceMap},
 };
 
 #[turbo_tasks::value]
@@ -56,12 +56,16 @@ impl ModuleReference for SourceMapReference {
 #[turbo_tasks::value_impl]
 impl GenerateSourceMap for SourceMapReference {
     #[turbo_tasks::function]
-    async fn generate_source_map(&self) -> Result<Vc<OptionSourceMap>> {
+    async fn generate_source_map(&self) -> Result<Vc<OptionStringifiedSourceMap>> {
         let Some(file) = self.get_file().await else {
             return Ok(Vc::cell(None));
         };
-        let source_map = SourceMap::new_from_file(file).await?;
-        Ok(Vc::cell(source_map.map(|m| m.resolved_cell())))
+        let source_map = file
+            .read()
+            .await?
+            .as_content()
+            .map(|m| m.content().clone().resolved_cell());
+        Ok(Vc::cell(source_map))
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/mod.rs
@@ -248,6 +248,21 @@ impl SourceMap {
     }
 }
 
+#[turbo_tasks::value_impl]
+impl SourceMap {
+    /// This function should be used sparingly to reduce memory usage, only in cold code paths
+    /// (issue resolving, etc).
+    #[turbo_tasks::function]
+    pub async fn new_from_rope_cached(
+        content: Vc<OptionStringifiedSourceMap>,
+    ) -> Result<Vc<OptionSourceMap>> {
+        let Some(content) = &*content.await? else {
+            return Ok(OptionSourceMap::none());
+        };
+        Ok(Vc::cell(SourceMap::new_from_rope(content)?))
+    }
+}
+
 impl SourceMap {
     pub async fn to_source_map(&self) -> Result<Arc<CrateMapWrapper>> {
         Ok(match self {

--- a/turbopack/crates/turbopack-core/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/mod.rs
@@ -768,22 +768,3 @@ impl SourceMapSection {
         })
     }
 }
-
-pub async fn convert_to_turbopack_source_map(
-    source_map: Vc<OptionStringifiedSourceMap>,
-    origin: Vc<FileSystemPath>,
-) -> Result<Option<Rope>> {
-    let Some(source_map) = &*source_map.await? else {
-        return Ok(None);
-    };
-    let Some(source_map) = SourceMap::new_from_rope(source_map)? else {
-        return Ok(None);
-    };
-    Ok(Some(
-        source_map
-            .with_resolved_sources(origin)
-            .await?
-            .to_rope()
-            .await?,
-    ))
-}

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -43,12 +43,13 @@ impl Asset for SourceMapAsset {
         else {
             bail!("asset does not support generating source maps")
         };
-        let sm = if let Some(sm) = &*generate_source_map.generate_source_map().await? {
-            sm.await?
+        if let Some(sm) = &*generate_source_map.generate_source_map().await? {
+            Ok(AssetContent::file(File::from(sm.clone()).into()))
         } else {
-            SourceMap::empty().to_rope().await?
-        };
-        Ok(AssetContent::file(File::from(sm).into()))
+            Ok(AssetContent::file(
+                File::from(SourceMap::empty().to_rope().await?).into(),
+            ))
+        }
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -44,11 +44,10 @@ impl Asset for SourceMapAsset {
             bail!("asset does not support generating source maps")
         };
         let sm = if let Some(sm) = &*generate_source_map.generate_source_map().await? {
-            **sm
+            sm.await?
         } else {
-            SourceMap::empty()
+            SourceMap::empty().to_rope().await?
         };
-        let sm = sm.to_rope().await?;
         Ok(AssetContent::file(File::from(sm).into()))
     }
 }

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -47,7 +47,7 @@ impl Asset for SourceMapAsset {
             Ok(AssetContent::file(File::from(sm.clone()).into()))
         } else {
             Ok(AssetContent::file(
-                File::from(SourceMap::empty().to_rope().await?).into(),
+                File::from(SourceMap::empty_rope()).into(),
             ))
         }
     }

--- a/turbopack/crates/turbopack-core/src/source_map/utils.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/utils.rs
@@ -1,7 +1,11 @@
 use std::collections::HashSet;
 
+use anyhow::{Context, Result};
 use const_format::concatcp;
+use serde::{Deserialize, Serialize};
 use sourcemap::SourceMap;
+use turbo_tasks::Vc;
+use turbo_tasks_fs::{rope::Rope, util::uri_from_file, DiskFileSystem, FileSystemPath};
 
 use crate::SOURCE_MAP_PREFIX;
 
@@ -20,4 +24,72 @@ pub fn add_default_ignore_list(map: &mut SourceMap) {
     for ignored_id in ignored_ids {
         map.add_to_ignore_list(ignored_id as _);
     }
+}
+
+/// Turns `turbopack://[project]`` references in sourcemap sources into absolute
+/// `file://` uris. This is useful for debugging environments.
+pub async fn fileify_source_map(
+    map: Option<&Rope>,
+    context_path: Vc<FileSystemPath>,
+) -> Result<Option<Rope>> {
+    #[derive(Serialize, Deserialize)]
+    struct SourceMapSectionOffsetJson {
+        line: u32,
+        offset: u32,
+    }
+    #[derive(Serialize, Deserialize)]
+    struct SourceMapSectionJson {
+        offset: SourceMapSectionOffsetJson,
+        map: SourceMapJson,
+    }
+    #[derive(Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct SourceMapJson {
+        version: u32,
+        file: Option<String>,
+        source_root: Option<String>,
+        sources: Vec<Option<String>>,
+        sources_content: Option<Vec<Option<String>>>,
+        names: Vec<String>,
+        mappings: String,
+        ignore_list: Option<Vec<u32>>,
+        sections: Option<Vec<SourceMapSectionJson>>,
+    }
+
+    let Some(map) = map else {
+        return Ok(None);
+    };
+
+    let context_fs = context_path.fs();
+    let context_fs = &*Vc::try_resolve_downcast_type::<DiskFileSystem>(context_fs)
+        .await?
+        .context("Expected the chunking context to have a DiskFileSystem")?
+        .await?;
+    let prefix = format!("{}[{}]/", SOURCE_MAP_PREFIX, context_fs.name());
+
+    // TODO this could be made (much) more efficient by not even de- and serializing other fields
+    // (apart from `sources`) and just keep storing them as strings.
+    let mut map: SourceMapJson = serde_json::from_reader(map.read())?;
+
+    let transform_source = async |src: &mut Option<String>| {
+        if let Some(src) = src {
+            if let Some(src_rest) = src.strip_prefix(&prefix) {
+                *src = uri_from_file(context_path, Some(src_rest)).await?;
+            }
+        }
+        anyhow::Ok(())
+    };
+
+    for src in map.sources.iter_mut() {
+        transform_source(src).await?;
+    }
+    for section in map.sections.iter_mut().flatten() {
+        for src in section.map.sources.iter_mut() {
+            transform_source(src).await?;
+        }
+    }
+
+    let map = Rope::from(serde_json::to_vec(&map)?);
+
+    Ok(Some(map))
 }

--- a/turbopack/crates/turbopack-core/src/source_map/utils.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/utils.rs
@@ -45,12 +45,17 @@ struct SourceMapSectionItemJson {
 #[serde(rename_all = "camelCase")]
 struct SourceMapSectionJson {
     version: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
     file: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     source_root: Option<String>,
     sources: Vec<Option<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     sources_content: Option<Vec<Option<String>>>,
-    names: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    names: Option<Vec<String>>,
     mappings: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore_list: Option<Vec<u32>>,
 }
 
@@ -58,6 +63,7 @@ struct SourceMapSectionJson {
 struct SourceMapJson {
     #[serde(flatten)]
     map: SourceMapSectionJson,
+    #[serde(skip_serializing_if = "Option::is_none")]
     sections: Option<Vec<SourceMapSectionItemJson>>,
 }
 

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -299,7 +299,7 @@ impl CssChunkItem for CssModuleChunkItem {
                 inner_code: output_code.to_owned().into(),
                 imports,
                 import_context: self.module.await?.import_context,
-                source_map: Some(*source_map),
+                source_map: source_map.await?.clone_value(),
             }
             .into())
         } else {

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -299,7 +299,7 @@ impl CssChunkItem for CssModuleChunkItem {
                 inner_code: output_code.to_owned().into(),
                 imports,
                 import_context: self.module.await?.import_context,
-                source_map: source_map.await?.clone_value(),
+                source_map: source_map.owned().await?,
             }
             .into())
         } else {

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -13,7 +13,7 @@ use turbopack_core::{
         round_chunk_item_size, AsyncModuleInfo, Chunk, ChunkItem, ChunkItemWithAsyncModuleInfo,
         ChunkType, ChunkableModule, ChunkingContext, ModuleId, OutputChunk, OutputChunkRuntimeInfo,
     },
-    code_builder::{fileify_source_map, Code, CodeBuilder},
+    code_builder::{Code, CodeBuilder},
     ident::AssetIdent,
     introspect::{
         module::IntrospectableModule,
@@ -24,7 +24,7 @@ use turbopack_core::{
     output::{OutputAsset, OutputAssets},
     reference_type::ImportContext,
     server_fs::ServerFileSystem,
-    source_map::{GenerateSourceMap, OptionStringifiedSourceMap},
+    source_map::{utils::fileify_source_map, GenerateSourceMap, OptionStringifiedSourceMap},
 };
 
 use self::{single_item_chunk::chunk::SingleItemCssChunk, source_map::CssChunkSourceMapAsset};

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -24,11 +24,11 @@ use turbopack_core::{
     output::{OutputAsset, OutputAssets},
     reference_type::ImportContext,
     server_fs::ServerFileSystem,
-    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap},
+    source_map::{GenerateSourceMap, OptionStringifiedSourceMap},
 };
 
 use self::{single_item_chunk::chunk::SingleItemCssChunk, source_map::CssChunkSourceMapAsset};
-use crate::{process::ParseCssResultSourceMap, util::stringify_js, ImportAssetReference};
+use crate::{util::stringify_js, ImportAssetReference};
 
 #[turbo_tasks::value]
 pub struct CssChunk {

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -11,7 +11,7 @@ use turbopack_core::{
     ident::AssetIdent,
     introspect::Introspectable,
     output::{OutputAsset, OutputAssets},
-    source_map::{GenerateSourceMap, OptionSourceMap},
+    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap},
 };
 
 use super::source_map::SingleItemCssChunkSourceMapAsset;
@@ -57,10 +57,7 @@ impl SingleItemCssChunk {
         let content = this.item.content().await?;
         let close = write_import_context(&mut code, content.import_context).await?;
 
-        code.push_source(
-            &content.inner_code,
-            content.source_map.map(ResolvedVc::upcast),
-        );
+        code.push_source(&content.inner_code, content.source_map.clone());
         write!(code, "{close}")?;
 
         if *this
@@ -146,7 +143,7 @@ impl Asset for SingleItemCssChunk {
 #[turbo_tasks::value_impl]
 impl GenerateSourceMap for SingleItemCssChunk {
     #[turbo_tasks::function]
-    fn generate_source_map(self: Vc<Self>) -> Vc<OptionSourceMap> {
+    fn generate_source_map(self: Vc<Self>) -> Vc<OptionStringifiedSourceMap> {
         self.code().generate_source_map()
     }
 }

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -11,7 +11,7 @@ use turbopack_core::{
     ident::AssetIdent,
     introspect::Introspectable,
     output::{OutputAsset, OutputAssets},
-    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap},
+    source_map::{GenerateSourceMap, OptionStringifiedSourceMap},
 };
 
 use super::source_map::SingleItemCssChunkSourceMapAsset;

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
@@ -39,7 +39,7 @@ impl Asset for SingleItemCssChunkSourceMapAsset {
             Ok(AssetContent::file(File::from(sm.clone()).into()))
         } else {
             Ok(AssetContent::file(
-                File::from(SourceMap::empty().to_rope().await?).into(),
+                File::from(SourceMap::empty_rope()).into(),
             ))
         }
     }

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
@@ -35,12 +35,12 @@ impl OutputAsset for SingleItemCssChunkSourceMapAsset {
 impl Asset for SingleItemCssChunkSourceMapAsset {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<AssetContent>> {
-        let sm = if let Some(sm) = *self.chunk.generate_source_map().await? {
-            *sm
+        if let Some(sm) = &*self.chunk.generate_source_map().await? {
+            Ok(AssetContent::file(File::from(sm.clone()).into()))
         } else {
-            SourceMap::empty()
-        };
-        let sm = sm.to_rope().await?;
-        Ok(AssetContent::file(File::from(sm).into()))
+            Ok(AssetContent::file(
+                File::from(SourceMap::empty().to_rope().await?).into(),
+            ))
+        }
     }
 }

--- a/turbopack/crates/turbopack-css/src/chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/source_map.rs
@@ -39,7 +39,7 @@ impl Asset for CssChunkSourceMapAsset {
             Ok(AssetContent::file(File::from(sm.clone()).into()))
         } else {
             Ok(AssetContent::file(
-                File::from(SourceMap::empty().to_rope().await?).into(),
+                File::from(SourceMap::empty_rope()).into(),
             ))
         }
     }

--- a/turbopack/crates/turbopack-css/src/chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/source_map.rs
@@ -35,12 +35,12 @@ impl OutputAsset for CssChunkSourceMapAsset {
 impl Asset for CssChunkSourceMapAsset {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<AssetContent>> {
-        let sm = if let Some(sm) = *self.chunk.generate_source_map().await? {
-            *sm
+        if let Some(sm) = &*self.chunk.generate_source_map().await? {
+            Ok(AssetContent::file(File::from(sm.clone()).into()))
         } else {
-            SourceMap::empty()
-        };
-        let sm = sm.to_rope().await?;
-        Ok(AssetContent::file(File::from(sm).into()))
+            Ok(AssetContent::file(
+                File::from(SourceMap::empty().to_rope().await?).into(),
+            ))
+        }
     }
 }

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -6,7 +6,7 @@ use lightningcss::css_modules::CssModuleReference;
 use swc_core::common::{BytePos, FileName, LineCol, SourceMap};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, ResolvedVc, Value, ValueToString, Vc};
-use turbo_tasks_fs::FileSystemPath;
+use turbo_tasks_fs::{rope::Rope, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkItemExt, ChunkType, ChunkableModule, ChunkingContext},
@@ -19,7 +19,7 @@ use turbopack_core::{
     reference_type::{CssReferenceSubType, ReferenceType},
     resolve::{origin::ResolveOrigin, parse::Request},
     source::Source,
-    source_map::OptionSourceMap,
+    source_map::{OptionSourceMap, OptionStringifiedSourceMap},
 };
 use turbopack_ecmascript::{
     chunk::{
@@ -410,13 +410,13 @@ impl EcmascriptChunkItem for ModuleChunkItem {
             // We generate a minimal map for runtime code so that the filename is
             // displayed in dev tools.
             source_map: if source_map {
-                Some(ResolvedVc::upcast(
+                Some(
                     generate_minimal_source_map(
                         self.module.ident().to_string().await?.to_string(),
                         code,
                     )
                     .await?,
-                ))
+                )
             } else {
                 None
             },
@@ -426,10 +426,7 @@ impl EcmascriptChunkItem for ModuleChunkItem {
     }
 }
 
-async fn generate_minimal_source_map(
-    filename: String,
-    source: String,
-) -> Result<ResolvedVc<ParseResultSourceMap>> {
+async fn generate_minimal_source_map(filename: String, source: String) -> Result<Rope> {
     let mut mappings = vec![];
     // Start from 1 because 0 is reserved for dummy spans in SWC.
     let mut pos = 1;
@@ -445,8 +442,13 @@ async fn generate_minimal_source_map(
     }
     let sm: Arc<SourceMap> = Default::default();
     sm.new_source_file(FileName::Custom(filename).into(), source);
-    let map = ParseResultSourceMap::new(sm, mappings, OptionSourceMap::none().to_resolved().await?);
-    Ok(map.resolved_cell())
+    let map = ParseResultSourceMap::generate_source_map(
+        sm,
+        mappings,
+        OptionStringifiedSourceMap::none().to_resolved().await?,
+    )
+    .await?;
+    Ok(map)
 }
 
 #[turbo_tasks::value(shared)]

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -19,7 +19,7 @@ use turbopack_core::{
     reference_type::{CssReferenceSubType, ReferenceType},
     resolve::{origin::ResolveOrigin, parse::Request},
     source::Source,
-    source_map::{OptionSourceMap, OptionStringifiedSourceMap},
+    source_map::OptionStringifiedSourceMap,
 };
 use turbopack_ecmascript::{
     chunk::{

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -26,9 +26,9 @@ use turbopack_ecmascript::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
         EcmascriptChunkType, EcmascriptExports,
     },
+    parse::generate_js_source_map,
     runtime_functions::{TURBOPACK_EXPORT_VALUE, TURBOPACK_IMPORT},
     utils::StringifyJs,
-    ParseResultSourceMap,
 };
 
 use crate::{
@@ -442,7 +442,7 @@ async fn generate_minimal_source_map(filename: String, source: String) -> Result
     }
     let sm: Arc<SourceMap> = Default::default();
     sm.new_source_file(FileName::Custom(filename).into(), source);
-    let map = ParseResultSourceMap::generate_source_map(
+    let map = generate_js_source_map(
         sm,
         mappings,
         OptionStringifiedSourceMap::none().to_resolved().await?,

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -687,7 +687,7 @@ impl Issue for ParsingIssue {
     #[turbo_tasks::function]
     async fn source(&self) -> Result<Vc<OptionIssueSource>> {
         Ok(Vc::cell(match &self.source {
-            Some(s) => Some(s.resolve_source_map(*self.file).await?.into_owned()),
+            Some(s) => Some(s.resolve_source_map().await?.into_owned()),
             None => None,
         }))
     }

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -28,10 +28,7 @@ use turbopack_core::{
     reference_type::ImportContext,
     resolve::origin::ResolveOrigin,
     source::Source,
-    source_map::{
-        utils::add_default_ignore_list, GenerateSourceMap, OptionSourceMap,
-        OptionStringifiedSourceMap,
-    },
+    source_map::{utils::add_default_ignore_list, OptionStringifiedSourceMap},
     source_pos::SourcePos,
     SOURCE_MAP_PREFIX,
 };

--- a/turbopack/crates/turbopack-ecmascript/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+data-encoding = "2.3.3"
 either = { workspace = true }
 indexmap = { workspace = true }
 indoc = { workspace = true }

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -11,7 +11,6 @@ use turbopack_core::{
     code_builder::{fileify_source_map, Code, CodeBuilder},
     error::PrettyPrintError,
     issue::{code_gen::CodeGenerationIssue, IssueExt, IssueSeverity, StyledString},
-    source_map::{GenerateSourceMap, OptionStringifiedSourceMap},
 };
 
 use crate::{

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -8,9 +8,10 @@ use turbo_tasks::{
 use turbo_tasks_fs::{rope::Rope, FileSystemPath};
 use turbopack_core::{
     chunk::{AsyncModuleInfo, ChunkItem, ChunkItemExt, ChunkItemTy, ChunkingContext},
-    code_builder::{fileify_source_map, Code, CodeBuilder},
+    code_builder::{Code, CodeBuilder},
     error::PrettyPrintError,
     issue::{code_gen::CodeGenerationIssue, IssueExt, IssueSeverity, StyledString},
+    source_map::utils::fileify_source_map,
 };
 
 use crate::{

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -11,7 +11,7 @@ use turbopack_core::{
     code_builder::{fileify_source_map, Code, CodeBuilder},
     error::PrettyPrintError,
     issue::{code_gen::CodeGenerationIssue, IssueExt, IssueSeverity, StyledString},
-    source_map::GenerateSourceMap,
+    source_map::{GenerateSourceMap, OptionStringifiedSourceMap},
 };
 
 use crate::{
@@ -24,7 +24,7 @@ use crate::{
 #[derive(Default, Clone)]
 pub struct EcmascriptChunkItemContent {
     pub inner_code: Rope,
-    pub source_map: Option<ResolvedVc<Box<dyn GenerateSourceMap>>>,
+    pub source_map: Option<Rope>,
     pub options: EcmascriptChunkItemOptions,
     pub rewrite_source_path: Option<ResolvedVc<FileSystemPath>>,
     pub placeholder_for_future_extensions: (),
@@ -55,7 +55,7 @@ impl EcmascriptChunkItemContent {
                 None
             },
             inner_code: content.inner_code.clone(),
-            source_map: content.source_map,
+            source_map: content.source_map.clone(),
             options: if content.is_esm {
                 EcmascriptChunkItemOptions {
                     strict: true,
@@ -130,15 +130,9 @@ impl EcmascriptChunkItemContent {
         }
 
         let source_map = if let Some(rewrite_source_path) = self.rewrite_source_path {
-            let source_map = self.source_map.map(|m| m.generate_source_map());
-            match source_map {
-                Some(map) => fileify_source_map(map, *rewrite_source_path)
-                    .await?
-                    .map(ResolvedVc::upcast),
-                None => None,
-            }
+            fileify_source_map(self.source_map.as_ref(), *rewrite_source_path).await?
         } else {
-            self.source_map
+            self.source_map.clone()
         };
 
         code.push_source(&self.inner_code, source_map);

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -82,7 +82,7 @@ use turbopack_core::{
         FindContextFileResult,
     },
     source::Source,
-    source_map::{OptionSourceMap, OptionStringifiedSourceMap},
+    source_map::OptionStringifiedSourceMap,
 };
 // TODO remove this
 pub use turbopack_resolve::ecmascript as resolve;
@@ -91,7 +91,6 @@ use self::chunk::{EcmascriptChunkItemContent, EcmascriptChunkType, EcmascriptExp
 use crate::{
     chunk::EcmascriptChunkPlaceable,
     code_gen::CodeGens,
-    parse::InlineSourcesContentConfig,
     references::{analyse_ecmascript_module, async_module::OptionAsyncModule},
     transform::remove_shebang,
 };

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -40,7 +40,6 @@ use std::fmt::{Display, Formatter};
 use anyhow::Result;
 use chunk::EcmascriptChunkItem;
 use code_gen::{CodeGenerateable, CodeGeneration, CodeGenerationHoistedStmt};
-pub use parse::ParseResultSourceMap;
 use parse::{parse, ParseResult};
 use path_visitor::ApplyVisitors;
 use references::esm::UrlRewriteBehavior;
@@ -91,6 +90,7 @@ use self::chunk::{EcmascriptChunkItemContent, EcmascriptChunkType, EcmascriptExp
 use crate::{
     chunk::EcmascriptChunkPlaceable,
     code_gen::CodeGens,
+    parse::generate_js_source_map,
     references::{analyse_ecmascript_module, async_module::OptionAsyncModule},
     transform::remove_shebang,
 };
@@ -882,12 +882,8 @@ async fn gen_content_with_code_gens(
 
             let source_map = if generate_source_map {
                 Some(
-                    ParseResultSourceMap::generate_source_map(
-                        source_map.clone(),
-                        mappings,
-                        original_source_map,
-                    )
-                    .await?,
+                    generate_js_source_map(source_map.clone(), mappings, original_source_map)
+                        .await?,
                 )
             } else {
                 None

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -82,7 +82,7 @@ use turbopack_core::{
         FindContextFileResult,
     },
     source::Source,
-    source_map::{GenerateSourceMap, OptionSourceMap},
+    source_map::{OptionSourceMap, OptionStringifiedSourceMap},
 };
 // TODO remove this
 pub use turbopack_resolve::ecmascript as resolve;
@@ -91,6 +91,7 @@ use self::chunk::{EcmascriptChunkItemContent, EcmascriptChunkType, EcmascriptExp
 use crate::{
     chunk::EcmascriptChunkPlaceable,
     code_gen::CodeGens,
+    parse::InlineSourcesContentConfig,
     references::{analyse_ecmascript_module, async_module::OptionAsyncModule},
     transform::remove_shebang,
 };
@@ -747,7 +748,7 @@ impl EcmascriptChunkItem for ModuleChunkItem {
 #[turbo_tasks::value]
 pub struct EcmascriptModuleContent {
     pub inner_code: Rope,
-    pub source_map: Option<ResolvedVc<Box<dyn GenerateSourceMap>>>,
+    pub source_map: Option<Rope>,
     pub is_esm: bool,
     // pub refresh: bool,
 }
@@ -766,7 +767,7 @@ impl EcmascriptModuleContent {
         code_generation: Vc<CodeGens>,
         async_module: Vc<OptionAsyncModule>,
         generate_source_map: Vc<bool>,
-        original_source_map: ResolvedVc<OptionSourceMap>,
+        original_source_map: ResolvedVc<OptionStringifiedSourceMap>,
         exports: Vc<EcmascriptExports>,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<Self>> {
@@ -822,7 +823,7 @@ impl EcmascriptModuleContent {
             specified_module_type,
             &[],
             generate_source_map,
-            OptionSourceMap::none().to_resolved().await?,
+            OptionStringifiedSourceMap::none().to_resolved().await?,
         )
         .await
     }
@@ -834,7 +835,7 @@ async fn gen_content_with_code_gens(
     specified_module_type: SpecifiedModuleType,
     code_gens: impl IntoIterator<Item = &CodeGeneration>,
     generate_source_map: Vc<bool>,
-    original_source_map: ResolvedVc<OptionSourceMap>,
+    original_source_map: ResolvedVc<OptionStringifiedSourceMap>,
 ) -> Result<Vc<EcmascriptModuleContent>> {
     let parsed = parsed.await?;
 
@@ -862,29 +863,33 @@ async fn gen_content_with_code_gens(
 
             let mut mappings = vec![];
 
-            let comments = comments.consumable();
-
             let generate_source_map = *generate_source_map.await?;
 
-            let mut emitter = Emitter {
-                cfg: swc_core::ecma::codegen::Config::default(),
-                cm: source_map.clone(),
-                comments: Some(&comments),
-                wr: JsWriter::new(
-                    source_map.clone(),
-                    "\n",
-                    &mut bytes,
-                    generate_source_map.then_some(&mut mappings),
-                ),
-            };
-
-            emitter.emit_program(&program)?;
+            {
+                let comments = comments.consumable();
+                let mut emitter = Emitter {
+                    cfg: swc_core::ecma::codegen::Config::default(),
+                    cm: source_map.clone(),
+                    comments: Some(&comments),
+                    wr: JsWriter::new(
+                        source_map.clone(),
+                        "\n",
+                        &mut bytes,
+                        generate_source_map.then_some(&mut mappings),
+                    ),
+                };
+                emitter.emit_program(&program)?;
+            }
 
             let source_map = if generate_source_map {
-                let srcmap =
-                    ParseResultSourceMap::new(source_map.clone(), mappings, original_source_map)
-                        .resolved_cell();
-                Some(ResolvedVc::upcast(srcmap))
+                Some(
+                    ParseResultSourceMap::generate_source_map(
+                        source_map.clone(),
+                        mappings,
+                        original_source_map,
+                    )
+                    .await?,
+                )
             } else {
                 None
             };

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -19,7 +19,7 @@ use swc_core::{
         transforms::base::fixer::paren_remover,
     },
 };
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     code_builder::{Code, CodeBuilder},
@@ -119,10 +119,14 @@ pub async fn minify(
         src_map_buf.shrink_to_fit();
         builder.push_source(
             &src.into(),
-            Some(ResolvedVc::upcast(
-                ParseResultSourceMap::new(cm, src_map_buf, original_map.to_resolved().await?)
-                    .resolved_cell(),
-            )),
+            Some(
+                ParseResultSourceMap::generate_source_map(
+                    cm,
+                    src_map_buf,
+                    original_map.to_resolved().await?,
+                )
+                .await?,
+            ),
         );
 
         write!(

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -26,7 +26,7 @@ use turbopack_core::{
     source_map::GenerateSourceMap,
 };
 
-use crate::ParseResultSourceMap;
+use crate::parse::generate_js_source_map;
 
 #[turbo_tasks::function]
 pub async fn minify(
@@ -119,14 +119,7 @@ pub async fn minify(
         src_map_buf.shrink_to_fit();
         builder.push_source(
             &src.into(),
-            Some(
-                ParseResultSourceMap::generate_source_map(
-                    cm,
-                    src_map_buf,
-                    original_map.to_resolved().await?,
-                )
-                .await?,
-            ),
+            Some(generate_js_source_map(cm, src_map_buf, original_map.to_resolved().await?).await?),
         );
 
         write!(

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -30,7 +30,6 @@ use parking_lot::Mutex;
 use regex::Regex;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use sourcemap::decode_data_url;
 use swc_core::{
     atoms::JsWord,
     common::{
@@ -74,10 +73,7 @@ use turbopack_core::{
         resolve, FindContextFileResult, ModulePart,
     },
     source::Source,
-    source_map::{
-        convert_to_turbopack_source_map, GenerateSourceMap, OptionSourceMap,
-        OptionStringifiedSourceMap, SourceMap,
-    },
+    source_map::{GenerateSourceMap, OptionStringifiedSourceMap},
 };
 use turbopack_resolve::{
     ecmascript::{apply_cjs_specific_options, cjs_resolve_source},
@@ -567,7 +563,8 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                     analysis.set_source_map(source_map.to_resolved().await?);
                     source_map_from_comment = true;
                 } else if path.starts_with("data:application/json;base64,") {
-                    let source_map_origin = origin_path;
+                    // TODO what about the origin here?
+                    // let source_map_origin = origin_path;
                     let source_map = maybe_decode_data_url(path.into());
                     analysis.set_source_map(ResolvedVc::cell(source_map));
                     source_map_from_comment = true;
@@ -577,7 +574,8 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                 if let Some(generate_source_map) =
                     ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(source)
                 {
-                    let source_map_origin = source.ident().path();
+                    // TODO what about the origin here?
+                    // let source_map_origin = source.ident().path();
                     let x = generate_source_map.generate_source_map();
                     analysis.set_source_map(x.to_resolved().await?);
                 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -54,7 +54,7 @@ use turbo_tasks::{
     trace::TraceRawVcs, FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TaskInput,
     TryJoinIterExt, Upcast, Value, ValueToString, Vc,
 };
-use turbo_tasks_fs::FileSystemPath;
+use turbo_tasks_fs::{rope::Rope, FileSystemPath};
 use turbopack_core::{
     compile_time_info::{
         CompileTimeInfo, DefineableNameSegment, FreeVarReference, FreeVarReferences,
@@ -74,7 +74,10 @@ use turbopack_core::{
         resolve, FindContextFileResult, ModulePart,
     },
     source::Source,
-    source_map::{convert_to_turbopack_source_map, GenerateSourceMap, OptionSourceMap, SourceMap},
+    source_map::{
+        convert_to_turbopack_source_map, GenerateSourceMap, OptionSourceMap,
+        OptionStringifiedSourceMap, SourceMap,
+    },
 };
 use turbopack_resolve::{
     ecmascript::{apply_cjs_specific_options, cjs_resolve_source},
@@ -164,7 +167,7 @@ pub struct AnalyzeEcmascriptModuleResult {
     pub async_module: ResolvedVc<OptionAsyncModule>,
     /// `true` when the analysis was successful.
     pub successful: bool,
-    pub source_map: ResolvedVc<OptionSourceMap>,
+    pub source_map: ResolvedVc<OptionStringifiedSourceMap>,
 }
 
 /// A temporary analysis result builder to pass around, to be turned into an
@@ -178,7 +181,7 @@ pub struct AnalyzeEcmascriptModuleResultBuilder {
     exports: EcmascriptExports,
     async_module: ResolvedVc<OptionAsyncModule>,
     successful: bool,
-    source_map: Option<ResolvedVc<OptionSourceMap>>,
+    source_map: Option<ResolvedVc<OptionStringifiedSourceMap>>,
 }
 
 impl AnalyzeEcmascriptModuleResultBuilder {
@@ -243,7 +246,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     }
 
     /// Sets the analysis result ES export.
-    pub fn set_source_map(&mut self, source_map: ResolvedVc<OptionSourceMap>) {
+    pub fn set_source_map(&mut self, source_map: ResolvedVc<OptionStringifiedSourceMap>) {
         self.source_map = Some(source_map);
     }
 
@@ -287,7 +290,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
         let source_map = if let Some(source_map) = self.source_map {
             source_map
         } else {
-            OptionSourceMap::none().to_resolved().await?
+            OptionStringifiedSourceMap::none().to_resolved().await?
         };
 
         self.code_gens.shrink_to_fit();
@@ -561,20 +564,12 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                         .await?;
                     analysis.add_reference(reference);
                     let source_map = reference.generate_source_map();
-                    analysis.set_source_map(
-                        convert_to_turbopack_source_map(source_map, source_map_origin)
-                            .to_resolved()
-                            .await?,
-                    );
+                    analysis.set_source_map(source_map.to_resolved().await?);
                     source_map_from_comment = true;
                 } else if path.starts_with("data:application/json;base64,") {
                     let source_map_origin = origin_path;
                     let source_map = maybe_decode_data_url(path.into());
-                    analysis.set_source_map(
-                        convert_to_turbopack_source_map(source_map, source_map_origin)
-                            .to_resolved()
-                            .await?,
-                    );
+                    analysis.set_source_map(ResolvedVc::cell(source_map));
                     source_map_from_comment = true;
                 }
             }
@@ -583,14 +578,8 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                     ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(source)
                 {
                     let source_map_origin = source.ident().path();
-                    analysis.set_source_map(
-                        convert_to_turbopack_source_map(
-                            generate_source_map.generate_source_map(),
-                            source_map_origin,
-                        )
-                        .to_resolved()
-                        .await?,
-                    );
+                    let x = generate_source_map.generate_source_map();
+                    analysis.set_source_map(x.to_resolved().await?);
                 }
             }
             anyhow::Ok(())
@@ -3534,11 +3523,15 @@ fn is_invoking_node_process_eval(args: &[JsValue]) -> bool {
     false
 }
 
-#[turbo_tasks::function]
-fn maybe_decode_data_url(url: RcStr) -> Vc<OptionSourceMap> {
-    if let Ok(map) = decode_data_url(&url) {
-        Vc::cell(Some(SourceMap::new_decoded(map).resolved_cell()))
-    } else {
-        Vc::cell(None)
+fn maybe_decode_data_url(url: RcStr) -> Option<Rope> {
+    const DATA_PREAMBLE: &str = "data:application/json;base64,";
+
+    if !url.starts_with(DATA_PREAMBLE) {
+        return None;
     }
+    let data_b64 = &url[DATA_PREAMBLE.len()..];
+    data_encoding::BASE64
+        .decode(data_b64.as_bytes())
+        .ok()
+        .map(Rope::from)
 }

--- a/turbopack/crates/turbopack-ecmascript/src/static_code.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/static_code.rs
@@ -59,7 +59,7 @@ impl StaticEcmascriptCode {
         let mut code = CodeBuilder::default();
         code.push_source(
             &runtime_base_content.inner_code,
-            runtime_base_content.source_map,
+            runtime_base_content.source_map.clone(),
         );
         Ok(Code::cell(code.build()))
     }

--- a/turbopack/crates/turbopack-mdx/src/lib.rs
+++ b/turbopack/crates/turbopack-mdx/src/lib.rs
@@ -272,7 +272,7 @@ impl Issue for MdxIssue {
     #[turbo_tasks::function]
     async fn source(&self) -> Result<Vc<OptionIssueSource>> {
         Ok(Vc::cell(match &self.loc {
-            Some(loc) => Some(loc.resolve_source_map(*self.path).await?.into_owned()),
+            Some(loc) => Some(loc.resolve_source_map().await?.into_owned()),
             None => None,
         }))
     }

--- a/turbopack/crates/turbopack-node/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-node/src/source_map/mod.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use const_format::concatcp;
 use once_cell::sync::Lazy;
 use regex::Regex;
-pub use trace::{SourceMapTrace, StackFrame, TraceResult};
+pub use trace::{trace_source_map, StackFrame, TraceResult};
 use tracing::{instrument, Level};
 use turbo_tasks::{ReadRef, Vc};
 use turbo_tasks_fs::{
@@ -228,7 +228,7 @@ async fn resolve_source_mapping(
     let Some(sm) = &*SourceMap::new_from_rope_cached(sm).await? else {
         return Ok(ResolvedSourceMapping::NoSourceMap);
     };
-    let trace = SourceMapTrace::trace(sm, line, column, name.map(|s| s.clone().into())).await?;
+    let trace = trace_source_map(sm, line, column, name.map(|s| &**s)).await?;
     match trace {
         TraceResult::Found(frame) => {
             let lib_code = frame.file.contains("/node_modules/");

--- a/turbopack/crates/turbopack-node/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-node/src/source_map/mod.rs
@@ -224,13 +224,11 @@ async fn resolve_source_mapping(
     let Some(generate_source_map) = map.get(file.as_ref()) else {
         return Ok(ResolvedSourceMapping::NoSourceMap);
     };
-    let Some(sm) = &*generate_source_map.generate_source_map().await? else {
+    let sm = generate_source_map.generate_source_map();
+    let Some(sm) = &*SourceMap::new_from_rope_cached(sm).await? else {
         return Ok(ResolvedSourceMapping::NoSourceMap);
     };
-    let Some(sm) = SourceMap::new_from_rope(sm)? else {
-        return Ok(ResolvedSourceMapping::NoSourceMap);
-    };
-    let trace = SourceMapTrace::trace(&sm, line, column, name.map(|s| s.clone().into())).await?;
+    let trace = SourceMapTrace::trace(sm, line, column, name.map(|s| s.clone().into())).await?;
     match trace {
         TraceResult::Found(frame) => {
             let lib_code = frame.file.contains("/node_modules/");

--- a/turbopack/crates/turbopack-node/src/source_map/trace.rs
+++ b/turbopack/crates/turbopack-node/src/source_map/trace.rs
@@ -1,16 +1,9 @@
 use std::{borrow::Cow, fmt::Display};
 
 use anyhow::Result;
-use mime::APPLICATION_JSON;
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::{rope::Rope, File};
-use turbopack_core::{
-    asset::AssetContent,
-    source_map::{SourceMap, Token},
-};
+use turbopack_core::source_map::{SourceMap, Token};
 use turbopack_ecmascript::magic_identifier::unmangle_identifiers;
 
 /// An individual stack frame, as parsed by the stacktrace-parser npm module.
@@ -86,10 +79,10 @@ impl Display for StackFrame<'_> {
 /// trace's token.
 #[derive(Debug)]
 pub struct SourceMapTrace {
-    map: SourceMap,
-    line: u32,
-    column: u32,
-    name: Option<RcStr>,
+    // map: SourceMap,
+    // line: u32,
+    // column: u32,
+    // name: Option<RcStr>,
 }
 
 /// The result of performing a source map trace.

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -22,7 +22,7 @@ use turbopack_core::{
     reference_type::{EntryReferenceSubType, InnerAssets, ReferenceType},
     resolve::{find_context_file_or_package_key, options::ImportMapping, FindContextFileResult},
     source::Source,
-    source_map::{GenerateSourceMap, OptionSourceMap},
+    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap},
     source_transform::SourceTransform,
     virtual_source::VirtualSource,
 };
@@ -459,7 +459,7 @@ async fn find_config_in_location(
 #[turbo_tasks::value_impl]
 impl GenerateSourceMap for PostCssTransformedAsset {
     #[turbo_tasks::function]
-    async fn generate_source_map(&self) -> Result<Vc<OptionSourceMap>> {
+    async fn generate_source_map(&self) -> Result<Vc<OptionStringifiedSourceMap>> {
         let source = Vc::try_resolve_sidecast::<Box<dyn GenerateSourceMap>>(*self.source).await?;
         match source {
             Some(source) => Ok(source.generate_source_map()),

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -22,7 +22,7 @@ use turbopack_core::{
     reference_type::{EntryReferenceSubType, InnerAssets, ReferenceType},
     resolve::{find_context_file_or_package_key, options::ImportMapping, FindContextFileResult},
     source::Source,
-    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap},
+    source_map::{GenerateSourceMap, OptionStringifiedSourceMap},
     source_transform::SourceTransform,
     virtual_source::VirtualSource,
 };

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -33,7 +33,9 @@ use turbopack_core::{
         resolve,
     },
     source::Source,
-    source_map::{GenerateSourceMap, OptionStringifiedSourceMap},
+    source_map::{
+        utils::resolve_source_map_sources, GenerateSourceMap, OptionStringifiedSourceMap,
+    },
     source_transform::SourceTransform,
     virtual_source::VirtualSource,
 };
@@ -281,6 +283,8 @@ impl WebpackLoadersProcessedAsset {
                 .map
                 .map(|source_map| Rope::from(source_map.into_owned()))
         };
+        let source_map = resolve_source_map_sources(source_map.as_ref(), resource_fs_path).await?;
+
         let file = match processed.source {
             Either::Left(str) => File::from(str),
             Either::Right(bytes) => File::from(bytes.binary),

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -11,7 +11,7 @@ use turbo_tasks::{
     trace::TraceRawVcs, Completion, NonLocalValue, OperationValue, OperationVc, ResolvedVc,
     TaskInput, TryJoinIterExt, Value, ValueToString, Vc,
 };
-use turbo_tasks_bytes::{stream::SingleValue, Bytes};
+use turbo_tasks_bytes::stream::SingleValue;
 use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::{
     glob::Glob, json::parse_json_with_source_context, rope::Rope, DirectoryEntry, File,
@@ -33,7 +33,7 @@ use turbopack_core::{
         resolve,
     },
     source::Source,
-    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap, SourceMap},
+    source_map::{GenerateSourceMap, OptionStringifiedSourceMap},
     source_transform::SourceTransform,
     virtual_source::VirtualSource,
 };
@@ -276,10 +276,10 @@ impl WebpackLoadersProcessedAsset {
         // handle SourceMap
         let source_map = if !transform.source_maps {
             None
-        } else if let Some(source_map) = processed.map {
-            Some(Rope::from(source_map.into_owned()))
         } else {
-            None
+            processed
+                .map
+                .map(|source_map| Rope::from(source_map.into_owned()))
         };
         let file = match processed.source {
             Either::Left(str) => File::from(str),

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
@@ -7,7 +7,7 @@ use turbopack_core::{
     chunk::{Chunk, ChunkingContext},
     introspect::{Introspectable, IntrospectableChildren},
     output::{OutputAsset, OutputAssets},
-    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap, SourceMapAsset},
+    source_map::{GenerateSourceMap, OptionStringifiedSourceMap, SourceMapAsset},
     version::VersionedContent,
 };
 use turbopack_ecmascript::chunk::EcmascriptChunk;

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
@@ -7,7 +7,7 @@ use turbopack_core::{
     chunk::{Chunk, ChunkingContext},
     introspect::{Introspectable, IntrospectableChildren},
     output::{OutputAsset, OutputAssets},
-    source_map::{GenerateSourceMap, OptionSourceMap, SourceMapAsset},
+    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap, SourceMapAsset},
     version::VersionedContent,
 };
 use turbopack_ecmascript::chunk::EcmascriptChunk;
@@ -113,7 +113,7 @@ impl Asset for EcmascriptBuildNodeChunk {
 #[turbo_tasks::value_impl]
 impl GenerateSourceMap for EcmascriptBuildNodeChunk {
     #[turbo_tasks::function]
-    fn generate_source_map(self: Vc<Self>) -> Vc<OptionSourceMap> {
+    fn generate_source_map(self: Vc<Self>) -> Vc<OptionStringifiedSourceMap> {
         self.own_content().generate_source_map()
     }
 }

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -9,7 +9,7 @@ use turbopack_core::{
     chunk::{ChunkItemExt, ChunkingContext, MinifyType, ModuleId},
     code_builder::{Code, CodeBuilder},
     output::OutputAsset,
-    source_map::{GenerateSourceMap, OptionSourceMap},
+    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap},
     version::{Version, VersionedContent},
 };
 use turbopack_ecmascript::{
@@ -131,7 +131,7 @@ impl EcmascriptBuildNodeChunkContent {
 #[turbo_tasks::value_impl]
 impl GenerateSourceMap for EcmascriptBuildNodeChunkContent {
     #[turbo_tasks::function]
-    fn generate_source_map(self: Vc<Self>) -> Vc<OptionSourceMap> {
+    fn generate_source_map(self: Vc<Self>) -> Vc<OptionStringifiedSourceMap> {
         self.code().generate_source_map()
     }
 }

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -9,7 +9,7 @@ use turbopack_core::{
     chunk::{ChunkItemExt, ChunkingContext, MinifyType, ModuleId},
     code_builder::{Code, CodeBuilder},
     output::OutputAsset,
-    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap},
+    source_map::{GenerateSourceMap, OptionStringifiedSourceMap},
     version::{Version, VersionedContent},
 };
 use turbopack_ecmascript::{

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -11,7 +11,7 @@ use turbopack_core::{
     code_builder::{Code, CodeBuilder},
     module_graph::ModuleGraph,
     output::{OutputAsset, OutputAssets},
-    source_map::{GenerateSourceMap, OptionSourceMap, SourceMapAsset},
+    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap, SourceMapAsset},
 };
 use turbopack_ecmascript::{chunk::EcmascriptChunkPlaceable, utils::StringifyJs};
 
@@ -217,7 +217,7 @@ impl Asset for EcmascriptBuildNodeEntryChunk {
 #[turbo_tasks::value_impl]
 impl GenerateSourceMap for EcmascriptBuildNodeEntryChunk {
     #[turbo_tasks::function]
-    fn generate_source_map(self: Vc<Self>) -> Vc<OptionSourceMap> {
+    fn generate_source_map(self: Vc<Self>) -> Vc<OptionStringifiedSourceMap> {
         self.code().generate_source_map()
     }
 }

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -11,7 +11,7 @@ use turbopack_core::{
     code_builder::{Code, CodeBuilder},
     module_graph::ModuleGraph,
     output::{OutputAsset, OutputAssets},
-    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap, SourceMapAsset},
+    source_map::{GenerateSourceMap, OptionStringifiedSourceMap, SourceMapAsset},
 };
 use turbopack_ecmascript::{chunk::EcmascriptChunkPlaceable, utils::StringifyJs};
 

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -11,7 +11,7 @@ use turbopack_core::{
     code_builder::{Code, CodeBuilder},
     ident::AssetIdent,
     output::{OutputAsset, OutputAssets},
-    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap, SourceMapAsset},
+    source_map::{GenerateSourceMap, OptionStringifiedSourceMap, SourceMapAsset},
 };
 use turbopack_ecmascript::utils::StringifyJs;
 use turbopack_ecmascript_runtime::RuntimeType;

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -11,7 +11,7 @@ use turbopack_core::{
     code_builder::{Code, CodeBuilder},
     ident::AssetIdent,
     output::{OutputAsset, OutputAssets},
-    source_map::{GenerateSourceMap, OptionSourceMap, SourceMapAsset},
+    source_map::{GenerateSourceMap, OptionSourceMap, OptionStringifiedSourceMap, SourceMapAsset},
 };
 use turbopack_ecmascript::utils::StringifyJs;
 use turbopack_ecmascript_runtime::RuntimeType;
@@ -148,7 +148,7 @@ impl Asset for EcmascriptBuildNodeRuntimeChunk {
 #[turbo_tasks::value_impl]
 impl GenerateSourceMap for EcmascriptBuildNodeRuntimeChunk {
     #[turbo_tasks::function]
-    fn generate_source_map(self: Vc<Self>) -> Vc<OptionSourceMap> {
+    fn generate_source_map(self: Vc<Self>) -> Vc<OptionStringifiedSourceMap> {
         self.code().generate_source_map()
     }
 }

--- a/turbopack/crates/turbopack/benches/node_file_trace.rs
+++ b/turbopack/crates/turbopack/benches/node_file_trace.rs
@@ -121,7 +121,7 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
 
                 let emit_op =
                     emit_with_completion_operation(ResolvedVc::upcast(rebased), output_dir);
-                emit_op.connect().strongly_consistent().await?;
+                emit_op.read_strongly_consistent().await?;
                 apply_effects(emit_op).await?;
 
                 Ok::<Vc<()>, _>(Default::default())

--- a/turbopack/crates/turbopack/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack/tests/node-file-trace.rs
@@ -468,7 +468,7 @@ fn node_file_trace<B: Backend + 'static>(
 
                 let emit_op =
                     emit_with_completion_operation(ResolvedVc::upcast(rebased), output_dir);
-                emit_op.connect().strongly_consistent().await?;
+                emit_op.read_strongly_consistent().await?;
                 apply_effects(emit_op).await?;
 
                 #[cfg(not(feature = "bench_against_node_nft"))]


### PR DESCRIPTION
Store sourcemaps JSON-serialized (as opposed to structs containing arrays of decoded mappings), which is more memory efficient (and the main operation we perform is concatenation anyway, lookups are only used for error message locations)

This will also deduplicate sourcemaps (because cloning a `Rope` is just a reference-counted pointer).

```
testing against 0293c96cf32

canary e5fc495e3d
19,1 GB
TURBO_ENGINE_READ_ONLY=1 NEXT_TURBOPACK_TRACING= TURBOPACK=1 TURBOPACK_BUILD=  526.06s user 87.43s system 853% cpu 1:11.91 total
TURBO_ENGINE_READ_ONLY=1 NEXT_TURBOPACK_TRACING= TURBOPACK=1 TURBOPACK_BUILD=  510.69s user 82.93s system 835% cpu 1:11.06 total

sourcemap-rope 2dc238215a
16.94 GB

TURBO_ENGINE_READ_ONLY=1 NEXT_TURBOPACK_TRACING= TURBOPACK=1 TURBOPACK_BUILD=  535.61s user 85.04s system 855% cpu 1:12.55 total
TURBO_ENGINE_READ_ONLY=1 NEXT_TURBOPACK_TRACING= TURBOPACK=1 TURBOPACK_BUILD=  531.07s user 82.25s system 861% cpu 1:11.22 total
```


Closes PACK-3947