### PR TITLE
[dev-overlay] fix link styling on hydration errors

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.tsx
@@ -206,8 +206,6 @@ export const styles = css`
     bottom: calc(var(--size-gap-double) * 4.5);
   }
   p.nextjs__container_errors__link {
-    color: var(--color-red-900);
-    font-weight: 600;
     font-size: 14px;
   }
   p.nextjs__container_errors__notes {


### PR DESCRIPTION
Fix the link style to match the design

#### After

<img width="707" alt="image" src="https://github.com/user-attachments/assets/a9734833-8e28-4bfd-9155-b39a06fc275c" />

#### Before
<img width="693" alt="image" src="https://github.com/user-attachments/assets/a089af37-e8b0-490c-842c-f4fa9bca9275" />
