### PR TITLE
Allow `"use cache"` with `output: 'export'`

### DIFF
--- a/test/e2e/app-dir/use-cache-output-export/app/layout.tsx
+++ b/test/e2e/app-dir/use-cache-output-export/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/use-cache-output-export/app/page.tsx
+++ b/test/e2e/app-dir/use-cache-output-export/app/page.tsx
@@ -1,0 +1,9 @@
+'use cache'
+
+export default async function Page() {
+  const data = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random'
+  ).then((response) => response.text())
+
+  return <p>{data}</p>
+}

--- a/test/e2e/app-dir/use-cache-output-export/next.config.js
+++ b/test/e2e/app-dir/use-cache-output-export/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    useCache: true,
+  },
+  output: 'export',
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/use-cache-output-export/use-cache-output-export.test.ts
+++ b/test/e2e/app-dir/use-cache-output-export/use-cache-output-export.test.ts
@@ -11,8 +11,9 @@ describe('use-cache-output-export', () => {
   })
 
   if (process.env.__NEXT_EXPERIMENTAL_PPR === 'true') {
-    // PPR is not compatible with `output: 'export'`.
-    return
+    return it.skip('for PPR', () => {
+      // PPR is not compatible with `output: 'export'`.
+    })
   }
 
   it('should work', async () => {

--- a/test/e2e/app-dir/use-cache-output-export/use-cache-output-export.test.ts
+++ b/test/e2e/app-dir/use-cache-output-export/use-cache-output-export.test.ts
@@ -10,6 +10,11 @@ describe('use-cache-output-export', () => {
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })
 
+  if (process.env.__NEXT_EXPERIMENTAL_PPR === 'true') {
+    // PPR is not compatible with `output: 'export'`.
+    return
+  }
+
   it('should work', async () => {
     let html: string
     let server: Server | undefined

--- a/test/e2e/app-dir/use-cache-output-export/use-cache-output-export.test.ts
+++ b/test/e2e/app-dir/use-cache-output-export/use-cache-output-export.test.ts
@@ -1,0 +1,37 @@
+import { nextTestSetup } from 'e2e-utils'
+import { renderViaHTTP, startCleanStaticServer } from 'next-test-utils'
+import { join } from 'path'
+import { AddressInfo, Server } from 'net'
+
+describe('use-cache-output-export', () => {
+  const { next, isNextStart } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    skipStart: process.env.NEXT_TEST_MODE !== 'dev',
+  })
+
+  it('should work', async () => {
+    let html: string
+    let server: Server | undefined
+
+    if (isNextStart) {
+      const { cliOutput } = await next.build()
+
+      expect(cliOutput).not.toInclude(
+        'Server Actions are not supported with static export.'
+      )
+
+      server = await startCleanStaticServer(join(next.testDir, 'out'))
+      const { port } = server.address() as AddressInfo
+      html = await renderViaHTTP(port, '/')
+    } else {
+      html = await next.render('/')
+    }
+
+    expect(html).toMatch(/<p>[0,1]\.\d+<\/p>/)
+
+    if (server) {
+      await new Promise((resolve) => server.close(resolve))
+    }
+  })
+})


### PR DESCRIPTION
Previously, when using `"use cache"` together with `output: 'export'`, we were failing the build with the error `Server Actions are not supported with static export.`

Now, instead of failing the build with any entry in the server reference manifest, we only fail the build if the manifest includes a server action, and allow the presence of server references for `"use cache"` functions. We can differentiate those by looking at the server reference information byte at the start of the server reference ID.

Notably, we're currently not preventing a user from using a `"use cache"` function on the client. This would result in an error at runtime.

closes NAR-77