### PR TITLE
Improve hydration diff view

### DIFF
--- a/packages/next/src/client/components/errors/attach-hydration-error-state.ts
+++ b/packages/next/src/client/components/errors/attach-hydration-error-state.ts
@@ -1,6 +1,6 @@
 import {
-  isHydrationError,
   getDefaultHydrationErrorMessage,
+  testReactHydrationWarning,
 } from '../is-hydration-error'
 import {
   hydrationErrorState,
@@ -8,39 +8,50 @@ import {
 } from './hydration-error-info'
 
 export function attachHydrationErrorState(error: Error) {
-  if (
-    isHydrationError(error) &&
-    !error.message.includes(
-      'https://nextjs.org/docs/messages/react-hydration-error'
-    )
-  ) {
-    const reactHydrationDiffSegments = getReactHydrationDiffSegments(
-      error.message
-    )
-    let parsedHydrationErrorState: typeof hydrationErrorState = {}
-    if (reactHydrationDiffSegments) {
+  const reactHydrationDiffSegments = getReactHydrationDiffSegments(
+    error.message
+  )
+  let parsedHydrationErrorState: typeof hydrationErrorState = {}
+  const isHydrationWarning = testReactHydrationWarning(error.message)
+  // If the reactHydrationDiffSegments exists
+  // and the diff (reactHydrationDiffSegments[1]) exists
+  // e.g. the hydration diff log error.
+  if (reactHydrationDiffSegments && reactHydrationDiffSegments[1]) {
+    parsedHydrationErrorState = {
+      ...(error as any).details,
+      ...hydrationErrorState,
+      warning: hydrationErrorState.warning || [
+        getDefaultHydrationErrorMessage(),
+      ],
+      notes: isHydrationWarning ? '' : reactHydrationDiffSegments[0],
+      reactOutputComponentDiff: reactHydrationDiffSegments[1],
+    }
+    // Cache the `reactOutputComponentDiff` into hydrationErrorState.
+    // This is only required for now when we still squashed the hydration diff log into hydration error.
+    // Once the all error is logged to dev overlay in order, this will go away.
+    hydrationErrorState.reactOutputComponentDiff =
+      parsedHydrationErrorState.reactOutputComponentDiff
+  } else {
+    // Normal runtime error, where it doesn't contain the hydration diff.
+
+    // If there's any extra information in the error message to display,
+    // append it to the error message details property
+    if (hydrationErrorState.warning) {
+      // The patched console.error found hydration errors logged by React
+      // Append the logged warning to the error message
       parsedHydrationErrorState = {
         ...(error as any).details,
+        // It contains the warning, component stack, server and client tag names
         ...hydrationErrorState,
-        warning: hydrationErrorState.warning || [
-          getDefaultHydrationErrorMessage(),
-        ],
-        notes: reactHydrationDiffSegments[0],
-        reactOutputComponentDiff: reactHydrationDiffSegments[1],
-      }
-    } else {
-      // If there's any extra information in the error message to display,
-      // append it to the error message details property
-      if (hydrationErrorState.warning) {
-        // The patched console.error found hydration errors logged by React
-        // Append the logged warning to the error message
-        parsedHydrationErrorState = {
-          ...(error as any).details,
-          // It contains the warning, component stack, server and client tag names
-          ...hydrationErrorState,
-        }
       }
     }
-    ;(error as any).details = parsedHydrationErrorState
+    // Consume the cached hydration diff.
+    // This is only required for now when we still squashed the hydration diff log into hydration error.
+    // Once the all error is logged to dev overlay in order, this will go away.
+    if (hydrationErrorState.reactOutputComponentDiff) {
+      parsedHydrationErrorState.reactOutputComponentDiff =
+        hydrationErrorState.reactOutputComponentDiff
+    }
   }
+  ;(error as any).details = parsedHydrationErrorState
 }

--- a/packages/next/src/client/components/errors/hydration-error-info.ts
+++ b/packages/next/src/client/components/errors/hydration-error-info.ts
@@ -31,8 +31,6 @@ const textAndTagsMismatchWarnings = new Set([
   'Warning: Expected server HTML to contain a matching text node for "%s" in <%s>.%s',
   'Warning: Did not expect server HTML to contain the text node "%s" in <%s>.%s',
 ])
-// const textMismatchWarning =
-//   'Warning: Text content did not match. Server: "%s" Client: "%s"%s'
 
 export const getHydrationWarningType = (
   message: NullableText
@@ -55,27 +53,8 @@ export const getHydrationWarningType = (
 
 const isHtmlTagsWarning = (message: string) => htmlTagsWarnings.has(message)
 
-// const isTextMismatchWarning = (message: string) =>
-//   textMismatchWarning === message
 const isTextInTagsMismatchWarning = (msg: string) =>
   textAndTagsMismatchWarnings.has(msg)
-
-// const isKnownHydrationWarning = (message: NullableText) => {
-//   if (typeof message !== 'string') {
-//     return false
-//   }
-//   // React 18 has the `Warning: ` prefix.
-//   // React 19 does not.
-//   const normalizedMessage = message.startsWith('Warning: ')
-//     ? message
-//     : `Warning: ${message}`
-
-//   return (
-//     isHtmlTagsWarning(normalizedMessage) ||
-//     isTextInTagsMismatchWarning(normalizedMessage) ||
-//     isTextMismatchWarning(normalizedMessage)
-//   )
-// }
 
 export const getReactHydrationDiffSegments = (msg: NullableText) => {
   if (msg) {

--- a/packages/next/src/client/components/errors/hydration-error-info.ts
+++ b/packages/next/src/client/components/errors/hydration-error-info.ts
@@ -90,16 +90,100 @@ export const getReactHydrationDiffSegments = (msg: NullableText) => {
  */
 
 export function storeHydrationErrorStateFromConsoleArgs(...args: any[]) {
-  const [msg, serverContent, clientContent, componentStack] = args
+  let [msg, firstContent, secondContent, ...rest] = args
   if (isKnownHydrationWarning(msg)) {
-    hydrationErrorState.warning = [
+    // Some hydration warnings has 4 arguments, some has 3, fallback to the last argument
+    // when the 3rd argument is not the component stack but an empty string
+    const isReact18 = msg.startsWith('Warning: ')
+
+    // For some warnings, there's only 1 argument for template.
+    // The second argument is the diff or component stack.
+    if (args.length === 3) {
+      secondContent = ''
+    }
+
+    const warning: [string, string, string] = [
       // remove the last %s from the message
       msg,
-      serverContent,
-      clientContent,
+      firstContent,
+      secondContent,
     ]
-    hydrationErrorState.componentStack = componentStack
-    hydrationErrorState.serverContent = serverContent
-    hydrationErrorState.clientContent = clientContent
+
+    const lastArg = (rest[rest.length - 1] || '').trim()
+    if (!isReact18) {
+      hydrationErrorState.reactOutputComponentDiff = lastArg
+    } else {
+      hydrationErrorState.reactOutputComponentDiff =
+        generateHydrationDiffReact18(firstContent, secondContent, lastArg)
+    }
+
+    hydrationErrorState.warning = warning
+    hydrationErrorState.serverContent = firstContent
+    hydrationErrorState.clientContent = secondContent
   }
+}
+
+/*
+ * Some hydration errors in React 18 does not have the diff in the error message.
+ * Instead it has the error stack trace which is component stack that we can leverage.
+ * Will parse the diff from the error stack trace
+ *  e.g.
+ *  Warning: Expected server HTML to contain a matching <div> in <p>.
+ *    at div
+ *    at p
+ *    at div
+ *    at div
+ *    at Page
+ *  output:
+ *    <Page>
+ *      <div>
+ *        <p>
+ *  >       <div>
+ */
+function generateHydrationDiffReact18(
+  firstContent: string,
+  secondContent: string,
+  lastArg: string
+) {
+  const componentStack = lastArg
+  let firstIndex = -1
+  let secondIndex = -1
+
+  // at div\n at Foo\n at Bar (....)\n -> [div, Foo]
+  const components = componentStack
+    .split('\n')
+    // .reverse()
+    .map((line: string, index: number) => {
+      // `<space>at <component> (<location>)` -> `at <component> (<location>)`
+      line = line.trim()
+      // extract `<space>at <component>` to `<<component>>`
+      // e.g. `  at Foo` -> `<Foo>`
+      const [, component, location] = /at (\w+)( \((.*)\))?/.exec(line) || []
+      // If there's no location then it's user-land stack frame
+      if (!location) {
+        if (component === firstContent && firstIndex === -1) {
+          firstIndex = index
+        } else if (component === secondContent && secondIndex === -1) {
+          secondIndex = index
+        }
+      }
+      return location ? '' : component
+    })
+    .filter(Boolean)
+    .reverse()
+
+  let diff = ''
+  for (let i = 0; i < components.length; i++) {
+    const component = components[i]
+    const matchFirstContent = i === components.length - firstIndex - 1
+    const matchSecondContent = i === components.length - secondIndex - 1
+    if (matchFirstContent || matchSecondContent) {
+      const spaces = ' '.repeat(Math.max(i * 2 - 2, 0) + 2)
+      diff += `> ${spaces}<${component}>\n`
+    } else {
+      const spaces = ' '.repeat(i * 2 + 2)
+      diff += `${spaces}<${component}>\n`
+    }
+  }
+  return diff
 }

--- a/packages/next/src/client/components/errors/hydration-error-info.ts
+++ b/packages/next/src/client/components/errors/hydration-error-info.ts
@@ -1,4 +1,7 @@
-import { getHydrationErrorStackInfo } from '../is-hydration-error'
+import {
+  getHydrationErrorStackInfo,
+  testReactHydrationWarning,
+} from '../is-hydration-error'
 
 export type HydrationErrorState = {
   // Hydration warning template format: <message> <serverContent> <clientContent>
@@ -28,8 +31,8 @@ const textAndTagsMismatchWarnings = new Set([
   'Warning: Expected server HTML to contain a matching text node for "%s" in <%s>.%s',
   'Warning: Did not expect server HTML to contain the text node "%s" in <%s>.%s',
 ])
-const textMismatchWarning =
-  'Warning: Text content did not match. Server: "%s" Client: "%s"%s'
+// const textMismatchWarning =
+//   'Warning: Text content did not match. Server: "%s" Client: "%s"%s'
 
 export const getHydrationWarningType = (
   message: NullableText
@@ -52,27 +55,27 @@ export const getHydrationWarningType = (
 
 const isHtmlTagsWarning = (message: string) => htmlTagsWarnings.has(message)
 
-const isTextMismatchWarning = (message: string) =>
-  textMismatchWarning === message
+// const isTextMismatchWarning = (message: string) =>
+//   textMismatchWarning === message
 const isTextInTagsMismatchWarning = (msg: string) =>
   textAndTagsMismatchWarnings.has(msg)
 
-const isKnownHydrationWarning = (message: NullableText) => {
-  if (typeof message !== 'string') {
-    return false
-  }
-  // React 18 has the `Warning: ` prefix.
-  // React 19 does not.
-  const normalizedMessage = message.startsWith('Warning: ')
-    ? message
-    : `Warning: ${message}`
+// const isKnownHydrationWarning = (message: NullableText) => {
+//   if (typeof message !== 'string') {
+//     return false
+//   }
+//   // React 18 has the `Warning: ` prefix.
+//   // React 19 does not.
+//   const normalizedMessage = message.startsWith('Warning: ')
+//     ? message
+//     : `Warning: ${message}`
 
-  return (
-    isHtmlTagsWarning(normalizedMessage) ||
-    isTextInTagsMismatchWarning(normalizedMessage) ||
-    isTextMismatchWarning(normalizedMessage)
-  )
-}
+//   return (
+//     isHtmlTagsWarning(normalizedMessage) ||
+//     isTextInTagsMismatchWarning(normalizedMessage) ||
+//     isTextMismatchWarning(normalizedMessage)
+//   )
+// }
 
 export const getReactHydrationDiffSegments = (msg: NullableText) => {
   if (msg) {
@@ -91,7 +94,7 @@ export const getReactHydrationDiffSegments = (msg: NullableText) => {
 
 export function storeHydrationErrorStateFromConsoleArgs(...args: any[]) {
   let [msg, firstContent, secondContent, ...rest] = args
-  if (isKnownHydrationWarning(msg)) {
+  if (testReactHydrationWarning(msg)) {
     // Some hydration warnings has 4 arguments, some has 3, fallback to the last argument
     // when the 3rd argument is not the component stack but an empty string
     const isReact18 = msg.startsWith('Warning: ')

--- a/packages/next/src/client/components/is-hydration-error.ts
+++ b/packages/next/src/client/components/is-hydration-error.ts
@@ -25,18 +25,24 @@ export function isReactHydrationErrorMessage(msg: string): boolean {
 }
 
 const hydrationWarningRegexes = [
-  /In HTML, (.+?) cannot be a child of <(.+?)>\.(.*)\nThis will cause a hydration error\.(.*)/,
-  /In HTML, (.+?) cannot be a descendant of <(.+?)>\.\nThis will cause a hydration error\.(.*)/,
-  /In HTML, text nodes cannot be a child of <(.+?)>\.\nThis will cause a hydration error\./,
-  /In HTML, whitespace text nodes cannot be a child of <(.+?)>\. Make sure you don't have any extra whitespace between tags on each line of your source code\.\nThis will cause a hydration error\./,
-  /Expected server HTML to contain a matching <(.+?)> in <(.+?)>\.(.*)/,
-  /Did not expect server HTML to contain a <(.+?)> in <(.+?)>\.(.*)/,
-  /Expected server HTML to contain a matching text node for "(.+?)" in <(.+?)>\.(.*)/,
-  /Did not expect server HTML to contain the text node "(.+?)" in <(.+?)>\.(.*)/,
-  /Text content did not match\. Server: "(.+?)" Client: "(.+?)"(.*)/,
+  /^In HTML, (.+?) cannot be a child of <(.+?)>\.(.*)\nThis will cause a hydration error\.(.*)/,
+  /^In HTML, (.+?) cannot be a descendant of <(.+?)>\.\nThis will cause a hydration error\.(.*)/,
+  /^In HTML, text nodes cannot be a child of <(.+?)>\.\nThis will cause a hydration error\./,
+  /^In HTML, whitespace text nodes cannot be a child of <(.+?)>\. Make sure you don't have any extra whitespace between tags on each line of your source code\.\nThis will cause a hydration error\./,
+  /^Expected server HTML to contain a matching <(.+?)> in <(.+?)>\.(.*)/,
+  /^Did not expect server HTML to contain a <(.+?)> in <(.+?)>\.(.*)/,
+  /^Expected server HTML to contain a matching text node for "(.+?)" in <(.+?)>\.(.*)/,
+  /^Did not expect server HTML to contain the text node "(.+?)" in <(.+?)>\.(.*)/,
+  /^Text content did not match\. Server: "(.+?)" Client: "(.+?)"(.*)/,
 ]
 
 export function testReactHydrationWarning(msg: string): boolean {
+  if (!msg) return false
+  // React 18 has the `Warning: ` prefix.
+  // React 19 does not.
+  if (msg.startsWith('Warning: ')) {
+    msg = msg.slice('Warning: '.length)
+  }
   return hydrationWarningRegexes.some((regex) => regex.test(msg))
 }
 

--- a/packages/next/src/client/components/is-hydration-error.ts
+++ b/packages/next/src/client/components/is-hydration-error.ts
@@ -37,7 +37,7 @@ const hydrationWarningRegexes = [
 ]
 
 export function testReactHydrationWarning(msg: string): boolean {
-  if (typeof msg !== 'string' && msg) return false
+  if (typeof msg !== 'string' || !msg) return false
   // React 18 has the `Warning: ` prefix.
   // React 19 does not.
   if (msg.startsWith('Warning: ')) {

--- a/packages/next/src/client/components/is-hydration-error.ts
+++ b/packages/next/src/client/components/is-hydration-error.ts
@@ -24,6 +24,22 @@ export function isReactHydrationErrorMessage(msg: string): boolean {
   return reactHydrationStartMessages.some((prefix) => msg.startsWith(prefix))
 }
 
+const hydrationWarningRegexes = [
+  /In HTML, (.+?) cannot be a child of <(.+?)>\.(.*)\nThis will cause a hydration error\.(.*)/,
+  /In HTML, (.+?) cannot be a descendant of <(.+?)>\.\nThis will cause a hydration error\.(.*)/,
+  /In HTML, text nodes cannot be a child of <(.+?)>\.\nThis will cause a hydration error\./,
+  /In HTML, whitespace text nodes cannot be a child of <(.+?)>\. Make sure you don't have any extra whitespace between tags on each line of your source code\.\nThis will cause a hydration error\./,
+  /Expected server HTML to contain a matching <(.+?)> in <(.+?)>\.(.*)/,
+  /Did not expect server HTML to contain a <(.+?)> in <(.+?)>\.(.*)/,
+  /Expected server HTML to contain a matching text node for "(.+?)" in <(.+?)>\.(.*)/,
+  /Did not expect server HTML to contain the text node "(.+?)" in <(.+?)>\.(.*)/,
+  /Text content did not match\. Server: "(.+?)" Client: "(.+?)"(.*)/,
+]
+
+export function testReactHydrationWarning(msg: string): boolean {
+  return hydrationWarningRegexes.some((regex) => regex.test(msg))
+}
+
 export function getHydrationErrorStackInfo(rawMessage: string): {
   message: string | null
   link?: string
@@ -31,9 +47,28 @@ export function getHydrationErrorStackInfo(rawMessage: string): {
   diff?: string
 } {
   rawMessage = rawMessage.replace(/^Error: /, '')
-  if (!isReactHydrationErrorMessage(rawMessage)) {
-    return { message: null }
+  rawMessage = rawMessage.replace('Warning: ', '')
+  const isReactHydrationWarning = testReactHydrationWarning(rawMessage)
+
+  if (!isReactHydrationErrorMessage(rawMessage) && !isReactHydrationWarning) {
+    return {
+      message: null,
+      link: '',
+      stack: rawMessage,
+      diff: '',
+    }
   }
+
+  if (isReactHydrationWarning) {
+    const [message, diff] = rawMessage.split('\n\n')
+    return {
+      message: message.trim(),
+      link: reactHydrationErrorDocLink,
+      stack: '',
+      diff: diff.trim(),
+    }
+  }
+
   const firstLineBreak = rawMessage.indexOf('\n')
   rawMessage = rawMessage.slice(firstLineBreak + 1).trim()
 

--- a/packages/next/src/client/components/is-hydration-error.ts
+++ b/packages/next/src/client/components/is-hydration-error.ts
@@ -66,12 +66,12 @@ export function getHydrationErrorStackInfo(rawMessage: string): {
   }
 
   if (isReactHydrationWarning) {
-    const [message, diff] = rawMessage.split('\n\n')
+    const [message, diffLog] = rawMessage.split('\n\n')
     return {
       message: message.trim(),
       link: reactHydrationErrorDocLink,
       stack: '',
-      diff: diff.trim(),
+      diff: (diffLog || '').trim(),
     }
   }
 

--- a/packages/next/src/client/components/is-hydration-error.ts
+++ b/packages/next/src/client/components/is-hydration-error.ts
@@ -37,7 +37,7 @@ const hydrationWarningRegexes = [
 ]
 
 export function testReactHydrationWarning(msg: string): boolean {
-  if (!msg) return false
+  if (typeof msg !== 'string' && msg) return false
   // React 18 has the `Warning: ` prefix.
   // React 19 does not.
   if (msg.startsWith('Warning: ')) {

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.tsx
@@ -186,10 +186,9 @@ export function Errors({
         <PseudoHtmlDiff
           className="nextjs__container_errors__component-stack"
           hydrationMismatchType={hydrationErrorType}
-          componentStackFrames={activeError.componentStackFrames || []}
           firstContent={serverContent}
           secondContent={clientContent}
-          reactOutputComponentDiff={errorDetails.reactOutputComponentDiff}
+          reactOutputComponentDiff={errorDetails.reactOutputComponentDiff || ''}
         />
       ) : null}
       <RuntimeError

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/component-stack-pseudo-html.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/component-stack-pseudo-html.stories.tsx
@@ -13,28 +13,8 @@ const meta: Meta<typeof PseudoHtmlDiff> = {
 export default meta
 type Story = StoryObj<typeof PseudoHtmlDiff>
 
-const sampleComponentStack = [
-  {
-    component: 'div',
-    canOpenInEditor: false,
-  },
-  {
-    component: 'article',
-    canOpenInEditor: false,
-  },
-  {
-    component: 'main',
-    canOpenInEditor: false,
-  },
-  {
-    component: 'Home',
-    canOpenInEditor: false,
-  },
-]
-
 export const TextMismatch: Story = {
   args: {
-    componentStackFrames: sampleComponentStack,
     firstContent: 'Server rendered content',
     secondContent: 'Client rendered content',
     hydrationMismatchType: 'text',
@@ -44,7 +24,6 @@ export const TextMismatch: Story = {
 
 export const TextInTagMismatch: Story = {
   args: {
-    componentStackFrames: sampleComponentStack,
     firstContent: 'Mismatched content',
     secondContent: 'p',
     hydrationMismatchType: 'text-in-tag',
@@ -54,7 +33,6 @@ export const TextInTagMismatch: Story = {
 
 export const ReactUnifiedMismatch: Story = {
   args: {
-    componentStackFrames: sampleComponentStack,
     hydrationMismatchType: 'tag',
     reactOutputComponentDiff: `<Page>
   <Layout>

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/component-stack-pseudo-html.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/component-stack-pseudo-html.tsx
@@ -21,7 +21,7 @@ export const PSEUDO_HTML_DIFF_STYLES = css`
     line-height: calc(5 / 3);
   }
   [data-nextjs-container-errors-pseudo-html-line--error] {
-    background: var(--color-amber-300);
+    background: var(--color-amber-100);
     font-weight: bold;
   }
   [data-nextjs-container-errors-pseudo-html-collapse-button] {
@@ -53,7 +53,7 @@ export const PSEUDO_HTML_DIFF_STYLES = css`
   }
   [data-nextjs-container-errors-pseudo-html-line--error]
     [data-nextjs-container-errors-pseudo-html-line-sign] {
-    color: var(--color-red-900);
+    color: var(--color-amber-900);
   }
   ${/* hide but text are still accessible in DOM */ ''}
   [data-nextjs-container-errors-pseudo-html--hint] {

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/component-stack-pseudo-html.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/component-stack-pseudo-html.tsx
@@ -1,340 +1,6 @@
-import { useMemo, Fragment, useState } from 'react'
-import type { ComponentStackFrame } from '../../helpers/parse-component-stack'
-import { CollapseIcon } from '../../icons/collapse-icon'
 import { noop as css } from '../../helpers/noop-template'
 
-function getAdjacentProps(isAdj: boolean) {
-  return { 'data-nextjs-container-errors-pseudo-html--tag-adjacent': isAdj }
-}
-
-/**
- *
- * Format component stack into pseudo HTML
- * component stack is an array of strings, e.g.: ['p', 'p', 'Page', ...]
- *
- * For html tags mismatch, it will render it for the code block
- *
- * ```
- * <pre>
- *  <code>{`
- *    <Page>
- *       <p red>
- *         <p red>
- *  `}</code>
- * </pre>
- * ```
- *
- * For text mismatch, it will render it for the code block
- *
- * ```
- * <pre>
- * <code>{`
- *   <Page>
- *     <p>
- *       "Server Text" (green)
- *       "Client Text" (red)
- *     </p>
- *   </Page>
- * `}</code>
- * ```
- *
- * For bad text under a tag it will render it for the code block,
- * e.g. "Mismatched Text" under <p>
- *
- * ```
- * <pre>
- * <code>{`
- *   <Page>
- *     <div>
- *       <p>
- *         "Mismatched Text" (red)
- *      </p>
- *     </div>
- *   </Page>
- * `}</code>
- * ```
- *
- */
-export function PseudoHtmlDiff({
-  componentStackFrames,
-  firstContent,
-  secondContent,
-  hydrationMismatchType,
-  reactOutputComponentDiff,
-  ...props
-}: {
-  componentStackFrames: ComponentStackFrame[]
-  firstContent: string
-  secondContent: string
-  reactOutputComponentDiff: string | undefined
-  hydrationMismatchType: 'tag' | 'text' | 'text-in-tag'
-} & React.HTMLAttributes<HTMLPreElement>) {
-  const isHtmlTagsWarning = hydrationMismatchType === 'tag'
-  const isReactHydrationDiff = !!reactOutputComponentDiff
-
-  // For text mismatch, mismatched text will take 2 rows, so we display 4 rows of component stack
-  const MAX_NON_COLLAPSED_FRAMES = isHtmlTagsWarning ? 6 : 4
-  const [isHtmlCollapsed, toggleCollapseHtml] = useState(true)
-
-  const htmlComponents = useMemo(() => {
-    const componentStacks: React.ReactNode[] = []
-    // React 19 unified mismatch
-    if (isReactHydrationDiff) {
-      let currentComponentIndex = componentStackFrames.length - 1
-      const reactComponentDiffLines = reactOutputComponentDiff.split('\n')
-      const diffHtmlStack: React.ReactNode[] = []
-      reactComponentDiffLines.forEach((line, index) => {
-        let trimmedLine = line.trim()
-        const isDiffLine = trimmedLine[0] === '+' || trimmedLine[0] === '-'
-        const spaces = ' '.repeat(Math.max(componentStacks.length * 2, 1))
-
-        if (isDiffLine) {
-          const sign = trimmedLine[0]
-          trimmedLine = trimmedLine.slice(1).trim() // trim spaces after sign
-          diffHtmlStack.push(
-            <span
-              key={'comp-diff' + index}
-              data-nextjs-container-errors-pseudo-html-line
-              data-nextjs-container-errors-pseudo-html--diff={
-                sign === '+' ? 'add' : 'remove'
-              }
-            >
-              <span>
-                {/* Slice 2 spaces for the icon */}
-                {spaces.slice(2)}
-                {trimmedLine}
-                {'\n'}
-              </span>
-            </span>
-          )
-        } else if (currentComponentIndex >= 0) {
-          const isUserLandComponent = trimmedLine.startsWith(
-            '<' + componentStackFrames[currentComponentIndex].component
-          )
-          // If it's matched userland component or it's ... we will keep the component stack in diff
-          if (isUserLandComponent || trimmedLine === '...') {
-            currentComponentIndex--
-            componentStacks.push(
-              <span
-                data-nextjs-container-errors-pseudo-html-line
-                key={'comp-diff' + index}
-              >
-                {spaces}
-                {trimmedLine}
-                {'\n'}
-              </span>
-            )
-          } else if (!isHtmlCollapsed) {
-            componentStacks.push(
-              <span
-                data-nextjs-container-errors-pseudo-html-line
-                key={'comp-diff' + index}
-              >
-                {spaces}
-                {trimmedLine}
-                {'\n'}
-              </span>
-            )
-          }
-        } else if (!isHtmlCollapsed) {
-          // In general, if it's not collapsed, show the whole diff
-          componentStacks.push(
-            <span
-              data-nextjs-container-errors-pseudo-html-line
-              key={'comp-diff' + index}
-            >
-              {spaces}
-              {trimmedLine}
-              {'\n'}
-            </span>
-          )
-        }
-      })
-      return componentStacks.concat(diffHtmlStack)
-    }
-
-    const nestedHtmlStack: React.ReactNode[] = []
-    const tagNames = isHtmlTagsWarning
-      ? // tags could have < or > in the name, so we always remove them to match
-        [firstContent.replace(/<|>/g, ''), secondContent.replace(/<|>/g, '')]
-      : []
-
-    let lastText = ''
-
-    const componentStack = componentStackFrames
-      .map((frame) => frame.component)
-      .reverse()
-
-    // [child index, parent index]
-    const matchedIndex = [-1, -1]
-    if (isHtmlTagsWarning) {
-      // Reverse search for the child tag
-      for (let i = componentStack.length - 1; i >= 0; i--) {
-        if (componentStack[i] === tagNames[0]) {
-          matchedIndex[0] = i
-          break
-        }
-      }
-      // Start searching parent tag from child tag above
-      for (let i = matchedIndex[0] - 1; i >= 0; i--) {
-        if (componentStack[i] === tagNames[1]) {
-          matchedIndex[1] = i
-          break
-        }
-      }
-    }
-
-    componentStack.forEach((component, index, componentList) => {
-      const spaces = ' '.repeat(nestedHtmlStack.length * 2)
-
-      // When component is the server or client tag name, highlight it
-      const isHighlightedTag = isHtmlTagsWarning
-        ? index === matchedIndex[0] || index === matchedIndex[1]
-        : tagNames.includes(component)
-      const isAdjacentTag =
-        isHighlightedTag ||
-        Math.abs(index - matchedIndex[0]) <= 1 ||
-        Math.abs(index - matchedIndex[1]) <= 1
-
-      const isLastFewFrames =
-        !isHtmlTagsWarning && index >= componentList.length - 6
-
-      const adjProps = getAdjacentProps(isAdjacentTag)
-
-      if ((isHtmlTagsWarning && isAdjacentTag) || isLastFewFrames) {
-        const codeLine = (
-          <span
-            data-nextjs-container-errors-pseudo-html-line
-            {...(isHighlightedTag
-              ? {
-                  'data-nextjs-container-errors-pseudo-html-line--error': true,
-                }
-              : undefined)}
-          >
-            {spaces}
-            <span {...adjProps}>{`<${component}>\n`}</span>
-          </span>
-        )
-        lastText = component
-
-        const wrappedCodeLine = (
-          <Fragment key={nestedHtmlStack.length}>
-            {codeLine}
-            {/* Add ^^^^ to the target tags used for snapshots but not displayed for users */}
-            {isHighlightedTag && (
-              <span data-nextjs-container-errors-pseudo-html--hint>
-                {spaces + '^'.repeat(component.length + 2) + '\n'}
-              </span>
-            )}
-          </Fragment>
-        )
-        nestedHtmlStack.push(wrappedCodeLine)
-      } else {
-        if (
-          nestedHtmlStack.length >= MAX_NON_COLLAPSED_FRAMES &&
-          isHtmlCollapsed
-        ) {
-          return
-        }
-
-        if (!isHtmlCollapsed || isLastFewFrames) {
-          nestedHtmlStack.push(
-            <span
-              {...adjProps}
-              key={nestedHtmlStack.length}
-              data-nextjs-container-errors-pseudo-html-line
-            >
-              {spaces}
-              {'<' + component + '>\n'}
-            </span>
-          )
-        } else if (isHtmlCollapsed && lastText !== '...') {
-          lastText = '...'
-          nestedHtmlStack.push(
-            <span
-              {...adjProps}
-              key={nestedHtmlStack.length}
-              data-nextjs-container-errors-pseudo-html-line
-            >
-              {spaces}
-              {'...\n'}
-            </span>
-          )
-        }
-      }
-    })
-    // Hydration mismatch: text or text-tag
-    if (!isHtmlTagsWarning) {
-      const spaces = ' '.repeat(nestedHtmlStack.length * 2)
-      let wrappedCodeLine
-      if (hydrationMismatchType === 'text') {
-        // hydration type is "text", represent [server content, client content]
-        wrappedCodeLine = (
-          <Fragment key={nestedHtmlStack.length}>
-            <span
-              data-nextjs-container-errors-pseudo-html-line
-              data-nextjs-container-errors-pseudo-html--diff="remove"
-            >
-              {spaces + `"${firstContent}"\n`}
-            </span>
-            <span
-              data-nextjs-container-errors-pseudo-html-line
-              data-nextjs-container-errors-pseudo-html--diff="add"
-            >
-              {spaces + `"${secondContent}"\n`}
-            </span>
-          </Fragment>
-        )
-      } else if (hydrationMismatchType === 'text-in-tag') {
-        // hydration type is "text-in-tag", represent [parent tag, mismatch content]
-        wrappedCodeLine = (
-          <Fragment key={nestedHtmlStack.length}>
-            <span
-              data-nextjs-container-errors-pseudo-html-line
-              data-nextjs-container-errors-pseudo-html--tag-adjacent
-            >
-              {spaces + `<${secondContent}>\n`}
-            </span>
-            <span
-              data-nextjs-container-errors-pseudo-html-line
-              data-nextjs-container-errors-pseudo-html--diff="remove"
-            >
-              {spaces + `  "${firstContent}"\n`}
-            </span>
-          </Fragment>
-        )
-      }
-      nestedHtmlStack.push(wrappedCodeLine)
-    }
-
-    return nestedHtmlStack
-  }, [
-    componentStackFrames,
-    isHtmlCollapsed,
-    firstContent,
-    secondContent,
-    isHtmlTagsWarning,
-    hydrationMismatchType,
-    MAX_NON_COLLAPSED_FRAMES,
-    isReactHydrationDiff,
-    reactOutputComponentDiff,
-  ])
-
-  return (
-    <div data-nextjs-container-errors-pseudo-html>
-      <button
-        tabIndex={10} // match CallStackFrame
-        data-nextjs-container-errors-pseudo-html-collapse
-        onClick={() => toggleCollapseHtml(!isHtmlCollapsed)}
-      >
-        <CollapseIcon collapsed={isHtmlCollapsed} />
-      </button>
-      <pre {...props}>
-        <code>{htmlComponents}</code>
-      </pre>
-    </div>
-  )
-}
+export { PseudoHtmlDiff } from '../../../../hydration-diff/diff-view'
 
 export const PSEUDO_HTML_DIFF_STYLES = css`
   [data-nextjs-container-errors-pseudo-html] {
@@ -358,16 +24,7 @@ export const PSEUDO_HTML_DIFF_STYLES = css`
     background: var(--color-amber-300);
     font-weight: bold;
   }
-  [data-nextjs-container-errors-pseudo-html-line--error]::before {
-    content: '>';
-    color: var(--color-red-900);
-    float: left;
-    width: 0;
-    margin-left: calc(var(--size-6) * -1);
-    margin-right: var(--size-8);
-  }
-
-  [data-nextjs-container-errors-pseudo-html-collapse] {
+  [data-nextjs-container-errors-pseudo-html-collapse-button] {
     all: unset;
     margin-left: var(--size-3);
     &:focus {
@@ -377,24 +34,26 @@ export const PSEUDO_HTML_DIFF_STYLES = css`
   [data-nextjs-container-errors-pseudo-html--diff='add'] {
     background: var(--color-green-300);
   }
-  [data-nextjs-container-errors-pseudo-html--diff='add']::before {
-    content: '+';
-    color: var(--color-green-900);
-    float: left;
-    width: 0;
+  [data-nextjs-container-errors-pseudo-html-line-sign] {
     margin-left: calc(var(--size-6) * -1);
-    margin-right: var(--size-8);
+    margin-right: var(--size-6);
+  }
+  [data-nextjs-container-errors-pseudo-html--diff='add']
+    [data-nextjs-container-errors-pseudo-html-line-sign] {
+    color: var(--color-green-900);
   }
   [data-nextjs-container-errors-pseudo-html--diff='remove'] {
     background: var(--color-red-300);
   }
-  [data-nextjs-container-errors-pseudo-html--diff='remove']::before {
-    content: '-';
+  [data-nextjs-container-errors-pseudo-html--diff='remove']
+    [data-nextjs-container-errors-pseudo-html-line-sign] {
     color: var(--color-red-900);
-    float: left;
-    width: 0;
     margin-left: calc(var(--size-6) * -1);
-    margin-right: var(--size-8);
+    margin-right: var(--size-6);
+  }
+  [data-nextjs-container-errors-pseudo-html-line--error]
+    [data-nextjs-container-errors-pseudo-html-line-sign] {
+    color: var(--color-red-900);
   }
   ${/* hide but text are still accessible in DOM */ ''}
   [data-nextjs-container-errors-pseudo-html--hint] {
@@ -408,10 +67,22 @@ export const PSEUDO_HTML_DIFF_STYLES = css`
   .nextjs__container_errors__component-stack {
     margin: 0;
   }
+  [data-nextjs-container-errors-pseudo-html-collapse='true']
+    .nextjs__container_errors__component-stack
+    code {
+    max-height: 100px;
+    mask-image: linear-gradient(to top, rgba(0, 0, 0, 0) 0%, black 50%);
+  }
   .nextjs__container_errors__component-stack code {
     display: block;
     width: 100%;
     white-space: pre-wrap;
+    scroll-snap-type: y mandatory;
+    overflow-y: hidden;
+  }
+  [data-nextjs-container-errors-pseudo-html--diff],
+  [data-nextjs-container-errors-pseudo-html-line--error] {
+    scroll-snap-align: center;
   }
   .error-overlay-hydration-error-diff-plus-icon {
     color: var(--color-green-900);

--- a/packages/next/src/client/components/react-dev-overlay/hydration-diff/diff-view.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/hydration-diff/diff-view.tsx
@@ -1,0 +1,142 @@
+import { useMemo, useState } from 'react'
+import { CollapseIcon } from '../internal/icons/CollapseIcon'
+
+/**
+ *
+ * Format component stack into pseudo HTML
+ * component stack is an array of strings, e.g.: ['p', 'p', 'Page', ...]
+ *
+ * For html tags mismatch, it will render it for the code block
+ *
+ * ```
+ * <pre>
+ *  <code>{`
+ *    <Page>
+ *       <p red>
+ *         <p red>
+ *  `}</code>
+ * </pre>
+ * ```
+ *
+ * For text mismatch, it will render it for the code block
+ *
+ * ```
+ * <pre>
+ * <code>{`
+ *   <Page>
+ *     <p>
+ *       "Server Text" (green)
+ *       "Client Text" (red)
+ *     </p>
+ *   </Page>
+ * `}</code>
+ * ```
+ *
+ * For bad text under a tag it will render it for the code block,
+ * e.g. "Mismatched Text" under <p>
+ *
+ * ```
+ * <pre>
+ * <code>{`
+ *   <Page>
+ *     <div>
+ *       <p>
+ *         "Mismatched Text" (red)
+ *      </p>
+ *     </div>
+ *   </Page>
+ * `}</code>
+ * ```
+ *
+ */
+export function PseudoHtmlDiff({
+  firstContent,
+  secondContent,
+  hydrationMismatchType,
+  reactOutputComponentDiff,
+  ...props
+}: {
+  firstContent: string
+  secondContent: string
+  reactOutputComponentDiff: string
+  hydrationMismatchType: 'tag' | 'text' | 'text-in-tag'
+} & React.HTMLAttributes<HTMLPreElement>) {
+  const [isDiffCollapsed, toggleCollapseHtml] = useState(true)
+
+  const htmlComponents = useMemo(() => {
+    const componentStacks: React.ReactNode[] = []
+    const reactComponentDiffLines = reactOutputComponentDiff!.split('\n')
+    reactComponentDiffLines.forEach((line, index) => {
+      let trimmedLine = line.trim()
+      const isDiffLine = trimmedLine[0] === '+' || trimmedLine[0] === '-'
+      const isHighlightedLine = trimmedLine[0] === '>'
+      const hasSign = isDiffLine || isHighlightedLine
+      const sign = hasSign ? trimmedLine[0] : ''
+      const signIndex = hasSign ? line.indexOf(sign) : -1
+      const [prefix, suffix] = hasSign
+        ? [line.slice(0, signIndex), line.slice(signIndex + 1)]
+        : [line, '']
+
+      if (isDiffLine) {
+        componentStacks.push(
+          <span
+            key={'comp-diff' + index}
+            data-nextjs-container-errors-pseudo-html-line
+            data-nextjs-container-errors-pseudo-html--diff={
+              sign === '+' ? 'add' : 'remove'
+            }
+          >
+            <span>
+              {/* Slice 2 spaces for the icon */}
+              {prefix}
+              <span data-nextjs-container-errors-pseudo-html-line-sign>
+                {sign}
+              </span>
+              {suffix}
+              {'\n'}
+            </span>
+          </span>
+        )
+      } else {
+        // In general, if it's not collapsed, show the whole diff
+        componentStacks.push(
+          <span
+            data-nextjs-container-errors-pseudo-html-line
+            key={'comp-diff' + index}
+            {...(isHighlightedLine
+              ? {
+                  'data-nextjs-container-errors-pseudo-html-line--error': true,
+                }
+              : undefined)}
+          >
+            {prefix}
+            <span data-nextjs-container-errors-pseudo-html-line-sign>
+              {sign}
+            </span>
+            {suffix}
+            {'\n'}
+          </span>
+        )
+      }
+    })
+    return componentStacks
+  }, [reactOutputComponentDiff])
+
+  return (
+    <div
+      data-nextjs-container-errors-pseudo-html
+      data-nextjs-container-errors-pseudo-html-collapse={isDiffCollapsed}
+    >
+      <button
+        tabIndex={10} // match CallStackFrame
+        data-nextjs-container-errors-pseudo-html-collapse-button
+        onClick={() => toggleCollapseHtml(!isDiffCollapsed)}
+      >
+        <CollapseIcon collapsed={isDiffCollapsed} />
+      </button>
+      <pre {...props}>
+        <code>{htmlComponents}</code>
+      </pre>
+    </div>
+  )
+}

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
@@ -386,10 +386,11 @@ export function Errors({
               <PseudoHtmlDiff
                 className="nextjs__container_errors__component-stack"
                 hydrationMismatchType={hydrationErrorType}
-                componentStackFrames={activeError.componentStackFrames || []}
                 firstContent={serverContent}
                 secondContent={clientContent}
-                reactOutputComponentDiff={errorDetails.reactOutputComponentDiff}
+                reactOutputComponentDiff={
+                  errorDetails.reactOutputComponentDiff || ''
+                }
               />
             ) : null}
             {isServerError ? (

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
@@ -1,309 +1,62 @@
-import { useMemo, Fragment, useState } from 'react'
-import type { ComponentStackFrame } from '../../helpers/parse-component-stack'
-import { CollapseIcon } from '../../icons/CollapseIcon'
+import { noop as css } from '../../helpers/noop-template'
 
-function getAdjacentProps(isAdj: boolean) {
-  return { 'data-nextjs-container-errors-pseudo-html--tag-adjacent': isAdj }
-}
+export { PseudoHtmlDiff } from '../../../hydration-diff/diff-view'
 
-/**
- *
- * Format component stack into pseudo HTML
- * component stack is an array of strings, e.g.: ['p', 'p', 'Page', ...]
- *
- * For html tags mismatch, it will render it for the code block
- *
- * ```
- * <pre>
- *  <code>{`
- *    <Page>
- *       <p red>
- *         <p red>
- *  `}</code>
- * </pre>
- * ```
- *
- * For text mismatch, it will render it for the code block
- *
- * ```
- * <pre>
- * <code>{`
- *   <Page>
- *     <p>
- *       "Server Text" (green)
- *       "Client Text" (red)
- *     </p>
- *   </Page>
- * `}</code>
- * ```
- *
- * For bad text under a tag it will render it for the code block,
- * e.g. "Mismatched Text" under <p>
- *
- * ```
- * <pre>
- * <code>{`
- *   <Page>
- *     <div>
- *       <p>
- *         "Mismatched Text" (red)
- *      </p>
- *     </div>
- *   </Page>
- * `}</code>
- * ```
- *
- */
-export function PseudoHtmlDiff({
-  componentStackFrames,
-  firstContent,
-  secondContent,
-  hydrationMismatchType,
-  reactOutputComponentDiff,
-  ...props
-}: {
-  componentStackFrames: ComponentStackFrame[]
-  firstContent: string
-  secondContent: string
-  reactOutputComponentDiff: string | undefined
-  hydrationMismatchType: 'tag' | 'text' | 'text-in-tag'
-} & React.HTMLAttributes<HTMLPreElement>) {
-  const isHtmlTagsWarning = hydrationMismatchType === 'tag'
-  const isReactHydrationDiff = !!reactOutputComponentDiff
-
-  // For text mismatch, mismatched text will take 2 rows, so we display 4 rows of component stack
-  const MAX_NON_COLLAPSED_FRAMES = isHtmlTagsWarning ? 6 : 4
-  const [isHtmlCollapsed, toggleCollapseHtml] = useState(true)
-
-  const htmlComponents = useMemo(() => {
-    const componentStacks: React.ReactNode[] = []
-    // React 19 unified mismatch
-    if (isReactHydrationDiff) {
-      let currentComponentIndex = componentStackFrames.length - 1
-      const reactComponentDiffLines = reactOutputComponentDiff.split('\n')
-      const diffHtmlStack: React.ReactNode[] = []
-      reactComponentDiffLines.forEach((line, index) => {
-        let trimmedLine = line.trim()
-        const isDiffLine = trimmedLine[0] === '+' || trimmedLine[0] === '-'
-        const spaces = ' '.repeat(Math.max(componentStacks.length * 2, 1))
-
-        if (isDiffLine) {
-          const sign = trimmedLine[0]
-          trimmedLine = trimmedLine.slice(1).trim() // trim spaces after sign
-          diffHtmlStack.push(
-            <span
-              key={'comp-diff' + index}
-              data-nextjs-container-errors-pseudo-html--diff={
-                sign === '+' ? 'add' : 'remove'
-              }
-            >
-              {sign}
-              {spaces}
-              {trimmedLine}
-              {'\n'}
-            </span>
-          )
-        } else if (currentComponentIndex >= 0) {
-          const isUserLandComponent = trimmedLine.startsWith(
-            '<' + componentStackFrames[currentComponentIndex].component
-          )
-          // If it's matched userland component or it's ... we will keep the component stack in diff
-          if (isUserLandComponent || trimmedLine === '...') {
-            currentComponentIndex--
-            componentStacks.push(
-              <span key={'comp-diff' + index}>
-                {spaces}
-                {trimmedLine}
-                {'\n'}
-              </span>
-            )
-          } else if (!isHtmlCollapsed) {
-            componentStacks.push(
-              <span key={'comp-diff' + index}>
-                {spaces}
-                {trimmedLine}
-                {'\n'}
-              </span>
-            )
-          }
-        } else if (!isHtmlCollapsed) {
-          // In general, if it's not collapsed, show the whole diff
-          componentStacks.push(
-            <span key={'comp-diff' + index}>
-              {spaces}
-              {trimmedLine}
-              {'\n'}
-            </span>
-          )
-        }
-      })
-      return componentStacks.concat(diffHtmlStack)
-    }
-
-    const nestedHtmlStack: React.ReactNode[] = []
-    const tagNames = isHtmlTagsWarning
-      ? // tags could have < or > in the name, so we always remove them to match
-        [firstContent.replace(/<|>/g, ''), secondContent.replace(/<|>/g, '')]
-      : []
-
-    let lastText = ''
-
-    const componentStack = componentStackFrames
-      .map((frame) => frame.component)
-      .reverse()
-
-    // [child index, parent index]
-    const matchedIndex = [-1, -1]
-    if (isHtmlTagsWarning) {
-      // Reverse search for the child tag
-      for (let i = componentStack.length - 1; i >= 0; i--) {
-        if (componentStack[i] === tagNames[0]) {
-          matchedIndex[0] = i
-          break
-        }
-      }
-      // Start searching parent tag from child tag above
-      for (let i = matchedIndex[0] - 1; i >= 0; i--) {
-        if (componentStack[i] === tagNames[1]) {
-          matchedIndex[1] = i
-          break
-        }
-      }
-    }
-
-    componentStack.forEach((component, index, componentList) => {
-      const spaces = ' '.repeat(nestedHtmlStack.length * 2)
-
-      // When component is the server or client tag name, highlight it
-      const isHighlightedTag = isHtmlTagsWarning
-        ? index === matchedIndex[0] || index === matchedIndex[1]
-        : tagNames.includes(component)
-      const isAdjacentTag =
-        isHighlightedTag ||
-        Math.abs(index - matchedIndex[0]) <= 1 ||
-        Math.abs(index - matchedIndex[1]) <= 1
-
-      const isLastFewFrames =
-        !isHtmlTagsWarning && index >= componentList.length - 6
-
-      const adjProps = getAdjacentProps(isAdjacentTag)
-
-      if ((isHtmlTagsWarning && isAdjacentTag) || isLastFewFrames) {
-        const codeLine = (
-          <span>
-            {spaces}
-            <span
-              {...adjProps}
-              {...{
-                ...(isHighlightedTag
-                  ? {
-                      'data-nextjs-container-errors-pseudo-html--tag-error':
-                        true,
-                    }
-                  : undefined),
-              }}
-            >
-              {`<${component}>\n`}
-            </span>
-          </span>
-        )
-        lastText = component
-
-        const wrappedCodeLine = (
-          <Fragment key={nestedHtmlStack.length}>
-            {codeLine}
-            {/* Add ^^^^ to the target tags used for snapshots but not displayed for users */}
-            {isHighlightedTag && (
-              <span data-nextjs-container-errors-pseudo-html--hint>
-                {spaces + '^'.repeat(component.length + 2) + '\n'}
-              </span>
-            )}
-          </Fragment>
-        )
-        nestedHtmlStack.push(wrappedCodeLine)
-      } else {
-        if (
-          nestedHtmlStack.length >= MAX_NON_COLLAPSED_FRAMES &&
-          isHtmlCollapsed
-        ) {
-          return
-        }
-
-        if (!isHtmlCollapsed || isLastFewFrames) {
-          nestedHtmlStack.push(
-            <span {...adjProps} key={nestedHtmlStack.length}>
-              {spaces}
-              {'<' + component + '>\n'}
-            </span>
-          )
-        } else if (isHtmlCollapsed && lastText !== '...') {
-          lastText = '...'
-          nestedHtmlStack.push(
-            <span {...adjProps} key={nestedHtmlStack.length}>
-              {spaces}
-              {'...\n'}
-            </span>
-          )
-        }
-      }
-    })
-    // Hydration mismatch: text or text-tag
-    if (!isHtmlTagsWarning) {
-      const spaces = ' '.repeat(nestedHtmlStack.length * 2)
-      let wrappedCodeLine
-      if (hydrationMismatchType === 'text') {
-        // hydration type is "text", represent [server content, client content]
-        wrappedCodeLine = (
-          <Fragment key={nestedHtmlStack.length}>
-            <span data-nextjs-container-errors-pseudo-html--diff="remove">
-              {spaces + `"${firstContent}"\n`}
-            </span>
-            <span data-nextjs-container-errors-pseudo-html--diff="add">
-              {spaces + `"${secondContent}"\n`}
-            </span>
-          </Fragment>
-        )
-      } else if (hydrationMismatchType === 'text-in-tag') {
-        // hydration type is "text-in-tag", represent [parent tag, mismatch content]
-        wrappedCodeLine = (
-          <Fragment key={nestedHtmlStack.length}>
-            <span data-nextjs-container-errors-pseudo-html--tag-adjacent>
-              {spaces + `<${secondContent}>\n`}
-            </span>
-            <span data-nextjs-container-errors-pseudo-html--diff="remove">
-              {spaces + `  "${firstContent}"\n`}
-            </span>
-          </Fragment>
-        )
-      }
-      nestedHtmlStack.push(wrappedCodeLine)
-    }
-
-    return nestedHtmlStack
-  }, [
-    componentStackFrames,
-    isHtmlCollapsed,
-    firstContent,
-    secondContent,
-    isHtmlTagsWarning,
-    hydrationMismatchType,
-    MAX_NON_COLLAPSED_FRAMES,
-    isReactHydrationDiff,
-    reactOutputComponentDiff,
-  ])
-
-  return (
-    <div data-nextjs-container-errors-pseudo-html>
-      <button
-        tabIndex={10} // match CallStackFrame
-        data-nextjs-container-errors-pseudo-html-collapse
-        onClick={() => toggleCollapseHtml(!isHtmlCollapsed)}
-      >
-        <CollapseIcon collapsed={isHtmlCollapsed} />
-      </button>
-      <pre {...props}>
-        <code>{htmlComponents}</code>
-      </pre>
-    </div>
-  )
-}
+export const styles = css`
+  [data-nextjs-container-errors-pseudo-html] {
+    position: relative;
+  }
+  [data-nextjs-container-errors-pseudo-html-collapse-button] {
+    position: absolute;
+    left: 10px;
+    top: 10px;
+    color: inherit;
+    background: none;
+    border: none;
+    padding: 0;
+  }
+  [data-nextjs-container-errors-pseudo-html-line] {
+    display: inline-block;
+    width: 100%;
+    padding-left: var(--size-10);
+    font-size: var(--size-font-small);
+    line-height: calc(5 / 3);
+    white-space: pre;
+  }
+  [data-nextjs-container-errors-pseudo-html--diff='add'] {
+    color: var(--color-ansi-green);
+  }
+  [data-nextjs-container-errors-pseudo-html--diff='remove'] {
+    color: var(--color-ansi-red);
+  }
+  [data-nextjs-container-errors-pseudo-html-line--error] {
+    color: var(--color-ansi-yellow);
+    font-weight: bold;
+  }
+  [data-nextjs-container-errors-pseudo-html--tag-error] {
+    color: var(--color-ansi-red);
+    font-weight: bold;
+  }
+  ${/* hide but text are still accessible in DOM */ ''}
+  [data-nextjs-container-errors-pseudo-html--hint] {
+    display: inline-block;
+    font-size: 0;
+  }
+  [data-nextjs-container-errors-pseudo-html-collapse='true']
+    .nextjs__container_errors__component-stack
+    code {
+    max-height: 100px;
+    mask-image: linear-gradient(to top, rgba(0, 0, 0, 0) 0%, black 50%);
+  }
+  .nextjs__container_errors__component-stack code {
+    display: block;
+    width: 100%;
+    white-space: pre-wrap;
+    scroll-snap-type: y mandatory;
+    overflow-y: hidden;
+  }
+  [data-nextjs-container-errors-pseudo-html--diff],
+  [data-nextjs-container-errors-pseudo-html-line--error] {
+    scroll-snap-align: center;
+  }
+`

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
@@ -197,35 +197,4 @@ export const styles = css`
   [data-nextjs-collapsed-call-stack-details] [data-nextjs-call-stack-frame] {
     margin-bottom: var(--size-gap-double);
   }
-
-  [data-nextjs-container-errors-pseudo-html] {
-    position: relative;
-  }
-  [data-nextjs-container-errors-pseudo-html-collapse] {
-    position: absolute;
-    left: 10px;
-    top: 10px;
-    color: inherit;
-    background: none;
-    border: none;
-    padding: 0;
-  }
-  [data-nextjs-container-errors-pseudo-html--diff='add'] {
-    color: var(--color-ansi-green);
-  }
-  [data-nextjs-container-errors-pseudo-html--diff='remove'] {
-    color: var(--color-ansi-red);
-  }
-  [data-nextjs-container-errors-pseudo-html--tag-error] {
-    color: var(--color-ansi-red);
-    font-weight: bold;
-  }
-  /* hide but text are still accessible in DOM */
-  [data-nextjs-container-errors-pseudo-html--hint] {
-    display: inline-block;
-    font-size: 0;
-  }
-  [data-nextjs-container-errors-pseudo-html--tag-adjacent='false'] {
-    color: var(--color-accents-1);
-  }
 `

--- a/packages/next/src/client/components/react-dev-overlay/internal/styles/ComponentStyles.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/styles/ComponentStyles.tsx
@@ -8,6 +8,7 @@ import { styles as versionStaleness } from '../components/VersionStalenessInfo'
 import { styles as buildErrorStyles } from '../container/BuildError'
 import { styles as containerErrorStyles } from '../container/Errors'
 import { styles as containerRuntimeErrorStyles } from '../container/RuntimeError'
+import { styles as pseudoHtmlStyles } from '../container/RuntimeError/component-stack-pseudo-html'
 import { noop as css } from '../helpers/noop-template'
 
 export function ComponentStyles() {
@@ -24,6 +25,7 @@ export function ComponentStyles() {
         ${containerErrorStyles}
         ${containerRuntimeErrorStyles}
         ${versionStaleness}
+        ${pseudoHtmlStyles}
       `}
     </style>
   )

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -10,7 +10,7 @@ import { getRedboxTotalErrorCount, retry } from 'next-test-utils'
 const enableOwnerStacks = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
 
 describe('Error overlay for hydration errors in App router', () => {
-  const { next, isTurbopack } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
     skipStart: true,
   })
@@ -96,23 +96,26 @@ describe('Error overlay for hydration errors in App router', () => {
     )
 
     const pseudoHtml = await session.getRedboxComponentStack()
-
-    if (isTurbopack) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          ...
-        +  client
-        -  server"
-      `)
-    } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          <div className="parent">
-            <main className="child">
-        +      client
-        -      server"
-      `)
-    }
+    expect(pseudoHtml).toMatchInlineSnapshot(`
+     "...
+         <RenderFromTemplateContext>
+           <ScrollAndFocusHandler segmentPath={[...]}>
+             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                 <LoadingBoundary loading={null}>
+                   <HTTPAccessFallbackBoundary notFound={[...]} forbidden={undefined} unauthorized={undefined}>
+                     <HTTPAccessFallbackErrorBoundary pathname="/" notFound={[...]} forbidden={undefined} ...>
+                       <RedirectBoundary>
+                         <RedirectErrorBoundary router={{...}}>
+                           <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                             <ClientPageRoot Component={function Mismatch} searchParams={{}} params={{}}>
+                               <Mismatch params={Promise} searchParams={Promise}>
+                                 <div className="parent">
+                                   <main className="child">
+     +                               client
+     -                               server
+                             ..."
+    `)
 
     await session.patch(
       'app/page.js',
@@ -159,20 +162,24 @@ describe('Error overlay for hydration errors in App router', () => {
     expect(await getRedboxTotalErrorCount(browser)).toBe(1)
 
     const pseudoHtml = await session.getRedboxComponentStack()
-    if (isTurbopack) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          ...
-        +  <main className="only">"
-      `)
-    } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          <div className="parent">
-            ...
-        +    <main className="only">"
-      `)
-    }
+    expect(pseudoHtml).toMatchInlineSnapshot(`
+     "...
+         <RenderFromTemplateContext>
+           <ScrollAndFocusHandler segmentPath={[...]}>
+             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                 <LoadingBoundary loading={null}>
+                   <HTTPAccessFallbackBoundary notFound={[...]} forbidden={undefined} unauthorized={undefined}>
+                     <HTTPAccessFallbackErrorBoundary pathname="/" notFound={[...]} forbidden={undefined} ...>
+                       <RedirectBoundary>
+                         <RedirectErrorBoundary router={{...}}>
+                           <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                             <ClientPageRoot Component={function Mismatch} searchParams={{}} params={{}}>
+                               <Mismatch params={Promise} searchParams={Promise}>
+                                 <div className="parent">
+     +                             <main className="only">
+                             ..."
+    `)
 
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
       `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:"`
@@ -208,7 +215,24 @@ describe('Error overlay for hydration errors in App router', () => {
     expect(await getRedboxTotalErrorCount(browser)).toBe(1)
 
     const pseudoHtml = await session.getRedboxComponentStack()
-    expect(pseudoHtml).toMatchInlineSnapshot(`"- className="server-html""`)
+    expect(pseudoHtml).toMatchInlineSnapshot(`
+     "...
+         <HotReload assetPrefix="" globalError={[...]}>
+           <ReactDevOverlay state={{nextId:1, ...}} dispatcher={{...}} globalError={[...]}>
+             <DevRootHTTPAccessFallbackBoundary>
+               <HTTPAccessFallbackBoundary notFound={<NotAllowedRootHTTPFallbackError>}>
+                 <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<NotAllowedRootHTTPFallbackError>} ...>
+                   <RedirectBoundary>
+                     <RedirectErrorBoundary router={{...}}>
+                       <Head>
+                       <ClientSegmentRoot Component={function Root} slots={{...}} params={{}}>
+                         <Root params={Promise}>
+                           <html
+     -                       className="server-html"
+                           >
+                       ...
+             ..."
+    `)
 
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
       `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:"`
@@ -243,22 +267,27 @@ describe('Error overlay for hydration errors in App router', () => {
     expect(await getRedboxTotalErrorCount(browser)).toBe(1)
 
     const pseudoHtml = await session.getRedboxComponentStack()
-    if (isTurbopack) {
-      expect(pseudoHtml).toEqual(outdent`
-        ...
-          ...
-            ...
-        +  second
-        -  <footer className="3">
-      `)
-    } else {
-      expect(pseudoHtml).toEqual(outdent`
-        ...
-          <div className="parent">
-        +    second
-        -    <footer className="3">
-      `)
-    }
+    expect(pseudoHtml).toMatchInlineSnapshot(`
+     "...
+         <RenderFromTemplateContext>
+           <ScrollAndFocusHandler segmentPath={[...]}>
+             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                 <LoadingBoundary loading={null}>
+                   <HTTPAccessFallbackBoundary notFound={[...]} forbidden={undefined} unauthorized={undefined}>
+                     <HTTPAccessFallbackErrorBoundary pathname="/" notFound={[...]} forbidden={undefined} ...>
+                       <RedirectBoundary>
+                         <RedirectErrorBoundary router={{...}}>
+                           <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                             <ClientPageRoot Component={function Mismatch} searchParams={{}} params={{}}>
+                               <Mismatch params={Promise} searchParams={Promise}>
+                                 <div className="parent">
+                                   <header>
+     +                             second
+     -                             <footer className="3">
+                                   ...
+                             ..."
+    `)
 
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
       `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:"`
@@ -291,19 +320,24 @@ describe('Error overlay for hydration errors in App router', () => {
     expect(await getRedboxTotalErrorCount(browser)).toBe(1)
 
     const pseudoHtml = await session.getRedboxComponentStack()
-    if (isTurbopack) {
-      expect(pseudoHtml).toEqual(outdent`
-        ...
-          ...
-        -  <main className="only">
-      `)
-    } else {
-      expect(pseudoHtml).toEqual(outdent`
-        ...
-          <div className="parent">
-        -    <main className="only">
-      `)
-    }
+    expect(pseudoHtml).toMatchInlineSnapshot(`
+     "...
+         <RenderFromTemplateContext>
+           <ScrollAndFocusHandler segmentPath={[...]}>
+             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                 <LoadingBoundary loading={null}>
+                   <HTTPAccessFallbackBoundary notFound={[...]} forbidden={undefined} unauthorized={undefined}>
+                     <HTTPAccessFallbackErrorBoundary pathname="/" notFound={[...]} forbidden={undefined} ...>
+                       <RedirectBoundary>
+                         <RedirectErrorBoundary router={{...}}>
+                           <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                             <ClientPageRoot Component={function Mismatch} searchParams={{}} params={{}}>
+                               <Mismatch params={Promise} searchParams={Promise}>
+                                 <div className="parent">
+     -                             <main className="only">
+                             ..."
+    `)
 
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
       `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:"`
@@ -336,20 +370,24 @@ describe('Error overlay for hydration errors in App router', () => {
     )
 
     const pseudoHtml = await session.getRedboxComponentStack()
-
-    if (isTurbopack) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          ...
-        -  only"
-      `)
-    } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          <div className="parent">
-        -    only"
-      `)
-    }
+    expect(pseudoHtml).toMatchInlineSnapshot(`
+     "...
+         <RenderFromTemplateContext>
+           <ScrollAndFocusHandler segmentPath={[...]}>
+             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                 <LoadingBoundary loading={null}>
+                   <HTTPAccessFallbackBoundary notFound={[...]} forbidden={undefined} unauthorized={undefined}>
+                     <HTTPAccessFallbackErrorBoundary pathname="/" notFound={[...]} forbidden={undefined} ...>
+                       <RedirectBoundary>
+                         <RedirectErrorBoundary router={{...}}>
+                           <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                             <ClientPageRoot Component={function Mismatch} searchParams={{}} params={{}}>
+                               <Mismatch params={Promise} searchParams={Promise}>
+                                 <div className="parent">
+     -                             only
+                             ..."
+    `)
   })
 
   it('should show correct hydration error when server renders an extra text node in an invalid place', async () => {
@@ -386,21 +424,24 @@ describe('Error overlay for hydration errors in App router', () => {
     )
 
     const pseudoHtml = await session.getRedboxComponentStack()
-    if (isTurbopack) {
-      expect(pseudoHtml).toEqual(outdent`
-        ...
-          ...
-        +  <table>
-        -  test
-      `)
-    } else {
-      expect(pseudoHtml).toEqual(outdent`
-        ...
-          ...
-        +  <table>
-        -  test
-    }`)
-    }
+    expect(pseudoHtml).toMatchInlineSnapshot(`
+     "...
+         <RenderFromTemplateContext>
+           <ScrollAndFocusHandler segmentPath={[...]}>
+             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                 <LoadingBoundary loading={null}>
+                   <HTTPAccessFallbackBoundary notFound={[...]} forbidden={undefined} unauthorized={undefined}>
+                     <HTTPAccessFallbackErrorBoundary pathname="/" notFound={[...]} forbidden={undefined} ...>
+                       <RedirectBoundary>
+                         <RedirectErrorBoundary router={{...}}>
+                           <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                             <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                               <Page params={Promise} searchParams={Promise}>
+     +                           <table>
+     -                           test
+                             ..."
+    `)
   })
 
   it('should show correct hydration error when server renders an extra whitespace in an invalid place', async () => {
@@ -428,11 +469,9 @@ describe('Error overlay for hydration errors in App router', () => {
 
     expect(await getRedboxTotalErrorCount(browser)).toBe(1)
 
-    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
-     "In HTML, whitespace text nodes cannot be a child of <table>. Make sure you don't have any extra whitespace between tags on each line of your source code.
-     This will cause a hydration error.
-
-       ...
+    const pseudoHtml = await session.getRedboxComponentStack()
+    expect(pseudoHtml).toMatchInlineSnapshot(`
+     "...
          <RenderFromTemplateContext>
            <ScrollAndFocusHandler segmentPath={[...]}>
              <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
@@ -448,13 +487,8 @@ describe('Error overlay for hydration errors in App router', () => {
      >                           <table>
      >                             {" "}
                                    ...
-                             ...
-     "
+                             ..."
     `)
-
-    // FIXME: fix the `pseudoHtml` should be extracted from the description
-    // const pseudoHtml = await session.getRedboxComponentStack()
-    // expect(pseudoHtml).toMatchInlineSnapshot(``)
   })
 
   it('should show correct hydration error when client renders an extra node inside Suspense content', async () => {
@@ -486,24 +520,26 @@ describe('Error overlay for hydration errors in App router', () => {
     await session.openRedbox()
 
     const pseudoHtml = await session.getRedboxComponentStack()
-    if (isTurbopack) {
-      expect(pseudoHtml).toEqual(outdent`
-      ...
-        ...
-          ...
-      +  <main className="second">
-      -  <footer className="3">
+    expect(pseudoHtml).toMatchInlineSnapshot(`
+     "...
+         <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+           <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+             <LoadingBoundary loading={null}>
+               <HTTPAccessFallbackBoundary notFound={[...]} forbidden={undefined} unauthorized={undefined}>
+                 <HTTPAccessFallbackErrorBoundary pathname="/" notFound={[...]} forbidden={undefined} unauthorized={undefined} ...>
+                   <RedirectBoundary>
+                     <RedirectErrorBoundary router={{...}}>
+                       <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                         <ClientPageRoot Component={function Mismatch} searchParams={{}} params={{}}>
+                           <Mismatch params={Promise} searchParams={Promise}>
+                             <div className="parent">
+                               <Suspense fallback={<p>}>
+                                 <header>
+     +                           <main className="second">
+     -                           <footer className="3">
+                                 ...
+                         ..."
     `)
-    } else {
-      expect(pseudoHtml).toEqual(outdent`
-      ...
-        <div className="parent">
-          <Suspense fallback={<p>}>
-            ...
-      +      <main className="second">
-      -      <footer className="3">
-    `)
-    }
 
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
       `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:"`
@@ -581,25 +617,24 @@ describe('Error overlay for hydration errors in App router', () => {
 
     const pseudoHtml = await session.getRedboxComponentStack()
 
-    // Turbopack currently has longer component stack trace
-    if (isTurbopack) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          <Page>
-            <p>
-            ^^^
-              <p>
-              ^^^"
-      `)
-    } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "<Page>
-          <p>
-          ^^^
-            <p>
-            ^^^"
-      `)
-    }
+    expect(pseudoHtml).toMatchInlineSnapshot(`
+     "...
+         <RenderFromTemplateContext>
+           <ScrollAndFocusHandler segmentPath={[...]}>
+             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                 <LoadingBoundary loading={null}>
+                   <HTTPAccessFallbackBoundary notFound={[...]} forbidden={undefined} unauthorized={undefined}>
+                     <HTTPAccessFallbackErrorBoundary pathname="/" notFound={[...]} forbidden={undefined} ...>
+                       <RedirectBoundary>
+                         <RedirectErrorBoundary router={{...}}>
+                           <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                             <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                               <Page params={Promise} searchParams={Promise}>
+     >                           <p>
+     >                             <p>
+                             ..."
+    `)
   })
 
   it('should only show one hydration error when bad nesting happened - div under p', async () => {
@@ -642,12 +677,23 @@ describe('Error overlay for hydration errors in App router', () => {
     const pseudoHtml = await session.getRedboxComponentStack()
 
     expect(pseudoHtml).toMatchInlineSnapshot(`
-      "...
-        <div>
-          <p>
-          ^^^
-            <div>
-            ^^^^^"
+     "...
+         <ScrollAndFocusHandler segmentPath={[...]}>
+           <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+             <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+               <LoadingBoundary loading={null}>
+                 <HTTPAccessFallbackBoundary notFound={[...]} forbidden={undefined} unauthorized={undefined}>
+                   <HTTPAccessFallbackErrorBoundary pathname="/" notFound={[...]} forbidden={undefined} ...>
+                     <RedirectBoundary>
+                       <RedirectErrorBoundary router={{...}}>
+                         <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                           <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                             <Page params={Promise} searchParams={Promise}>
+                               <div>
+                                 <div>
+     >                             <p>
+     >                               <div>
+                           ..."
     `)
   })
 
@@ -675,32 +721,31 @@ describe('Error overlay for hydration errors in App router', () => {
     })
 
     const description = await session.getRedboxDescription()
-    expect(description).toEqual(outdent`
-      In HTML, <tr> cannot be a child of <div>.
-      This will cause a hydration error.
+    expect(description).toMatchInlineSnapshot(`
+     "In HTML, <tr> cannot be a child of <div>.
+     This will cause a hydration error."
     `)
 
     const pseudoHtml = await session.getRedboxComponentStack()
 
-    // Turbopack currently has longer component stack trace
-    if (isTurbopack) {
-      expect(pseudoHtml).toEqual(outdent`
-        ...
-          <Page>
-            <div>
-            ^^^^^
-              <tr>
-              ^^^^
-      `)
-    } else {
-      expect(pseudoHtml).toEqual(outdent`
-        <Page>
-          <div>
-          ^^^^^
-            <tr>
-            ^^^^
-      `)
-    }
+    expect(pseudoHtml).toMatchInlineSnapshot(`
+     "...
+         <RenderFromTemplateContext>
+           <ScrollAndFocusHandler segmentPath={[...]}>
+             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                 <LoadingBoundary loading={null}>
+                   <HTTPAccessFallbackBoundary notFound={[...]} forbidden={undefined} unauthorized={undefined}>
+                     <HTTPAccessFallbackErrorBoundary pathname="/" notFound={[...]} forbidden={undefined} ...>
+                       <RedirectBoundary>
+                         <RedirectErrorBoundary router={{...}}>
+                           <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                             <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                               <Page params={Promise} searchParams={Promise}>
+     >                           <div>
+     >                             <tr>
+                             ..."
+    `)
   })
 
   it('should show the highlighted bad nesting html snippet when bad nesting happened', async () => {
@@ -735,32 +780,28 @@ describe('Error overlay for hydration errors in App router', () => {
     )
 
     const pseudoHtml = await session.getRedboxComponentStack()
-
-    // Turbopack currently has longer component stack trace
-    if (isTurbopack) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          <Page>
-            <p>
-            ^^^
-              <span>
-                ...
-                  <span>
-                    <p>
-                    ^^^"
-      `)
-    } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "<Page>
-          <p>
-          ^^^
-            <span>
-              ...
-                <span>
-                  <p>
-                  ^^^"
-      `)
-    }
+    expect(pseudoHtml).toMatchInlineSnapshot(`
+     "...
+         <RenderFromTemplateContext>
+           <ScrollAndFocusHandler segmentPath={[...]}>
+             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                 <LoadingBoundary loading={null}>
+                   <HTTPAccessFallbackBoundary notFound={[...]} forbidden={undefined} unauthorized={undefined}>
+                     <HTTPAccessFallbackErrorBoundary pathname="/" notFound={[...]} forbidden={undefined} ...>
+                       <RedirectBoundary>
+                         <RedirectErrorBoundary router={{...}}>
+                           <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                             <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                               <Page params={Promise} searchParams={Promise}>
+     >                           <p>
+                                   <span>
+                                     <span>
+                                       <span>
+                                         <span>
+     >                                     <p>
+                             ..."
+    `)
   })
 
   it('should show error if script is directly placed under html instead of body', async () => {
@@ -811,125 +852,12 @@ describe('Error overlay for hydration errors in App router', () => {
     // TODO: assert on 2nd error being "In HTML, <script> cannot be a child of <html>."
     // TODO: assert on 3rd error that's specific to owner stacks
     const description = await session.getRedboxDescription()
-    expect(description).toEqual(outdent`
-      Cannot render a sync or defer <script> outside the main document without knowing its order. Try adding async="" or moving it into the root <head> tag.
-    `)
+    expect(description).toMatchInlineSnapshot(
+      `"Cannot render a sync or defer <script> outside the main document without knowing its order. Try adding async="" or moving it into the root <head> tag."`
+    )
 
     const pseudoHtml = await session.getRedboxComponentStack()
     // 1st error has no component context.
-    expect(pseudoHtml).toEqual(null)
-  })
-
-  it('should collapse and uncollapse properly when there are many frames', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        [
-          'app/page.js',
-          outdent`
-            'use client'
-
-            const isServer = typeof window === 'undefined'
-            
-            function Mismatch() {
-              return (
-                <p>
-                  <span>
-                    hello {isServer ? 'server' : 'client'}
-                  </span>
-                </p>
-              )
-            }
-            
-            export default function Page() {
-              return (
-                <div>
-                  <div>
-                    <div>
-                      <div>
-                        <Mismatch />
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              )
-            }
-          `,
-        ],
-      ])
-    )
-    const { session, browser } = sandbox
-    await session.openRedbox()
-
-    expect(await getRedboxTotalErrorCount(browser)).toBe(1)
-
-    const pseudoHtml = await session.getRedboxComponentStack()
-    if (isTurbopack) {
-      // FIXME: Should not fork on Turbopack i.e. match the snapshot in the else-branch
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          ...
-        +  client
-        -  server"
-      `)
-    } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          <div>
-            <div>
-              <div>
-                <div>
-                  <Mismatch>
-                    <p>
-                      <span>
-        +                client
-        -                server"
-      `)
-    }
-
-    await session.toggleCollapseComponentStack()
-
-    const fullPseudoHtml = await session.getRedboxComponentStack()
-    if (isTurbopack) {
-      expect(fullPseudoHtml).toMatchInlineSnapshot(`
-       "...
-         <HTTPAccessFallbackErrorBoundary pathname="/" notFound={[...]} forbidden={undefined} unauthorized={undefined} ...>
-           <RedirectBoundary>
-             <RedirectErrorBoundary router={{...}}>
-               <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
-                 <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
-                   <Page params={Promise} searchParams={Promise}>
-                     <div>
-                       <div>
-                         <div>
-                           <div>
-                             <Mismatch>
-                               <p>
-                                 <span>
-                                   ...
-       +                            client
-       -                            server"
-      `)
-    } else {
-      expect(fullPseudoHtml).toMatchInlineSnapshot(`
-       "...
-         <HTTPAccessFallbackErrorBoundary pathname="/" notFound={[...]} forbidden={undefined} unauthorized={undefined} ...>
-           <RedirectBoundary>
-             <RedirectErrorBoundary router={{...}}>
-               <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
-                 <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
-                   <Page params={Promise} searchParams={Promise}>
-                     <div>
-                       <div>
-                         <div>
-                           <div>
-                             <Mismatch>
-                               <p>
-                                 <span>
-                                   ...
-       +                            client
-       -                            server"
-      `)
-    }
+    expect(pseudoHtml).toMatchInlineSnapshot(`null`)
   })
 })

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -113,7 +113,9 @@ describe('Error overlay for hydration errors in Pages router', () => {
       expect(pseudoHtml).toMatchInlineSnapshot(`
        "<Mismatch>
            <div>
-             <main>"
+             <main>
+       +       "server"
+       -       "client""
       `)
     } else {
       expect(pseudoHtml).toMatchInlineSnapshot(`
@@ -135,7 +137,6 @@ describe('Error overlay for hydration errors in Pages router', () => {
     await session.patch(
       'index.js',
       outdent`
-      'use client'
       export default function Mismatch() {
         return (
           <div className="parent">
@@ -245,7 +246,9 @@ describe('Error overlay for hydration errors in Pages router', () => {
     if (isReact18) {
       expect(pseudoHtml).toMatchInlineSnapshot(`
        "<Mismatch>
-       >   <div>"
+           <div>
+       >     <div>
+       >       "second""
       `)
     } else {
       expect(pseudoHtml).toMatchInlineSnapshot(`
@@ -368,7 +371,9 @@ describe('Error overlay for hydration errors in Pages router', () => {
     if (isReact18) {
       expect(pseudoHtml).toMatchInlineSnapshot(`
        "<Mismatch>
-       >   <div>"
+           <div>
+       >     <div>
+       >       "only""
       `)
     } else {
       expect(pseudoHtml).toMatchInlineSnapshot(`
@@ -586,8 +591,6 @@ describe('Error overlay for hydration errors in Pages router', () => {
         [
           'index.js',
           outdent`
-            'use client'
-
             import { useId } from "react"
 
             export default function Page() {
@@ -621,8 +624,6 @@ describe('Error overlay for hydration errors in Pages router', () => {
         [
           'index.js',
           outdent`
-            'use client'
-
             export default function Page() {
               return (
                 <p>
@@ -686,8 +687,6 @@ describe('Error overlay for hydration errors in Pages router', () => {
         [
           'index.js',
           outdent`
-            'use client'
-
             export default function Page() {
               return (
                 <div>
@@ -814,8 +813,6 @@ describe('Error overlay for hydration errors in Pages router', () => {
         [
           'index.js',
           outdent`
-            'use client'
-
             export default function Page() {
               return (
                 <p><span><span><span><span><p>hello world</p></span></span></span></span></p>

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -9,7 +9,7 @@ const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 // https://github.com/facebook/react/blob/main/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js used as a reference
 
 describe('Error overlay for hydration errors in Pages router', () => {
-  const { next, isTurbopack } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
     skipStart: true,
   })
@@ -109,22 +109,15 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     const pseudoHtml = await session.getRedboxComponentStack()
 
-    if (isTurbopack) {
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "...
-            <ErrorBoundary>
-              <PathnameContextProviderAdapter>
-                <App>
-                  <Mismatch>
-                    <div>
-                      <main>
-                        "server"
-                        "client""
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-         "...
+    if (isReact18) {
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "<Mismatch>
+           <div>
+             <main>"
+      `)
+    } else {
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "...
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
@@ -134,30 +127,11 @@ describe('Error overlay for hydration errors in Pages router', () => {
                        <Mismatch>
                          <div className="parent">
                            <main className="child">
-         +                    client
-         -                    server"
-        `)
-      }
-    } else {
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "<Mismatch>
-            <div>
-              <main>
-                "server"
-                "client""
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "...
-            <div className="parent">
-              <main className="child">
-          +      client
-          -      server"
-        `)
-      }
+       +                     client
+       -                     server
+                     ..."
+      `)
     }
-
     await session.patch(
       'index.js',
       outdent`
@@ -205,19 +179,15 @@ describe('Error overlay for hydration errors in Pages router', () => {
     })
 
     const pseudoHtml = await session.getRedboxComponentStack()
-    if (isTurbopack) {
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "...
-            <Mismatch>
-              <div>
-              ^^^^^
-                <main>
-                ^^^^^^"
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-         "...
+    if (isReact18) {
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "<Mismatch>
+       >   <div>
+       >     <main>"
+      `)
+    } else {
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "...
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
@@ -226,27 +196,9 @@ describe('Error overlay for hydration errors in Pages router', () => {
                      <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Mismatch>
                          <div className="parent">
-                           ...
-         +                  <main className="only">"
-        `)
-      }
-    } else {
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "<Mismatch>
-            <div>
-            ^^^^^
-              <main>
-              ^^^^^^"
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "...
-            <div className="parent">
-              ...
-          +    <main className="only">"
-        `)
-      }
+       +                   <main className="only">
+                     ..."
+      `)
     }
 
     if (isReact18) {
@@ -290,22 +242,14 @@ describe('Error overlay for hydration errors in Pages router', () => {
     })
 
     const pseudoHtml = await session.getRedboxComponentStack()
-    if (isTurbopack) {
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "...
-            <ReactDevOverlay>
-              <ErrorBoundary>
-                <PathnameContextProviderAdapter>
-                  <App>
-                    <Mismatch>
-                      <div>
-                        <div>
-                          "second""
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-         "...
+    if (isReact18) {
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "<Mismatch>
+       >   <div>"
+      `)
+    } else {
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "...
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
@@ -314,26 +258,12 @@ describe('Error overlay for hydration errors in Pages router', () => {
                      <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Mismatch>
                          <div className="parent">
-         +                  second
-         -                  <footer className="3">"
-        `)
-      }
-    } else {
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "<Mismatch>
-            <div>
-              <div>
-                "second""
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "...
-            <div className="parent">
-          +    second
-          -    <footer className="3">"
-        `)
-      }
+                           <header>
+       +                   second
+       -                   <footer className="3">
+                           ...
+                     ..."
+      `)
     }
 
     if (isReact18) {
@@ -371,15 +301,15 @@ describe('Error overlay for hydration errors in Pages router', () => {
     expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 2 : 1)
 
     const pseudoHtml = await session.getRedboxComponentStack()
-    if (isTurbopack) {
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "<Root>
-            ..."
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-         "<Root callbacks={[...]}>
+    if (isReact18) {
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "<Mismatch>
+       >   <div>"
+      `)
+    } else {
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "<Root callbacks={[...]}>
+           <Head>
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
@@ -388,22 +318,9 @@ describe('Error overlay for hydration errors in Pages router', () => {
                      <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Mismatch>
                          <div className="parent">
-         -                  <main className="only">"
-        `)
-      }
-    } else {
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "<Mismatch>
-            ..."
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "<Mismatch>
-            <div className="parent">
-          -    <main className="only">"
-        `)
-      }
+       -                   <main className="only">
+                     ..."
+      `)
     }
 
     if (isReact18) {
@@ -448,22 +365,15 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     const pseudoHtml = await session.getRedboxComponentStack()
 
-    if (isTurbopack) {
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "...
-            <ReactDevOverlay>
-              <ErrorBoundary>
-                <PathnameContextProviderAdapter>
-                  <App>
-                    <Mismatch>
-                      <div>
-                        <div>
-                          "only""
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-         "<Root callbacks={[...]}>
+    if (isReact18) {
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "<Mismatch>
+       >   <div>"
+      `)
+    } else {
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "<Root callbacks={[...]}>
+           <Head>
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
@@ -472,24 +382,9 @@ describe('Error overlay for hydration errors in Pages router', () => {
                      <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Mismatch>
                          <div className="parent">
-         -                  only"
-        `)
-      }
-    } else {
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "<Mismatch>
-            <div>
-              <div>
-                "only""
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "<Mismatch>
-            <div className="parent">
-          -    only"
-        `)
-      }
+       -                   only
+                     ..."
+      `)
     }
   })
 
@@ -525,30 +420,27 @@ describe('Error overlay for hydration errors in Pages router', () => {
       )
     })
 
-    // FIXME: Should also have "text nodes cannot be a child of tr"
     if (isReact18) {
       expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
         `"Expected server HTML to contain a matching <table> in <div>."`
       )
     } else {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-        `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:"`
-      )
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
+       "In HTML, text nodes cannot be a child of <tr>.
+       This will cause a hydration error."
+      `)
     }
 
     const pseudoHtml = await session.getRedboxComponentStack()
-    if (isTurbopack) {
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "<Root>
-            ...
-              <Page>
-                <table>
-                ^^^^^^^"
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-         "<Root callbacks={[...]}>
+    if (isReact18) {
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "<Page>
+       >   <table>"
+      `)
+    } else {
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "<Root callbacks={[...]}>
+           <Head>
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
@@ -556,26 +448,10 @@ describe('Error overlay for hydration errors in Pages router', () => {
                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                      <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Page>
-                         ...
-         +                <table>
-         -                test"
-        `)
-      }
-    } else {
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "<Page>
-            <table>
-            ^^^^^^^"
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "<Page>
-            ...
-          +  <table>
-          -  test"
-        `)
-      }
+       +                 <table>
+       -                 test
+                     ..."
+      `)
     }
   })
 
@@ -589,7 +465,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
             export default function Page() {
               return (
                 <table>
-                  {' '}
+                  {' 123'}
                   <tbody></tbody>
                 </table>
               )
@@ -598,23 +474,46 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-    const { session } = sandbox
-    // FIXME: Should have getRedboxDescription() "text nodes cannot be a child of tr"
+    const { session, browser } = sandbox
     await expect(session.hasErrorToast()).resolves.toBe(false)
 
-    //
+    await session.assertHasRedbox()
 
-    // expect(await session.hasRedbox()).toBe(false)
-    // expect(await getRedboxTotalErrorCount(browser)).toBe(0)
+    if (isReact18) {
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+        `"Expected server HTML to contain a matching <table> in <div>."`
+      )
 
-    // expect(await session.getRedboxDescription()).toEqual(outdent`
-    //   Something
-    // `)
+      const pseudoHtml = await session.getRedboxComponentStack()
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "<Page>
+       >   <table>"
+      `)
 
-    // const pseudoHtml = await session.getRedboxComponentStack()
-    // expect(pseudoHtml).toEqual(outdent`
-    //   Something
-    // `)
+      expect(await getRedboxTotalErrorCount(browser)).toBe(3)
+    } else {
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
+       "In HTML, text nodes cannot be a child of <table>.
+       This will cause a hydration error."
+      `)
+
+      const pseudoHtml = await session.getRedboxComponentStack()
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "<Root callbacks={[...]}>
+           <Head>
+           <AppContainer>
+             <Container fn={function fn}>
+               <ReactDevOverlay>
+                 <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                   <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
+                     <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+                       <Page>
+       +                 <table>
+       -                 {" 123"}
+                     ..."
+      `)
+      expect(await getRedboxTotalErrorCount(browser)).toBe(1)
+    }
   })
 
   it('should show correct hydration error when client renders an extra node inside Suspense content', async () => {
@@ -642,47 +541,31 @@ describe('Error overlay for hydration errors in Pages router', () => {
       ])
     )
     const { session } = sandbox
+    await session.assertHasRedbox()
     const pseudoHtml = await session.getRedboxComponentStack()
-    if (isTurbopack) {
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "...
-            <Mismatch>
-              <div>
-              ^^^^^
-                <Suspense>
-                  <main>
-                  ^^^^^^"
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "...
-            ...
-              ...
-          +  <main className="second">
-          -  <footer className="3">"
-        `)
-      }
+    if (isReact18) {
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "<Mismatch>
+       >   <div>
+             <Suspense>
+       >       <main>"
+      `)
     } else {
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "<Mismatch>
-            <div>
-            ^^^^^
-              <Suspense>
-                <main>
-                ^^^^^^"
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "...
-            <div className="parent">
-              <Suspense fallback={<p>}>
-                ...
-          +      <main className="second">
-          -      <footer className="3">"
-        `)
-      }
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "...
+           <ReactDevOverlay>
+             <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+               <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
+                 <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+                   <Mismatch>
+                     <div className="parent">
+                       <Suspense fallback={<p>}>
+                         <header>
+       +                 <main className="second">
+       -                 <footer className="3">
+                         ...
+                 ..."
+      `)
     }
 
     if (isReact18) {
@@ -769,47 +652,30 @@ describe('Error overlay for hydration errors in Pages router', () => {
       `)
     }
 
+    await session.assertHasRedbox()
     const pseudoHtml = await session.getRedboxComponentStack()
 
-    // Turbopack currently has longer component stack trace
-    if (isTurbopack) {
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "...
-            <Page>
-              <p>
-              ^^^
-                <p>
-                ^^^"
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "...
-            <Page>
-              <p>
-              ^^^
-                <p>
-                ^^^"
-        `)
-      }
+    if (isReact18) {
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "<Page>
+       >   <p>
+       >     <p>"
+      `)
     } else {
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "<Page>
-            <p>
-            ^^^
-              <p>
-              ^^^"
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "<Page>
-            <p>
-            ^^^
-              <p>
-              ^^^"
-        `)
-      }
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "<Root callbacks={[...]}>
+           <Head>
+           <AppContainer>
+             <Container fn={function fn}>
+               <ReactDevOverlay>
+                 <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                   <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
+                     <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+                       <Page>
+       >                 <p>
+       >                   <p>
+                     ..."
+      `)
     }
   })
 
@@ -859,21 +725,26 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     if (isReact18) {
       expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          <div>
-            <p>
-            ^^^
-              <div>
-              ^^^^^"
+       "<Page>
+           <div>
+             <div>
+       >       <p>
+       >         <div>"
       `)
     } else {
       expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          <div>
-            <p>
-            ^^^
-              <div>
-              ^^^^^"
+       "...
+           <Container fn={function fn}>
+             <ReactDevOverlay>
+               <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                 <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
+                   <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+                     <Page>
+                       <div>
+                         <div>
+       >                   <p>
+       >                     <div>
+                   ..."
       `)
     }
   })
@@ -912,45 +783,27 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     const pseudoHtml = await session.getRedboxComponentStack()
 
-    // Turbopack currently has longer component stack trace
-    if (isTurbopack) {
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "...
-            <Page>
-              <div>
-              ^^^^^
-                <tr>
-                ^^^^"
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "...
-            <Page>
-              <div>
-              ^^^^^
-                <tr>
-                ^^^^"
-        `)
-      }
+    if (isReact18) {
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "<Page>
+       >   <div>
+       >     <tr>"
+      `)
     } else {
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "<Page>
-            <div>
-            ^^^^^
-              <tr>
-              ^^^^"
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "<Page>
-            <div>
-            ^^^^^
-              <tr>
-              ^^^^"
-        `)
-      }
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "<Root callbacks={[...]}>
+           <Head>
+           <AppContainer>
+             <Container fn={function fn}>
+               <ReactDevOverlay>
+                 <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                   <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
+                     <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+                       <Page>
+       >                 <div>
+       >                   <tr>
+                     ..."
+      `)
     }
   })
 
@@ -992,52 +845,35 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     const pseudoHtml = await session.getRedboxComponentStack()
 
-    // Turbopack currently has longer component stack trace
-    if (isTurbopack) {
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "...
-            <span>
-              <span>
-              ^^^^^^
-                <p>
-                ^^^"
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "...
-            <Page>
-              <p>
-              ^^^
-                <span>
-                  ...
-                    <span>
-                      <p>
-                      ^^^"
-        `)
-      }
+    if (isReact18) {
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "<Page>
+           <p>
+             <span>
+               <span>
+                 <span>
+       >           <span>
+       >             <p>"
+      `)
     } else {
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "...
-            <span>
-              <span>
-              ^^^^^^
-                <p>
-                ^^^"
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "<Page>
-            <p>
-            ^^^
-              <span>
-                ...
-                  <span>
-                    <p>
-                    ^^^"
-        `)
-      }
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+       "<Root callbacks={[...]}>
+           <Head>
+           <AppContainer>
+             <Container fn={function fn}>
+               <ReactDevOverlay>
+                 <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                   <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
+                     <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+                       <Page>
+       >                 <p>
+                           <span>
+                             <span>
+                               <span>
+                                 <span>
+       >                           <p>
+                     ..."
+      `)
     }
   })
 
@@ -1081,182 +917,5 @@ describe('Error overlay for hydration errors in Pages router', () => {
     const { session } = sandbox
     // FIXME: Should have a redbox just like with App router
     await session.assertNoRedbox()
-  })
-
-  it('should collapse and uncollapse properly when there are many frames', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        [
-          'index.js',
-          outdent`
-            'use client'
-
-            const isServer = typeof window === 'undefined'
-            
-            function Mismatch() {
-              return (
-                <p>
-                  <span>
-                    
-                    hello {isServer ? 'server' : 'client'}
-                  </span>
-                </p>
-              )
-            }
-            
-            export default function Page() {
-              return (
-                <div>
-                  <div>
-                    <div>
-                      <div>
-                        <Mismatch />
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              )
-            }
-          `,
-        ],
-      ])
-    )
-    const { session, browser } = sandbox
-    await session.assertHasRedbox()
-    await retry(async () => {
-      await expect(await getRedboxTotalErrorCount(browser)).toBe(
-        // This case only hit 2 errors in React 18
-        isReact18 ? 2 : 1
-      )
-    })
-
-    const pseudoHtml = await session.getRedboxComponentStack()
-    if (isTurbopack) {
-      // FIXME: Should not fork on Turbopack i.e. match the snapshot in the else-branch
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "...
-            <div>
-              <div>
-                <div>
-                  <Mismatch>
-                    <p>
-                      <span>
-                        "server"
-                        "client""
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "...
-            ...
-          +  client
-          -  server"
-        `)
-      }
-    } else {
-      if (isReact18) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "...
-            <div>
-              <div>
-                <div>
-                  <Mismatch>
-                    <p>
-                      <span>
-                        "server"
-                        "client""
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-          "...
-            <div>
-              <div>
-                <div>
-                  <div>
-                    <Mismatch>
-                      <p>
-                        <span>
-          +                client
-          -                server"
-        `)
-      }
-    }
-
-    await session.toggleCollapseComponentStack()
-
-    const fullPseudoHtml = await session.getRedboxComponentStack()
-    if (isTurbopack) {
-      if (isReact18) {
-        expect(fullPseudoHtml).toMatchInlineSnapshot(`
-          "<Root>
-            <AppContainer>
-              <Container>
-                <ReactDevOverlay>
-                  <ErrorBoundary>
-                    <PathnameContextProviderAdapter>
-                      <App>
-                        <Page>
-                          <div>
-                            <div>
-                              <div>
-                                <div>
-                                  <Mismatch>
-                                    <p>
-                                      <span>
-                                        "server"
-                                        "client""
-        `)
-      } else {
-        expect(fullPseudoHtml).toMatchInlineSnapshot(`
-          "...
-            <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-              <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
-                <Page>
-                  <div>
-                    <div>
-                      <div>
-                        <div>
-                          <Mismatch>
-                            <p>
-                              <span>
-                                ...
-          +                      client
-          -                      server"
-        `)
-      }
-    } else {
-      if (isReact18) {
-        expect(fullPseudoHtml).toMatchInlineSnapshot(`
-          "<Page>
-            <div>
-              <div>
-                <div>
-                  <div>
-                    <Mismatch>
-                      <p>
-                        <span>
-                          "server"
-                          "client""
-        `)
-      } else {
-        expect(fullPseudoHtml).toMatchInlineSnapshot(`
-          "...
-            <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-              <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
-                <Page>
-                  <div>
-                    <div>
-                      <div>
-                        <div>
-                          <Mismatch>
-                            <p>
-                              <span>
-                                ...
-          +                      client
-          -                      server"
-        `)
-      }
-    }
   })
 })

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -9,7 +9,7 @@ const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 // https://github.com/facebook/react/blob/main/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js used as a reference
 
 describe('Error overlay for hydration errors in Pages router', () => {
-  const { next } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
     skipStart: true,
   })
@@ -503,20 +503,37 @@ describe('Error overlay for hydration errors in Pages router', () => {
       `)
 
       const pseudoHtml = await session.getRedboxComponentStack()
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "<Root callbacks={[...]}>
-           <Head>
-           <AppContainer>
-             <Container fn={function fn}>
-               <ReactDevOverlay>
-                 <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
-                   <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                     <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
-                       <Page>
-       +                 <table>
-       -                 {" 123"}
-                     ..."
-      `)
+      if (isTurbopack) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "<Root callbacks={[...]}>
+              <Head>
+              <AppContainer>
+                <Container fn={function fn}>
+                  <ReactDevOverlay>
+                    <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                      <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
+                        <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+                          <Page>
+          +                 <table>
+          -                 {" 123"}
+                        ..."
+         `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+         "<Root callbacks={[...]}>
+             <Head>
+             <AppContainer>
+               <Container fn={function fn}>
+                 <ReactDevOverlay>
+                   <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                     <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
+                       <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+                         <Page>
+         +                 <table>
+         -                 {" 123"}
+                       ..."
+        `)
+      }
       expect(await getRedboxTotalErrorCount(browser)).toBe(1)
     }
   })

--- a/test/development/app-dir/hydration-error-count/app/bad-nesting/page.tsx
+++ b/test/development/app-dir/hydration-error-count/app/bad-nesting/page.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 export default function Page() {
   return (
     <p>

--- a/test/development/app-dir/missing-required-html-tags/index.test.ts
+++ b/test/development/app-dir/missing-required-html-tags/index.test.ts
@@ -7,59 +7,64 @@ import {
 } from 'next-test-utils'
 import { outdent } from 'outdent'
 
-describe('app-dir - missing required html tags', () => {
-  const { next } = nextTestSetup({ files: __dirname })
+const isNewOverlay = process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
 
-  it('should show error overlay', async () => {
-    const browser = await next.browser('/')
+// FIXME: NDX-797
+;(isNewOverlay ? describe.skip : describe)(
+  'app-dir - missing required html tags',
+  () => {
+    const { next } = nextTestSetup({ files: __dirname })
 
-    // There was a bug where multiple dialogs were being rendered when required
-    // html tags were missing. This test ensures there is no regression.
-    await retry(async () => {
-      const dialogs = await browser.elementsByCss('nextjs-portal')
-      expect(dialogs).toHaveLength(1)
-    })
+    it('should show error overlay', async () => {
+      const browser = await next.browser('/')
 
-    await assertHasRedbox(browser)
-    expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(`
+      // There was a bug where multiple dialogs were being rendered when required
+      // html tags were missing. This test ensures there is no regression.
+      await retry(async () => {
+        const dialogs = await browser.elementsByCss('nextjs-portal')
+        expect(dialogs).toHaveLength(1)
+      })
+
+      await assertHasRedbox(browser)
+      expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(`
       "The following tags are missing in the Root Layout: <html>, <body>.
       Read more at https://nextjs.org/docs/messages/missing-root-layout-tags"
     `)
-  })
+    })
 
-  it('should hmr when you fix the error', async () => {
-    const browser = await next.browser('/')
+    it('should hmr when you fix the error', async () => {
+      const browser = await next.browser('/')
 
-    await next.patchFile('app/layout.js', (code) =>
-      code.replace('return children', 'return <body>{children}</body>')
-    )
+      await next.patchFile('app/layout.js', (code) =>
+        code.replace('return children', 'return <body>{children}</body>')
+      )
 
-    await assertHasRedbox(browser)
-    // Wait for the HMR to apply and the updated error to show.
-    await retry(async () => {
-      expect(await getRedboxDescription(browser)).toEqual(outdent`
+      await assertHasRedbox(browser)
+      // Wait for the HMR to apply and the updated error to show.
+      await retry(async () => {
+        expect(await getRedboxDescription(browser)).toEqual(outdent`
         The following tags are missing in the Root Layout: <html>.
         Read more at https://nextjs.org/docs/messages/missing-root-layout-tags
       `)
-    })
+      })
 
-    await next.patchFile('app/layout.js', (code) =>
-      code.replace(
-        'return <body>{children}</body>',
-        'return <html><body>{children}</body></html>'
+      await next.patchFile('app/layout.js', (code) =>
+        code.replace(
+          'return <body>{children}</body>',
+          'return <html><body>{children}</body></html>'
+        )
       )
-    )
 
-    await assertNoRedbox(browser)
-    expect(await browser.elementByCss('p').text()).toBe('hello world')
+      await assertNoRedbox(browser)
+      expect(await browser.elementByCss('p').text()).toBe('hello world')
 
-    // Reintroduce the bug, but only missing html tag
-    await next.patchFile('app/layout.js', (code) =>
-      code.replace(
-        'return <html><body>{children}</body></html>',
-        'return children'
+      // Reintroduce the bug, but only missing html tag
+      await next.patchFile('app/layout.js', (code) =>
+        code.replace(
+          'return <html><body>{children}</body></html>',
+          'return children'
+        )
       )
-    )
 
     // TODO(NDX-768): Should show "missing tags" error
     await assertNoRedbox(browser)

--- a/test/development/app-dir/missing-required-html-tags/index.test.ts
+++ b/test/development/app-dir/missing-required-html-tags/index.test.ts
@@ -7,64 +7,59 @@ import {
 } from 'next-test-utils'
 import { outdent } from 'outdent'
 
-const isNewOverlay = process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
+describe('app-dir - missing required html tags', () => {
+  const { next } = nextTestSetup({ files: __dirname })
 
-// FIXME: NDX-797
-;(isNewOverlay ? describe.skip : describe)(
-  'app-dir - missing required html tags',
-  () => {
-    const { next } = nextTestSetup({ files: __dirname })
+  it('should show error overlay', async () => {
+    const browser = await next.browser('/')
 
-    it('should show error overlay', async () => {
-      const browser = await next.browser('/')
+    // There was a bug where multiple dialogs were being rendered when required
+    // html tags were missing. This test ensures there is no regression.
+    await retry(async () => {
+      const dialogs = await browser.elementsByCss('nextjs-portal')
+      expect(dialogs).toHaveLength(1)
+    })
 
-      // There was a bug where multiple dialogs were being rendered when required
-      // html tags were missing. This test ensures there is no regression.
-      await retry(async () => {
-        const dialogs = await browser.elementsByCss('nextjs-portal')
-        expect(dialogs).toHaveLength(1)
-      })
-
-      await assertHasRedbox(browser)
-      expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(`
+    await assertHasRedbox(browser)
+    expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(`
       "The following tags are missing in the Root Layout: <html>, <body>.
       Read more at https://nextjs.org/docs/messages/missing-root-layout-tags"
     `)
-    })
+  })
 
-    it('should hmr when you fix the error', async () => {
-      const browser = await next.browser('/')
+  it('should hmr when you fix the error', async () => {
+    const browser = await next.browser('/')
 
-      await next.patchFile('app/layout.js', (code) =>
-        code.replace('return children', 'return <body>{children}</body>')
-      )
+    await next.patchFile('app/layout.js', (code) =>
+      code.replace('return children', 'return <body>{children}</body>')
+    )
 
-      await assertHasRedbox(browser)
-      // Wait for the HMR to apply and the updated error to show.
-      await retry(async () => {
-        expect(await getRedboxDescription(browser)).toEqual(outdent`
+    await assertHasRedbox(browser)
+    // Wait for the HMR to apply and the updated error to show.
+    await retry(async () => {
+      expect(await getRedboxDescription(browser)).toEqual(outdent`
         The following tags are missing in the Root Layout: <html>.
         Read more at https://nextjs.org/docs/messages/missing-root-layout-tags
       `)
-      })
+    })
 
-      await next.patchFile('app/layout.js', (code) =>
-        code.replace(
-          'return <body>{children}</body>',
-          'return <html><body>{children}</body></html>'
-        )
+    await next.patchFile('app/layout.js', (code) =>
+      code.replace(
+        'return <body>{children}</body>',
+        'return <html><body>{children}</body></html>'
       )
+    )
 
-      await assertNoRedbox(browser)
-      expect(await browser.elementByCss('p').text()).toBe('hello world')
+    await assertNoRedbox(browser)
+    expect(await browser.elementByCss('p').text()).toBe('hello world')
 
-      // Reintroduce the bug, but only missing html tag
-      await next.patchFile('app/layout.js', (code) =>
-        code.replace(
-          'return <html><body>{children}</body></html>',
-          'return children'
-        )
+    // Reintroduce the bug, but only missing html tag
+    await next.patchFile('app/layout.js', (code) =>
+      code.replace(
+        'return <html><body>{children}</body></html>',
+        'return children'
       )
+    )
 
     // TODO(NDX-768): Should show "missing tags" error
     await assertNoRedbox(browser)

--- a/test/lib/development-sandbox.ts
+++ b/test/lib/development-sandbox.ts
@@ -10,7 +10,6 @@ import {
   waitFor,
   openRedbox,
   getRedboxDescriptionWarning,
-  // toggleCollapseComponentStack,
   getRedboxErrorLink,
 } from './next-test-utils'
 import webdriver, { WebdriverOptions } from './next-webdriver'
@@ -154,9 +153,6 @@ export async function createSandbox(
         getRedboxComponentStack() {
           return getRedboxComponentStack(browser)
         },
-        // async toggleCollapseComponentStack() {
-        //   return toggleCollapseComponentStack(browser)
-        // },
         async getVersionCheckerText() {
           return getVersionCheckerText(browser)
         },

--- a/test/lib/development-sandbox.ts
+++ b/test/lib/development-sandbox.ts
@@ -10,7 +10,7 @@ import {
   waitFor,
   openRedbox,
   getRedboxDescriptionWarning,
-  toggleCollapseComponentStack,
+  // toggleCollapseComponentStack,
   getRedboxErrorLink,
 } from './next-test-utils'
 import webdriver, { WebdriverOptions } from './next-webdriver'
@@ -151,12 +151,12 @@ export async function createSandbox(
         /**
          * @returns `null` if there are no frames
          */
-        async getRedboxComponentStack() {
+        getRedboxComponentStack() {
           return getRedboxComponentStack(browser)
         },
-        async toggleCollapseComponentStack() {
-          return toggleCollapseComponentStack(browser)
-        },
+        // async toggleCollapseComponentStack() {
+        //   return toggleCollapseComponentStack(browser)
+        // },
         async getVersionCheckerText() {
           return getVersionCheckerText(browser)
         },

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1320,14 +1320,6 @@ export async function getRedboxComponentStack(
   return componentStackFrameTexts.join('\n').trim()
 }
 
-// export async function toggleCollapseComponentStack(
-//   browser: BrowserInterface
-// ): Promise<void> {
-//   await browser
-//     .elementByCss('[data-nextjs-container-errors-pseudo-html-collapse]')
-//     .click()
-// }
-
 export async function hasRedboxCallStack(browser: BrowserInterface) {
   return browser.eval(() => {
     const portal = [].slice

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1306,8 +1306,7 @@ export function getSnapshotTestDescribe(variant: TestVariants) {
 export async function getRedboxComponentStack(
   browser: BrowserInterface
 ): Promise<string | null> {
-  // TODO: the type for elementsByCss is incorrect
-  const componentStackFrameElements: any = await browser.elementsByCss(
+  const componentStackFrameElements = await browser.elementsByCss(
     '[data-nextjs-container-errors-pseudo-html] code'
   )
   if (componentStackFrameElements.length === 0) {
@@ -1321,13 +1320,13 @@ export async function getRedboxComponentStack(
   return componentStackFrameTexts.join('\n').trim()
 }
 
-export async function toggleCollapseComponentStack(
-  browser: BrowserInterface
-): Promise<void> {
-  await browser
-    .elementByCss('[data-nextjs-container-errors-pseudo-html-collapse]')
-    .click()
-}
+// export async function toggleCollapseComponentStack(
+//   browser: BrowserInterface
+// ): Promise<void> {
+//   await browser
+//     .elementByCss('[data-nextjs-container-errors-pseudo-html-collapse]')
+//     .click()
+// }
 
 export async function hasRedboxCallStack(browser: BrowserInterface) {
   return browser.eval(() => {


### PR DESCRIPTION
### Why

Currently the hydration diff is collapsable and we built a solution to toggle collapse the hydration diff, so that we can show the user-land components by default and users can focus on the user-land errors. However the solution was bit complex, by filtering with the user-land components stack. The complexity especially grows when we need to deal with React 18 and 19 compatibility, as the formats are different and diff is not always in the error log. This makes everything difficult to tune.

Hence I came up with an idea that we could always show the original diff, if the diff is not included in error log like some cases in React 18, we generate one based on the component stack. We still need to deal with when the content is too long. Collapsor is very useful in those cases that we want to leverage. I used some CSS tricks to limit the height and scroll to the line that being highlighted while collapsed, with a little bit mask on it. And then when you expand the full diff shows up.

### Improvements

* Good news since we're displaying the original hydration diff, so most of the hydration diff test are identical now between turbopack and webpack
* Addressed few FIXME in hydration test
* Reuse the hydration diff view between two overlay, and much simpler implementation


### Looks 

| legacy overlay | new overlay |
|:-------|:------|
| <img width="967" alt="image" src="https://github.com/user-attachments/assets/249b982f-bfc4-436b-82d6-bdaa2bb67332" /> | <img width="963" alt="image" src="https://github.com/user-attachments/assets/5a8b25e9-2bae-4a56-bec7-c4ef8f44936e" /> |
| <img width="975" alt="image" src="https://github.com/user-attachments/assets/4b963570-16cc-4eb3-af51-f1d47752c795" /> | <img width="968" alt="image" src="https://github.com/user-attachments/assets/a49dbeb8-0dbc-4a78-9cc8-ca91d24e1bd9" /> |


Closes NDX-771