### PR TITLE
chore(github): skip nissuer when Documentation issue template is used

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -18,8 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       ${{
-        github.event_name != 'issue_comment' ||
-        (github.event_name == 'issue_comment' && !contains(github.event.issue.labels.*.name, 'stale'))
+        (github.event_name != 'issue_comment' ||
+        (github.event_name == 'issue_comment' && !contains(github.event.issue.labels.*.name, 'stale'))) &&
+        github.event.issue.type.name != 'Documentation'
       }}
     steps:
       - uses: balazsorban44/nissuer@1.10.0


### PR DESCRIPTION
## Why?

Issues with the `Documentation` **Type**, which is issues opened via the `Documentation` issue template, should not be prematurely closed with **Invalid Link** from [nissuer](https://github.com/balazsorban44/nissuer).