### PR TITLE
[dev-overlay] fix scrollbars overflow

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dialog/dialog.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dialog/dialog.tsx
@@ -31,7 +31,7 @@ export function ErrorOverlayDialog({
 
 export const DIALOG_STYLES = css`
   .error-overlay-dialog {
-    overflow-y: auto;
+    overflow: hidden;
     -webkit-font-smoothing: antialiased;
     background: var(--color-background-100);
     background-clip: padding-box;


### PR DESCRIPTION
### What?
Fixes the scrollbars overflow in the new dev overlay

### How?
Adding `overflow: hidden` to the overlay

Fixes #75818 
