### PR TITLE
Feat: Drop Dead Browser Support via Browserlist (Internet Explorer, Opera Mini)

### DIFF
--- a/packages/next/src/shared/lib/modern-browserslist-target.d.ts
+++ b/packages/next/src/shared/lib/modern-browserslist-target.d.ts
@@ -5,6 +5,7 @@ declare const MODERN_BROWSERSLIST_TARGET: [
   'firefox 67',
   'opera 51',
   'safari 12',
+  'not IE > 0',
 ]
 
 export default MODERN_BROWSERSLIST_TARGET

--- a/packages/next/src/shared/lib/modern-browserslist-target.js
+++ b/packages/next/src/shared/lib/modern-browserslist-target.js
@@ -12,6 +12,7 @@ const MODERN_BROWSERSLIST_TARGET = [
   'firefox 67',
   'opera 51',
   'safari 12',
+  'not IE > 0',
 ]
 
 module.exports = MODERN_BROWSERSLIST_TARGET


### PR DESCRIPTION
### What?

Drop Dead Browsers as a target for browserlist

> [!NOTE]
> I can update the docs, however would like more feedback before going and doing that. see the **How** section for more details

### Why?

Smaller build output, Bush isn't President, etc etc


> In addition, to reduce bundle size, Next.js will only load these polyfills for browsers that require them. The majority of the web traffic globally will not download these polyfills.

> see the docs: <https://nextjs.org/docs/14/architecture/supported-browsers>



### How?

Really it should be something like:


```jsonc
      "> 0.2% and not dead",
      "iOS >= 14",
      "not IE > 0",
      "not op_mini all",
      "last 4 versions",
      "not and_uc 12.12",
      "not samsung 4",
      "not ios_saf 12.2-12.5"
```



