### PR TITLE
[error overlay] fix missing html error is not displayed

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/dialog/styles.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/dialog/styles.ts
@@ -29,7 +29,9 @@ const styles = css`
     outline: none;
   }
 
-  /* Place overflow: hidden on this so we can break out from [data-nextjs-dialog] */
+  ${
+    '' /* Place overflow: hidden on this so we can break out from [data-nextjs-dialog] */
+  }
   [data-nextjs-dialog-sizer] {
     overflow: hidden;
     border-radius: inherit;
@@ -48,7 +50,6 @@ const styles = css`
   [data-nextjs-dialog-content] {
     border: none;
     margin: 0;
-    height: 100%;
     display: flex;
     flex-direction: column;
     position: relative;


### PR DESCRIPTION
### What

`[data-nextjs-dialog-content]` was set to `height: 100%`, which has conflicted with useMeasureHeight hook. `data-nextjs-dialog-content]` 's parent is always controlled by `useMeasureHeight`, and the height is anmiating from 0 to the child height. If the child is aligned with that parent, then the height is always 0, which lead to not displayed

Closes NDX-797