### PR TITLE
Docs: corrected a statement about the default caching behavior of `fetch`

### DIFF
--- a/docs/01-app/03-building-your-application/02-data-fetching/01-fetching.mdx
+++ b/docs/01-app/03-building-your-application/02-data-fetching/01-fetching.mdx
@@ -57,7 +57,7 @@ This example demonstrates a basic server-side data fetch using the `fetch` API i
 
 ### Fetching data on the server with the `fetch` API
 
-This component will fetch and display a list of blog posts. The response from `fetch` is not cached by default.
+This component will fetch and display a list of blog posts. The response from `fetch` is cached by default.
 
 ```tsx filename="app/page.tsx" switcher
 export default async function Page() {


### PR DESCRIPTION
In [Data Fetching and Caching](https://nextjs.org/docs/app/building-your-application/data-fetching/fetching#fetching-data-on-the-server-with-the-fetch-api), some part of the docs states:

> The response from `fetch` is **not** cached by default.

I removed "_not_", because the remainer of the docs seems to indicate otherwise.

## Context

Right below the statement I quoted, it is said the following

> If you are not using any [Dynamic APIs](https://nextjs.org/docs/app/building-your-application/rendering/server-components#dynamic-rendering) anywhere else in this route, it will be prerendered during next build to a static page.

I think this statement is conflicting with `fetch` not being cached by default, because the documentation page about server components indicates this:

> | Dynamic APIs | Data       | Route                |
> | ------------ | ---------- | -------------------- |
> | No           | Cached     | Statically Rendered  |
> | Yes          | Cached     | Dynamically Rendered |
> | No           | Not Cached | Dynamically Rendered |
> | Yes          | Not Cached | Dynamically Rendered |

This suggests that Next.js will opt in for static rendering only if `fetch` is cached, which seems confirmed in the API reference of `fetch` ([`options.cache`](https://nextjs.org/docs/app/api-reference/functions/fetch#optionscache)):

> `auto no cache` (default): Next.js [...] will fetch once during `next build` because the route will be statically prerendered. 

## What's still unclear

I'm not issuing this PR with 100% confidence. It is difficult for me to find a clear source of truth about the default caching behaviors of `fetch`.

The headline of the [Next.js v15 announcement](https://nextjs.org/blog/next-15) states: "_`fetch` requests [...] are no longer cached by default._", which contradicts my findings above. 

However, if you head to the [Caching Semantics section](https://nextjs.org/blog/next-15#caching-semantics) of that blog post, it provides no further context about `fetch` no longer being cached. 

You actually need to scroll down to the [Other Changes section](https://nextjs.org/blog/next-15#other-changes) to discover that, in fact, `fetch` is no longer cached only in specific scenarios. Namely, _`force-dynamic` will now set a `no-store` default to the fetch cache_. I could not find any mention of that relationship between `force-dynamic` and `no-store` in the docs.

I find the API reference for `fetch` even more confusing:

  1. By default, Next.js "_will **fetch once** during `next build` because the route will be statically prerendered._"
  2. Also, by default, Next.js "_**fetches** the resource from the remote server **on every request in development**_"
  3. What's more, "_Next.js **caches** `fetch` responses in Server Components across Hot Module Replacement (HMR) **in local development**_", which seems to be in direct contradiction with `2.`

And there is no mention of `force-dynamic` making `no-store` the new default for `fetch`'s cache.

For these reasons, I think further updates are needed in the docs to clarify the default caching behavior of `fetch` in Next.js.