### PR TITLE
[error overlay] missing html tags error should be blocking

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay/error-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay/error-overlay.tsx
@@ -43,14 +43,16 @@ export function ErrorOverlay({
   if (!!state.rootLayoutMissingTags?.length) {
     return (
       <RootLayoutMissingTagsError
-        missingTags={state.rootLayoutMissingTags}
         {...commonProps}
+        // This is a runtime error, forcedly display error overlay
+        rendered
+        missingTags={state.rootLayoutMissingTags}
       />
     )
   }
 
   if (state.buildError !== null) {
-    return <BuildError message={state.buildError} {...commonProps} />
+    return <BuildError {...commonProps} message={state.buildError} />
   }
 
   // No Runtime Errors.
@@ -64,12 +66,12 @@ export function ErrorOverlay({
 
   return (
     <Errors
+      {...commonProps}
       debugInfo={state.debugInfo}
       readyErrors={readyErrors}
       onClose={() => {
         setIsErrorOverlayOpen(false)
       }}
-      {...commonProps}
     />
   )
 }

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/use-error-hook.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/use-error-hook.ts
@@ -30,8 +30,7 @@ function getErrorSignature(ev: SupportedErrorEvent): string {
       break
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const _ = event satisfies never
+  event satisfies never
   return ''
 }
 
@@ -109,7 +108,7 @@ export function useErrorHook({
     // missing tags won't be dismissed until resolved, the
     // total number of errors may be fixed to their length.
     totalErrorCount: rootLayoutMissingTags?.length
-      ? rootLayoutMissingTags.length
+      ? 1
       : !!buildError
         ? 1
         : readyErrors.length,

--- a/test/development/app-dir/missing-required-html-tags-new-overlay/app/layout.js
+++ b/test/development/app-dir/missing-required-html-tags-new-overlay/app/layout.js
@@ -1,0 +1,3 @@
+export default function Layout({ children }) {
+  return <body>{children}</body>
+}

--- a/test/development/app-dir/missing-required-html-tags-new-overlay/app/page.js
+++ b/test/development/app-dir/missing-required-html-tags-new-overlay/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/development/app-dir/missing-required-html-tags-new-overlay/missing-html-tags-new-overlay.test.ts
+++ b/test/development/app-dir/missing-required-html-tags-new-overlay/missing-html-tags-new-overlay.test.ts
@@ -1,0 +1,47 @@
+import { nextTestSetup } from 'e2e-utils'
+import {
+  assertHasRedbox,
+  assertNoRedbox,
+  getRedboxDescription,
+  getToastErrorCount,
+  hasErrorToast,
+  retry,
+} from 'next-test-utils'
+import { outdent } from 'outdent'
+
+// TODO: merge with test/development/app-dir/missing-required-html-tags/index.test.ts
+//  once new overlay is stable
+describe('app-dir - missing required html tags', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should display correct error count in dev indicator', async () => {
+    const browser = await next.browser('/')
+
+    retry(async () => {
+      expect(await hasErrorToast(browser)).toBe(true)
+    })
+    // Dev indicator should show 1 error
+    expect(await getToastErrorCount(browser)).toBe(1)
+
+    await assertHasRedbox(browser)
+
+    await retry(async () => {
+      expect(await getRedboxDescription(browser)).toEqual(outdent`
+        The following tags are missing in the Root Layout: <html>.
+        Read more at https://nextjs.org/docs/messages/missing-root-layout-tags
+      `)
+    })
+
+    await next.patchFile('app/layout.js', (code) =>
+      code.replace(
+        'return <body>{children}</body>',
+        'return <html><body>{children}</body></html>'
+      )
+    )
+
+    await assertNoRedbox(browser)
+    expect(await browser.elementByCss('p').text()).toBe('hello world')
+  })
+})

--- a/test/development/app-dir/missing-required-html-tags-new-overlay/next.config.js
+++ b/test/development/app-dir/missing-required-html-tags-new-overlay/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+module.exports = {
+  experimental: {
+    newDevOverlay: true,
+  },
+}

--- a/test/development/app-dir/missing-required-html-tags/index.test.ts
+++ b/test/development/app-dir/missing-required-html-tags/index.test.ts
@@ -64,7 +64,7 @@ describe('app-dir - missing required html tags', () => {
     )
 
     await openRedbox(browser)
-    // TODO(NDX-768): Should show "missing tags" error
+
     expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(`
       "In HTML, <p> cannot be a child of <#document>.
       This will cause a hydration error."


### PR DESCRIPTION
### What

missing html tags error should always show the overlay when exist, and the dev indicator count should be 1 since we require users to resolve this first then React can hydrate the right content. After this they can move to others.

Since the indicator count is not covered in old test, I add a new test for new overlay rn, later we can merge them

#### Observed 

* Currently it requires to click the indicator to show the error
* The indicator count shows 2

#### Expected

* The overlay should pop up as it's a runtime error
* The indicator count shows 1
