### PR TITLE
docs: add Chrome debugging port configuration steps

### DIFF
--- a/docs/01-app/03-building-your-application/07-configuring/16-debugging.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/16-debugging.mdx
@@ -131,9 +131,11 @@ ready - started server on 0.0.0.0:3000, url: http://localhost:3000
 For Chrome:
 
 1. Open a new tab and visit `chrome://inspect`
-2. Look for your Next.js application in the **Remote Target** section
-3. Click **inspect** to open a separate DevTools window
-4. Go to the **Sources** tab
+2. Click **Configure...** to ensure both debugging ports are listed
+3. Add both `localhost:9229` and `localhost:9230` if they're not already present
+4. Look for your Next.js application in the **Remote Target** section
+5. Click **inspect** to open a separate DevTools window
+6. Go to the **Sources** tab
 
 For Firefox:
 


### PR DESCRIPTION
This configure step is potentially required for the ports to show up in the remote targets.