### PR TITLE
[Turbopack] fix recompute invalidation

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -682,6 +682,13 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             return Ok(Err(listener));
         }
 
+        let _span = tracing::trace_span!(
+            "recomputation",
+            cell_type = registry::get_value_type_global_name(cell.type_id),
+            cell_index = cell.index
+        )
+        .entered();
+
         // We create the event and potentially schedule the task
         let in_progress = InProgressCellState::new(task_id, cell);
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1223,8 +1223,10 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         // take the children from the task to process them
         let mut new_children = take(new_children);
 
-        // TODO handle stateful
-        let _ = stateful;
+        // handle stateful
+        if stateful {
+            task.insert(CachedDataItem::Stateful { value: () });
+        }
 
         // handle cell counters: update max index and remove cells that are no longer used
         let mut old_counters: FxHashMap<_, _> =

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
@@ -29,34 +29,32 @@ impl UpdateCellOperation {
             in_progress.event.notify(usize::MAX);
         }
 
-        let recomputed = !task.has_key(&CachedDataItemKey::Dirty {});
-        // recomputed means task wasn't invalidated, so we just recompute, so the content has not
-        // actually changed (At least we have to assume that tasks are deterministic and
-        // pure).
+        // We need to detect recomputation, because here the content has not actually changed (even
+        // if it's not equal to the old content, as not all values implement Eq). We have to
+        // assume that tasks are deterministic and pure.
 
-        if recomputed || !ctx.should_track_dependencies() {
+        if ctx.should_track_dependencies() && task.has_key(&CachedDataItemKey::Dirty {}) {
+            let dependent = get_many!(
+                task,
+                CellDependent { cell: dependent_cell, task }
+                if dependent_cell == cell
+                => task
+            );
+
             drop(task);
             drop(old_content);
-            return;
+
+            InvalidateOperation::run(
+                dependent,
+                #[cfg(feature = "trace_task_dirty")]
+                TaskDirtyCause::CellChange {
+                    value_type: cell.type_id,
+                },
+                ctx,
+            );
+        } else {
+            drop(task);
+            drop(old_content);
         }
-
-        let dependent = get_many!(
-            task,
-            CellDependent { cell: dependent_cell, task }
-            if dependent_cell == cell
-            => task
-        );
-
-        drop(task);
-        drop(old_content);
-
-        InvalidateOperation::run(
-            dependent,
-            #[cfg(feature = "trace_task_dirty")]
-            TaskDirtyCause::CellChange {
-                value_type: cell.type_id,
-            },
-            ctx,
-        );
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
@@ -29,7 +29,7 @@ impl UpdateCellOperation {
             in_progress.event.notify(usize::MAX);
         }
 
-        let recomputed = old_content.is_none() && !task.has_key(&CachedDataItemKey::Dirty {});
+        let recomputed = !task.has_key(&CachedDataItemKey::Dirty {});
         // recomputed means task wasn't invalidated, so we just recompute, so the content has not
         // actually changed (At least we have to assume that tasks are deterministic and
         // pure).

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
@@ -33,7 +33,12 @@ impl UpdateCellOperation {
         // if it's not equal to the old content, as not all values implement Eq). We have to
         // assume that tasks are deterministic and pure.
 
-        if ctx.should_track_dependencies() && task.has_key(&CachedDataItemKey::Dirty {}) {
+        if ctx.should_track_dependencies()
+            && (task.has_key(&CachedDataItemKey::Dirty {})
+                ||
+                // This is a hack for the streaming hack. Stateful tasks are never recomputed, so this forces invalidation for them in case of this hack.
+                task.has_key(&CachedDataItemKey::Stateful {}))
+        {
             let dependent = get_many!(
                 task,
                 CellDependent { cell: dependent_cell, task }

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -440,6 +440,11 @@ pub enum CachedDataItem {
         value: DirtyContainerCount,
     },
 
+    // Flags
+    Stateful {
+        value: (),
+    },
+
     // Transient Root Type
     #[serde(skip)]
     Activeness {
@@ -509,6 +514,7 @@ impl CachedDataItem {
                 !collectible.cell.task.is_transient()
             }
             CachedDataItem::AggregatedDirtyContainerCount { .. } => true,
+            CachedDataItem::Stateful { .. } => true,
             CachedDataItem::Activeness { .. } => false,
             CachedDataItem::InProgress { .. } => false,
             CachedDataItem::InProgressCell { .. } => false,
@@ -562,7 +568,8 @@ impl CachedDataItem {
             | Self::Upper { .. }
             | Self::AggregatedDirtyContainer { .. }
             | Self::AggregatedCollectible { .. }
-            | Self::AggregatedDirtyContainerCount { .. } => TaskDataCategory::Meta,
+            | Self::AggregatedDirtyContainerCount { .. }
+            | Self::Stateful { .. } => TaskDataCategory::Meta,
 
             Self::OutdatedCollectible { .. }
             | Self::OutdatedOutputDependency { .. }
@@ -601,6 +608,7 @@ impl CachedDataItemKey {
                 !collectible.cell.task.is_transient()
             }
             CachedDataItemKey::AggregatedDirtyContainerCount { .. } => true,
+            CachedDataItemKey::Stateful { .. } => true,
             CachedDataItemKey::Activeness { .. } => false,
             CachedDataItemKey::InProgress { .. } => false,
             CachedDataItemKey::InProgressCell { .. } => false,
@@ -642,7 +650,8 @@ impl CachedDataItemType {
             | Self::Upper { .. }
             | Self::AggregatedDirtyContainer { .. }
             | Self::AggregatedCollectible { .. }
-            | Self::AggregatedDirtyContainerCount { .. } => TaskDataCategory::Meta,
+            | Self::AggregatedDirtyContainerCount { .. }
+            | Self::Stateful { .. } => TaskDataCategory::Meta,
 
             Self::OutdatedCollectible { .. }
             | Self::OutdatedOutputDependency { .. }

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1676,6 +1676,7 @@ pub fn mark_stateful() -> SerializationInvalidator {
 }
 
 pub fn prevent_gc() {
+    // There is a hack in UpdateCellOperation that need to be updated when this is changed.
     mark_stateful();
 }
 


### PR DESCRIPTION
### What?

* add tracing to recomputation
* fix recomputation hanging in a loop (reexecution should not invalidate recomputed cells, even if they still have content and Eq says they are not equal. Some value types does implement Eq as always false, e. g. the AST)



Closes PACK-3930