### PR TITLE
[Turbopack] Add `final_read_hint` API and change `clone_value` to `owned`

### DIFF
--- a/crates/napi/src/next_api/endpoint.rs
+++ b/crates/napi/src/next_api/endpoint.rs
@@ -173,7 +173,7 @@ pub async fn endpoint_write_to_disk(
         .await
         .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;
     Ok(TurbopackResult {
-        result: NapiWrittenEndpoint::from(written.map(|v| ReadRef::into_owned(v))),
+        result: NapiWrittenEndpoint::from(written.map(ReadRef::into_owned)),
         issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
         diagnostics: diags.iter().map(|d| NapiDiagnostic::from(d)).collect(),
     })

--- a/crates/napi/src/next_api/endpoint.rs
+++ b/crates/napi/src/next_api/endpoint.rs
@@ -173,7 +173,7 @@ pub async fn endpoint_write_to_disk(
         .await
         .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;
     Ok(TurbopackResult {
-        result: NapiWrittenEndpoint::from(written.map(|v| v.clone_value())),
+        result: NapiWrittenEndpoint::from(written.map(|v| ReadRef::into_owned(v))),
         issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
         diagnostics: diags.iter().map(|d| NapiDiagnostic::from(d)).collect(),
     })

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1,5 +1,3 @@
-use std::future::IntoFuture;
-
 use anyhow::{Context, Result};
 use next_core::{
     all_assets_from_entries,
@@ -195,7 +193,7 @@ impl AppProject {
             self.project().project_path(),
             self.project().execution_context(),
             self.project().client_compile_time_info().environment(),
-            Value::new(self.client_ty().await?.clone_value()),
+            Value::new(self.client_ty().owned().await?),
             self.project().next_mode(),
             self.project().next_config(),
             self.project().encryption_key(),
@@ -206,7 +204,7 @@ impl AppProject {
     async fn client_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_client_resolve_options_context(
             self.project().project_path(),
-            Value::new(self.client_ty().await?.clone_value()),
+            Value::new(self.client_ty().owned().await?),
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
@@ -229,7 +227,7 @@ impl AppProject {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
-            Value::new(self.rsc_ty().await?.clone_value()),
+            Value::new(self.rsc_ty().owned().await?),
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::NodeJs,
@@ -242,7 +240,7 @@ impl AppProject {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
-            Value::new(self.rsc_ty().await?.clone_value()),
+            Value::new(self.rsc_ty().owned().await?),
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::Edge,
@@ -255,7 +253,7 @@ impl AppProject {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
-            Value::new(self.route_ty().await?.clone_value()),
+            Value::new(self.route_ty().owned().await?),
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::NodeJs,
@@ -268,7 +266,7 @@ impl AppProject {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
-            Value::new(self.route_ty().await?.clone_value()),
+            Value::new(self.route_ty().owned().await?),
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::Edge,
@@ -280,7 +278,7 @@ impl AppProject {
     async fn rsc_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_server_resolve_options_context(
             self.project().project_path(),
-            Value::new(self.rsc_ty().await?.clone_value()),
+            Value::new(self.rsc_ty().owned().await?),
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
@@ -291,7 +289,7 @@ impl AppProject {
     async fn edge_rsc_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_edge_resolve_options_context(
             self.project().project_path(),
-            Value::new(self.rsc_ty().await?.clone_value()),
+            Value::new(self.rsc_ty().owned().await?),
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
@@ -302,7 +300,7 @@ impl AppProject {
     async fn route_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_server_resolve_options_context(
             self.project().project_path(),
-            Value::new(self.route_ty().await?.clone_value()),
+            Value::new(self.route_ty().owned().await?),
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
@@ -315,7 +313,7 @@ impl AppProject {
     ) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_edge_resolve_options_context(
             self.project().project_path(),
-            Value::new(self.route_ty().await?.clone_value()),
+            Value::new(self.route_ty().owned().await?),
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
@@ -576,7 +574,7 @@ impl AppProject {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
-            Value::new(self.ssr_ty().await?.clone_value()),
+            Value::new(self.ssr_ty().owned().await?),
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::NodeJs,
@@ -589,7 +587,7 @@ impl AppProject {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
-            Value::new(self.ssr_ty().await?.clone_value()),
+            Value::new(self.ssr_ty().owned().await?),
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::Edge,
@@ -601,7 +599,7 @@ impl AppProject {
     async fn ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_server_resolve_options_context(
             self.project().project_path(),
-            Value::new(self.ssr_ty().await?.clone_value()),
+            Value::new(self.ssr_ty().owned().await?),
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
@@ -612,7 +610,7 @@ impl AppProject {
     async fn edge_ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_edge_resolve_options_context(
             self.project().project_path(),
-            Value::new(self.ssr_ty().await?.clone_value()),
+            Value::new(self.ssr_ty().owned().await?),
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
@@ -724,7 +722,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn runtime_entries(self: Vc<Self>) -> Result<Vc<RuntimeEntries>> {
         Ok(get_server_runtime_entries(
-            Value::new(self.rsc_ty().await?.clone_value()),
+            Value::new(self.rsc_ty().owned().await?),
             self.project().next_mode(),
         ))
     }
@@ -753,7 +751,7 @@ impl AppProject {
     async fn client_runtime_entries(self: Vc<Self>) -> Result<Vc<EvaluatableAssets>> {
         Ok(get_client_runtime_entries(
             self.project().project_path(),
-            Value::new(self.client_ty().await?.clone_value()),
+            Value::new(self.client_ty().owned().await?),
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
@@ -772,8 +770,8 @@ impl AppProject {
                     Ok((
                         pathname.to_string().into(),
                         app_entry_point_to_route(self, app_entrypoint.clone())
-                            .await?
-                            .clone_value(),
+                            .owned()
+                            .await?,
                     ))
                 })
                 .try_join()
@@ -1478,7 +1476,7 @@ impl AppEndpoint {
                             .clone()
                             .map(Regions::Multiple),
                         matchers: vec![matchers],
-                        env: project.edge_env().await?.clone_value(),
+                        env: project.edge_env().owned().await?,
                     };
                     let middleware_manifest_v2 = MiddlewaresManifestV2 {
                         sorted_middleware: vec![app_entry.original_name.clone()],
@@ -1629,11 +1627,8 @@ impl AppEndpoint {
 
         Ok(match runtime {
             NextRuntime::Edge => {
-                let mut evaluatable_assets = this
-                    .app_project
-                    .edge_rsc_runtime_entries()
-                    .await?
-                    .clone_value();
+                let mut evaluatable_assets =
+                    this.app_project.edge_rsc_runtime_entries().owned().await?;
                 let evaluatable = ResolvedVc::try_sidecast(app_entry.rsc_entry)
                     .context("Entry module must be evaluatable")?;
                 evaluatable_assets.push(evaluatable);
@@ -1656,8 +1651,7 @@ impl AppEndpoint {
                 }
             }
             NextRuntime::NodeJs => {
-                let mut evaluatable_assets =
-                    this.app_project.rsc_runtime_entries().await?.clone_value();
+                let mut evaluatable_assets = this.app_project.rsc_runtime_entries().owned().await?;
 
                 evaluatable_assets.push(server_action_manifest_loader);
 
@@ -1829,16 +1823,13 @@ impl Endpoint for AppEndpoint {
                 .is_development()
             {
                 let node_root = this.app_project.project().node_root();
-                let server_paths = all_server_paths(output_assets, node_root)
-                    .await?
-                    .clone_value();
+                let server_paths = all_server_paths(output_assets, node_root).owned().await?;
 
                 let client_relative_root = this.app_project.project().client_relative_path();
                 let client_paths = all_paths_in_root(output_assets, client_relative_root)
-                    .into_future()
+                    .owned()
                     .instrument(tracing::info_span!("client_paths"))
-                    .await?
-                    .clone_value();
+                    .await?;
                 (server_paths, client_paths)
             } else {
                 (vec![], vec![])

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -120,8 +120,8 @@ impl InstrumentationEndpoint {
             this.project.next_mode(),
         )
         .resolve_entries(*this.asset_context)
-        .await?
-        .clone_value();
+        .owned()
+        .await?;
 
         let Some(module) = ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(module)
         else {
@@ -187,7 +187,7 @@ impl InstrumentationEndpoint {
 
         if this.is_edge {
             let edge_files = self.edge_files();
-            let mut output_assets = edge_files.await?.clone_value();
+            let mut output_assets = edge_files.owned().await?;
 
             let node_root = this.project.node_root();
             let node_root_value = node_root.await?;
@@ -256,9 +256,7 @@ impl Endpoint for InstrumentationEndpoint {
 
             let server_paths = if this.project.next_mode().await?.is_development() {
                 let node_root = this.project.node_root();
-                all_server_paths(output_assets, node_root)
-                    .await?
-                    .clone_value()
+                all_server_paths(output_assets, node_root).owned().await?
             } else {
                 vec![]
             };

--- a/crates/next-api/src/loadable_manifest.rs
+++ b/crates/next-api/src/loadable_manifest.rs
@@ -27,7 +27,7 @@ pub async fn create_react_loadable_manifest(
     for (_, (module_id, chunk_output)) in dynamic_import_entries.into_iter() {
         let chunk_output = chunk_output.await?;
 
-        let id = module_id.to_string().await?.clone_value();
+        let id = module_id.to_string().owned().await?;
 
         let client_relative_path_value = client_relative_path.await?;
         let files = chunk_output

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -503,10 +503,10 @@ impl ReducedGraphs {
                     .server_actions
                     .iter()
                     .map(|graph| async move {
-                        Ok(graph
+                        graph
                             .get_server_actions_for_endpoint(entry, rsc_asset_context)
                             .owned()
-                            .await?)
+                            .await
                     })
                     .try_flat_join()
                     .await?;

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -12,7 +12,8 @@ use next_core::{
 use rustc_hash::FxHashMap;
 use tracing::Instrument;
 use turbo_tasks::{
-    CollectiblesSource, FxIndexMap, FxIndexSet, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Vc,
+    CollectiblesSource, FxIndexMap, FxIndexSet, ReadRef, ResolvedVc, TryFlatJoinIterExt,
+    TryJoinIterExt, Vc,
 };
 use turbopack_core::{
     context::AssetContext,
@@ -504,8 +505,8 @@ impl ReducedGraphs {
                     .map(|graph| async move {
                         Ok(graph
                             .get_server_actions_for_endpoint(entry, rsc_asset_context)
-                            .await?
-                            .clone_value())
+                            .owned()
+                            .await?)
                     })
                     .try_flat_join()
                     .await?;
@@ -530,8 +531,8 @@ impl ReducedGraphs {
                 // Just a single graph, no need to merge results
                 graph
                     .get_client_references_for_endpoint(entry)
+                    .owned()
                     .await?
-                    .clone_value()
             } else {
                 let results = self
                     .client_references
@@ -544,8 +545,9 @@ impl ReducedGraphs {
                     .try_join()
                     .await?;
 
-                let mut result = results[0].clone_value();
-                for r in results.into_iter().skip(1) {
+                let mut iter = results.into_iter();
+                let mut result = ReadRef::into_owned(iter.next().unwrap());
+                for r in iter {
                     result.extend(&r);
                 }
                 result

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1,5 +1,3 @@
-use std::future::IntoFuture;
-
 use anyhow::{bail, Context, Result};
 use futures::future::BoxFuture;
 use next_core::{
@@ -959,7 +957,7 @@ impl PageEndpoint {
 
             let is_edge = matches!(runtime, NextRuntime::Edge);
             if is_edge {
-                let mut evaluatable_assets = edge_runtime_entries.await?.clone_value();
+                let mut evaluatable_assets = edge_runtime_entries.owned().await?;
                 let evaluatable = ResolvedVc::try_sidecast(ssr_module)
                     .context("could not process page loader entry module")?;
                 evaluatable_assets.push(evaluatable);
@@ -1107,7 +1105,7 @@ impl PageEndpoint {
             .context("ssr chunk entry path must be inside the node root")?;
 
         let pages_manifest = PagesManifest {
-            pages: [(self.pathname.await?.clone_value(), asset_path.into())]
+            pages: [(self.pathname.owned().await?, asset_path.into())]
                 .into_iter()
                 .collect(),
         };
@@ -1146,7 +1144,7 @@ impl PageEndpoint {
         let node_root = self.pages_project.project().node_root();
         let client_relative_path = self.pages_project.project().client_relative_path();
         let build_manifest = BuildManifest {
-            pages: fxindexmap!(self.pathname.await?.clone_value() => client_chunks),
+            pages: fxindexmap!(self.pathname.owned().await? => client_chunks),
             ..Default::default()
         };
         let manifest_path_prefix = get_asset_prefix_from_pathname(&self.pathname.await?);
@@ -1185,7 +1183,7 @@ impl PageEndpoint {
         };
         let emit_manifests = !matches!(this.ty, PageEndpointType::Data);
 
-        let pathname = this.pathname.await?;
+        let pathname = this.pathname.owned().await?;
         let original_name = &*this.original_name.await?;
 
         let client_assets = OutputAssets::new(client_assets).to_resolved().await?;
@@ -1301,23 +1299,23 @@ impl PageEndpoint {
                     let named_regex = get_named_middleware_regex(&pathname).into();
                     let matchers = MiddlewareMatcher {
                         regexp: Some(named_regex),
-                        original_source: pathname.clone_value(),
+                        original_source: pathname.clone(),
                         ..Default::default()
                     };
-                    let original_name = this.original_name.await?;
+                    let original_name = this.original_name.owned().await?;
                     let edge_function_definition = EdgeFunctionDefinition {
                         files: file_paths_from_root,
                         wasm: wasm_paths_to_bindings(wasm_paths_from_root),
                         assets: paths_to_bindings(all_assets),
-                        name: pathname.clone_value(),
-                        page: original_name.clone_value(),
+                        name: pathname.clone(),
+                        page: original_name.clone(),
                         regions: None,
                         matchers: vec![matchers],
-                        env: this.pages_project.project().edge_env().await?.clone_value(),
+                        env: this.pages_project.project().edge_env().owned().await?,
                     };
                     let middleware_manifest_v2 = MiddlewaresManifestV2 {
-                        sorted_middleware: vec![pathname.clone_value()],
-                        functions: [(pathname.clone_value(), edge_function_definition)]
+                        sorted_middleware: vec![pathname.clone()],
+                        functions: [(pathname.clone(), edge_function_definition)]
                             .into_iter()
                             .collect(),
                         ..Default::default()
@@ -1405,16 +1403,13 @@ impl Endpoint for PageEndpoint {
                 .await?
                 .is_development()
             {
-                let server_paths = all_server_paths(output_assets, node_root)
-                    .await?
-                    .clone_value();
+                let server_paths = all_server_paths(output_assets, node_root).owned().await?;
 
                 let client_relative_root = this.pages_project.project().client_relative_path();
                 let client_paths = all_paths_in_root(output_assets, client_relative_root)
-                    .into_future()
+                    .owned()
                     .instrument(tracing::info_span!("client_paths"))
-                    .await?
-                    .clone_value();
+                    .await?;
                 (server_paths, client_paths)
             } else {
                 (vec![], vec![])

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1676,7 +1676,7 @@ async fn any_output_changed(
 async fn get_referenced_output_assets(
     parent: ResolvedVc<Box<dyn OutputAsset>>,
 ) -> Result<impl Iterator<Item = ResolvedVc<Box<dyn OutputAsset>>> + Send> {
-    Ok(parent.references().await?.clone_value().into_iter())
+    Ok(parent.references().owned().await?.into_iter())
 }
 
 #[turbo_tasks::function(operation)]

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1511,7 +1511,9 @@ impl Project {
         // first seen version of the session.
         let state = VersionState::new(
             version
-                .into_trait_ref_strongly_consistent_untracked()
+                .into_trait_ref()
+                .strongly_consistent()
+                .untracked()
                 .await?,
         )
         .await?;

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -237,7 +237,7 @@ impl DirectoryTree {
         let mut subdirectories = BTreeMap::new();
 
         for (name, subdirectory) in &self.subdirectories {
-            subdirectories.insert(name.clone(), subdirectory.into_plain().await?.clone_value());
+            subdirectories.insert(name.clone(), subdirectory.into_plain().owned().await?);
         }
 
         Ok(PlainDirectoryTree {
@@ -1161,7 +1161,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
     // segment config. https://nextjs.org/docs/app/building-your-application/rendering/edge-and-nodejs-runtimes#segment-runtime-option
     // Pass down layouts from each tree to apply segment config when adding route.
     let root_layouts = if let Some(layout) = modules.layout {
-        let mut layouts = root_layouts.await?.clone_value();
+        let mut layouts = root_layouts.owned().await?;
         layouts.push(layout);
         ResolvedVc::cell(layouts)
     } else {

--- a/crates/next-core/src/bootstrap.rs
+++ b/crates/next-core/src/bootstrap.rs
@@ -70,7 +70,7 @@ pub async fn bootstrap(
 
     let pathname = normalize_app_page_to_pathname(path);
 
-    let mut config = config.await?.clone_value();
+    let mut config = config.owned().await?;
     config.insert("PAGE".to_string(), path.to_string());
     config.insert("PATHNAME".to_string(), pathname);
 
@@ -97,7 +97,7 @@ pub async fn bootstrap(
         .to_resolved()
         .await?;
 
-    let mut inner_assets = inner_assets.await?.clone_value();
+    let mut inner_assets = inner_assets.owned().await?;
     inner_assets.insert("ENTRY".into(), asset);
     inner_assets.insert("BOOTSTRAP_CONFIG".into(), config_asset);
 

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -80,7 +80,7 @@ pub async fn get_app_route_entry(
             "VAR_DEFINITION_FILENAME" => path.file_stem().await?.as_ref().unwrap().as_str().into(),
             // TODO(alexkirsz) Is this necessary?
             "VAR_DEFINITION_BUNDLE_PATH" => "".to_string().into(),
-            "VAR_RESOLVED_PAGE_PATH" => path.to_string().await?.clone_value(),
+            "VAR_RESOLVED_PAGE_PATH" => path.to_string().owned().await?,
             "VAR_USERLAND" => INNER.into(),
         },
         fxindexmap! {

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -203,7 +203,7 @@ pub async fn get_client_resolve_options_context(
         enable_typescript: true,
         enable_react: true,
         enable_mjs_extension: true,
-        custom_extensions: next_config.resolve_extension().await?.clone_value(),
+        custom_extensions: next_config.resolve_extension().owned().await?,
         rules: vec![(
             foreign_code_context_condition(next_config, project_path).await?,
             module_options_context.clone().resolved_cell(),
@@ -337,7 +337,7 @@ pub async fn get_client_module_options_context(
         execution_context: Some(execution_context),
         tree_shaking_mode: tree_shaking_mode_for_user_code,
         enable_postcss_transform,
-        side_effect_free_packages: next_config.optimize_package_imports().await?.clone_value(),
+        side_effect_free_packages: next_config.optimize_package_imports().owned().await?,
         keep_last_successful_parse: next_mode.is_development(),
         ..Default::default()
     };

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -190,7 +190,7 @@ pub async fn get_edge_resolve_options_context(
         enable_react: true,
         enable_mjs_extension: true,
         enable_edge_node_externals: true,
-        custom_extensions: next_config.resolve_extension().await?.clone_value(),
+        custom_extensions: next_config.resolve_extension().owned().await?,
         rules: vec![(
             foreign_code_context_condition(next_config, project_path).await?,
             resolve_options_context.clone().resolved_cell(),

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -238,8 +238,8 @@ impl NextFontGoogleCssModuleReplacer {
                     scoped_font_family,
                     font_fallback.has_size_adjust(),
                 )
-                .await?
-                .clone_value(),
+                .owned()
+                .await?,
             ),
             None => {
                 println!(
@@ -303,7 +303,7 @@ impl ImportMappingReplacement for NextFontGoogleCssModuleReplacer {
             return Ok(ImportMapResult::NoEntry.cell());
         };
 
-        Ok(self.import_map_result(query_vc.await?.clone_value()))
+        Ok(self.import_map_result(query_vc.owned().await?))
     }
 }
 

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -345,7 +345,7 @@ impl Issue for FontResolvingIssue {
         let this = self.await?;
         Ok(StyledString::Line(vec![
             StyledString::Text("Font file not found: Can't resolve '".into()),
-            StyledString::Code(this.font_path.await?.clone_value()),
+            StyledString::Code(this.font_path.owned().await?),
             StyledString::Text("'".into()),
         ])
         .cell())

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -338,11 +338,12 @@ impl ClientReferenceManifest {
                     .server_path()
                     .with_extension("".into())
                     .to_string()
+                    .owned()
                     .await?;
                 let mut entry_css_files_with_chunk = Vec::new();
                 let entry_js_files = entry_manifest
                     .entry_js_files
-                    .entry(server_component_name.clone_value())
+                    .entry(server_component_name.clone())
                     .or_default();
 
                 let client_chunks = &client_chunks.await?;
@@ -388,7 +389,7 @@ impl ClientReferenceManifest {
 
                 let entry_css_files = entry_manifest
                     .entry_css_files
-                    .entry(server_component_name.clone_value())
+                    .entry(server_component_name)
                     .or_default();
                 entry_css_files.extend(entry_css_files_vec);
             }

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -155,8 +155,8 @@ pub async fn get_server_resolve_options_context(
     .await?;
 
     let mut transpiled_packages = get_transpiled_packages(next_config, *project_path)
-        .await?
-        .clone_value();
+        .owned()
+        .await?;
 
     transpiled_packages.extend(
         (*next_config.optimize_package_imports().await?)
@@ -325,7 +325,7 @@ pub async fn get_server_resolve_options_context(
         enable_typescript: true,
         enable_react: true,
         enable_mjs_extension: true,
-        custom_extensions: next_config.resolve_extension().await?.clone_value(),
+        custom_extensions: next_config.resolve_extension().owned().await?,
         rules: vec![(
             foreign_code_context_condition,
             resolve_options_context.clone().resolved_cell(),
@@ -550,7 +550,7 @@ pub async fn get_server_module_options_context(
             ..Default::default()
         },
         tree_shaking_mode: tree_shaking_mode_for_user_code,
-        side_effect_free_packages: next_config.optimize_package_imports().await?.clone_value(),
+        side_effect_free_packages: next_config.optimize_package_imports().owned().await?,
         enable_externals_tracing: if next_mode.is_production() {
             Some(project_path)
         } else {

--- a/crates/next-core/src/next_shared/transforms/server_actions.rs
+++ b/crates/next-core/src/next_shared/transforms/server_actions.rs
@@ -58,7 +58,7 @@ impl CustomTransformer for NextServerActions {
                 is_react_server_layer: matches!(self.transform, ActionsTransform::Server),
                 use_cache_enabled: self.use_cache_enabled,
                 hash_salt: self.encryption_key.await?.to_string(),
-                cache_kinds: self.cache_kinds.await?.clone_value(),
+                cache_kinds: self.cache_kinds.owned().await?,
             },
             ctx.comments.clone(),
             Default::default(),

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -43,7 +43,7 @@ pub async fn maybe_add_babel_loader(
 
     if has_babel_config {
         let mut rules = if let Some(webpack_rules) = webpack_rules {
-            webpack_rules.await?.clone_value()
+            webpack_rules.owned().await?
         } else {
             Default::default()
         };
@@ -87,7 +87,7 @@ pub async fn maybe_add_babel_loader(
                     options: Default::default(),
                 };
                 if let Some(rule) = rule {
-                    let mut loaders = rule.loaders.await?.clone_value();
+                    let mut loaders = rule.loaders.owned().await?;
                     loaders.push(loader);
                     rule.loaders = ResolvedVc::cell(loaders);
                 } else {

--- a/crates/next-core/src/next_shared/webpack_rules/sass.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/sass.rs
@@ -24,7 +24,7 @@ pub async fn maybe_add_sass_loader(
 
     sass_options.insert("silenceDeprecations".into(), silence_deprecations);
     let mut rules = if let Some(webpack_rules) = webpack_rules {
-        webpack_rules.await?.clone_value()
+        webpack_rules.owned().await?
     } else {
         Default::default()
     };
@@ -76,7 +76,7 @@ pub async fn maybe_add_sass_loader(
             if rename_as != "*" {
                 continue;
             }
-            let mut loaders = rule.loaders.await?.clone_value();
+            let mut loaders = rule.loaders.owned().await?;
             loaders.push(resolve_url_loader);
             loaders.push(sass_loader);
             rule.loaders = ResolvedVc::cell(loaders);

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -98,7 +98,7 @@ pub async fn get_transpiled_packages(
     next_config: Vc<NextConfig>,
     project_path: ResolvedVc<FileSystemPath>,
 ) -> Result<Vc<Vec<RcStr>>> {
-    let mut transpile_packages: Vec<RcStr> = next_config.transpile_packages().await?.clone_value();
+    let mut transpile_packages: Vec<RcStr> = next_config.transpile_packages().owned().await?;
 
     let default_transpiled_packages: Vec<RcStr> = load_next_js_templateon(
         project_path,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -636,13 +636,11 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         let mut task = ctx.task(task_id, TaskDataCategory::Data);
         let content = if options.final_read_hint {
             remove!(task, CellData { cell })
+        } else if let Some(content) = get!(task, CellData { cell }) {
+            let content = content.clone();
+            Some(content)
         } else {
-            if let Some(content) = get!(task, CellData { cell }) {
-                let content = content.clone();
-                Some(content)
-            } else {
-                None
-            }
+            None
         };
         if let Some(content) = content {
             add_cell_dependency(self, task, reader, cell, task_id, &mut ctx);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -31,8 +31,8 @@ use turbo_tasks::{
     registry,
     task_statistics::TaskStatisticsApi,
     util::IdFactoryWithReuse,
-    CellId, FunctionId, FxDashMap, RawVc, ReadConsistency, SessionId, TaskId, TraitTypeId,
-    TurboTasksBackendApi, ValueTypeId, TRANSIENT_TASK_BIT,
+    CellId, FunctionId, FxDashMap, RawVc, ReadCellOptions, ReadConsistency, SessionId, TaskId,
+    TraitTypeId, TurboTasksBackendApi, ValueTypeId, TRANSIENT_TASK_BIT,
 };
 
 pub use self::{operation::AnyOperation, storage::TaskDataCategory};
@@ -591,6 +591,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         task_id: TaskId,
         reader: Option<TaskId>,
         cell: CellId,
+        _options: ReadCellOptions,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) -> Result<Result<TypedCellContent, EventListener>> {
         fn add_cell_dependency<B: BackingStorage>(
@@ -1609,6 +1610,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         &self,
         task_id: TaskId,
         cell: CellId,
+        _options: ReadCellOptions,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) -> Result<TypedCellContent> {
         let mut ctx = self.execute_context(turbo_tasks);
@@ -2038,29 +2040,33 @@ impl<B: BackingStorage> Backend for TurboTasksBackend<B> {
         task_id: TaskId,
         cell: CellId,
         reader: TaskId,
+        options: ReadCellOptions,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> Result<Result<TypedCellContent, EventListener>> {
         self.0
-            .try_read_task_cell(task_id, Some(reader), cell, turbo_tasks)
+            .try_read_task_cell(task_id, Some(reader), cell, options, turbo_tasks)
     }
 
     fn try_read_task_cell_untracked(
         &self,
         task_id: TaskId,
         cell: CellId,
+        options: ReadCellOptions,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> Result<Result<TypedCellContent, EventListener>> {
-        self.0.try_read_task_cell(task_id, None, cell, turbo_tasks)
+        self.0
+            .try_read_task_cell(task_id, None, cell, options, turbo_tasks)
     }
 
     fn try_read_own_task_cell_untracked(
         &self,
         task_id: TaskId,
         cell: CellId,
+        options: ReadCellOptions,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> Result<TypedCellContent> {
         self.0
-            .try_read_own_task_cell_untracked(task_id, cell, turbo_tasks)
+            .try_read_own_task_cell_untracked(task_id, cell, options, turbo_tasks)
     }
 
     fn read_task_collectibles(

--- a/turbopack/crates/turbo-tasks-env/src/custom.rs
+++ b/turbopack/crates/turbo-tasks-env/src/custom.rs
@@ -24,11 +24,11 @@ impl CustomProcessEnv {
 impl ProcessEnv for CustomProcessEnv {
     #[turbo_tasks::function]
     async fn read_all(&self) -> Result<Vc<EnvMap>> {
-        let prior = self.prior.read_all().await?;
-        let custom = self.custom.await?;
+        let prior = self.prior.read_all().owned().await?;
+        let custom = self.custom.owned().await?;
 
-        let mut extended = prior.clone_value();
-        extended.extend(custom.clone_value());
+        let mut extended = prior;
+        extended.extend(custom);
         Ok(Vc::cell(extended))
     }
 

--- a/turbopack/crates/turbo-tasks-env/src/dotenv.rs
+++ b/turbopack/crates/turbo-tasks-env/src/dotenv.rs
@@ -2,7 +2,7 @@ use std::{env, sync::MutexGuard};
 
 use anyhow::{anyhow, Context, Result};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, ResolvedVc, ValueToString, Vc};
+use turbo_tasks::{FxIndexMap, ReadRef, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 
 use crate::{sorted_env_vars, EnvMap, ProcessEnv, GLOBAL_ENV_LOCK};
@@ -71,7 +71,9 @@ impl DotenvProcessEnv {
 
             Ok(Vc::cell(vars))
         } else {
-            Ok(Vc::cell(prior.clone_value()))
+            // We want to cell the value here and not just return the Vc.
+            // This is important to avoid Vc changes when adding/removing the env file.
+            Ok(ReadRef::cell(prior))
         }
     }
 }

--- a/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
+++ b/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
@@ -79,11 +79,11 @@ async fn hash_directory(directory: Vc<FileSystemPath>) -> Result<Vc<RcStr>> {
                 match entry {
                     DirectoryEntry::File(path) => {
                         let name = filename(**path).await?;
-                        hashes.insert(name, hash_file(**path).await?.clone_value());
+                        hashes.insert(name, hash_file(**path).owned().await?);
                     }
                     DirectoryEntry::Directory(path) => {
                         let name = filename(**path).await?;
-                        hashes.insert(name, hash_directory(**path).await?.clone_value());
+                        hashes.insert(name, hash_directory(**path).owned().await?);
                     }
                     _ => {}
                 }

--- a/turbopack/crates/turbo-tasks-fs/examples/hash_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/examples/hash_glob.rs
@@ -74,13 +74,13 @@ async fn hash_glob_result(result: Vc<ReadGlobResult>) -> Result<Vc<RcStr>> {
     let mut hashes = BTreeMap::new();
     for (name, entry) in result.results.iter() {
         if let DirectoryEntry::File(path) = entry {
-            hashes.insert(name, hash_file(**path).await?.clone_value());
+            hashes.insert(name, hash_file(**path).owned().await?);
         }
     }
     for (name, result) in result.inner.iter() {
-        let hash = hash_glob_result(**result).await?;
+        let hash = hash_glob_result(**result).owned().await?;
         if !hash.is_empty() {
-            hashes.insert(name, hash.clone_value());
+            hashes.insert(name, hash);
         }
     }
     if hashes.is_empty() {

--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -407,13 +407,7 @@ impl Glob {
         }
         Ok(Self::cell(Glob {
             expression: vec![GlobPart::Alternatives(
-                globs
-                    .into_iter()
-                    .try_join()
-                    .await?
-                    .into_iter()
-                    .map(|g| g.clone_value())
-                    .collect(),
+                globs.into_iter().map(|g| g.owned()).try_join().await?,
             )],
         }))
     }

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1545,7 +1545,7 @@ impl FileSystemPath {
             .cell());
         }
         let parent = self.parent().to_resolved().await?;
-        let parent_result = parent.realpath_with_links().await?;
+        let parent_result = parent.realpath_with_links().owned().await?;
         let basename = this
             .path
             .rsplit_once('/')
@@ -1559,7 +1559,7 @@ impl FileSystemPath {
         } else {
             self
         };
-        let mut result = parent_result.clone_value();
+        let mut result = parent_result;
         if matches!(*real_self.get_type().await?, FileSystemEntryType::Symlink) {
             if let LinkContent::Link { target, link_type } = &*real_self.read_link().await? {
                 result.symlinks.push(real_self);
@@ -1864,7 +1864,7 @@ impl From<&[u8]> for File {
 
 impl From<ReadRef<Rope>> for File {
     fn from(rope: ReadRef<Rope>) -> Self {
-        File::from_rope(rope.clone_value())
+        File::from_rope(ReadRef::into_owned(rope))
     }
 }
 

--- a/turbopack/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -25,7 +25,7 @@ use turbo_tasks::{
     event::EventListener,
     task_statistics::TaskStatisticsApi,
     util::{IdFactoryWithReuse, NoMoveVec},
-    CellId, FunctionId, RawVc, ReadConsistency, TaskId, TaskIdSet, TraitTypeId,
+    CellId, FunctionId, RawVc, ReadCellOptions, ReadConsistency, TaskId, TaskIdSet, TraitTypeId,
     TurboTasksBackendApi, Unused, ValueTypeId, TRANSIENT_TASK_BIT,
 };
 
@@ -504,6 +504,7 @@ impl Backend for MemoryBackend {
         task_id: TaskId,
         index: CellId,
         reader: TaskId,
+        _options: ReadCellOptions,
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) -> Result<Result<TypedCellContent, EventListener>> {
         if task_id == reader {
@@ -535,6 +536,7 @@ impl Backend for MemoryBackend {
         &self,
         current_task: TaskId,
         index: CellId,
+        _options: ReadCellOptions,
         _turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) -> Result<TypedCellContent> {
         Ok(self.with_task(current_task, |task| {
@@ -547,6 +549,7 @@ impl Backend for MemoryBackend {
         &self,
         task_id: TaskId,
         index: CellId,
+        _options: ReadCellOptions,
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) -> Result<Result<TypedCellContent, EventListener>> {
         self.with_task(task_id, |task| {

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -20,8 +20,8 @@ use turbo_tasks::{
     registry,
     test_helpers::with_turbo_tasks_for_testing,
     util::{SharedError, StaticOrArc},
-    CellId, InvalidationReason, LocalTaskId, MagicAny, RawVc, ReadConsistency, TaskId,
-    TaskPersistence, TraitTypeId, TurboTasksApi, TurboTasksCallApi,
+    CellId, InvalidationReason, LocalTaskId, MagicAny, RawVc, ReadCellOptions, ReadConsistency,
+    TaskId, TaskPersistence, TraitTypeId, TurboTasksApi, TurboTasksCallApi,
 };
 
 pub use crate::run::{run, run_with_tt, run_without_cache_check, Registration};
@@ -193,6 +193,7 @@ impl TurboTasksApi for VcStorage {
         &self,
         task: TaskId,
         index: CellId,
+        _options: ReadCellOptions,
     ) -> Result<Result<TypedCellContent, EventListener>> {
         let map = self.cells.lock().unwrap();
         Ok(Ok(if let Some(cell) = map.get(&(task, index)) {
@@ -207,6 +208,7 @@ impl TurboTasksApi for VcStorage {
         &self,
         task: TaskId,
         index: CellId,
+        _options: ReadCellOptions,
     ) -> Result<Result<TypedCellContent, EventListener>> {
         let map = self.cells.lock().unwrap();
         Ok(Ok(if let Some(cell) = map.get(&(task, index)) {
@@ -221,8 +223,9 @@ impl TurboTasksApi for VcStorage {
         &self,
         current_task: TaskId,
         index: CellId,
+        options: ReadCellOptions,
     ) -> Result<TypedCellContent> {
-        self.read_own_task_cell(current_task, index)
+        self.read_own_task_cell(current_task, index, options)
     }
 
     fn try_read_local_output(
@@ -258,7 +261,12 @@ impl TurboTasksApi for VcStorage {
         unimplemented!()
     }
 
-    fn read_own_task_cell(&self, task: TaskId, index: CellId) -> Result<TypedCellContent> {
+    fn read_own_task_cell(
+        &self,
+        task: TaskId,
+        index: CellId,
+        _options: ReadCellOptions,
+    ) -> Result<TypedCellContent> {
         let map = self.cells.lock().unwrap();
         Ok(if let Some(cell) = map.get(&(task, index)) {
             cell.to_owned()

--- a/turbopack/crates/turbo-tasks-testing/tests/basic.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/basic.rs
@@ -63,7 +63,7 @@ async fn func_without_args() -> Result<Vc<Value>> {
 #[turbo_tasks::function]
 async fn nested_func_without_args_waiting() -> Result<Vc<Value>> {
     println!("nested_func_without_args_waiting");
-    let value = func_without_args().await?.clone_value();
+    let value = func_without_args().owned().await?;
     Ok(value.cell())
 }
 

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -22,8 +22,8 @@ use crate::{
     task::shared_reference::TypedSharedReference,
     task_statistics::TaskStatisticsApi,
     triomphe_utils::unchecked_sidecast_triomphe_arc,
-    FunctionId, RawVc, ReadRef, SharedReference, TaskId, TaskIdSet, TraitRef, TraitTypeId,
-    ValueTypeId, VcRead, VcValueTrait, VcValueType,
+    FunctionId, RawVc, ReadCellOptions, ReadRef, SharedReference, TaskId, TaskIdSet, TraitRef,
+    TraitTypeId, ValueTypeId, VcRead, VcValueTrait, VcValueType,
 };
 
 pub type TransientTaskRoot =
@@ -498,6 +498,7 @@ pub trait Backend: Sync + Send {
         task: TaskId,
         index: CellId,
         reader: TaskId,
+        options: ReadCellOptions,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> Result<Result<TypedCellContent, EventListener>>;
 
@@ -507,6 +508,7 @@ pub trait Backend: Sync + Send {
         &self,
         task: TaskId,
         index: CellId,
+        options: ReadCellOptions,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> Result<Result<TypedCellContent, EventListener>>;
 
@@ -516,9 +518,10 @@ pub trait Backend: Sync + Send {
         &self,
         current_task: TaskId,
         index: CellId,
+        options: ReadCellOptions,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> Result<TypedCellContent> {
-        match self.try_read_task_cell_untracked(current_task, index, turbo_tasks)? {
+        match self.try_read_task_cell_untracked(current_task, index, options, turbo_tasks)? {
             Ok(content) => Ok(content),
             Err(_) => Ok(TypedCellContent(index.type_id, CellContent(None))),
         }

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -65,6 +65,7 @@ mod output;
 pub mod persisted_graph;
 pub mod primitives;
 mod raw_vc;
+mod read_options;
 mod read_ref;
 pub mod registry;
 mod scope;
@@ -109,6 +110,7 @@ pub use manager::{
 };
 pub use output::OutputContent;
 pub use raw_vc::{CellId, RawVc, ReadRawVcFuture, ResolveTypeError};
+pub use read_options::ReadCellOptions;
 pub use read_ref::ReadRef;
 use rustc_hash::FxHasher;
 pub use scope::scope;

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -543,7 +543,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
             read_task_output_untracked(self, task_id, ReadConsistency::Eventual).await?;
         turbo_tasks_future_scope(
             self.pin(),
-            ReadVcFuture::<Completion>::from(raw_result.into_read_untracked_with_turbo_tasks(self)),
+            ReadVcFuture::<Completion>::from(raw_result.into_read().untracked()),
         )
         .await?;
 
@@ -1553,7 +1553,7 @@ pub async fn run_once<T: Send + 'static>(
     // INVALIDATION: A Once task will never invalidate, therefore we don't need to
     // track a dependency
     let raw_result = read_task_output_untracked(&*tt, task_id, ReadConsistency::Eventual).await?;
-    let raw_future = raw_result.into_read_untracked_with_turbo_tasks(&*tt);
+    let raw_future = raw_result.into_read().untracked();
     turbo_tasks_future_scope(tt, ReadVcFuture::<Completion>::from(raw_future)).await?;
 
     Ok(rx.await?)
@@ -1579,7 +1579,7 @@ pub async fn run_once_with_reason<T: Send + 'static>(
     // INVALIDATION: A Once task will never invalidate, therefore we don't need to
     // track a dependency
     let raw_result = read_task_output_untracked(&*tt, task_id, ReadConsistency::Eventual).await?;
-    let raw_future = raw_result.into_read_untracked_with_turbo_tasks(&*tt);
+    let raw_future = raw_result.into_read().untracked();
     turbo_tasks_future_scope(tt, ReadVcFuture::<Completion>::from(raw_future)).await?;
 
     Ok(rx.await?)

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -43,8 +43,8 @@ use crate::{
     trait_helpers::get_trait_method,
     util::StaticOrArc,
     vc::ReadVcFuture,
-    Completion, InvalidationReason, InvalidationReasonSet, ResolvedVc, SharedReference, TaskId,
-    TaskIdSet, ValueTypeId, Vc, VcRead, VcValueTrait, VcValueType,
+    Completion, InvalidationReason, InvalidationReasonSet, ReadCellOptions, ResolvedVc,
+    SharedReference, TaskId, TaskIdSet, ValueTypeId, Vc, VcRead, VcValueTrait, VcValueType,
 };
 
 pub trait TurboTasksCallApi: Sync + Send {
@@ -122,6 +122,7 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
         &self,
         task: TaskId,
         index: CellId,
+        options: ReadCellOptions,
     ) -> Result<Result<TypedCellContent, EventListener>>;
 
     /// INVALIDATION: Be careful with this, it will not track dependencies, so
@@ -130,6 +131,7 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
         &self,
         task: TaskId,
         index: CellId,
+        options: ReadCellOptions,
     ) -> Result<Result<TypedCellContent, EventListener>>;
 
     /// This does not accept a consistency argument, as you cannot control consistency of a read of
@@ -153,9 +155,15 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
         &self,
         current_task: TaskId,
         index: CellId,
+        options: ReadCellOptions,
     ) -> Result<TypedCellContent>;
 
-    fn read_own_task_cell(&self, task: TaskId, index: CellId) -> Result<TypedCellContent>;
+    fn read_own_task_cell(
+        &self,
+        task: TaskId,
+        index: CellId,
+        options: ReadCellOptions,
+    ) -> Result<TypedCellContent>;
     fn update_own_task_cell(&self, task: TaskId, index: CellId, content: CellContent);
     fn mark_own_task_as_finished(&self, task: TaskId);
     fn set_own_task_aggregation_number(&self, task: TaskId, aggregation_number: u32);
@@ -1237,26 +1245,30 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         &self,
         task: TaskId,
         index: CellId,
+        options: ReadCellOptions,
     ) -> Result<Result<TypedCellContent, EventListener>> {
         self.backend
-            .try_read_task_cell(task, index, current_task("reading Vcs"), self)
+            .try_read_task_cell(task, index, current_task("reading Vcs"), options, self)
     }
 
     fn try_read_task_cell_untracked(
         &self,
         task: TaskId,
         index: CellId,
+        options: ReadCellOptions,
     ) -> Result<Result<TypedCellContent, EventListener>> {
-        self.backend.try_read_task_cell_untracked(task, index, self)
+        self.backend
+            .try_read_task_cell_untracked(task, index, options, self)
     }
 
     fn try_read_own_task_cell_untracked(
         &self,
         current_task: TaskId,
         index: CellId,
+        options: ReadCellOptions,
     ) -> Result<TypedCellContent> {
         self.backend
-            .try_read_own_task_cell_untracked(current_task, index, self)
+            .try_read_own_task_cell_untracked(current_task, index, options, self)
     }
 
     fn try_read_local_output(
@@ -1322,9 +1334,14 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         }
     }
 
-    fn read_own_task_cell(&self, task: TaskId, index: CellId) -> Result<TypedCellContent> {
+    fn read_own_task_cell(
+        &self,
+        task: TaskId,
+        index: CellId,
+        options: ReadCellOptions,
+    ) -> Result<TypedCellContent> {
         // INVALIDATION: don't need to track a dependency to itself
-        self.try_read_own_task_cell_untracked(task, index)
+        self.try_read_own_task_cell_untracked(task, index, options)
     }
 
     fn update_own_task_cell(&self, task: TaskId, index: CellId, content: CellContent) {
@@ -1753,9 +1770,10 @@ pub(crate) async fn read_task_cell(
     this: &dyn TurboTasksApi,
     id: TaskId,
     index: CellId,
+    options: ReadCellOptions,
 ) -> Result<TypedCellContent> {
     loop {
-        match this.try_read_task_cell(id, index)? {
+        match this.try_read_task_cell(id, index, options)? {
             Ok(result) => return Ok(result),
             Err(listener) => listener.await,
         }
@@ -1798,7 +1816,9 @@ impl CurrentCellRef {
         functor: impl FnOnce(Option<&SharedReference>) -> Option<SharedReference>,
     ) {
         let tt = turbo_tasks();
-        let cell_content = tt.read_own_task_cell(self.current_task, self.index).ok();
+        let cell_content = tt
+            .read_own_task_cell(self.current_task, self.index, ReadCellOptions::default())
+            .ok();
         let update = functor(cell_content.as_ref().and_then(|cc| cc.1 .0.as_ref()));
         if let Some(update) = update {
             tt.update_own_task_cell(self.current_task, self.index, CellContent(Some(update)))
@@ -1911,7 +1931,9 @@ impl CurrentCellRef {
     /// VcRead<T>>::Repr` type for its representation of the value.
     pub fn update_with_shared_reference(&self, shared_ref: SharedReference) {
         let tt = turbo_tasks();
-        let content = tt.read_own_task_cell(self.current_task, self.index).ok();
+        let content = tt
+            .read_own_task_cell(self.current_task, self.index, ReadCellOptions::default())
+            .ok();
         let update = if let Some(TypedCellContent(_, CellContent(Some(shared_ref_exp)))) = content {
             // pointer equality (not value equality)
             shared_ref_exp != shared_ref

--- a/turbopack/crates/turbo-tasks/src/read_options.rs
+++ b/turbopack/crates/turbo-tasks/src/read_options.rs
@@ -1,2 +1,4 @@
 #[derive(Clone, Copy, Debug, Default)]
-pub struct ReadCellOptions {}
+pub struct ReadCellOptions {
+    pub final_read_hint: bool,
+}

--- a/turbopack/crates/turbo-tasks/src/read_options.rs
+++ b/turbopack/crates/turbo-tasks/src/read_options.rs
@@ -1,0 +1,2 @@
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ReadCellOptions {}

--- a/turbopack/crates/turbo-tasks/src/read_ref.rs
+++ b/turbopack/crates/turbo-tasks/src/read_ref.rs
@@ -265,11 +265,23 @@ where
 impl<T> ReadRef<T>
 where
     T: VcValueType,
+{
+    pub fn try_unwrap(this: Self) -> Result<VcReadTarget<T>, Self> {
+        match triomphe::Arc::try_unwrap(this.0) {
+            Ok(value) => Ok(T::Read::value_to_target(value)),
+            Err(arc) => Err(Self(arc)),
+        }
+    }
+}
+
+impl<T> ReadRef<T>
+where
+    T: VcValueType,
     VcReadTarget<T>: Clone,
 {
-    /// This will clone the contained value instead of cloning the ReadRef.
-    /// This clone is more expensive, but allows to get an mutable owned value.
-    pub fn clone_value(&self) -> VcReadTarget<T> {
-        (**self).clone()
+    /// This is return a owned version of the value. It potentially clones the value.
+    /// The clone might be expensive. Prefer Deref to get a reference to the value.
+    pub fn into_owned(this: Self) -> VcReadTarget<T> {
+        Self::try_unwrap(this).unwrap_or_else(|this| (*this).clone())
     }
 }

--- a/turbopack/crates/turbo-tasks/src/trait_ref.rs
+++ b/turbopack/crates/turbo-tasks/src/trait_ref.rs
@@ -124,8 +124,6 @@ pub trait IntoTraitRef {
     type Future: Future<Output = Result<<VcValueTraitCast<Self::ValueTrait> as VcCast>::Output>>;
 
     fn into_trait_ref(self) -> Self::Future;
-    fn into_trait_ref_untracked(self) -> Self::Future;
-    fn into_trait_ref_strongly_consistent_untracked(self) -> Self::Future;
 }
 
 impl<T> IntoTraitRef for Vc<T>
@@ -138,13 +136,5 @@ where
 
     fn into_trait_ref(self) -> Self::Future {
         self.node.into_read().into()
-    }
-
-    fn into_trait_ref_untracked(self) -> Self::Future {
-        self.node.into_read_untracked().into()
-    }
-
-    fn into_trait_ref_strongly_consistent_untracked(self) -> Self::Future {
-        self.node.into_strongly_consistent_read_untracked().into()
     }
 }

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -597,14 +597,21 @@ where
     #[cfg(feature = "non_operation_vc_strongly_consistent")]
     #[must_use]
     pub fn strongly_consistent(self) -> ReadVcFuture<T> {
-        self.node.into_strongly_consistent_read().into()
+        self.node.into_read().strongly_consistent().into()
     }
 
     /// Returns a untracked read of the value. This will not invalidate the current function when
     /// the read value changed.
     #[must_use]
     pub fn untracked(self) -> ReadVcFuture<T> {
-        self.node.into_read_untracked().into()
+        self.node.into_read().untracked().into()
+    }
+
+    /// Returns a untracked read of the value. This will not invalidate the current function when
+    /// the read value changed.
+    #[must_use]
+    pub fn final_read_hint(self) -> ReadVcFuture<T> {
+        self.node.into_read().final_read_hint().into()
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/vc/operation.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/operation.rs
@@ -129,7 +129,7 @@ impl<T: ?Sized> OperationVc<T> {
     where
         T: VcValueType,
     {
-        self.connect().node.into_strongly_consistent_read().into()
+        self.connect().node.into_read().strongly_consistent().into()
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/vc/read.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/read.rs
@@ -222,7 +222,7 @@ where
 
 impl<T> ReadVcFuture<T, VcValueTypeCast<T>>
 where
-    T: VcValueType + ?Sized,
+    T: VcValueType,
     VcReadTarget<T>: Clone,
 {
     pub fn owned(self) -> ReadOwnedVcFuture<T> {
@@ -272,7 +272,7 @@ where
 
 pub struct ReadOwnedVcFuture<T>
 where
-    T: VcValueType + ?Sized,
+    T: VcValueType,
     VcReadTarget<T>: Clone,
 {
     future: ReadVcFuture<T, VcValueTypeCast<T>>,
@@ -280,7 +280,7 @@ where
 
 impl<T> Future for ReadOwnedVcFuture<T>
 where
-    T: VcValueType + ?Sized,
+    T: VcValueType,
     VcReadTarget<T>: Clone,
 {
     type Output = Result<VcReadTarget<T>>;

--- a/turbopack/crates/turbo-tasks/src/vc/read.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/read.rs
@@ -183,6 +183,27 @@ where
     _phantom_cast: PhantomData<Cast>,
 }
 
+impl<T, Cast> ReadVcFuture<T, Cast>
+where
+    T: ?Sized,
+    Cast: VcCast,
+{
+    pub fn strongly_consistent(mut self) -> Self {
+        self.raw = self.raw.strongly_consistent();
+        self
+    }
+
+    pub fn untracked(mut self) -> Self {
+        self.raw = self.raw.untracked();
+        self
+    }
+
+    pub fn final_read_hint(mut self) -> Self {
+        self.raw = self.raw.final_read_hint();
+        self
+    }
+}
+
 impl<T> From<ReadRawVcFuture> for ReadVcFuture<T, VcValueTypeCast<T>>
 where
     T: VcValueType,

--- a/turbopack/crates/turbo-tasks/src/vc/read.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/read.rs
@@ -4,7 +4,9 @@ use anyhow::Result;
 use futures::Future;
 
 use super::traits::VcValueType;
-use crate::{ReadRawVcFuture, VcCast, VcValueTrait, VcValueTraitCast, VcValueTypeCast};
+use crate::{ReadRawVcFuture, ReadRef, VcCast, VcValueTrait, VcValueTraitCast, VcValueTypeCast};
+
+type VcReadTarget<T> = <<T as VcValueType>::Read as VcRead<T>>::Target;
 
 /// Trait that controls [`crate::Vc`]'s read representation.
 ///
@@ -39,6 +41,9 @@ where
     /// Convert a reference to a value to a reference to the target type.
     fn value_to_target_ref(value: &T) -> &Self::Target;
 
+    /// Convert a value to the target type.
+    fn value_to_target(value: T) -> Self::Target;
+
     /// Convert the value type to the repr.
     fn value_to_repr(value: T) -> Self::Repr;
 
@@ -72,6 +77,10 @@ where
     type Repr = T;
 
     fn value_to_target_ref(value: &T) -> &Self::Target {
+        value
+    }
+
+    fn value_to_target(value: T) -> Self::Target {
         value
     }
 
@@ -123,6 +132,13 @@ where
         // See https://users.rust-lang.org/t/transmute-doesnt-work-on-generic-types/87272/9
         unsafe {
             std::mem::transmute_copy::<ManuallyDrop<&T>, &Self::Target>(&ManuallyDrop::new(value))
+        }
+    }
+
+    fn value_to_target(value: T) -> Self::Target {
+        // Safety: see `Self::value_to_target_ref` above.
+        unsafe {
+            std::mem::transmute_copy::<ManuallyDrop<T>, Self::Target>(&ManuallyDrop::new(value))
         }
     }
 
@@ -204,6 +220,16 @@ where
     }
 }
 
+impl<T> ReadVcFuture<T, VcValueTypeCast<T>>
+where
+    T: VcValueType + ?Sized,
+    VcReadTarget<T>: Clone,
+{
+    pub fn owned(self) -> ReadOwnedVcFuture<T> {
+        ReadOwnedVcFuture { future: self }
+    }
+}
+
 impl<T> From<ReadRawVcFuture> for ReadVcFuture<T, VcValueTypeCast<T>>
 where
     T: VcValueType,
@@ -241,5 +267,31 @@ where
         // Safety: We never move the contents of `self`
         let raw = unsafe { self.map_unchecked_mut(|this| &mut this.raw) };
         Poll::Ready(std::task::ready!(raw.poll(cx)).and_then(Cast::cast))
+    }
+}
+
+pub struct ReadOwnedVcFuture<T>
+where
+    T: VcValueType + ?Sized,
+    VcReadTarget<T>: Clone,
+{
+    future: ReadVcFuture<T, VcValueTypeCast<T>>,
+}
+
+impl<T> Future for ReadOwnedVcFuture<T>
+where
+    T: VcValueType + ?Sized,
+    VcReadTarget<T>: Clone,
+{
+    type Output = Result<VcReadTarget<T>>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        // Safety: We never move the contents of `self`
+        let future = unsafe { self.map_unchecked_mut(|this| &mut this.future) };
+        match future.poll(cx) {
+            Poll::Ready(Ok(result)) => Poll::Ready(Ok(ReadRef::into_owned(result))),
+            Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
+            Poll::Pending => Poll::Pending,
+        }
     }
 }

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -321,8 +321,11 @@ impl ChunkingContext for BrowserChunkingContext {
         extension: RcStr,
     ) -> Result<Vc<FileSystemPath>> {
         let root_path = self.chunk_root_path;
-        let name = ident.output_name(*self.root_path, extension).await?;
-        Ok(root_path.join(name.clone_value()))
+        let name = ident
+            .output_name(*self.root_path, extension)
+            .owned()
+            .await?;
+        Ok(root_path.join(name))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -217,7 +217,7 @@ fn modifier() -> Vc<RcStr> {
 impl OutputAsset for EcmascriptDevEvaluateChunk {
     #[turbo_tasks::function]
     async fn path(&self) -> Result<Vc<FileSystemPath>> {
-        let mut ident = self.ident.await?.clone_value();
+        let mut ident = self.ident.owned().await?;
 
         ident.add_modifier(modifier().to_resolved().await?);
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
@@ -92,7 +92,7 @@ fn chunk_key() -> Vc<RcStr> {
 impl OutputAsset for EcmascriptDevChunkList {
     #[turbo_tasks::function]
     async fn path(&self) -> Result<Vc<FileSystemPath>> {
-        let mut ident = self.ident.await?.clone_value();
+        let mut ident = self.ident.owned().await?;
         ident.add_modifier(modifier().to_resolved().await?);
 
         match self.source {

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/version.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/version.rs
@@ -45,7 +45,7 @@ impl Version for EcmascriptDevChunkListVersion {
                 .by_merger
                 .iter()
                 .map(|(_merger, version)| async move {
-                    Ok(TraitRef::cell(version.clone()).id().owned().await?)
+                    TraitRef::cell(version.clone()).id().owned().await
                 })
                 .try_join()
                 .await?;

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/version.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/version.rs
@@ -32,7 +32,7 @@ impl Version for EcmascriptDevChunkListVersion {
                 .by_path
                 .iter()
                 .map(|(path, version)| async move {
-                    let id = TraitRef::cell(version.clone()).id().await?.clone_value();
+                    let id = TraitRef::cell(version.clone()).id().owned().await?;
                     Ok((path, id))
                 })
                 .try_join()
@@ -45,7 +45,7 @@ impl Version for EcmascriptDevChunkListVersion {
                 .by_merger
                 .iter()
                 .map(|(_merger, version)| async move {
-                    Ok(TraitRef::cell(version.clone()).id().await?.clone_value())
+                    Ok(TraitRef::cell(version.clone()).id().owned().await?)
                 })
                 .try_join()
                 .await?;

--- a/turbopack/crates/turbopack-browser/src/ecmascript/merged/update.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/merged/update.rs
@@ -85,9 +85,8 @@ impl EcmascriptModuleEntry {
     async fn from_code(id: &ModuleId, code: Vc<Code>, chunk_path: &str) -> Result<Self> {
         let map = match &*code.generate_source_map().await? {
             Some(map) => {
-                let map = map.to_rope().await?;
                 // Cloning a rope is cheap.
-                Some(map.clone_value())
+                Some(map.to_rope().owned().await?)
             }
             None => None,
         };

--- a/turbopack/crates/turbopack-core/src/changed.rs
+++ b/turbopack/crates/turbopack-core/src/changed.rs
@@ -14,15 +14,15 @@ use crate::{
 async fn get_referenced_output_assets(
     parent: ResolvedVc<Box<dyn OutputAsset>>,
 ) -> Result<impl Iterator<Item = ResolvedVc<Box<dyn OutputAsset>>> + Send> {
-    Ok(parent.references().await?.clone_value().into_iter())
+    Ok(parent.references().owned().await?.into_iter())
 }
 
 pub async fn get_referenced_modules(
     parent: ResolvedVc<Box<dyn Module>>,
 ) -> Result<impl Iterator<Item = ResolvedVc<Box<dyn Module>>> + Send> {
     Ok(primary_referenced_modules(*parent)
+        .owned()
         .await?
-        .clone_value()
         .into_iter())
 }
 

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -233,8 +233,8 @@ pub async fn make_chunk_group(
         "".into(),
         Vc::cell(referenced_output_assets),
     )
-    .await?
-    .clone_value();
+    .owned()
+    .await?;
 
     Ok(MakeChunkGroupResult {
         chunks,

--- a/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
@@ -81,7 +81,7 @@ impl EvaluatableAssets {
         self: Vc<Self>,
         entry: ResolvedVc<Box<dyn EvaluatableAsset>>,
     ) -> Result<Vc<EvaluatableAssets>> {
-        let mut entries = self.await?.clone_value();
+        let mut entries = self.owned().await?;
         entries.push(entry);
         Ok(EvaluatableAssets(entries).cell())
     }

--- a/turbopack/crates/turbopack-core/src/chunk/module_id_strategies.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/module_id_strategies.rs
@@ -31,7 +31,7 @@ impl DevModuleIdStrategy {
 impl ModuleIdStrategy for DevModuleIdStrategy {
     #[turbo_tasks::function]
     async fn get_module_id(self: Vc<Self>, ident: Vc<AssetIdent>) -> Result<Vc<ModuleId>> {
-        Ok(ModuleId::String(ident.to_string().await?.clone_value()).cell())
+        Ok(ModuleId::String(ident.to_string().owned().await?).cell())
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/diagnostics/mod.rs
+++ b/turbopack/crates/turbopack-core/src/diagnostics/mod.rs
@@ -64,9 +64,9 @@ pub trait Diagnostic {
 
     async fn into_plain(self: Vc<Self>) -> Result<Vc<PlainDiagnostic>> {
         Ok(PlainDiagnostic {
-            category: self.category().await?.clone_value(),
-            name: self.name().await?.clone_value(),
-            payload: self.payload().await?.clone_value(),
+            category: self.category().owned().await?,
+            name: self.name().owned().await?,
+            payload: self.payload().owned().await?,
         }
         .cell())
     }

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -53,7 +53,7 @@ impl AssetIdent {
 impl ValueToString for AssetIdent {
     #[turbo_tasks::function]
     async fn to_string(&self) -> Result<Vc<RcStr>> {
-        let mut s = self.path.to_string().await?.clone_value().into_owned();
+        let mut s = self.path.to_string().owned().await?.into_owned();
 
         let query = self.query.await?;
         if !query.is_empty() {

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -167,12 +167,12 @@ pub trait Issue {
 
         Ok(PlainIssue {
             severity: *self.severity().await?,
-            file_path: self.file_path().to_string().await?.clone_value(),
-            stage: self.stage().await?.clone_value(),
-            title: self.title().await?.clone_value(),
+            file_path: self.file_path().to_string().owned().await?,
+            stage: self.stage().owned().await?,
+            title: self.title().owned().await?,
             description,
             detail,
-            documentation_link: self.documentation_link().await?.clone_value(),
+            documentation_link: self.documentation_link().owned().await?,
             source: {
                 if let Some(s) = &*self.source().await? {
                     Some(s.into_plain().await?)

--- a/turbopack/crates/turbopack-core/src/issue/resolve.rs
+++ b/turbopack/crates/turbopack-core/src/issue/resolve.rs
@@ -35,12 +35,7 @@ impl Issue for ResolvingIssue {
 
     #[turbo_tasks::function]
     async fn title(&self) -> Result<Vc<StyledString>> {
-        let request = self
-            .request
-            .request_pattern()
-            .to_string()
-            .await?
-            .clone_value();
+        let request = self.request.request_pattern().to_string().owned().await?;
         Ok(StyledString::Line(vec![
             StyledString::Strong("Module not found".into()),
             StyledString::Text(": Can't resolve ".into()),

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -253,13 +253,13 @@ pub async fn primary_referenced_modules(module: Vc<Box<dyn Module>>) -> Result<V
         .await?
         .iter()
         .map(|reference| async {
-            Ok(reference
+            reference
                 .resolve_reference()
                 .resolve()
                 .await?
                 .primary_modules()
                 .owned()
-                .await?)
+                .await
         })
         .try_join()
         .await?

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -258,8 +258,8 @@ pub async fn primary_referenced_modules(module: Vc<Box<dyn Module>>) -> Result<V
                 .resolve()
                 .await?
                 .primary_modules()
-                .await?
-                .clone_value())
+                .owned()
+                .await?)
         })
         .try_join()
         .await?
@@ -297,8 +297,8 @@ pub async fn primary_chunkable_referenced_modules(
                         .resolve()
                         .await?
                         .primary_modules()
-                        .await?
-                        .clone_value();
+                        .owned()
+                        .await?;
                     return Ok(Some((chunking_type.clone(), resolved)));
                 }
             }

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -662,7 +662,7 @@ impl Request {
                 requests
                     .iter()
                     .map(async |r: &ResolvedVc<Request>| -> Result<Pattern> {
-                        Ok(r.request_pattern().await?.clone_value())
+                        Ok(r.request_pattern().owned().await?)
                     })
                     .try_join()
                     .await?,

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -306,7 +306,7 @@ impl OutputAsset for CssChunk {
     async fn references(self: Vc<Self>) -> Result<Vc<OutputAssets>> {
         let this = self.await?;
         let content = this.content.await?;
-        let mut references = content.referenced_output_assets.await?.clone_value();
+        let mut references = content.referenced_output_assets.owned().await?;
         references.extend(
             content
                 .chunk_items
@@ -366,7 +366,7 @@ impl CssChunkContext {
         self: Vc<Self>,
         chunk_item: Vc<Box<dyn CssChunkItem>>,
     ) -> Result<Vc<ModuleId>> {
-        Ok(ModuleId::String(chunk_item.asset_ident().to_string().await?.clone_value()).cell())
+        Ok(ModuleId::String(chunk_item.asset_ident().to_string().owned().await?).cell())
     }
 }
 
@@ -443,8 +443,8 @@ impl Introspectable for CssChunk {
     #[turbo_tasks::function]
     async fn children(self: Vc<Self>) -> Result<Vc<IntrospectableChildren>> {
         let mut children = children_from_output_assets(OutputAsset::references(self))
-            .await?
-            .clone_value();
+            .owned()
+            .await?;
         children.extend(
             self.await?
                 .content

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -101,14 +101,14 @@ impl DevHtmlAsset {
 impl DevHtmlAsset {
     #[turbo_tasks::function]
     pub async fn with_path(self: Vc<Self>, path: ResolvedVc<FileSystemPath>) -> Result<Vc<Self>> {
-        let mut html: DevHtmlAsset = self.await?.clone_value();
+        let mut html: DevHtmlAsset = self.owned().await?;
         html.path = path;
         Ok(html.cell())
     }
 
     #[turbo_tasks::function]
     pub async fn with_body(self: Vc<Self>, body: RcStr) -> Result<Vc<Self>> {
-        let mut html: DevHtmlAsset = self.await?.clone_value();
+        let mut html: DevHtmlAsset = self.owned().await?;
         html.body = Some(body);
         Ok(html.cell())
     }

--- a/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    fxindexmap, trace::TraceRawVcs, FxIndexMap, NonLocalValue, ResolvedVc, TaskInput,
+    fxindexmap, trace::TraceRawVcs, FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TaskInput,
     TryJoinIterExt, ValueToString, Vc,
 };
 
@@ -321,7 +321,7 @@ impl RouteTree {
         self: Vc<Self>,
         segments: Vec<BaseSegment>,
     ) -> Result<Vc<RouteTree>> {
-        let mut this = self.await?.clone_value();
+        let mut this = self.owned().await?;
         this.prepend_base(segments);
         Ok(this.cell())
     }
@@ -330,7 +330,7 @@ impl RouteTree {
     async fn with_base_len(self: Vc<Self>, base_len: usize) -> Result<Vc<RouteTree>> {
         let this = self.await?;
         if this.base.len() > base_len {
-            let mut inner = this.clone_value();
+            let mut inner = ReadRef::into_owned(this);
             let mut drain = inner.base.drain(base_len..);
             let selector_segment = drain.next().unwrap();
             let inner_base = drain.collect();
@@ -362,7 +362,7 @@ impl RouteTree {
         self: Vc<Self>,
         mapper: Vc<Box<dyn MapGetContentSourceContent>>,
     ) -> Result<Vc<Self>> {
-        let mut this = self.await?.clone_value();
+        let mut this = self.owned().await?;
         let RouteTree {
             base: _,
             static_segments,

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
@@ -72,7 +72,7 @@ impl ChunkType for EcmascriptChunkType {
                 )
                 .try_join()
                 .await?,
-            referenced_output_assets: referenced_output_assets.await?.clone_value(),
+            referenced_output_assets: referenced_output_assets.owned().await?,
         }
         .cell();
         Ok(Vc::upcast(EcmascriptChunk::new(chunking_context, content)))

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -46,7 +46,7 @@ impl EcmascriptChunkItemContent {
             .await?;
 
         let content = content.await?;
-        let async_module = async_module_options.await?.clone_value();
+        let async_module = async_module_options.owned().await?;
 
         Ok(EcmascriptChunkItemContent {
             rewrite_source_path: if *chunking_context.should_use_file_source_map_uris().await? {

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -216,8 +216,8 @@ impl Introspectable for EcmascriptChunk {
     #[turbo_tasks::function]
     async fn children(self: Vc<Self>) -> Result<Vc<IntrospectableChildren>> {
         let mut children = children_from_output_assets(self.references())
-            .await?
-            .clone_value();
+            .owned()
+            .await?;
         let chunk_item_module_key = chunk_item_module_key().to_resolved().await?;
         for chunk_item in self.await?.content.included_chunk_items().await? {
             children.insert((

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -565,7 +565,7 @@ impl Module for EcmascriptModuleAsset {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         if let Some(inner_assets) = self.inner_assets {
-            let mut ident = self.source.ident().await?.clone_value();
+            let mut ident = self.source.ident().owned().await?;
             for (name, asset) in inner_assets.await?.iter() {
                 ident.add_asset(
                     ResolvedVc::cell(name.to_string().into()),

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -455,7 +455,7 @@ impl Issue for InvalidExport {
                     StyledString::Text("The export ".into()),
                     StyledString::Code(self.export.clone()),
                     StyledString::Text(" was not found in module ".into()),
-                    StyledString::Strong(self.module.ident().to_string().await?.clone_value()),
+                    StyledString::Strong(self.module.ident().to_string().owned().await?),
                     StyledString::Text(".".into()),
                 ]),
                 if let Some(did_you_mean) = did_you_mean {

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1338,7 +1338,7 @@ async fn compile_time_info_for_module_type(
     let compile_time_info = compile_time_info.await?;
     let free_var_references = compile_time_info.free_var_references;
 
-    let mut free_var_references = free_var_references.await?.clone_value();
+    let mut free_var_references = free_var_references.owned().await?;
     let (typeof_exports, typeof_module, require) = if is_esm {
         ("undefined", "undefined", TURBOPACK_REQUIRE_STUB)
     } else {

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -371,15 +371,11 @@ async fn to_single_pattern_mapping(
         match resolve_type {
             ResolveType::AsyncChunkLoader => {
                 let loader_id = chunking_context.async_loader_chunk_item_id(*chunkable);
-                return Ok(SinglePatternMapping::ModuleLoader(
-                    loader_id.await?.clone_value(),
-                ));
+                return Ok(SinglePatternMapping::ModuleLoader(loader_id.owned().await?));
             }
             ResolveType::ChunkItem => {
                 let chunk_item = chunkable.as_chunk_item(module_graph, chunking_context);
-                return Ok(SinglePatternMapping::Module(
-                    chunk_item.id().await?.clone_value(),
-                ));
+                return Ok(SinglePatternMapping::Module(chunk_item.id().owned().await?));
             }
         }
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -298,7 +298,7 @@ impl CodeGenerateable for RequireContextAssetReference {
         let chunk_item = self
             .inner
             .as_chunk_item(module_graph, Vc::upcast(chunking_context));
-        let module_id = chunk_item.id().await?.clone_value();
+        let module_id = chunk_item.id().owned().await?;
 
         let mut visitors = Vec::new();
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
@@ -63,7 +63,7 @@ impl EcmascriptChunkItem for EcmascriptModuleFacadeChunkItem {
             .get_async_module()
             .module_options(async_module_info);
 
-        let async_module = async_module_options.await?.clone_value();
+        let async_module = async_module_options.owned().await?;
 
         let mut code = RopeBuilder::default();
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -82,7 +82,7 @@ impl Module for EcmascriptModuleFacadeModule {
                 };
                 let result = module.analyze().await?;
                 let references = result.evaluation_references;
-                let mut references = references.await?.clone_value();
+                let mut references = references.owned().await?;
                 references.push(ResolvedVc::upcast(
                     EcmascriptModulePartReference::new_part(*self.module, ModulePart::locals())
                         .to_resolved()
@@ -101,7 +101,7 @@ impl Module for EcmascriptModuleFacadeModule {
                 };
                 let result = module.analyze().await?;
                 let references = result.reexport_references;
-                let mut references = references.await?.clone_value();
+                let mut references = references.owned().await?;
                 references.push(ResolvedVc::upcast(
                     EcmascriptModulePartReference::new_part(*self.module, ModulePart::locals())
                         .to_resolved()

--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -102,8 +102,8 @@ impl EcmascriptInputTransforms {
 
     #[turbo_tasks::function]
     pub async fn extend(self: Vc<Self>, other: Vc<EcmascriptInputTransforms>) -> Result<Vc<Self>> {
-        let mut transforms = self.await?.clone_value();
-        transforms.extend(other.await?.clone_value());
+        let mut transforms = self.owned().await?;
+        transforms.extend(other.owned().await?);
         Ok(Vc::cell(transforms))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effect_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effect_module.rs
@@ -53,7 +53,7 @@ impl SideEffectsModule {
 impl Module for SideEffectsModule {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
-        let mut ident = self.module.ident().await?.clone_value();
+        let mut ident = self.module.ident().owned().await?;
         ident.parts.push(self.part.clone());
 
         ident.add_asset(

--- a/turbopack/crates/turbopack-node/src/render/render_proxy.rs
+++ b/turbopack/crates/turbopack-node/src/render/render_proxy.rs
@@ -117,8 +117,8 @@ async fn proxy_error(
         "An error occurred while proxying the request to Node.js".into(),
         format!("{message}\n\n{}", details.join("\n")).into(),
     )
-    .await?
-    .clone_value();
+    .owned()
+    .await?;
 
     RenderingIssue {
         file_path: path,

--- a/turbopack/crates/turbopack-node/src/render/rendered_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/rendered_source.rs
@@ -234,7 +234,7 @@ impl GetContentSourceContent for NodeRenderContentSource {
                     result_op,
                     ProxyResult {
                         status,
-                        headers: headers.await?.clone_value(),
+                        headers: headers.owned().await?,
                         body: body.clone(),
                     }
                     .resolved_cell(),

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -606,7 +606,7 @@ async fn apply_webpack_resolve_options(
     resolve_options: Vc<ResolveOptions>,
     webpack_resolve_options: WebpackResolveOptions,
 ) -> Result<Vc<ResolveOptions>> {
-    let mut resolve_options = resolve_options.await?.clone_value();
+    let mut resolve_options = resolve_options.owned().await?;
     if let Some(alias_fields) = webpack_resolve_options.alias_fields {
         let mut old = resolve_options
             .in_package

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -276,8 +276,11 @@ impl ChunkingContext for NodeJsChunkingContext {
         extension: RcStr,
     ) -> Result<Vc<FileSystemPath>> {
         let root_path = *self.chunk_root_path;
-        let name = ident.output_name(*self.root_path, extension).await?;
-        Ok(root_path.join(name.clone_value()))
+        let name = ident
+            .output_name(*self.root_path, extension)
+            .owned()
+            .await?;
+        Ok(root_path.join(name))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-resolve/src/ecmascript.rs
+++ b/turbopack/crates/turbopack-resolve/src/ecmascript.rs
@@ -59,7 +59,7 @@ async fn apply_esm_specific_options_internal(
     options: Vc<ResolveOptions>,
     clear_extensions: bool,
 ) -> Result<Vc<ResolveOptions>> {
-    let mut options: ResolveOptions = options.await?.clone_value();
+    let mut options: ResolveOptions = options.owned().await?;
     // TODO set fully_specified when in strict ESM mode
     // options.fully_specified = true;
     for conditions in get_condition_maps(&mut options) {
@@ -76,7 +76,7 @@ async fn apply_esm_specific_options_internal(
 
 #[turbo_tasks::function]
 pub async fn apply_cjs_specific_options(options: Vc<ResolveOptions>) -> Result<Vc<ResolveOptions>> {
-    let mut options: ResolveOptions = options.await?.clone_value();
+    let mut options: ResolveOptions = options.owned().await?;
     for conditions in get_condition_maps(&mut options) {
         conditions.insert("import".into(), ConditionValue::Unset);
         conditions.insert("require".into(), ConditionValue::Set);

--- a/turbopack/crates/turbopack-resolve/src/resolve.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve.rs
@@ -98,7 +98,7 @@ async fn base_resolve_options(
     let root = resolve_path_value.fs.root();
     let mut direct_mappings = AliasMap::new();
     let node_externals = if let Some(environment) = emulating {
-        environment.node_externals().await?.clone_value()
+        environment.node_externals().owned().await?
     } else {
         opt.enable_node_externals
     };
@@ -194,7 +194,7 @@ async fn base_resolve_options(
     let extensions = if let Some(custom_extension) = &opt.custom_extensions {
         custom_extension.clone()
     } else if let Some(environment) = emulating {
-        environment.resolve_extensions().await?.clone_value()
+        environment.resolve_extensions().owned().await?
     } else {
         let mut ext = Vec::new();
         if opt.enable_typescript && opt.enable_react {

--- a/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
@@ -84,7 +84,7 @@ pub struct ResolveOptionsContext {
 impl ResolveOptionsContext {
     #[turbo_tasks::function]
     pub async fn with_types_enabled(self: Vc<Self>) -> Result<Vc<Self>> {
-        let mut clone = self.await?.clone_value();
+        let mut clone = self.owned().await?;
         clone.enable_types = true;
         clone.enable_typescript = true;
         Ok(Self::cell(clone))
@@ -97,7 +97,7 @@ impl ResolveOptionsContext {
         self: Vc<Self>,
         import_map: Vc<ImportMap>,
     ) -> Result<Vc<Self>> {
-        let mut resolve_options_context = self.await?.clone_value();
+        let mut resolve_options_context = self.owned().await?;
         resolve_options_context.import_map = Some(
             resolve_options_context
                 .import_map
@@ -116,7 +116,7 @@ impl ResolveOptionsContext {
         self: Vc<Self>,
         fallback_import_map: Vc<ImportMap>,
     ) -> Result<Vc<Self>> {
-        let mut resolve_options_context = self.await?.clone_value();
+        let mut resolve_options_context = self.owned().await?;
         resolve_options_context.fallback_import_map = Some(
             resolve_options_context
                 .fallback_import_map

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -38,7 +38,7 @@ pub struct TsConfigIssue {
 
 #[turbo_tasks::function]
 async fn json_only(resolve_options: Vc<ResolveOptions>) -> Result<Vc<ResolveOptions>> {
-    let mut opts = resolve_options.await?.clone_value();
+    let mut opts = resolve_options.owned().await?;
     opts.extensions = vec![".json".into()];
     Ok(opts.cell())
 }
@@ -353,7 +353,7 @@ pub async fn apply_tsconfig_resolve_options(
     tsconfig_resolve_options: Vc<TsConfigResolveOptions>,
 ) -> Result<Vc<ResolveOptions>> {
     let tsconfig_resolve_options = tsconfig_resolve_options.await?;
-    let mut resolve_options = resolve_options.await?.clone_value();
+    let mut resolve_options = resolve_options.owned().await?;
     if let Some(base_url) = tsconfig_resolve_options.base_url {
         // We want to resolve in `compilerOptions.baseUrl` first, then in other
         // locations as a fallback.
@@ -465,7 +465,7 @@ pub async fn type_resolve(
 
 #[turbo_tasks::function]
 pub async fn as_typings_result(result: Vc<ModuleResolveResult>) -> Result<Vc<ModuleResolveResult>> {
-    let mut result = result.await?.clone_value();
+    let mut result = result.owned().await?;
     result.primary = take(&mut result.primary)
         .into_iter()
         .map(|(mut k, v)| {
@@ -480,7 +480,7 @@ pub async fn as_typings_result(result: Vc<ModuleResolveResult>) -> Result<Vc<Mod
 async fn apply_typescript_types_options(
     resolve_options: Vc<ResolveOptions>,
 ) -> Result<Vc<ResolveOptions>> {
-    let mut resolve_options = resolve_options.await?.clone_value();
+    let mut resolve_options = resolve_options.owned().await?;
     resolve_options.extensions = vec![".tsx".into(), ".ts".into(), ".d.ts".into()];
     resolve_options.into_package = resolve_options
         .into_package

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -178,10 +178,10 @@ async fn run(resource: PathBuf, snapshot_mode: IssueSnapshotMode) -> Result<JsRe
     tt.run_once(async move {
         let emit_op =
             run_inner_operation(resource.to_str().unwrap().into(), Value::new(snapshot_mode));
-        let result = emit_op.read_strongly_consistent().await?;
+        let result = emit_op.read_strongly_consistent().owned().await?;
         apply_effects(emit_op).await?;
 
-        Ok(result.clone_value())
+        Ok(result)
     })
     .await
 }

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -20,8 +20,8 @@ use turbopack_core::{
 };
 use turbopack_ecmascript::{
     chunk::{
-        EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkItemOptions,
-        EcmascriptChunkPlaceable, EcmascriptChunkType, EcmascriptExports,
+        EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
+        EcmascriptChunkType, EcmascriptExports,
     },
     references::async_module::OptionAsyncModule,
 };
@@ -265,17 +265,13 @@ impl EcmascriptChunkItem for ModuleChunkItem {
             .await?
             .context("EcmascriptModuleAsset must implement EcmascriptChunkItem")?;
 
-        let chunk_item_content = ecmascript_item
+        let mut chunk_item_content = ecmascript_item
             .content_with_async_module_info(async_module_info)
+            .owned()
             .await?;
 
-        Ok(EcmascriptChunkItemContent {
-            options: EcmascriptChunkItemOptions {
-                wasm: true,
-                ..chunk_item_content.options.clone()
-            },
-            ..chunk_item_content.clone_value()
-        }
-        .into())
+        chunk_item_content.options.wasm = true;
+
+        Ok(chunk_item_content.cell())
     }
 }

--- a/turbopack/crates/turbopack/src/evaluate_context.rs
+++ b/turbopack/crates/turbopack/src/evaluate_context.rs
@@ -37,7 +37,7 @@ pub async fn node_evaluate_asset_context(
     ignore_dynamic_requests: bool,
 ) -> Result<Vc<Box<dyn AssetContext>>> {
     let mut import_map = if let Some(import_map) = import_map {
-        import_map.await?.clone_value()
+        import_map.owned().await?
     } else {
         ImportMap::empty()
     };


### PR DESCRIPTION
### What?

* add ReadCellOptions to cell reads
* refactor read future api and add final_read_hint
* add `ReadRef::try_unwrap`, `.owned`
* remove `.clone_value`
* remove cell on final_read_hint

Closes PACK-3938