### PR TITLE
Use TypeScript to check if a default case is required in `switch`

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/use-error-hook.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/use-error-hook.ts
@@ -21,17 +21,13 @@ export type SupportedErrorEvent = {
 
 function getErrorSignature(ev: SupportedErrorEvent): string {
   const { event } = ev
+  // eslint-disable-next-line default-case -- TypeScript checks this
   switch (event.type) {
     case ACTION_UNHANDLED_ERROR:
     case ACTION_UNHANDLED_REJECTION: {
       return `${event.reason.name}::${event.reason.message}::${event.reason.stack}`
     }
-    default:
-      break
   }
-
-  event satisfies never
-  return ''
 }
 
 export function useErrorHook({


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/75839/files#r1948806062. TypeScript as `switch` exhaustiveness checks built in.