### PR TITLE
[Error Overlay] Fix bottom stack animation

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/dialog/styles.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/dialog/styles.ts
@@ -71,19 +71,20 @@ const styles = css`
   }
 
   [data-nextjs-dialog-footer] {
-    width: 100%;
+    /* Subtract border width */
+    width: calc(100% - 2px);
     /* 
       We make this element absolute to fix it to the bottom during the height transition.
       If you make this relative it will jump during the transition and not collapse or expand smoothly.
     */
-    position: absolute;
-    bottom: 0;
+    position: fixed;
+    bottom: 1px;
     min-height: var(--next-dialog-footer-height);
     border-radius: 0 0 var(--next-dialog-radius) var(--next-dialog-radius);
     overflow: hidden;
 
     > * {
-      height: 100%;
+      min-height: var(--next-dialog-footer-height);
     }
   }
 

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/dialog/styles.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/dialog/styles.ts
@@ -74,8 +74,9 @@ const styles = css`
     /* Subtract border width */
     width: calc(100% - 2px);
     /* 
-      We make this element absolute to fix it to the bottom during the height transition.
+      We make this element fixed to anchor it to the bottom during the height transition.
       If you make this relative it will jump during the transition and not collapse or expand smoothly.
+      If you make this absolute it will remain stuck at its initial position when scrolling the dialog.
     */
     position: fixed;
     bottom: 1px;

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/dialog/styles.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/dialog/styles.ts
@@ -56,7 +56,7 @@ const styles = css`
   }
 
   /* Account for the footer height, when present */
-  [data-nextjs-dialog-body]:has(~ [data-nextjs-dialog-footer]) {
+  [data-nextjs-dialog][data-has-footer='true'] [data-nextjs-dialog-body] {
     margin-bottom: calc(var(--next-dialog-footer-height) + 2px);
   }
 
@@ -72,7 +72,10 @@ const styles = css`
 
   [data-nextjs-dialog-footer] {
     width: 100%;
-    /* We make this element absolute to fix it to the bottom during the height transition */
+    /* 
+      We make this element absolute to fix it to the bottom during the height transition.
+      If you make this relative it will jump during the transition and not collapse or expand smoothly.
+    */
     position: absolute;
     bottom: 0;
     min-height: var(--next-dialog-footer-height);

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/dialog/styles.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/dialog/styles.ts
@@ -57,7 +57,7 @@ const styles = css`
 
   /* Account for the footer height, when present */
   [data-nextjs-dialog][data-has-footer='true'] [data-nextjs-dialog-body] {
-    margin-bottom: calc(var(--next-dialog-footer-height) + 2px);
+    margin-bottom: var(--next-dialog-footer-height);
   }
 
   [data-nextjs-dialog-content] > [data-nextjs-dialog-header] {

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/call-stack/call-stack.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/call-stack/call-stack.tsx
@@ -127,7 +127,6 @@ function ChevronUpDown() {
 
 export const CALL_STACK_STYLES = css`
   .error-overlay-call-stack-container {
-    border-top: 1px solid var(--color-gray-400);
     position: relative;
   }
 

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-layout/error-overlay-layout.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-layout/error-overlay-layout.tsx
@@ -119,12 +119,11 @@ export function ErrorOverlayLayout({
                 />
               </DialogFooter>
             )}
-
-            <ErrorOverlayBottomStack
-              count={readyErrors?.length ?? 0}
-              activeIdx={activeIdx ?? 0}
-            />
           </DialogContent>
+          <ErrorOverlayBottomStack
+            count={readyErrors?.length ?? 0}
+            activeIdx={activeIdx ?? 0}
+          />
         </ErrorOverlayDialog>
       </div>
     </ErrorOverlayOverlay>

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-layout/error-overlay-layout.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-layout/error-overlay-layout.tsx
@@ -80,7 +80,7 @@ export function ErrorOverlayLayout({
     } as React.CSSProperties,
   }
 
-  const hasFooter = footerMessage || errorCode
+  const hasFooter = Boolean(footerMessage || errorCode)
 
   return (
     <ErrorOverlayOverlay fixed={isBuildError} {...animationProps}>

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-layout/error-overlay-layout.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-layout/error-overlay-layout.tsx
@@ -89,7 +89,7 @@ export function ErrorOverlayLayout({
           onClose={onClose}
           isTurbopack={isTurbopack}
           dialogResizerRef={dialogResizerRef}
-          data-has-footer={!!hasFooter}
+          data-has-footer={hasFooter}
         >
           <DialogContent>
             <ErrorOverlayFloatingHeader

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-layout/error-overlay-layout.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-layout/error-overlay-layout.tsx
@@ -80,6 +80,8 @@ export function ErrorOverlayLayout({
     } as React.CSSProperties,
   }
 
+  const hasFooter = footerMessage || errorCode
+
   return (
     <ErrorOverlayOverlay fixed={isBuildError} {...animationProps}>
       <div data-nextjs-dialog-root {...animationProps}>
@@ -87,6 +89,7 @@ export function ErrorOverlayLayout({
           onClose={onClose}
           isTurbopack={isTurbopack}
           dialogResizerRef={dialogResizerRef}
+          data-has-footer={!!hasFooter}
         >
           <DialogContent>
             <ErrorOverlayFloatingHeader
@@ -110,16 +113,15 @@ export function ErrorOverlayLayout({
             </ErrorOverlayDialogHeader>
 
             <ErrorOverlayDialogBody>{children}</ErrorOverlayDialogBody>
-
-            {(footerMessage || errorCode) && (
-              <DialogFooter>
-                <ErrorOverlayFooter
-                  footerMessage={footerMessage}
-                  errorCode={errorCode}
-                />
-              </DialogFooter>
-            )}
           </DialogContent>
+          {hasFooter && (
+            <DialogFooter>
+              <ErrorOverlayFooter
+                footerMessage={footerMessage}
+                errorCode={errorCode}
+              />
+            </DialogFooter>
+          )}
           <ErrorOverlayBottomStack
             count={readyErrors?.length ?? 0}
             activeIdx={activeIdx ?? 0}


### PR DESCRIPTION
### Why?

The bottom stack style was regressed.

![image](https://github.com/user-attachments/assets/5f7243e8-12e7-486d-a9ed-d88a8740bc46)

This PR closes [NDX-808](https://linear.app/vercel/issue/NDX-808/fix-regression-in-bottom-stacks-style)