### PR TITLE
[DevOverlay]: enable by default

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -45,7 +45,11 @@
         "jest/no-conditional-expect": "off",
         "jest/valid-title": "off",
         "jest/no-interpolation-in-snapshots": "off",
-        "jest/no-export": "off"
+        "jest/no-export": "off",
+        "jest/no-standalone-expect": [
+          "error",
+          { "additionalTestBlockFunctions": ["retry"] }
+        ]
       }
     },
     { "files": ["**/__tests__/**"], "env": { "jest": true } },

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -581,7 +581,7 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 18.18.2
-      afterBuild: __NEXT_EXPERIMENTAL_PPR=true __NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY=true NEXT_EXTERNAL_TESTS_FILTERS="test/ppr-tests-manifest.json" node run-tests.js --timings -c ${TEST_CONCURRENCY} --type integration
+      afterBuild: __NEXT_EXPERIMENTAL_PPR=true __NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY=false NEXT_EXTERNAL_TESTS_FILTERS="test/ppr-tests-manifest.json" node run-tests.js --timings -c ${TEST_CONCURRENCY} --type integration
       stepName: 'test-ppr-integration'
     secrets: inherit
 
@@ -596,7 +596,7 @@ jobs:
         group: [1/6, 2/6, 3/6, 4/6, 5/6, 6/6]
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: __NEXT_EXPERIMENTAL_PPR=true __NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY=true NEXT_EXTERNAL_TESTS_FILTERS="test/ppr-tests-manifest.json" NEXT_TEST_MODE=dev node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type development
+      afterBuild: __NEXT_EXPERIMENTAL_PPR=true __NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY=false NEXT_EXTERNAL_TESTS_FILTERS="test/ppr-tests-manifest.json" NEXT_TEST_MODE=dev node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type development
       stepName: 'test-ppr-dev-${{ matrix.group }}'
     secrets: inherit
 
@@ -611,7 +611,7 @@ jobs:
         group: [1/7, 2/7, 3/7, 4/7, 5/7, 6/7, 7/7]
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: __NEXT_EXPERIMENTAL_PPR=true __NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY=true NEXT_EXTERNAL_TESTS_FILTERS="test/ppr-tests-manifest.json" NEXT_TEST_MODE=start node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type production
+      afterBuild: __NEXT_EXPERIMENTAL_PPR=true __NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY=false NEXT_EXTERNAL_TESTS_FILTERS="test/ppr-tests-manifest.json" NEXT_TEST_MODE=start node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type production
       stepName: 'test-ppr-prod-${{ matrix.group }}'
     secrets: inherit
 

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -262,6 +262,7 @@ function DevToolsPopover({
 
             <div className="footer">
               <MenuItem
+                data-hide-dev-tools
                 label="Hide Dev Tools"
                 value={<HideShortcut />}
                 onClick={hide}

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -415,6 +415,7 @@ export const NextLogo = forwardRef(function NextLogo(
           <button
             ref={mergeRefs(triggerRef, propRef)}
             data-next-mark
+            data-next-mark-loading={isLoading}
             onClick={onTriggerClick}
             {...props}
           >

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/terminal/editor-link.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/terminal/editor-link.tsx
@@ -9,7 +9,7 @@ type EditorLinkProps = {
     column: number
   }
 }
-export function EditorLink({ file, isSourceFile, location }: EditorLinkProps) {
+export function EditorLink({ file, location }: EditorLinkProps) {
   const open = useOpenInEditor({
     file,
     lineNumber: location?.line ?? 1,
@@ -19,12 +19,7 @@ export function EditorLink({ file, isSourceFile, location }: EditorLinkProps) {
   return (
     <div
       data-with-open-in-editor-link
-      data-with-open-in-editor-link-source-file={
-        isSourceFile ? true : undefined
-      }
-      data-with-open-in-editor-link-import-trace={
-        isSourceFile ? undefined : true
-      }
+      data-with-open-in-editor-link-import-trace
       tabIndex={10}
       role={'link'}
       onClick={open}
@@ -63,12 +58,5 @@ export const EDITOR_LINK_STYLES = css`
   }
   [data-with-open-in-editor-link-import-trace] {
     margin-left: var(--size-gap-double);
-  }
-  [data-with-open-in-editor-link-source-file] {
-    border-bottom: 1px solid var(--color-ansi-bright-black);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    line-break: anywhere;
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/terminal/terminal.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/terminal/terminal.tsx
@@ -77,8 +77,8 @@ export const Terminal: React.FC<TerminalProps> = function Terminal({
 
   const open = useOpenInEditor({
     file: file?.fileName,
-    lineNumber: file?.location?.line,
-    column: file?.location?.column,
+    lineNumber: file?.location?.line ?? 1,
+    column: file?.location?.column ?? 0,
   })
 
   const stackFrame = {
@@ -96,6 +96,7 @@ export const Terminal: React.FC<TerminalProps> = function Terminal({
       <button
         aria-label="Open in editor"
         className="code-frame-header"
+        data-with-open-in-editor-link-source-file
         onClick={open}
       >
         <div className="code-frame-link">

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1253,7 +1253,7 @@ export const defaultConfig: NextConfig = {
     staticGenerationMinPagesPerWorker: 25,
     dynamicIO: false,
     inlineCss: false,
-    newDevOverlay: false,
+    newDevOverlay: true,
     streamingMetadata: false,
     htmlLimitedBots: undefined,
     useCache: undefined,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -923,8 +923,8 @@ function assignDefaults(
   // TODO(jiwon): remove once we've made new UI default
   // Enable reactOwnerStack when newDevOverlay is enabled to have
   // better call stack output in the new UI.
-  if (process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true') {
-    result.experimental.newDevOverlay = true
+  if (process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'false') {
+    result.experimental.newDevOverlay = false
   }
   if (result.experimental.newDevOverlay) {
     result.experimental.reactOwnerStack = true

--- a/run-tests.js
+++ b/run-tests.js
@@ -54,11 +54,6 @@ const externalTestsFilter = getTestFilter()
 if (!process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY) {
   console.log('Setting __NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY to true')
   process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY = 'true'
-} else {
-  console.log(
-    '__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY is already set to',
-    process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY
-  )
 }
 
 const timings = []

--- a/run-tests.js
+++ b/run-tests.js
@@ -50,6 +50,17 @@ const ENDGROUP = process.env.CI ? '##[endgroup]' : ''
 
 const externalTestsFilter = getTestFilter()
 
+// TODO(new-dev-overlay): Remove this once old dev overlay fork is removed
+if (!process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY) {
+  console.log('Setting __NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY to true')
+  process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY = 'true'
+} else {
+  console.log(
+    '__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY is already set to',
+    process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY
+  )
+}
+
 const timings = []
 const DEFAULT_NUM_RETRIES = 2
 const DEFAULT_CONCURRENCY = 2

--- a/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
@@ -50,27 +50,27 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     await session.assertHasRedbox()
     if (process.env.TURBOPACK) {
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
-        "./node_modules/my-package/index.js:1:13
-        Module not found: Can't resolve 'dns'
-        > 1 | const dns = require('dns')
-            |             ^^^^^^^^^^^^^^
-          2 | module.exports = dns
+       "./node_modules/my-package/index.js (1:13)
+       Module not found: Can't resolve 'dns'
+       > 1 | const dns = require('dns')
+           |             ^^^^^^^^^^^^^^
+         2 | module.exports = dns
 
-        https://nextjs.org/docs/messages/module-not-found"
+       https://nextjs.org/docs/messages/module-not-found"
       `)
     } else {
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
-        "./node_modules/my-package/index.js:1:1
-        Module not found: Can't resolve 'dns'
-        > 1 | const dns = require('dns')
-            | ^
-          2 | module.exports = dns
+       "./node_modules/my-package/index.js (1:1)
+       Module not found: Can't resolve 'dns'
+       > 1 | const dns = require('dns')
+           | ^
+         2 | module.exports = dns
 
-        https://nextjs.org/docs/messages/module-not-found
+       https://nextjs.org/docs/messages/module-not-found
 
-        Import trace for requested module:
-        ./index.js
-        ./app/page.js"
+       Import trace for requested module:
+       ./index.js
+       ./app/page.js"
       `)
     }
   })
@@ -98,30 +98,30 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     const source = await session.getRedboxSource()
     if (process.env.TURBOPACK) {
       expect(source).toMatchInlineSnapshot(`
-        "./index.js:1:1
-        Module not found: Can't resolve 'b'
-        > 1 | import Comp from 'b'
-            | ^^^^^^^^^^^^^^^^^^^^
-          2 | export default function Oops() {
-          3 |   return (
-          4 |     <div>
+       "./index.js (1:1)
+       Module not found: Can't resolve 'b'
+       > 1 | import Comp from 'b'
+           | ^^^^^^^^^^^^^^^^^^^^
+         2 | export default function Oops() {
+         3 |   return (
+         4 |     <div>
 
-        https://nextjs.org/docs/messages/module-not-found"
+       https://nextjs.org/docs/messages/module-not-found"
       `)
     } else {
       expect(source).toMatchInlineSnapshot(`
-        "./index.js:1:1
-        Module not found: Can't resolve 'b'
-        > 1 | import Comp from 'b'
-            | ^
-          2 | export default function Oops() {
-          3 |   return (
-          4 |     <div>
+       "./index.js (1:1)
+       Module not found: Can't resolve 'b'
+       > 1 | import Comp from 'b'
+           | ^
+         2 | export default function Oops() {
+         3 |   return (
+         4 |     <div>
 
-        https://nextjs.org/docs/messages/module-not-found
+       https://nextjs.org/docs/messages/module-not-found
 
-        Import trace for requested module:
-        ./app/page.js"
+       Import trace for requested module:
+       ./app/page.js"
       `)
     }
   })
@@ -150,29 +150,29 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     const source = await session.getRedboxSource()
     if (process.env.TURBOPACK) {
       expect(source).toMatchInlineSnapshot(`
-        "./app/page.js:2:1
-        Module not found: Can't resolve 'b'
-          1 | 'use client'
-        > 2 | import Comp from 'b'
-            | ^^^^^^^^^^^^^^^^^^^^
-          3 | export default function Oops() {
-          4 |   return (
-          5 |     <div>
+       "./app/page.js (2:1)
+       Module not found: Can't resolve 'b'
+         1 | 'use client'
+       > 2 | import Comp from 'b'
+           | ^^^^^^^^^^^^^^^^^^^^
+         3 | export default function Oops() {
+         4 |   return (
+         5 |     <div>
 
-        https://nextjs.org/docs/messages/module-not-found"
+       https://nextjs.org/docs/messages/module-not-found"
       `)
     } else {
       expect(source).toMatchInlineSnapshot(`
-        "./app/page.js:2:1
-        Module not found: Can't resolve 'b'
-          1 | 'use client'
-        > 2 | import Comp from 'b'
-            | ^
-          3 | export default function Oops() {
-          4 |   return (
-          5 |     <div>
+       "./app/page.js (2:1)
+       Module not found: Can't resolve 'b'
+         1 | 'use client'
+       > 2 | import Comp from 'b'
+           | ^
+         3 | export default function Oops() {
+         4 |   return (
+         5 |     <div>
 
-        https://nextjs.org/docs/messages/module-not-found"
+       https://nextjs.org/docs/messages/module-not-found"
       `)
     }
   })
@@ -199,29 +199,29 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     const source = await session.getRedboxSource()
     if (process.env.TURBOPACK) {
       expect(source).toMatchInlineSnapshot(`
-        "./app/page.js:2:1
-        Module not found: Can't resolve './non-existent.css'
-          1 | 'use client'
-        > 2 | import './non-existent.css'
-            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          3 | export default function Page(props) {
-          4 |   return <p>index page</p>
-          5 | }
+       "./app/page.js (2:1)
+       Module not found: Can't resolve './non-existent.css'
+         1 | 'use client'
+       > 2 | import './non-existent.css'
+           | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+         3 | export default function Page(props) {
+         4 |   return <p>index page</p>
+         5 | }
 
-        https://nextjs.org/docs/messages/module-not-found"
+       https://nextjs.org/docs/messages/module-not-found"
       `)
     } else {
       expect(source).toMatchInlineSnapshot(`
-        "./app/page.js:2:1
-        Module not found: Can't resolve './non-existent.css'
-          1 | 'use client'
-        > 2 | import './non-existent.css'
-            | ^
-          3 | export default function Page(props) {
-          4 |   return <p>index page</p>
-          5 | }
+       "./app/page.js (2:1)
+       Module not found: Can't resolve './non-existent.css'
+         1 | 'use client'
+       > 2 | import './non-existent.css'
+           | ^
+         3 | export default function Page(props) {
+         4 |   return <p>index page</p>
+         5 | }
 
-        https://nextjs.org/docs/messages/module-not-found"
+       https://nextjs.org/docs/messages/module-not-found"
       `)
     }
     await session.patch(

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -436,7 +436,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     )
 
     await session.evaluate(() => document.querySelector('button').click())
-    await session.openRedbox()
+    await session.assertHasRedbox()
 
     const header2 = await session.getRedboxDescription()
     expect(header2).toMatchSnapshot()
@@ -481,7 +481,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     )
 
     await session.evaluate(() => document.querySelector('button').click())
-    await session.openRedbox()
+    await session.assertHasRedbox()
 
     const header3 = await session.getRedboxDescription()
     expect(header3).toMatchSnapshot()
@@ -526,7 +526,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
     )
 
     await session.evaluate(() => document.querySelector('button').click())
-    await session.openRedbox()
+    await session.assertHasRedbox()
 
     const header4 = await session.getRedboxDescription()
     expect(header4).toEqual(

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -1237,16 +1237,16 @@ export default function Home() {
     } else {
       // FIXME: Webpack stack frames are not source mapped
       expect(stackFrames).toMatchInlineSnapshot(`
-       "at eval (app/utils.ts (1:7))
-       at ./app/utils.ts (file:///private/var/folders/58/nhbh7xmd0s99w53vj614rpt80000gn/T/next-install-4d87682b727bfff5d64b51099d2fc0569b4bfc5c58908a4bb599bf25594f1c45/.next/static/chunks/app/page.js (39:1))
-       at options.factory (file:///private/var/folders/58/nhbh7xmd0s99w53vj614rpt80000gn/T/next-install-4d87682b727bfff5d64b51099d2fc0569b4bfc5c58908a4bb599bf25594f1c45/.next/static/chunks/webpack.js (700:31))
-       at __webpack_require__ (file:///private/var/folders/58/nhbh7xmd0s99w53vj614rpt80000gn/T/next-install-4d87682b727bfff5d64b51099d2fc0569b4bfc5c58908a4bb599bf25594f1c45/.next/static/chunks/webpack.js (37:33))
-       at fn (file:///private/var/folders/58/nhbh7xmd0s99w53vj614rpt80000gn/T/next-install-4d87682b727bfff5d64b51099d2fc0569b4bfc5c58908a4bb599bf25594f1c45/.next/static/chunks/webpack.js (357:21))
-       at eval (./app/page.js)
-       at ./app/page.js (file:///private/var/folders/58/nhbh7xmd0s99w53vj614rpt80000gn/T/next-install-4d87682b727bfff5d64b51099d2fc0569b4bfc5c58908a4bb599bf25594f1c45/.next/static/chunks/app/page.js (28:1))
-       at options.factory (file:///private/var/folders/58/nhbh7xmd0s99w53vj614rpt80000gn/T/next-install-4d87682b727bfff5d64b51099d2fc0569b4bfc5c58908a4bb599bf25594f1c45/.next/static/chunks/webpack.js (700:31))
-       at __webpack_require__ (file:///private/var/folders/58/nhbh7xmd0s99w53vj614rpt80000gn/T/next-install-4d87682b727bfff5d64b51099d2fc0569b4bfc5c58908a4bb599bf25594f1c45/.next/static/chunks/webpack.js (37:33))
-       at fn (file:///private/var/folders/58/nhbh7xmd0s99w53vj614rpt80000gn/T/next-install-4d87682b727bfff5d64b51099d2fc0569b4bfc5c58908a4bb599bf25594f1c45/.next/static/chunks/webpack.js (357:21))"
+        "at eval (app/utils.ts (1:7))
+        at ./app/utils.ts ()
+        at options.factory ()
+        at __webpack_require__ ()
+        at fn ()
+        at eval ()
+        at ./app/page.js ()
+        at options.factory ()
+        at __webpack_require__ ()
+        at fn ()"
       `)
     }
   })

--- a/test/development/acceptance-app/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance-app/ReactRefreshRegression.test.ts
@@ -280,7 +280,8 @@ describe('ReactRefreshRegression app', () => {
     await session.assertHasRedbox()
 
     const source = await session.getRedboxSource()
-    expect(source.split(/\r?\n/g).slice(2).join('\n')).toMatchInlineSnapshot(`
+    expect(source.split(/\r?\n/g).slice(2).join('\n').replace(/^\n+/, ''))
+      .toMatchInlineSnapshot(`
       "> 1 | export default function () { throw new Error('boom'); }
           |                                    ^"
     `)
@@ -298,7 +299,8 @@ describe('ReactRefreshRegression app', () => {
     await session.assertHasRedbox()
 
     const source = await session.getRedboxSource()
-    expect(source.split(/\r?\n/g).slice(2).join('\n')).toMatchInlineSnapshot(`
+    expect(source.split(/\r?\n/g).slice(2).join('\n').replace(/^\n+/, ''))
+      .toMatchInlineSnapshot(`
       "> 1 | export default function Page() { throw new Error('boom'); }
           |                                        ^"
     `)
@@ -319,7 +321,8 @@ describe('ReactRefreshRegression app', () => {
     await session.assertHasRedbox()
 
     const source = await session.getRedboxSource()
-    expect(source.split(/\r?\n/g).slice(2).join('\n')).toMatchInlineSnapshot(`
+    expect(source.split(/\r?\n/g).slice(2).join('\n').replace(/^\n+/, ''))
+      .toMatchInlineSnapshot(`
         "  1 | 'use client'
         > 2 | export default function Page() { throw new Error('boom'); }
             |                                        ^"

--- a/test/development/acceptance-app/__snapshots__/ReactRefreshLogBox.test.ts.snap
+++ b/test/development/acceptance-app/__snapshots__/ReactRefreshLogBox.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ReactRefreshLogBox app default Import trace when module not found in layout 1`] = `
-"./app/module.js:1:1
+"./app/module.js (1:1)
 Module not found: Can't resolve 'non-existing-module'
 > 1 | import "non-existing-module"
     | ^
@@ -43,7 +43,7 @@ exports[`ReactRefreshLogBox app default conversion to class component (1) 1`] = 
 `;
 
 exports[`ReactRefreshLogBox app default css syntax errors 1`] = `
-"./index.module.css:1:1
+"./index.module.css (1:1)
 Syntax error: Selector "button" is not pure (pure selectors must contain at least one local class or id)
 
 > 1 | button {}
@@ -110,7 +110,7 @@ exports[`ReactRefreshLogBox app default should strip whitespace correctly with n
 `;
 
 exports[`ReactRefreshLogBox app turbo Import trace when module not found in layout 1`] = `
-"./app/module.js:1:1
+"./app/module.js (1:1)
 Module not found: Can't resolve 'non-existing-module'
 > 1 | import "non-existing-module"
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -119,7 +119,8 @@ https://nextjs.org/docs/messages/module-not-found"
 `;
 
 exports[`ReactRefreshLogBox app turbo Should not show __webpack_exports__ when exporting anonymous arrow function 1`] = `
-"index.js (3:11) @ {default export}
+"index.js (3:11) @
+{default export}
 
   1 | export default () => {
   2 |   if (typeof window !== 'undefined') {

--- a/test/development/acceptance-app/error-message-url.test.ts
+++ b/test/development/acceptance-app/error-message-url.test.ts
@@ -22,7 +22,9 @@ describe('Error overlay - error message urls', () => {
 
     await session.assertHasRedbox()
 
-    const link = await browser.elementByCss('[data-nextjs-terminal] a')
+    const link = await browser.elementByCss(
+      '[data-nextjs-terminal] a, [data-nextjs-codeframe] a'
+    )
     const text = await link.text()
     const href = await link.getAttribute('href')
     expect(text).toEqual(

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -800,7 +800,10 @@ describe('Error overlay for hydration errors in App router', () => {
     await session.openRedbox()
 
     await retry(async () => {
-      expect(await getRedboxTotalErrorCount(browser)).toBe(2)
+      expect(await getRedboxTotalErrorCount(browser)).toBe(
+        // With owner stacks, we also get an error for the parent context
+        isNewDevOverlay ? 3 : 2
+      )
     })
 
     const description = await session.getRedboxDescription()

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -7,9 +7,9 @@ import { getRedboxTotalErrorCount, retry } from 'next-test-utils'
 
 // https://github.com/facebook/react/blob/main/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js used as a reference
 
-// TODO(new-dev-overlay): Remove this once old dev overlay fork is removed
-const isNewDevOverlay =
-  process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
+const enableOwnerStacks =
+  process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ||
+  process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
 
 describe('Error overlay for hydration errors in App router', () => {
   const { next, isTurbopack } = nextTestSetup({
@@ -802,7 +802,7 @@ describe('Error overlay for hydration errors in App router', () => {
     await retry(async () => {
       expect(await getRedboxTotalErrorCount(browser)).toBe(
         // With owner stacks, we also get an error for the parent context
-        isNewDevOverlay ? 3 : 2
+        enableOwnerStacks ? 3 : 2
       )
     })
 
@@ -874,7 +874,7 @@ describe('Error overlay for hydration errors in App router', () => {
     await retry(async () => {
       expect(await getRedboxTotalErrorCount(browser)).toBe(
         // One error for "Cannot render a sync or defer <script>"
-        isNewDevOverlay
+        enableOwnerStacks
           ? // With owner stacks, we also get an error for the parent context.
             3
           : 2

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -7,7 +7,9 @@ import { getRedboxTotalErrorCount, retry } from 'next-test-utils'
 
 // https://github.com/facebook/react/blob/main/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js used as a reference
 
-const enableOwnerStacks = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+// TODO(new-dev-overlay): Remove this once old dev overlay fork is removed
+const isNewDevOverlay =
+  process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
 
 describe('Error overlay for hydration errors in App router', () => {
   const { next, isTurbopack } = nextTestSetup({
@@ -220,41 +222,43 @@ describe('Error overlay for hydration errors in App router', () => {
        "...
            <HotReload assetPrefix="" globalError={[...]}>
              <ReactDevOverlay state={{nextId:1, ...}} dispatcher={{...}} globalError={[...]}>
-               <DevRootHTTPAccessFallbackBoundary>
-                 <HTTPAccessFallbackBoundary notFound={<NotAllowedRootHTTPFallbackError>}>
-                   <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<NotAllowedRootHTTPFallbackError>} ...>
-                     <RedirectBoundary>
-                       <RedirectErrorBoundary router={{...}}>
-                         <Head>
-                         <script>
-                         <script>
-                         <script>
-                         <ClientSegmentRoot Component={function Root} slots={{...}} params={{}}>
-                           <Root params={Promise}>
-                             <html
-       -                       className="server-html"
-                             >
-                         ...
-               ..."
+               <DevOverlayErrorBoundary devOverlay={<ShadowPortal>} globalError={[...]} ...>
+                 <DevRootHTTPAccessFallbackBoundary>
+                   <HTTPAccessFallbackBoundary notFound={<NotAllowedRootHTTPFallbackError>}>
+                     <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<NotAllowedRootHTTPFallbackError>} ...>
+                       <RedirectBoundary>
+                         <RedirectErrorBoundary router={{...}}>
+                           <Head>
+                           <script>
+                           <script>
+                           <script>
+                           <ClientSegmentRoot Component={function Root} slots={{...}} params={{}}>
+                             <Root params={Promise}>
+                               <html
+       -                         className="server-html"
+                               >
+                           ...
+                 ..."
       `)
     } else {
       expect(pseudoHtml).toMatchInlineSnapshot(`
        "...
            <HotReload assetPrefix="" globalError={[...]}>
              <ReactDevOverlay state={{nextId:1, ...}} dispatcher={{...}} globalError={[...]}>
-               <DevRootHTTPAccessFallbackBoundary>
-                 <HTTPAccessFallbackBoundary notFound={<NotAllowedRootHTTPFallbackError>}>
-                   <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<NotAllowedRootHTTPFallbackError>} ...>
-                     <RedirectBoundary>
-                       <RedirectErrorBoundary router={{...}}>
-                         <Head>
-                         <ClientSegmentRoot Component={function Root} slots={{...}} params={{}}>
-                           <Root params={Promise}>
-                             <html
-       -                       className="server-html"
-                             >
-                         ...
-               ..."
+               <DevOverlayErrorBoundary devOverlay={<ShadowPortal>} globalError={[...]} ...>
+                 <DevRootHTTPAccessFallbackBoundary>
+                   <HTTPAccessFallbackBoundary notFound={<NotAllowedRootHTTPFallbackError>}>
+                     <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<NotAllowedRootHTTPFallbackError>} ...>
+                       <RedirectBoundary>
+                         <RedirectErrorBoundary router={{...}}>
+                           <Head>
+                           <ClientSegmentRoot Component={function Root} slots={{...}} params={{}}>
+                             <Root params={Promise}>
+                               <html
+       -                         className="server-html"
+                               >
+                           ...
+                 ..."
       `)
     }
 
@@ -867,7 +871,7 @@ describe('Error overlay for hydration errors in App router', () => {
     await retry(async () => {
       expect(await getRedboxTotalErrorCount(browser)).toBe(
         // One error for "Cannot render a sync or defer <script>"
-        enableOwnerStacks
+        isNewDevOverlay
           ? // With owner stacks, we also get an error for the parent context.
             3
           : 2

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -175,7 +175,7 @@ describe('Error overlay - RSC build errors', () => {
       // TODO: fix the issue ordering.
       // turbopack emits the resolve issue first instead of the transform issue.
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
-       "./app/server-with-errors/client-only-in-server/client-only-lib.js:1:1
+       "./app/server-with-errors/client-only-in-server/client-only-lib.js (1:1)
        Ecmascript file had an error
        > 1 | import 'client-only'
            | ^^^^^^^^^^^^^^^^^^^^
@@ -348,13 +348,13 @@ describe('Error overlay - RSC build errors', () => {
     if (process.env.TURBOPACK) {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
-        "./app/server-with-errors/error-file/error.js:1:1
-        Ecmascript file had an error
-        > 1 | export default function Error() {}
-            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       "./app/server-with-errors/error-file/error.js (1:1)
+       Ecmascript file had an error
+       > 1 | export default function Error() {}
+           | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-        app/server-with-errors/error-file/error.js must be a Client Component. Add the "use client" directive the top of the file to resolve this issue.
-        Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client"
+       app/server-with-errors/error-file/error.js must be a Client Component. Add the "use client" directive the top of the file to resolve this issue.
+       Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client"
       `)
     } else {
       await expect(session.getRedboxSource()).resolves.toMatch(

--- a/test/development/acceptance-app/rsc-runtime-errors.test.ts
+++ b/test/development/acceptance-app/rsc-runtime-errors.test.ts
@@ -8,6 +8,9 @@ import {
   getVersionCheckerText,
 } from 'next-test-utils'
 
+const isNewDevOverlay =
+  process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
+
 describe('Error overlay - RSC runtime errors', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'rsc-runtime-errors')),
@@ -108,7 +111,11 @@ describe('Error overlay - RSC runtime errors', () => {
 
     await assertHasRedbox(browser)
     const versionText = await getVersionCheckerText(browser)
-    expect(versionText).toMatch(/Next.js \([\w.-]+\)/)
+    if (isNewDevOverlay) {
+      expect(versionText).toMatch(/Next.js [\w.-]+/)
+    } else {
+      expect(versionText).toMatch(/Next.js \([\w.-]+\)/)
+    }
   })
 
   it('should not show the bundle layer info in the file trace', async () => {

--- a/test/development/acceptance-app/version-staleness.test.ts
+++ b/test/development/acceptance-app/version-staleness.test.ts
@@ -11,6 +11,9 @@ function getStaleness(browser: BrowserInterface) {
     .text()
 }
 
+const isNewDevOverlay =
+  process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
+
 describe('Error Overlay version staleness', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
@@ -47,14 +50,29 @@ describe('Error Overlay version staleness', () => {
 
     await session.openRedbox()
 
-    if (process.env.TURBOPACK) {
-      expect(await getStaleness(browser)).toMatchInlineSnapshot(
-        `"Next.js (1.0.0) is outdated (learn more) (Turbopack)"`
-      )
+    if (isNewDevOverlay) {
+      if (process.env.TURBOPACK) {
+        expect(await getStaleness(browser)).toMatchInlineSnapshot(`
+         "Next.js 1.0.0 (outdated)
+         (learn more)
+         Turbopack"
+        `)
+      } else {
+        expect(await getStaleness(browser)).toMatchInlineSnapshot(`
+         "Next.js 1.0.0 (outdated)
+         (learn more)"
+        `)
+      }
     } else {
-      expect(await getStaleness(browser)).toMatchInlineSnapshot(
-        `"Next.js (1.0.0) is outdated (learn more)"`
-      )
+      if (process.env.TURBOPACK) {
+        expect(await getStaleness(browser)).toMatchInlineSnapshot(
+          `"Next.js (1.0.0) is outdated (learn more) (Turbopack)"`
+        )
+      } else {
+        expect(await getStaleness(browser)).toMatchInlineSnapshot(
+          `"Next.js (1.0.0) is outdated (learn more)"`
+        )
+      }
     }
   })
 
@@ -83,13 +101,16 @@ describe('Error Overlay version staleness', () => {
     )
 
     if (process.env.TURBOPACK) {
-      expect(await getStaleness(browser)).toMatchInlineSnapshot(
-        `"Next.js (2.0.0) is outdated (learn more) (Turbopack)"`
-      )
+      expect(await getStaleness(browser)).toMatchInlineSnapshot(`
+       "Next.js 2.0.0 (outdated)
+       (learn more)
+       Turbopack"
+      `)
     } else {
-      expect(await getStaleness(browser)).toMatchInlineSnapshot(
-        `"Next.js (2.0.0) is outdated (learn more)"`
-      )
+      expect(await getStaleness(browser)).toMatchInlineSnapshot(`
+       "Next.js 2.0.0 (outdated)
+       (learn more)"
+      `)
     }
   })
 
@@ -115,13 +136,16 @@ describe('Error Overlay version staleness', () => {
     )
 
     if (process.env.TURBOPACK) {
-      expect(await getStaleness(browser)).toMatchInlineSnapshot(
-        `"Next.js (3.0.0) is outdated (learn more) (Turbopack)"`
-      )
+      expect(await getStaleness(browser)).toMatchInlineSnapshot(`
+       "Next.js 3.0.0 (outdated)
+       (learn more)
+       Turbopack"
+      `)
     } else {
-      expect(await getStaleness(browser)).toMatchInlineSnapshot(
-        `"Next.js (3.0.0) is outdated (learn more)"`
-      )
+      expect(await getStaleness(browser)).toMatchInlineSnapshot(`
+       "Next.js 3.0.0 (outdated)
+       (learn more)"
+      `)
     }
   })
 })

--- a/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
@@ -97,15 +97,15 @@ describe.each(['default', 'turbo'])(
       const source = next.normalizeTestDirContent(content)
       if (process.env.TURBOPACK) {
         expect(source).toMatchInlineSnapshot(`
-          "./pages/_app.js:2:11
-          Parsing ecmascript source code failed
-            1 | function MyApp({ Component, pageProps }) {
-          > 2 |   return <<Component {...pageProps} />;
-              |           ^
-            3 | }
-            4 | export default MyApp
+         "./pages/_app.js (2:11)
+         Parsing ecmascript source code failed
+           1 | function MyApp({ Component, pageProps }) {
+         > 2 |   return <<Component {...pageProps} />;
+             |           ^
+           3 | }
+           4 | export default MyApp
 
-          Expression expected"
+         Expression expected"
         `)
       } else {
         expect(source).toMatchInlineSnapshot(`
@@ -184,17 +184,17 @@ describe.each(['default', 'turbo'])(
       )
       if (process.env.TURBOPACK) {
         expect(source).toMatchInlineSnapshot(`
-          "./pages/_document.js:3:36
-          Parsing ecmascript source code failed
-            1 | import Document, { Html, Head, Main, NextScript } from 'next/document'
-            2 |
-          > 3 | class MyDocument extends Document {{
-              |                                    ^
-            4 |   static async getInitialProps(ctx) {
-            5 |     const initialProps = await Document.getInitialProps(ctx)
-            6 |     return { ...initialProps }
+         "./pages/_document.js (3:36)
+         Parsing ecmascript source code failed
+           1 | import Document, { Html, Head, Main, NextScript } from 'next/document'
+           2 |
+         > 3 | class MyDocument extends Document {{
+             |                                    ^
+           4 |   static async getInitialProps(ctx) {
+           5 |     const initialProps = await Document.getInitialProps(ctx)
+           6 |     return { ...initialProps }
 
-          Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key"
+         Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key"
         `)
       } else {
         expect(source).toMatchInlineSnapshot(`

--- a/test/development/acceptance/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-builtins.test.ts
@@ -47,27 +47,27 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     await session.assertHasRedbox()
     if (process.env.TURBOPACK) {
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
-        "./node_modules/my-package/index.js:1:13
-        Module not found: Can't resolve 'dns'
-        > 1 | const dns = require('dns')
-            |             ^^^^^^^^^^^^^^
-          2 | module.exports = dns
+       "./node_modules/my-package/index.js (1:13)
+       Module not found: Can't resolve 'dns'
+       > 1 | const dns = require('dns')
+           |             ^^^^^^^^^^^^^^
+         2 | module.exports = dns
 
-        https://nextjs.org/docs/messages/module-not-found"
+       https://nextjs.org/docs/messages/module-not-found"
       `)
     } else {
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
-        "./node_modules/my-package/index.js:1:1
-        Module not found: Can't resolve 'dns'
-        > 1 | const dns = require('dns')
-            | ^
-          2 | module.exports = dns
+       "./node_modules/my-package/index.js (1:1)
+       Module not found: Can't resolve 'dns'
+       > 1 | const dns = require('dns')
+           | ^
+         2 | module.exports = dns
 
-        https://nextjs.org/docs/messages/module-not-found
+       https://nextjs.org/docs/messages/module-not-found
 
-        Import trace for requested module:
-        ./index.js
-        ./pages/index.js"
+       Import trace for requested module:
+       ./index.js
+       ./pages/index.js"
       `)
     }
   })
@@ -96,30 +96,30 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     const source = await session.getRedboxSource()
     if (process.env.TURBOPACK) {
       expect(source).toMatchInlineSnapshot(`
-        "./index.js:1:1
-        Module not found: Can't resolve 'b'
-        > 1 | import Comp from 'b'
-            | ^^^^^^^^^^^^^^^^^^^^
-          2 |
-          3 | export default function Oops() {
-          4 |   return (
+       "./index.js (1:1)
+       Module not found: Can't resolve 'b'
+       > 1 | import Comp from 'b'
+           | ^^^^^^^^^^^^^^^^^^^^
+         2 |
+         3 | export default function Oops() {
+         4 |   return (
 
-        https://nextjs.org/docs/messages/module-not-found"
+       https://nextjs.org/docs/messages/module-not-found"
       `)
     } else {
       expect(source).toMatchInlineSnapshot(`
-        "./index.js:1:1
-        Module not found: Can't resolve 'b'
-        > 1 | import Comp from 'b'
-            | ^
-          2 |
-          3 | export default function Oops() {
-          4 |   return (
+       "./index.js (1:1)
+       Module not found: Can't resolve 'b'
+       > 1 | import Comp from 'b'
+           | ^
+         2 |
+         3 | export default function Oops() {
+         4 |   return (
 
-        https://nextjs.org/docs/messages/module-not-found
+       https://nextjs.org/docs/messages/module-not-found
 
-        Import trace for requested module:
-        ./pages/index.js"
+       Import trace for requested module:
+       ./pages/index.js"
       `)
     }
   })
@@ -148,27 +148,27 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     const source = await session.getRedboxSource()
     if (process.env.TURBOPACK) {
       expect(source).toMatchInlineSnapshot(`
-        "./pages/index.js:1:1
-        Module not found: Can't resolve 'b'
-        > 1 | import Comp from 'b'
-            | ^^^^^^^^^^^^^^^^^^^^
-          2 |
-          3 | export default function Oops() {
-          4 |   return (
+       "./pages/index.js (1:1)
+       Module not found: Can't resolve 'b'
+       > 1 | import Comp from 'b'
+           | ^^^^^^^^^^^^^^^^^^^^
+         2 |
+         3 | export default function Oops() {
+         4 |   return (
 
-        https://nextjs.org/docs/messages/module-not-found"
+       https://nextjs.org/docs/messages/module-not-found"
       `)
     } else {
       expect(source).toMatchInlineSnapshot(`
-        "./pages/index.js:1:1
-        Module not found: Can't resolve 'b'
-        > 1 | import Comp from 'b'
-            | ^
-          2 |
-          3 | export default function Oops() {
-          4 |   return (
+       "./pages/index.js (1:1)
+       Module not found: Can't resolve 'b'
+       > 1 | import Comp from 'b'
+           | ^
+         2 |
+         3 | export default function Oops() {
+         4 |   return (
 
-        https://nextjs.org/docs/messages/module-not-found"
+       https://nextjs.org/docs/messages/module-not-found"
       `)
     }
   })
@@ -203,27 +203,27 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     const source = await session.getRedboxSource()
     if (process.env.TURBOPACK) {
       expect(source).toMatchInlineSnapshot(`
-        "./pages/_app.js:1:1
-        Module not found: Can't resolve './non-existent.css'
-        > 1 | import './non-existent.css'
-            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          2 |
-          3 | export default function App({ Component, pageProps }) {
-          4 |   return <Component {...pageProps} />
+       "./pages/_app.js (1:1)
+       Module not found: Can't resolve './non-existent.css'
+       > 1 | import './non-existent.css'
+           | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+         2 |
+         3 | export default function App({ Component, pageProps }) {
+         4 |   return <Component {...pageProps} />
 
-        https://nextjs.org/docs/messages/module-not-found"
+       https://nextjs.org/docs/messages/module-not-found"
       `)
     } else {
       expect(source).toMatchInlineSnapshot(`
-        "./pages/_app.js:1:1
-        Module not found: Can't resolve './non-existent.css'
-        > 1 | import './non-existent.css'
-            | ^
-          2 |
-          3 | export default function App({ Component, pageProps }) {
-          4 |   return <Component {...pageProps} />
+       "./pages/_app.js (1:1)
+       Module not found: Can't resolve './non-existent.css'
+       > 1 | import './non-existent.css'
+           | ^
+         2 |
+         3 | export default function App({ Component, pageProps }) {
+         4 |   return <Component {...pageProps} />
 
-        https://nextjs.org/docs/messages/module-not-found"
+       https://nextjs.org/docs/messages/module-not-found"
       `)
     }
 

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -213,14 +213,14 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     const source = next.normalizeTestDirContent(await session.getRedboxSource())
     if (process.env.TURBOPACK) {
       expect(source).toMatchInlineSnapshot(`
-        "./index.js:7:1
-        Parsing ecmascript source code failed
-          5 |     div
-          6 |   )
-        > 7 | }
-            | ^
+       "./index.js (7:1)
+       Parsing ecmascript source code failed
+         5 |     div
+         6 |   )
+       > 7 | }
+           | ^
 
-        Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?"
+       Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?"
       `)
     } else {
       expect(source).toMatchInlineSnapshot(`
@@ -345,8 +345,8 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     const source = await session.getRedboxSource()
     expect(source).toMatch(
       process.env.TURBOPACK
-        ? './index.module.css:1:9'
-        : './index.module.css:1:1'
+        ? './index.module.css (1:9)'
+        : './index.module.css (1:1)'
     )
     if (!process.env.TURBOPACK) {
       expect(source).toMatch('Syntax error: ')
@@ -798,13 +798,13 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     if (process.env.TURBOPACK) {
       expect(stack).toMatchInlineSnapshot(`
        "at <unknown> (pages/index.js (3:11))
-       at Array.map ()
+       at Array.map (<anonymous> (0:0))
        at Page (pages/index.js (2:13))"
       `)
     } else {
       expect(stack).toMatchInlineSnapshot(`
        "at eval (pages/index.js (3:11))
-       at Array.map ()
+       at Array.map (<anonymous> (0:0))
        at Page (pages/index.js (2:13))"
       `)
     }
@@ -837,7 +837,9 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     const stack = await getStackFramesContent(browser)
     expect(stack).toMatchInlineSnapshot(`
      "at createURL (pages/index.js (4:3))
-     at getServerSideProps (pages/index.js (8:3))"
+     at getServerSideProps (pages/index.js (8:3))
+     at eval (./dist/esm/server/route-modules/pages/module.js)
+     at renderToHTMLImpl (./dist/esm/server/route-modules/pages/module.js)"
     `)
 
     await toggleCollapseCallStackFrames(browser)

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -798,13 +798,13 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     if (process.env.TURBOPACK) {
       expect(stack).toMatchInlineSnapshot(`
        "at <unknown> (pages/index.js (3:11))
-       at Array.map (<anonymous> (0:0))
+       at Array.map ()
        at Page (pages/index.js (2:13))"
       `)
     } else {
       expect(stack).toMatchInlineSnapshot(`
        "at eval (pages/index.js (3:11))
-       at Array.map (<anonymous> (0:0))
+       at Array.map ()
        at Page (pages/index.js (2:13))"
       `)
     }
@@ -837,9 +837,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     const stack = await getStackFramesContent(browser)
     expect(stack).toMatchInlineSnapshot(`
      "at createURL (pages/index.js (4:3))
-     at getServerSideProps (pages/index.js (8:3))
-     at eval (./dist/esm/server/route-modules/pages/module.js)
-     at renderToHTMLImpl (./dist/esm/server/route-modules/pages/module.js)"
+     at getServerSideProps (pages/index.js (8:3))"
     `)
 
     await toggleCollapseCallStackFrames(browser)

--- a/test/development/acceptance/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance/ReactRefreshRegression.test.ts
@@ -285,8 +285,8 @@ describe('ReactRefreshRegression', () => {
 
     const source = await session.getRedboxSource()
     expect(source.split(/\r?\n/g).slice(2).join('\n')).toMatchInlineSnapshot(`
-      "> 1 | export default function () { throw new Error('boom'); }
-          |                                    ^"
+     "> 1 | export default function () { throw new Error('boom'); }
+         |                                    ^"
     `)
   })
 

--- a/test/development/acceptance/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance/ReactRefreshRegression.test.ts
@@ -284,7 +284,8 @@ describe('ReactRefreshRegression', () => {
     await session.assertHasRedbox()
 
     const source = await session.getRedboxSource()
-    expect(source.split(/\r?\n/g).slice(2).join('\n')).toMatchInlineSnapshot(`
+    expect(source.split(/\r?\n/g).slice(2).join('\n').replace(/^\n+/, ''))
+      .toMatchInlineSnapshot(`
      "> 1 | export default function () { throw new Error('boom'); }
          |                                    ^"
     `)

--- a/test/development/acceptance/__snapshots__/ReactRefreshLogBox.test.ts.snap
+++ b/test/development/acceptance/__snapshots__/ReactRefreshLogBox.test.ts.snap
@@ -19,7 +19,7 @@ exports[`ReactRefreshLogBox default conversion to class component (1) 1`] = `
 `;
 
 exports[`ReactRefreshLogBox default css syntax errors 1`] = `
-"./index.module.css:1:1
+"./index.module.css (1:1)
 Syntax error: Selector "button" is not pure (pure selectors must contain at least one local class or id)
 
 > 1 | button {}

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -437,14 +437,14 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     if (isTurbopack) {
       // TODO: Remove this branching once import traces are implemented in Turbopack
       expect(redboxSource).toMatchInlineSnapshot(`
-        "./index.js:7:41
-        Parsing ecmascript source code failed
-          5 |   throw Error('no ' + i)
-          6 | }, 1000)
-        > 7 | export default function FunctionNamed() {
-            |                                         ^
+       "./index.js (7:41)
+       Parsing ecmascript source code failed
+         5 |   throw Error('no ' + i)
+         6 | }, 1000)
+       > 7 | export default function FunctionNamed() {
+           |                                         ^
 
-        Expected '}', got '<eof>'"
+       Expected '}', got '<eof>'"
       `)
     } else {
       expect(redboxSource).toMatchInlineSnapshot(`
@@ -474,14 +474,14 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     if (isTurbopack) {
       // TODO: Remove this branching once import traces are implemented in Turbopack
       expect(redboxSource).toMatchInlineSnapshot(`
-        "./index.js:7:41
-        Parsing ecmascript source code failed
-          5 |   throw Error('no ' + i)
-          6 | }, 1000)
-        > 7 | export default function FunctionNamed() {
-            |                                         ^
+       "./index.js (7:41)
+       Parsing ecmascript source code failed
+         5 |   throw Error('no ' + i)
+         6 | }, 1000)
+       > 7 | export default function FunctionNamed() {
+           |                                         ^
 
-        Expected '}', got '<eof>'"
+       Expected '}', got '<eof>'"
       `)
     } else {
       expect(redboxSource).toMatchInlineSnapshot(`

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -486,14 +486,6 @@ describe('Error overlay for hydration errors in Pages router', () => {
       ])
     )
     const { session, browser } = sandbox
-    await retry(async () => {
-      // In the old overlay, there were two states to display, either toast or overlay.
-      // Hence this hasErrorToast() was to check if the overlay was opened. However,
-      // since the new overlay can have both toast and overlay, changed the expect
-      // to be true, and the assertHasRedbox() will check if the overlay is opened.
-      await expect(session.hasErrorToast()).resolves.toBe(true)
-    })
-
     await session.assertHasRedbox()
 
     if (isReact18) {

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -513,7 +513,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
              <AppContainer>
                <Container fn={function fn}>
                  <ReactDevOverlay>
-                   <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                   <DevOverlayErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                      <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                        <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                          <Page>

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -123,7 +123,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
-                 <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                 <DevOverlayErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                      <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Mismatch>
@@ -131,7 +131,8 @@ describe('Error overlay for hydration errors in Pages router', () => {
                            <main className="child">
        +                     client
        -                     server
-                     ..."
+                     ...
+                 ..."
       `)
     }
     await session.patch(
@@ -192,13 +193,14 @@ describe('Error overlay for hydration errors in Pages router', () => {
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
-                 <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                 <DevOverlayErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                      <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Mismatch>
                          <div className="parent">
        +                   <main className="only">
-                     ..."
+                     ...
+                 ..."
       `)
     }
 
@@ -256,7 +258,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
-                 <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                 <DevOverlayErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                      <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Mismatch>
@@ -265,7 +267,8 @@ describe('Error overlay for hydration errors in Pages router', () => {
        +                   second
        -                   <footer className="3">
                            ...
-                     ..."
+                     ...
+                 ..."
       `)
     }
 
@@ -316,13 +319,14 @@ describe('Error overlay for hydration errors in Pages router', () => {
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
-                 <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                 <DevOverlayErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                      <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Mismatch>
                          <div className="parent">
        -                   <main className="only">
-                     ..."
+                     ...
+                 ..."
       `)
     }
 
@@ -382,13 +386,14 @@ describe('Error overlay for hydration errors in Pages router', () => {
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
-                 <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                 <DevOverlayErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                      <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Mismatch>
                          <div className="parent">
        -                   only
-                     ..."
+                     ...
+                 ..."
       `)
     }
   })
@@ -449,13 +454,14 @@ describe('Error overlay for hydration errors in Pages router', () => {
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
-                 <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                 <DevOverlayErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                      <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Page>
        +                 <table>
        -                 test
-                     ..."
+                     ...
+                 ..."
       `)
     }
   })
@@ -524,13 +530,14 @@ describe('Error overlay for hydration errors in Pages router', () => {
              <AppContainer>
                <Container fn={function fn}>
                  <ReactDevOverlay>
-                   <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                   <DevOverlayErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                      <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                        <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                          <Page>
          +                 <table>
          -                 {" 123"}
-                       ..."
+                       ...
+                   ..."
         `)
       }
       expect(await getRedboxTotalErrorCount(browser)).toBe(1)
@@ -575,7 +582,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
       expect(pseudoHtml).toMatchInlineSnapshot(`
        "...
            <ReactDevOverlay>
-             <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+             <DevOverlayErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                  <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                    <Mismatch>
@@ -585,7 +592,8 @@ describe('Error overlay for hydration errors in Pages router', () => {
        +                 <main className="second">
        -                 <footer className="3">
                          ...
-                 ..."
+                 ...
+             ..."
       `)
     }
 
@@ -685,13 +693,14 @@ describe('Error overlay for hydration errors in Pages router', () => {
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
-                 <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                 <DevOverlayErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                      <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Page>
        >                 <p>
        >                   <p>
-                     ..."
+                     ...
+                 ..."
       `)
     }
   })
@@ -751,7 +760,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
        "...
            <Container fn={function fn}>
              <ReactDevOverlay>
-               <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+               <DevOverlayErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                  <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                    <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                      <Page>
@@ -759,7 +768,8 @@ describe('Error overlay for hydration errors in Pages router', () => {
                          <div>
        >                   <p>
        >                     <div>
-                   ..."
+                   ...
+               ..."
       `)
     }
   })
@@ -811,13 +821,14 @@ describe('Error overlay for hydration errors in Pages router', () => {
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
-                 <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                 <DevOverlayErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                      <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Page>
        >                 <div>
        >                   <tr>
-                     ..."
+                     ...
+                 ..."
       `)
     }
   })
@@ -875,7 +886,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
-                 <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                 <DevOverlayErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                      <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Page>
@@ -885,7 +896,8 @@ describe('Error overlay for hydration errors in Pages router', () => {
                                <span>
                                  <span>
        >                           <p>
-                     ..."
+                     ...
+                 ..."
       `)
     }
   })

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -486,7 +486,13 @@ describe('Error overlay for hydration errors in Pages router', () => {
       ])
     )
     const { session, browser } = sandbox
-    await expect(session.hasErrorToast()).resolves.toBe(false)
+    await retry(async () => {
+      // In the old overlay, there were two states to display, either toast or overlay.
+      // Hence this hasErrorToast() was to check if the overlay was opened. However,
+      // since the new overlay can have both toast and overlay, changed the expect
+      // to be true, and the assertHasRedbox() will check if the overlay is opened.
+      await expect(session.hasErrorToast()).resolves.toBe(true)
+    })
 
     await session.assertHasRedbox()
 

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -1,4 +1,3 @@
-/* eslint-env jest */
 import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
@@ -6,6 +5,9 @@ import { outdent } from 'outdent'
 import { getRedboxTotalErrorCount, retry } from 'next-test-utils'
 
 const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
+// TODO(new-dev-overlay): Remove this once old dev overlay fork is removed
+const isNewDevOverlay =
+  process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
 // https://github.com/facebook/react/blob/main/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js used as a reference
 
 describe('Error overlay for hydration errors in Pages router', () => {
@@ -486,6 +488,12 @@ describe('Error overlay for hydration errors in Pages router', () => {
       ])
     )
     const { session, browser } = sandbox
+
+    // in the new overlay, `assertHasRedbox` is redundant with `hasErrorToast`
+    if (!isNewDevOverlay) {
+      await expect(session.hasErrorToast()).resolves.toBe(false)
+    }
+
     await session.assertHasRedbox()
 
     if (isReact18) {
@@ -519,7 +527,8 @@ describe('Error overlay for hydration errors in Pages router', () => {
                          <Page>
          +                 <table>
          -                 {" 123"}
-                       ..."
+                       ...
+                   ..."
         `)
       } else {
         expect(pseudoHtml).toMatchInlineSnapshot(`

--- a/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
+++ b/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
@@ -52,15 +52,15 @@ describe('Error Overlay for server components compiler errors in pages', () => {
     if (process.env.TURBOPACK) {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
-        "./components/Comp.js:1:1
-        Ecmascript file had an error
-        > 1 | import { cookies } from 'next/headers'
-            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          2 |
-          3 | export default function Page() {
-          4 |   return <p>hello world</p>
+       "./components/Comp.js (1:1)
+       Ecmascript file had an error
+       > 1 | import { cookies } from 'next/headers'
+           | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+         2 |
+         3 | export default function Page() {
+         4 |   return <p>hello world</p>
 
-        You're importing a component that needs "next/headers". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components"
+       You're importing a component that needs "next/headers". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components"
       `)
     } else {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
@@ -108,15 +108,15 @@ describe('Error Overlay for server components compiler errors in pages', () => {
     if (process.env.TURBOPACK) {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
-        "./components/Comp.js:1:1
-        Ecmascript file had an error
-        > 1 | import 'server-only'
-            | ^^^^^^^^^^^^^^^^^^^^
-          2 |
-          3 | export default function Page() {
-          4 |   return 'hello world'
+       "./components/Comp.js (1:1)
+       Ecmascript file had an error
+       > 1 | import 'server-only'
+           | ^^^^^^^^^^^^^^^^^^^^
+         2 |
+         3 | export default function Page() {
+         4 |   return 'hello world'
 
-        You're importing a component that needs "server-only". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components"
+       You're importing a component that needs "server-only". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components"
       `)
     } else {
       expect(
@@ -166,15 +166,15 @@ describe('Error Overlay for server components compiler errors in pages', () => {
     if (process.env.TURBOPACK) {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
-        "./components/Comp.js:1:10
-        Ecmascript file had an error
-        > 1 | import { after } from 'next/server'
-            |          ^^^^^
-          2 |
-          3 | export default function Page() {
-          4 |   return 'hello world'
+       "./components/Comp.js (1:10)
+       Ecmascript file had an error
+       > 1 | import { after } from 'next/server'
+           |          ^^^^^
+         2 |
+         3 | export default function Page() {
+         4 |   return 'hello world'
 
-        You're importing a component that needs "after". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components"
+       You're importing a component that needs "after". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components"
       `)
     } else {
       expect(

--- a/test/development/app-dir/capture-console-error/capture-console-error.test.ts
+++ b/test/development/app-dir/capture-console-error/capture-console-error.test.ts
@@ -34,8 +34,8 @@ describe('app-dir - capture-console-error', () => {
     files: __dirname,
   })
 
-  if (process.env.__NEXT_EXPERIMENTAL_PPR === 'true') {
-    it('skip test for experimental PPR', () => {
+  if (process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true') {
+    it('skip test for new overlay', () => {
       // Cover these tests in the owner stack tests suite
     })
     return

--- a/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
+++ b/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
@@ -11,9 +11,8 @@ describe('error-ignored-frames', () => {
   })
 
   if (
-    // TODO: remove this when reactOwnerStack is enabled by default
-    // Since PPR mode is just going to add owner stack, skip this test for now
-    process.env.__NEXT_EXPERIMENTAL_PPR === 'true' ||
+    // TODO(new-dev-overlay): Remove this once old dev overlay fork is removed
+    process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ||
     // Skip react 18 test as the call stacks are different
     process.env.NEXT_TEST_REACT_VERSION === '18.3.1'
   ) {

--- a/test/development/app-dir/missing-required-html-tags-new-overlay/missing-html-tags-new-overlay.test.ts
+++ b/test/development/app-dir/missing-required-html-tags-new-overlay/missing-html-tags-new-overlay.test.ts
@@ -9,39 +9,43 @@ import {
 } from 'next-test-utils'
 import { outdent } from 'outdent'
 
-// TODO: merge with test/development/app-dir/missing-required-html-tags/index.test.ts
+// TODO(new-dev-overlay): merge with test/development/app-dir/missing-required-html-tags/index.test.ts
 //  once new overlay is stable
-describe('app-dir - missing required html tags', () => {
-  const { next } = nextTestSetup({
-    files: __dirname,
-  })
-
-  it('should display correct error count in dev indicator', async () => {
-    const browser = await next.browser('/')
-
-    retry(async () => {
-      expect(await hasErrorToast(browser)).toBe(true)
+const isDisabled = process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'false'
+;(isDisabled ? describe.skip : describe)(
+  'app-dir - missing required html tags',
+  () => {
+    const { next } = nextTestSetup({
+      files: __dirname,
     })
-    // Dev indicator should show 1 error
-    expect(await getToastErrorCount(browser)).toBe(1)
 
-    await assertHasRedbox(browser)
+    it('should display correct error count in dev indicator', async () => {
+      const browser = await next.browser('/')
 
-    await retry(async () => {
-      expect(await getRedboxDescription(browser)).toEqual(outdent`
+      retry(async () => {
+        expect(await hasErrorToast(browser)).toBe(true)
+      })
+      // Dev indicator should show 1 error
+      expect(await getToastErrorCount(browser)).toBe(1)
+
+      await assertHasRedbox(browser)
+
+      await retry(async () => {
+        expect(await getRedboxDescription(browser)).toEqual(outdent`
         The following tags are missing in the Root Layout: <html>.
         Read more at https://nextjs.org/docs/messages/missing-root-layout-tags
       `)
-    })
+      })
 
-    await next.patchFile('app/layout.js', (code) =>
-      code.replace(
-        'return <body>{children}</body>',
-        'return <html><body>{children}</body></html>'
+      await next.patchFile('app/layout.js', (code) =>
+        code.replace(
+          'return <body>{children}</body>',
+          'return <html><body>{children}</body></html>'
+        )
       )
-    )
 
-    await assertNoRedbox(browser)
-    expect(await browser.elementByCss('p').text()).toBe('hello world')
-  })
-})
+      await assertNoRedbox(browser)
+      expect(await browser.elementByCss('p').text()).toBe('hello world')
+    })
+  }
+)

--- a/test/development/app-dir/owner-stack-invalid-element-type/invalid-element-type.test.ts
+++ b/test/development/app-dir/owner-stack-invalid-element-type/invalid-element-type.test.ts
@@ -8,7 +8,8 @@ import {
 } from 'next-test-utils'
 
 // TODO: When owner stack is enabled by default, remove the condition and only keep one test
-const isOwnerStackEnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+const isOwnerStackEnabled =
+  process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
 
 ;(isOwnerStackEnabled ? describe.skip : describe)(
   'app-dir - invalid-element-type',

--- a/test/development/app-dir/owner-stack-invalid-element-type/invalid-element-type.test.ts
+++ b/test/development/app-dir/owner-stack-invalid-element-type/invalid-element-type.test.ts
@@ -7,9 +7,10 @@ import {
   getStackFramesContent,
 } from 'next-test-utils'
 
-// TODO: When owner stack is enabled by default, remove the condition and only keep one test
+// TODO(new-dev-overlay): When owner stack is enabled by default, remove the condition and only keep one test
 const isOwnerStackEnabled =
-  process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
+  process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ||
+  process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
 
 ;(isOwnerStackEnabled ? describe.skip : describe)(
   'app-dir - invalid-element-type',

--- a/test/development/app-dir/owner-stack-invalid-element-type/owner-stack-invalid-element-type.test.ts
+++ b/test/development/app-dir/owner-stack-invalid-element-type/owner-stack-invalid-element-type.test.ts
@@ -5,7 +5,7 @@ import {
   getStackFramesContent,
 } from 'next-test-utils'
 
-// TODO: When owner stack is enabled by default, remove the condition and only keep one test
+// TODO(new-dev-overlay): When owner stack is enabled by default, remove the condition and only keep one test
 const isOwnerStackEnabled =
   process.env.TEST_OWNER_STACK !== 'false' ||
   process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'

--- a/test/development/app-dir/owner-stack-invalid-element-type/owner-stack-invalid-element-type.test.ts
+++ b/test/development/app-dir/owner-stack-invalid-element-type/owner-stack-invalid-element-type.test.ts
@@ -8,7 +8,7 @@ import {
 // TODO: When owner stack is enabled by default, remove the condition and only keep one test
 const isOwnerStackEnabled =
   process.env.TEST_OWNER_STACK !== 'false' ||
-  process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+  process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
 
 ;(isOwnerStackEnabled ? describe : describe.skip)(
   'app-dir - owner-stack-invalid-element-type',

--- a/test/development/app-dir/owner-stack-react-missing-key-prop/owner-stack-react-missing-key-prop.test.ts
+++ b/test/development/app-dir/owner-stack-react-missing-key-prop/owner-stack-react-missing-key-prop.test.ts
@@ -5,11 +5,12 @@ import {
   getStackFramesContent,
 } from 'next-test-utils'
 
-// TODO: When owner stack is enabled by default, remove the condition and only keep one test
-const isOwnerStackEnabled =
+// TODO(new-dev-overlay): When owner stack is enabled by default, remove the condition and only keep one test
+const isExperimentalReact =
+  process.env.__NEXT_EXPERIMENTAL_PPR === 'true' ||
   process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
 
-;(isOwnerStackEnabled ? describe : describe.skip)(
+;(isExperimentalReact ? describe : describe.skip)(
   'app-dir - owner-stack-react-missing-key-prop',
   () => {
     const { next } = nextTestSetup({

--- a/test/development/app-dir/owner-stack-react-missing-key-prop/owner-stack-react-missing-key-prop.test.ts
+++ b/test/development/app-dir/owner-stack-react-missing-key-prop/owner-stack-react-missing-key-prop.test.ts
@@ -6,7 +6,8 @@ import {
 } from 'next-test-utils'
 
 // TODO: When owner stack is enabled by default, remove the condition and only keep one test
-const isOwnerStackEnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+const isOwnerStackEnabled =
+  process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
 
 ;(isOwnerStackEnabled ? describe : describe.skip)(
   'app-dir - owner-stack-react-missing-key-prop',
@@ -29,8 +30,8 @@ const isOwnerStackEnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
           at Page (app/rsc/page.tsx (6:13))"
           `)
         expect(source).toMatchInlineSnapshot(`
-            "app/rsc/page.tsx (7:10) @ <anonymous>
-            
+         "app/rsc/page.tsx (7:10) @ <anonymous>
+
             5 |     <div>
             6 |       {list.map((item, index) => (
          >  7 |         <span>{item}</span>
@@ -38,7 +39,7 @@ const isOwnerStackEnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
             8 |       ))}
             9 |     </div>
            10 |   )"
-              `)
+        `)
       } else {
         expect(stackFramesContent).toMatchInlineSnapshot(`
          "at span ()

--- a/test/development/app-dir/owner-stack-react-missing-key-prop/owner-stack-react-missing-key-prop.test.ts
+++ b/test/development/app-dir/owner-stack-react-missing-key-prop/owner-stack-react-missing-key-prop.test.ts
@@ -25,10 +25,10 @@ const isOwnerStackEnabled =
 
       if (process.env.TURBOPACK) {
         expect(stackFramesContent).toMatchInlineSnapshot(`
-          "at span (<anonymous> (0:0))
-          at <anonymous> (app/rsc/page.tsx (7:10))
-          at Page (app/rsc/page.tsx (6:13))"
-          `)
+         "at span ()
+         at <anonymous> (app/rsc/page.tsx (7:10))
+         at Page (app/rsc/page.tsx (6:13))"
+        `)
         expect(source).toMatchInlineSnapshot(`
          "app/rsc/page.tsx (7:10) @ <anonymous>
 
@@ -68,9 +68,9 @@ const isOwnerStackEnabled =
       const source = await getRedboxSource(browser)
       if (process.env.TURBOPACK) {
         expect(stackFramesContent).toMatchInlineSnapshot(`
-         "at p (<anonymous> (0:0))
+         "at p ()
          at <unknown> (app/ssr/page.tsx (9:9))
-         at Array.map (<anonymous> (0:0))
+         at Array.map ()
          at Page (app/ssr/page.tsx (8:13))"
         `)
         expect(source).toMatchInlineSnapshot(`

--- a/test/development/app-dir/owner-stack-react-missing-key-prop/react-missing-key-prop.test.ts
+++ b/test/development/app-dir/owner-stack-react-missing-key-prop/react-missing-key-prop.test.ts
@@ -5,8 +5,9 @@ import {
   hasRedboxCallStack,
 } from 'next-test-utils'
 
-// TODO: When owner stack is enabled by default, remove the condition and only keep one test
-const isOwnerStackEnabled =
+// TODO(new-dev-overlay): When owner stack is enabled by default, remove the condition and only keep one test
+const isExperimentalReact =
+  process.env.__NEXT_EXPERIMENTAL_PPR === 'true' ||
   process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
 
 async function getStackFramesContent(browser) {
@@ -38,7 +39,7 @@ async function getStackFramesContent(browser) {
 }
 
 // Without owner stack, the source is not available
-;(isOwnerStackEnabled ? describe.skip : describe)(
+;(isExperimentalReact ? describe.skip : describe)(
   'app-dir - react-missing-key-prop',
   () => {
     const { next } = nextTestSetup({

--- a/test/development/app-dir/owner-stack-react-missing-key-prop/react-missing-key-prop.test.ts
+++ b/test/development/app-dir/owner-stack-react-missing-key-prop/react-missing-key-prop.test.ts
@@ -6,7 +6,8 @@ import {
 } from 'next-test-utils'
 
 // TODO: When owner stack is enabled by default, remove the condition and only keep one test
-const isOwnerStackEnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+const isOwnerStackEnabled =
+  process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
 
 async function getStackFramesContent(browser) {
   await hasRedboxCallStack(browser)

--- a/test/development/app-dir/owner-stack/owner-stack.test.ts
+++ b/test/development/app-dir/owner-stack/owner-stack.test.ts
@@ -259,7 +259,7 @@ describe('app-dir - owner-stack', () => {
        at renderRootSync 
        at performWorkOnRoot 
        at performWorkOnRootViaSchedulerTask 
-       at MessagePort.performWorkUntilDeadline  The above error occurred in the <Page> component. It was handled by the <DevOverlayErrorBoundary> error boundary."
+       at MessagePort.performWorkUntilDeadline  The above error occurred in the <Page> component. It was handled by the <ReactDevOverlay> error boundary."
       `)
     }
   })

--- a/test/development/app-dir/owner-stack/owner-stack.test.ts
+++ b/test/development/app-dir/owner-stack/owner-stack.test.ts
@@ -71,7 +71,7 @@ describe('app-dir - owner-stack', () => {
       return log.message.includes('Error: browser error')
     }).message
 
-    // TODO(jiwon): Remove this once we have a new dev overlay at stable.
+    // TODO(new-dev-overlay): Remove this once old dev overlay fork is removed
     if (isNewDevOverlay) {
       if (process.env.TURBOPACK) {
         expect(normalizeStackTrace(errorLog)).toMatchInlineSnapshot(`
@@ -115,22 +115,22 @@ describe('app-dir - owner-stack', () => {
     } else {
       if (process.env.TURBOPACK) {
         expect(normalizeStackTrace(errorLog)).toMatchInlineSnapshot(`
-          "%o
-          %s Error: browser error
-          at useThrowError 
-          at useErrorHook 
-          at Page 
-          at react-stack-bottom-frame 
-          at renderWithHooks 
-          at updateFunctionComponent 
-          at beginWork 
-          at runWithFiberInDEV 
-          at performUnitOfWork 
-          at workLoopSync 
-          at renderRootSync 
-          at performWorkOnRoot 
-          at performWorkOnRootViaSchedulerTask 
-          at MessagePort.performWorkUntilDeadline  The above error occurred in the <Page> component. It was handled by the <ReactDevOverlay> error boundary."
+         "%o
+         %s Error: browser error
+         at useThrowError 
+         at useErrorHook 
+         at Page 
+         at react-stack-bottom-frame 
+         at renderWithHooks 
+         at updateFunctionComponent 
+         at beginWork 
+         at runWithFiberInDEV 
+         at performUnitOfWork 
+         at workLoopSync 
+         at renderRootSync 
+         at performWorkOnRoot 
+         at performWorkOnRootViaSchedulerTask 
+         at MessagePort.performWorkUntilDeadline  The above error occurred in the <Page> component. It was handled by the <DevOverlayErrorBoundary> error boundary."
         `)
       } else {
         expect(normalizeStackTrace(errorLog)).toMatchInlineSnapshot(`
@@ -259,8 +259,8 @@ describe('app-dir - owner-stack', () => {
        at renderRootSync 
        at performWorkOnRoot 
        at performWorkOnRootViaSchedulerTask 
-       at MessagePort.performWorkUntilDeadline  The above error occurred in the <Page> component. It was handled by the <ReactDevOverlay> error boundary."
-    `)
+       at MessagePort.performWorkUntilDeadline  The above error occurred in the <Page> component. It was handled by the <DevOverlayErrorBoundary> error boundary."
+      `)
     }
   })
 

--- a/test/development/app-dir/server-component-next-dynamic-ssr-false/server-component-next-dynamic-ssr-false.test.ts
+++ b/test/development/app-dir/server-component-next-dynamic-ssr-false/server-component-next-dynamic-ssr-false.test.ts
@@ -5,7 +5,7 @@ import {
   getRedboxSource,
 } from 'next-test-utils'
 
-// Enabling PPR testing also enables the new dev overlay.
+// TODO(new-dev-overlay): Remove this once old dev overlay fork is removed
 const isNewDevOverlay =
   process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
 
@@ -24,23 +24,22 @@ describe('app-dir - server-component-next-dynamic-ssr-false', () => {
 
     expect(redbox.description).toBe('Failed to compile')
 
-    // TODO(jiwon): Remove this once we have a new dev overlay at stable.
+    // TODO(new-dev-overlay): Remove this once old dev overlay fork is removed
     if (isNewDevOverlay) {
       if (process.env.TURBOPACK) {
         expect(redbox.source).toMatchInlineSnapshot(`
-                "./app/page.js (3:23)
+         "./app/page.js (3:23)
+         Ecmascript file had an error
+           1 | import dynamic from 'next/dynamic'
+           2 |
+         > 3 | const DynamicClient = dynamic(() => import('./client'), { ssr: false })
+             |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+           4 |
+           5 | export default function Page() {
+           6 |   return <DynamicClient />
 
-                Ecmascript file had an error
-                  1 | import dynamic from 'next/dynamic'
-                  2 |
-                > 3 | const DynamicClient = dynamic(() => import('./client'), { ssr: false })
-                    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                  4 |
-                  5 | export default function Page() {
-                  6 |   return <DynamicClient />
-
-                \`ssr: false\` is not allowed with \`next/dynamic\` in Server Components. Please move it into a client component."
-              `)
+         \`ssr: false\` is not allowed with \`next/dynamic\` in Server Components. Please move it into a client component."
+        `)
       } else {
         expect(redbox.source).toMatchInlineSnapshot(`
          "./app/page.js
@@ -59,18 +58,18 @@ describe('app-dir - server-component-next-dynamic-ssr-false', () => {
     } else {
       if (process.env.TURBOPACK) {
         expect(redbox.source).toMatchInlineSnapshot(`
-                 "./app/page.js:3:23
-                 Ecmascript file had an error
-                   1 | import dynamic from 'next/dynamic'
-                   2 |
-                 > 3 | const DynamicClient = dynamic(() => import('./client'), { ssr: false })
-                     |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                   4 |
-                   5 | export default function Page() {
-                   6 |   return <DynamicClient />
+         "./app/page.js (3:23)
+         Ecmascript file had an error
+           1 | import dynamic from 'next/dynamic'
+           2 |
+         > 3 | const DynamicClient = dynamic(() => import('./client'), { ssr: false })
+             |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+           4 |
+           5 | export default function Page() {
+           6 |   return <DynamicClient />
 
-                 \`ssr: false\` is not allowed with \`next/dynamic\` in Server Components. Please move it into a client component."
-              `)
+         \`ssr: false\` is not allowed with \`next/dynamic\` in Server Components. Please move it into a client component."
+        `)
       } else {
         expect(redbox.source).toMatchInlineSnapshot(`
                  "./app/page.js

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -7,8 +7,11 @@ import {
   getRedboxSource,
 } from 'next-test-utils'
 
-const isReactExperimental = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
-const isNewDevOverlay = isReactExperimental
+const isNewDevOverlay =
+  process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
+const isReactExperimental =
+  process.env.__NEXT_EXPERIMENTAL_PPR === 'true' || isNewDevOverlay
+
 const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 
 describe('react-dom/server in React Server environment', () => {
@@ -282,21 +285,21 @@ describe('react-dom/server in React Server environment', () => {
     }
     if (isTurbopack) {
       expect(redbox).toMatchInlineSnapshot(`
-        {
-          "description": "Failed to compile",
-          "source": "./app/exports/app-code/react-dom-server-edge-implicit/page.js:3:1
-        Ecmascript file had an error
-          1 | import * as ReactDOMServerEdge from 'react-dom/server'
-          2 | // Fine to drop once React is on ESM
-        > 3 | import ReactDOMServerEdgeDefault from 'react-dom/server'
-            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          4 |
-          5 | export const runtime = 'edge'
-          6 |
+       {
+         "description": "Failed to compile",
+         "source": "./app/exports/app-code/react-dom-server-edge-implicit/page.js (3:1)
+       Ecmascript file had an error
+         1 | import * as ReactDOMServerEdge from 'react-dom/server'
+         2 | // Fine to drop once React is on ESM
+       > 3 | import ReactDOMServerEdgeDefault from 'react-dom/server'
+           | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+         4 |
+         5 | export const runtime = 'edge'
+         6 |
 
-        You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
-        Learn more: https://nextjs.org/docs/app/building-your-application/rendering",
-        }
+       You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
+       Learn more: https://nextjs.org/docs/app/building-your-application/rendering",
+       }
       `)
     } else {
       expect(redbox).toMatchInlineSnapshot(`
@@ -377,24 +380,24 @@ describe('react-dom/server in React Server environment', () => {
     }
     if (isTurbopack) {
       expect(redbox).toMatchInlineSnapshot(`
-        {
-          "description": "Failed to compile",
-          "source": "./app/exports/app-code/react-dom-server-node-implicit/page.js:3:1
-        Ecmascript file had an error
-          1 | import * as ReactDOMServerNode from 'react-dom/server'
-          2 | // Fine to drop once React is on ESM
-        > 3 | import ReactDOMServerNodeDefault from 'react-dom/server'
-            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          4 |
-          5 | export const runtime = 'nodejs'
-          6 |
+       {
+         "description": "Failed to compile",
+         "source": "./app/exports/app-code/react-dom-server-node-implicit/page.js (3:1)
+       Ecmascript file had an error
+         1 | import * as ReactDOMServerNode from 'react-dom/server'
+         2 | // Fine to drop once React is on ESM
+       > 3 | import ReactDOMServerNodeDefault from 'react-dom/server'
+           | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+         4 |
+         5 | export const runtime = 'nodejs'
+         6 |
 
-        You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
-        Learn more: https://nextjs.org/docs/app/building-your-application/rendering",
-        }
+       You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
+       Learn more: https://nextjs.org/docs/app/building-your-application/rendering",
+       }
       `)
     } else {
-      // TODO(jiwon): Remove this once we have a new dev overlay at stable.
+      // TODO(new-dev-overlay): Remove this once old dev overlay fork is removed
       if (isNewDevOverlay) {
         expect(redbox).toMatchInlineSnapshot(`
          {
@@ -831,16 +834,16 @@ describe('react-dom/server in React Server environment', () => {
         `)
       } else {
         expect(redbox).toMatchInlineSnapshot(`
-          {
-            "description": "Error: react-dom/server is not supported in React Server Components.",
-            "source": "internal-pkg/server.node.js (1:1) @ [project]/internal-pkg/server.node.js [app-rsc] (ecmascript)
+         {
+           "description": "Error: react-dom/server is not supported in React Server Components.",
+           "source": "internal-pkg/server.node.js (1:1) @ [project]/internal-pkg/server.node.js [app-rsc] (ecmascript)
 
-          > 1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
-              | ^
-            2 | // Fine to drop once React is on ESM
-            3 | import ReactDOMServerEdgeDefault from 'react-dom/server.node'
-            4 |",
-          }
+         > 1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
+             | ^
+           2 | // Fine to drop once React is on ESM
+           3 | import ReactDOMServerEdgeDefault from 'react-dom/server.node'
+           4 |",
+         }
         `)
       }
     } else {

--- a/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
+++ b/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
@@ -11,9 +11,25 @@ import {
 } from 'next-test-utils'
 import { NextInstance } from 'e2e-utils'
 
+// TODO(new-dev-overlay): Remove this once old dev overlay fork is removed
+const isNewDevOverlay =
+  process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
+
 const installCheckVisible = (browser) => {
-  return browser.eval(`(function() {
-    window.checkInterval = setInterval(function() {
+  if (isNewDevOverlay) {
+    return browser.eval(`(function() {
+      window.checkInterval = setInterval(function() {
+      const root = document.querySelector('nextjs-portal').shadowRoot;
+      const indicator = root.querySelector('[data-next-mark]')
+      window.showedBuilder = window.showedBuilder || (
+        indicator.getAttribute('data-next-mark-loading') === 'true'
+      )
+      if (window.showedBuilder) clearInterval(window.checkInterval)
+    }, 50)
+  })()`)
+  } else {
+    return browser.eval(`(function() {
+      window.checkInterval = setInterval(function() {
       let watcherDiv = document.querySelector('#__next-build-indicator')
       watcherDiv = watcherDiv.shadowRoot || watcherDiv
       window.showedBuilder = window.showedBuilder || (
@@ -22,6 +38,7 @@ const installCheckVisible = (browser) => {
       if (window.showedBuilder) clearInterval(window.checkInterval)
     }, 50)
   })()`)
+  }
 }
 
 describe('GS(S)P Server-Side Change Reloading', () => {

--- a/test/development/basic/hmr/error-recovery.test.ts
+++ b/test/development/basic/hmr/error-recovery.test.ts
@@ -15,8 +15,8 @@ import { nextTestSetup } from 'e2e-utils'
 import { outdent } from 'outdent'
 
 describe.each([
-  { basePath: '', assetPrefix: '' },
-  { basePath: '', assetPrefix: '/asset-prefix' },
+  // { basePath: '', assetPrefix: '' },
+  // { basePath: '', assetPrefix: '/asset-prefix' },
   { basePath: '/docs', assetPrefix: '' },
   { basePath: '/docs', assetPrefix: '/asset-prefix' },
 ])(
@@ -231,7 +231,7 @@ describe.each([
         `)
       } else if (basePath === '/docs' && process.env.TURBOPACK) {
         expect(source).toMatchInlineSnapshot(`
-            "./pages/hmr/about2.js:7:1
+            "./pages/hmr/about2.js (7:1)
             Parsing ecmascript source code failed
               5 |     div
               6 |   )

--- a/test/development/basic/hmr/error-recovery.test.ts
+++ b/test/development/basic/hmr/error-recovery.test.ts
@@ -15,8 +15,8 @@ import { nextTestSetup } from 'e2e-utils'
 import { outdent } from 'outdent'
 
 describe.each([
-  // { basePath: '', assetPrefix: '' },
-  // { basePath: '', assetPrefix: '/asset-prefix' },
+  { basePath: '', assetPrefix: '' },
+  { basePath: '', assetPrefix: '/asset-prefix' },
   { basePath: '/docs', assetPrefix: '' },
   { basePath: '/docs', assetPrefix: '/asset-prefix' },
 ])(

--- a/test/development/basic/hmr/error-recovery.test.ts
+++ b/test/development/basic/hmr/error-recovery.test.ts
@@ -195,16 +195,16 @@ describe.each([
         `)
       } else if (basePath === '' && process.env.TURBOPACK) {
         expect(source).toMatchInlineSnapshot(`
-            "./pages/hmr/about2.js:7:1
-            Parsing ecmascript source code failed
-              5 |     div
-              6 |   )
-            > 7 | }
-                | ^
-              8 |
+         "./pages/hmr/about2.js (7:1)
+         Parsing ecmascript source code failed
+           5 |     div
+           6 |   )
+         > 7 | }
+             | ^
+           8 |
 
-            Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?"
-          `)
+         Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?"
+        `)
       } else if (basePath === '/docs' && !process.env.TURBOPACK) {
         expect(source).toMatchInlineSnapshot(`
           "./pages/hmr/about2.js
@@ -594,17 +594,17 @@ describe.each([
         if (process.env.TURBOPACK) {
           expect(next.normalizeTestDirContent(redboxSource))
             .toMatchInlineSnapshot(`
-              "./components/parse-error.js:3:1
-              Parsing ecmascript source code failed
-                1 | This
-                2 | is
-              > 3 | }}}
-                  | ^
-                4 | invalid
-                5 | js
+           "./components/parse-error.js (3:1)
+           Parsing ecmascript source code failed
+             1 | This
+             2 | is
+           > 3 | }}}
+               | ^
+             4 | invalid
+             5 | js
 
-              Expression expected"
-            `)
+           Expression expected"
+          `)
         } else {
           redboxSource = redboxSource.substring(
             0,

--- a/test/development/client-dev-overlay/index.test.ts
+++ b/test/development/client-dev-overlay/index.test.ts
@@ -29,11 +29,15 @@ describe('client-dev-overlay', () => {
   const selectors = {
     fullScreenDialog: '[data-nextjs-dialog]',
     toast: '[data-nextjs-toast]',
-    minimizeButton: '[data-nextjs-errors-dialog-left-right-close-button]',
-    hideButton: '[data-nextjs-toast-errors-hide-button]',
+    popover: '[data-nextjs-dev-tools-button]',
+    minimizeButton: 'body',
+    hideButton: '[data-hide-dev-tools]',
   }
   function getToast() {
     return browser.elementByCss(selectors.toast)
+  }
+  function getPopover() {
+    return browser.elementByCss(selectors.popover)
   }
   function getMinimizeButton() {
     return browser.elementByCss(selectors.minimizeButton)
@@ -64,10 +68,11 @@ describe('client-dev-overlay', () => {
 
   it('should be able to hide the minimized overlay', async () => {
     await getMinimizeButton().click()
+    await getPopover().click()
     await getHideButton().click()
 
     await check(async () => {
-      const exists = await elementExistsInNextJSPortalShadowDOM('div')
+      const exists = await elementExistsInNextJSPortalShadowDOM(selectors.toast)
       return exists ? 'found' : 'success'
     }, 'success')
   })

--- a/test/development/pages-dir/client-navigation/fixture/pages/nav/shallow-routing.js
+++ b/test/development/pages-dir/client-navigation/fixture/pages/nav/shallow-routing.js
@@ -41,7 +41,7 @@ export default withRouter(
 
     render() {
       return (
-        <div className="shallow-routing">
+        <div className="shallow-routing" style={{ paddingBottom: 60 }}>
           <Link href="/nav" id="home-link" style={linkStyle}>
             Home
           </Link>

--- a/test/development/sass-error/index.test.ts
+++ b/test/development/sass-error/index.test.ts
@@ -26,17 +26,17 @@ describe('app dir - css', () => {
 
           // css-loader does not report an error for this case
           expect(source).toMatchInlineSnapshot(`
-            "./app/global.scss.css:45:1
-            Parsing css source code failed
-              43 | }
-              44 |
-            > 45 | input.defaultCheckbox::before path {
-                 | ^
-              46 |   fill: currentColor;
-              47 | }
-              48 |
+           "./app/global.scss.css (45:1)
+           Parsing css source code failed
+             43 | }
+             44 |
+           > 45 | input.defaultCheckbox::before path {
+                | ^
+             46 |   fill: currentColor;
+             47 | }
+             48 |
 
-            Pseudo-elements like '::before' or '::after' can't be followed by selectors like 'Ident("path")' at [project]/app/global.scss.css:0:884"
+           Pseudo-elements like '::before' or '::after' can't be followed by selectors like 'Ident("path")' at [project]/app/global.scss.css:0:884"
           `)
         })
       }

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.server-action.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.server-action.test.ts
@@ -25,8 +25,12 @@ describe('dynamic-io', () => {
       expect(await browser.elementByCss('p').text()).toBe('result')
     })
 
-    if (process.env.__NEXT_EXPERIMENTAL_PPR && isNextDev) {
-      // TODO(react-time-info): Remove this branch for PPR in dev mode when the
+    if (
+      (process.env.__NEXT_EXPERIMENTAL_PPR ||
+        process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY) &&
+      isNextDev
+    ) {
+      // TODO(react-time-info): Remove this branch for experimental React in dev mode when the
       // issue is resolved where the inclusion of server timings in the RSC
       // payload makes the serialized bound args not suitable to be used as a
       // cache key.

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
@@ -19,14 +19,15 @@ describe('dynamic-io', () => {
 
   if (isNextDev && !WITH_PPR) {
     async function hasStaticIndicator(browser: BrowserInterface) {
-      const staticIndicatorPresent = await browser.eval(() =>
-        Boolean(
+      await browser.elementByCss('[data-nextjs-dev-tools-button]').click()
+
+      return await browser.eval(
+        () =>
           document
             .querySelector('nextjs-portal')
-            .shadowRoot.querySelector('.nextjs-static-indicator-toast-wrapper')
-        )
+            .shadowRoot.querySelector('[data-nextjs-route-type]')
+            .getAttribute('data-nextjs-route-type') === 'static'
       )
-      return staticIndicatorPresent
     }
 
     it('should not have static indicator on dynamic method route', async () => {

--- a/test/e2e/app-dir/error-on-next-codemod-comment/error-on-next-codemod-comment.test.ts
+++ b/test/e2e/app-dir/error-on-next-codemod-comment/error-on-next-codemod-comment.test.ts
@@ -26,23 +26,22 @@ describe('app-dir - error-on-next-codemod-comment', () => {
 
       await assertHasRedbox(browser)
 
-      // TODO(jiwon): Remove this once we have a new dev overlay at stable.
+      // TODO(new-dev-overlay): Remove this once old dev overlay fork is removed
       if (isNewDevOverlay) {
         if (process.env.TURBOPACK) {
           expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-                     "./app/page.tsx (2:2)
+           "./app/page.tsx (2:2)
+           Ecmascript file had an error
+             1 | export default function Page() {
+           > 2 |   // @next-codemod-error remove jsx of next line
+               |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             3 |   return <p>hello world</p>
+             4 | }
+             5 |
 
-                     Ecmascript file had an error
-                       1 | export default function Page() {
-                     > 2 |   // @next-codemod-error remove jsx of next line
-                         |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                       3 |   return <p>hello world</p>
-                       4 | }
-                       5 |
-
-                     You have an unresolved @next/codemod comment "remove jsx of next line" that needs review.
-                     After review, either remove the comment if you made the necessary changes or replace "@next-codemod-error" with "@next-codemod-ignore" to bypass the build error if no action at this line can be taken."
-                  `)
+           You have an unresolved @next/codemod comment "remove jsx of next line" that needs review.
+           After review, either remove the comment if you made the necessary changes or replace "@next-codemod-error" with "@next-codemod-ignore" to bypass the build error if no action at this line can be taken."
+          `)
         } else {
           expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
            "./app/page.tsx
@@ -62,18 +61,18 @@ describe('app-dir - error-on-next-codemod-comment', () => {
       } else {
         if (process.env.TURBOPACK) {
           expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-                     "./app/page.tsx:2:2
-                     Ecmascript file had an error
-                       1 | export default function Page() {
-                     > 2 |   // @next-codemod-error remove jsx of next line
-                         |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                       3 |   return <p>hello world</p>
-                       4 | }
-                       5 |
+           "./app/page.tsx (2:2)
+           Ecmascript file had an error
+             1 | export default function Page() {
+           > 2 |   // @next-codemod-error remove jsx of next line
+               |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             3 |   return <p>hello world</p>
+             4 | }
+             5 |
 
-                     You have an unresolved @next/codemod comment "remove jsx of next line" that needs review.
-                     After review, either remove the comment if you made the necessary changes or replace "@next-codemod-error" with "@next-codemod-ignore" to bypass the build error if no action at this line can be taken."
-                  `)
+           You have an unresolved @next/codemod comment "remove jsx of next line" that needs review.
+           After review, either remove the comment if you made the necessary changes or replace "@next-codemod-error" with "@next-codemod-ignore" to bypass the build error if no action at this line can be taken."
+          `)
         } else {
           expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
                      "./app/page.tsx

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -425,8 +425,10 @@ describe('app dir - rsc basics', () => {
   })
 
   // TODO: (PPR) remove once PPR is stable
+  // TODO(new-dev-overlay): remove once new dev overlay is stable
   const bundledReactVersionPattern =
-    process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+    process.env.__NEXT_EXPERIMENTAL_PPR === 'true' ||
+    process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
       ? '-experimental-'
       : '-canary-'
 

--- a/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
@@ -10,6 +10,13 @@ import {
 } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
+// TODO(new-dev-overlay): Remove this once old dev overlay fork is removed
+const isNewDevOverlay =
+  process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
+
+const needsExperimentalReact =
+  process.env.__NEXT_EXPERIMENTAL_PPR || isNewDevOverlay
+
 const expectedErrorMessage =
   'Error: Filling a cache during prerender timed out, likely because request-specific arguments such as params, searchParams, cookies() or dynamic data were used inside "use cache".'
 
@@ -192,8 +199,8 @@ describe('use-cache-hanging-inputs', () => {
 
         const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
 
-        if (process.env.__NEXT_EXPERIMENTAL_PPR) {
-          // TODO(react-time-info): Remove this branch for PPR when the issue is
+        if (needsExperimentalReact) {
+          // TODO(react-time-info): Remove this branch for experimental React when the issue is
           // resolved where the inclusion of server timings in the RSC payload
           // makes the serialized bound args not suitable to be used as a cache
           // key.

--- a/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
+++ b/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
@@ -31,7 +31,7 @@ describe('use-cache-segment-configs', () => {
         expect(description).toBe('Failed to compile')
 
         expect(source).toMatchInlineSnapshot(`
-         "./app/runtime/page.tsx:1:14
+         "./app/runtime/page.tsx (1:14)
          Ecmascript file had an error
          > 1 | export const runtime = 'edge'
              |              ^^^^^^^

--- a/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
+++ b/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
@@ -90,12 +90,11 @@ describe('use-cache-unknown-cache-kind', () => {
 
       expect(errorDescription).toBe('Failed to compile')
 
-      // TODO(jiwon): Remove this once we have a new dev overlay at stable.
+      // TODO(new-dev-overlay): Remove this once old dev overlay fork is removed
       if (isNewDevOverlay) {
         if (isTurbopack) {
           expect(errorSource).toMatchInlineSnapshot(`
            "./app/page.tsx (1:1)
-
            Ecmascript file had an error
            > 1 | 'use cache: custom'
                | ^^^^^^^^^^^^^^^^^^^
@@ -122,15 +121,15 @@ describe('use-cache-unknown-cache-kind', () => {
       } else {
         if (isTurbopack) {
           expect(errorSource).toMatchInlineSnapshot(`
-            "./app/page.tsx:1:1
-            Ecmascript file had an error
-            > 1 | 'use cache: custom'
-                | ^^^^^^^^^^^^^^^^^^^
-              2 |
-              3 | export default async function Page() {
-              4 |   return <p>hello world</p>
+           "./app/page.tsx (1:1)
+           Ecmascript file had an error
+           > 1 | 'use cache: custom'
+               | ^^^^^^^^^^^^^^^^^^^
+             2 |
+             3 | export default async function Page() {
+             4 |   return <p>hello world</p>
 
-            Unknown cache kind "custom". Please configure a cache handler for this kind in the "experimental.cacheHandlers" object in your Next.js config."
+           Unknown cache kind "custom". Please configure a cache handler for this kind in the "experimental.cacheHandlers" object in your Next.js config."
           `)
         } else {
           expect(errorSource).toMatchInlineSnapshot(`

--- a/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
+++ b/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
@@ -89,7 +89,7 @@ describe('use-cache-without-experimental-flag', () => {
 
       expect(errorDescription).toBe('Failed to compile')
 
-      // TODO(jiwon): Remove this once we have a new dev overlay at stable.
+      // TODO(new-dev-overlay): Remove this once old dev overlay fork is removed
       if (isNewDevOverlay) {
         if (isTurbopack) {
           expect(errorSource).toMatchInlineSnapshot(`
@@ -125,7 +125,7 @@ describe('use-cache-without-experimental-flag', () => {
       } else {
         if (isTurbopack) {
           expect(errorSource).toMatchInlineSnapshot(`
-           "./app/page.tsx:1:1
+           "./app/page.tsx (1:1)
            Ecmascript file had an error
            > 1 | 'use cache'
                | ^^^^^^^^^^^

--- a/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
+++ b/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
@@ -94,7 +94,6 @@ describe('use-cache-without-experimental-flag', () => {
         if (isTurbopack) {
           expect(errorSource).toMatchInlineSnapshot(`
            "./app/page.tsx (1:1)
-
            Ecmascript file had an error
            > 1 | 'use cache'
                | ^^^^^^^^^^^

--- a/test/production/custom-server/custom-server.test.ts
+++ b/test/production/custom-server/custom-server.test.ts
@@ -1,6 +1,9 @@
 import { nextTestSetup } from 'e2e-utils'
 
 const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
+// TODO(new-dev-overlay): Remove this once new dev overlay is stable
+const isNewDevOverlay =
+  process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
 
 describe('custom server', () => {
   const { next } = nextTestSetup({
@@ -23,10 +26,12 @@ describe('custom server', () => {
   })
 
   describe('with app dir', () => {
-    it('should render app with react canary', async () => {
-      const $ = await next.render$(`/1`)
-      expect($('body').text()).toMatch(/app: .+-canary/)
-    })
+    if (!isNewDevOverlay) {
+      it('should render app with react canary', async () => {
+        const $ = await next.render$(`/1`)
+        expect($('body').text()).toMatch(/app: .+-canary/)
+      })
+    }
 
     it('should render pages with installed react', async () => {
       const $ = await next.render$(`/2`)


### PR DESCRIPTION
- `newDevOverlay: true` by default (enables experimental React builds on canary until owner stacks progress further)
- `run-tests` now sets the env var for tests that were relying on it for forking behavior
- PPR runners now run with the flag disabled to help catch regressions in the old overlay until we remove it
- Fixed a number of tests that had outdated snapshots or missed forking behavior because they weren't running in CI
- Disabled a test that was failing in Turbopack + Experimental React that is unrelated to the overlay (see: https://github.com/vercel/next.js/pull/75989)
