### PR TITLE
Add test to verify that inner caches are excluded from Resume Data Cache

### DIFF
--- a/packages/next/src/server/resume-data-cache/cache-store.ts
+++ b/packages/next/src/server/resume-data-cache/cache-store.ts
@@ -8,7 +8,10 @@ import type { CachedFetchValue } from '../response-cache/types'
 /**
  * A generic cache store type that provides a subset of Map functionality
  */
-type CacheStore<T> = Pick<Map<string, T>, 'entries' | 'size' | 'get' | 'set'>
+type CacheStore<T> = Pick<
+  Map<string, T>,
+  'entries' | 'keys' | 'size' | 'get' | 'set'
+>
 
 /**
  * A cache store specifically for fetch cache values

--- a/test/e2e/app-dir/use-cache/app/rdc/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/rdc/page.tsx
@@ -1,0 +1,33 @@
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+async function outermost(id: string) {
+  'use cache'
+  return id + middle('middle')
+}
+
+async function middle(id: string) {
+  'use cache'
+  return id + innermost('inner')
+}
+
+async function innermost(id: string) {
+  'use cache'
+  return id
+}
+
+async function Dynamic() {
+  await connection()
+  return null
+}
+
+export default async function Page() {
+  await outermost('outer')
+  await innermost('inner')
+
+  return (
+    <Suspense>
+      <Dynamic />
+    </Suspense>
+  )
+}


### PR DESCRIPTION
The Resume Data Cache (RDC) is used to provide cache consistency when resuming a partial prerendered static shell. When reading from this cache, it is not possible for there to be a miss because, regardless of the cache age, we always consume the cache entries on resume because they are temporarily bound to the static shell being served for this particular request. Since the cache entry can never miss, there is no need to store inner cache entries in the Resume Data Cache because the only time you would encounter an inner entry is if the outer entry had to revalidate.

We have already optimized the Resume Data Cache by excluding writing to it during prerendering (and dev warmup rendering) if we're already inside a cache scope. We also handle that you can have an inner cache entry fill the backing cache and omit the RDC entry, and then later we encounter that same cache entry in the prerender scope, and even though we don't need to produce a new cache entry (it was already cached in the backing cache implementation), we do still write it to the Resume Data Cache.

The test added in this PR verifies this behavior and ensures that we don't regress in the future.

closes NAR-54