### PR TITLE
fix: separate timers per module context

### DIFF
--- a/packages/next/src/server/web/sandbox/resource-managers.ts
+++ b/packages/next/src/server/web/sandbox/resource-managers.ts
@@ -1,86 +1,149 @@
-abstract class ResourceManager<T, Args> {
-  private resources: T[] = []
+type ResouceManagerOpts<T, Args> = {
+  create(resourceArgs: Args): T
+  destroy(resource: T): void
+}
 
-  abstract create(resourceArgs: Args): T
-  abstract destroy(resource: T): void
+function createResourceManager<T, Args extends any[]>({
+  create,
+  destroy,
+}: ResouceManagerOpts<T, Args>) {
+  let resources = new Set<T>()
+  return {
+    set(...resourceArgs: Args) {
+      const resource = create(resourceArgs)
+      resources.add(resource)
+      return resource
+    },
 
-  add(resourceArgs: Args) {
-    const resource = this.create(resourceArgs)
-    this.resources.push(resource)
-    return resource
-  }
+    clear(resource: T) {
+      if (resources.delete(resource)) {
+        destroy(resource)
+      }
+    },
 
-  remove(resource: T) {
-    this.resources = this.resources.filter((r) => r !== resource)
-    this.destroy(resource)
-  }
-
-  removeAll() {
-    this.resources.forEach(this.destroy)
-    this.resources = []
+    removeAll() {
+      resources.forEach(destroy)
+      resources.clear()
+    },
   }
 }
 
-export class IntervalsManager extends ResourceManager<
-  number,
-  Parameters<typeof setInterval>
-> {
-  create(args: Parameters<typeof setInterval>) {
-    // TODO: use the edge runtime provided `setInterval` instead
-    return webSetIntervalPolyfill(...args)
+export function createWebTimers(
+  globalObject: typeof globalThis,
+  impls: {
+    setInterval: typeof setInterval
+    clearInterval: typeof clearInterval
+    setTimeout: typeof setTimeout
+    clearTimeout: typeof clearTimeout
   }
+) {
+  const {
+    setInterval: setIntervalImpl,
+    clearInterval: clearIntervalImpl,
+    setTimeout: setTimeoutImpl,
+    clearTimeout: clearTimeoutImpl,
+  } = impls
 
-  destroy(interval: number) {
-    clearInterval(interval)
+  // setInterval/clearInterval
+
+  const webSetIntervalPolyfill = createWebSetIntervalPolyfill(
+    globalObject,
+    setIntervalImpl
+  )
+
+  const intervalsManager = createResourceManager<
+    number,
+    Parameters<typeof webSetIntervalPolyfill>
+  >({
+    create(args) {
+      // TODO: use the edge runtime provided `setInterval` instead
+      return webSetIntervalPolyfill.apply(null, args)
+    },
+    destroy(interval) {
+      clearIntervalImpl(interval)
+    },
+  })
+
+  // setTimeout/clearTimeout
+
+  const webSetTimeoutPolyfill = createWebSetTimeoutPolyfill(
+    globalObject,
+    setTimeoutImpl,
+    clearTimeoutImpl
+  )
+
+  const timeoutsManager = createResourceManager<
+    number,
+    Parameters<typeof webSetTimeoutPolyfill>
+  >({
+    create(args) {
+      // TODO: use the edge runtime provided `setTimeout` instead
+      return webSetTimeoutPolyfill.apply(null, args)
+    },
+    destroy(timeout) {
+      clearTimeoutImpl(timeout)
+    },
+  })
+
+  return {
+    timers: {
+      setInterval: intervalsManager.set.bind(intervalsManager),
+      clearInterval: intervalsManager.clear.bind(intervalsManager),
+      setTimeout: timeoutsManager.set.bind(timeoutsManager),
+      clearTimeout: timeoutsManager.clear.bind(timeoutsManager),
+    },
+    destroy: () => {
+      intervalsManager.removeAll()
+      timeoutsManager.removeAll()
+    },
   }
 }
 
-export class TimeoutsManager extends ResourceManager<
-  number,
-  Parameters<typeof setTimeout>
-> {
-  create(args: Parameters<typeof setTimeout>) {
-    // TODO: use the edge runtime provided `setTimeout` instead
-    return webSetTimeoutPolyfill(...args)
-  }
+export type TimersManager = ReturnType<typeof createWebTimers>
 
-  destroy(timeout: number) {
-    clearTimeout(timeout)
+function createWebSetIntervalPolyfill(
+  globalObject: typeof globalThis,
+  setIntervalImpl: typeof setInterval
+) {
+  return function setInterval<TArgs extends any[]>(
+    callback: (...args: TArgs) => void,
+    ms?: number,
+    ...args: TArgs
+  ): number {
+    return setIntervalImpl(() => {
+      // node's `setInterval` sets `this` to the `Timeout` instance it returned,
+      // but web `setInterval` always sets `this` to `window`
+      // see: https://developer.mozilla.org/en-US/docs/Web/API/Window/setInterval#the_this_problem
+      return callback.apply(globalObject, args)
+    }, ms)[Symbol.toPrimitive]()
   }
 }
 
-function webSetIntervalPolyfill<TArgs extends any[]>(
-  callback: (...args: TArgs) => void,
-  ms?: number,
-  ...args: TArgs
-): number {
-  return setInterval(() => {
-    // node's `setInterval` sets `this` to the `Timeout` instance it returned,
-    // but web `setInterval` always sets `this` to `window`
-    // see: https://developer.mozilla.org/en-US/docs/Web/API/Window/setInterval#the_this_problem
-    return callback.apply(globalThis, args)
-  }, ms)[Symbol.toPrimitive]()
-}
-
-function webSetTimeoutPolyfill<TArgs extends any[]>(
-  callback: (...args: TArgs) => void,
-  ms?: number,
-  ...args: TArgs
-): number {
-  const wrappedCallback = () => {
-    try {
-      // node's `setTimeout` sets `this` to the `Timeout` instance it returned,
-      // but web `setTimeout` always sets `this` to `window`
-      // see: https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#the_this_problem
-      return callback.apply(globalThis, args)
-    } finally {
-      // On certain older node versions (<20.16.0, <22.4.0),
-      // a `setTimeout` whose Timeout was converted to a primitive will leak.
-      // See: https://github.com/nodejs/node/issues/53335
-      // We can work around this by explicitly calling `clearTimeout` after the callback runs.
-      clearTimeout(timeout)
+function createWebSetTimeoutPolyfill(
+  globalObject: typeof globalThis,
+  setTimeoutImpl: typeof setTimeout,
+  clearTimeoutImpl: typeof clearTimeout
+) {
+  return function setTimeout<TArgs extends any[]>(
+    callback: (...args: TArgs) => void,
+    ms?: number,
+    ...args: TArgs
+  ): number {
+    const wrappedCallback = () => {
+      try {
+        // node's `setTimeout` sets `this` to the `Timeout` instance it returned,
+        // but web `setTimeout` always sets `this` to `window`
+        // see: https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#the_this_problem
+        return callback.apply(globalObject, args)
+      } finally {
+        // On certain older node versions (<20.16.0, <22.4.0),
+        // a `setTimeout` whose Timeout was converted to a primitive will leak.
+        // See: https://github.com/nodejs/node/issues/53335
+        // We can work around this by explicitly calling `clearTimeout` after the callback runs.
+        clearTimeoutImpl(timeout)
+      }
     }
+    const timeout = setTimeoutImpl(wrappedCallback, ms)
+    return timeout[Symbol.toPrimitive]()
   }
-  const timeout = setTimeout(wrappedCallback, ms)
-  return timeout[Symbol.toPrimitive]()
 }

--- a/packages/next/src/server/web/sandbox/resource-managers.ts
+++ b/packages/next/src/server/web/sandbox/resource-managers.ts
@@ -21,7 +21,7 @@ abstract class ResourceManager<T, Args> {
   }
 }
 
-class IntervalsManager extends ResourceManager<
+export class IntervalsManager extends ResourceManager<
   number,
   Parameters<typeof setInterval>
 > {
@@ -35,7 +35,7 @@ class IntervalsManager extends ResourceManager<
   }
 }
 
-class TimeoutsManager extends ResourceManager<
+export class TimeoutsManager extends ResourceManager<
   number,
   Parameters<typeof setTimeout>
 > {
@@ -84,6 +84,3 @@ function webSetTimeoutPolyfill<TArgs extends any[]>(
   const timeout = setTimeout(wrappedCallback, ms)
   return timeout[Symbol.toPrimitive]()
 }
-
-export const intervalsManager = new IntervalsManager()
-export const timeoutsManager = new TimeoutsManager()


### PR DESCRIPTION
the timer managers are shared across all module contexts even though module contexts can be reset individually, that seems wrong