### PR TITLE
refactor(webpack-config): Pass through jsConfigPath

### DIFF
--- a/packages/next/src/build/load-jsconfig.ts
+++ b/packages/next/src/build/load-jsconfig.ts
@@ -49,6 +49,7 @@ export default async function loadJsConfig(
 ): Promise<{
   useTypeScript: boolean
   jsConfig: JsConfig
+  jsConfigPath?: string
   resolvedBaseUrl: ResolvedBaseUrl
 }> {
   let typeScriptPath: string | undefined
@@ -110,5 +111,10 @@ export default async function loadJsConfig(
     useTypeScript,
     jsConfig,
     resolvedBaseUrl,
+    jsConfigPath: useTypeScript
+      ? tsConfigPath
+      : fs.existsSync(jsConfigPath)
+        ? jsConfigPath
+        : undefined,
   }
 }


### PR DESCRIPTION
Extracted from the try-ci-test work: #75443

I'm just trying to find small unobjectionable pieces we can get merged to get the size of the in-flight changeset down.

<!--
Co-authored-by: JJ Kasper <jj@jjsweb.site>

Closes PACK-3928