### PR TITLE
fix(turbopack): Update Cargo.toml/package.json license field for turbopack-related crates

### DIFF
--- a/crates/next-api/Cargo.toml
+++ b/crates/next-api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "next-api"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/crates/next-build-test/Cargo.toml
+++ b/crates/next-build-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "next-build-test"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/crates/next-build/Cargo.toml
+++ b/crates/next-build/Cargo.toml
@@ -2,7 +2,7 @@
 name = "next-build"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "next-core"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 
 [lib]

--- a/turbopack/crates/turbo-prehash/Cargo.toml
+++ b/turbopack/crates/turbo-prehash/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbo-prehash"
 version = "0.1.0"
 edition = "2021"
-license = "MPL-2.0"
+license = "MIT"
 
 [dependencies]
 

--- a/turbopack/crates/turbo-static/Cargo.toml
+++ b/turbopack/crates/turbo-static/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbo-static"
 version = "0.1.0"
 edition = "2021"
-license = "MPL-2.0"
+license = "MIT"
 
 [dependencies]
 bincode = "1.3.3"

--- a/turbopack/crates/turbo-tasks-auto-hash-map/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-auto-hash-map/Cargo.toml
@@ -2,7 +2,7 @@
 name = "auto-hash-map"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 
 [lints]

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbo-tasks-backend"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbo-tasks-build/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-build/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbo-tasks-build"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 
 [lib]

--- a/turbopack/crates/turbo-tasks-bytes/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-bytes/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbo-tasks-bytes"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 
 [lib]

--- a/turbopack/crates/turbo-tasks-env/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-env/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbo-tasks-env"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 
 [lib]

--- a/turbopack/crates/turbo-tasks-fetch/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fetch/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbo-tasks-fetch"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 
 [lib]

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbo-tasks-fs"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 
 [lib]

--- a/turbopack/crates/turbo-tasks-hash/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-hash/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbo-tasks-hash"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbo-tasks-macros-shared/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-macros-shared/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 
 [lib]

--- a/turbopack/crates/turbo-tasks-macros-tests/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-macros-tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbo-tasks-macros-tests"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 
 [dev-dependencies]

--- a/turbopack/crates/turbo-tasks-macros/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbo-tasks-macros"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 
 [lib]

--- a/turbopack/crates/turbo-tasks-malloc/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-malloc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbo-tasks-malloc"
 version = "0.1.0"
 description = "A wrapper around mimalloc or the system allocator that tracks allocations"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbo-tasks-memory/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-memory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbo-tasks-memory"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbo-tasks-testing/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-testing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbo-tasks-testing"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 autotests = false

--- a/turbopack/crates/turbo-tasks/Cargo.toml
+++ b/turbopack/crates/turbo-tasks/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbo-tasks"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 
 [lib]

--- a/turbopack/crates/turbopack-bench/Cargo.toml
+++ b/turbopack/crates/turbopack-bench/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-bench"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-browser/Cargo.toml
+++ b/turbopack/crates/turbopack-browser/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-browser"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-cli-utils/Cargo.toml
+++ b/turbopack/crates/turbopack-cli-utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-cli-utils"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-cli/Cargo.toml
+++ b/turbopack/crates/turbopack-cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-cli"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-core/Cargo.toml
+++ b/turbopack/crates/turbopack-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-core"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-create-test-app/Cargo.toml
+++ b/turbopack/crates/turbopack-create-test-app/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-create-test-app"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 
 # don't publish this crate (for now)

--- a/turbopack/crates/turbopack-css/Cargo.toml
+++ b/turbopack/crates/turbopack-css/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-css"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-dev-server/Cargo.toml
+++ b/turbopack/crates/turbopack-dev-server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-dev-server"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-ecmascript-hmr-protocol/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript-hmr-protocol/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-ecmascript-plugins/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript-plugins/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-ecmascript-runtime/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript-runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-ecmascript/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-ecmascript"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-env/Cargo.toml
+++ b/turbopack/crates/turbopack-env/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-env"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-image/Cargo.toml
+++ b/turbopack/crates/turbopack-image/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-image"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-json/Cargo.toml
+++ b/turbopack/crates/turbopack-json/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-json"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-mdx/Cargo.toml
+++ b/turbopack/crates/turbopack-mdx/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-mdx"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-node/Cargo.toml
+++ b/turbopack/crates/turbopack-node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-node"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-nodejs/Cargo.toml
+++ b/turbopack/crates/turbopack-nodejs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-nodejs"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-resolve/Cargo.toml
+++ b/turbopack/crates/turbopack-resolve/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-resolve"
 version = "0.1.0"
 description = "Methods to create and modify resolver options"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-static/Cargo.toml
+++ b/turbopack/crates/turbopack-static/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-static"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-swc-ast-explorer/Cargo.toml
+++ b/turbopack/crates/turbopack-swc-ast-explorer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "swc-ast-explorer"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 
 # don't publish this crate (for now)

--- a/turbopack/crates/turbopack-swc-utils/Cargo.toml
+++ b/turbopack/crates/turbopack-swc-utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-swc-utils"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-test-utils/Cargo.toml
+++ b/turbopack/crates/turbopack-test-utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-test-utils"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-tests/Cargo.toml
+++ b/turbopack/crates/turbopack-tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-tests"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-trace-server/Cargo.toml
+++ b/turbopack/crates/turbopack-trace-server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-trace-server"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-trace-utils/Cargo.toml
+++ b/turbopack/crates/turbopack-trace-utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-trace-utils"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack-wasm/Cargo.toml
+++ b/turbopack/crates/turbopack-wasm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack-wasm"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/crates/turbopack/Cargo.toml
+++ b/turbopack/crates/turbopack/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopack"
 version = "0.1.0"
 description = "TBD"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 autobenches = false
 

--- a/turbopack/packages/devlow-bench/package.json
+++ b/turbopack/packages/devlow-bench/package.json
@@ -24,7 +24,7 @@
   ],
   "keywords": [],
   "author": "Tobias Koppers",
-  "license": "MPL-2.0",
+  "license": "MIT",
   "exports": {
     ".": "./dist/index.js",
     "./browser": "./dist/browser.js",

--- a/turbopack/packages/node-module-trace/package.json
+++ b/turbopack/packages/node-module-trace/package.json
@@ -2,7 +2,7 @@
   "name": "@vercel/experimental-nft",
   "version": "0.0.5-alpha.0",
   "description": "Node.js module trace",
-  "license": "MPL-2.0",
+  "license": "MIT",
   "alias": "node-file-trace",
   "publishConfig": {
     "access": "public"

--- a/turbopack/packages/turbo-tracing-next-plugin/package.json
+++ b/turbopack/packages/turbo-tracing-next-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vercel/experimental-nft-next-plugin",
   "version": "0.0.3-alpha.2",
-  "license": "MPL-2.0",
+  "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/turbopack/packages/webpack-nmt/package.json
+++ b/turbopack/packages/webpack-nmt/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vercel/webpack-nft",
   "version": "0.0.15-alpha.2",
-  "license": "MPL-2.0",
+  "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/turbopack/xtask/Cargo.toml
+++ b/turbopack/xtask/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xtask"
 version = "0.1.0"
 description = "https://github.com/matklad/cargo-xtask/"
-license = "MPL-2.0"
+license = "MIT"
 edition = "2021"
 
 # don't publish this crate


### PR DESCRIPTION
Make this match what the license.md file in the root already says.

Got approval from legal here: https://vercel.slack.com/archives/C08CP9WLM6X/p1739235323414089

Closes PACK-3944