### PR TITLE
[Turbopack] scale down process pool when module graph is finished

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -900,6 +900,15 @@ impl Project {
             let module_graphs_op = whole_app_module_graph_operation(self);
             let module_graphs_vc = module_graphs_op.connect().resolve().await?;
             let _ = module_graphs_op.take_issues_with_path().await?;
+
+            // At this point all modules have been computed and we can get rid of the node.js
+            // process pools
+            if self.await?.watch.enable {
+                turbopack_node::evaluate::scale_down();
+            } else {
+                turbopack_node::evaluate::scale_zero();
+            }
+
             Ok(module_graphs_vc)
         }
         .instrument(tracing::info_span!("module graph for app"))

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -652,6 +652,14 @@ impl EvaluateContext for BasicEvaluateContext {
     }
 }
 
+pub fn scale_zero() {
+    NodeJsPool::scale_zero();
+}
+
+pub fn scale_down() {
+    NodeJsPool::scale_down();
+}
+
 async fn print_error(
     error: StructuredError,
     pool: &NodeJsPool,

--- a/turbopack/crates/turbopack-node/src/pool.rs
+++ b/turbopack/crates/turbopack-node/src/pool.rs
@@ -706,8 +706,11 @@ enum AcquiredPermits {
     },
 }
 
-static ACTIVE_POOLS: Lazy<Mutex<Vec<Arc<Mutex<BinaryHeap<NodeJsPoolProcess>>>>>> =
-    Lazy::new(|| Default::default());
+type IdleProcessesList = Arc<Mutex<BinaryHeap<NodeJsPoolProcess>>>;
+
+/// All non-empty `IdleProcessesList`s of the whole application.
+/// This is used to scale down processes globally.
+static ACTIVE_POOLS: Lazy<Mutex<Vec<IdleProcessesList>>> = Lazy::new(Default::default);
 
 /// A pool of Node.js workers operating on [entrypoint] with specific [cwd] and
 /// [env].

--- a/turbopack/crates/turbopack-node/src/pool.rs
+++ b/turbopack/crates/turbopack-node/src/pool.rs
@@ -801,7 +801,7 @@ impl NodeJsPool {
                 let process = {
                     let mut processes = self.processes.lock();
                     let process = processes.pop().unwrap();
-                    {
+                    if processes.is_empty() {
                         let mut pools = ACTIVE_POOLS.lock();
                         if let Some(idx) = pools.iter().position(|p| Arc::ptr_eq(p, &self.processes)) {
                             pools.swap_remove(idx);


### PR DESCRIPTION
### What?

in build mode we don't need to process pools anymore after the module graph has finished.

Note: I'm not super happy with this design, but it will work for now... In future we need something more general...

Closes PACK-3948