### PR TITLE
[Turbopack] allow to disable active tracking in turbo-tasks

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -283,6 +283,7 @@ impl AggregatedDataUpdate {
         &self,
         task: &mut impl TaskGuard,
         session_id: SessionId,
+        should_track_activeness: bool,
         queue: &mut AggregationUpdateQueue,
     ) -> AggregatedDataUpdate {
         let Self {
@@ -291,11 +292,13 @@ impl AggregatedDataUpdate {
         } = self;
         let mut result = Self::default();
         if let Some((dirty_container_id, count)) = dirty_container_update {
-            // When a dirty container count is increased and the task is considered as active
-            // we need to schedule the dirty tasks in the new dirty container
-            let current_session_update = count.get(session_id);
-            if current_session_update > 0 && task.has_key(&CachedDataItemKey::Activeness {}) {
-                queue.push_find_and_schedule_dirty(*dirty_container_id)
+            if should_track_activeness {
+                // When a dirty container count is increased and the task is considered as active
+                // we need to schedule the dirty tasks in the new dirty container
+                let current_session_update = count.get(session_id);
+                if current_session_update > 0 && task.has_key(&CachedDataItemKey::Activeness {}) {
+                    queue.push_find_and_schedule_dirty(*dirty_container_id)
+                }
             }
 
             let mut aggregated_update = DirtyContainerCount::default();
@@ -332,8 +335,8 @@ impl AggregatedDataUpdate {
                 });
                 if let Some((_, count)) = result.dirty_container_update.as_ref() {
                     if count.get(session_id) < 0 {
-                        // When the current task is no longer dirty, we need to fire the aggregate
-                        // root events and do some cleanup
+                        // When the current task is no longer dirty, we need to fire the
+                        // aggregate root events and do some cleanup
                         if let Some(root_state) = get_mut!(task, Activeness) {
                             root_state.all_clean_event.notify(usize::MAX);
                             root_state.unset_active_until_clean();
@@ -1035,7 +1038,12 @@ impl AggregationUpdateQueue {
                         // followers
                         let data = AggregatedDataUpdate::from_task(&mut task);
                         let followers = get_followers(&task);
-                        let diff = data.apply(&mut upper, ctx.session_id(), self);
+                        let diff = data.apply(
+                            &mut upper,
+                            ctx.session_id(),
+                            ctx.should_track_activeness(),
+                            self,
+                        );
 
                         if !upper_ids.is_empty() && !diff.is_empty() {
                             // Notify uppers about changed aggregated data
@@ -1054,7 +1062,9 @@ impl AggregationUpdateQueue {
                             });
                         }
 
-                        if upper.has_key(&CachedDataItemKey::Activeness {}) {
+                        if ctx.should_track_activeness()
+                            && upper.has_key(&CachedDataItemKey::Activeness {})
+                        {
                             // If the upper node is has `Activeness` we need to schedule the
                             // dirty tasks in the new dirty container
                             self.push_find_and_schedule_dirty(task_id);
@@ -1069,12 +1079,14 @@ impl AggregationUpdateQueue {
                         });
                     }
 
-                    // Follower was removed, we might need to update the active count
-                    let has_active_count =
-                        get!(upper, Activeness).is_some_and(|a| a.active_counter > 0);
-                    if has_active_count {
-                        // TODO combine both operations to avoid the clone
-                        self.push(AggregationUpdateJob::DecreaseActiveCount { task: task_id })
+                    if ctx.should_track_activeness() {
+                        // Follower was removed, we might need to update the active count
+                        let has_active_count =
+                            get!(upper, Activeness).is_some_and(|a| a.active_counter > 0);
+                        if has_active_count {
+                            // TODO combine both operations to avoid the clone
+                            self.push(AggregationUpdateJob::DecreaseActiveCount { task: task_id })
+                        }
                     }
                 }
                 std::cmp::Ordering::Equal => {}
@@ -1099,11 +1111,15 @@ impl AggregationUpdateQueue {
                         if count!(upper, Follower).is_power_of_two() {
                             self.push_optimize_task(upper_id);
                         }
-                        // update active count
-                        let has_active_count =
-                            get!(task, Activeness).is_some_and(|a| a.active_counter > 0);
-                        if has_active_count {
-                            self.push(AggregationUpdateJob::IncreaseActiveCount { task: task_id });
+                        if ctx.should_track_activeness() {
+                            // update active count
+                            let has_active_count =
+                                get!(task, Activeness).is_some_and(|a| a.active_counter > 0);
+                            if has_active_count {
+                                self.push(AggregationUpdateJob::IncreaseActiveCount {
+                                    task: task_id,
+                                });
+                            }
                         }
                         // notify uppers about new follower
                         if !upper_ids.is_empty() {
@@ -1118,7 +1134,12 @@ impl AggregationUpdateQueue {
                     // followers
                     let data = AggregatedDataUpdate::from_task(&mut task).invert();
                     let followers = get_followers(&task);
-                    let diff = data.apply(&mut upper, ctx.session_id(), self);
+                    let diff = data.apply(
+                        &mut upper,
+                        ctx.session_id(),
+                        ctx.should_track_activeness(),
+                        self,
+                    );
                     if !upper_ids.is_empty() && !diff.is_empty() {
                         self.push(
                             AggregatedDataUpdateJob {
@@ -1157,7 +1178,7 @@ impl AggregationUpdateQueue {
 
     /// Schedules the task if it's dirty.
     ///
-    /// For aggregating nodes that are
+    /// Only used when activeness is tracked.
     fn find_and_schedule_dirty(&mut self, task_id: TaskId, ctx: &mut impl ExecuteContext) {
         #[cfg(feature = "trace_find_and_schedule")]
         let _span = trace_span!(
@@ -1205,7 +1226,12 @@ impl AggregationUpdateQueue {
     ) {
         for upper_id in upper_ids {
             let mut upper = ctx.task(upper_id, TaskDataCategory::Meta);
-            let diff = update.apply(&mut upper, ctx.session_id(), self);
+            let diff = update.apply(
+                &mut upper,
+                ctx.session_id(),
+                ctx.should_track_activeness(),
+                self,
+            );
             if !diff.is_empty() {
                 let upper_ids = get_uppers(&upper);
                 if !upper_ids.is_empty() {
@@ -1264,7 +1290,12 @@ impl AggregationUpdateQueue {
                 for upper_id in upper_ids.iter() {
                     // remove data from upper
                     let mut upper = ctx.task(*upper_id, TaskDataCategory::Meta);
-                    let diff = data.apply(&mut upper, ctx.session_id(), self);
+                    let diff = data.apply(
+                        &mut upper,
+                        ctx.session_id(),
+                        ctx.should_track_activeness(),
+                        self,
+                    );
                     if !diff.is_empty() {
                         let upper_ids = get_uppers(&upper);
                         self.push(
@@ -1304,8 +1335,8 @@ impl AggregationUpdateQueue {
                     self.push_optimize_task(upper_id);
                 }
 
-                let has_active_count =
-                    get!(upper, Activeness).is_some_and(|a| a.active_counter > 0);
+                let has_active_count = ctx.should_track_activeness()
+                    && get!(upper, Activeness).is_some_and(|a| a.active_counter > 0);
                 let upper_ids = get_uppers(&upper);
                 drop(upper);
                 // update active count
@@ -1365,7 +1396,12 @@ impl AggregationUpdateQueue {
                 if !data.is_empty() {
                     // remove data from upper
                     let mut upper = ctx.task(upper_id, TaskDataCategory::Meta);
-                    let diff = data.apply(&mut upper, ctx.session_id(), self);
+                    let diff = data.apply(
+                        &mut upper,
+                        ctx.session_id(),
+                        ctx.should_track_activeness(),
+                        self,
+                    );
                     if !diff.is_empty() {
                         let upper_ids = get_uppers(&upper);
                         self.push(
@@ -1461,11 +1497,13 @@ impl AggregationUpdateQueue {
                         self.push_optimize_task(upper_id);
                     }
 
-                    // update active count
-                    let has_active_count =
-                        get!(upper, Activeness).is_some_and(|a| a.active_counter > 0);
-                    if has_active_count {
-                        tasks_for_which_increment_active_count.push(new_follower_id);
+                    if ctx.should_track_activeness() {
+                        // update active count
+                        let has_active_count =
+                            get!(upper, Activeness).is_some_and(|a| a.active_counter > 0);
+                        if has_active_count {
+                            tasks_for_which_increment_active_count.push(new_follower_id);
+                        }
                     }
                     // notify uppers about new follower
                     upper_upper_ids_with_new_follower.extend(iter_uppers(&upper));
@@ -1483,7 +1521,8 @@ impl AggregationUpdateQueue {
                 false
             } else {
                 // It's an inner node, continue with the list
-                if upper.has_key(&CachedDataItemKey::Activeness {}) {
+                if ctx.should_track_activeness() && upper.has_key(&CachedDataItemKey::Activeness {})
+                {
                     is_active = true;
                 }
                 true
@@ -1531,7 +1570,12 @@ impl AggregationUpdateQueue {
                     for upper_id in upper_ids.iter() {
                         // add data to upper
                         let mut upper = ctx.task(*upper_id, TaskDataCategory::Meta);
-                        let diff = data.apply(&mut upper, ctx.session_id(), self);
+                        let diff = data.apply(
+                            &mut upper,
+                            ctx.session_id(),
+                            ctx.should_track_activeness(),
+                            self,
+                        );
                         if !diff.is_empty() {
                             let upper_ids = get_uppers(&upper);
                             self.push(
@@ -1597,15 +1641,17 @@ impl AggregationUpdateQueue {
             .collect::<Vec<_>>();
 
         let mut new_followers_of_upper_uppers = SmallVec::new();
-        let is_active;
-        let has_active_count;
+        let mut is_active = false;
+        let mut has_active_count = false;
         let mut upper_upper_ids_for_new_followers = SmallVec::new();
         let upper_aggregation_number;
         {
             let mut upper = ctx.task(upper_id, TaskDataCategory::Meta);
-            let activeness_state = get!(upper, Activeness);
-            is_active = activeness_state.is_some();
-            has_active_count = activeness_state.is_some_and(|a| a.active_counter > 0);
+            if ctx.should_track_activeness() {
+                let activeness_state = get!(upper, Activeness);
+                is_active = activeness_state.is_some();
+                has_active_count = activeness_state.is_some_and(|a| a.active_counter > 0);
+            }
             // decide if it should be an inner or follower
             upper_aggregation_number = get_aggregation_number(&upper);
 
@@ -1694,7 +1740,12 @@ impl AggregationUpdateQueue {
                 let diffs = upper_data_updates
                     .into_iter()
                     .filter_map(|data| {
-                        let diff = data.apply(&mut upper, ctx.session_id(), self);
+                        let diff = data.apply(
+                            &mut upper,
+                            ctx.session_id(),
+                            ctx.should_track_activeness(),
+                            self,
+                        );
                         (!diff.is_empty()).then_some(diff)
                     })
                     .collect::<Vec<_>>();
@@ -1761,17 +1812,21 @@ impl AggregationUpdateQueue {
     ) {
         #[cfg(feature = "trace_aggregation_update")]
         let _span = trace_span!("process new follower").entered();
+        let should_track_activeness = ctx.should_track_activeness();
 
         let (follower_aggregation_number, already_active) = {
             let follower = ctx.task(new_follower_id, TaskDataCategory::Meta);
             (
                 get_aggregation_number(&follower),
-                follower.has_key(&CachedDataItemKey::Activeness {}),
+                should_track_activeness && follower.has_key(&CachedDataItemKey::Activeness {}),
             )
         };
 
         let mut upper = ctx.task(upper_id, TaskDataCategory::Meta);
-        if !already_active && upper.has_key(&CachedDataItemKey::Activeness {}) {
+        if should_track_activeness
+            && !already_active
+            && upper.has_key(&CachedDataItemKey::Activeness {})
+        {
             self.push_find_and_schedule_dirty(new_follower_id);
         }
         // decide if it should be an inner or follower
@@ -1796,8 +1851,8 @@ impl AggregationUpdateQueue {
                     self.push_optimize_task(upper_id);
                 }
 
-                let has_active_count =
-                    get!(upper, Activeness).is_some_and(|a| a.active_counter > 0);
+                let has_active_count = ctx.should_track_activeness()
+                    && get!(upper, Activeness).is_some_and(|a| a.active_counter > 0);
                 let upper_ids = get_uppers(&upper);
                 drop(upper);
                 // update active count
@@ -1843,7 +1898,12 @@ impl AggregationUpdateQueue {
                 if !data.is_empty() {
                     // add data to upper
                     let mut upper = ctx.task(upper_id, TaskDataCategory::Meta);
-                    let diff = data.apply(&mut upper, ctx.session_id(), self);
+                    let diff = data.apply(
+                        &mut upper,
+                        ctx.session_id(),
+                        ctx.should_track_activeness(),
+                        self,
+                    );
                     if !diff.is_empty() {
                         let upper_ids = get_uppers(&upper);
                         self.push(
@@ -1865,6 +1925,9 @@ impl AggregationUpdateQueue {
         }
     }
 
+    /// Decreases the active count of a task.
+    ///
+    /// Only used when activeness is tracked.
     fn decrease_active_count(&mut self, ctx: &mut impl ExecuteContext, task_id: TaskId) {
         #[cfg(feature = "trace_aggregation_update")]
         let _span = trace_span!("decrease active count").entered();
@@ -1887,6 +1950,9 @@ impl AggregationUpdateQueue {
         }
     }
 
+    /// Increases the active count of a task.
+    ///
+    /// Only used when activeness is tracked.
     fn increase_active_count(&mut self, ctx: &mut impl ExecuteContext, task_id: TaskId) {
         #[cfg(feature = "trace_aggregation_update")]
         let _span = trace_span!("increase active count").entered();

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -102,8 +102,9 @@ impl Operation for CleanupOldEdgesOperation {
                                     });
                                 } else {
                                     let upper_ids = get_uppers(&task);
-                                    let has_active_count = get!(task, Activeness)
-                                        .is_some_and(|a| a.active_counter > 0);
+                                    let has_active_count = ctx.should_track_activeness()
+                                        && get!(task, Activeness)
+                                            .is_some_and(|a| a.active_counter > 0);
                                     drop(task);
                                     if has_active_count {
                                         // TODO combine both operations to avoid the clone

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
@@ -16,6 +16,7 @@ pub fn connect_children(
     new_children: FxHashSet<TaskId>,
     queue: &mut AggregationUpdateQueue,
     has_active_count: bool,
+    should_track_activeness: bool,
 ) {
     if new_children.is_empty() {
         return;
@@ -49,7 +50,7 @@ pub fn connect_children(
         // We need to decrease the active count because we temporarily increased it during
         // connect_child. We need to increase the active count when the parent has active
         // count, because it's added as follower.
-        if !has_active_count {
+        if should_track_activeness && !has_active_count {
             queue.push(AggregationUpdateJob::DecreaseActiveCounts {
                 task_ids: new_follower_ids,
             })
@@ -62,8 +63,10 @@ pub fn connect_children(
         });
         // We need to decrease the active count because we temporarily increased it during
         // connect_child.
-        queue.push(AggregationUpdateJob::DecreaseActiveCounts {
-            task_ids: new_follower_ids,
-        })
+        if should_track_activeness {
+            queue.push(AggregationUpdateJob::DecreaseActiveCounts {
+                task_ids: new_follower_ids,
+            });
+        }
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
@@ -22,7 +22,6 @@ use crate::{
 #[derive(Serialize, Deserialize, Clone, Default)]
 #[allow(clippy::large_enum_variant)]
 pub enum InvalidateOperation {
-    // TODO DetermineActiveness
     MakeDirty {
         task_ids: SmallVec<[TaskId; 4]>,
         #[cfg(feature = "trace_task_dirty")]
@@ -274,7 +273,7 @@ pub fn make_task_dirty_internal(
                 AggregatedDataUpdate::new().dirty_container_update(task_id, aggregated_update),
             ));
         }
-        task.has_key(&CachedDataItemKey::Activeness {})
+        !ctx.should_track_activeness() || task.has_key(&CachedDataItemKey::Activeness {})
     } else {
         true
     };

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -90,6 +90,7 @@ pub trait ExecuteContext<'e>: Sized {
     fn get_task_description(&self, task_id: TaskId) -> String;
     fn should_track_children(&self) -> bool;
     fn should_track_dependencies(&self) -> bool;
+    fn should_track_activeness(&self) -> bool;
 }
 
 pub struct ParentRef<'a> {
@@ -356,6 +357,10 @@ where
 
     fn should_track_dependencies(&self) -> bool {
         self.backend.should_track_dependencies()
+    }
+
+    fn should_track_activeness(&self) -> bool {
+        self.backend.should_track_activeness()
     }
 }
 

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -171,6 +171,7 @@ async fn run(resource: PathBuf, snapshot_mode: IssueSnapshotMode) -> Result<JsRe
     let tt = TurboTasks::new(TurboTasksBackend::new(
         BackendOptions {
             storage_mode: None,
+            dependency_tracking: false,
             ..Default::default()
         },
         noop_backing_storage(),


### PR DESCRIPTION
### What?

* allow to disable active tracking
* disable active tracking when dependency tracking is disabled

This allows to skip a lot of active counter increases and decreases for better performance.

Without dependency tracking there can't be any inactive tasks in the system, so we don't need to track that at all.

Closes PACK-3936