### PR TITLE
test: Write files before install

### DIFF
--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -13,8 +13,8 @@ describe('app-dir - server source maps', () => {
     // 'link:' is not suitable for this test since this makes packages
     // not appear in node_modules.
     {
-      'internal-pkg': `file:${path.resolve(__dirname, 'fixtures/default/internal-pkg')}`,
-      'external-pkg': `file:${path.resolve(__dirname, 'fixtures/default/external-pkg')}`,
+      'internal-pkg': `file:./internal-pkg`,
+      'external-pkg': `file:./external-pkg`,
     }
   const { skipped, next, isNextDev, isTurbopack } = nextTestSetup({
     dependencies,

--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -38,6 +38,7 @@ async function createNextInstall({
   packageJson = {},
   dirSuffix = '',
   keepRepoDir = false,
+  beforeInstall,
 }) {
   const tmpDir = await fs.realpath(process.env.NEXT_TEST_DIR || os.tmpdir())
 
@@ -151,6 +152,12 @@ async function createNextInstall({
           2
         )
       )
+
+      if (beforeInstall !== undefined) {
+        rootSpan.traceChild('beforeInstall').traceAsyncFn(async (span) => {
+          await beforeInstall(span, installDir)
+        })
+      }
 
       if (installCommand) {
         const installString =


### PR DESCRIPTION
That way we can install packages that are local to the install (e.g. via `link:` or `file:` protocol).

Before, we had to reference the packages in the Next.js monorepo. This wouldn't allow simulating the install dir as a classic monorepo.