### PR TITLE
Add test for missing sourcemap loader support of `ignoreList`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -48,6 +48,7 @@ bench/nested-deps/components/**/*
 **/.tina/__generated__/**
 test/lib/amp-validator-wasm.js
 test/production/pages-dir/production/fixture/amp-validator-wasm.js
+test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/ignored.js
 test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.js
 test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.js
 test/e2e/async-modules/amp-validator-wasm.js

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/app/rsc-error-log-ignore-listed/page.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/app/rsc-error-log-ignore-listed/page.js
@@ -1,8 +1,9 @@
 import { connection } from 'next/server'
-import { run as runInternal } from 'internal-pkg'
-import { run as runInternalSourceMapped } from 'internal-pkg/sourcemapped'
-import { run as runExternal } from 'external-pkg'
-import { run as runExternalSourceMapped } from 'external-pkg/sourcemapped'
+import { runInternal } from 'internal-pkg'
+import { runInternalSourceMapped } from 'internal-pkg/sourcemapped'
+import { runInternalIgnored } from 'internal-pkg/ignored'
+import { runExternal } from 'external-pkg'
+import { runExternalSourceMapped } from 'external-pkg/sourcemapped'
 
 function logError() {
   const error = new Error('Boom')
@@ -16,7 +17,9 @@ export default async function Page() {
     runInternalSourceMapped(function runWithInternalSourceMapped() {
       runExternal(function runWithExternal() {
         runExternalSourceMapped(function runWithExternalSourceMapped() {
-          logError()
+          runInternalIgnored(function runWithInternalIgnored() {
+            logError()
+          })
         })
       })
     })

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/app/ssr-error-log-ignore-listed/page.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/app/ssr-error-log-ignore-listed/page.js
@@ -1,8 +1,9 @@
 'use client'
-import { run as runInternal } from 'internal-pkg'
-import { run as runInternalSourceMapped } from 'internal-pkg/sourcemapped'
-import { run as runExternal } from 'external-pkg'
-import { run as runExternalSourceMapped } from 'external-pkg/sourcemapped'
+import { runInternal } from 'internal-pkg'
+import { runInternalSourceMapped } from 'internal-pkg/sourcemapped'
+import { runInternalIgnored } from 'internal-pkg/ignored'
+import { runExternal } from 'external-pkg'
+import { runExternalSourceMapped } from 'external-pkg/sourcemapped'
 
 function logError() {
   const error = new Error('Boom')
@@ -14,7 +15,9 @@ export default function Page() {
     runInternalSourceMapped(function runWithInternalSourceMapped() {
       runExternal(function runWithExternal() {
         runExternalSourceMapped(function runWithExternalSourceMapped() {
-          logError()
+          runInternalIgnored(function runWithInternalIgnored() {
+            logError()
+          })
         })
       })
     })

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/index.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/index.js
@@ -1,3 +1,3 @@
-export function run(fn) {
+export function runExternal(fn) {
   return fn()
 }

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.js
@@ -1,4 +1,4 @@
-export function run(fn) {
+export function runExternalSourceMapped(fn) {
     return fn();
 }
 //# sourceMappingURL=sourcemapped.js.map

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.js.map
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.js.map
@@ -1,1 +1,10 @@
-{"version":3,"file":"sourcemapped.js","sourceRoot":"","sources":["sourcemapped.ts"],"names":[],"mappings":"AAGA,MAAM,UAAU,GAAG,CAAI,EAAS;IAC9B,OAAO,EAAE,EAAE,CAAA;AACb,CAAC"}
+{
+  "version": 3,
+  "file": "sourcemapped.js",
+  "sourceRoot": "",
+  "sources": [
+    "sourcemapped.ts"
+  ],
+  "names": [],
+  "mappings": "AAGA,MAAM,UAAU,uBAAuB,CAAI,EAAS;IAClD,OAAO,EAAE,EAAE,CAAA;AACb,CAAC"
+}

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.ts
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.ts
@@ -1,6 +1,6 @@
 // Compile with pnpm tsc test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.ts --sourceMap --target esnext
 // tsc compile errors can be ignored
 type Fn<T> = () => T
-export function run<T>(fn: Fn<T>): T {
+export function runExternalSourceMapped<T>(fn: Fn<T>): T {
   return fn()
 }

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/ignored.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/ignored.js
@@ -1,0 +1,4 @@
+export function runInternalIgnored(fn) {
+    return fn();
+}
+//# sourceMappingURL=ignored.js.map

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/ignored.js.map
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/ignored.js.map
@@ -1,0 +1,13 @@
+{
+  "version": 3,
+  "file": "ignored.js",
+  "sourceRoot": "",
+  "sources": [
+    "ignored.ts"
+  ],
+  "ignoreList": [
+    0
+  ],
+  "names": [],
+  "mappings": "AAIA,MAAM,UAAU,kBAAkB,CAAI,EAAS;IAC7C,OAAO,EAAE,EAAE,CAAA;AACb,CAAC"
+}

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/ignored.ts
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/ignored.ts
@@ -1,0 +1,7 @@
+// Compile with pnpm tsc test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/ignored.ts --sourceMap --target esnext
+// tsc compile errors can be ignored
+// Then ensure `ignoreList` references all `sources`
+type Fn<T> = () => T
+export function runInternalIgnored<T>(fn: Fn<T>): T {
+  return fn()
+}

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/index.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/index.js
@@ -1,3 +1,3 @@
-export function run(fn) {
+export function runInternal(fn) {
   return fn()
 }

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/package.json
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/package.json
@@ -6,6 +6,9 @@
     ".": {
       "default": "./index.js"
     },
+    "./ignored": {
+      "default": "./ignored.js"
+    },
     "./sourcemapped": {
       "default": "./sourcemapped.js"
     }

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.js
@@ -1,4 +1,4 @@
-export function run(fn) {
+export function runInternalSourceMapped(fn) {
     return fn();
 }
 //# sourceMappingURL=sourcemapped.js.map

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.js.map
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"sourcemapped.js","sourceRoot":"","sources":["sourcemapped.ts"],"names":[],"mappings":"AAGA,MAAM,UAAU,GAAG,CAAI,EAAS;IAC9B,OAAO,EAAE,EAAE,CAAA;AACb,CAAC"}
+{"version":3,"file":"sourcemapped.js","sourceRoot":"","sources":["sourcemapped.ts"],"names":[],"mappings":"AAGA,MAAM,UAAU,uBAAuB,CAAI,EAAS;IAClD,OAAO,EAAE,EAAE,CAAA;AACb,CAAC"}

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.ts
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.ts
@@ -1,6 +1,6 @@
-// Compile with p tsc test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.ts --sourceMap --target esnext
+// Compile with pnpm tsc test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.ts --sourceMap --target esnext
 // tsc compile errors can be ignored
 type Fn<T> = () => T
-export function run<T>(fn: Fn<T>): T {
+export function runInternalSourceMapped<T>(fn: Fn<T>): T {
   return fn()
 }


### PR DESCRIPTION
Neither Webpack nor Turbopack preserve this property. Webpack is even worse because the original source URLs are malformed.