### PR TITLE
refactor: minor cleanups in webpack actions code

### DIFF
--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -120,16 +120,12 @@ export function getRSCModuleInformation(
   const parsedActionsMeta = actionsJson
     ? (JSON.parse(actionsJson[1]) as Record<string, string>)
     : undefined
-  const actions = parsedActionsMeta
-    ? (Object.values(parsedActionsMeta) as string[])
-    : undefined
   const clientInfoMatch = source.match(CLIENT_MODULE_LABEL)
   const isClientRef = !!clientInfoMatch
 
   if (!isReactServerLayer) {
     return {
       type: RSC_MODULE_TYPES.client,
-      actions,
       actionIds: parsedActionsMeta,
       isClientRef,
     }
@@ -145,7 +141,6 @@ export function getRSCModuleInformation(
 
   return {
     type,
-    actions,
     actionIds: parsedActionsMeta,
     clientRefs,
     clientEntryType,

--- a/packages/next/src/build/webpack/loaders/get-module-build-info.ts
+++ b/packages/next/src/build/webpack/loaders/get-module-build-info.ts
@@ -28,7 +28,6 @@ export function getModuleBuildInfo(webpackModule: webpack.Module) {
 
 export interface RSCMeta {
   type: RSCModuleType
-  actions?: string[]
   actionIds?: Record<string, string>
   clientRefs?: string[]
   clientEntryType?: 'cjs' | 'auto'

--- a/packages/next/src/build/webpack/loaders/next-flight-action-entry-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-action-entry-loader.ts
@@ -1,18 +1,24 @@
+import type { webpack } from 'next/dist/compiled/webpack/webpack'
+
 export type NextFlightActionEntryLoaderOptions = {
   actions: string
 }
 
-function nextFlightActionEntryLoader(this: any) {
+export type FlightActionEntryLoaderActions = [
+  path: string,
+  actions: [id: string, name: string][],
+][]
+
+function nextFlightActionEntryLoader(
+  this: webpack.LoaderContext<NextFlightActionEntryLoaderOptions>
+) {
   const { actions }: NextFlightActionEntryLoaderOptions = this.getOptions()
 
-  const actionList = JSON.parse(actions) as [
-    string,
-    [id: string, name: string][],
-  ][]
+  const actionList = JSON.parse(actions) as FlightActionEntryLoaderActions
   const individualActions = actionList
     .map(([path, actionsFromModule]) => {
       return actionsFromModule.map(([id, name]) => {
-        return [id, path, name]
+        return [id, path, name] as const
       })
     })
     .flat()

--- a/packages/next/src/build/webpack/loaders/next-flight-action-entry-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-action-entry-loader.ts
@@ -6,7 +6,7 @@ export type NextFlightActionEntryLoaderOptions = {
 
 export type FlightActionEntryLoaderActions = [
   path: string,
-  actions: [id: string, name: string][],
+  actions: { id: string; exportedName: string }[],
 ][]
 
 function nextFlightActionEntryLoader(
@@ -17,17 +17,17 @@ function nextFlightActionEntryLoader(
   const actionList = JSON.parse(actions) as FlightActionEntryLoaderActions
   const individualActions = actionList
     .map(([path, actionsFromModule]) => {
-      return actionsFromModule.map(([id, name]) => {
-        return [id, path, name] as const
+      return actionsFromModule.map(({ id, exportedName }) => {
+        return [id, path, exportedName] as const
       })
     })
     .flat()
 
   return `
 ${individualActions
-  .map(([id, path, name]) => {
+  .map(([id, path, exportedName]) => {
     // Re-export the same functions from the original module path as action IDs.
-    return `export { ${name} as "${id}" } from ${JSON.stringify(path)}`
+    return `export { ${exportedName} as "${id}" } from ${JSON.stringify(path)}`
   })
   .join('\n')}
 `

--- a/packages/next/src/build/webpack/loaders/utils.ts
+++ b/packages/next/src/build/webpack/loaders/utils.ts
@@ -1,20 +1,18 @@
 import type webpack from 'webpack'
 import { RSC_MODULE_TYPES } from '../../../shared/lib/constants'
+import { getModuleBuildInfo } from './get-module-build-info'
 
 const imageExtensions = ['jpg', 'jpeg', 'png', 'webp', 'avif', 'ico', 'svg']
 const imageRegex = new RegExp(`\\.(${imageExtensions.join('|')})$`)
 
 // Determine if the whole module is client action, 'use server' in nested closure in the client module
-function isActionClientLayerModule(mod: { resource: string; buildInfo?: any }) {
-  const rscInfo = mod.buildInfo.rsc
+function isActionClientLayerModule(mod: webpack.NormalModule) {
+  const rscInfo = getModuleBuildInfo(mod).rsc
   return !!(rscInfo?.actionIds && rscInfo?.type === RSC_MODULE_TYPES.client)
 }
 
-export function isClientComponentEntryModule(mod: {
-  resource: string
-  buildInfo?: any
-}) {
-  const rscInfo = mod.buildInfo.rsc
+export function isClientComponentEntryModule(mod: webpack.NormalModule) {
+  const rscInfo = getModuleBuildInfo(mod).rsc
   const hasClientDirective = rscInfo?.isClientRef
   const isActionLayerEntry = isActionClientLayerModule(mod)
   return (
@@ -41,14 +39,6 @@ export function isCSSMod(mod: {
         loader.includes('@vanilla-extract/webpack-plugin/loader/')
     )
   )
-}
-
-// Gives { id: name } record of actions from the build info.
-export function getActionsFromBuildInfo(mod: {
-  resource: string
-  buildInfo?: any
-}): undefined | Record<string, string> {
-  return mod.buildInfo?.rsc?.actionIds
 }
 
 export function encodeToBase64<T extends object>(obj: T): string {

--- a/packages/next/src/build/webpack/loaders/utils.ts
+++ b/packages/next/src/build/webpack/loaders/utils.ts
@@ -7,7 +7,7 @@ const imageRegex = new RegExp(`\\.(${imageExtensions.join('|')})$`)
 // Determine if the whole module is client action, 'use server' in nested closure in the client module
 function isActionClientLayerModule(mod: { resource: string; buildInfo?: any }) {
   const rscInfo = mod.buildInfo.rsc
-  return !!(rscInfo?.actions && rscInfo?.type === RSC_MODULE_TYPES.client)
+  return !!(rscInfo?.actionIds && rscInfo?.type === RSC_MODULE_TYPES.client)
 }
 
 export function isClientComponentEntryModule(mod: {

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -27,7 +27,6 @@ import {
   UNDERSCORE_NOT_FOUND_ROUTE_ENTRY,
 } from '../../../shared/lib/constants'
 import {
-  getActionsFromBuildInfo,
   isClientComponentEntryModule,
   isCSSMod,
   regexCSS,
@@ -578,9 +577,9 @@ export class FlightClientEntryPlugin {
         if (visitedModule.has(modResource)) return
         visitedModule.add(modResource)
 
-        const actions = getActionsFromBuildInfo(mod)
-        if (actions) {
-          collectedActions.set(modResource, Object.entries(actions))
+        const actionsIds = getModuleBuildInfo(mod).rsc?.actionIds
+        if (actionsIds) {
+          collectedActions.set(modResource, Object.entries(actionsIds))
         }
 
         // Collect used exported actions transversely.
@@ -672,9 +671,9 @@ export class FlightClientEntryPlugin {
       }
       visitedOfClientComponentsTraverse.add(modResource)
 
-      const actions = getActionsFromBuildInfo(mod)
-      if (actions) {
-        actionImports.push([modResource, Object.entries(actions)])
+      const actionsIds = getModuleBuildInfo(mod).rsc?.actionIds
+      if (actionsIds) {
+        actionImports.push([modResource, Object.entries(actionsIds)])
       }
 
       if (isCSSMod(mod)) {

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -45,6 +45,7 @@ import { getAssumedSourceType } from '../loaders/next-flight-loader'
 import { isAppRouteRoute } from '../../../lib/is-app-route-route'
 import { isMetadataRoute } from '../../../lib/metadata/is-metadata-route'
 import type { MetadataRouteLoaderOptions } from '../loaders/next-metadata-route-loader'
+import type { FlightActionEntryLoaderActions } from '../loaders/next-flight-action-entry-loader'
 
 interface Options {
   dev: boolean
@@ -880,7 +881,9 @@ export class FlightClientEntryPlugin {
     }
 
     const actionLoader = `next-flight-action-entry-loader?${stringify({
-      actions: JSON.stringify(actionsArray),
+      actions: JSON.stringify(
+        actionsArray satisfies FlightActionEntryLoaderActions
+      ),
       __client_imported__: fromClient,
     })}!`
 


### PR DESCRIPTION
this is a bundle of small cleanups i did while working on https://github.com/vercel/next.js/pull/75908, and i decided to pull them out.
**this PR is intended to be reviewed commit-by-commit**.
i don't want to turn this into a stack because that'll take much longer to merge (unless someone REALLY wants me to)

changes by commit:
1. i removed `RSCMeta.actions`, because it was unused except for one place where `RSCMeta.actionIds` is enough
2. fixed some places that were accessing `module.buildInfo.rsc` in a non-typesafe way, removed redundant `getActionsFromBuildInfo` helper
3. added some type safety to the huge queryparam passed to `next-flight-action-entry-loader`
4. replaced some `[id, name]` tuples in `flight-client-entry-plugin` `next-flight-action-entry-loader` with `{ id, exportedName }`. IMHO tuples where both items are the same type are asking for trouble, names are harder to mess up