### PR TITLE
[DevOverlay]: render indicator in pages router

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/pages/error-boundary.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/pages/error-boundary.tsx
@@ -3,7 +3,6 @@ import * as React from 'react'
 type DevOverlayErrorBoundaryProps = {
   children?: React.ReactNode
   onError: (error: Error, componentStack: string | null) => void
-  isMounted?: boolean
 }
 type DevOverlayErrorBoundaryState = { error: Error | null }
 

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/pages/react-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/pages/react-dev-overlay.tsx
@@ -20,13 +20,8 @@ interface ReactDevOverlayProps {
 }
 
 export default function ReactDevOverlay({ children }: ReactDevOverlayProps) {
-  const {
-    isMounted,
-    state,
-    onComponentError,
-    hasRuntimeErrors,
-    hasBuildError,
-  } = usePagesReactDevOverlay()
+  const { state, onComponentError, hasRuntimeErrors, hasBuildError } =
+    usePagesReactDevOverlay()
 
   const { readyErrors, totalErrorCount } = useErrorHook({
     state,
@@ -37,33 +32,31 @@ export default function ReactDevOverlay({ children }: ReactDevOverlayProps) {
 
   return (
     <>
-      <DevOverlayErrorBoundary isMounted={isMounted} onError={onComponentError}>
+      <DevOverlayErrorBoundary onError={onComponentError}>
         {children ?? null}
       </DevOverlayErrorBoundary>
 
-      {isMounted && (
-        <ShadowPortal>
-          <CssReset />
-          <Base />
-          <Colors />
-          <ComponentStyles />
+      <ShadowPortal>
+        <CssReset />
+        <Base />
+        <Colors />
+        <ComponentStyles />
 
-          <DevToolsIndicator
+        <DevToolsIndicator
+          state={state}
+          errorCount={totalErrorCount}
+          setIsErrorOverlayOpen={setIsErrorOverlayOpen}
+        />
+
+        {(hasRuntimeErrors || hasBuildError) && (
+          <ErrorOverlay
             state={state}
-            errorCount={totalErrorCount}
+            readyErrors={readyErrors}
+            isErrorOverlayOpen={isErrorOverlayOpen}
             setIsErrorOverlayOpen={setIsErrorOverlayOpen}
           />
-
-          {(hasRuntimeErrors || hasBuildError) && (
-            <ErrorOverlay
-              state={state}
-              readyErrors={readyErrors}
-              isErrorOverlayOpen={isErrorOverlayOpen}
-              setIsErrorOverlayOpen={setIsErrorOverlayOpen}
-            />
-          )}
-        </ShadowPortal>
-      )}
+        )}
+      </ShadowPortal>
     </>
   )
 }

--- a/packages/next/src/client/components/react-dev-overlay/pages/error-boundary.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/pages/error-boundary.tsx
@@ -3,7 +3,6 @@ import * as React from 'react'
 type ErrorBoundaryProps = {
   children?: React.ReactNode
   onError: (error: Error, componentStack: string | null) => void
-  isMounted?: boolean
 }
 type ErrorBoundaryState = { error: Error | null }
 

--- a/packages/next/src/client/components/react-dev-overlay/pages/hooks.ts
+++ b/packages/next/src/client/components/react-dev-overlay/pages/hooks.ts
@@ -21,15 +21,8 @@ export const usePagesReactDevOverlay = () => {
 
   const hasBuildError = state.buildError != null
   const hasRuntimeErrors = Boolean(state.errors.length)
-  const errorType = hasBuildError
-    ? 'build'
-    : hasRuntimeErrors
-      ? 'runtime'
-      : null
-  const isMounted = errorType !== null
 
   return {
-    isMounted,
     hasBuildError,
     hasRuntimeErrors,
     state,

--- a/packages/next/src/client/components/react-dev-overlay/pages/old-react-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/pages/old-react-dev-overlay.tsx
@@ -16,17 +16,13 @@ export default function ReactDevOverlay({
 }: {
   children?: React.ReactNode
 }) {
-  const {
-    isMounted,
-    hasBuildError,
-    hasRuntimeErrors,
-    state,
-    onComponentError,
-  } = usePagesReactDevOverlay()
+  const { hasBuildError, hasRuntimeErrors, state, onComponentError } =
+    usePagesReactDevOverlay()
+  const isMounted = hasBuildError || hasRuntimeErrors
 
   return (
     <>
-      <ErrorBoundary isMounted={isMounted} onError={onComponentError}>
+      <ErrorBoundary onError={onComponentError}>
         {children ?? null}
       </ErrorBoundary>
       {isMounted ? (

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -123,7 +123,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
-                 <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                 <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                      <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Mismatch>
@@ -192,7 +192,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
-                 <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                 <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                      <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Mismatch>
@@ -256,7 +256,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
-                 <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                 <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                      <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Mismatch>
@@ -316,7 +316,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
-                 <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                 <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                      <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Mismatch>
@@ -382,7 +382,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
-                 <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                 <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                      <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Mismatch>
@@ -449,7 +449,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
-                 <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                 <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                      <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Page>
@@ -505,19 +505,19 @@ describe('Error overlay for hydration errors in Pages router', () => {
       const pseudoHtml = await session.getRedboxComponentStack()
       if (isTurbopack) {
         expect(pseudoHtml).toMatchInlineSnapshot(`
-          "<Root callbacks={[...]}>
-              <Head>
-              <AppContainer>
-                <Container fn={function fn}>
-                  <ReactDevOverlay>
-                    <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
-                      <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                        <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
-                          <Page>
-          +                 <table>
-          -                 {" 123"}
-                        ..."
-         `)
+         "<Root callbacks={[...]}>
+             <Head>
+             <AppContainer>
+               <Container fn={function fn}>
+                 <ReactDevOverlay>
+                   <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                     <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
+                       <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+                         <Page>
+         +                 <table>
+         -                 {" 123"}
+                       ..."
+        `)
       } else {
         expect(pseudoHtml).toMatchInlineSnapshot(`
          "<Root callbacks={[...]}>
@@ -525,7 +525,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
              <AppContainer>
                <Container fn={function fn}>
                  <ReactDevOverlay>
-                   <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                   <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                      <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                        <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                          <Page>
@@ -576,7 +576,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
       expect(pseudoHtml).toMatchInlineSnapshot(`
        "...
            <ReactDevOverlay>
-             <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+             <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                  <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                    <Mismatch>
@@ -686,7 +686,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
-                 <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                 <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                      <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Page>
@@ -752,7 +752,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
        "...
            <Container fn={function fn}>
              <ReactDevOverlay>
-               <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+               <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                  <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                    <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                      <Page>
@@ -812,7 +812,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
-                 <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                 <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                      <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Page>
@@ -876,7 +876,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            <AppContainer>
              <Container fn={function fn}>
                <ReactDevOverlay>
-                 <ErrorBoundary isMounted={false} onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
+                 <ErrorBoundary onError={function usePagesReactDevOverlay.useCallback[onComponentError]}>
                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
                      <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
                        <Page>


### PR DESCRIPTION
We weren't rendering the new indicator when used in pages router -- `isMounted` was only true when there was an error. This PR keeps the `isMounted` logic for the old overlay but removes it for the new one.