### PR TITLE
Restore `--no-mangling` CLI option for `next build`

### DIFF
--- a/crates/napi/src/minify.rs
+++ b/crates/napi/src/minify.rs
@@ -119,13 +119,11 @@ fn patch_opts(opts: &mut JsMinifyOptions) {
         ..Default::default()
     });
 
-    if opts.mangle.is_true() {
-        opts.mangle = BoolOrDataConfig::from_obj(MangleOptions {
-            reserved: vec!["AbortSignal".into()],
-            ..Default::default()
-        });
-    } else if opts.mangle.is_obj() {
-        let mangle = std::mem::take(&mut opts.mangle);
+    if !opts.mangle.is_false() {
+        let mut mangle = std::mem::take(&mut opts.mangle);
+        if mangle.is_true() {
+            mangle = BoolOrDataConfig::from_obj(MangleOptions::default());
+        }
         opts.mangle = mangle.map(|mut mangle_opts| {
             mangle_opts.reserved.push("AbortSignal".into());
             mangle_opts

--- a/crates/napi/src/minify.rs
+++ b/crates/napi/src/minify.rs
@@ -118,10 +118,19 @@ fn patch_opts(opts: &mut JsMinifyOptions) {
         .collect(),
         ..Default::default()
     });
-    opts.mangle = BoolOrDataConfig::from_obj(MangleOptions {
-        reserved: vec!["AbortSignal".into()],
-        ..Default::default()
-    })
+
+    if opts.mangle.is_true() {
+        opts.mangle = BoolOrDataConfig::from_obj(MangleOptions {
+            reserved: vec!["AbortSignal".into()],
+            ..Default::default()
+        });
+    } else if opts.mangle.is_obj() {
+        let mangle = std::mem::take(&mut opts.mangle);
+        opts.mangle = mangle.map(|mut mangle_opts| {
+            mangle_opts.reserved.push("AbortSignal".into());
+            mangle_opts
+        });
+    }
 }
 
 #[napi]

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -144,6 +144,9 @@ pub struct NapiProjectOptions {
 
     /// The browserslist query to use for targeting browsers.
     pub browserslist_query: String,
+
+    /// Whether mangling should be disabled
+    pub no_mangling: bool,
 }
 
 /// [NapiProjectOptions] with all fields optional.
@@ -190,6 +193,9 @@ pub struct NapiPartialProjectOptions {
 
     /// The browserslist query to use for targeting browsers.
     pub browserslist_query: Option<String>,
+
+    /// Whether mangling should be disabled
+    pub no_mangling: Option<bool>,
 }
 
 #[napi(object)]
@@ -241,6 +247,7 @@ impl From<NapiProjectOptions> for ProjectOptions {
             build_id: val.build_id.into(),
             preview_props: val.preview_props.into(),
             browserslist_query: val.browserslist_query.into(),
+            no_mangling: val.no_mangling,
         }
     }
 }

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -145,7 +145,9 @@ pub struct NapiProjectOptions {
     /// The browserslist query to use for targeting browsers.
     pub browserslist_query: String,
 
-    /// Whether mangling should be disabled
+    /// When the code is minified, this opts out of the default mangling of
+    /// local names for variables, functions etc., which can be useful for
+    /// debugging/profiling purposes.
     pub no_mangling: bool,
 }
 
@@ -194,7 +196,9 @@ pub struct NapiPartialProjectOptions {
     /// The browserslist query to use for targeting browsers.
     pub browserslist_query: Option<String>,
 
-    /// Whether mangling should be disabled
+    /// When the code is minified, this opts out of the default mangling of
+    /// local names for variables, functions etc., which can be useful for
+    /// debugging/profiling purposes.
     pub no_mangling: Option<bool>,
 }
 

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -197,6 +197,7 @@ impl AppProject {
             self.project().next_mode(),
             self.project().next_config(),
             self.project().encryption_key(),
+            self.project().no_mangling(),
         ))
     }
 

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -331,6 +331,7 @@ impl PagesProject {
             self.project().next_mode(),
             self.project().next_config(),
             self.project().encryption_key(),
+            self.project().no_mangling(),
         ))
     }
 

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -175,7 +175,9 @@ pub struct ProjectOptions {
     /// The browserslist query to use for targeting browsers.
     pub browserslist_query: RcStr,
 
-    /// Whether mangling should be disabled
+    /// When the code is minified, this opts out of the default mangling of
+    /// local names for variables, functions etc., which can be useful for
+    /// debugging/profiling purposes.
     pub no_mangling: bool,
 }
 
@@ -549,7 +551,9 @@ pub struct Project {
 
     preview_props: DraftModeOptions,
 
-    /// Whether mangling should be disabled
+    /// When the code is minified, this opts out of the default mangling of
+    /// local names for variables, functions etc., which can be useful for
+    /// debugging/profiling purposes.
     no_mangling: bool,
 }
 

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -174,6 +174,9 @@ pub struct ProjectOptions {
 
     /// The browserslist query to use for targeting browsers.
     pub browserslist_query: RcStr,
+
+    /// Whether mangling should be disabled
+    pub no_mangling: bool,
 }
 
 #[derive(
@@ -421,6 +424,7 @@ impl ProjectContainer {
         let build_id;
         let preview_props;
         let browserslist_query;
+        let no_mangling;
         {
             let options = self.options_state.get();
             let options = options
@@ -443,6 +447,7 @@ impl ProjectContainer {
             build_id = options.build_id.clone();
             preview_props = options.preview_props.clone();
             browserslist_query = options.browserslist_query.clone();
+            no_mangling = options.no_mangling
         }
 
         let dist_dir = next_config
@@ -470,6 +475,7 @@ impl ProjectContainer {
             build_id,
             encryption_key,
             preview_props,
+            no_mangling,
         }
         .cell())
     }
@@ -542,6 +548,9 @@ pub struct Project {
     encryption_key: RcStr,
 
     preview_props: DraftModeOptions,
+
+    /// Whether mangling should be disabled
+    no_mangling: bool,
 }
 
 #[turbo_tasks::value]
@@ -727,6 +736,11 @@ impl Project {
     #[turbo_tasks::function]
     pub(super) fn encryption_key(&self) -> Vc<RcStr> {
         Vc::cell(self.encryption_key.clone())
+    }
+
+    #[turbo_tasks::function]
+    pub(super) fn no_mangling(&self) -> Vc<bool> {
+        Vc::cell(self.no_mangling)
     }
 
     #[turbo_tasks::function]
@@ -950,6 +964,7 @@ impl Project {
             self.module_id_strategy(),
             self.next_config().turbo_minify(self.next_mode()),
             self.next_config().turbo_source_maps(),
+            self.no_mangling(),
         )
     }
 
@@ -970,6 +985,7 @@ impl Project {
                 self.module_id_strategy(),
                 self.next_config().turbo_minify(self.next_mode()),
                 self.next_config().turbo_source_maps(),
+                self.no_mangling(),
             )
         } else {
             get_server_chunking_context(
@@ -981,6 +997,7 @@ impl Project {
                 self.module_id_strategy(),
                 self.next_config().turbo_minify(self.next_mode()),
                 self.next_config().turbo_source_maps(),
+                self.no_mangling(),
             )
         }
     }
@@ -1002,6 +1019,7 @@ impl Project {
                 self.module_id_strategy(),
                 self.next_config().turbo_minify(self.next_mode()),
                 self.next_config().turbo_source_maps(),
+                self.no_mangling(),
             )
         } else {
             get_edge_chunking_context(
@@ -1013,6 +1031,7 @@ impl Project {
                 self.module_id_strategy(),
                 self.next_config().turbo_minify(self.next_mode()),
                 self.next_config().turbo_source_maps(),
+                self.no_mangling(),
             )
         }
     }

--- a/crates/next-build-test/src/main.rs
+++ b/crates/next-build-test/src/main.rs
@@ -165,6 +165,7 @@ fn main() {
                 browserslist_query: "last 1 Chrome versions, last 1 Firefox versions, last 1 \
                                      Safari versions, last 1 Edge versions"
                     .into(),
+                no_mangling: false,
             };
 
             let json = serde_json::to_string_pretty(&options).unwrap();

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -222,6 +222,7 @@ pub async fn get_client_module_options_context(
     mode: Vc<NextMode>,
     next_config: Vc<NextConfig>,
     encryption_key: ResolvedVc<RcStr>,
+    no_mangling: Vc<bool>,
 ) -> Result<Vc<ModuleOptionsContext>> {
     let next_mode = mode.await?;
     let resolve_options_context = get_client_resolve_options_context(
@@ -382,7 +383,9 @@ pub async fn get_client_module_options_context(
         enable_mdx_rs,
         css: CssOptionsContext {
             minify_type: if *next_config.turbo_minify(mode).await? {
-                MinifyType::Minify
+                MinifyType::Minify {
+                    mangle: !*no_mangling.await?,
+                }
             } else {
                 MinifyType::NoMinify
             },
@@ -417,6 +420,7 @@ pub async fn get_client_chunking_context(
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     minify: Vc<bool>,
     source_maps: Vc<bool>,
+    no_mangling: Vc<bool>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
     let next_mode = mode.await?;
     let mut builder = BrowserChunkingContext::builder(
@@ -434,7 +438,9 @@ pub async fn get_client_chunking_context(
     )
     .chunk_base_path(asset_prefix)
     .minify_type(if *minify.await? {
-        MinifyType::Minify
+        MinifyType::Minify {
+            mangle: !*no_mangling.await?,
+        }
     } else {
         MinifyType::NoMinify
     })

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1499,9 +1499,9 @@ impl NextConfig {
 
     #[turbo_tasks::function]
     pub async fn turbo_source_maps(&self) -> Result<Vc<bool>> {
-        let minify = self.experimental.turbo.as_ref().and_then(|t| t.source_maps);
+        let source_maps = self.experimental.turbo.as_ref().and_then(|t| t.source_maps);
 
-        Ok(Vc::cell(minify.unwrap_or(true)))
+        Ok(Vc::cell(source_maps.unwrap_or(true)))
     }
 }
 

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -212,6 +212,7 @@ pub async fn get_edge_chunking_context_with_client_assets(
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     turbo_minify: Vc<bool>,
     turbo_source_maps: Vc<bool>,
+    no_mangling: Vc<bool>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
     let output_root = node_root.join("server/edge".into()).to_resolved().await?;
     let next_mode = mode.await?;
@@ -230,7 +231,9 @@ pub async fn get_edge_chunking_context_with_client_assets(
     )
     .asset_base_path(asset_prefix)
     .minify_type(if *turbo_minify.await? {
-        MinifyType::Minify
+        MinifyType::Minify {
+            mangle: !*no_mangling.await?,
+        }
     } else {
         MinifyType::NoMinify
     })
@@ -261,6 +264,7 @@ pub async fn get_edge_chunking_context(
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     turbo_minify: Vc<bool>,
     turbo_source_maps: Vc<bool>,
+    no_mangling: Vc<bool>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
     let output_root = node_root.join("server/edge".into()).to_resolved().await?;
     let next_mode = mode.await?;
@@ -280,7 +284,9 @@ pub async fn get_edge_chunking_context(
     // asset from the output directory.
     .asset_base_path(ResolvedVc::cell(Some("blob:server/edge/".into())))
     .minify_type(if *turbo_minify.await? {
-        MinifyType::Minify
+        MinifyType::Minify {
+            mangle: !*no_mangling.await?,
+        }
     } else {
         MinifyType::NoMinify
     })

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -990,6 +990,7 @@ pub async fn get_server_chunking_context_with_client_assets(
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     turbo_minify: Vc<bool>,
     turbo_source_maps: Vc<bool>,
+    no_mangling: Vc<bool>,
 ) -> Result<Vc<NodeJsChunkingContext>> {
     let next_mode = mode.await?;
     // TODO(alexkirsz) This should return a trait that can be implemented by the
@@ -1013,7 +1014,9 @@ pub async fn get_server_chunking_context_with_client_assets(
     )
     .asset_prefix(asset_prefix)
     .minify_type(if *turbo_minify.await? {
-        MinifyType::Minify
+        MinifyType::Minify {
+            mangle: !*no_mangling.await?,
+        }
     } else {
         MinifyType::NoMinify
     })
@@ -1049,6 +1052,7 @@ pub async fn get_server_chunking_context(
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     turbo_minify: Vc<bool>,
     turbo_source_maps: Vc<bool>,
+    no_mangling: Vc<bool>,
 ) -> Result<Vc<NodeJsChunkingContext>> {
     let next_mode = mode.await?;
     // TODO(alexkirsz) This should return a trait that can be implemented by the
@@ -1065,7 +1069,9 @@ pub async fn get_server_chunking_context(
         next_mode.runtime_type(),
     )
     .minify_type(if *turbo_minify.await? {
-        MinifyType::Minify
+        MinifyType::Minify {
+            mangle: !*no_mangling.await?,
+        }
     } else {
         MinifyType::NoMinify
     })

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -128,7 +128,11 @@ export interface NapiProjectOptions {
   previewProps: NapiDraftModeOptions
   /** The browserslist query to use for targeting browsers. */
   browserslistQuery: string
-  /** Whether mangling should be disabled */
+  /**
+   * When the code is minified, this opts out of the default mangling of
+   * local names for variables, functions etc., which can be useful for
+   * debugging/profiling purposes.
+   */
   noMangling: boolean
 }
 /** [NapiProjectOptions] with all fields optional. */
@@ -168,7 +172,11 @@ export interface NapiPartialProjectOptions {
   previewProps?: NapiDraftModeOptions
   /** The browserslist query to use for targeting browsers. */
   browserslistQuery?: string
-  /** Whether mangling should be disabled */
+  /**
+   * When the code is minified, this opts out of the default mangling of
+   * local names for variables, functions etc., which can be useful for
+   * debugging/profiling purposes.
+   */
   noMangling?: boolean
 }
 export interface NapiDefineEnv {

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -128,6 +128,8 @@ export interface NapiProjectOptions {
   previewProps: NapiDraftModeOptions
   /** The browserslist query to use for targeting browsers. */
   browserslistQuery: string
+  /** Whether mangling should be disabled */
+  noMangling: boolean
 }
 /** [NapiProjectOptions] with all fields optional. */
 export interface NapiPartialProjectOptions {
@@ -166,6 +168,8 @@ export interface NapiPartialProjectOptions {
   previewProps?: NapiDraftModeOptions
   /** The browserslist query to use for targeting browsers. */
   browserslistQuery?: string
+  /** Whether mangling should be disabled */
+  noMangling?: boolean
 }
 export interface NapiDefineEnv {
   client: Array<NapiEnvVar>

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1290,7 +1290,10 @@ export function transformSync(src: string, options?: any): any {
   return bindings.transformSync(src, options)
 }
 
-export async function minify(src: string, options: any): Promise<string> {
+export async function minify(
+  src: string,
+  options: any
+): Promise<{ code: string; map: any }> {
   let bindings = await loadBindings()
   return bindings.minify(src, options)
 }

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -380,6 +380,11 @@ export interface ProjectOptions {
    * The browserslist query to use for targeting browsers.
    */
   browserslistQuery: string
+
+  /**
+   * Whether mangling should be disabled
+   */
+  noMangling: boolean
 }
 
 export interface DefineEnv {

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -382,7 +382,9 @@ export interface ProjectOptions {
   browserslistQuery: string
 
   /**
-   * Whether mangling should be disabled
+   * When the code is minified, this opts out of the default mangling of local
+   * names for variables, functions etc., which can be useful for
+   * debugging/profiling purposes.
    */
   noMangling: boolean
 }

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -51,6 +51,7 @@ export async function turbopackBuild(): Promise<{
   const hasRewrites = NextBuildContext.hasRewrites!
   const rewrites = NextBuildContext.rewrites!
   const appDirOnly = NextBuildContext.appDirOnly!
+  const noMangling = NextBuildContext.noMangling!
 
   const startTime = process.hrtime()
   const bindings = await loadBindings(config?.experimental?.useWasmBinary)
@@ -90,6 +91,7 @@ export async function turbopackBuild(): Promise<{
       encryptionKey,
       previewProps,
       browserslistQuery: supportedBrowsers.join(', '),
+      noMangling,
     },
     {
       persistentCaching,

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -295,6 +295,7 @@ export default async function getBaseWebpackConfig(
     runWebpackSpan,
     appDir,
     middlewareMatchers,
+    noMangling,
     jsConfig,
     jsConfigPath,
     resolvedBaseUrl,
@@ -1105,7 +1106,7 @@ export default async function getBaseWebpackConfig(
               // @ts-ignore No typings yet
               const { MinifyPlugin } =
                 require('./webpack/plugins/minify-webpack-plugin/src/index.js') as typeof import('./webpack/plugins/minify-webpack-plugin/src')
-              new MinifyPlugin().apply(compiler)
+              new MinifyPlugin({ noMangling }).apply(compiler)
             },
             // Minify CSS
             (compiler: webpack.Compiler) => {

--- a/packages/next/src/build/webpack/plugins/minify-webpack-plugin/src/index.ts
+++ b/packages/next/src/build/webpack/plugins/minify-webpack-plugin/src/index.ts
@@ -2,13 +2,16 @@ import {
   webpack,
   ModuleFilenameHelpers,
   sources,
+  WebpackError,
+  type CacheFacade,
+  type Compilation,
 } from 'next/dist/compiled/webpack/webpack'
 import pLimit from 'next/dist/compiled/p-limit'
 import { spans } from '../../profiling-plugin'
 
 function buildError(error: any, file: string) {
   if (error.line) {
-    return new Error(
+    return new WebpackError(
       `${file} from Minifier\n${error.message} [${file}:${error.line},${
         error.col
       }]${
@@ -18,27 +21,44 @@ function buildError(error: any, file: string) {
   }
 
   if (error.stack) {
-    return new Error(`${file} from Minifier\n${error.message}\n${error.stack}`)
+    return new WebpackError(
+      `${file} from Minifier\n${error.message}\n${error.stack}`
+    )
   }
 
-  return new Error(`${file} from Minifier\n${error.message}`)
+  return new WebpackError(`${file} from Minifier\n${error.message}`)
 }
 
 const debugMinify = process.env.NEXT_DEBUG_MINIFY
 
 export class MinifyPlugin {
+  constructor(private options: { noMangling?: boolean }) {}
+
   async optimize(
     compiler: any,
-    compilation: any,
+    compilation: Compilation,
     assets: any,
-    cache: any,
-    { SourceMapSource, RawSource }: any
+    cache: CacheFacade,
+    {
+      SourceMapSource,
+      RawSource,
+    }: {
+      SourceMapSource: typeof sources.SourceMapSource
+      RawSource: typeof sources.RawSource
+    }
   ) {
+    const mangle = this.options.noMangling ? false : true
     const compilationSpan = spans.get(compilation)! || spans.get(compiler)
+
     const MinifierSpan = compilationSpan.traceChild(
       'minify-webpack-plugin-optimize'
     )
-    MinifierSpan.setAttribute('compilationName', compilation.name)
+
+    if (compilation.name) {
+      MinifierSpan.setAttribute('compilationName', compilation.name)
+    }
+
+    MinifierSpan.setAttribute('mangle', String(mangle))
 
     return MinifierSpan.traceAsyncFn(async () => {
       const assetsList = Object.keys(assets)
@@ -72,21 +92,21 @@ export class MinifyPlugin {
             return true
           })
           .map(async (name) => {
-            const { info, source } = compilation.getAsset(name)
+            const { info, source } = compilation.getAsset(name)!
 
-            const eTag = cache.getLazyHashedEtag(source)
-            const output = await cache.getPromise(name, eTag)
+            const eTag = cache.mergeEtags(
+              cache.getLazyHashedEtag(source),
+              JSON.stringify(this.options)
+            )
+
+            const output = await cache.getPromise<
+              { source: sources.Source } | undefined
+            >(name, eTag)
 
             if (debugMinify && debugMinify === '1') {
               console.log(
-                JSON.stringify({
-                  name,
-                  source: source.source().toString(),
-                }),
-                {
-                  breakLength: Infinity,
-                  maxStringLength: Infinity,
-                }
+                JSON.stringify({ name, source: source.source().toString() }),
+                { breakLength: Infinity, maxStringLength: Infinity }
               )
             }
             return { name, info, inputSource: source, output, eTag }
@@ -98,25 +118,29 @@ export class MinifyPlugin {
       // eslint-disable-next-line consistent-return
       const getWorker = () => {
         return {
-          minify: async (options: any) => {
-            const result = await require('../../../../swc').minify(
-              options.input,
-              {
-                ...(options.inputSourceMap
-                  ? {
-                      sourceMap: {
-                        content: JSON.stringify(options.inputSourceMap),
-                      },
-                    }
-                  : {}),
-                compress: true,
-                mangle: true,
-                module: 'unknown',
-                output: {
-                  comments: false,
-                },
-              }
-            )
+          minify: async (options: {
+            input: string
+            inputSourceMap: Object
+          }) => {
+            const result = await (
+              require('../../../../swc') as typeof import('../../../../swc')
+            ).minify(options.input, {
+              ...(options.inputSourceMap
+                ? {
+                    sourceMap: {
+                      content: JSON.stringify(options.inputSourceMap),
+                    },
+                  }
+                : {}),
+              // Compress options are defined in crates/napi/src/minify.rs.
+              compress: false,
+              // Mangle options may be amended in crates/napi/src/minify.rs.
+              mangle,
+              module: 'unknown',
+              output: {
+                comments: false,
+              },
+            })
 
             return result
           },
@@ -149,42 +173,38 @@ export class MinifyPlugin {
                   ? sourceFromInputSource.toString()
                   : sourceFromInputSource
 
-                const options = {
-                  name,
-                  input,
-                  inputSourceMap,
-                }
+                let minifiedOutput: { code: string; map: any } | undefined
 
                 try {
-                  output = await getWorker().minify(options)
+                  minifiedOutput = await getWorker().minify({
+                    input,
+                    inputSourceMap,
+                  })
                 } catch (error) {
                   compilation.errors.push(buildError(error, name))
 
                   return
                 }
 
-                if (output.map) {
-                  output.source = new SourceMapSource(
-                    output.code,
-                    name,
-                    output.map,
-                    input,
-                    inputSourceMap,
-                    true
-                  )
-                } else {
-                  output.source = new RawSource(output.code)
-                }
+                const source = minifiedOutput.map
+                  ? new SourceMapSource(
+                      minifiedOutput.code,
+                      name,
+                      minifiedOutput.map,
+                      input,
+                      inputSourceMap,
+                      true
+                    )
+                  : new RawSource(minifiedOutput.code)
 
-                await cache.storePromise(name, eTag, {
-                  source: output.source,
-                })
+                await cache.storePromise(name, eTag, { source })
+
+                output = { source }
               }
 
               const newInfo = { minimized: true }
-              const { source } = output
 
-              compilation.updateAsset(name, source, newInfo)
+              compilation.updateAsset(name, output.source, newInfo)
             })
           })
         )
@@ -199,48 +219,53 @@ export class MinifyPlugin {
   }
 
   apply(compiler: any) {
-    const { SourceMapSource, RawSource } = compiler?.webpack?.sources || sources
+    const { SourceMapSource, RawSource } = (compiler?.webpack?.sources ||
+      sources) as typeof sources
+
     const pluginName = this.constructor.name
 
-    compiler.hooks.thisCompilation.tap(pluginName, (compilation: any) => {
-      const cache = compilation.getCache('MinifierWebpackPlugin')
+    compiler.hooks.thisCompilation.tap(
+      pluginName,
+      (compilation: Compilation) => {
+        const cache = compilation.getCache('MinifierWebpackPlugin')
 
-      const handleHashForChunk = (hash: any, _chunk: any) => {
-        // increment 'c' to invalidate cache
-        hash.update('c')
-      }
+        const handleHashForChunk = (hash: any, _chunk: any) => {
+          // increment 'c' to invalidate cache
+          hash.update('c')
+        }
 
-      const JSModulesHooks =
-        webpack.javascript.JavascriptModulesPlugin.getCompilationHooks(
-          compilation
-        )
-      JSModulesHooks.chunkHash.tap(pluginName, (chunk, hash) => {
-        if (!chunk.hasRuntime()) return
-        return handleHashForChunk(hash, chunk)
-      })
-
-      compilation.hooks.processAssets.tapPromise(
-        {
-          name: pluginName,
-          stage: webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE,
-        },
-        (assets: any) =>
-          this.optimize(compiler, compilation, assets, cache, {
-            SourceMapSource,
-            RawSource,
-          })
-      )
-
-      compilation.hooks.statsPrinter.tap(pluginName, (stats: any) => {
-        stats.hooks.print
-          .for('asset.info.minimized')
-          .tap(
-            'minify-webpack-plugin',
-            (minimized: any, { green, formatFlag }: any) =>
-              // eslint-disable-next-line no-undefined
-              minimized ? green(formatFlag('minimized')) : undefined
+        const JSModulesHooks =
+          webpack.javascript.JavascriptModulesPlugin.getCompilationHooks(
+            compilation
           )
-      })
-    })
+        JSModulesHooks.chunkHash.tap(pluginName, (chunk, hash) => {
+          if (!chunk.hasRuntime()) return
+          return handleHashForChunk(hash, chunk)
+        })
+
+        compilation.hooks.processAssets.tapPromise(
+          {
+            name: pluginName,
+            stage: webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE,
+          },
+          (assets: any) =>
+            this.optimize(compiler, compilation, assets, cache, {
+              SourceMapSource,
+              RawSource,
+            })
+        )
+
+        compilation.hooks.statsPrinter.tap(pluginName, (stats: any) => {
+          stats.hooks.print
+            .for('asset.info.minimized')
+            .tap(
+              'minify-webpack-plugin',
+              (minimized: any, { green, formatFlag }: any) =>
+                // eslint-disable-next-line no-undefined
+                minimized ? green(formatFlag('minimized')) : undefined
+            )
+        })
+      }
+    )
   }
 }

--- a/packages/next/src/build/webpack/plugins/minify-webpack-plugin/src/index.ts
+++ b/packages/next/src/build/webpack/plugins/minify-webpack-plugin/src/index.ts
@@ -47,7 +47,7 @@ export class MinifyPlugin {
       RawSource: typeof sources.RawSource
     }
   ) {
-    const mangle = this.options.noMangling ? false : true
+    const mangle = !this.options.noMangling
     const compilationSpan = spans.get(compilation)! || spans.get(compiler)
 
     const MinifierSpan = compilationSpan.traceChild(

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -233,6 +233,7 @@ export async function createHotReloaderTurbopack(
       encryptionKey,
       previewProps: opts.fsChecker.prerenderManifest.preview,
       browserslistQuery: supportedBrowsers.join(', '),
+      noMangling: false,
     },
     {
       persistentCaching: isPersistentCachingEnabled(opts.nextConfig),

--- a/packages/next/types/$$compiled.internal.d.ts
+++ b/packages/next/types/$$compiled.internal.d.ts
@@ -772,13 +772,11 @@ declare module 'next/dist/compiled/webpack-sources3' {
 }
 
 declare module 'next/dist/compiled/webpack/webpack' {
-  import type webpackSources from 'webpack-sources1'
   import { type Compilation, Module } from 'webpack'
 
   export function init(): void
   export let BasicEvaluatedExpression: any
   export let GraphHelpers: any
-  export let sources: typeof webpackSources
   export let StringXor: any
   export class ConcatenatedModule extends Module {
     rootModule: Module
@@ -888,6 +886,8 @@ declare module 'next/dist/compiled/webpack/webpack' {
     NormalModule,
     ResolvePluginInstance,
     ModuleFilenameHelpers,
+    WebpackError,
+    sources,
   } from 'webpack'
   export type {
     javascript,
@@ -895,4 +895,6 @@ declare module 'next/dist/compiled/webpack/webpack' {
     LoaderContext,
     ModuleGraph,
   } from 'webpack'
+
+  export type CacheFacade = ReturnType<Compilation['getCache']>
 }

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -229,6 +229,7 @@ describe('next.rs api', () => {
         previewModeSigningKey: '12345',
       },
       browserslistQuery: 'last 2 versions',
+      noMangling: false,
     })
     projectUpdateSubscription = filterMapAsyncIterator(
       project.updateInfoSubscribe(1000),

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -35,7 +35,9 @@ export interface NextInstanceOpts {
   nextConfig?: NextConfig
   installCommand?: InstallCommand
   buildCommand?: string
+  buildOptions?: string[]
   startCommand?: string
+  startOptions?: string[]
   env?: Record<string, string>
   dirSuffix?: string
   turbo?: boolean
@@ -64,7 +66,9 @@ export class NextInstance {
   protected nextConfig?: NextConfig
   protected installCommand?: InstallCommand
   protected buildCommand?: string
+  protected buildOptions?: string
   protected startCommand?: string
+  protected startOptions?: string[]
   protected dependencies?: PackageJson['dependencies'] = {}
   protected resolutions?: PackageJson['resolutions']
   protected events: { [eventName: string]: Set<any> } = {}

--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -41,6 +41,10 @@ export class NextDevInstance extends NextInstance {
       startArgs = this.startCommand.split(' ')
     }
 
+    if (this.startOptions) {
+      startArgs.push(...this.startOptions)
+    }
+
     if (process.env.NEXT_SKIP_ISOLATE) {
       // without isolation yarn can't be used and pnpm must be used instead
       if (startArgs[0] === 'yarn') {

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -70,8 +70,16 @@ export class NextStartInstance extends NextInstance {
       buildArgs = this.buildCommand.split(' ')
     }
 
+    if (this.buildOptions) {
+      buildArgs.push(...this.buildOptions)
+    }
+
     if (this.startCommand) {
       startArgs = this.startCommand.split(' ')
+    }
+
+    if (this.startOptions) {
+      startArgs.push(...this.startOptions)
     }
 
     if (process.env.NEXT_SKIP_ISOLATE) {
@@ -185,6 +193,10 @@ export class NextStartInstance extends NextInstance {
     return new Promise((resolve) => {
       const curOutput = this._cliOutput.length
       const exportArgs = ['pnpm', 'next', 'build']
+
+      if (this.buildOptions) {
+        exportArgs.push(...this.buildOptions)
+      }
 
       if (this.childProcess) {
         throw new Error(

--- a/test/production/app-dir/no-mangling/app/layout.tsx
+++ b/test/production/app-dir/no-mangling/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/no-mangling/app/page.tsx
+++ b/test/production/app-dir/no-mangling/app/page.tsx
@@ -1,0 +1,4 @@
+export default function Page() {
+  throw new Error('Kaputt!')
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/no-mangling/next.config.js
+++ b/test/production/app-dir/no-mangling/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/production/app-dir/no-mangling/no-mangling.test.ts
+++ b/test/production/app-dir/no-mangling/no-mangling.test.ts
@@ -1,0 +1,23 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('no-mangling', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    buildOptions: ['--no-mangling'],
+    skipStart: true,
+  })
+
+  it('should show original function names in stack traces', async () => {
+    try {
+      await next.build()
+    } catch {
+      // we expect the build to fail
+    }
+
+    // `Page` is the original function name that would be mangled if `next
+    // build` was called without `--no-mangling`.
+    expect(next.cliOutput).toInclude(`
+Error: Kaputt!
+    at Page`)
+  })
+})

--- a/test/production/app-dir/no-mangling/no-mangling.test.ts
+++ b/test/production/app-dir/no-mangling/no-mangling.test.ts
@@ -1,23 +1,50 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('no-mangling', () => {
-  const { next } = nextTestSetup({
-    files: __dirname,
-    buildOptions: ['--no-mangling'],
-    skipStart: true,
-  })
+  describe('with the default `next build`', () => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+      skipStart: true,
+    })
 
-  it('should show original function names in stack traces', async () => {
-    try {
-      await next.build()
-    } catch {
-      // we expect the build to fail
-    }
+    it('should show mangled function names in stack traces', async () => {
+      try {
+        await next.build()
+      } catch {
+        // we expect the build to fail
+      }
 
-    // `Page` is the original function name that would be mangled if `next
-    // build` was called without `--no-mangling`.
-    expect(next.cliOutput).toInclude(`
+      expect(next.cliOutput).toInclude(`
+Error: Kaputt!
+    at `) // mangled function name omitted because it's undeterministic
+
+      // `Page` is the original function name that is mangled because `next
+      // build` was called without `--no-mangling`.
+      expect(next.cliOutput).not.toInclude(`
 Error: Kaputt!
     at Page`)
+    })
+  })
+
+  describe('with `next build --no-mangling`', () => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+      buildOptions: ['--no-mangling'],
+      skipStart: true,
+    })
+
+    it('should show original function names in stack traces', async () => {
+      try {
+        await next.build()
+      } catch {
+        // we expect the build to fail
+      }
+
+      // `Page` is the original function name that would be mangled if `next
+      // build` was called without `--no-mangling`.
+      expect(next.cliOutput).toInclude(`
+Error: Kaputt!
+    at Page`)
+    })
   })
 })

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -119,11 +119,9 @@ impl EcmascriptDevChunkContent {
         }
 
         let code = code.build().cell();
-        if matches!(
-            this.chunking_context.await?.minify_type(),
-            MinifyType::Minify
-        ) {
-            return Ok(minify(chunk_path_vc, code, source_maps));
+
+        if let MinifyType::Minify { mangle } = this.chunking_context.await?.minify_type() {
+            return Ok(minify(chunk_path_vc, code, source_maps, mangle));
         }
 
         Ok(code)

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -189,11 +189,9 @@ impl EcmascriptDevEvaluateChunk {
         }
 
         let code = code.build().cell();
-        if matches!(
-            this.chunking_context.await?.minify_type(),
-            MinifyType::Minify
-        ) {
-            return Ok(minify(chunk_path_vc, code, source_maps));
+
+        if let MinifyType::Minify { mangle } = this.chunking_context.await?.minify_type() {
+            return Ok(minify(chunk_path_vc, code, source_maps, mangle));
         }
 
         Ok(code)

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -86,7 +86,7 @@ impl TurbopackBuildBuilder {
             show_all: false,
             log_detail: false,
             source_maps_type: SourceMapsType::Full,
-            minify_type: MinifyType::Minify,
+            minify_type: MinifyType::Minify { mangle: true },
             target: Target::Node,
         }
     }
@@ -482,7 +482,7 @@ pub async fn build(args: &BuildArguments) -> Result<()> {
         .minify_type(if args.no_minify {
             MinifyType::NoMinify
         } else {
-            MinifyType::Minify
+            MinifyType::Minify { mangle: true }
         })
         .target(args.common.target.unwrap_or(Target::Node))
         .show_all(args.common.show_all);

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -18,7 +18,6 @@ use crate::{
 
 #[derive(
     Debug,
-    Default,
     TaskInput,
     Clone,
     Copy,
@@ -32,9 +31,14 @@ use crate::{
     NonLocalValue,
 )]
 pub enum MinifyType {
-    #[default]
-    Minify,
+    Minify { mangle: bool },
     NoMinify,
+}
+
+impl Default for MinifyType {
+    fn default() -> Self {
+        Self::Minify { mangle: true }
+    }
 }
 
 #[derive(

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -85,7 +85,7 @@ impl StyleSheetLike<'_, '_> {
         };
 
         let result = ss.to_css(PrinterOptions {
-            minify: matches!(minify_type, MinifyType::Minify),
+            minify: matches!(minify_type, MinifyType::Minify { .. }),
             source_map: srcmap.as_mut(),
             targets,
             analyze_dependencies: None,

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -33,6 +33,7 @@ pub async fn minify(
     path: Vc<FileSystemPath>,
     code: Vc<Code>,
     source_maps: Vc<bool>,
+    mangle: bool,
 ) -> Result<Vc<Code>> {
     let path = path.await?;
     let source_maps = source_maps.await?.then(|| code.generate_source_map());
@@ -91,10 +92,14 @@ pub async fn minify(
                                 passes: 2,
                                 ..Default::default()
                             }),
-                            mangle: Some(MangleOptions {
-                                reserved: vec!["AbortSignal".into()],
-                                ..Default::default()
-                            }),
+                            mangle: if mangle {
+                                Some(MangleOptions {
+                                    reserved: vec!["AbortSignal".into()],
+                                    ..Default::default()
+                                })
+                            } else {
+                                None
+                            },
                             ..Default::default()
                         },
                         &ExtraOptions {

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -107,11 +107,9 @@ impl EcmascriptBuildNodeChunkContent {
         }
 
         let code = code.build().cell();
-        if matches!(
-            this.chunking_context.await?.minify_type(),
-            MinifyType::Minify
-        ) {
-            return Ok(minify(chunk_path_vc, code, source_maps));
+
+        if let MinifyType::Minify { mangle } = this.chunking_context.await?.minify_type() {
+            return Ok(minify(chunk_path_vc, code, source_maps, mangle));
         }
 
         Ok(code)

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/options.json
@@ -1,4 +1,8 @@
 {
   "runtime": "NodeJs",
-  "minifyType": "Minify"
+  "minifyType": {
+    "Minify": {
+      "mangle": true
+    }
+  }
 }

--- a/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/options.json
@@ -1,3 +1,7 @@
 {
-  "minifyType": "Minify"
+  "minifyType": {
+    "Minify": {
+      "mangle": true
+    }
+  }
 }


### PR DESCRIPTION
The `--no-mangling` CLI option for `next build` was originally introduced in #42633. However, we lost this feature during our migration from Terser to SWC. As part of broader improvements for debugging dynamic accesses with Dynamic I/O enabled, I needed this functionality back, so I restored it for Webpack and also added it to Turbopack.

fixes #67037
fixes #50208