### PR TITLE
Prevent dev overlay infinite error loop

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/app/react-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/app/react-dev-overlay.tsx
@@ -1,7 +1,7 @@
 import type { OverlayState } from '../../shared'
 import type { GlobalErrorComponent } from '../../../error-boundary'
 
-import { useState } from 'react'
+import { useState, type ComponentProps } from 'react'
 import { DevOverlayErrorBoundary } from './error-boundary'
 import { ShadowPortal } from '../internal/components/shadow-portal'
 import { Base } from '../internal/styles/base'
@@ -11,9 +11,9 @@ import { Colors } from '../internal/styles/colors'
 import { ErrorOverlay } from '../internal/components/errors/error-overlay/error-overlay'
 import { DevToolsIndicator } from '../internal/components/errors/dev-tools-indicator/dev-tools-indicator'
 import { useErrorHook } from '../internal/container/runtime-error/use-error-hook'
-import { withSwallowError } from '../../internal/components/with-swallow-error'
+import { DevOverlayNoThrowErrorBoundary } from '../../internal/components/dev-overlay-no-throw-error-boundary'
 
-export default withSwallowError(function ReactDevOverlay({
+function ReactDevOverlayImpl({
   state,
   globalError,
   children,
@@ -63,4 +63,14 @@ export default withSwallowError(function ReactDevOverlay({
       {children}
     </DevOverlayErrorBoundary>
   )
-})
+}
+
+export default function ReactDevOverlay(
+  props: ComponentProps<typeof ReactDevOverlayImpl>
+) {
+  return (
+    <DevOverlayNoThrowErrorBoundary>
+      <ReactDevOverlayImpl {...props} />
+    </DevOverlayNoThrowErrorBoundary>
+  )
+}

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/app/react-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/app/react-dev-overlay.tsx
@@ -11,8 +11,9 @@ import { Colors } from '../internal/styles/colors'
 import { ErrorOverlay } from '../internal/components/errors/error-overlay/error-overlay'
 import { DevToolsIndicator } from '../internal/components/errors/dev-tools-indicator/dev-tools-indicator'
 import { useErrorHook } from '../internal/container/runtime-error/use-error-hook'
+import { withSwallowError } from '../../internal/components/with-swallow-error'
 
-export default function ReactDevOverlay({
+export default withSwallowError(function ReactDevOverlay({
   state,
   globalError,
   children,
@@ -62,4 +63,4 @@ export default function ReactDevOverlay({
       {children}
     </DevOverlayErrorBoundary>
   )
-}
+})

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/pages/react-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/pages/react-dev-overlay.tsx
@@ -12,6 +12,7 @@ import { Colors } from '../internal/styles/colors'
 import { ErrorOverlay } from '../internal/components/errors/error-overlay/error-overlay'
 import { DevToolsIndicator } from '../internal/components/errors/dev-tools-indicator/dev-tools-indicator'
 import { useErrorHook } from '../internal/container/runtime-error/use-error-hook'
+import { withSwallowError } from '../../internal/components/with-swallow-error'
 
 export type ErrorType = 'runtime' | 'build'
 
@@ -19,7 +20,9 @@ interface ReactDevOverlayProps {
   children?: React.ReactNode
 }
 
-export default function ReactDevOverlay({ children }: ReactDevOverlayProps) {
+export default withSwallowError(function ReactDevOverlay({
+  children,
+}: ReactDevOverlayProps) {
   const { state, onComponentError, hasRuntimeErrors, hasBuildError } =
     usePagesReactDevOverlay()
 
@@ -59,4 +62,4 @@ export default function ReactDevOverlay({ children }: ReactDevOverlayProps) {
       </ShadowPortal>
     </>
   )
-}
+})

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/pages/react-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/pages/react-dev-overlay.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { useState } from 'react'
+import { useState, type ComponentProps } from 'react'
 import { ShadowPortal } from '../internal/components/shadow-portal'
 import { Base } from '../internal/styles/base'
 import { ComponentStyles } from '../internal/styles/component-styles'
@@ -12,7 +12,7 @@ import { Colors } from '../internal/styles/colors'
 import { ErrorOverlay } from '../internal/components/errors/error-overlay/error-overlay'
 import { DevToolsIndicator } from '../internal/components/errors/dev-tools-indicator/dev-tools-indicator'
 import { useErrorHook } from '../internal/container/runtime-error/use-error-hook'
-import { withSwallowError } from '../../internal/components/with-swallow-error'
+import { DevOverlayNoThrowErrorBoundary } from '../../internal/components/dev-overlay-no-throw-error-boundary'
 
 export type ErrorType = 'runtime' | 'build'
 
@@ -20,9 +20,7 @@ interface ReactDevOverlayProps {
   children?: React.ReactNode
 }
 
-export default withSwallowError(function ReactDevOverlay({
-  children,
-}: ReactDevOverlayProps) {
+function ReactDevOverlayImpl({ children }: ReactDevOverlayProps) {
   const { state, onComponentError, hasRuntimeErrors, hasBuildError } =
     usePagesReactDevOverlay()
 
@@ -62,4 +60,14 @@ export default withSwallowError(function ReactDevOverlay({
       </ShadowPortal>
     </>
   )
-})
+}
+
+export default function ReactDevOverlay(
+  props: ComponentProps<typeof ReactDevOverlayImpl>
+) {
+  return (
+    <DevOverlayNoThrowErrorBoundary>
+      <ReactDevOverlayImpl {...props} />
+    </DevOverlayNoThrowErrorBoundary>
+  )
+}

--- a/packages/next/src/client/components/react-dev-overlay/internal/components/dev-overlay-no-throw-error-boundary.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/dev-overlay-no-throw-error-boundary.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 
-class ErrorBoundary extends React.Component<{ children: React.ReactNode }> {
+export class DevOverlayNoThrowErrorBoundary extends React.Component<{
+  children: React.ReactNode
+}> {
   state = { error: null }
 
   static getDerivedStateFromError(error: Error) {
@@ -20,17 +22,5 @@ class ErrorBoundary extends React.Component<{ children: React.ReactNode }> {
   render() {
     // Return null if there was an error to prevent infinite loops
     return this.state.error ? null : this.props.children
-  }
-}
-
-export function withSwallowError<P extends object>(
-  Component: React.ComponentType<P>
-): React.ComponentType<P> {
-  return function WithSwallowError(props: P): React.ReactElement {
-    return (
-      <ErrorBoundary>
-        <Component {...props} />
-      </ErrorBoundary>
-    )
   }
 }

--- a/packages/next/src/client/components/react-dev-overlay/internal/components/with-swallow-error.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/with-swallow-error.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react'
+
+class ErrorBoundary extends React.Component<{ children: React.ReactNode }> {
+  state = { error: null }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error }
+  }
+
+  componentDidCatch(error: Error) {
+    // TODO: figure out how to better handle errors thrown inside the dev overlay itself
+    // this is a temporary solution to prevent the dev overlay from causing an
+    // infinite loop of errors
+    console.error(
+      'This is a bug in Next.js: failed to render dev overlay',
+      error
+    )
+  }
+
+  render() {
+    // Return null if there was an error to prevent infinite loops
+    return this.state.error ? null : this.props.children
+  }
+}
+
+export function withSwallowError<P extends object>(
+  Component: React.ComponentType<P>
+): React.ComponentType<P> {
+  return function WithSwallowError(props: P): React.ReactElement {
+    return (
+      <ErrorBoundary>
+        <Component {...props} />
+      </ErrorBoundary>
+    )
+  }
+}


### PR DESCRIPTION
### What?
If the error overlay component itself throws an error, it can sometimes cause an infinite loop.

### Why?

1. React calls `console.error` when Dev Overlay throws an error
2. `console.error` is intercepted by https://github.com/vercel/next.js/blob/02-11-prevent_dev_overlay_infinite_error_loop/packages/next/src/client/components/react-dev-overlay/pages/client.ts#L54
3. `Bus.emit` is called
4. https://github.com/vercel/next.js/blob/02-11-prevent_dev_overlay_infinite_error_loop/packages/next/src/client/components/react-dev-overlay/pages/hooks.ts#L8-L13 calls `dispatch` with the new error
5. `ReactDevOverlay` is re-rendered by `usePagesReactDevOverlay` https://github.com/vercel/next.js/blob/02-11-prevent_dev_overlay_infinite_error_loop/packages/next/src/client/components/react-dev-overlay/_experimental/pages/react-dev-overlay.tsx#L26-L32
6. If the error preserves, it will jump back to step(1) and start this loop again

### How?

Wrap the DevOverlay with an error boundary to short-circuit this loop. If/when an error occurs in the DevOverlay, you will receive a console error about it:

![CleanShot 2025-02-11 at 16.15.20@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/rKSEEwxbNzdFs9t0yyxN/512f3a94-13b8-443a-bd10-b167c2c60072.png)


Closes NDX-816
