### PR TITLE
Use `compilation.{emitAsset,updateAsset}` api rather than mutating `assets` object

### DIFF
--- a/packages/next/src/build/webpack/plugins/app-build-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/app-build-manifest-plugin.ts
@@ -31,12 +31,12 @@ export class AppBuildManifestPlugin {
           name: PLUGIN_NAME,
           stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
         },
-        (assets: any) => this.createAsset(assets, compilation)
+        () => this.createAsset(compilation)
       )
     })
   }
 
-  private createAsset(assets: any, compilation: webpack.Compilation) {
+  private createAsset(compilation: webpack.Compilation) {
     const manifest: AppBuildManifest = {
       pages: {},
     }
@@ -67,6 +67,9 @@ export class AppBuildManifestPlugin {
 
     const json = JSON.stringify(manifest, null, 2)
 
-    assets[APP_BUILD_MANIFEST] = new sources.RawSource(json)
+    compilation.emitAsset(
+      APP_BUILD_MANIFEST,
+      new sources.RawSource(json) as unknown as webpack.sources.RawSource
+    )
   }
 }

--- a/packages/next/src/build/webpack/plugins/css-minimizer-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/css-minimizer-plugin.ts
@@ -79,10 +79,8 @@ export class CssMinimizerPlugin {
                   assetSpan.setAttribute('file', file)
 
                   return assetSpan.traceAsyncFn(async () => {
-                    const asset = assets[file]
-
-                    const etag = cache.getLazyHashedEtag(asset)
-
+                    const assetSource = compilation.getAsset(file).source
+                    const etag = cache.getLazyHashedEtag(assetSource)
                     const cachedResult = await cache.getPromise(file, etag)
 
                     assetSpan.setAttribute(
@@ -90,13 +88,13 @@ export class CssMinimizerPlugin {
                       cachedResult ? 'HIT' : 'MISS'
                     )
                     if (cachedResult) {
-                      assets[file] = cachedResult
+                      compilation.updateAsset(file, cachedResult)
                       return
                     }
 
-                    const result = await this.optimizeAsset(file, asset)
+                    const result = await this.optimizeAsset(file, assetSource)
                     await cache.storePromise(file, etag, result)
-                    assets[file] = result
+                    compilation.updateAsset(file, result)
                   })
                 })
             )

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -263,7 +263,7 @@ export class FlightClientEntryPlugin {
           name: PLUGIN_NAME,
           stage: webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH,
         },
-        (assets) => this.createActionAssets(compilation, assets)
+        () => this.createActionAssets(compilation)
       )
     })
   }
@@ -963,10 +963,7 @@ export class FlightClientEntryPlugin {
     })
   }
 
-  async createActionAssets(
-    compilation: webpack.Compilation,
-    assets: webpack.Compilation['assets']
-  ) {
+  async createActionAssets(compilation: webpack.Compilation) {
     const serverActions: ActionManifest['node'] = {}
     const edgeServerActions: ActionManifest['edge'] = {}
 
@@ -1039,12 +1036,16 @@ export class FlightClientEntryPlugin {
       this.dev ? 2 : undefined
     )
 
-    assets[`${this.assetPrefix}${SERVER_REFERENCE_MANIFEST}.js`] =
+    compilation.emitAsset(
+      `${this.assetPrefix}${SERVER_REFERENCE_MANIFEST}.js`,
       new sources.RawSource(
         `self.__RSC_SERVER_MANIFEST=${JSON.stringify(edgeJson)}`
       ) as unknown as webpack.sources.RawSource
-    assets[`${this.assetPrefix}${SERVER_REFERENCE_MANIFEST}.json`] =
+    )
+    compilation.emitAsset(
+      `${this.assetPrefix}${SERVER_REFERENCE_MANIFEST}.json`,
       new sources.RawSource(json) as unknown as webpack.sources.RawSource
+    )
   }
 }
 

--- a/packages/next/src/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/middleware-plugin.ts
@@ -154,7 +154,7 @@ function getCreateAssets(params: {
   opts: Options
 }) {
   const { compilation, metadataByEntry, opts } = params
-  return (assets: any) => {
+  return () => {
     const middlewareManifest: MiddlewareManifest = {
       version: MANIFEST_VERSION,
       middleware: {},
@@ -171,11 +171,14 @@ function getCreateAssets(params: {
     const interceptionRewrites = JSON.stringify(
       opts.rewrites.beforeFiles.filter(isInterceptionRouteRewrite)
     )
-    assets[`${INTERCEPTION_ROUTE_REWRITE_MANIFEST}.js`] = new sources.RawSource(
-      `self.__INTERCEPTION_ROUTE_REWRITE_MANIFEST=${JSON.stringify(
-        interceptionRewrites
-      )}`
-    ) as unknown as webpack.sources.RawSource
+    compilation.emitAsset(
+      `${INTERCEPTION_ROUTE_REWRITE_MANIFEST}.js`,
+      new sources.RawSource(
+        `self.__INTERCEPTION_ROUTE_REWRITE_MANIFEST=${JSON.stringify(
+          interceptionRewrites
+        )}`
+      ) as unknown as webpack.sources.RawSource
+    )
 
     for (const entrypoint of compilation.entrypoints.values()) {
       if (!entrypoint.name) {
@@ -242,8 +245,11 @@ function getCreateAssets(params: {
       Object.keys(middlewareManifest.middleware)
     )
 
-    assets[MIDDLEWARE_MANIFEST] = new sources.RawSource(
-      JSON.stringify(middlewareManifest, null, 2)
+    compilation.emitAsset(
+      MIDDLEWARE_MANIFEST,
+      new sources.RawSource(
+        JSON.stringify(middlewareManifest, null, 2)
+      ) as unknown as webpack.sources.RawSource
     )
   }
 }

--- a/packages/next/src/build/webpack/plugins/next-font-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-font-manifest-plugin.ts
@@ -67,7 +67,7 @@ export class NextFontManifestPlugin {
           name: PLUGIN_NAME,
           stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
         },
-        (assets: any) => {
+        () => {
           const nextFontManifest: NextFontManifest = {
             pages: {},
             app: {},
@@ -156,12 +156,19 @@ export class NextFontManifestPlugin {
 
           const manifest = JSON.stringify(nextFontManifest, null)
           // Create manifest for edge
-          assets[`server/${NEXT_FONT_MANIFEST}.js`] = new sources.RawSource(
-            `self.__NEXT_FONT_MANIFEST=${JSON.stringify(manifest)}`
+          compilation.emitAsset(
+            `server/${NEXT_FONT_MANIFEST}.js`,
+            new sources.RawSource(
+              `self.__NEXT_FONT_MANIFEST=${JSON.stringify(manifest)}`
+            ) as unknown as webpack.sources.RawSource
           )
+
           // Create manifest for server
-          assets[`server/${NEXT_FONT_MANIFEST}.json`] = new sources.RawSource(
-            manifest
+          compilation.emitAsset(
+            `server/${NEXT_FONT_MANIFEST}.json`,
+            new sources.RawSource(
+              manifest
+            ) as unknown as webpack.sources.RawSource
           )
         }
       )

--- a/packages/next/src/build/webpack/plugins/pages-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/pages-manifest-plugin.ts
@@ -43,7 +43,7 @@ export default class PagesManifestPlugin
     this.appDirEnabled = appDirEnabled
   }
 
-  async createAssets(compilation: any, assets: any) {
+  async createAssets(compilation: any) {
     const entrypoints = compilation.entrypoints
     const pages: PagesManifest = {}
     const appPaths: PagesManifest = {}
@@ -134,14 +134,17 @@ export default class PagesManifestPlugin
     } else {
       const pagesManifestPath =
         (!this.dev && !this.isEdgeRuntime ? '../' : '') + PAGES_MANIFEST
-      assets[pagesManifestPath] = new sources.RawSource(
-        JSON.stringify(
-          {
-            ...edgeServerPages,
-            ...nodeServerPages,
-          },
-          null,
-          2
+      compilation.emitAsset(
+        pagesManifestPath,
+        new sources.RawSource(
+          JSON.stringify(
+            {
+              ...edgeServerPages,
+              ...nodeServerPages,
+            },
+            null,
+            2
+          )
         )
       )
     }
@@ -158,17 +161,18 @@ export default class PagesManifestPlugin
           ...nodeServerAppPaths,
         })
       } else {
-        assets[
-          (!this.dev && !this.isEdgeRuntime ? '../' : '') + APP_PATHS_MANIFEST
-        ] = new sources.RawSource(
-          JSON.stringify(
-            {
-              ...edgeServerAppPaths,
-              ...nodeServerAppPaths,
-            },
-            null,
-            2
-          )
+        compilation.emitAsset(
+          (!this.dev && !this.isEdgeRuntime ? '../' : '') + APP_PATHS_MANIFEST,
+          new sources.RawSource(
+            JSON.stringify(
+              {
+                ...edgeServerAppPaths,
+                ...nodeServerAppPaths,
+              },
+              null,
+              2
+            )
+          ) as unknown as webpack.sources.RawSource
         )
       }
     }
@@ -181,7 +185,7 @@ export default class PagesManifestPlugin
           name: 'NextJsPagesManifest',
           stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
         },
-        (assets) => this.createAssets(compilation, assets)
+        () => this.createAssets(compilation)
       )
     })
   }


### PR DESCRIPTION
This uses the proper webpack apis for setting these assets instead of mutating the `assets` object. Rspack doesn’t seem to support the latter very well.


Closes PACK-3953