### PR TITLE
docs(css-in-js): update warning about using css-in-js with server components

### DIFF
--- a/docs/01-app/03-building-your-application/05-styling/04-css-in-js.mdx
+++ b/docs/01-app/03-building-your-application/05-styling/04-css-in-js.mdx
@@ -7,9 +7,7 @@ description: Use CSS-in-JS libraries with Next.js
 
 <AppOnly>
 
-> **Warning:** CSS-in-JS libraries which require runtime JavaScript are not currently supported in Server Components. Using CSS-in-JS with newer React features like Server Components and Streaming requires library authors to support the latest version of React, including [concurrent rendering](https://react.dev/blog/2022/03/29/react-v18#what-is-concurrent-react).
->
-> We're working with the React team on upstream APIs to handle CSS and JavaScript assets with support for React Server Components and streaming architecture.
+> **Warning:** Using CSS-in-JS with newer React features like Server Components and Streaming requires library authors to support the latest version of React, including [concurrent rendering](https://react.dev/blog/2022/03/29/react-v18#what-is-concurrent-react).
 
 The following libraries are supported in Client Components in the `app` directory (alphabetical):
 


### PR DESCRIPTION
## Why?

The warning suggests its not supported in Server Components, but since React 19 was released, there is better support! Need to just re-word the warning a bit.

- Fixes https://github.com/vercel/next.js/issues/75895

- https://nextjs.org/docs/app/building-your-application/styling/css-in-js
- https://react.dev/blog/2024/12/05/react-19#support-for-stylesheets