### PR TITLE
[DevOverlay]: fix missing Error context for build-time errors

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -635,5 +635,6 @@
   "634": "Route %s used \"searchParams\" inside \"use cache\". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \"searchParams\" outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
   "635": "%s: Invalid source map. Only conformant source maps can be used to find the original code.",
   "636": "Invariant: frames must be a function when the React version has React.use. This is a bug in Next.js.",
-  "637": "Invariant: frames must be an array when the React version does not have React.use. This is a bug in Next.js."
+  "637": "Invariant: frames must be an array when the React version does not have React.use. This is a bug in Next.js.",
+  "638": "The following tags are missing in the Root Layout: %s.\\nRead more at https://nextjs.org/docs/messages/missing-root-layout-tags"
 }

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/app/react-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/app/react-dev-overlay.tsx
@@ -21,11 +21,15 @@ export default function ReactDevOverlay({
   globalError: [GlobalErrorComponent, React.ReactNode]
   children: React.ReactNode
 }) {
-  const [isErrorOverlayOpen, setIsErrorOverlayOpen] = useState(false)
+  const [_isErrorOverlayOpen, setIsErrorOverlayOpen] = useState(false)
   const { readyErrors, totalErrorCount } = useErrorHook({
     state,
     isAppDir: true,
   })
+
+  // Build errors cannot be dismissed. If one is triggered, we ignore the
+  // user's preference and open the error overlay.
+  const isErrorOverlayOpen = Boolean(state.buildError) || _isErrorOverlayOpen
 
   const devOverlay = (
     <ShadowPortal>

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-layout/error-overlay-layout.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-layout/error-overlay-layout.tsx
@@ -39,7 +39,7 @@ interface ErrorOverlayLayoutProps extends ErrorBaseProps {
   errorType: ErrorType
   children?: React.ReactNode
   errorCode?: string
-  error?: Error
+  error: Error
   debugInfo?: DebugInfo
   isBuildError?: boolean
   onClose?: () => void

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/copy-stack-trace-button.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/copy-stack-trace-button.tsx
@@ -1,14 +1,14 @@
 import { CopyButton } from '../../copy-button'
 
-export function CopyStackTraceButton({ error }: { error: Error | undefined }) {
+export function CopyStackTraceButton({ error }: { error: Error }) {
   return (
     <CopyButton
       data-nextjs-data-runtime-error-copy-stack
       className="copy-stack-trace-button"
       actionLabel="Copy Stack Trace"
       successLabel="Stack Trace Copied"
-      content={error?.stack || ''}
-      disabled={!error?.stack}
+      content={error.stack || ''}
+      disabled={!error.stack}
     />
   )
 }

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/error-overlay-toolbar.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/error-overlay-toolbar.tsx
@@ -5,7 +5,7 @@ import { CopyStackTraceButton } from './copy-stack-trace-button'
 import { DocsLinkButton } from './docs-link-button'
 
 type ErrorOverlayToolbarProps = {
-  error: Error | undefined
+  error: Error
   debugInfo: DebugInfo | undefined
 }
 
@@ -19,7 +19,7 @@ export function ErrorOverlayToolbar({
       <NodejsInspectorButton
         devtoolsFrontendUrl={debugInfo?.devtoolsFrontendUrl}
       />
-      <DocsLinkButton errorMessage={error?.message || ''} />
+      <DocsLinkButton errorMessage={error.message} />
     </span>
   )
 }

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/build-error.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/build-error.tsx
@@ -13,15 +13,17 @@ export const BuildError: React.FC<BuildErrorProps> = function BuildError({
   ...props
 }) {
   const noop = React.useCallback(() => {}, [])
+  const error = new Error(message)
   return (
     <ErrorOverlayLayout
       errorType="Build Error"
       errorMessage="Failed to compile"
       onClose={noop}
+      error={error}
       footerMessage="This error occurred during the build process and can only be dismissed by fixing the error."
       {...props}
     >
-      <Terminal content={message} />
+      <Terminal content={error.message} />
     </ErrorOverlayLayout>
   )
 }

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/root-layout-missing-tags-error.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/root-layout-missing-tags-error.tsx
@@ -12,18 +12,18 @@ export function RootLayoutMissingTagsError({
   ...props
 }: RootLayoutMissingTagsErrorProps) {
   const noop = useCallback(() => {}, [])
+  const error = new Error(
+    `The following tags are missing in the Root Layout: ${missingTags
+      .map((tagName) => `<${tagName}>`)
+      .join(
+        ', '
+      )}.\nRead more at https://nextjs.org/docs/messages/missing-root-layout-tags`
+  )
   return (
     <ErrorOverlayLayout
       errorType="Missing Required HTML Tag"
-      errorMessage={
-        <HotlinkedText
-          text={`The following tags are missing in the Root Layout: ${missingTags
-            .map((tagName) => `<${tagName}>`)
-            .join(
-              ', '
-            )}.\nRead more at https://nextjs.org/docs/messages/missing-root-layout-tags`}
-        />
-      }
+      error={error}
+      errorMessage={<HotlinkedText text={error.message} />}
       onClose={noop}
       {...props}
     />


### PR DESCRIPTION
`Error` should not be an optional property of the toolbar or error overlay layout, since that information is needed for parsing the message to determine if a docs link should be shown or if a stack trace can be copied.

This marks those properties as non-optional so that TypeScript will warn us in spots that were missing it. I updated the missing spots to construct an error where one was not available. 

Build time errors are also not meant to be dismissible. This forces the error open until the build error is remedied. 

Closes NDX-819