### PR TITLE
[Turbopack] avoid attaching referenced output assets to chunks

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -39,8 +39,8 @@ use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    Completion, FxIndexSet, NonLocalValue, ResolvedVc, TryJoinIterExt, ValueToString, Vc,
-    fxindexset, trace::TraceRawVcs,
+    Completion, NonLocalValue, ResolvedVc, TryJoinIterExt, ValueToString, Vc, fxindexset,
+    trace::TraceRawVcs,
 };
 use turbo_tasks_env::{CustomProcessEnv, ProcessEnv};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
@@ -63,7 +63,7 @@ use turbopack_core::{
         GraphEntries, ModuleGraph, SingleModuleGraph, VisitedModules,
         chunk_group_info::{ChunkGroup, ChunkGroupEntry},
     },
-    output::{OutputAsset, OutputAssets},
+    output::{OutputAsset, OutputAssets, OutputAssetsWithReferenced},
     raw_output::RawOutput,
     reference_type::{CommonJsReferenceSubType, CssReferenceSubType, ReferenceType},
     resolve::{origin::PlainResolveOrigin, parse::Request, pattern::Pattern},
@@ -1240,13 +1240,16 @@ impl AppEndpoint {
             .await?;
 
             let mut client_shared_chunks = vec![];
-            for chunk in client_shared_chunk_group.assets.await?.iter().copied() {
+            for &chunk in client_shared_chunk_group.assets.await? {
                 client_assets.insert(chunk);
 
                 let chunk_path = chunk.path().await?;
                 if chunk_path.has_extension(".js") {
                     client_shared_chunks.push(chunk);
                 }
+            }
+            for &chunk in client_shared_chunk_group.referenced_assets.await? {
+                client_assets.insert(chunk);
             }
 
             (
@@ -1285,30 +1288,39 @@ impl AppEndpoint {
         .await?;
         let client_references_chunks_ref = client_references_chunks.await?;
 
-        let mut entry_client_chunks = FxIndexSet::default();
-        // TODO(alexkirsz) In which manifest does this go?
-        let mut entry_ssr_chunks = FxIndexSet::default();
-        for chunks in client_references_chunks_ref
+        for OutputAssetsWithReferenced {
+            assets,
+            referenced_assets,
+        } in client_references_chunks_ref
             .layout_segment_client_chunks
             .values()
         {
-            entry_client_chunks.extend(chunks.await?.iter().copied());
+            client_assets.extend(assets.await?.iter().copied());
+            client_assets.extend(referenced_assets.await?.iter().copied());
         }
-        for (chunks, _) in client_references_chunks_ref
+        for ChunkGroupResult {
+            assets,
+            referenced_assets,
+            availability_info: _,
+        } in client_references_chunks_ref
             .client_component_client_chunks
             .values()
         {
-            client_assets.extend(chunks.await?.iter().copied());
+            client_assets.extend(assets.await?.iter().copied());
+            client_assets.extend(referenced_assets.await?.iter().copied());
         }
-        for (chunks, _) in client_references_chunks_ref
+        for ChunkGroupResult {
+            assets,
+            referenced_assets,
+            availability_info: _,
+        } in client_references_chunks_ref
             .client_component_ssr_chunks
             .values()
         {
-            entry_ssr_chunks.extend(chunks.await?.iter().copied());
+            // TODO(alexkirsz) In which manifest does this go?
+            server_assets.extend(assets.await?.iter().copied());
+            server_assets.extend(referenced_assets.await?.iter().copied());
         }
-
-        client_assets.extend(entry_client_chunks.iter().copied());
-        server_assets.extend(entry_ssr_chunks.iter().copied());
 
         let manifest_path_prefix = &app_entry.original_name;
 
@@ -1377,12 +1389,16 @@ impl AppEndpoint {
             // initialization
             let client_references_chunks = &*client_references_chunks.await?;
 
-            for (ssr_chunks, _) in client_references_chunks
+            for ChunkGroupResult {
+                assets,
+                referenced_assets,
+                availability_info: _,
+            } in client_references_chunks
                 .client_component_ssr_chunks
                 .values()
             {
-                let ssr_chunks = ssr_chunks.await?;
-                middleware_assets.extend(ssr_chunks);
+                middleware_assets.extend(assets.await?);
+                middleware_assets.extend(referenced_assets.await?);
             }
         }
 
@@ -1426,8 +1442,17 @@ impl AppEndpoint {
             )
             .to_resolved()
             .await?;
+        let app_entry_chunk_group_ref = app_entry_chunks.await?;
+        let app_entry_chunks = app_entry_chunk_group_ref.assets;
         let app_entry_chunks_ref = app_entry_chunks.await?;
         server_assets.extend(app_entry_chunks_ref.iter().copied());
+        server_assets.extend(
+            app_entry_chunk_group_ref
+                .referenced_assets
+                .await?
+                .iter()
+                .copied(),
+        );
 
         let client_assets = OutputAssets::new(client_assets.iter().map(|asset| **asset).collect())
             .to_resolved()
@@ -1701,7 +1726,7 @@ impl AppEndpoint {
         server_path: FileSystemPath,
         process_client_assets: bool,
         module_graph: Vc<ModuleGraph>,
-    ) -> Result<Vc<OutputAssets>> {
+    ) -> Result<Vc<OutputAssetsWithReferenced>> {
         let this = self.await?;
         let project = this.app_project.project();
         let app_entry = self.app_endpoint_entry().await?;
@@ -1713,6 +1738,7 @@ impl AppEndpoint {
             NextRuntime::Edge => {
                 let ChunkGroupResult {
                     assets,
+                    referenced_assets,
                     availability_info,
                 } = *chunking_context
                     .chunk_group(
@@ -1727,17 +1753,25 @@ impl AppEndpoint {
                     )
                     .await?;
 
-                assets.concatenate(
-                    chunking_context
-                        .evaluated_chunk_group_assets(
-                            app_entry.rsc_entry.ident(),
-                            ChunkGroup::Entry(vec![app_entry.rsc_entry]),
-                            module_graph,
-                            availability_info,
-                        )
-                        .resolve()
+                let chunk_group = chunking_context
+                    .evaluated_chunk_group_assets(
+                        app_entry.rsc_entry.ident(),
+                        ChunkGroup::Entry(vec![app_entry.rsc_entry]),
+                        module_graph,
+                        availability_info,
+                    )
+                    .await?;
+                OutputAssetsWithReferenced {
+                    assets: assets
+                        .concatenate(*chunk_group.assets)
+                        .to_resolved()
                         .await?,
-                )
+                    referenced_assets: referenced_assets
+                        .concatenate(*chunk_group.referenced_assets)
+                        .to_resolved()
+                        .await?,
+                }
+                .cell()
             }
             NextRuntime::NodeJs => {
                 let Some(rsc_entry) = ResolvedVc::try_downcast(app_entry.rsc_entry) else {
@@ -1748,6 +1782,7 @@ impl AppEndpoint {
 
                 async {
                     let mut current_chunks = OutputAssets::empty();
+                    let mut current_referenced_assets = OutputAssets::empty();
                     let mut current_availability_info = AvailabilityInfo::Root;
 
                     let client_references = client_references.await?;
@@ -1759,7 +1794,11 @@ impl AppEndpoint {
                             .map(async |m| Ok(ResolvedVc::upcast(m.await?.module)))
                             .try_join()
                             .await?;
-                        let chunk_group = chunking_context
+                        let ChunkGroupResult {
+                            assets,
+                            referenced_assets,
+                            availability_info,
+                        } = *chunking_context
                             .chunk_group(
                                 AssetIdent::from_path(
                                     this.app_project.project().project_path().owned().await?,
@@ -1772,11 +1811,12 @@ impl AppEndpoint {
                             )
                             .await?;
 
-                        current_chunks = current_chunks
-                            .concatenate(*chunk_group.assets)
+                        current_chunks = current_chunks.concatenate(*assets).resolve().await?;
+                        current_referenced_assets = current_referenced_assets
+                            .concatenate(*referenced_assets)
                             .resolve()
                             .await?;
-                        current_availability_info = chunk_group.availability_info;
+                        current_availability_info = availability_info;
 
                         anyhow::Ok(())
                     }
@@ -1798,7 +1838,11 @@ impl AppEndpoint {
                             name = server_component.ident().to_string().await?.as_str()
                         );
                         async {
-                            let chunk_group = chunking_context
+                            let ChunkGroupResult {
+                                assets,
+                                referenced_assets,
+                                availability_info,
+                            } = *chunking_context
                                 .chunk_group(
                                     server_component.ident(),
                                     // TODO this should be ChunkGroup::Shared
@@ -1810,11 +1854,12 @@ impl AppEndpoint {
                                 )
                                 .await?;
 
-                            current_chunks = current_chunks
-                                .concatenate(*chunk_group.assets)
+                            current_chunks = current_chunks.concatenate(*assets).resolve().await?;
+                            current_referenced_assets = current_referenced_assets
+                                .concatenate(*referenced_assets)
                                 .resolve()
                                 .await?;
-                            current_availability_info = chunk_group.availability_info;
+                            current_availability_info = availability_info;
 
                             anyhow::Ok(())
                         }
@@ -1823,7 +1868,11 @@ impl AppEndpoint {
                     }
 
                     {
-                        let chunk_group = chunking_context
+                        let ChunkGroupResult {
+                            assets,
+                            referenced_assets,
+                            availability_info,
+                        } = *chunking_context
                             .chunk_group(
                                 server_action_manifest_loader.ident(),
                                 ChunkGroup::Entry(vec![ResolvedVc::upcast(
@@ -1834,28 +1883,36 @@ impl AppEndpoint {
                             )
                             .await?;
 
-                        current_chunks = current_chunks
-                            .concatenate(*chunk_group.assets)
+                        current_chunks = current_chunks.concatenate(*assets).resolve().await?;
+                        current_referenced_assets = current_referenced_assets
+                            .concatenate(*referenced_assets)
                             .resolve()
                             .await?;
-                        current_availability_info = chunk_group.availability_info;
+                        current_availability_info = availability_info;
                     }
 
-                    anyhow::Ok(Vc::cell(vec![
-                        chunking_context
-                            .entry_chunk_group_asset(
-                                server_path.join(&format!(
-                                    "app{original_name}.js",
-                                    original_name = app_entry.original_name
-                                ))?,
-                                evaluatable_assets,
-                                module_graph,
-                                current_chunks,
-                                current_availability_info,
-                            )
-                            .to_resolved()
-                            .await?,
-                    ]))
+                    anyhow::Ok(
+                        OutputAssetsWithReferenced {
+                            assets: ResolvedVc::cell(vec![
+                                chunking_context
+                                    .entry_chunk_group_asset(
+                                        server_path.join(&format!(
+                                            "app{original_name}.js",
+                                            original_name = app_entry.original_name
+                                        ))?,
+                                        evaluatable_assets,
+                                        module_graph,
+                                        current_chunks,
+                                        current_referenced_assets,
+                                        current_availability_info,
+                                    )
+                                    .to_resolved()
+                                    .await?,
+                            ]),
+                            referenced_assets: ResolvedVc::cell(vec![]),
+                        }
+                        .cell(),
+                    )
                 }
                 .instrument(tracing::trace_span!("server node entrypoint"))
                 .await?

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -68,7 +68,7 @@ pub(crate) async fn collect_next_dynamic_chunks(
                         .client_component_client_chunks
                         .get(&parent_client_reference.unwrap())
                         .unwrap()
-                        .1
+                        .availability_info
                 }
                 NextDynamicChunkAvailability::AvailabilityInfo(availability_info) => {
                     *availability_info

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -20,7 +20,7 @@ use turbopack_core::{
         GraphEntries,
         chunk_group_info::{ChunkGroup, ChunkGroupEntry},
     },
-    output::{OutputAsset, OutputAssets},
+    output::{OutputAsset, OutputAssets, OutputAssetsWithReferenced},
     reference_type::{EntryReferenceSubType, ReferenceType},
     source::Source,
     virtual_output::VirtualOutputAsset,
@@ -97,21 +97,19 @@ impl InstrumentationEndpoint {
     }
 
     #[turbo_tasks::function]
-    async fn edge_files(self: Vc<Self>) -> Result<Vc<OutputAssets>> {
+    async fn edge_chunk_group(self: Vc<Self>) -> Result<Vc<OutputAssetsWithReferenced>> {
         let this = self.await?;
         let module = self.core_modules().await?.edge_entry_module;
 
         let module_graph = this.project.module_graph(*module);
 
         let edge_chunking_context = this.project.edge_chunking_context(false);
-        let edge_files: Vc<OutputAssets> = edge_chunking_context.evaluated_chunk_group_assets(
+        Ok(edge_chunking_context.evaluated_chunk_group_assets(
             module.ident(),
             ChunkGroup::Entry(vec![module]),
             module_graph,
             AvailabilityInfo::Root,
-        );
-
-        Ok(edge_files)
+        ))
     }
 
     #[turbo_tasks::function]
@@ -136,6 +134,7 @@ impl InstrumentationEndpoint {
                 Vc::cell(vec![module]),
                 module_graph,
                 OutputAssets::empty(),
+                OutputAssets::empty(),
                 AvailabilityInfo::Root,
             )
             .await?;
@@ -147,19 +146,20 @@ impl InstrumentationEndpoint {
         let this = self.await?;
 
         if this.is_edge {
-            let edge_files = self.edge_files();
-            let mut output_assets = edge_files.owned().await?;
+            let edge_chunk_group = self.edge_chunk_group();
+            let edge_all_assets = edge_chunk_group.all_assets();
 
             let node_root = this.project.node_root().owned().await?;
             let node_root_value = node_root.clone();
 
             let file_paths_from_root =
-                get_js_paths_from_root(&node_root_value, &output_assets).await?;
+                get_js_paths_from_root(&node_root_value, &edge_chunk_group.await?.assets.await?)
+                    .await?;
 
-            let all_output_assets = all_assets_from_entries(edge_files).await?;
+            let mut output_assets = all_assets_from_entries(edge_all_assets).owned().await?;
 
             let wasm_paths_from_root =
-                get_wasm_paths_from_root(&node_root_value, &all_output_assets).await?;
+                get_wasm_paths_from_root(&node_root_value, &output_assets).await?;
 
             let instrumentation_definition = InstrumentationDefinition {
                 files: file_paths_from_root,

--- a/crates/next-core/src/next_app/app_client_shared_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_shared_chunks.rs
@@ -20,6 +20,7 @@ pub async fn get_app_client_shared_chunk_group(
     if app_client_runtime_entries.await?.is_empty() {
         return Ok(ChunkGroupResult {
             assets: OutputAssets::empty().to_resolved().await?,
+            referenced_assets: OutputAssets::empty().to_resolved().await?,
             availability_info: AvailabilityInfo::Root,
         }
         .cell());

--- a/test/production/deployment-id-handling/app/tsconfig.json
+++ b/test/production/deployment-id-handling/app/tsconfig.json
@@ -12,7 +12,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "plugins": [
       {
         "name": "next"
@@ -21,6 +21,12 @@
     "strictNullChecks": true,
     "target": "ES2017"
   },
-  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "next-env.d.ts",
+    "**/*.mts"
+  ],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/test/production/deployment-id-handling/deployment-id-cookie-handling.test.ts
+++ b/test/production/deployment-id-handling/deployment-id-cookie-handling.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { join } from 'node:path'
 
 describe('deployment-id-handling disabled', () => {
@@ -62,10 +62,7 @@ describe('deployment-id-handling disabled', () => {
 
       await browser.elementByCss('#dynamic-import').click()
 
-      await check(
-        () => (requests.length > 0 ? 'success' : JSON.stringify(requests)),
-        'success'
-      )
+      await retry(() => expect(requests).not.toBeEmpty())
 
       try {
         expect(

--- a/test/production/deployment-id-handling/deployment-id-handling.test.ts
+++ b/test/production/deployment-id-handling/deployment-id-handling.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check, retry } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { join } from 'node:path'
 
 describe.each(['NEXT_DEPLOYMENT_ID', 'CUSTOM_DEPLOYMENT_ID'])(
@@ -58,10 +58,7 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'CUSTOM_DEPLOYMENT_ID'])(
 
         await browser.elementByCss('#dynamic-import').click()
 
-        await check(
-          () => (requests.length > 0 ? 'success' : JSON.stringify(requests)),
-          'success'
-        )
+        await retry(() => expect(requests).not.toBeEmpty())
 
         try {
           expect(
@@ -190,10 +187,7 @@ describe('deployment-id-handling disabled', () => {
 
       await browser.elementByCss('#dynamic-import').click()
 
-      await check(
-        () => (requests.length > 0 ? 'success' : JSON.stringify(requests)),
-        'success'
-      )
+      await retry(() => expect(requests).not.toBeEmpty())
 
       try {
         expect(

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -577,6 +577,7 @@ impl ChunkingContext for BrowserChunkingContext {
             let input_availability_info = availability_info;
             let MakeChunkGroupResult {
                 chunks,
+                referenced_output_assets,
                 availability_info,
             } = make_chunk_group(
                 modules,
@@ -618,6 +619,7 @@ impl ChunkingContext for BrowserChunkingContext {
 
             Ok(ChunkGroupResult {
                 assets: ResolvedVc::cell(assets),
+                referenced_assets: ResolvedVc::cell(referenced_output_assets),
                 availability_info,
             }
             .cell())
@@ -645,6 +647,7 @@ impl ChunkingContext for BrowserChunkingContext {
 
             let MakeChunkGroupResult {
                 chunks,
+                referenced_output_assets,
                 availability_info,
             } = make_chunk_group(
                 entries,
@@ -693,6 +696,7 @@ impl ChunkingContext for BrowserChunkingContext {
 
             Ok(ChunkGroupResult {
                 assets: ResolvedVc::cell(assets),
+                referenced_assets: ResolvedVc::cell(referenced_output_assets),
                 availability_info,
             }
             .cell())
@@ -708,6 +712,7 @@ impl ChunkingContext for BrowserChunkingContext {
         _evaluatable_assets: Vc<EvaluatableAssets>,
         _module_graph: Vc<ModuleGraph>,
         _extra_chunks: Vc<OutputAssets>,
+        _extra_referenced_assets: Vc<OutputAssets>,
         _availability_info: AvailabilityInfo,
     ) -> Result<Vc<EntryChunkGroupResult>> {
         bail!("Browser chunking context does not support entry chunk groups")

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -25,13 +25,14 @@ use crate::{
         },
         module_batches::{BatchingConfig, ModuleBatchesGraphEdge},
     },
-    output::OutputAssets,
+    output::{OutputAsset, OutputAssets},
     reference::ModuleReference,
     traced_asset::TracedAsset,
 };
 
 pub struct MakeChunkGroupResult {
     pub chunks: Vec<ResolvedVc<Box<dyn Chunk>>>,
+    pub referenced_output_assets: Vec<ResolvedVc<Box<dyn OutputAsset>>>,
     pub availability_info: AvailabilityInfo,
 }
 
@@ -155,12 +156,12 @@ pub async fn make_chunk_group(
         chunk_items,
         chunk_item_batch_groups,
         rcstr!(""),
-        ResolvedVc::cell(referenced_output_assets),
     )
     .await?;
 
     Ok(MakeChunkGroupResult {
         chunks,
+        referenced_output_assets,
         availability_info,
     })
 }

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -519,7 +519,7 @@ async fn evaluated_chunk_group_assets(
         .await?;
     Ok(OutputAssetsWithReferenced {
         assets: evaluated_chunk_group.assets,
-        referenced_assets: ResolvedVc::cell(vec![]),
+        referenced_assets: evaluated_chunk_group.referenced_assets,
     }
     .cell())
 }

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -17,7 +17,7 @@ use crate::{
         ModuleGraph, chunk_group_info::ChunkGroup, export_usage::ModuleExportUsage,
         module_batches::BatchingConfig,
     },
-    output::{OutputAsset, OutputAssets},
+    output::{OutputAsset, OutputAssets, OutputAssetsWithReferenced},
 };
 
 #[derive(
@@ -87,8 +87,10 @@ pub enum ChunkGroupType {
 }
 
 #[turbo_tasks::value(shared)]
+#[derive(Clone, Copy)]
 pub struct ChunkGroupResult {
     pub assets: ResolvedVc<OutputAssets>,
+    pub referenced_assets: ResolvedVc<OutputAssets>,
     pub availability_info: AvailabilityInfo,
 }
 
@@ -273,6 +275,7 @@ pub trait ChunkingContext {
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
+        extra_referenced_assets: Vc<OutputAssets>,
         availability_info: AvailabilityInfo,
     ) -> Result<Vc<EntryChunkGroupResult>>;
 
@@ -313,7 +316,7 @@ pub trait ChunkingContextExt {
         ident: Vc<AssetIdent>,
         chunk_group: ChunkGroup,
         module_graph: Vc<ModuleGraph>,
-    ) -> Vc<OutputAssets>
+    ) -> Vc<OutputAssetsWithReferenced>
     where
         Self: Send;
 
@@ -323,7 +326,7 @@ pub trait ChunkingContextExt {
         chunk_group: ChunkGroup,
         module_graph: Vc<ModuleGraph>,
         availability_info: AvailabilityInfo,
-    ) -> Vc<OutputAssets>
+    ) -> Vc<OutputAssetsWithReferenced>
     where
         Self: Send;
 
@@ -333,6 +336,7 @@ pub trait ChunkingContextExt {
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
+        extra_referenced_assets: Vc<OutputAssets>,
         availability_info: AvailabilityInfo,
     ) -> Vc<Box<dyn OutputAsset>>
     where
@@ -344,6 +348,7 @@ pub trait ChunkingContextExt {
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
+        extra_referenced_assets: Vc<OutputAssets>,
     ) -> Vc<EntryChunkGroupResult>
     where
         Self: Send;
@@ -354,6 +359,7 @@ pub trait ChunkingContextExt {
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
+        extra_referenced_assets: Vc<OutputAssets>,
     ) -> Vc<Box<dyn OutputAsset>>
     where
         Self: Send;
@@ -364,7 +370,7 @@ pub trait ChunkingContextExt {
         chunk_group: ChunkGroup,
         module_graph: Vc<ModuleGraph>,
         availability_info: AvailabilityInfo,
-    ) -> Vc<OutputAssets>
+    ) -> Vc<OutputAssetsWithReferenced>
     where
         Self: Send;
 }
@@ -384,7 +390,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
         ident: Vc<AssetIdent>,
         chunk_group: ChunkGroup,
         module_graph: Vc<ModuleGraph>,
-    ) -> Vc<OutputAssets> {
+    ) -> Vc<OutputAssetsWithReferenced> {
         root_chunk_group_assets(
             Vc::upcast_non_strict(self),
             ident,
@@ -399,7 +405,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
         chunk_group: ChunkGroup,
         module_graph: Vc<ModuleGraph>,
         availability_info: AvailabilityInfo,
-    ) -> Vc<OutputAssets> {
+    ) -> Vc<OutputAssetsWithReferenced> {
         evaluated_chunk_group_assets(
             Vc::upcast_non_strict(self),
             ident,
@@ -415,6 +421,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
+        extra_referenced_assets: Vc<OutputAssets>,
         availability_info: AvailabilityInfo,
     ) -> Vc<Box<dyn OutputAsset>> {
         entry_chunk_group_asset(
@@ -423,6 +430,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
             evaluatable_assets,
             module_graph,
             extra_chunks,
+            extra_referenced_assets,
             availability_info,
         )
     }
@@ -433,12 +441,14 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
+        extra_referenced_assets: Vc<OutputAssets>,
     ) -> Vc<EntryChunkGroupResult> {
         self.entry_chunk_group(
             path,
             evaluatable_assets,
             module_graph,
             extra_chunks,
+            extra_referenced_assets,
             AvailabilityInfo::Root,
         )
     }
@@ -449,6 +459,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
+        extra_referenced_assets: Vc<OutputAssets>,
     ) -> Vc<Box<dyn OutputAsset>> {
         entry_chunk_group_asset(
             Vc::upcast_non_strict(self),
@@ -456,6 +467,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
             evaluatable_assets,
             module_graph,
             extra_chunks,
+            extra_referenced_assets,
             AvailabilityInfo::Root,
         )
     }
@@ -466,7 +478,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
         chunk_group: ChunkGroup,
         module_graph: Vc<ModuleGraph>,
         availability_info: AvailabilityInfo,
-    ) -> Vc<OutputAssets> {
+    ) -> Vc<OutputAssetsWithReferenced> {
         chunk_group_assets(
             Vc::upcast_non_strict(self),
             ident,
@@ -483,11 +495,15 @@ async fn root_chunk_group_assets(
     ident: Vc<AssetIdent>,
     chunk_group: ChunkGroup,
     module_graph: Vc<ModuleGraph>,
-) -> Result<Vc<OutputAssets>> {
-    Ok(*chunking_context
+) -> Result<Vc<OutputAssetsWithReferenced>> {
+    let root_chunk_group = chunking_context
         .root_chunk_group(ident, chunk_group, module_graph)
-        .await?
-        .assets)
+        .await?;
+    Ok(OutputAssetsWithReferenced {
+        assets: root_chunk_group.assets,
+        referenced_assets: root_chunk_group.referenced_assets,
+    }
+    .cell())
 }
 
 #[turbo_tasks::function]
@@ -497,11 +513,15 @@ async fn evaluated_chunk_group_assets(
     chunk_group: ChunkGroup,
     module_graph: Vc<ModuleGraph>,
     availability_info: AvailabilityInfo,
-) -> Result<Vc<OutputAssets>> {
-    Ok(*chunking_context
+) -> Result<Vc<OutputAssetsWithReferenced>> {
+    let evaluated_chunk_group = chunking_context
         .evaluated_chunk_group(ident, chunk_group, module_graph, availability_info)
-        .await?
-        .assets)
+        .await?;
+    Ok(OutputAssetsWithReferenced {
+        assets: evaluated_chunk_group.assets,
+        referenced_assets: ResolvedVc::cell(vec![]),
+    }
+    .cell())
 }
 
 #[turbo_tasks::function]
@@ -511,6 +531,7 @@ async fn entry_chunk_group_asset(
     evaluatable_assets: Vc<EvaluatableAssets>,
     module_graph: Vc<ModuleGraph>,
     extra_chunks: Vc<OutputAssets>,
+    extra_referenced_assets: Vc<OutputAssets>,
     availability_info: AvailabilityInfo,
 ) -> Result<Vc<Box<dyn OutputAsset>>> {
     Ok(*chunking_context
@@ -519,6 +540,7 @@ async fn entry_chunk_group_asset(
             evaluatable_assets,
             module_graph,
             extra_chunks,
+            extra_referenced_assets,
             availability_info,
         )
         .await?
@@ -532,9 +554,13 @@ async fn chunk_group_assets(
     chunk_group: ChunkGroup,
     module_graph: Vc<ModuleGraph>,
     availability_info: AvailabilityInfo,
-) -> Result<Vc<OutputAssets>> {
-    Ok(*chunking_context
+) -> Result<Vc<OutputAssetsWithReferenced>> {
+    let chunk_group = chunking_context
         .chunk_group(ident, chunk_group, module_graph, availability_info)
-        .await?
-        .assets)
+        .await?;
+    Ok(OutputAssetsWithReferenced {
+        assets: chunk_group.assets,
+        referenced_assets: chunk_group.referenced_assets,
+    }
+    .cell())
 }

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -481,7 +481,6 @@ pub trait ChunkType: ValueToString {
         chunking_context: Vc<Box<dyn ChunkingContext>>,
         chunk_items: Vec<ChunkItemOrBatchWithAsyncModuleInfo>,
         batch_groups: Vec<ResolvedVc<ChunkItemBatchGroup>>,
-        referenced_output_assets: Vc<OutputAssets>,
     ) -> Vc<Box<dyn Chunk>>;
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/output.rs
+++ b/turbopack/crates/turbopack-core/src/output.rs
@@ -59,3 +59,18 @@ impl OutputAssets {
 /// A set of [OutputAsset]s
 #[turbo_tasks::value(transparent)]
 pub struct OutputAssetsSet(FxIndexSet<ResolvedVc<Box<dyn OutputAsset>>>);
+
+#[turbo_tasks::value(shared)]
+#[derive(Clone, Copy)]
+pub struct OutputAssetsWithReferenced {
+    pub assets: ResolvedVc<OutputAssets>,
+    pub referenced_assets: ResolvedVc<OutputAssets>,
+}
+
+#[turbo_tasks::value_impl]
+impl OutputAssetsWithReferenced {
+    #[turbo_tasks::function]
+    pub fn all_assets(&self) -> Vc<OutputAssets> {
+        self.assets.concatenate(*self.referenced_assets)
+    }
+}

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
@@ -11,7 +11,7 @@ use turbopack_core::{
     module_graph::{
         ModuleGraph, chunk_group_info::ChunkGroup, module_batch::ChunkableModuleOrBatch,
     },
-    output::OutputAssets,
+    output::{OutputAssets, OutputAssetsWithReferenced},
 };
 
 use crate::{
@@ -34,7 +34,7 @@ pub struct AsyncLoaderChunkItem {
 #[turbo_tasks::value_impl]
 impl AsyncLoaderChunkItem {
     #[turbo_tasks::function]
-    pub(super) async fn chunks(&self) -> Result<Vc<OutputAssets>> {
+    pub(super) async fn chunk_group(&self) -> Result<Vc<OutputAssetsWithReferenced>> {
         let module = self.module.await?;
         if let Some(chunk_items) = module.availability_info.available_modules() {
             let inner_module = ResolvedVc::upcast(module.inner);
@@ -47,7 +47,11 @@ impl AsyncLoaderChunkItem {
                 ChunkableModuleOrBatch::from_module_or_batch(module_or_batch)
                 && *chunk_items.get(chunkable_module_or_batch).await?
             {
-                return Ok(Vc::cell(vec![]));
+                return Ok(OutputAssetsWithReferenced {
+                    assets: ResolvedVc::cell(vec![]),
+                    referenced_assets: ResolvedVc::cell(vec![]),
+                }
+                .cell());
             }
         }
         Ok(self.chunking_context.chunk_group_assets(
@@ -63,7 +67,7 @@ impl AsyncLoaderChunkItem {
         let this = self.await?;
         Ok(ChunkData::from_assets(
             this.chunking_context.output_root().owned().await?,
-            self.chunks(),
+            *self.chunk_group().await?.assets,
         ))
     }
 }
@@ -162,7 +166,7 @@ impl ChunkItem for AsyncLoaderChunkItem {
 
     #[turbo_tasks::function]
     fn references(self: Vc<Self>) -> Vc<OutputAssets> {
-        self.chunks()
+        self.chunk_group().all_assets()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
@@ -1,12 +1,9 @@
 use anyhow::{Result, bail};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueDefault, ValueToString, Vc};
-use turbopack_core::{
-    chunk::{
-        AsyncModuleInfo, Chunk, ChunkItem, ChunkItemBatchGroup,
-        ChunkItemOrBatchWithAsyncModuleInfo, ChunkType, ChunkingContext, round_chunk_item_size,
-    },
-    output::OutputAssets,
+use turbopack_core::chunk::{
+    AsyncModuleInfo, Chunk, ChunkItem, ChunkItemBatchGroup, ChunkItemOrBatchWithAsyncModuleInfo,
+    ChunkType, ChunkingContext, round_chunk_item_size,
 };
 
 use super::{EcmascriptChunk, EcmascriptChunkContent, EcmascriptChunkItem};
@@ -37,7 +34,6 @@ impl ChunkType for EcmascriptChunkType {
         chunking_context: Vc<Box<dyn ChunkingContext>>,
         chunk_items: Vec<ChunkItemOrBatchWithAsyncModuleInfo>,
         batch_groups: Vec<ResolvedVc<ChunkItemBatchGroup>>,
-        referenced_output_assets: Vc<OutputAssets>,
     ) -> Result<Vc<Box<dyn Chunk>>> {
         let content = EcmascriptChunkContent {
             chunk_items: chunk_items
@@ -53,7 +49,6 @@ impl ChunkType for EcmascriptChunkType {
                 })
                 .try_join()
                 .await?,
-            referenced_output_assets: referenced_output_assets.owned().await?,
         }
         .cell();
         Ok(Vc::upcast(EcmascriptChunk::new(chunking_context, content)))

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/content.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/content.rs
@@ -3,10 +3,7 @@ use std::future::IntoFuture;
 use anyhow::Result;
 use either::Either;
 use turbo_tasks::{ReadRef, ResolvedVc, TryJoinIterExt, Vc};
-use turbopack_core::{
-    chunk::{ChunkItem, ChunkItems, batch_info},
-    output::OutputAsset,
-};
+use turbopack_core::chunk::{ChunkItem, ChunkItems, batch_info};
 
 use crate::chunk::{
     CodeAndIds,
@@ -18,7 +15,6 @@ use crate::chunk::{
 pub struct EcmascriptChunkContent {
     pub chunk_items: Vec<EcmascriptChunkItemOrBatchWithAsyncInfo>,
     pub batch_groups: Vec<ResolvedVc<EcmascriptChunkItemBatchGroup>>,
-    pub referenced_output_assets: Vec<ResolvedVc<Box<dyn OutputAsset>>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -19,7 +19,7 @@ use turbopack_core::{
         Introspectable, IntrospectableChildren, module::IntrospectableModule,
         utils::children_from_output_assets,
     },
-    output::{OutputAsset, OutputAssets},
+    output::OutputAssets,
     server_fs::ServerFileSystem,
 };
 
@@ -130,13 +130,12 @@ impl Chunk for EcmascriptChunk {
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<OutputAssets>> {
         let content = self.content.await?;
-        let mut referenced_output_assets: Vec<ResolvedVc<Box<dyn OutputAsset>>> = content
+        let referenced_output_assets = content
             .chunk_items
             .iter()
             .map(async |with_info| Ok(with_info.references().await?.into_iter().copied()))
             .try_flat_join()
             .await?;
-        referenced_output_assets.extend(content.referenced_output_assets.iter().copied());
         Ok(Vc::cell(referenced_output_assets))
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
@@ -33,7 +33,7 @@ impl ManifestChunkItem {
     async fn chunks_data(&self) -> Result<Vc<ChunksData>> {
         Ok(ChunkData::from_assets(
             self.chunking_context.output_root().owned().await?,
-            self.manifest.chunks(),
+            *self.manifest.chunk_group().await?.assets,
         ))
     }
 }
@@ -77,8 +77,8 @@ impl ChunkItem for ManifestChunkItem {
     }
 
     #[turbo_tasks::function]
-    async fn references(&self) -> Result<Vc<OutputAssets>> {
-        Ok(self.manifest.chunks())
+    fn references(&self) -> Vc<OutputAssets> {
+        self.manifest.chunk_group().all_assets()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
@@ -67,10 +67,10 @@ impl ManifestLoaderChunkItem {
 
     #[turbo_tasks::function]
     pub async fn chunks_data(&self) -> Result<Vc<ChunksData>> {
-        let chunks = self.manifest.manifest_chunks();
+        let chunks = self.manifest.manifest_chunk_group().await?.assets;
         Ok(ChunkData::from_assets(
             self.chunking_context.output_root().owned().await?,
-            chunks,
+            *chunks,
         ))
     }
 
@@ -93,8 +93,8 @@ impl ChunkItem for ManifestLoaderChunkItem {
     }
 
     #[turbo_tasks::function]
-    async fn references(&self) -> Result<Vc<OutputAssets>> {
-        Ok(self.manifest.manifest_chunks())
+    fn references(&self) -> Vc<OutputAssets> {
+        self.manifest.manifest_chunk_group().all_assets()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -10,7 +10,7 @@ use turbopack_core::{
     ident::AssetIdent,
     module::Module,
     module_graph::{ModuleGraph, chunk_group_info::ChunkGroup},
-    output::OutputAssets,
+    output::{OutputAssets, OutputAssetsWithReferenced},
 };
 
 use super::module::WorkerLoaderModule;
@@ -33,7 +33,7 @@ pub struct WorkerLoaderChunkItem {
 #[turbo_tasks::value_impl]
 impl WorkerLoaderChunkItem {
     #[turbo_tasks::function]
-    async fn chunks(&self) -> Result<Vc<OutputAssets>> {
+    async fn chunk_group(&self) -> Result<Vc<OutputAssetsWithReferenced>> {
         let module = self.module.await?;
 
         Ok(self.chunking_context.evaluated_chunk_group_assets(
@@ -49,7 +49,7 @@ impl WorkerLoaderChunkItem {
         let this = self.await?;
         Ok(ChunkData::from_assets(
             this.chunking_context.output_root().owned().await?,
-            self.chunks(),
+            *self.chunk_group().await?.assets,
         ))
     }
 }
@@ -94,7 +94,7 @@ impl ChunkItem for WorkerLoaderChunkItem {
 
     #[turbo_tasks::function]
     fn references(self: Vc<Self>) -> Vc<OutputAssets> {
-        self.chunks()
+        self.chunk_group().all_assets()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -177,6 +177,7 @@ async fn emit_evaluate_pool_assets_operation(
             .with_entry(*ResolvedVc::try_downcast(entry_module).unwrap()),
         module_graph,
         OutputAssets::empty(),
+        OutputAssets::empty(),
     );
 
     let output_root = chunking_context.output_root().owned().await?;

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -280,6 +280,7 @@ pub async fn get_intermediate_asset(
             false,
         ),
         OutputAssets::empty(),
+        OutputAssets::empty(),
     ))
 }
 

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -26,6 +26,7 @@ pub(crate) struct EcmascriptBuildNodeEntryChunk {
     other_chunks: ResolvedVc<OutputAssets>,
     evaluatable_assets: ResolvedVc<EvaluatableAssets>,
     exported_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
+    referenced_output_assets: ResolvedVc<OutputAssets>,
     module_graph: ResolvedVc<ModuleGraph>,
     chunking_context: ResolvedVc<NodeJsChunkingContext>,
 }
@@ -39,6 +40,7 @@ impl EcmascriptBuildNodeEntryChunk {
         other_chunks: ResolvedVc<OutputAssets>,
         evaluatable_assets: ResolvedVc<EvaluatableAssets>,
         exported_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
+        referenced_output_assets: ResolvedVc<OutputAssets>,
         module_graph: ResolvedVc<ModuleGraph>,
         chunking_context: ResolvedVc<NodeJsChunkingContext>,
     ) -> Vc<Self> {
@@ -47,6 +49,7 @@ impl EcmascriptBuildNodeEntryChunk {
             other_chunks,
             evaluatable_assets,
             exported_module,
+            referenced_output_assets,
             module_graph,
             chunking_context,
         }
@@ -190,6 +193,11 @@ impl OutputAsset for EcmascriptBuildNodeEntryChunk {
 
         let other_chunks = this.other_chunks.await?;
         references.extend(other_chunks.iter().copied());
+
+        let referenced_output_assets = this.referenced_output_assets.await?;
+        for &referenced_output_asset in &*referenced_output_assets {
+            references.push(referenced_output_asset);
+        }
 
         Ok(Vc::cell(references))
     }


### PR DESCRIPTION
### What?

`referenced_output_assets` are different for every chunk group. Attaching them as references to a random chunk in the group causes a different Chunk instance which not only causes duplicate work, but also multiple writes to the same file.

This fixes that by refactoring that and attaching the `referenced_output_assets`  higher. Actually it simplifies it.

Closes PACK-4322
Closes PACK-4392