### PR TITLE
[error overlay] hornor the original erroring order

### DIFF
--- a/packages/next/src/client/components/errors/enqueue-client-error.ts
+++ b/packages/next/src/client/components/errors/enqueue-client-error.ts
@@ -1,22 +1,12 @@
-import { isHydrationError } from '../is-hydration-error'
-
 // Dedupe the two consecutive errors: If the previous one is same as current one, ignore the current one.
 export function enqueueConsecutiveDedupedError(
   queue: Array<Error>,
   error: Error
 ) {
-  const isFront = isHydrationError(error)
-  const previousError = isFront ? queue[0] : queue[queue.length - 1]
+  const previousError = queue[queue.length - 1]
   // Compare the error stack to dedupe the consecutive errors
   if (previousError && previousError.stack === error.stack) {
     return
   }
-  // TODO: change all to push error into errorQueue,
-  // currently there's a async api error is always erroring while hydration error showing up.
-  // Move hydration error to the front of the queue to unblock.
-  if (isFront) {
-    queue.unshift(error)
-  } else {
-    queue.push(error)
-  }
+  queue.push(error)
 }

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -442,29 +442,30 @@ describe('Error overlay for hydration errors in App router', () => {
       expect(await getRedboxTotalErrorCount(browser)).toBe(2)
     })
 
-    // FIXME: Should also have "text nodes cannot be a child of tr"
-    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-      `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:"`
-    )
+    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
+     "In HTML, text nodes cannot be a child of <tr>.
+     This will cause a hydration error."
+    `)
 
     const pseudoHtml = await session.getRedboxComponentStack()
     expect(pseudoHtml).toMatchInlineSnapshot(`
      "...
-         <RenderFromTemplateContext>
-           <ScrollAndFocusHandler segmentPath={[...]}>
-             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary loading={null}>
-                   <HTTPAccessFallbackBoundary notFound={[...]} forbidden={undefined} unauthorized={undefined}>
-                     <HTTPAccessFallbackErrorBoundary pathname="/" notFound={[...]} forbidden={undefined} ...>
-                       <RedirectBoundary>
-                         <RedirectErrorBoundary router={{...}}>
-                           <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
-                             <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
-                               <Page params={Promise} searchParams={Promise}>
-     +                           <table>
-     -                           test
-                             ..."
+         <ScrollAndFocusHandler segmentPath={[...]}>
+           <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+             <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+               <LoadingBoundary loading={null}>
+                 <HTTPAccessFallbackBoundary notFound={[...]} forbidden={undefined} unauthorized={undefined}>
+                   <HTTPAccessFallbackErrorBoundary pathname="/" notFound={[...]} forbidden={undefined} ...>
+                     <RedirectBoundary>
+                       <RedirectErrorBoundary router={{...}}>
+                         <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                           <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                             <Page params={Promise} searchParams={Promise}>
+                               <table>
+                                 <tbody>
+                                   <tr>
+     >                               test
+                           ..."
     `)
   })
 

--- a/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
+++ b/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
@@ -56,6 +56,43 @@ describe('hydration-error-count', () => {
     // - has notes
     expect(firstError).toMatchInlineSnapshot(`
      {
+       "description": "In HTML, <p> cannot be a descendant of <p>.
+     This will cause a hydration error.",
+       "diff": "...
+         <OuterLayoutRouter parallelRouterKey="children" template={<RenderFromTemplateContext>}>
+           <RenderFromTemplateContext>
+             <ScrollAndFocusHandler segmentPath={[...]}>
+               <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                   <LoadingBoundary loading={null}>
+                     <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
+                       <RedirectBoundary>
+                         <RedirectErrorBoundary router={{...}}>
+                           <InnerLayoutRouter url="/two-issues" tree={[...]} cacheNode={{lazyData:null, ...}} ...>
+                             <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                               <Page params={Promise} searchParams={Promise}>
+     >                           <p className="client">
+     >                             <p>
+                             ...",
+       "highlightedLines": [
+         [
+           "error",
+           ">",
+         ],
+         [
+           "error",
+           ">",
+         ],
+       ],
+       "notes": undefined,
+     }
+    `)
+
+    // Hydration console.error
+    // - contains a diff
+    // - no notes
+    expect(secondError).toMatchInlineSnapshot(`
+     {
        "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
        "diff": "...
          <OuterLayoutRouter parallelRouterKey="children" template={<RenderFromTemplateContext>}>
@@ -92,43 +129,6 @@ describe('hydration-error-count', () => {
      - Invalid HTML tag nesting.
 
      It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.",
-     }
-    `)
-
-    // Hydration console.error
-    // - contains a diff
-    // - no notes
-    expect(secondError).toMatchInlineSnapshot(`
-     {
-       "description": "In HTML, <p> cannot be a descendant of <p>.
-     This will cause a hydration error.",
-       "diff": "...
-         <OuterLayoutRouter parallelRouterKey="children" template={<RenderFromTemplateContext>}>
-           <RenderFromTemplateContext>
-             <ScrollAndFocusHandler segmentPath={[...]}>
-               <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                   <LoadingBoundary loading={null}>
-                     <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                       <RedirectBoundary>
-                         <RedirectErrorBoundary router={{...}}>
-                           <InnerLayoutRouter url="/two-issues" tree={[...]} cacheNode={{lazyData:null, ...}} ...>
-                             <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
-                               <Page params={Promise} searchParams={Promise}>
-     >                           <p className="client">
-     >                             <p>
-                             ...",
-       "highlightedLines": [
-         [
-           "error",
-           ">",
-         ],
-         [
-           "error",
-           ">",
-         ],
-       ],
-       "notes": undefined,
      }
     `)
   })


### PR DESCRIPTION
### What

Addressing the hack we introduced in #71483, where we always display the hydration error with squashed hydration info into the first error. Now we're displaying the errors with its own corresponding hydration info properly, so we don't have to order it in a certain place, but just test the displayed error itself.


Closes NDX-484