### PR TITLE
[error overlay] fix highlighted lines

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/component-stack-pseudo-html.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/component-stack-pseudo-html.tsx
@@ -20,7 +20,7 @@ export const PSEUDO_HTML_DIFF_STYLES = css`
     padding-left: var(--size-10);
     line-height: calc(5 / 3);
   }
-  [data-nextjs-container-errors-pseudo-html-line--error] {
+  [data-nextjs-container-errors-pseudo-html--diff='error'] {
     background: var(--color-amber-100);
     font-weight: bold;
   }
@@ -51,7 +51,7 @@ export const PSEUDO_HTML_DIFF_STYLES = css`
     margin-left: calc(var(--size-6) * -1);
     margin-right: var(--size-6);
   }
-  [data-nextjs-container-errors-pseudo-html-line--error]
+  [data-nextjs-container-errors-pseudo-html--diff='error']
     [data-nextjs-container-errors-pseudo-html-line-sign] {
     color: var(--color-amber-900);
   }
@@ -81,7 +81,7 @@ export const PSEUDO_HTML_DIFF_STYLES = css`
     overflow-y: hidden;
   }
   [data-nextjs-container-errors-pseudo-html--diff],
-  [data-nextjs-container-errors-pseudo-html-line--error] {
+  [data-nextjs-container-errors-pseudo-html--diff='error'] {
     scroll-snap-align: center;
   }
   .error-overlay-hydration-error-diff-plus-icon {

--- a/packages/next/src/client/components/react-dev-overlay/hydration-diff/diff-view.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/hydration-diff/diff-view.tsx
@@ -68,8 +68,8 @@ export function PseudoHtmlDiff({
     const reactComponentDiffLines = reactOutputComponentDiff!.split('\n')
     reactComponentDiffLines.forEach((line, index) => {
       let trimmedLine = line.trim()
-      const isDiffLine = trimmedLine[0] === '+' || trimmedLine[0] === '-'
-      const isHighlightedLine = trimmedLine[0] === '>'
+      const isDiffLine = line[0] === '+' || line[0] === '-'
+      const isHighlightedLine = line[0] === '>'
       const hasSign = isDiffLine || isHighlightedLine
       const sign = hasSign ? trimmedLine[0] : ''
       const signIndex = hasSign ? line.indexOf(sign) : -1
@@ -105,7 +105,7 @@ export function PseudoHtmlDiff({
             key={'comp-diff' + index}
             {...(isHighlightedLine
               ? {
-                  'data-nextjs-container-errors-pseudo-html-line--error': true,
+                  'data-nextjs-container-errors-pseudo-html--diff': 'error',
                 }
               : undefined)}
           >

--- a/packages/next/src/client/components/react-dev-overlay/hydration-diff/diff-view.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/hydration-diff/diff-view.tsx
@@ -67,11 +67,10 @@ export function PseudoHtmlDiff({
     const componentStacks: React.ReactNode[] = []
     const reactComponentDiffLines = reactOutputComponentDiff!.split('\n')
     reactComponentDiffLines.forEach((line, index) => {
-      let trimmedLine = line.trim()
       const isDiffLine = line[0] === '+' || line[0] === '-'
       const isHighlightedLine = line[0] === '>'
       const hasSign = isDiffLine || isHighlightedLine
-      const sign = hasSign ? trimmedLine[0] : ''
+      const sign = hasSign ? line[0] : ''
       const signIndex = hasSign ? line.indexOf(sign) : -1
       const [prefix, suffix] = hasSign
         ? [line.slice(0, signIndex), line.slice(signIndex + 1)]

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
@@ -29,7 +29,7 @@ export const styles = css`
   [data-nextjs-container-errors-pseudo-html--diff='remove'] {
     color: var(--color-ansi-red);
   }
-  [data-nextjs-container-errors-pseudo-html-line--error] {
+  [data-nextjs-container-errors-pseudo-html--diff='error'] {
     color: var(--color-ansi-yellow);
     font-weight: bold;
   }
@@ -56,7 +56,7 @@ export const styles = css`
     overflow-y: hidden;
   }
   [data-nextjs-container-errors-pseudo-html--diff],
-  [data-nextjs-container-errors-pseudo-html-line--error] {
+  [data-nextjs-container-errors-pseudo-html--diff='error'] {
     scroll-snap-align: center;
   }
 `

--- a/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
+++ b/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
@@ -76,8 +76,14 @@ describe('hydration-error-count', () => {
                                  >
                              ...",
        "highlightedLines": [
-         "add",
-         "remove",
+         [
+           "add",
+           "+",
+         ],
+         [
+           "remove",
+           "-",
+         ],
        ],
        "notes": "- A server/client branch \`if (typeof window !== 'undefined')\`.
      - Variable input such as \`Date.now()\` or \`Math.random()\` which changes each time it's called.
@@ -113,8 +119,14 @@ describe('hydration-error-count', () => {
      >                             <p>
                              ...",
        "highlightedLines": [
-         "error",
-         "error",
+         [
+           "error",
+           ">",
+         ],
+         [
+           "error",
+           ">",
+         ],
        ],
        "notes": undefined,
      }

--- a/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
+++ b/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
@@ -8,6 +8,7 @@ import {
   getRedboxComponentStack,
   goToNextErrorView,
   getRedboxDescriptionWarning,
+  getHighlightedDiffLines,
 } from 'next-test-utils'
 import { BrowserInterface } from 'next-webdriver'
 
@@ -74,6 +75,10 @@ describe('hydration-error-count', () => {
      -                             className="server"
                                  >
                              ...",
+       "highlightedLines": [
+         "add",
+         "remove",
+       ],
        "notes": "- A server/client branch \`if (typeof window !== 'undefined')\`.
      - Variable input such as \`Date.now()\` or \`Math.random()\` which changes each time it's called.
      - Date formatting in a user's locale which doesn't match the server.
@@ -107,6 +112,10 @@ describe('hydration-error-count', () => {
      >                           <p className="client">
      >                             <p>
                              ...",
+       "highlightedLines": [
+         "error",
+         "error",
+       ],
        "notes": undefined,
      }
     `)
@@ -117,10 +126,12 @@ async function getHydrationErrorSnapshot(browser: BrowserInterface) {
   const description = await getRedboxDescription(browser)
   const notes = await getRedboxDescriptionWarning(browser)
   const diff = await getRedboxComponentStack(browser)
+  const highlightedLines = await getHighlightedDiffLines(browser)
 
   return {
     description,
     notes,
     diff,
+    highlightedLines,
   }
 }

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1673,13 +1673,14 @@ export async function assertNoConsoleErrors(browser: BrowserInterface) {
 
 export async function getHighlightedDiffLines(
   browser: BrowserInterface
-): Promise<string[]> {
+): Promise<[string, string][]> {
   const lines = await browser.elementsByCss(
     '[data-nextjs-container-errors-pseudo-html--diff]'
   )
   return Promise.all(
-    lines.map((line) =>
-      line.getAttribute('data-nextjs-container-errors-pseudo-html--diff')
-    )
+    lines.map(async (line) => [
+      await line.getAttribute('data-nextjs-container-errors-pseudo-html--diff'),
+      (await line.innerText())[0],
+    ])
   )
 }

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1670,3 +1670,16 @@ export async function assertNoConsoleErrors(browser: BrowserInterface) {
 
   expect(warningsAndErrors).toEqual([])
 }
+
+export async function getHighlightedDiffLines(
+  browser: BrowserInterface
+): Promise<string[]> {
+  const lines = await browser.elementsByCss(
+    '[data-nextjs-container-errors-pseudo-html--diff]'
+  )
+  return Promise.all(
+    lines.map((line) =>
+      line.getAttribute('data-nextjs-container-errors-pseudo-html--diff')
+    )
+  )
+}


### PR DESCRIPTION
### What

We should treat each line's first character to determine the leading sign, rather than treating the trimed line's first character as sign.

The bad case was the close tag `>` was treated as leading error sign
```
> <p // should be treated as errored line ✅
   >   //  should not be treated as errored line ❌
```

Also align the attribute name for highlighted lines