### PR TITLE
fix: workaround for TS bug in Object.defineProperty

### DIFF
--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -2274,7 +2274,14 @@ fn create_var_declarator(ident: &Ident, extra_items: &mut Vec<ModuleItem>) {
 fn assign_name_to_ident(ident: &Ident, name: &str, extra_items: &mut Vec<ModuleItem>) {
     // Assign a name with `Object.defineProperty($$ACTION_0, 'name', {value: 'default'})`
     extra_items.push(quote!(
-        "Object.defineProperty($action, \"name\", { value: $name, writable: false });"
+        // WORKAROUND for https://github.com/microsoft/TypeScript/issues/61165
+        // This should just be
+        //
+        //   "Object.defineProperty($action, \"name\", { value: $name, writable: false });"
+        //
+        // but due to the above typescript bug, `Object.defineProperty` calls are typechecked incorrectly
+        // in js files, and it can cause false positives when typechecking our fixture files.
+        "Object[\"defineProperty\"]($action, \"name\", { value: $name, writable: false });"
             as ModuleItem,
         action: Ident = ident.clone(),
         name: Expr = name.into(),

--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -24,6 +24,7 @@ use swc_core::{
         utils::{private_ident, quote_ident, ExprFactory},
         visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith},
     },
+    quote,
 };
 use turbo_rcstr::RcStr;
 
@@ -2272,48 +2273,12 @@ fn create_var_declarator(ident: &Ident, extra_items: &mut Vec<ModuleItem>) {
 
 fn assign_name_to_ident(ident: &Ident, name: &str, extra_items: &mut Vec<ModuleItem>) {
     // Assign a name with `Object.defineProperty($$ACTION_0, 'name', {value: 'default'})`
-    extra_items.push(ModuleItem::Stmt(Stmt::Expr(ExprStmt {
-        span: DUMMY_SP,
-        expr: Box::new(Expr::Call(CallExpr {
-            span: DUMMY_SP,
-            callee: Callee::Expr(Box::new(Expr::Member(MemberExpr {
-                span: DUMMY_SP,
-                obj: Box::new(Expr::Ident(Ident::new(
-                    "Object".into(),
-                    DUMMY_SP,
-                    ident.ctxt,
-                ))),
-                prop: MemberProp::Ident(IdentName::new("defineProperty".into(), DUMMY_SP)),
-            }))),
-            args: vec![
-                ExprOrSpread {
-                    spread: None,
-                    expr: Box::new(Expr::Ident(ident.clone())),
-                },
-                ExprOrSpread {
-                    spread: None,
-                    expr: Box::new("name".into()),
-                },
-                ExprOrSpread {
-                    spread: None,
-                    expr: Box::new(Expr::Object(ObjectLit {
-                        span: DUMMY_SP,
-                        props: vec![
-                            PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
-                                key: PropName::Str("value".into()),
-                                value: Box::new(name.into()),
-                            }))),
-                            PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
-                                key: PropName::Str("writable".into()),
-                                value: Box::new(false.into()),
-                            }))),
-                        ],
-                    })),
-                },
-            ],
-            ..Default::default()
-        })),
-    })));
+    extra_items.push(quote!(
+        "Object.defineProperty($action, \"name\", { value: $name, writable: false });"
+            as ModuleItem,
+        action: Ident = ident.clone(),
+        name: Expr = name.into(),
+    ));
 }
 
 fn assign_arrow_expr(ident: &Ident, expr: Expr) -> Expr {

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/6/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/6/output.js
@@ -2,7 +2,7 @@
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export default /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_0 = ()=>{};
 var $$RSC_SERVER_ACTION_0;
-Object.defineProperty($$RSC_SERVER_ACTION_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_ACTION_0, "name", {
     value: "default",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/6/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/6/output.js
@@ -3,8 +3,8 @@ import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc
 export default /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_0 = ()=>{};
 var $$RSC_SERVER_ACTION_0;
 Object.defineProperty($$RSC_SERVER_ACTION_0, "name", {
-    "value": "default",
-    "writable": false
+    value: "default",
+    writable: false
 });
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([

--- a/crates/next-custom-transforms/tests/fixture/next-font-with-directive/use-cache/output.js
+++ b/crates/next-custom-transforms/tests/fixture/next-font-with-directive/use-cache/output.js
@@ -6,8 +6,8 @@ import inter from '@next/font/google/target.css?{"path":"app/test.tsx","import":
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$cache__("default", "c0dd5bb6fef67f5ab84327f5164ac2c3111a159337", 0, async function Cached({ children }) {
     return <div className={inter.className}>{children}</div>;
 });
-Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
-    "value": "Cached",
-    "writable": false
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
+    value: "Cached",
+    writable: false
 });
 export var Cached = registerServerReference($$RSC_SERVER_CACHE_0, "c0dd5bb6fef67f5ab84327f5164ac2c3111a159337", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/11/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/11/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"00c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export default /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ async function $$RSC_SERVER_ACTION_0() {}
-Object.defineProperty($$RSC_SERVER_ACTION_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_ACTION_0, "name", {
     value: "default",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/11/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/11/output.js
@@ -2,8 +2,8 @@
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export default /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ async function $$RSC_SERVER_ACTION_0() {}
 Object.defineProperty($$RSC_SERVER_ACTION_0, "name", {
-    "value": "default",
-    "writable": false
+    value: "default",
+    writable: false
 });
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/15/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/15/output.js
@@ -5,8 +5,8 @@ export default /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_0 =
 };
 var $$RSC_SERVER_ACTION_0;
 Object.defineProperty($$RSC_SERVER_ACTION_0, "name", {
-    "value": "default",
-    "writable": false
+    value: "default",
+    writable: false
 });
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/15/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/15/output.js
@@ -4,7 +4,7 @@ export default /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_0 =
     console.log(a, b);
 };
 var $$RSC_SERVER_ACTION_0;
-Object.defineProperty($$RSC_SERVER_ACTION_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_ACTION_0, "name", {
     value: "default",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/22/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/22/output.js
@@ -5,8 +5,8 @@ export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ action = validator(async 
 export default /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_0 = validator(async ()=>{});
 var $$RSC_SERVER_ACTION_0;
 Object.defineProperty($$RSC_SERVER_ACTION_0, "name", {
-    "value": "default",
-    "writable": false
+    value: "default",
+    writable: false
 });
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/22/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/22/output.js
@@ -4,7 +4,7 @@ import { validator } from 'auth';
 export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ action = validator(async ()=>{});
 export default /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_0 = validator(async ()=>{});
 var $$RSC_SERVER_ACTION_0;
-Object.defineProperty($$RSC_SERVER_ACTION_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_ACTION_0, "name", {
     value: "default",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/33/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/33/output.js
@@ -6,8 +6,8 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$ca
     return 'hello, ' + v;
 });
 Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
-    "value": "fn",
-    "writable": false
+    value: "fn",
+    writable: false
 });
 var fn = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
 export async function Component() {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/33/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/33/output.js
@@ -5,7 +5,7 @@ const v = 'world';
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function fn() {
     return 'hello, ' + v;
 });
-Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "fn",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/34/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/34/output.js
@@ -4,7 +4,7 @@ import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function() {
     return 'foo';
 });
-Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "foo",
     writable: false
 });
@@ -13,7 +13,7 @@ export { bar };
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_1 = $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", 0, async function bar() {
     return 'bar';
 });
-Object.defineProperty($$RSC_SERVER_CACHE_1, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_1, "name", {
     value: "bar",
     writable: false
 });
@@ -25,7 +25,7 @@ const qux = async function qux() {
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_2 = $$cache__("default", "8069348c79fce073bae2f70f139565a2fda1c74c74", 0, async function baz() {
     return qux() + 'baz';
 });
-Object.defineProperty($$RSC_SERVER_CACHE_2, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_2, "name", {
     value: "baz",
     writable: false
 });
@@ -33,7 +33,7 @@ const baz = registerServerReference($$RSC_SERVER_CACHE_2, "8069348c79fce073bae2f
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_3 = $$cache__("default", "8012a8d21b6362b4cc8f5b15560525095bc48dba80", 0, async function() {
     return 'quux';
 });
-Object.defineProperty($$RSC_SERVER_CACHE_3, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_3, "name", {
     value: "quux",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/34/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/34/output.js
@@ -5,8 +5,8 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$ca
     return 'foo';
 });
 Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
-    "value": "foo",
-    "writable": false
+    value: "foo",
+    writable: false
 });
 const foo = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
 export { bar };
@@ -14,8 +14,8 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_1 = $$ca
     return 'bar';
 });
 Object.defineProperty($$RSC_SERVER_CACHE_1, "name", {
-    "value": "bar",
-    "writable": false
+    value: "bar",
+    writable: false
 });
 var bar = registerServerReference($$RSC_SERVER_CACHE_1, "80951c375b4a6a6e89d67b743ec5808127cfde405d", null);
 // Should not be wrapped in $$cache__.
@@ -26,16 +26,16 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_2 = $$ca
     return qux() + 'baz';
 });
 Object.defineProperty($$RSC_SERVER_CACHE_2, "name", {
-    "value": "baz",
-    "writable": false
+    value: "baz",
+    writable: false
 });
 const baz = registerServerReference($$RSC_SERVER_CACHE_2, "8069348c79fce073bae2f70f139565a2fda1c74c74", null);
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_3 = $$cache__("default", "8012a8d21b6362b4cc8f5b15560525095bc48dba80", 0, async function() {
     return 'quux';
 });
 Object.defineProperty($$RSC_SERVER_CACHE_3, "name", {
-    "value": "quux",
-    "writable": false
+    value: "quux",
+    writable: false
 });
 const quux = registerServerReference($$RSC_SERVER_CACHE_3, "8012a8d21b6362b4cc8f5b15560525095bc48dba80", null);
 export { foo, baz };

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/35/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/35/output.js
@@ -5,7 +5,7 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$ca
     return 'data';
 });
 Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
-    "value": "my_fn",
-    "writable": false
+    value: "my_fn",
+    writable: false
 });
 export const my_fn = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/35/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/35/output.js
@@ -4,7 +4,7 @@ import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function() {
     return 'data';
 });
-Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "my_fn",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/36/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/36/output.js
@@ -4,7 +4,7 @@ import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function foo() {
     return 'data A';
 });
-Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "foo",
     writable: false
 });
@@ -12,7 +12,7 @@ export var foo = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_1 = $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", 0, async function bar() {
     return 'data B';
 });
-Object.defineProperty($$RSC_SERVER_CACHE_1, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_1, "name", {
     value: "bar",
     writable: false
 });
@@ -20,7 +20,7 @@ export var bar = registerServerReference($$RSC_SERVER_CACHE_1, "80951c375b4a6a6e
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_2 = $$cache__("default", "c069348c79fce073bae2f70f139565a2fda1c74c74", 0, async function Cached({ children }) {
     return children;
 });
-Object.defineProperty($$RSC_SERVER_CACHE_2, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_2, "name", {
     value: "Cached",
     writable: false
 });
@@ -28,7 +28,7 @@ export default registerServerReference($$RSC_SERVER_CACHE_2, "c069348c79fce073ba
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_3 = $$cache__("default", "8012a8d21b6362b4cc8f5b15560525095bc48dba80", 0, async function baz() {
     return 'data C';
 });
-Object.defineProperty($$RSC_SERVER_CACHE_3, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_3, "name", {
     value: "baz",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/36/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/36/output.js
@@ -5,31 +5,31 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$ca
     return 'data A';
 });
 Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
-    "value": "foo",
-    "writable": false
+    value: "foo",
+    writable: false
 });
 export var foo = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_1 = $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", 0, async function bar() {
     return 'data B';
 });
 Object.defineProperty($$RSC_SERVER_CACHE_1, "name", {
-    "value": "bar",
-    "writable": false
+    value: "bar",
+    writable: false
 });
 export var bar = registerServerReference($$RSC_SERVER_CACHE_1, "80951c375b4a6a6e89d67b743ec5808127cfde405d", null);
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_2 = $$cache__("default", "c069348c79fce073bae2f70f139565a2fda1c74c74", 0, async function Cached({ children }) {
     return children;
 });
 Object.defineProperty($$RSC_SERVER_CACHE_2, "name", {
-    "value": "Cached",
-    "writable": false
+    value: "Cached",
+    writable: false
 });
 export default registerServerReference($$RSC_SERVER_CACHE_2, "c069348c79fce073bae2f70f139565a2fda1c74c74", null);
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_3 = $$cache__("default", "8012a8d21b6362b4cc8f5b15560525095bc48dba80", 0, async function baz() {
     return 'data C';
 });
 Object.defineProperty($$RSC_SERVER_CACHE_3, "name", {
-    "value": "baz",
-    "writable": false
+    value: "baz",
+    writable: false
 });
 export const baz = registerServerReference($$RSC_SERVER_CACHE_3, "8012a8d21b6362b4cc8f5b15560525095bc48dba80", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/37/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/37/output.js
@@ -5,8 +5,8 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$ca
     return 'foo';
 });
 Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
-    "value": "fn",
-    "writable": false
+    value: "fn",
+    writable: false
 });
 var fn = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
 async function Component() {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/37/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/37/output.js
@@ -4,7 +4,7 @@ import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function fn() {
     return 'foo';
 });
-Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "fn",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/38/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/38/output.js
@@ -4,7 +4,7 @@ import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$cache__("x", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function foo() {
     return 'data';
 });
-Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "foo",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/38/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/38/output.js
@@ -5,7 +5,7 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$ca
     return 'data';
 });
 Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
-    "value": "foo",
-    "writable": false
+    value: "foo",
+    writable: false
 });
 export var foo = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/39/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/39/output.js
@@ -8,8 +8,8 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$ca
     };
 });
 Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
-    "value": "fn",
-    "writable": false
+    value: "fn",
+    writable: false
 });
 async function Component({ foo }) {
     const a = 123;

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/39/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/39/output.js
@@ -7,7 +7,7 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$ca
         foo: $$ACTION_ARG_1
     };
 });
-Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "fn",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/40/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/40/output.js
@@ -12,8 +12,8 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$ca
     ];
 });
 Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
-    "value": "cache",
-    "writable": false
+    value: "cache",
+    writable: false
 });
 export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_2 = async function action($$ACTION_CLOSURE_BOUND, c) {
     var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("601c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", $$ACTION_CLOSURE_BOUND);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/40/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/40/output.js
@@ -11,7 +11,7 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$ca
         }
     ];
 });
-Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "cache",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/41/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/41/output.js
@@ -15,7 +15,7 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_1 = $$ca
     // @ts-expect-error: data is not a valid react child
     return <div>{data}</div>;
 });
-Object.defineProperty($$RSC_SERVER_CACHE_1, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_1, "name", {
     value: "Component",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/41/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/41/output.js
@@ -16,7 +16,7 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_1 = $$ca
     return <div>{data}</div>;
 });
 Object.defineProperty($$RSC_SERVER_CACHE_1, "name", {
-    "value": "Component",
-    "writable": false
+    value: "Component",
+    writable: false
 });
 export var Component = registerServerReference($$RSC_SERVER_CACHE_1, "c0951c375b4a6a6e89d67b743ec5808127cfde405d", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/42/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/42/output.js
@@ -8,8 +8,8 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$ca
     };
 });
 Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
-    "value": "fn",
-    "writable": false
+    value: "fn",
+    writable: false
 });
 async function Component({ foo }) {
     const a = 123;

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/42/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/42/output.js
@@ -7,7 +7,7 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$ca
         foo: $$ACTION_ARG_1
     };
 });
-Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "fn",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/43/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/43/output.js
@@ -15,7 +15,7 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_1 = $$ca
         r: children
     };
 });
-Object.defineProperty($$RSC_SERVER_CACHE_1, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_1, "name", {
     value: "getCachedRandom",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/43/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/43/output.js
@@ -16,7 +16,7 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_1 = $$ca
     };
 });
 Object.defineProperty($$RSC_SERVER_CACHE_1, "name", {
-    "value": "getCachedRandom",
-    "writable": false
+    value: "getCachedRandom",
+    writable: false
 });
 var getCachedRandom = registerServerReference($$RSC_SERVER_CACHE_1, "e0951c375b4a6a6e89d67b743ec5808127cfde405d", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/45/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/45/output.js
@@ -11,7 +11,7 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$ca
     return <Foo/>;
 });
 Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
-    "value": "bar",
-    "writable": false
+    value: "bar",
+    writable: false
 });
 export var bar = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/45/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/45/output.js
@@ -10,7 +10,7 @@ function Foo() {
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function bar() {
     return <Foo/>;
 });
-Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "bar",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/46/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/46/output.js
@@ -10,8 +10,8 @@ export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "e03128060c414d59f8552e47
     ];
 });
 Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
-    "value": "f1",
-    "writable": false
+    value: "f1",
+    writable: false
 });
 var f1 = registerServerReference($$RSC_SERVER_CACHE_0, "e03128060c414d59f8552e4788b846c0d2b7f74743", null);
 export const // Should be 0 110000 0, which is "60" in hex.
@@ -31,8 +31,8 @@ export var // Should be 1 111111 1, which is "ff" in hex.
     ];
 });
 Object.defineProperty($$RSC_SERVER_CACHE_2, "name", {
-    "value": "f3",
-    "writable": false
+    value: "f3",
+    writable: false
 });
 var f3 = registerServerReference($$RSC_SERVER_CACHE_2, "ff69348c79fce073bae2f70f139565a2fda1c74c74", null);
 export const // Should be 0 111110 0, which is "7c" in hex.
@@ -71,7 +71,7 @@ export var // Should be 1 111111 1, which is "ff" in hex.
     ];
 });
 Object.defineProperty($$RSC_SERVER_CACHE_5, "name", {
-    "value": "f6",
-    "writable": false
+    value: "f6",
+    writable: false
 });
 var f6 = registerServerReference($$RSC_SERVER_CACHE_5, "ff471a5eb0be1c31686dd4ba938a80328b80b1615d", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/46/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/46/output.js
@@ -9,7 +9,7 @@ export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "e03128060c414d59f8552e47
         b
     ];
 });
-Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "f1",
     writable: false
 });
@@ -30,7 +30,7 @@ export var // Should be 1 111111 1, which is "ff" in hex.
         rest
     ];
 });
-Object.defineProperty($$RSC_SERVER_CACHE_2, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_2, "name", {
     value: "f3",
     writable: false
 });
@@ -70,7 +70,7 @@ export var // Should be 1 111111 1, which is "ff" in hex.
         g
     ];
 });
-Object.defineProperty($$RSC_SERVER_CACHE_5, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_5, "name", {
     value: "f6",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/48/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/48/output.js
@@ -30,7 +30,7 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$ca
       {b}
     </div>;
 });
-Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "cache",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/48/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/48/output.js
@@ -31,8 +31,8 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$ca
     </div>;
 });
 Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
-    "value": "cache",
-    "writable": false
+    value: "cache",
+    writable: false
 });
 // Should be 1 110000 0, which is "e0" in hex.
 export var cache = registerServerReference($$RSC_SERVER_CACHE_0, "e03128060c414d59f8552e4788b846c0d2b7f74743", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/50/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/50/output.js
@@ -9,7 +9,7 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$ca
     </div>;
 });
 Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
-    "value": "default",
-    "writable": false
+    value: "default",
+    writable: false
 });
 export default registerServerReference($$RSC_SERVER_CACHE_0, "f03128060c414d59f8552e4788b846c0d2b7f74743", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/50/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/50/output.js
@@ -8,7 +8,7 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$ca
       {c}
     </div>;
 });
-Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "default",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/51/input.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/51/input.js
@@ -1,11 +1,5 @@
 'use cache'
 
-// FIXME: this produces incorrect output, with
-//
-//   Object.defineProperty($$RSC_SERVER_ACTION_0, ...)
-//
-// where `$$RSC_SERVER_ACTION_0` doesn't exist.
-// but why is typescript not complaining about an undefined variable there?
 export default async function (a, b, c) {
   'use server'
 

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/51/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/51/output.js
@@ -8,7 +8,7 @@ export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_1 = a
     </div>;
 };
 export default registerServerReference($$RSC_SERVER_ACTION_1, "7090b5db271335765a4b0eab01f044b381b5ebd5cd", null);
-Object.defineProperty($$RSC_SERVER_ACTION_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_ACTION_0, "name", {
     value: "default",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/51/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/51/output.js
@@ -9,8 +9,8 @@ export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_1 = a
 };
 export default registerServerReference($$RSC_SERVER_ACTION_1, "7090b5db271335765a4b0eab01f044b381b5ebd5cd", null);
 Object.defineProperty($$RSC_SERVER_ACTION_0, "name", {
-    "value": "default",
-    "writable": false
+    value: "default",
+    writable: false
 });
 export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_2 = async function foo(a, b) {
     return <div>

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/52/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/52/output.js
@@ -6,8 +6,8 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$ca
     return $$ACTION_ARG_0 + $$ACTION_ARG_1 + c;
 });
 Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
-    "value": "fn1",
-    "writable": false
+    value: "fn1",
+    writable: false
 });
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_2 = $$cache__("default", "c069348c79fce073bae2f70f139565a2fda1c74c74", 2, async function // Should be 1 100000 0, which is "c0" in hex (counts as one param,
 // because of the encrypted bound args param)
@@ -15,8 +15,8 @@ fn2([$$ACTION_ARG_0, $$ACTION_ARG_1]) {
     return $$ACTION_ARG_0 + $$ACTION_ARG_1;
 });
 Object.defineProperty($$RSC_SERVER_CACHE_2, "name", {
-    "value": "fn2",
-    "writable": false
+    value: "fn2",
+    writable: false
 });
 export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_4 = async function // Should be 0 110000 0, which is "60" in hex (counts as two params,
 // because of the encrypted bound args param)

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/52/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/52/output.js
@@ -5,7 +5,7 @@ import { Client } from 'components';
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", 2, async function([$$ACTION_ARG_0, $$ACTION_ARG_1], c) {
     return $$ACTION_ARG_0 + $$ACTION_ARG_1 + c;
 });
-Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "fn1",
     writable: false
 });
@@ -14,7 +14,7 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_2 = $$ca
 fn2([$$ACTION_ARG_0, $$ACTION_ARG_1]) {
     return $$ACTION_ARG_0 + $$ACTION_ARG_1;
 });
-Object.defineProperty($$RSC_SERVER_CACHE_2, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_2, "name", {
     value: "fn2",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/53/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/53/output.js
@@ -2,7 +2,7 @@
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function foo() {});
-Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "foo",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/53/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/53/output.js
@@ -3,8 +3,8 @@ import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function foo() {});
 Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
-    "value": "foo",
-    "writable": false
+    value: "foo",
+    writable: false
 });
 export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_1 = async function bar() {};
 export const obj = {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/54/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/54/output.js
@@ -5,8 +5,8 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$ca
     return $$ACTION_ARG_0 * $$ACTION_ARG_1;
 });
 Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
-    "value": "foo",
-    "writable": false
+    value: "foo",
+    writable: false
 });
 export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_2 = async function bar($$ACTION_CLOSURE_BOUND) {
     var [$$ACTION_ARG_0] = await decryptActionBoundArgs("401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", $$ACTION_CLOSURE_BOUND);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/54/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/54/output.js
@@ -4,7 +4,7 @@ import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", 2, async function foo([$$ACTION_ARG_0, $$ACTION_ARG_1]) {
     return $$ACTION_ARG_0 * $$ACTION_ARG_1;
 });
-Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "foo",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/55/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/55/output.js
@@ -5,8 +5,8 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$ca
     return fetch('https://example.com').then((res)=>res.json());
 });
 Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
-    "value": "fetch",
-    "writable": false
+    value: "fetch",
+    writable: false
 });
 export const api = {
     product: {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/55/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/55/output.js
@@ -4,7 +4,7 @@ import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function fetch1() {
     return fetch('https://example.com').then((res)=>res.json());
 });
-Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "fetch",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/57/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/57/output.js
@@ -5,8 +5,8 @@ export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$ca
     return fetch('https://example.com').then((res)=>res.json());
 });
 Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
-    "value": "foo",
-    "writable": false
+    value: "foo",
+    writable: false
 });
 export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_1 = async function bar() {
     console.log(42);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/57/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/57/output.js
@@ -4,7 +4,7 @@ import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function foo() {
     return fetch('https://example.com').then((res)=>res.json());
 });
-Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "foo",
     writable: false
 });

--- a/crates/next-custom-transforms/tests/fixture/server-actions/tsconfig.json
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/tsconfig.json
@@ -23,7 +23,7 @@
     "moduleDetection": "force"
   },
   "files": ["./index.ts"], // loads ambient declarations for modules used in tests
-  "include": ["./**/*/input.js", "./**/*/output.js"],
+  "include": ["./**/*/input.js", "./**/*/output.js", "./**/*/output.tsx"],
   "exclude": [
     // FIXME: invalid transformation of hoisted functions (https://github.com/vercel/next.js/issues/57392)
     "./server-graph/25/output.js",

--- a/crates/next-custom-transforms/tests/fixture/server-actions/tsconfig.json
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/tsconfig.json
@@ -23,7 +23,7 @@
     "moduleDetection": "force"
   },
   "files": ["./index.ts"], // loads ambient declarations for modules used in tests
-  "include": ["./**/*/input.js", "./**/*/output.js", "./**/*/output.tsx"],
+  "include": ["./**/*/input.js", "./**/*/output.js"],
   "exclude": [
     // FIXME: invalid transformation of hoisted functions (https://github.com/vercel/next.js/issues/57392)
     "./server-graph/25/output.js",

--- a/crates/next-custom-transforms/tests/fixture/source-maps/use-cache/1/output.js
+++ b/crates/next-custom-transforms/tests/fixture/source-maps/use-cache/1/output.js
@@ -2,16 +2,16 @@
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function() {});
-Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
-    "value": "foo",
-    "writable": false
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
+    value: "foo",
+    writable: false
 });
 const foo = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
 export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_1 = $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", 0, async function bar() {
     return foo();
 });
-Object.defineProperty($$RSC_SERVER_CACHE_1, "name", {
-    "value": "bar",
-    "writable": false
+Object["defineProperty"]($$RSC_SERVER_CACHE_1, "name", {
+    value: "bar",
+    writable: false
 });
 export var bar = registerServerReference($$RSC_SERVER_CACHE_1, "80951c375b4a6a6e89d67b743ec5808127cfde405d", null);


### PR DESCRIPTION
This PR changes the server action generated code a bit to work around a typescript bug and remove some false positives we got while typechecking: https://github.com/microsoft/TypeScript/issues/61165

The trick is that typescript seems to look for *exactly* `Object.defineProperty(obj, 'literal', { value: ... })`, and changing any part of the expression bypasses the bug, so we can just use `Object['defineProperty']` instead.

