### PR TITLE
docs: add just-styled to CSS-in-JS libraries list

### DIFF
--- a/docs/01-app/03-building-your-application/05-styling/04-css-in-js.mdx
+++ b/docs/01-app/03-building-your-application/05-styling/04-css-in-js.mdx
@@ -14,6 +14,7 @@ The following libraries are supported in Client Components in the `app` director
 - [`ant-design`](https://ant.design/docs/react/use-with-next#using-app-router)
 - [`chakra-ui`](https://chakra-ui.com/getting-started/nextjs-app-guide)
 - [`@fluentui/react-components`](https://react.fluentui.dev/?path=/docs/concepts-developer-server-side-rendering-next-js-appdir-setup--page)
+- [`just-styled`](https://github.com/yukukotani/just-styled)
 - [`kuma-ui`](https://kuma-ui.com)
 - [`@mui/material`](https://mui.com/material-ui/guides/next-js-app-router/)
 - [`@mui/joy`](https://mui.com/joy-ui/integrations/next-js-app-router/)


### PR DESCRIPTION
Add [just-styled](https://github.com/yukukotani/just-styled/), a minimal CSS-in-JS library that relies on [React19's style tag](https://react.dev/blog/2024/12/05/react-19#support-for-stylesheets), to the App Router compatible libraries list.