### PR TITLE
Fix flaky error-recovery test

### DIFF
--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
-import { check, describeVariants as describe } from 'next-test-utils'
+import { check, describeVariants as describe, retry } from 'next-test-utils'
 import { outdent } from 'outdent'
 import path from 'path'
 
@@ -301,7 +301,10 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     )
     await session.assertHasRedbox()
 
-    await expect(session.getRedboxSource()).resolves.toInclude('render() {')
+    // wait for patch to get applied
+    await retry(async () => {
+      await expect(session.getRedboxSource()).resolves.toInclude('render() {')
+    })
 
     expect(await session.getRedboxSource()).toInclude(
       "throw new Error('nooo');"


### PR DESCRIPTION
Fixes e.g. https://github.com/vercel/next.js/actions/runs/13280374165/job/37077362978?pr=75917#step:33:473