### PR TITLE
Turbopack: make tracing easier

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1428,7 +1428,10 @@ export default async function build(
             duration: compilerDuration,
             shutdownPromise: p,
             ...rest
-          } = await turbopackBuild(!process.env.NEXT_TURBOPACK_NO_WORKER)
+          } = await turbopackBuild(
+            process.env.NEXT_TURBOPACK_USE_WORKER === undefined ||
+              process.env.NEXT_TURBOPACK_USE_WORKER !== '0'
+          )
           shutdownPromise = p
           traceMemoryUsage('Finished build', nextBuildSpan)
 

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1428,7 +1428,7 @@ export default async function build(
             duration: compilerDuration,
             shutdownPromise: p,
             ...rest
-          } = await turbopackBuild(true)
+          } = await turbopackBuild(!process.env.NEXT_TURBOPACK_NO_WORKER)
           shutdownPromise = p
           traceMemoryUsage('Finished build', nextBuildSpan)
 

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -17,6 +17,7 @@ default = []
 verify_serialization = []
 trace_aggregation_update = []
 trace_find_and_schedule = []
+trace_task_completion = []
 trace_task_dirty = []
 lmdb = ["dep:lmdb-rkv"]
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1381,6 +1381,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         drop(task);
 
         if !queue.is_empty() || !old_edges.is_empty() {
+            #[cfg(feature = "trace_task_completion")]
             let _span = tracing::trace_span!("remove old edges and prepare new children").entered();
             // Remove outdated edges first, before removing in_progress+dirty flag.
             // We need to make sure all outdated edges are removed before the task can potentially
@@ -1443,6 +1444,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         drop(task);
 
         if has_children {
+            #[cfg(feature = "trace_task_completion")]
             let _span = tracing::trace_span!("connect new children").entered();
             queue.execute(&mut ctx);
         }


### PR DESCRIPTION
- Add an env var to run Turbopack in the same process: `NEXT_TURBOPACK_USE_WORKER=0`
- Put some turbo-task spans behind a feature. This alone makes traces 20% smaller. There is still one span that accounts for the time spent in turbo-tasks:

![Bildschirmfoto 2025-02-12 um 13 33 20](https://github.com/user-attachments/assets/0cdf9250-d289-4208-962f-9b2ba0105ee7)


Closes PACK-3949