### PR TITLE
[Turbopack] disable session dependent tasks when dependency tracking is disabled

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1801,6 +1801,10 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         task: TaskId,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) {
+        if !self.should_track_dependencies() {
+            // Without dependency tracking we don't need session dependent tasks
+            return;
+        }
         let mut ctx = self.execute_context(turbo_tasks);
         let mut task = ctx.task(task, TaskDataCategory::Data);
         if let Some(InProgressState::InProgress(box InProgressStateInner {


### PR DESCRIPTION
### What?

Without dependency tracking we don't need session dependent tasks since there is only a single session.

The problem is that we would track all file system tasks as dirty containers for every page which is pretty memory intense.

Closes PACK-3950