### PR TITLE
fix: make sure that the patched fetch cache set promise is properly awaited

### DIFF
--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -676,7 +676,7 @@ export function createPatchedFetcher(
                   // We are dynamically rendering including dev mode. We want to return
                   // the response to the caller as soon as possible because it might stream
                   // over a very long time.
-                  cloned1
+                  const cacheSetPromise = cloned1
                     .arrayBuffer()
                     .then(async (arrayBuffer) => {
                       const bodyBuffer = Buffer.from(arrayBuffer)
@@ -709,6 +709,26 @@ export function createPatchedFetcher(
                       console.warn(`Failed to set fetch cache`, input, error)
                     )
                     .finally(handleUnlock)
+
+                  const pendingRevalidateKey = `cache-set-${cacheKey}`
+                  workStore.pendingRevalidates ??= {}
+                  if (pendingRevalidateKey in workStore.pendingRevalidates) {
+                    // there is already a pending revalidate entry that
+                    // we need to await to avoid race conditions
+                    await workStore.pendingRevalidates[pendingRevalidateKey]
+                  }
+                  workStore.pendingRevalidates[pendingRevalidateKey] =
+                    cacheSetPromise.finally(() => {
+                      // If the pending revalidate is not present in the store, then
+                      // we have nothing to delete.
+                      if (
+                        !workStore.pendingRevalidates?.[pendingRevalidateKey]
+                      ) {
+                        return
+                      }
+
+                      delete workStore.pendingRevalidates[pendingRevalidateKey]
+                    })
 
                   return cloned2
                 }


### PR DESCRIPTION
The [promise created for updating the incremental cache on successful fetches](https://github.com/vercel/next.js/blob/106e17ca8f093899d300885938eab863ffa478a7/packages/next/src/server/lib/patch-fetch.ts#L687-L728) is not used, returned nor awaited in any way. I imagine that this can be fine in environments such as Node.js servers where the dangling promise will eventually run, in other environments however the promise might be cancelled causing the cache update not to happen, so it would be appropriate, when possible that the promise is awaited using `waitUntil` (for more context, I've encountered this issue in the [OpenNext project](https://github.com/opennextjs)).

So in this PR I'm adding the promise to the `pendingRevalidates` map so that it will eventually be properly awaited.

cc. @vicb, @conico974

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
