### PR TITLE
fix: handle parsing destination with patterns in hostname

### DIFF
--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -33,6 +33,7 @@ import { addRequestMeta } from '../../request-meta'
 import {
   compileNonPath,
   matchHas,
+  parseDestination,
   prepareDestination,
 } from '../../../shared/lib/router/utils/prepare-destination'
 import type { TLSSocket } from 'tls'
@@ -45,7 +46,6 @@ import {
 import { getSelectedParams } from '../../../client/components/router-reducer/compute-changed-path'
 import { isInterceptionRouteRewrite } from '../../../lib/generate-interception-routes-rewrites'
 import { parseAndValidateFlightRouterState } from '../../app-render/parse-and-validate-flight-router-state'
-import { parseUrl } from '../../../shared/lib/router/utils/parse-url'
 
 const debug = setupDebug('next:router-server:resolve-routes')
 
@@ -737,7 +737,11 @@ export function getResolveRoutes(
           // the response headers. We don't want to use the following
           // `parsedDestination` as the query object is mutated.
           const { search: destinationSearch, pathname: destinationPathname } =
-            parseUrl(route.destination)
+            parseDestination({
+              destination: route.destination,
+              params: rewriteParams,
+              query: parsedUrl.query,
+            })
 
           const { parsedDestination } = prepareDestination({
             appendParamsToQuery: true,

--- a/packages/next/src/shared/lib/router/utils/prepare-destination.test.ts
+++ b/packages/next/src/shared/lib/router/utils/prepare-destination.test.ts
@@ -1,0 +1,78 @@
+import { parseDestination } from './prepare-destination'
+
+describe('parseDestination', () => {
+  it('should parse the destination', () => {
+    const destination = '/hello/:name'
+    const params = { name: 'world' }
+    const query = { foo: 'bar' }
+
+    const result = parseDestination({
+      destination,
+      params,
+      query,
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+     {
+       "hash": "",
+       "hostname": undefined,
+       "href": "/hello/:name",
+       "pathname": "/hello/:name",
+       "query": {},
+       "search": "",
+     }
+    `)
+  })
+
+  it('should parse the destination with a hash', () => {
+    const destination = 'https://o:foo.com/hello/:name#bar'
+    const params = { name: 'world' }
+    const query = { foo: 'bar' }
+
+    const result = parseDestination({
+      destination,
+      params,
+      query,
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+     {
+       "hash": "#bar",
+       "hostname": "o:foo.com",
+       "href": "https://o:foo.com/hello/:name#bar",
+       "pathname": "/hello/:name",
+       "port": "",
+       "protocol": "https:",
+       "query": {},
+       "search": "",
+     }
+    `)
+  })
+
+  it('should parse the destination with a host', () => {
+    const destination = 'https://o:foo.com/hello/:name?foo=:bar'
+    const params = { name: 'world' }
+    const query = { foo: 'bar' }
+
+    const result = parseDestination({
+      destination,
+      params,
+      query,
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+     {
+       "hash": "",
+       "hostname": "o:foo.com",
+       "href": "https://o:foo.com/hello/:name?foo=:bar",
+       "pathname": "/hello/:name",
+       "port": "",
+       "protocol": "https:",
+       "query": {
+         "foo": ":bar",
+       },
+       "search": "?foo=:bar",
+     }
+    `)
+  })
+})

--- a/packages/next/src/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/src/shared/lib/router/utils/prepare-destination.ts
@@ -160,6 +160,49 @@ export function compileNonPath(value: string, params: Params): string {
   return compile(`/${value}`, { validate: false })(params).slice(1)
 }
 
+export function parseDestination(args: {
+  destination: string
+  params: Readonly<Params>
+  query: Readonly<NextParsedUrlQuery>
+}) {
+  let escaped = args.destination
+  for (const param of Object.keys({ ...args.params, ...args.query })) {
+    if (!param) continue
+
+    escaped = escapeSegment(escaped, param)
+  }
+
+  const parsed = parseUrl(escaped)
+
+  let pathname = parsed.pathname
+  if (pathname) {
+    pathname = unescapeSegments(pathname)
+  }
+
+  let href = parsed.href
+  if (href) {
+    href = unescapeSegments(href)
+  }
+
+  let hostname = parsed.hostname
+  if (hostname) {
+    hostname = unescapeSegments(hostname)
+  }
+
+  let hash = parsed.hash
+  if (hash) {
+    hash = unescapeSegments(hash)
+  }
+
+  return {
+    ...parsed,
+    pathname,
+    hostname,
+    href,
+    hash,
+  }
+}
+
 export function prepareDestination(args: {
   appendParamsToQuery: boolean
   destination: string
@@ -169,29 +212,32 @@ export function prepareDestination(args: {
   const query = Object.assign({}, args.query)
   delete query[NEXT_RSC_UNION_QUERY]
 
-  let escapedDestination = args.destination
+  const parsedDestination = parseDestination(args)
 
-  for (const param of Object.keys({ ...args.params, ...query })) {
-    escapedDestination = param
-      ? escapeSegment(escapedDestination, param)
-      : escapedDestination
+  const { hostname: destHostname, query: destQuery } = parsedDestination
+
+  // The following code assumes that the pathname here includes the hash if it's
+  // present.
+  let destPath = parsedDestination.pathname
+  if (parsedDestination.hash) {
+    destPath = `${destPath}${parsedDestination.hash}`
   }
-
-  const parsedDestination = parseUrl(escapedDestination)
-  const destQuery = parsedDestination.query
-  const destPath = unescapeSegments(
-    `${parsedDestination.pathname!}${parsedDestination.hash || ''}`
-  )
-  const destHostname = unescapeSegments(parsedDestination.hostname || '')
-  const destPathParamKeys: Key[] = []
-  const destHostnameParamKeys: Key[] = []
-  pathToRegexp(destPath, destPathParamKeys)
-  pathToRegexp(destHostname, destHostnameParamKeys)
 
   const destParams: (string | number)[] = []
 
-  destPathParamKeys.forEach((key) => destParams.push(key.name))
-  destHostnameParamKeys.forEach((key) => destParams.push(key.name))
+  const destPathParamKeys: Key[] = []
+  pathToRegexp(destPath, destPathParamKeys)
+  for (const key of destPathParamKeys) {
+    destParams.push(key.name)
+  }
+
+  if (destHostname) {
+    const destHostnameParamKeys: Key[] = []
+    pathToRegexp(destHostname, destHostnameParamKeys)
+    for (const key of destHostnameParamKeys) {
+      destParams.push(key.name)
+    }
+  }
 
   const destPathCompiler = compile(
     destPath,
@@ -204,7 +250,10 @@ export function prepareDestination(args: {
     { validate: false }
   )
 
-  const destHostnameCompiler = compile(destHostname, { validate: false })
+  let destHostnameCompiler
+  if (destHostname) {
+    destHostnameCompiler = compile(destHostname, { validate: false })
+  }
 
   // update any params in query values
   for (const [key, strOrArray] of Object.entries(destQuery)) {
@@ -261,7 +310,9 @@ export function prepareDestination(args: {
     newUrl = destPathCompiler(args.params)
 
     const [pathname, hash] = newUrl.split('#', 2)
-    parsedDestination.hostname = destHostnameCompiler(args.params)
+    if (destHostnameCompiler) {
+      parsedDestination.hostname = destHostnameCompiler(args.params)
+    }
     parsedDestination.pathname = pathname
     parsedDestination.hash = `${hash ? '#' : ''}${hash || ''}`
     delete (parsedDestination as any).search


### PR DESCRIPTION
This handles when the rewrite destination is not a valid URL (as it's a pattern anyways, containing characters like `:` for patterns like `:subdomain.google.com` which wouldn't be valid). This uses the existing escaping behaviour to extract the url parts.

Fixes https://github.com/vercel/next.js/issues/75956