### PR TITLE
fix: compiler error when next/cache is used in a client module

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -639,7 +639,22 @@ impl ReactServerComponentValidator {
 
             invalid_client_imports: vec![Atom::from("server-only"), Atom::from("next/headers")],
 
-            invalid_client_lib_apis_mapping: FxHashMap::from_iter([("next/server", vec!["after"])]),
+            invalid_client_lib_apis_mapping: FxHashMap::from_iter([
+                ("next/server", vec!["after"]),
+                (
+                    "next/cache",
+                    vec![
+                        "revalidatePath",
+                        "revalidateTag",
+                        // "unstable_cache", // useless in client, but doesn't technically error
+                        "unstable_cacheLife",
+                        "unstable_cacheTag",
+                        "unstable_expirePath",
+                        "unstable_expireTag",
+                        // "unstable_noStore" // no-op in client, but allowed for legacy reasons
+                    ],
+                ),
+            ]),
             imports: ImportMap::default(),
         }
     }

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/next-cache-in-client/revalidatepath/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/next-cache-in-client/revalidatepath/page.js
@@ -1,0 +1,8 @@
+'use client'
+import { revalidatePath } from 'next/cache'
+
+console.log({ revalidatePath })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/next-cache-in-client/revalidatetag/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/next-cache-in-client/revalidatetag/page.js
@@ -1,0 +1,8 @@
+'use client'
+import { revalidateTag } from 'next/cache'
+
+console.log({ revalidateTag })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/next-cache-in-client/unstable_cache/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/next-cache-in-client/unstable_cache/page.js
@@ -1,0 +1,8 @@
+'use client'
+import { unstable_cache } from 'next/cache'
+
+console.log({ unstable_cache })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/next-cache-in-client/unstable_cachelife/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/next-cache-in-client/unstable_cachelife/page.js
@@ -1,0 +1,8 @@
+'use client'
+import { unstable_cacheLife } from 'next/cache'
+
+console.log({ unstable_cacheLife })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/next-cache-in-client/unstable_cachetag/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/next-cache-in-client/unstable_cachetag/page.js
@@ -1,0 +1,8 @@
+'use client'
+import { unstable_cacheTag } from 'next/cache'
+
+console.log({ unstable_cacheTag })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/next-cache-in-client/unstable_expirepath/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/next-cache-in-client/unstable_expirepath/page.js
@@ -1,0 +1,8 @@
+'use client'
+import { unstable_expirePath } from 'next/cache'
+
+console.log({ unstable_expirePath })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/next-cache-in-client/unstable_expiretag/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/next-cache-in-client/unstable_expiretag/page.js
@@ -1,0 +1,8 @@
+'use client'
+import { unstable_expireTag } from 'next/cache'
+
+console.log({ unstable_expireTag })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/next-cache-in-client/unstable_nostore/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/next-cache-in-client/unstable_nostore/page.js
@@ -1,0 +1,8 @@
+'use client'
+import { unstable_noStore } from 'next/cache'
+
+console.log({ unstable_noStore })
+
+export default function Page() {
+  return null
+}


### PR DESCRIPTION
Most functions in `next/cache` don't work on the client, and produce confusing error messages when called there. It's better to just ban them at compile time.

NOTE: For legacy/compat reasons, we're allowing `unstable_cache` and `unstable_noStore`, since they don't currently throw when called.