### PR TITLE
Update toolchain to nightly-2025-02-12

### DIFF
--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -9,9 +9,10 @@
 //!     [implementation 2](https://github.com/vercel/next.js/pull/56389/files#diff-791951bbe1fa09bcbad9be9173412d0848168f7d658758f11b6e8888a021552c),
 //!     [implementation 3](https://github.com/vercel/next.js/pull/56389/files#diff-c33f6895801329243dd3f627c69da259bcab95c2c9d12993152842591931ff01R557)
 //! - When running an application,
-//!    - Server reads generated `react-loadable-manifest.json`, sets dynamicImportIds with the mapping of the import ids, and dynamicImports to the actual corresponding chunks.
-//!         [implementation 1](https://github.com/vercel/next.js/blob/ad42b610c25b72561ad367b82b1c7383fd2a5dd2/packages/next/src/server/load-components.ts#L119),
-//!         [implementation 2](https://github.com/vercel/next.js/blob/ad42b610c25b72561ad367b82b1c7383fd2a5dd2/packages/next/src/server/render.tsx#L1417C7-L1420)
+//!    - Server reads generated `react-loadable-manifest.json`, sets dynamicImportIds with the
+//!      mapping of the import ids, and dynamicImports to the actual corresponding chunks.
+//!      [implementation 1](https://github.com/vercel/next.js/blob/ad42b610c25b72561ad367b82b1c7383fd2a5dd2/packages/next/src/server/load-components.ts#L119),
+//!      [implementation 2](https://github.com/vercel/next.js/blob/ad42b610c25b72561ad367b82b1c7383fd2a5dd2/packages/next/src/server/render.tsx#L1417C7-L1420)
 //!    - Server embeds those into __NEXT_DATA__ and [send to the client.](https://github.com/vercel/next.js/blob/ad42b610c25b72561ad367b82b1c7383fd2a5dd2/packages/next/src/server/render.tsx#L1453)
 //!    - When client boots up, pass it to the [client preload](https://github.com/vercel/next.js/blob/ad42b610c25b72561ad367b82b1c7383fd2a5dd2/packages/next/src/client/index.tsx#L943)
 //!    - Loadable runtime [injects preload fn](https://github.com/vercel/next.js/blob/ad42b610c25b72561ad367b82b1c7383fd2a5dd2/packages/next/src/shared/lib/loadable.shared-runtime.tsx#L281)

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -225,10 +225,7 @@ pub fn parse_server_actions(
         comments.iter().find_map(|c| {
             c.text
                 .split_once("__next_internal_action_entry_do_not_use__")
-                .and_then(|(_, actions)| match serde_json::from_str(actions) {
-                    Ok(v) => Some(v),
-                    Err(_) => None,
-                })
+                .and_then(|(_, actions)| serde_json::from_str(actions).ok())
         })
     })
 }

--- a/crates/next-core/src/lib.rs
+++ b/crates/next-core/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(async_closure)]
 #![feature(str_split_remainder)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(arbitrary_self_types)]

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -230,7 +230,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                 *node_resolved_from_original_location.first_source().await?
             else {
                 if is_esm
-                    && package_subpath != ""
+                    && !package_subpath.is_empty()
                     && package_subpath != "/"
                     && !request_str.ends_with(".js")
                 {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-12-10"
+channel = "nightly-2025-02-12"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -63,7 +63,7 @@ unsafe impl Sync for RcStr {}
 
 const DYNAMIC_TAG: u8 = 0b_00;
 const INLINE_TAG: u8 = 0b_01; // len in upper nybble
-const INLINE_TAG_INIT: NonZeroU8 = unsafe { NonZeroU8::new_unchecked(INLINE_TAG) };
+const INLINE_TAG_INIT: NonZeroU8 = NonZeroU8::new(INLINE_TAG).unwrap();
 const TAG_MASK: u8 = 0b_11;
 const LEN_OFFSET: usize = 4;
 const LEN_MASK: u8 = 0xf0;

--- a/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
+++ b/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
@@ -65,7 +65,7 @@ async fn print_hash(dir_hash: Vc<RcStr>) -> Result<Vc<()>> {
 }
 
 async fn filename(path: Vc<FileSystemPath>) -> Result<String> {
-    Ok(path.await?.path.split('/').last().unwrap().to_string())
+    Ok(path.await?.path.split('/').next_back().unwrap().to_string())
 }
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_type.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_type.stderr
@@ -4,7 +4,7 @@ error: methods taking `self` are not supported with `operation`
 13 |     fn arbitrary_self_type(self: OperationVc<Self>) -> Vc<()> {
    |                            ^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `fn(OperationVc<Foobar>) -> Vc<()> {Foobar::arbitrary_self_type_turbo_tasks_function_inline}: turbo_tasks::task::function::IntoTaskFnWithThis<_, _, _>` is not satisfied
+error[E0277]: the trait bound `fn(...) -> ... {...::arbitrary_self_type_turbo_tasks_function_inline}: IntoTaskFnWithThis<_, _, _>` is not satisfied
   --> tests/function/fail_operation_method_self_type.rs:10:1
    |
 10 | #[turbo_tasks::value_impl]
@@ -20,6 +20,7 @@ note: required by a bound in `NativeFunction::new_method`
 ...
    |         I: IntoTaskFnWithThis<Mode, This, Inputs>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `NativeFunction::new_method`
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the attribute macro `turbo_tasks::value_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0307]: invalid `self` parameter type: `OperationVc<Foobar>`

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_type.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_type.stderr
@@ -28,5 +28,5 @@ error[E0307]: invalid `self` parameter type: `OperationVc<Foobar>`
 13 |     fn arbitrary_self_type(self: OperationVc<Self>) -> Vc<()> {
    |                                  ^^^^^^^^^^^^^^^^^
    |
-   = note: type of `self` must be `Self` or a type that dereferences to it
-   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
+   = note: type of `self` must be `Self` or some type implementing `Receiver`
+   = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`

--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -105,7 +105,7 @@ impl TurboFn<'_> {
                     // other forms of self.
 
                     let definition_context = match &definition_context {
-                        DefinitionContext::NakedFn { .. } => return None,
+                        DefinitionContext::NakedFn => return None,
                         _ => &definition_context,
                     };
 
@@ -182,7 +182,7 @@ impl TurboFn<'_> {
 
                     if let Pat::Ident(ident) = &*typed.pat {
                         if ident.ident == "self" {
-                            if let DefinitionContext::NakedFn { .. } = definition_context {
+                            if let DefinitionContext::NakedFn = definition_context {
                                 // The function is not associated. The compiler will emit an error
                                 // on its own.
                                 return None;
@@ -201,10 +201,10 @@ impl TurboFn<'_> {
                             });
                         } else {
                             match definition_context {
-                                DefinitionContext::NakedFn { .. }
-                                | DefinitionContext::ValueInherentImpl { .. } => {}
-                                DefinitionContext::ValueTraitImpl { .. }
-                                | DefinitionContext::ValueTrait { .. } => {
+                                DefinitionContext::NakedFn
+                                | DefinitionContext::ValueInherentImpl => {}
+                                DefinitionContext::ValueTraitImpl
+                                | DefinitionContext::ValueTrait => {
                                     typed
                                         .span()
                                         .unwrap()

--- a/turbopack/crates/turbopack-browser/src/lib.rs
+++ b/turbopack/crates/turbopack-browser/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(async_closure)]
 #![feature(iter_intersperse)]
 #![feature(int_roundings)]
 #![feature(arbitrary_self_types)]

--- a/turbopack/crates/turbopack-cli-utils/src/lib.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(async_closure)]
 #![feature(min_specialization)]
 #![feature(round_char_boundary)]
 #![feature(thread_id_value)]

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -331,7 +331,7 @@ impl AssetIdent {
             }
         }
         if i > 0 {
-            let hash = encode_hex(hash_xxh3_hash64(name[..i].as_bytes()));
+            let hash = encode_hex(hash_xxh3_hash64(&name.as_bytes()[..i]));
             let truncated_hash = &hash[..5];
             name = format!("{}_{}", truncated_hash, &name[i..]);
         }

--- a/turbopack/crates/turbopack-core/src/lib.rs
+++ b/turbopack/crates/turbopack-core/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(async_closure)]
 #![feature(min_specialization)]
 #![feature(type_alias_impl_trait)]
 #![feature(assert_matches)]
@@ -6,7 +5,6 @@
 #![feature(arbitrary_self_types_pointers)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(iter_intersperse)]
-#![feature(map_many_mut)]
 
 pub mod asset;
 pub mod changed;

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -269,7 +269,7 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraph) -> Result<Vc<ChunkGro
                         } else {
                             // Fast path
                             let [Some(parent_chunk_groups), Some(current_chunk_groups)] =
-                                module_chunk_groups.get_many_mut([&parent, &node.module])
+                                module_chunk_groups.get_disjoint_mut([&parent, &node.module])
                             else {
                                 // All modules are inserted in the previous iteration
                                 unreachable!()

--- a/turbopack/crates/turbopack-css/src/lib.rs
+++ b/turbopack/crates/turbopack-css/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(async_closure)]
 #![feature(min_specialization)]
 #![feature(box_patterns)]
 #![feature(iter_intersperse)]

--- a/turbopack/crates/turbopack-dev-server/src/source/router.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/router.rs
@@ -84,9 +84,13 @@ impl ContentSource for PrefixedRouterContentSource {
             debug_assert!(prefix.is_empty() || prefix.ends_with('/'));
             debug_assert!(!prefix.starts_with('/'));
         }
-        let prefix = (!prefix.is_empty())
-            .then(|| BaseSegment::from_static_pathname(prefix.as_str()).collect())
-            .unwrap_or(Vec::new());
+
+        let prefix = if prefix.is_empty() {
+            Vec::new()
+        } else {
+            BaseSegment::from_static_pathname(prefix.as_str()).collect()
+        };
+
         let inner_trees = self.routes.iter().map(|(path, source)| {
             let prepended_base = prefix
                 .iter()

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -1723,11 +1723,11 @@ impl JsValue {
                         format!("path.resolve({cwd})"),
                         "The Node.js path.resolve method: https://nodejs.org/api/path.html#pathresolvepaths",
                     ),
-                    WellKnownFunctionKind::Import { .. } => (
+                    WellKnownFunctionKind::Import => (
                         "import".to_string(),
                         "The dynamic import() method from the ESM specification: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#dynamic_imports"
                     ),
-                    WellKnownFunctionKind::Require { .. } => ("require".to_string(), "The require method from CommonJS"),
+                    WellKnownFunctionKind::Require => ("require".to_string(), "The require method from CommonJS"),
                     WellKnownFunctionKind::RequireResolve => ("require.resolve".to_string(), "The require.resolve method from CommonJS"),
                     WellKnownFunctionKind::RequireContext => ("require.context".to_string(), "The require.context method from webpack"),
                     WellKnownFunctionKind::RequireContextRequire(..) => ("require.context(...)".to_string(), "The require.context(...) method from webpack: https://webpack.js.org/api/module-methods/#requirecontext"),
@@ -1802,7 +1802,7 @@ impl JsValue {
                       "load/loadSync".to_string(),
                       "require('@grpc/proto-loader').load(filepath, { includeDirs: [root] }) https://github.com/grpc/grpc-node"
                     ),
-                    WellKnownFunctionKind::WorkerConstructor { .. } => (
+                    WellKnownFunctionKind::WorkerConstructor => (
                       "Worker".to_string(),
                       "The standard Worker constructor: https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker"
                     ),
@@ -3876,7 +3876,7 @@ pub mod test_utils {
         let mut new_value = match v {
             JsValue::Call(
                 _,
-                box JsValue::WellKnownFunction(WellKnownFunctionKind::Import { .. }),
+                box JsValue::WellKnownFunction(WellKnownFunctionKind::Import),
                 ref args,
             ) => match &args[0] {
                 JsValue::Constant(v) => JsValue::Module(ModuleValue {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known.rs
@@ -515,13 +515,13 @@ pub fn path_to_file_url(args: Vec<JsValue>) -> JsValue {
 
 pub fn well_known_function_member(kind: WellKnownFunctionKind, prop: JsValue) -> (JsValue, bool) {
     let new_value = match (kind, prop.as_str()) {
-        (WellKnownFunctionKind::Require { .. }, Some("resolve")) => {
+        (WellKnownFunctionKind::Require, Some("resolve")) => {
             JsValue::WellKnownFunction(WellKnownFunctionKind::RequireResolve)
         }
-        (WellKnownFunctionKind::Require { .. }, Some("cache")) => {
+        (WellKnownFunctionKind::Require, Some("cache")) => {
             JsValue::WellKnownObject(WellKnownObjectKind::RequireCache)
         }
-        (WellKnownFunctionKind::Require { .. }, Some("context")) => {
+        (WellKnownFunctionKind::Require, Some("context")) => {
             JsValue::WellKnownFunction(WellKnownFunctionKind::RequireContext)
         }
         (WellKnownFunctionKind::RequireContextRequire(val), Some("resolve")) => {
@@ -536,7 +536,7 @@ pub fn well_known_function_member(kind: WellKnownFunctionKind, prop: JsValue) ->
         (WellKnownFunctionKind::NodeResolveFrom, Some("silent")) => {
             JsValue::WellKnownFunction(WellKnownFunctionKind::NodeResolveFrom)
         }
-        (WellKnownFunctionKind::Import { .. }, Some("meta")) => {
+        (WellKnownFunctionKind::Import, Some("meta")) => {
             JsValue::WellKnownObject(WellKnownObjectKind::ImportMeta)
         }
         #[allow(unreachable_patterns)]

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -1,6 +1,5 @@
 // Needed for swc visit_ macros
 #![allow(non_local_definitions)]
-#![feature(async_closure)]
 #![feature(box_patterns)]
 #![feature(min_specialization)]
 #![feature(iter_intersperse)]

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2303,7 +2303,7 @@ async fn handle_member(
         }
 
         if is_prop_cache {
-            if let JsValue::WellKnownFunction(WellKnownFunctionKind::Require { .. }) =
+            if let JsValue::WellKnownFunction(WellKnownFunctionKind::Require) =
                 obj.as_ref().unwrap()
             {
                 analysis.add_code_gen(CjsRequireCacheAccess::new(ast_path.to_vec().into()));

--- a/turbopack/crates/turbopack-env/src/lib.rs
+++ b/turbopack/crates/turbopack-env/src/lib.rs
@@ -9,7 +9,6 @@
 //! cannot override it). Later dotenv files can reference variables prior
 //! defined variables.
 
-#![feature(async_closure)]
 #![feature(min_specialization)]
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(async_closure)]
 #![feature(min_specialization)]
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -612,7 +612,9 @@ async fn apply_webpack_resolve_options(
     if let Some(alias_fields) = webpack_resolve_options.alias_fields {
         let mut old = resolve_options
             .in_package
-            .extract_if(|field| matches!(field, ResolveInPackage::AliasField(..)))
+            .extract_if(0.., |field| {
+                matches!(field, ResolveInPackage::AliasField(..))
+            })
             .collect::<Vec<_>>();
         for field in alias_fields {
             if &*field == "..." {
@@ -653,7 +655,9 @@ async fn apply_webpack_resolve_options(
     if let Some(main_fields) = webpack_resolve_options.main_fields {
         let mut old = resolve_options
             .into_package
-            .extract_if(|field| matches!(field, ResolveIntoPackage::MainField { .. }))
+            .extract_if(0.., |field| {
+                matches!(field, ResolveIntoPackage::MainField { .. })
+            })
             .collect::<Vec<_>>();
         for field in main_fields {
             if &*field == "..." {

--- a/turbopack/crates/turbopack-nodejs/src/lib.rs
+++ b/turbopack/crates/turbopack-nodejs/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(async_closure)]
 #![feature(iter_intersperse)]
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]

--- a/turbopack/crates/turbopack-trace-utils/src/lib.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(async_closure)]
 #![feature(min_specialization)]
 #![feature(round_char_boundary)]
 #![feature(thread_id_value)]


### PR DESCRIPTION
This updates the Rust toolchain to nightly-2025-02-12. It required:

- Removing `#![feature(async_closure)]`
- Removing `#![feature(map_many_mut)]` and renaming `map.get_many_mut()` to `map.get_disjoint_mut()`
- Adding a range argument to `vec.extract_if()`

Test Plan: CI


Closes PACK-3958