### PR TITLE
Fix: Build error causes infinite loop on new dev overlay in Turbopack

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/app/react-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/app/react-dev-overlay.tsx
@@ -10,7 +10,7 @@ import { CssReset } from '../internal/styles/css-reset'
 import { Colors } from '../internal/styles/colors'
 import { ErrorOverlay } from '../internal/components/errors/error-overlay/error-overlay'
 import { DevToolsIndicator } from '../internal/components/errors/dev-tools-indicator/dev-tools-indicator'
-import { useErrorHook } from '../internal/container/runtime-error/use-error-hook'
+import { RenderError } from '../internal/container/runtime-error/render-error'
 
 export default function ReactDevOverlay({
   state,
@@ -21,15 +21,7 @@ export default function ReactDevOverlay({
   globalError: [GlobalErrorComponent, React.ReactNode]
   children: React.ReactNode
 }) {
-  const [_isErrorOverlayOpen, setIsErrorOverlayOpen] = useState(false)
-  const { readyErrors, totalErrorCount } = useErrorHook({
-    state,
-    isAppDir: true,
-  })
-
-  // Build errors cannot be dismissed. If one is triggered, we ignore the
-  // user's preference and open the error overlay.
-  const isErrorOverlayOpen = Boolean(state.buildError) || _isErrorOverlayOpen
+  const [isErrorOverlayOpen, setIsErrorOverlayOpen] = useState(false)
 
   const devOverlay = (
     <ShadowPortal>
@@ -38,18 +30,26 @@ export default function ReactDevOverlay({
       <Colors />
       <ComponentStyles />
 
-      <DevToolsIndicator
-        state={state}
-        errorCount={totalErrorCount}
-        setIsErrorOverlayOpen={setIsErrorOverlayOpen}
-      />
+      <RenderError state={state} isAppDir={true}>
+        {({ readyErrors, totalErrorCount }) => {
+          return (
+            <>
+              <DevToolsIndicator
+                state={state}
+                errorCount={totalErrorCount}
+                setIsErrorOverlayOpen={setIsErrorOverlayOpen}
+              />
 
-      <ErrorOverlay
-        state={state}
-        readyErrors={readyErrors}
-        isErrorOverlayOpen={isErrorOverlayOpen}
-        setIsErrorOverlayOpen={setIsErrorOverlayOpen}
-      />
+              <ErrorOverlay
+                state={state}
+                readyErrors={readyErrors}
+                isErrorOverlayOpen={isErrorOverlayOpen}
+                setIsErrorOverlayOpen={setIsErrorOverlayOpen}
+              />
+            </>
+          )
+        }}
+      </RenderError>
     </ShadowPortal>
   )
 

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -509,7 +509,13 @@ function useMeasureWidth(ref: React.RefObject<HTMLDivElement | null>) {
 
 function NextMark({ isLoading }: { isLoading?: boolean }) {
   return (
-    <svg width="40" height="40" viewBox="0 0 40 40" fill="none">
+    <svg
+      width="40"
+      height="40"
+      viewBox="0 0 40 40"
+      fill="none"
+      data-next-mark-loading={isLoading}
+    >
       <g transform="translate(8.5, 13)">
         <path
           className={isLoading ? 'path0' : 'paused'}

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay/error-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay/error-overlay.tsx
@@ -44,7 +44,7 @@ export function ErrorOverlay({
     return (
       <RootLayoutMissingTagsError
         {...commonProps}
-        // This is a runtime error, forcedly display error overlay
+        // This is not a runtime error, forcedly display error overlay
         rendered
         missingTags={state.rootLayoutMissingTags}
       />
@@ -52,7 +52,14 @@ export function ErrorOverlay({
   }
 
   if (state.buildError !== null) {
-    return <BuildError {...commonProps} message={state.buildError} />
+    return (
+      <BuildError
+        {...commonProps}
+        message={state.buildError}
+        // This is not a runtime error, forcedly display error overlay
+        rendered
+      />
+    )
   }
 
   // No Runtime Errors.

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/pages/react-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/pages/react-dev-overlay.tsx
@@ -11,7 +11,7 @@ import { usePagesReactDevOverlay } from '../../pages/hooks'
 import { Colors } from '../internal/styles/colors'
 import { ErrorOverlay } from '../internal/components/errors/error-overlay/error-overlay'
 import { DevToolsIndicator } from '../internal/components/errors/dev-tools-indicator/dev-tools-indicator'
-import { useErrorHook } from '../internal/container/runtime-error/use-error-hook'
+import { RenderError } from '../internal/container/runtime-error/render-error'
 
 export type ErrorType = 'runtime' | 'build'
 
@@ -22,11 +22,6 @@ interface ReactDevOverlayProps {
 export default function ReactDevOverlay({ children }: ReactDevOverlayProps) {
   const { state, onComponentError, hasRuntimeErrors, hasBuildError } =
     usePagesReactDevOverlay()
-
-  const { readyErrors, totalErrorCount } = useErrorHook({
-    state,
-    isAppDir: false,
-  })
 
   const [isErrorOverlayOpen, setIsErrorOverlayOpen] = useState(true)
 
@@ -42,20 +37,26 @@ export default function ReactDevOverlay({ children }: ReactDevOverlayProps) {
         <Colors />
         <ComponentStyles />
 
-        <DevToolsIndicator
-          state={state}
-          errorCount={totalErrorCount}
-          setIsErrorOverlayOpen={setIsErrorOverlayOpen}
-        />
+        <RenderError state={state} isAppDir={false}>
+          {({ readyErrors, totalErrorCount }) => (
+            <>
+              <DevToolsIndicator
+                state={state}
+                errorCount={totalErrorCount}
+                setIsErrorOverlayOpen={setIsErrorOverlayOpen}
+              />
 
-        {(hasRuntimeErrors || hasBuildError) && (
-          <ErrorOverlay
-            state={state}
-            readyErrors={readyErrors}
-            isErrorOverlayOpen={isErrorOverlayOpen}
-            setIsErrorOverlayOpen={setIsErrorOverlayOpen}
-          />
-        )}
+              {(hasRuntimeErrors || hasBuildError) && (
+                <ErrorOverlay
+                  state={state}
+                  readyErrors={readyErrors}
+                  isErrorOverlayOpen={isErrorOverlayOpen}
+                  setIsErrorOverlayOpen={setIsErrorOverlayOpen}
+                />
+              )}
+            </>
+          )}
+        </RenderError>
       </ShadowPortal>
     </>
   )


### PR DESCRIPTION
### What?

When you enable both Turbopack, and the new dev overlay, you will see that the dev overlay is frozen and the network tab shows that it is fetching the stack frames API indefinitely.

### Why?

​During our migration to the new development overlay, we implemented a refactor to ensure that logic for handling runtime errors is executed consistently, even in the case of build-time errors. This change involves invoking the getErrorByType function for build errors. However, this function attempts to retrieve stack frames for the build-time error, inadvertently triggering Turbopack to initiate a rebuild.

Once Turbopack completes the rebuild process, it dispatches a Hot Module Replacement (HMR) event to indicate the presence of a new error. This event prompts getErrorByType to attempt fetching the stack frames again, which in turn causes Turbopack to rebuild once more. This creates an endless loop of rebuilding and error signaling.

You can repro it by running
```
__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY='true' TURBOPACK=1 pnpm testonly-dev test/development/acceptance-app/editor-links.test.ts
```
with the test file change in this PR. (Important to add that. Otherwise the test would still complete successfully)

### How?

Do not run the runtime error logic for build errors.


Closes NDX-816