### PR TITLE
fix(turbopack CI): Pin corepack version for production tests manifest update action

### DIFF
--- a/.github/workflows/turbopack-update-tests-manifest.yml
+++ b/.github/workflows/turbopack-update-tests-manifest.yml
@@ -62,7 +62,10 @@ jobs:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
 
-      - run: corepack enable
+      - name: Setup corepack
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
 
       - name: Install dependencies
         shell: bash


### PR DESCRIPTION
Looks like this was overlooked when updating our CI configs to work around the recent corepack issue.

https://github.com/vercel/next.js/actions/runs/13279886936/job/37075996177

![Screenshot 2025-02-12 at 3.04.02 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/731e4b13-35ef-4bc5-8041-7eae8581f0fd.png)



Closes PACK-3961