### PR TITLE
fix(CI): Initialize non-existent bundler manifests

### DIFF
--- a/.github/workflows/rspack-update-tests-manifest.yml
+++ b/.github/workflows/rspack-update-tests-manifest.yml
@@ -42,8 +42,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           BRANCH_NAME: rspack-manifest
           SCRIPT: test/build-rspack-dev-tests-manifest.js
-          PR_TITLE: Update Rspack development test manifest
-          PR_BODY: This auto-generated PR updates the development integration test manifest used when testing Rspack.
+          PR_TITLE: Update bundler development test manifest
+          PR_BODY: This auto-generated PR updates the development integration test manifest used when testing alternative bundlers.
   update_build_manifest:
     name: Update and upload Rspack production test manifest
     if: github.repository_owner == 'vercel'
@@ -78,5 +78,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           BRANCH_NAME: rspack-manifest
           SCRIPT: test/build-rspack-build-tests-manifest.js
-          PR_TITLE: Update Rspack production test manifest
-          PR_BODY: This auto-generated PR updates the production integration test manifest used when testing Rspack.
+          PR_TITLE: Update bundler production test manifest
+          PR_BODY: This auto-generated PR updates the production integration test manifest used when testing alternative bundlers.

--- a/test/rspack-build-tests-manifest.json
+++ b/test/rspack-build-tests-manifest.json
@@ -1,0 +1,5420 @@
+{
+  "version": 2,
+  "suites": {
+    "test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts": {
+      "passed": [
+        "non-root-project-monorepo import.meta.url should work during RSC",
+        "non-root-project-monorepo import.meta.url should work during SSR",
+        "non-root-project-monorepo import.meta.url should work on client-side",
+        "non-root-project-monorepo monorepo-package should work during RSC",
+        "non-root-project-monorepo monorepo-package should work during SSR",
+        "non-root-project-monorepo monorepo-package should work on client-side"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/not-found-default/index.test.ts": {
+      "passed": [
+        "app dir - not found with default 404 page should be able to navigate to page calling not-found",
+        "app dir - not found with default 404 page should be able to navigate to page with calling not-found in metadata",
+        "app dir - not found with default 404 page should error on client notFound from root layout in browser",
+        "app dir - not found with default 404 page should error on server notFound from root layout on server-side",
+        "app dir - not found with default 404 page should render default 404 with root layout for non-existent page",
+        "app dir - not found with default 404 page should render default not found for group routes if not found is not defined",
+        "app dir - not found with default 404 page should return 404 status code for default not-found page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/not-found/basic/index.test.ts": {
+      "passed": [
+        "app dir - not-found - basic should include not found client reference manifest in the file trace",
+        "app dir - not-found - basic should not output /404 in tree view logs",
+        "app dir - not-found - basic should propagate notFound errors past a segment's error boundary",
+        "app dir - not-found - basic should return 404 status code for custom not-found page",
+        "app dir - not-found - basic should use root not-found content for 404 html",
+        "app dir - not-found - basic with default runtime should create the 404 mapping and copy the file to pages",
+        "app dir - not-found - basic with default runtime should escalate notFound to parent layout if no not-found boundary present in current layer",
+        "app dir - not-found - basic with default runtime should match dynamic route not-found boundary correctly",
+        "app dir - not-found - basic with default runtime should use the not-found page for non-matching routes",
+        "app dir - not-found - basic with runtime = edge should escalate notFound to parent layout if no not-found boundary present in current layer",
+        "app dir - not-found - basic with runtime = edge should match dynamic route not-found boundary correctly",
+        "app dir - not-found - basic with runtime = edge should use the not-found page for non-matching routes"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/not-found/conflict-route/index.test.ts": {
+      "passed": [
+        "app dir - not-found - conflict route with default runtime should allow to have a valid /not-found route",
+        "app dir - not-found - conflict route with default runtime should use the not-found page for non-matching routes",
+        "app dir - not-found - conflict route with runtime = edge should allow to have a valid /not-found route",
+        "app dir - not-found - conflict route with runtime = edge should use the not-found page for non-matching routes"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/not-found/css-precedence/index.test.ts": {
+      "passed": [
+        "not-found app dir css should load css while navigation between not-found and page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/not-found/default/default.test.ts": {
+      "passed": [
+        "app dir - not-found - default should contain noindex contain in the page",
+        "app dir - not-found - default should has noindex in the head html"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/not-found/group-route-root-not-found/index.test.ts": {
+      "passed": [
+        "app dir - group routes with root not-found should render default 404 with root layout for non-existent page",
+        "app dir - group routes with root not-found should render root not found for group routes if hit 404"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/not-found/group-route/index.test.ts": {
+      "passed": [
+        "app dir - not-found - group route with default runtime should use the not-found page under group routes",
+        "app dir - not-found - group route with runtime = edge should use the not-found page under group routes"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/options-request/options-request.test.ts": {
+      "passed": [
+        "options-request should 404 for an OPTIONS request to a non-existent route",
+        "options-request should respond with a 200 + response body when invoking a pages API route with an OPTIONS request",
+        "options-request should respond with a 204 No Content when invoking an app route handler with an OPTIONS request",
+        "options-request should return a 400 status code when invoking /app-page with an OPTIONS request",
+        "options-request should return a 400 status code when invoking /pages-page with an OPTIONS request"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/pages-to-app-routing/pages-to-app-routing.test.ts": {
+      "passed": ["pages-to-app-routing should work using browser"],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/parallel-route-not-found-params/parallel-route-not-found-params.test.ts": {
+      "passed": [
+        "parallel-route-not-found should behave correctly without any errors",
+        "parallel-route-not-found should handle the not found case correctly without any errors"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/parallel-route-not-found/parallel-route-not-found.test.ts": {
+      "passed": [
+        "parallel-route-not-found should handle `notFound()` in a slot",
+        "parallel-route-not-found should handle `notFound()` in generateMetadata on a page that also renders a parallel route",
+        "parallel-route-not-found should handle a layout that attempts to render a missing parallel route",
+        "parallel-route-not-found should handle multiple missing parallel routes",
+        "parallel-route-not-found should not include any parallel route warnings for a deliberate notFound()",
+        "parallel-route-not-found should render the page & slots if all parallel routes are found"
+      ],
+      "failed": [],
+      "pending": [
+        "parallel-route-not-found should handle `notFound()` in a slot with no `children` slot"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/parallel-routes-and-interception-basepath/parallel-routes-and-interception-basepath.test.ts": {
+      "passed": [
+        "parallel-routes-and-interception-basepath should show normal route via direct link with basepath when parallel intercepted slot exist",
+        "parallel-routes-and-interception-basepath should show parallel intercepted slot with basepath"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/parallel-routes-and-interception-catchall/parallel-routes-and-interception-catchall.test.ts": {
+      "passed": [
+        "parallel-routes-and-interception-catchall should render intercepted route and preserve other slots"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/parallel-routes-and-interception-from-root/parallel-routes-and-interception-from-root.test.ts": {
+      "passed": [
+        "parallel-routes-and-interception-from-root should interpolate [locale] in \"/[locale]/example/(...)[locale]/intercepted\""
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts": {
+      "passed": [
+        "parallel-routes-and-interception parallel routes should apply the catch-all route to the parallel route if no matching route is found",
+        "parallel-routes-and-interception parallel routes should display all parallel route params with useParams",
+        "parallel-routes-and-interception parallel routes should handle a loading state",
+        "parallel-routes-and-interception parallel routes should load CSS for a default page that exports another page",
+        "parallel-routes-and-interception parallel routes should match parallel routes",
+        "parallel-routes-and-interception parallel routes should match parallel routes in route groups",
+        "parallel-routes-and-interception parallel routes should match the catch-all routes of the more specific path, if there is more than one catch-all route",
+        "parallel-routes-and-interception parallel routes should navigate with a link with prefetch=false",
+        "parallel-routes-and-interception parallel routes should only scroll to the parallel route that was navigated to",
+        "parallel-routes-and-interception parallel routes should render nested parallel routes",
+        "parallel-routes-and-interception parallel routes should support layout files in parallel routes",
+        "parallel-routes-and-interception parallel routes should support parallel route tab bars",
+        "parallel-routes-and-interception parallel routes should throw a 404 when no matching parallel route is found",
+        "parallel-routes-and-interception route intercepting should intercept on routes that contain hyphenated/special dynamic params",
+        "parallel-routes-and-interception route intercepting should not have /default paths in the prerender manifest",
+        "parallel-routes-and-interception route intercepting should re-render the layout on the server when it had a default child route",
+        "parallel-routes-and-interception route intercepting should render an intercepted route at the top level from a nested path",
+        "parallel-routes-and-interception route intercepting should render an intercepted route from a slot",
+        "parallel-routes-and-interception route intercepting should render intercepted route",
+        "parallel-routes-and-interception route intercepting should render intercepted route from a nested route",
+        "parallel-routes-and-interception route intercepting should render modal when paired with parallel routes",
+        "parallel-routes-and-interception route intercepting should support intercepting local dynamic sibling routes",
+        "parallel-routes-and-interception route intercepting should support intercepting with beforeFiles rewrites",
+        "parallel-routes-and-interception route intercepting with dynamic catch-all routes should render intercepted route",
+        "parallel-routes-and-interception route intercepting with dynamic optional catch-all routes should render intercepted route",
+        "parallel-routes-and-interception route intercepting with dynamic routes should render intercepted route",
+        "parallel-routes-and-interception-conflicting-pages should gracefully handle when two page segments match the `children` parallel slot"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/parallel-routes-breadcrumbs/parallel-routes-breadcrumbs.test.ts": {
+      "passed": [
+        "parallel-routes-breadcrumbs should provide an unmatched catch-all route with params",
+        "parallel-routes-breadcrumbs should render the breadcrumbs correctly with catchall route segments",
+        "parallel-routes-breadcrumbs should render the breadcrumbs correctly with optional catchall route segments",
+        "parallel-routes-breadcrumbs should render the breadcrumbs correctly with the non-dynamic route segments"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/parallel-routes-catchall-children-slot/parallel-routes-catchall-children-slot.test.ts": {
+      "passed": [
+        "parallel-routes-catchall-children-slot should match the @children slot for a page before attempting to match the catchall"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/parallel-routes-catchall-default/parallel-routes-catchall-default.test.ts": {
+      "passed": [
+        "parallel-routes-catchall-default should match default paths before catch-all"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/parallel-routes-catchall-dynamic-segment/parallel-routes-catchall-dynamic-segment.test.ts": {
+      "passed": [
+        "parallel-routes-catchall-dynamic-segment should match default and dynamic segment paths before catch-all"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/parallel-routes-catchall-groups/parallel-routes-catchall-groups.test.ts": {
+      "passed": [
+        "parallel-routes-catchall-groups should work without throwing any errors about conflicting paths"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/parallel-routes-catchall-slotted-non-catchalls/parallel-routes-catchall-slotted-non-catchalls.test.ts": {
+      "passed": [
+        "parallel-routes-catchall-slotted-non-catchalls should match default and dynamic segment paths before catch-all"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/parallel-routes-catchall-specificity/parallel-routes-catchall-specificity.test.ts": {
+      "passed": [
+        "parallel-routes-catchall-specificity should match the catch-all route when navigating from a page with a similar path depth as the previously matched slot"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/parallel-routes-catchall/parallel-routes-catchall.test.ts": {
+      "passed": [
+        "parallel-routes-catchall should match both the catch-all page & slot",
+        "parallel-routes-catchall should match correctly when defining an explicit page & slot",
+        "parallel-routes-catchall should match correctly when defining an explicit page but no slot",
+        "parallel-routes-catchall should match correctly when defining an explicit slot but no page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/parallel-routes-css/parallel-routes-css.test.ts": {
+      "passed": [
+        "parallel-routes-catchall-css should properly load the Head content from multiple leaf segments"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/parallel-routes-generate-static-params/parallel-routes-generate-static-params.test.ts": {
+      "passed": [
+        "parallel-routes-generate-static-params should render the intercepted/non-intercepted modal"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/parallel-routes-layouts/parallel-routes-layouts.test.ts": {
+      "passed": [
+        "parallel-routes-layouts should properly render layouts for multiple slots"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts": {
+      "passed": [
+        "parallel-routes-and-interception should not render the @children slot when the @slot is not found"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts": {
+      "passed": [
+        "parallel-routes-revalidation router.refresh (dynamic) - searchParams: false should correctly refresh data for previously intercepted modal and active page slot",
+        "parallel-routes-revalidation router.refresh (dynamic) - searchParams: false should correctly refresh data for the intercepted route and previously active page slot",
+        "parallel-routes-revalidation router.refresh (dynamic) - searchParams: true should correctly refresh data for previously intercepted modal and active page slot",
+        "parallel-routes-revalidation router.refresh (dynamic) - searchParams: true should correctly refresh data for the intercepted route and previously active page slot",
+        "parallel-routes-revalidation router.refresh (regular) - searchParams: false should correctly refresh data for previously intercepted modal and active page slot",
+        "parallel-routes-revalidation router.refresh (regular) - searchParams: false should correctly refresh data for the intercepted route and previously active page slot",
+        "parallel-routes-revalidation router.refresh (regular) - searchParams: true should correctly refresh data for previously intercepted modal and active page slot",
+        "parallel-routes-revalidation router.refresh (regular) - searchParams: true should correctly refresh data for the intercepted route and previously active page slot",
+        "parallel-routes-revalidation server action revalidation handles refreshing when multiple parallel slots are active",
+        "parallel-routes-revalidation server action revalidation should not trigger a refresh for the page that is being redirected to",
+        "parallel-routes-revalidation should handle a redirect action when called in a slot",
+        "parallel-routes-revalidation should handle router.refresh() when called in a slot",
+        "parallel-routes-revalidation should not trigger full page when calling router.refresh() on an intercepted route",
+        "parallel-routes-revalidation should not trigger interception when calling router.refresh() on an intercepted route (/catchall/foobar)",
+        "parallel-routes-revalidation should not trigger interception when calling router.refresh() on an intercepted route (/detail-page)",
+        "parallel-routes-revalidation should not trigger interception when calling router.refresh() on an intercepted route (/dynamic/foobar)",
+        "parallel-routes-revalidation should not trigger the intercepted route when lazy-fetching missing data",
+        "parallel-routes-revalidation should refresh the correct page when a server action triggers a redirect",
+        "parallel-routes-revalidation should submit the action and revalidate the page data"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/parallel-routes-root-slot/parallel-routes-root-slot.test.ts": {
+      "passed": [
+        "parallel-routes-root-slot Should render the root parallel route"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/parallel-routes-use-selected-layout-segment/parallel-routes-use-selected-layout-segment.test.ts": {
+      "passed": [
+        "parallel-routes-use-selected-layout-segment hard nav to parallel route",
+        "parallel-routes-use-selected-layout-segment hard nav to router page and soft nav around other router pages",
+        "parallel-routes-use-selected-layout-segment hard nav to router page and soft nav to parallel route and soft nav back to another router page",
+        "parallel-routes-use-selected-layout-segment hard nav to router page and soft nav to parallel routes"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/params-hooks-compat/index.test.ts": {
+      "passed": [
+        "app-dir - params hooks compat should only access path params with useParams",
+        "app-dir - params hooks compat should only access search params with useSearchParams"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/phase-changes/cookies.test.ts": {
+      "passed": [
+        "setting cookies stops cookie mutations when changing phases from a route handler to after via closure",
+        "setting cookies stops cookie mutations when changing phases from an action to a page render",
+        "setting cookies stops cookie mutations when changing phases from an action to after via closure",
+        "setting cookies stops cookie mutations when changing phases from middleware to after via closure"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/ppr-errors/ppr-errors.test.ts": {
+      "passed": [
+        "ppr build errors production mode outside of a suspense boundary should fail the build for uncaught errors",
+        "ppr build errors production mode when a postpone call is caught and logged it should should include a message telling why",
+        "ppr build errors production mode within a suspense boundary should fail the build for uncaught prerender errors"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/ppr-full/ppr-full.test.ts": {
+      "passed": [
+        "ppr-full Dynamic Data pages Incidental postpones should initially render with optimistic UI",
+        "ppr-full Dynamic Data pages Incidental postpones should render entirely dynamically when force-dynamic",
+        "ppr-full Dynamic Data pages Incidental postpones should render entirely statically with force-static",
+        "ppr-full Dynamic Data pages Optimistic UI should initially render with optimistic UI",
+        "ppr-full Dynamic Data pages Optimistic UI should render entirely dynamically when force-dynamic",
+        "ppr-full Dynamic Data pages Optimistic UI should render entirely statically with force-static",
+        "ppr-full Dynamic RSC Response for / should contain dynamic content",
+        "ppr-full Dynamic RSC Response for / should have correct headers",
+        "ppr-full Dynamic RSC Response for /dynamic/force-dynamic should contain dynamic content",
+        "ppr-full Dynamic RSC Response for /dynamic/force-dynamic should have correct headers",
+        "ppr-full Dynamic RSC Response for /dynamic/force-dynamic/nested/a should contain dynamic content",
+        "ppr-full Dynamic RSC Response for /dynamic/force-dynamic/nested/a should have correct headers",
+        "ppr-full Dynamic RSC Response for /dynamic/force-dynamic/nested/b should contain dynamic content",
+        "ppr-full Dynamic RSC Response for /dynamic/force-dynamic/nested/b should have correct headers",
+        "ppr-full Dynamic RSC Response for /dynamic/force-dynamic/nested/c should contain dynamic content",
+        "ppr-full Dynamic RSC Response for /dynamic/force-dynamic/nested/c should have correct headers",
+        "ppr-full Dynamic RSC Response for /dynamic/force-static should have correct headers",
+        "ppr-full Dynamic RSC Response for /dynamic/force-static should not contain dynamic content",
+        "ppr-full Dynamic RSC Response for /loading/a should contain dynamic content",
+        "ppr-full Dynamic RSC Response for /loading/a should have correct headers",
+        "ppr-full Dynamic RSC Response for /loading/b should contain dynamic content",
+        "ppr-full Dynamic RSC Response for /loading/b should have correct headers",
+        "ppr-full Dynamic RSC Response for /loading/c should contain dynamic content",
+        "ppr-full Dynamic RSC Response for /loading/c should have correct headers",
+        "ppr-full Dynamic RSC Response for /metadata should contain dynamic content",
+        "ppr-full Dynamic RSC Response for /metadata should have correct headers",
+        "ppr-full Dynamic RSC Response for /nested/a should contain dynamic content",
+        "ppr-full Dynamic RSC Response for /nested/a should have correct headers",
+        "ppr-full Dynamic RSC Response for /nested/b should contain dynamic content",
+        "ppr-full Dynamic RSC Response for /nested/b should have correct headers",
+        "ppr-full Dynamic RSC Response for /nested/c should contain dynamic content",
+        "ppr-full Dynamic RSC Response for /nested/c should have correct headers",
+        "ppr-full Dynamic RSC Response for /no-suspense should contain dynamic content",
+        "ppr-full Dynamic RSC Response for /no-suspense should have correct headers",
+        "ppr-full Dynamic RSC Response for /no-suspense/nested/a should contain dynamic content",
+        "ppr-full Dynamic RSC Response for /no-suspense/nested/a should have correct headers",
+        "ppr-full Dynamic RSC Response for /no-suspense/nested/b should contain dynamic content",
+        "ppr-full Dynamic RSC Response for /no-suspense/nested/b should have correct headers",
+        "ppr-full Dynamic RSC Response for /no-suspense/nested/c should contain dynamic content",
+        "ppr-full Dynamic RSC Response for /no-suspense/nested/c should have correct headers",
+        "ppr-full Dynamic RSC Response for /on-demand/a should contain dynamic content",
+        "ppr-full Dynamic RSC Response for /on-demand/a should have correct headers",
+        "ppr-full Dynamic RSC Response for /on-demand/b should contain dynamic content",
+        "ppr-full Dynamic RSC Response for /on-demand/b should have correct headers",
+        "ppr-full Dynamic RSC Response for /on-demand/c should contain dynamic content",
+        "ppr-full Dynamic RSC Response for /on-demand/c should have correct headers",
+        "ppr-full Dynamic RSC Response for /static should have correct headers",
+        "ppr-full Dynamic RSC Response for /static should not contain dynamic content",
+        "ppr-full HTML Fallback Dynamic Shell should render the dynamic shell as static if the page is static",
+        "ppr-full HTML Fallback Dynamic Shell should render the fallback shell on first visit",
+        "ppr-full HTML Fallback Dynamic Shell should render the route shell on the second visit",
+        "ppr-full HTML Fallback Dynamic Shell will allow dynamic fallback shells even when static is enforced",
+        "ppr-full HTML Fallback Dynamic Shell will only revalidate the page",
+        "ppr-full HTML Fallback Dynamic Shell will revalidate the page and fallback shell",
+        "ppr-full HTML Fallback for /fallback/nested/params/slug-01/slug-02 should render the fallback HTML immediately",
+        "ppr-full HTML Fallback for /fallback/nested/use-params/slug-01/slug-02 should render the fallback HTML immediately",
+        "ppr-full HTML Fallback for /fallback/nested/use-pathname/slug-01/slug-02 should render the fallback HTML immediately",
+        "ppr-full HTML Fallback for /fallback/nested/use-selected-layout-segment/slug-01/slug-02 should render the fallback HTML immediately",
+        "ppr-full HTML Fallback for /fallback/nested/use-selected-layout-segments/slug-01/slug-02 should render the fallback HTML immediately",
+        "ppr-full HTML Fallback for /fallback/params/slug-01 should render the fallback HTML immediately",
+        "ppr-full HTML Fallback for /fallback/use-params/slug-01 should render the fallback HTML immediately",
+        "ppr-full HTML Fallback for /fallback/use-pathname/slug-01 should render the fallback HTML immediately",
+        "ppr-full HTML Fallback for /fallback/use-selected-layout-segment/slug-01 should render the fallback HTML immediately",
+        "ppr-full HTML Fallback for /fallback/use-selected-layout-segments/slug-01 should render the fallback HTML immediately",
+        "ppr-full HTML Fallback should allow client layouts without postponing fallback if params are not accessed",
+        "ppr-full HTML Fallback should postpone in client layout when fallback params are accessed",
+        "ppr-full HTML Response for / should allow navigations to and from a pages/ page",
+        "ppr-full HTML Response for / should cache the static part",
+        "ppr-full HTML Response for / should have correct headers",
+        "ppr-full HTML Response for / should resume with dynamic content",
+        "ppr-full HTML Response for /dynamic/force-dynamic should allow navigations to and from a pages/ page",
+        "ppr-full HTML Response for /dynamic/force-dynamic should have correct headers",
+        "ppr-full HTML Response for /dynamic/force-dynamic should resume with dynamic content",
+        "ppr-full HTML Response for /dynamic/force-dynamic/nested/a should allow navigations to and from a pages/ page",
+        "ppr-full HTML Response for /dynamic/force-dynamic/nested/a should have correct headers",
+        "ppr-full HTML Response for /dynamic/force-dynamic/nested/a should resume with dynamic content",
+        "ppr-full HTML Response for /dynamic/force-dynamic/nested/b should allow navigations to and from a pages/ page",
+        "ppr-full HTML Response for /dynamic/force-dynamic/nested/b should have correct headers",
+        "ppr-full HTML Response for /dynamic/force-dynamic/nested/b should resume with dynamic content",
+        "ppr-full HTML Response for /dynamic/force-dynamic/nested/c should allow navigations to and from a pages/ page",
+        "ppr-full HTML Response for /dynamic/force-dynamic/nested/c should have correct headers",
+        "ppr-full HTML Response for /dynamic/force-dynamic/nested/c should resume with dynamic content",
+        "ppr-full HTML Response for /dynamic/force-static should allow navigations to and from a pages/ page",
+        "ppr-full HTML Response for /dynamic/force-static should have correct headers",
+        "ppr-full HTML Response for /dynamic/force-static should not contain dynamic content",
+        "ppr-full HTML Response for /loading/a should allow navigations to and from a pages/ page",
+        "ppr-full HTML Response for /loading/a should cache the static part",
+        "ppr-full HTML Response for /loading/a should have correct headers",
+        "ppr-full HTML Response for /loading/a should resume with dynamic content",
+        "ppr-full HTML Response for /loading/b should allow navigations to and from a pages/ page",
+        "ppr-full HTML Response for /loading/b should cache the static part",
+        "ppr-full HTML Response for /loading/b should have correct headers",
+        "ppr-full HTML Response for /loading/b should resume with dynamic content",
+        "ppr-full HTML Response for /loading/c should allow navigations to and from a pages/ page",
+        "ppr-full HTML Response for /loading/c should cache the static part",
+        "ppr-full HTML Response for /loading/c should have correct headers",
+        "ppr-full HTML Response for /loading/c should resume with dynamic content",
+        "ppr-full HTML Response for /metadata should allow navigations to and from a pages/ page",
+        "ppr-full HTML Response for /metadata should cache the static part",
+        "ppr-full HTML Response for /metadata should have correct headers",
+        "ppr-full HTML Response for /metadata should resume with dynamic content",
+        "ppr-full HTML Response for /nested/a should allow navigations to and from a pages/ page",
+        "ppr-full HTML Response for /nested/a should cache the static part",
+        "ppr-full HTML Response for /nested/a should have correct headers",
+        "ppr-full HTML Response for /nested/a should resume with dynamic content",
+        "ppr-full HTML Response for /nested/b should allow navigations to and from a pages/ page",
+        "ppr-full HTML Response for /nested/b should cache the static part",
+        "ppr-full HTML Response for /nested/b should have correct headers",
+        "ppr-full HTML Response for /nested/b should resume with dynamic content",
+        "ppr-full HTML Response for /nested/c should allow navigations to and from a pages/ page",
+        "ppr-full HTML Response for /nested/c should cache the static part",
+        "ppr-full HTML Response for /nested/c should have correct headers",
+        "ppr-full HTML Response for /nested/c should resume with dynamic content",
+        "ppr-full HTML Response for /no-suspense should allow navigations to and from a pages/ page",
+        "ppr-full HTML Response for /no-suspense should cache the static part",
+        "ppr-full HTML Response for /no-suspense should have correct headers",
+        "ppr-full HTML Response for /no-suspense should resume with dynamic content",
+        "ppr-full HTML Response for /no-suspense/nested/a should allow navigations to and from a pages/ page",
+        "ppr-full HTML Response for /no-suspense/nested/a should cache the static part",
+        "ppr-full HTML Response for /no-suspense/nested/a should have correct headers",
+        "ppr-full HTML Response for /no-suspense/nested/a should resume with dynamic content",
+        "ppr-full HTML Response for /no-suspense/nested/b should allow navigations to and from a pages/ page",
+        "ppr-full HTML Response for /no-suspense/nested/b should cache the static part",
+        "ppr-full HTML Response for /no-suspense/nested/b should have correct headers",
+        "ppr-full HTML Response for /no-suspense/nested/b should resume with dynamic content",
+        "ppr-full HTML Response for /no-suspense/nested/c should allow navigations to and from a pages/ page",
+        "ppr-full HTML Response for /no-suspense/nested/c should cache the static part",
+        "ppr-full HTML Response for /no-suspense/nested/c should have correct headers",
+        "ppr-full HTML Response for /no-suspense/nested/c should resume with dynamic content",
+        "ppr-full HTML Response for /on-demand/a should allow navigations to and from a pages/ page",
+        "ppr-full HTML Response for /on-demand/a should cache the static part",
+        "ppr-full HTML Response for /on-demand/a should have correct headers",
+        "ppr-full HTML Response for /on-demand/a should resume with dynamic content",
+        "ppr-full HTML Response for /on-demand/b should allow navigations to and from a pages/ page",
+        "ppr-full HTML Response for /on-demand/b should cache the static part",
+        "ppr-full HTML Response for /on-demand/b should have correct headers",
+        "ppr-full HTML Response for /on-demand/b should resume with dynamic content",
+        "ppr-full HTML Response for /on-demand/c should allow navigations to and from a pages/ page",
+        "ppr-full HTML Response for /on-demand/c should cache the static part",
+        "ppr-full HTML Response for /on-demand/c should have correct headers",
+        "ppr-full HTML Response for /on-demand/c should resume with dynamic content",
+        "ppr-full HTML Response for /static should allow navigations to and from a pages/ page",
+        "ppr-full HTML Response for /static should have correct headers",
+        "ppr-full HTML Response for /static should not contain dynamic content",
+        "ppr-full Metadata should set the right metadata when generateMetadata uses dynamic APIs",
+        "ppr-full Navigation Signals notFound() for /navigation/not-found should have correct headers",
+        "ppr-full Navigation Signals notFound() for /navigation/not-found/dynamic should cache the static part",
+        "ppr-full Navigation Signals notFound() for /navigation/not-found/dynamic should have correct headers",
+        "ppr-full Navigation Signals redirect() for /navigation/redirect should have correct headers",
+        "ppr-full Navigation Signals redirect() for /navigation/redirect/dynamic should cache the static part",
+        "ppr-full Navigation Signals redirect() for /navigation/redirect/dynamic should have correct headers",
+        "ppr-full Prefetch RSC Response for / should have correct headers",
+        "ppr-full Prefetch RSC Response for / should not contain dynamic content",
+        "ppr-full Prefetch RSC Response for /dynamic/force-dynamic should have correct headers",
+        "ppr-full Prefetch RSC Response for /dynamic/force-dynamic should not contain dynamic content",
+        "ppr-full Prefetch RSC Response for /dynamic/force-dynamic/nested/a should have correct headers",
+        "ppr-full Prefetch RSC Response for /dynamic/force-dynamic/nested/a should not contain dynamic content",
+        "ppr-full Prefetch RSC Response for /dynamic/force-dynamic/nested/b should have correct headers",
+        "ppr-full Prefetch RSC Response for /dynamic/force-dynamic/nested/b should not contain dynamic content",
+        "ppr-full Prefetch RSC Response for /dynamic/force-dynamic/nested/c should have correct headers",
+        "ppr-full Prefetch RSC Response for /dynamic/force-dynamic/nested/c should not contain dynamic content",
+        "ppr-full Prefetch RSC Response for /dynamic/force-static should have correct headers",
+        "ppr-full Prefetch RSC Response for /dynamic/force-static should not contain dynamic content",
+        "ppr-full Prefetch RSC Response for /loading/a should have correct headers",
+        "ppr-full Prefetch RSC Response for /loading/a should not contain dynamic content",
+        "ppr-full Prefetch RSC Response for /loading/b should have correct headers",
+        "ppr-full Prefetch RSC Response for /loading/b should not contain dynamic content",
+        "ppr-full Prefetch RSC Response for /loading/c should have correct headers",
+        "ppr-full Prefetch RSC Response for /loading/c should not contain dynamic content",
+        "ppr-full Prefetch RSC Response for /metadata should have correct headers",
+        "ppr-full Prefetch RSC Response for /metadata should not contain dynamic content",
+        "ppr-full Prefetch RSC Response for /nested/a should have correct headers",
+        "ppr-full Prefetch RSC Response for /nested/a should not contain dynamic content",
+        "ppr-full Prefetch RSC Response for /nested/b should have correct headers",
+        "ppr-full Prefetch RSC Response for /nested/b should not contain dynamic content",
+        "ppr-full Prefetch RSC Response for /nested/c should have correct headers",
+        "ppr-full Prefetch RSC Response for /nested/c should not contain dynamic content",
+        "ppr-full Prefetch RSC Response for /no-suspense should have correct headers",
+        "ppr-full Prefetch RSC Response for /no-suspense should not contain dynamic content",
+        "ppr-full Prefetch RSC Response for /no-suspense/nested/a should have correct headers",
+        "ppr-full Prefetch RSC Response for /no-suspense/nested/a should not contain dynamic content",
+        "ppr-full Prefetch RSC Response for /no-suspense/nested/b should have correct headers",
+        "ppr-full Prefetch RSC Response for /no-suspense/nested/b should not contain dynamic content",
+        "ppr-full Prefetch RSC Response for /no-suspense/nested/c should have correct headers",
+        "ppr-full Prefetch RSC Response for /no-suspense/nested/c should not contain dynamic content",
+        "ppr-full Prefetch RSC Response for /on-demand/a should have correct headers",
+        "ppr-full Prefetch RSC Response for /on-demand/a should not contain dynamic content",
+        "ppr-full Prefetch RSC Response for /on-demand/b should have correct headers",
+        "ppr-full Prefetch RSC Response for /on-demand/b should not contain dynamic content",
+        "ppr-full Prefetch RSC Response for /on-demand/c should have correct headers",
+        "ppr-full Prefetch RSC Response for /on-demand/c should not contain dynamic content",
+        "ppr-full Prefetch RSC Response for /static should have correct headers",
+        "ppr-full Prefetch RSC Response for /static should not contain dynamic content",
+        "ppr-full Test Setup has all the test pathnames listed in the links component"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/ppr-history-replace-state/ppr-history-replace-state.test.ts": {
+      "passed": ["ppr-history-replace-state should not remount component"],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/ppr-incremental/ppr-incremental.test.ts": {
+      "passed": [
+        "ppr-incremental ppr disabled / should not have the dynamic content hidden /",
+        "ppr-incremental ppr disabled / should render without the fallback in the initial load /",
+        "ppr-incremental ppr disabled /disabled should not have the dynamic content hidden /disabled",
+        "ppr-incremental ppr disabled /disabled should render without the fallback in the initial load /disabled",
+        "ppr-incremental ppr disabled /dynamic/[slug] should not have the dynamic content hidden /dynamic/a",
+        "ppr-incremental ppr disabled /dynamic/[slug] should not have the dynamic content hidden /dynamic/b",
+        "ppr-incremental ppr disabled /dynamic/[slug] should not have the dynamic content hidden /dynamic/c",
+        "ppr-incremental ppr disabled /dynamic/[slug] should render without the fallback in the initial load /dynamic/a",
+        "ppr-incremental ppr disabled /dynamic/[slug] should render without the fallback in the initial load /dynamic/b",
+        "ppr-incremental ppr disabled /dynamic/[slug] should render without the fallback in the initial load /dynamic/c",
+        "ppr-incremental ppr disabled /dynamic/disabled/[slug] should not have the dynamic content hidden /dynamic/disabled/a",
+        "ppr-incremental ppr disabled /dynamic/disabled/[slug] should not have the dynamic content hidden /dynamic/disabled/b",
+        "ppr-incremental ppr disabled /dynamic/disabled/[slug] should not have the dynamic content hidden /dynamic/disabled/c",
+        "ppr-incremental ppr disabled /dynamic/disabled/[slug] should render without the fallback in the initial load /dynamic/disabled/a",
+        "ppr-incremental ppr disabled /dynamic/disabled/[slug] should render without the fallback in the initial load /dynamic/disabled/b",
+        "ppr-incremental ppr disabled /dynamic/disabled/[slug] should render without the fallback in the initial load /dynamic/disabled/c",
+        "ppr-incremental ppr disabled /nested/disabled/[slug] should not have the dynamic content hidden /nested/disabled/a",
+        "ppr-incremental ppr disabled /nested/disabled/[slug] should not have the dynamic content hidden /nested/disabled/b",
+        "ppr-incremental ppr disabled /nested/disabled/[slug] should not have the dynamic content hidden /nested/disabled/c",
+        "ppr-incremental ppr disabled /nested/disabled/[slug] should render without the fallback in the initial load /nested/disabled/a",
+        "ppr-incremental ppr disabled /nested/disabled/[slug] should render without the fallback in the initial load /nested/disabled/b",
+        "ppr-incremental ppr disabled /nested/disabled/[slug] should render without the fallback in the initial load /nested/disabled/c",
+        "ppr-incremental ppr disabled /nested/disabled/disabled/[slug] should not have the dynamic content hidden /nested/disabled/disabled/a",
+        "ppr-incremental ppr disabled /nested/disabled/disabled/[slug] should not have the dynamic content hidden /nested/disabled/disabled/b",
+        "ppr-incremental ppr disabled /nested/disabled/disabled/[slug] should not have the dynamic content hidden /nested/disabled/disabled/c",
+        "ppr-incremental ppr disabled /nested/disabled/disabled/[slug] should render without the fallback in the initial load /nested/disabled/disabled/a",
+        "ppr-incremental ppr disabled /nested/disabled/disabled/[slug] should render without the fallback in the initial load /nested/disabled/disabled/b",
+        "ppr-incremental ppr disabled /nested/disabled/disabled/[slug] should render without the fallback in the initial load /nested/disabled/disabled/c",
+        "ppr-incremental ppr disabled /nested/enabled/disabled/[slug] should not have the dynamic content hidden /nested/enabled/disabled/a",
+        "ppr-incremental ppr disabled /nested/enabled/disabled/[slug] should not have the dynamic content hidden /nested/enabled/disabled/b",
+        "ppr-incremental ppr disabled /nested/enabled/disabled/[slug] should not have the dynamic content hidden /nested/enabled/disabled/c",
+        "ppr-incremental ppr disabled /nested/enabled/disabled/[slug] should render without the fallback in the initial load /nested/enabled/disabled/a",
+        "ppr-incremental ppr disabled /nested/enabled/disabled/[slug] should render without the fallback in the initial load /nested/enabled/disabled/b",
+        "ppr-incremental ppr disabled /nested/enabled/disabled/[slug] should render without the fallback in the initial load /nested/enabled/disabled/c",
+        "ppr-incremental ppr disabled /omitted/[slug] should not have the dynamic content hidden /omitted/a",
+        "ppr-incremental ppr disabled /omitted/[slug] should not have the dynamic content hidden /omitted/b",
+        "ppr-incremental ppr disabled /omitted/[slug] should not have the dynamic content hidden /omitted/c",
+        "ppr-incremental ppr disabled /omitted/[slug] should render without the fallback in the initial load /omitted/a",
+        "ppr-incremental ppr disabled /omitted/[slug] should render without the fallback in the initial load /omitted/b",
+        "ppr-incremental ppr disabled /omitted/[slug] should render without the fallback in the initial load /omitted/c",
+        "ppr-incremental ppr disabled /omitted/disabled/[slug] should not have the dynamic content hidden /omitted/disabled/a",
+        "ppr-incremental ppr disabled /omitted/disabled/[slug] should not have the dynamic content hidden /omitted/disabled/b",
+        "ppr-incremental ppr disabled /omitted/disabled/[slug] should not have the dynamic content hidden /omitted/disabled/c",
+        "ppr-incremental ppr disabled /omitted/disabled/[slug] should render without the fallback in the initial load /omitted/disabled/a",
+        "ppr-incremental ppr disabled /omitted/disabled/[slug] should render without the fallback in the initial load /omitted/disabled/b",
+        "ppr-incremental ppr disabled /omitted/disabled/[slug] should render without the fallback in the initial load /omitted/disabled/c",
+        "ppr-incremental ppr disabled should not trigger a dynamic request for static pages",
+        "ppr-incremental ppr enabled /dynamic/enabled/[slug] should have the dynamic content hidden /dynamic/enabled/a",
+        "ppr-incremental ppr enabled /dynamic/enabled/[slug] should have the dynamic content hidden /dynamic/enabled/b",
+        "ppr-incremental ppr enabled /dynamic/enabled/[slug] should have the dynamic content hidden /dynamic/enabled/c",
+        "ppr-incremental ppr enabled /dynamic/enabled/[slug] should render with the fallback in the initial load /dynamic/enabled/a",
+        "ppr-incremental ppr enabled /dynamic/enabled/[slug] should render with the fallback in the initial load /dynamic/enabled/b",
+        "ppr-incremental ppr enabled /dynamic/enabled/[slug] should render with the fallback in the initial load /dynamic/enabled/c",
+        "ppr-incremental ppr enabled /enabled should have the dynamic content hidden /enabled",
+        "ppr-incremental ppr enabled /enabled should render with the fallback in the initial load /enabled",
+        "ppr-incremental ppr enabled /nested/disabled/enabled/[slug] should have the dynamic content hidden /nested/disabled/enabled/a",
+        "ppr-incremental ppr enabled /nested/disabled/enabled/[slug] should have the dynamic content hidden /nested/disabled/enabled/b",
+        "ppr-incremental ppr enabled /nested/disabled/enabled/[slug] should have the dynamic content hidden /nested/disabled/enabled/c",
+        "ppr-incremental ppr enabled /nested/disabled/enabled/[slug] should render with the fallback in the initial load /nested/disabled/enabled/a",
+        "ppr-incremental ppr enabled /nested/disabled/enabled/[slug] should render with the fallback in the initial load /nested/disabled/enabled/b",
+        "ppr-incremental ppr enabled /nested/disabled/enabled/[slug] should render with the fallback in the initial load /nested/disabled/enabled/c",
+        "ppr-incremental ppr enabled /nested/enabled/[slug] should have the dynamic content hidden /nested/enabled/a",
+        "ppr-incremental ppr enabled /nested/enabled/[slug] should have the dynamic content hidden /nested/enabled/b",
+        "ppr-incremental ppr enabled /nested/enabled/[slug] should have the dynamic content hidden /nested/enabled/c",
+        "ppr-incremental ppr enabled /nested/enabled/[slug] should render with the fallback in the initial load /nested/enabled/a",
+        "ppr-incremental ppr enabled /nested/enabled/[slug] should render with the fallback in the initial load /nested/enabled/b",
+        "ppr-incremental ppr enabled /nested/enabled/[slug] should render with the fallback in the initial load /nested/enabled/c",
+        "ppr-incremental ppr enabled /nested/enabled/enabled/[slug] should have the dynamic content hidden /nested/enabled/enabled/a",
+        "ppr-incremental ppr enabled /nested/enabled/enabled/[slug] should have the dynamic content hidden /nested/enabled/enabled/b",
+        "ppr-incremental ppr enabled /nested/enabled/enabled/[slug] should have the dynamic content hidden /nested/enabled/enabled/c",
+        "ppr-incremental ppr enabled /nested/enabled/enabled/[slug] should render with the fallback in the initial load /nested/enabled/enabled/a",
+        "ppr-incremental ppr enabled /nested/enabled/enabled/[slug] should render with the fallback in the initial load /nested/enabled/enabled/b",
+        "ppr-incremental ppr enabled /nested/enabled/enabled/[slug] should render with the fallback in the initial load /nested/enabled/enabled/c",
+        "ppr-incremental ppr enabled /omitted/enabled/[slug] should have the dynamic content hidden /omitted/enabled/a",
+        "ppr-incremental ppr enabled /omitted/enabled/[slug] should have the dynamic content hidden /omitted/enabled/b",
+        "ppr-incremental ppr enabled /omitted/enabled/[slug] should have the dynamic content hidden /omitted/enabled/c",
+        "ppr-incremental ppr enabled /omitted/enabled/[slug] should render with the fallback in the initial load /omitted/enabled/a",
+        "ppr-incremental ppr enabled /omitted/enabled/[slug] should render with the fallback in the initial load /omitted/enabled/b",
+        "ppr-incremental ppr enabled /omitted/enabled/[slug] should render with the fallback in the initial load /omitted/enabled/c"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/ppr-missing-root-params/ppr-missing-root-params.test.ts": {
+      "passed": [
+        "ppr-missing-root-params (multiple) should result in a build error",
+        "ppr-missing-root-params (nested) should result in a build error",
+        "ppr-missing-root-params (single) should result in a build error"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/ppr-navigations/avoid-popstate-flash/avoid-popstate-flash.test.ts": {
+      "passed": [
+        "avoid-popstate-flash does not flash back to partial PPR data during back/forward navigation"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/ppr-navigations/incremental/incremental.test.ts": {
+      "passed": [
+        "ppr-navigations incremental can navigate between all the links and back without writing to disk"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/ppr-navigations/loading-tsx-no-partial-rendering/loading-tsx-no-partial-rendering.test.ts": {
+      "passed": [
+        "loading-tsx-no-partial-rendering when PPR is enabled, loading.tsx boundaries do not cause a partial prefetch"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/ppr-navigations/prefetch-navigation/prefetch-navigation.test.ts": {
+      "passed": [
+        "prefetch-navigation should render the prefetch without waiting for the RSC request"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/ppr-navigations/search-params/search-params.test.ts": {
+      "passed": [
+        "search-params updates page data during a nav even if no shared layouts have changed (e.g. updating a search param on the current page)"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/ppr-navigations/simple/per-segment-prefetching.test.ts": {
+      "passed": [
+        "per segment prefetching basic route tree prefetch",
+        "per segment prefetching respond with 204 if the segment does not have prefetch data"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/ppr-navigations/simple/simple.test.ts": {
+      "passed": [
+        "ppr-navigations simple can navigate between all the links and back"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/ppr-navigations/stale-prefetch-entry/stale-prefetch-entry.test.ts": {
+      "passed": [
+        "stale-prefetch-entry works if a prefetched route entry has become stale (too much time has elapsed since it was prefetched)"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/ppr-unstable-cache/ppr-unstable-cache.test.ts": {
+      "passed": ["ppr-unstable-cache should not cache inner fetch calls"],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/ppr/ppr.test.ts": {
+      "passed": [
+        "ppr /no-suspense/node/gsp/[slug] should serve the static & dynamic parts",
+        "ppr /suspense/node/gsp/[slug] should not have the dynamic part",
+        "ppr /suspense/node/gsp/[slug] should serve the static part first",
+        "ppr build output correctly marks pages as being partially prerendered in the build output",
+        "ppr for /loading/nested/1 should not have the dynamic part",
+        "ppr for /loading/nested/1 should serve the static part",
+        "ppr for /loading/nested/2 should not have the dynamic part",
+        "ppr for /loading/nested/2 should serve the static part",
+        "ppr for /loading/nested/3 should not have the dynamic part",
+        "ppr for /loading/nested/3 should serve the static part",
+        "ppr for /suspense/node should not have the dynamic part",
+        "ppr for /suspense/node should serve the static part",
+        "ppr for /suspense/node/nested/1 should not have the dynamic part",
+        "ppr for /suspense/node/nested/1 should serve the static part",
+        "ppr for /suspense/node/nested/2 should not have the dynamic part",
+        "ppr for /suspense/node/nested/2 should serve the static part",
+        "ppr for /suspense/node/nested/3 should not have the dynamic part",
+        "ppr for /suspense/node/nested/3 should serve the static part",
+        "ppr search parameters should render the page with the search parameters",
+        "ppr should indicate the feature is experimental",
+        "ppr telemetry should send ppr feature usage event",
+        "ppr with suspense for /suspense/edge should eventually render the dynamic part",
+        "ppr with suspense for /suspense/node should eventually render the dynamic part",
+        "ppr without suspense for /no-suspense should immediately render the dynamic part"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/prefetch-searchparam/prefetch-searchparam.test.ts": {
+      "passed": [
+        "prefetch-searchparam should set prefetch cache properly on different search params"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/prefetching-not-found/prefetching-not-found.test.ts": {
+      "passed": [
+        "prefetching-not-found should correctly navigate to/from a global 404 page when following links with prefetch=auto"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/prerender-encoding/prerender-encoding.test.ts": {
+      "passed": [
+        "prerender-encoding should respond with the prerendered page correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/random-in-sass/random-in-sass.test.ts": {
+      "passed": ["random-in-sass should work using browser"],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/react-max-headers-length/react-max-headers-length.test.ts": {
+      "passed": [
+        "react-max-headers-length reactMaxHeadersLength = 0 should respect reactMaxHeadersLength",
+        "react-max-headers-length reactMaxHeadersLength = 10000 should respect reactMaxHeadersLength",
+        "react-max-headers-length reactMaxHeadersLength = 400 should respect reactMaxHeadersLength",
+        "react-max-headers-length reactMaxHeadersLength = undefined should respect reactMaxHeadersLength"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/react-owner-stacks-svgr/react-owner-stacks-svgr.test.ts": {
+      "passed": [
+        "react-owner-stacks-svgr renders an SVG that is transformed by @svgr/webpack into a React component"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/reexport-client-component-metadata/reexport-client-component-metadata.test.ts": {
+      "passed": [
+        "app-dir - reexport-client-component-metadata should render the layout metadata if not override",
+        "app-dir - reexport-client-component-metadata should render the page metadata if override"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/remove-console/remove-console.test.ts": {
+      "passed": ["remove-console should remove console.log"],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/resolve-extensions/resolve-extensions.test.ts": {
+      "passed": [
+        "turbo-resolve-extensions should SSR",
+        "turbo-resolve-extensions should work using browser"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/resource-url-encoding/resource-url-encoding.test.ts": {
+      "passed": [],
+      "failed": [],
+      "pending": [
+        "scripts encodes characters in app router",
+        "scripts encodes characters in pages router",
+        "styles encodes characters in app router",
+        "styles encodes characters in pages router"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/revalidate-dynamic/revalidate-dynamic.test.ts": {
+      "passed": [
+        "app-dir revalidate-dynamic should correctly mark a route handler that uses unstable_expireTag as dynamic",
+        "app-dir revalidate-dynamic should revalidate the data with /api/revalidate-path",
+        "app-dir revalidate-dynamic should revalidate the data with /api/revalidate-tag"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/revalidatetag-rsc/revalidatetag-rsc.test.ts": {
+      "passed": [
+        "unstable_expireTag-rsc should error if unstable_expireTag is called during render",
+        "unstable_expireTag-rsc should revalidate fetch cache if unstable_expireTag invoked via server action"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/rewrite-headers/rewrite-headers.test.ts": {
+      "passed": [
+        "rewrite-headers dynamic HTML (/hello/mary) should have the expected headers",
+        "rewrite-headers dynamic HTML with query (/hello/mary?key=value) should have the expected headers",
+        "rewrite-headers dynamic Prefetch RSC (/hello/mary) should have the expected headers",
+        "rewrite-headers dynamic Prefetch RSC with query (/hello/mary?key=value) should have the expected headers",
+        "rewrite-headers dynamic RSC (/hello/mary) should have the expected headers",
+        "rewrite-headers dynamic RSC with query (/hello/mary?key=value) should have the expected headers",
+        "rewrite-headers middleware rewrite HTML (/hello/wyatt) should have the expected headers",
+        "rewrite-headers middleware rewrite Prefetch RSC (/hello/wyatt) should have the expected headers",
+        "rewrite-headers middleware rewrite RSC (/hello/wyatt) should have the expected headers",
+        "rewrite-headers middleware rewrite dynamic HTML (/hello/bob) should have the expected headers",
+        "rewrite-headers middleware rewrite dynamic Prefetch RSC (/hello/bob) should have the expected headers",
+        "rewrite-headers middleware rewrite dynamic RSC (/hello/bob) should have the expected headers",
+        "rewrite-headers middleware rewrite external HTML (/hello/vercel) should have the expected headers",
+        "rewrite-headers middleware rewrite query HTML (/hello/john) should have the expected headers",
+        "rewrite-headers middleware rewrite query Prefetch RSC (/hello/john) should have the expected headers",
+        "rewrite-headers middleware rewrite query RSC (/hello/john) should have the expected headers",
+        "rewrite-headers next.config.js rewrites HTML (/hello/sam) should have the expected headers",
+        "rewrite-headers next.config.js rewrites Prefetch RSC (/hello/sam) should have the expected headers",
+        "rewrite-headers next.config.js rewrites RSC (/hello/sam) should have the expected headers",
+        "rewrite-headers next.config.js rewrites external URL (/hello/google) should have the expected headers",
+        "rewrite-headers next.config.js rewrites static HTML (/hello/other) should have the expected headers",
+        "rewrite-headers next.config.js rewrites static Prefetch RSC (/hello/other) should have the expected headers",
+        "rewrite-headers next.config.js rewrites static RSC (/hello/other) should have the expected headers",
+        "rewrite-headers next.config.js rewrites with query HTML (/hello/fred) should have the expected headers",
+        "rewrite-headers next.config.js rewrites with query Prefetch RSC (/hello/fred) should have the expected headers",
+        "rewrite-headers next.config.js rewrites with query RSC (/hello/fred) should have the expected headers",
+        "rewrite-headers prerender HTML (/hello/world) should have the expected headers",
+        "rewrite-headers prerendered Prefetch RSC (/hello/world) should have the expected headers",
+        "rewrite-headers prerendered RSC (/hello/world) should have the expected headers",
+        "rewrite-headers static HTML (/) should have the expected headers",
+        "rewrite-headers static Prefetch RSC (/) should have the expected headers",
+        "rewrite-headers static RSC (/) should have the expected headers"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts": {
+      "passed": [
+        "redirects and rewrites navigation using button should redirect from middleware correctly",
+        "redirects and rewrites navigation using button should redirect from next.config.js correctly",
+        "redirects and rewrites navigation using button should redirect from next.config.js correctly with empty query params",
+        "redirects and rewrites navigation using button should redirect using catchall from next.config.js correctly",
+        "redirects and rewrites navigation using button should rewrite from middleware correctly",
+        "redirects and rewrites navigation using button should rewrite from next.config.js correctly",
+        "redirects and rewrites navigation using link should redirect from middleware correctly",
+        "redirects and rewrites navigation using link should redirect from next.config.js correctly",
+        "redirects and rewrites navigation using link should redirect from next.config.js correctly with empty query params",
+        "redirects and rewrites navigation using link should redirect using catchall from next.config.js correctly",
+        "redirects and rewrites navigation using link should rewrite from middleware correctly",
+        "redirects and rewrites navigation using link should rewrite from next.config.js correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/root-layout-redirect/root-layout-redirect.test.ts": {
+      "passed": ["root-layout-redirect should work using browser"],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/root-layout-render-once/index.test.ts": {
+      "passed": [
+        "app-dir root layout render once should only render root layout once"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/root-layout/root-layout.test.ts": {
+      "passed": [
+        "app-dir root layout Should do a mpa navigation when switching root layout should work with basic routes",
+        "app-dir root layout Should do a mpa navigation when switching root layout should work with dynamic catchall routes",
+        "app-dir root layout Should do a mpa navigation when switching root layout should work with dynamic routes",
+        "app-dir root layout Should do a mpa navigation when switching root layout should work with parallel routes",
+        "app-dir root layout Should do a mpa navigation when switching root layout should work with route groups",
+        "app-dir root layout Should do a mpa navigation when switching root layout should work with static routes",
+        "app-dir root layout should correctly handle navigation between multiple root layouts",
+        "app-dir root layout should correctly handle navigation between multiple root layouts when redirecting in a server action"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/route-page-manifest-bug/route-page-manifest-bug.test.ts": {
+      "passed": [
+        "route-page-manifest-bug should work when requesting route handler after page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts": {
+      "passed": [
+        "router autoscrolling on navigation bugs Should apply scroll when loading.js is used",
+        "router autoscrolling on navigation bugs Should scroll to the top of the layout when the first child is display none",
+        "router autoscrolling on navigation bugs Should scroll to the top of the layout when the first child is position fixed",
+        "router autoscrolling on navigation bugs Should scroll to the top of the layout when the first child is position sticky",
+        "router autoscrolling on navigation horizontal scroll should't scroll horizontally",
+        "router autoscrolling on navigation router.refresh() should not scroll when called alone",
+        "router autoscrolling on navigation router.refresh() should not stop router.push() from scrolling",
+        "router autoscrolling on navigation vertical scroll should not scroll to top of document if page in viewport",
+        "router autoscrolling on navigation vertical scroll should not scroll when the top of the page is in the viewport",
+        "router autoscrolling on navigation vertical scroll should scroll down to the navigated page when it's below viewort",
+        "router autoscrolling on navigation vertical scroll should scroll to top of document if possible while giving focus to page",
+        "router autoscrolling on navigation vertical scroll should scroll to top of document when navigating between to pages without layout",
+        "router autoscrolling on navigation vertical scroll should scroll to top of document with new metadata",
+        "router autoscrolling on navigation vertical scroll should scroll to top of page when scrolling to phe top of the document wouldn't have the page in the viewport"
+      ],
+      "failed": [],
+      "pending": [
+        "router autoscrolling on navigation router.refresh() should not scroll the page when we hot reload"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/router-stuck-dynamic-static-segment/router-stuck-dynamic-static-segment.test.ts": {
+      "passed": [
+        "router-stuck-dynamic-static-segment should allow navigation between dynamic parameter and static parameter of the same value"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/rsc-basic/rsc-basic.test.ts": {
+      "passed": [
+        "app dir - rsc basics client references with TLA (edge) should support TLA in lazy client reference",
+        "app dir - rsc basics client references with TLA (edge) should support TLA in sync client reference imports",
+        "app dir - rsc basics client references with TLA (node) should support TLA in lazy client reference",
+        "app dir - rsc basics client references with TLA (node) should support TLA in sync client reference imports",
+        "app dir - rsc basics next internal shared context should not error if just load next/navigation module in pages/api",
+        "app dir - rsc basics next internal shared context should not error if just load next/router module in app page",
+        "app dir - rsc basics react@experimental should opt into the react@experimental when enabling ppr",
+        "app dir - rsc basics react@experimental should opt into the react@experimental when enabling taint",
+        "app dir - rsc basics should be able to call legacy react-dom/server APIs in client components",
+        "app dir - rsc basics should be able to navigate between rsc routes",
+        "app dir - rsc basics should correctly render component returning null",
+        "app dir - rsc basics should correctly render component returning undefined",
+        "app dir - rsc basics should correctly render layout returning null",
+        "app dir - rsc basics should correctly render layout returning undefined",
+        "app dir - rsc basics should correctly render page returning null",
+        "app dir - rsc basics should correctly render page returning undefined",
+        "app dir - rsc basics should create client reference successfully for all file conventions",
+        "app dir - rsc basics should escape streaming data correctly",
+        "app dir - rsc basics should generate edge SSR manifests for Node.js",
+        "app dir - rsc basics should handle client components imported as namespace",
+        "app dir - rsc basics should handle named client components imported as page",
+        "app dir - rsc basics should handle streaming server components correctly",
+        "app dir - rsc basics should handle various kinds of exports correctly",
+        "app dir - rsc basics should link correctly with next/link without mpa navigation to the page",
+        "app dir - rsc basics should not apply rsc syntax checks in pages/api",
+        "app dir - rsc basics should not use bundled react for pages with app",
+        "app dir - rsc basics should render built-in 404 page for missing route if pagesDir is not presented",
+        "app dir - rsc basics should render server components correctly",
+        "app dir - rsc basics should resolve different kinds of components correctly",
+        "app dir - rsc basics should reuse the inline flight response without sending extra requests",
+        "app dir - rsc basics should stick to the url without trailing /page suffix",
+        "app dir - rsc basics should support multi-level server component imports",
+        "app dir - rsc basics should support native modules in server component",
+        "app dir - rsc basics should support next/link in server components",
+        "app dir - rsc basics should support partial hydration with inlined server data",
+        "app dir - rsc basics should support streaming for flight response",
+        "app dir - rsc basics should suspense next/image in server components",
+        "app dir - rsc basics should suspense next/legacy/image in server components",
+        "app dir - rsc basics should track client components in dynamic imports",
+        "app dir - rsc basics should use canary react for app"
+      ],
+      "failed": [],
+      "pending": [
+        "app dir - rsc basics should support partial hydration with inlined server data in browser"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/rsc-webpack-loader/rsc-webpack-loader.test.ts": {
+      "passed": [
+        "app dir - rsc webpack loader should support webpack loader rules"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/3rd-party-module/3rd-party-module.test.ts": {
+      "passed": [
+        "3rd Party CSS Module Support ({\"sass\": \"1.54.0\"}) should render the module",
+        "3rd Party CSS Module Support ({\"sass-embedded\": \"1.75.0\"}) should render the module"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/basic-module-additional-data/basic-module-additional-data.test.ts": {
+      "passed": [
+        "Basic Module Additional Data Support ({\"sass\": \"1.54.0\"}) should render the module",
+        "Basic Module Additional Data Support ({\"sass-embedded\": \"1.75.0\"}) should render the module"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/basic-module-include-paths/basic-module-include-paths.test.ts": {
+      "passed": [
+        "Basic Module Include Paths Support ({\"sass\": \"1.54.0\"}) should render the module",
+        "Basic Module Include Paths Support ({\"sass-embedded\": \"1.75.0\"}) should render the module"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/basic-module-prepend-data/basic-module-prepend-data.test.ts": {
+      "passed": [
+        "Basic Module Prepend Data Support ({\"sass\": \"1.54.0\"}) should render the module",
+        "Basic Module Prepend Data Support ({\"sass-embedded\": \"1.75.0\"}) should render the module"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/basic-module/basic-module.test.ts": {
+      "passed": [
+        "Basic SCSS Module Support ({\"sass\": \"1.54.0\"}) should render the module",
+        "Basic SCSS Module Support ({\"sass-embedded\": \"1.75.0\"}) should render the module"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/catch-all-module/catch-all-module.test.ts": {
+      "passed": [
+        "Catch-all Route CSS Module Usage ({\"sass\": \"1.54.0\"}) should render the module",
+        "Catch-all Route CSS Module Usage ({\"sass-embedded\": \"1.75.0\"}) should render the module"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/compilation-and-prefixing/compilation-and-prefixing.test.ts": {
+      "passed": [
+        "SCSS Support ({\"sass\": \"1.54.0\"}) Production only CSS Compilation and Prefixing should've compiled and prefixed",
+        "SCSS Support ({\"sass-embedded\": \"1.75.0\"}) Production only CSS Compilation and Prefixing should've compiled and prefixed"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/composes-basic/composes-basic.test.ts": {
+      "passed": [
+        "CSS Module Composes Usage (Basic) ({\"sass\": \"1.54.0\"}) should render the module",
+        "CSS Module Composes Usage (Basic) ({\"sass-embedded\": \"1.75.0\"}) should render the module"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/composes-external/composes-external.test.ts": {
+      "passed": [
+        "CSS Module Composes Usage (External) ({\"sass\": \"1.54.0\"}) should render the module",
+        "CSS Module Composes Usage (External) ({\"sass-embedded\": \"1.75.0\"}) should render the module"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/data-url/data-url.test.ts": {
+      "passed": [
+        "SCSS Support loader handling Data Urls ({\"sass\": \"1.54.0\"}) should render the module",
+        "SCSS Support loader handling Data Urls ({\"sass-embedded\": \"1.75.0\"}) should render the module"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/dev-module/dev-module.test.ts": {
+      "passed": [
+        "Has CSS Module in computed styles in Development ({\"sass\": \"1.54.0\"}) should have CSS for page",
+        "Has CSS Module in computed styles in Development ({\"sass-embedded\": \"1.75.0\"}) should have CSS for page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/dynamic-route-module/dynamic-route-module.test.ts": {
+      "passed": [
+        "Dynamic Route CSS Module Usage ({\"sass\": \"1.54.0\"}) should apply styles correctly",
+        "Dynamic Route CSS Module Usage ({\"sass-embedded\": \"1.75.0\"}) should apply styles correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/external-url/external-url.test.ts": {
+      "passed": [
+        "SCSS Support loader handling External imports ({\"sass\": \"1.54.0\"}) should include font on the page",
+        "SCSS Support loader handling External imports ({\"sass-embedded\": \"1.75.0\"}) should include font on the page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/hmr-module/hmr-module.test.ts": {
+      "passed": [],
+      "failed": [],
+      "pending": [
+        "Can hot reload CSS Module without losing state ({\"sass\": \"1.54.0\"}) development only should update CSS color without remounting <input>",
+        "Can hot reload CSS Module without losing state ({\"sass-embedded\": \"1.75.0\"}) development only should update CSS color without remounting <input>"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/invalid-global-module/invalid-global-module.test.ts": {
+      "passed": [],
+      "failed": [],
+      "pending": [
+        "Invalid CSS Global Module Usage in node_modules production only should fail to build"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts": {
+      "passed": [
+        "Invalid Global CSS with Custom App production only should fail to build"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts": {
+      "passed": ["Invalid Global CSS production only should fail to build"],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/invalid-module-document/invalid-module-document.test.ts": {
+      "passed": [
+        "Invalid SCSS in _document production only should fail to build"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/invalid-module/invalid-module.test.ts": {
+      "passed": [],
+      "failed": [],
+      "pending": [
+        "Invalid CSS Module Usage in node_modules production only should fail to build"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/loader-order/loader-order.test.ts": {
+      "passed": [
+        "SCSS Support loader handling Preprocessor loader order ({\"sass\": \"1.54.0\"}) should render the module",
+        "SCSS Support loader handling Preprocessor loader order ({\"sass-embedded\": \"1.75.0\"}) should render the module"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/multi-global-reversed/multi-global-reversed.test.ts": {
+      "passed": [
+        "(SCSS) Multi Global Support (reversed) ({\"sass\": \"1.54.0\"}) should render the page",
+        "(SCSS) Multi Global Support (reversed) ({\"sass-embedded\": \"1.75.0\"}) should render the page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/multi-global/multi-global.test.ts": {
+      "passed": [
+        "Multi Global Support ({\"sass\": \"1.54.0\"}) should render the page",
+        "Multi Global Support ({\"sass-embedded\": \"1.75.0\"}) should render the page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/multi-page/multi-page.test.ts": {
+      "passed": [
+        "SCSS Support ({\"sass\": \"1.54.0\"}) Has CSS in computed styles in Development should have CSS for page",
+        "SCSS Support ({\"sass\": \"1.54.0\"}) Has CSS in computed styles in Production should have CSS for page",
+        "SCSS Support ({\"sass-embedded\": \"1.75.0\"}) Has CSS in computed styles in Development should have CSS for page",
+        "SCSS Support ({\"sass-embedded\": \"1.75.0\"}) Has CSS in computed styles in Production should have CSS for page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/nested-global/nested-global.test.ts": {
+      "passed": [
+        "Nested @import() Global Support ({\"sass\": \"1.54.0\"}) should render the page",
+        "Nested @import() Global Support ({\"sass-embedded\": \"1.75.0\"}) should render the page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/nm-module-nested/nm-module-nested.test.ts": {
+      "passed": [
+        "Valid Nested CSS Module Usage from within node_modules ({\"sass\": \"1.54.0\"}) should render the page",
+        "Valid Nested CSS Module Usage from within node_modules ({\"sass-embedded\": \"1.75.0\"}) should render the page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/nm-module/nm-module.test.ts": {
+      "passed": [
+        "Valid CSS Module Usage from within node_modules ({\"sass\": \"1.54.0\"}) should render the page",
+        "Valid CSS Module Usage from within node_modules ({\"sass-embedded\": \"1.75.0\"}) should render the page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/npm-import-bad/npm-import-bad.test.ts": {
+      "passed": [
+        "CSS Import from node_modules production only should fail the build"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/npm-import-nested/npm-import-nested.test.ts": {
+      "passed": [
+        "Good Nested CSS Import from node_modules ({\"sass\": \"1.54.0\"}) should render the page",
+        "Good Nested CSS Import from node_modules ({\"sass-embedded\": \"1.75.0\"}) should render the page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/npm-import-tilde/npm-import-tilde.test.ts": {
+      "passed": [
+        "Good CSS Import from node_modules with tilde ({\"sass\": \"1.54.0\"}) should render the page",
+        "Good CSS Import from node_modules with tilde ({\"sass-embedded\": \"1.75.0\"}) should render the page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/npm-import/npm-import.test.ts": {
+      "passed": [
+        "Good CSS Import from node_modules ({\"sass\": \"1.54.0\"}) should render the page",
+        "Good CSS Import from node_modules ({\"sass-embedded\": \"1.75.0\"}) should render the page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/prod-module/prod-module.test.ts": {
+      "passed": [
+        "Has CSS Module in computed styles in Production ({\"sass\": \"1.54.0\"}) should render the page",
+        "Has CSS Module in computed styles in Production ({\"sass-embedded\": \"1.75.0\"}) should render the page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/scss-mixins/scss-mixins.test.ts": {
+      "passed": ["Scss Mixins should work using browser"],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/single-global-src/single-global-src.test.ts": {
+      "passed": [
+        "Basic Global Support with src/ dir ({\"sass\": \"1.54.0\"}) should render the page",
+        "Basic Global Support with src/ dir ({\"sass-embedded\": \"1.75.0\"}) should render the page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/single-global/single-global.test.ts": {
+      "passed": [
+        "Basic Global Support scss ({\"sass\": \"1.54.0\"}) should render the page",
+        "Basic Global Support scss ({\"sass-embedded\": \"1.75.0\"}) should render the page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/unused/unused.test.ts": {
+      "passed": [],
+      "failed": [],
+      "pending": [
+        "unused scss Body is not hidden when broken in Development development only should have body visible",
+        "unused scss Body is not hidden when unused in Development ($dependencies) development only should have body visible"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/app-dir/scss/url-global-asset-prefix-1/url-global-asset-prefix-1.test.ts": {
+      "passed": [],
+      "failed": [],
+      "pending": [
+        "SCSS Support loader handling CSS URL via `file-loader` and asset prefix (1) ({\"sass\": \"1.54.0\"}) should render the page",
+        "SCSS Support loader handling CSS URL via `file-loader` and asset prefix (1) ({\"sass-embedded\": \"1.75.0\"}) should render the page"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/opentelemetry/client-trace-metadata/client-trace-metadata.test.ts": {
+      "passed": [
+        "clientTraceMetadata app router hard loading a dynamic page twice should yield different dynamic trace data",
+        "clientTraceMetadata app router next start only should not inject propagation data for a statically server-side-rendered page",
+        "clientTraceMetadata app router next start only soft navigating to a dynamic page should not transform previous propagation data",
+        "clientTraceMetadata app router next start only soft navigating to a static page should not transform previous propagation data",
+        "clientTraceMetadata app router should inject propagation data for a dynamically server-side-rendered page",
+        "clientTraceMetadata app router should only insert the client trace metadata once",
+        "clientTraceMetadata pages router hard loading a dynamic page twice should yield different dynamic trace data",
+        "clientTraceMetadata pages router next start only should not inject propagation data for a statically server-side-rendered page",
+        "clientTraceMetadata pages router next start only soft navigating to a dynamic page should not transform previous propagation data",
+        "clientTraceMetadata pages router next start only soft navigating to a static page should not transform previous propagation data",
+        "clientTraceMetadata pages router should inject propagation data for a dynamically server-side-rendered page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/opentelemetry/instrumentation/instrumentation-pages-app-only.test.ts": {
+      "passed": [
+        "instrumentation app should start and serve correctly",
+        "instrumentation app src/ should start and serve correctly",
+        "instrumentation pages should start and serve correctly",
+        "instrumentation pages src/ should start and serve correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts": {
+      "passed": [
+        "opentelemetry incoming context propagation app router should handle RSC with fetch",
+        "opentelemetry incoming context propagation app router should handle RSC with fetch in RSC mode",
+        "opentelemetry incoming context propagation app router should handle RSC with fetch on edge",
+        "opentelemetry incoming context propagation app router should handle route handlers in app router",
+        "opentelemetry incoming context propagation app router should handle route handlers in app router on edge",
+        "opentelemetry incoming context propagation app router should propagate custom context without span",
+        "opentelemetry incoming context propagation app router should trace middleware",
+        "opentelemetry incoming context propagation pages should handle api routes in pages",
+        "opentelemetry incoming context propagation pages should handle api routes in pages on edge",
+        "opentelemetry incoming context propagation pages should handle getServerSideProps",
+        "opentelemetry incoming context propagation pages should handle getServerSideProps on edge",
+        "opentelemetry incoming context propagation pages should handle getStaticProps when fallback: 'blocking'",
+        "opentelemetry root context app router should handle RSC with fetch",
+        "opentelemetry root context app router should handle RSC with fetch in RSC mode",
+        "opentelemetry root context app router should handle RSC with fetch on edge",
+        "opentelemetry root context app router should handle route handlers in app router",
+        "opentelemetry root context app router should handle route handlers in app router on edge",
+        "opentelemetry root context app router should propagate custom context without span",
+        "opentelemetry root context app router should trace middleware",
+        "opentelemetry root context pages should handle api routes in pages",
+        "opentelemetry root context pages should handle api routes in pages on edge",
+        "opentelemetry root context pages should handle getServerSideProps",
+        "opentelemetry root context pages should handle getServerSideProps on edge",
+        "opentelemetry root context pages should handle getStaticProps when fallback: 'blocking'",
+        "opentelemetry with disabled fetch tracing root context app router with disabled fetch should handle RSC with disabled fetch"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/optimized-loading/test/index.test.ts": {
+      "passed": [
+        "Optimized loading page / should load scripts with defer in head",
+        "Optimized loading page / should not have JS preload links",
+        "Optimized loading page / should render the page /",
+        "Optimized loading page /page1 should load scripts with defer in head",
+        "Optimized loading page /page1 should not have JS preload links",
+        "Optimized loading page /page1 should render the page /page1"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/pages-performance-mark/index.test.ts": {
+      "passed": [
+        "pages performance mark should render the page correctly without crashing with performance mark"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/persistent-caching/persistent-caching.test.ts": {
+      "passed": [
+        "persistent-caching should allow to change files while stopped",
+        "persistent-caching should persistent cache loaders"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/postcss-config-cjs/index.test.ts": {
+      "passed": ["postcss-config-cjs works with postcss.config.cjs files"],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/postcss-config-package/index.test.ts": {
+      "passed": [
+        "postcss-config-json works with postcss config specified in package.json"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/prerender-crawler.test.ts": {
+      "passed": [
+        "Prerender crawler handling should block for crawler correctly",
+        "Prerender crawler handling should return fallback for non-crawler correctly",
+        "Prerender crawler handling should return prerendered page for correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/prerender-native-module.test.ts": {
+      "passed": [
+        "prerender native module should output traces",
+        "prerender native module should render /blog/first correctly",
+        "prerender native module should render /blog/second correctly",
+        "prerender native module should render index correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/prerender.test.ts": {
+      "passed": [
+        "Prerender outputs a prerender-manifest correctly",
+        "Prerender outputs dataRoutes in routes-manifest correctly",
+        "Prerender outputs prerendered files correctly",
+        "Prerender should 404 for a missing catchall explicit route",
+        "Prerender should 404 for an invalid data url",
+        "Prerender should SSR blocking path correctly (blocking)",
+        "Prerender should SSR blocking path correctly (pre-rendered)",
+        "Prerender should SSR catch-all page with brackets in param as object",
+        "Prerender should SSR catch-all page with brackets in param as string",
+        "Prerender should SSR dynamic page with brackets in param as object",
+        "Prerender should SSR dynamic page with brackets in param as string",
+        "Prerender should SSR incremental page correctly",
+        "Prerender should SSR normal page correctly",
+        "Prerender should allow rewriting to SSG page with fallback: 'blocking'",
+        "Prerender should allow rewriting to SSG page with fallback: false",
+        "Prerender should automatically reset cache TTL when an error occurs and build cache was available",
+        "Prerender should automatically reset cache TTL when an error occurs and runtime cache was available",
+        "Prerender should fetch /_next/data correctly with mismatched href and as",
+        "Prerender should handle de-duping correctly",
+        "Prerender should handle fallback only page correctly HTML",
+        "Prerender should handle fallback only page correctly data",
+        "Prerender should handle on-demand revalidate for fallback: blocking",
+        "Prerender should handle on-demand revalidate for fallback: false",
+        "Prerender should handle revalidating HTML correctly",
+        "Prerender should handle revalidating HTML correctly with blocking",
+        "Prerender should handle revalidating HTML correctly with blocking and seed",
+        "Prerender should handle revalidating JSON correctly",
+        "Prerender should handle revalidating JSON correctly with blocking",
+        "Prerender should handle revalidating JSON correctly with blocking and seed",
+        "Prerender should have gsp in __NEXT_DATA__",
+        "Prerender should navigate between pages successfully",
+        "Prerender should navigate to a normal page and back",
+        "Prerender should navigate to catch-all page with brackets in param as object",
+        "Prerender should navigate to catch-all page with brackets in param as string",
+        "Prerender should navigate to dynamic page with brackets in param as object",
+        "Prerender should navigate to dynamic page with brackets in param as string",
+        "Prerender should not error when flushing cache files",
+        "Prerender should not error when rewriting to fallback dynamic SSG page",
+        "Prerender should not fail to update incremental cache",
+        "Prerender should not fetch prerender data on mount",
+        "Prerender should not have attempted sending invalid payload",
+        "Prerender should not have experimental undici warning",
+        "Prerender should not have gsp in __NEXT_DATA__ for non-GSP page",
+        "Prerender should not on-demand revalidate for fallback: blocking with onlyGenerated if not generated",
+        "Prerender should not return data for fallback: false and missing dynamic page",
+        "Prerender should not revalidate when set to false",
+        "Prerender should not revalidate when set to false in blocking fallback mode",
+        "Prerender should not show error for invalid JSON returned from getStaticProps on CST",
+        "Prerender should not show error for invalid JSON returned from getStaticProps on SSR",
+        "Prerender should not supply query values to params in /_next/data request",
+        "Prerender should not supply query values to params or useRouter dynamic page SSR",
+        "Prerender should not supply query values to params or useRouter non-dynamic page SSR",
+        "Prerender should not throw error for on-demand revalidate for SSR path",
+        "Prerender should of formatted build output correctly",
+        "Prerender should on-demand revalidate for fallback: blocking with onlyGenerated if generated",
+        "Prerender should on-demand revalidate for revalidate: false",
+        "Prerender should on-demand revalidate that returns notFound: true",
+        "Prerender should only show warning once per page when large amount of page data is returned",
+        "Prerender should output traces",
+        "Prerender should parse query values on mount correctly",
+        "Prerender should reload page on failed data request",
+        "Prerender should render correctly for SSG pages that starts with api-docs",
+        "Prerender should respond for catch-all deep folder",
+        "Prerender should respond with 405 for POST to static page",
+        "Prerender should return data correctly",
+        "Prerender should return data correctly for SSG pages that starts with api-docs",
+        "Prerender should return data correctly for dynamic page",
+        "Prerender should return data correctly for dynamic page (non-seeded)",
+        "Prerender should revalidate on-demand revalidate with preview cookie",
+        "Prerender should server prerendered path correctly for SSG pages that starts with api-docs",
+        "Prerender should show warning when large amount of page data is returned",
+        "Prerender should support lazy catchall route",
+        "Prerender should support nested lazy catchall route",
+        "Prerender should support prerendered catchall route",
+        "Prerender should support prerendered catchall-explicit route (nested)",
+        "Prerender should support prerendered catchall-explicit route (single)",
+        "Prerender should use correct caching headers for a no-revalidate page",
+        "Prerender should use correct caching headers for a revalidate page"
+      ],
+      "failed": [],
+      "pending": [
+        "Prerender should reload page on failed data request, and retry"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/proxy-request-with-middleware/test/index.test.ts": {
+      "passed": [
+        "Requests not effected when middleware used should proxy GET request ",
+        "Requests not effected when middleware used should proxy POST request with body"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/react-compiler/react-compiler.test.ts": {
+      "passed": [
+        "react-compiler babelrc should render",
+        "react-compiler babelrc should show an experimental warning",
+        "react-compiler babelrc should work with a library that uses the react-server condition",
+        "react-compiler babelrc should work with a library using use client",
+        "react-compiler babelrc throws if the React Compiler is used in a React Server environment",
+        "react-compiler default should render",
+        "react-compiler default should show an experimental warning",
+        "react-compiler default should work with a library that uses the react-server condition",
+        "react-compiler default should work with a library using use client",
+        "react-compiler default throws if the React Compiler is used in a React Server environment"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/react-dnd-compile/react-dnd-compile.test.ts": {
+      "passed": [
+        "react-dnd-compile should work",
+        "react-dnd-compile should work on react-dnd import page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/react-version/react-version.test.ts": {
+      "passed": [
+        "react version should use default react condition for pages router apis",
+        "react version should use default react condition for pages router pages",
+        "react version should use react-server condition for app router client components pages",
+        "react version should use react-server condition for app router custom routes",
+        "react version should use react-server condition for app router server components pages"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/reload-scroll-backforward-restoration/index.test.ts": {
+      "passed": [
+        "reload-scroll-back-restoration should restore the scroll position on navigating back",
+        "reload-scroll-back-restoration should restore the scroll position on navigating forward"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/repeated-forward-slashes-error/repeated-forward-slashes-error.test.ts": {
+      "passed": [
+        "repeated-forward-slashes-error should log error when href has repeated forward-slashes"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/revalidate-reason/revalidate-reason.test.ts": {
+      "passed": [
+        "revalidate-reason should support revalidateReason: \"build\"",
+        "revalidate-reason should support revalidateReason: \"on-demand\"",
+        "revalidate-reason should support revalidateReason: \"stale\""
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/rsc-layers-transform/rsc-layers-transform.test.ts": {
+      "passed": [
+        "rsc layers transform should call instrumentation hook without errors",
+        "rsc layers transform should render installed react-server condition for middleware"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/skip-trailing-slash-redirect/index.test.ts": {
+      "passed": [
+        "skip-trailing-slash-redirect app dir - skip trailing slash redirect should navigate client side correctly",
+        "skip-trailing-slash-redirect app dir - skip trailing slash redirect should not apply trailing slash redirect (with slash)",
+        "skip-trailing-slash-redirect app dir - skip trailing slash redirect should not apply trailing slash redirect (without slash)",
+        "skip-trailing-slash-redirect app dir - skip trailing slash redirect should preserve original trailing slashes to links on client",
+        "skip-trailing-slash-redirect app dir - skip trailing slash redirect should respond to dynamic route correctly",
+        "skip-trailing-slash-redirect app dir - skip trailing slash redirect should respond to index correctly",
+        "skip-trailing-slash-redirect pages dir should navigate client side correctly",
+        "skip-trailing-slash-redirect pages dir should not apply trailing slash redirect (with slash)",
+        "skip-trailing-slash-redirect pages dir should not apply trailing slash redirect (without slash)",
+        "skip-trailing-slash-redirect pages dir should preserve original trailing slashes to links on client",
+        "skip-trailing-slash-redirect pages dir should respond to dynamic route correctly",
+        "skip-trailing-slash-redirect pages dir should respond to index correctly",
+        "skip-trailing-slash-redirect should allow response body from middleware with flag",
+        "skip-trailing-slash-redirect should allow rewriting invalid buildId correctly",
+        "skip-trailing-slash-redirect should apply config redirect correctly",
+        "skip-trailing-slash-redirect should apply config rewrites correctly",
+        "skip-trailing-slash-redirect should be able to redirect locale casing $1",
+        "skip-trailing-slash-redirect should correct skip URL normalizing in middleware",
+        "skip-trailing-slash-redirect should handle external rewrite correctly /chained-rewrite-ssg",
+        "skip-trailing-slash-redirect should handle external rewrite correctly /chained-rewrite-ssr",
+        "skip-trailing-slash-redirect should handle external rewrite correctly /chained-rewrite-static",
+        "skip-trailing-slash-redirect should handle external rewrite correctly /docs-auto-static/first",
+        "skip-trailing-slash-redirect should handle external rewrite correctly /docs-ssr/first",
+        "skip-trailing-slash-redirect should handle external rewrite correctly /docs/first",
+        "skip-trailing-slash-redirect should merge cookies from middleware and API routes correctly",
+        "skip-trailing-slash-redirect should merge cookies from middleware and edge API routes correctly",
+        "skip-trailing-slash-redirect should not apply trailing slash on load on client",
+        "skip-trailing-slash-redirect should not have trailing slash redirects in manifest",
+        "skip-trailing-slash-redirect should parse locale info for data request correctly",
+        "skip-trailing-slash-redirect should provide original _next/data URL with skipMiddlewareUrlNormalize"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/socket-io/index.test.js": {
+      "passed": [
+        "socket-io should support socket.io without falling back to polling"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/ssr-react-context/index.test.ts": {
+      "passed": [
+        "React Context should render a page with context",
+        "React Context should render correctly with context consumer"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/streaming-ssr/index.test.ts": {
+      "passed": [
+        "react 18 streaming SSR in minimal mode with node runtime should generate html response by streaming correctly",
+        "react 18 streaming SSR in minimal mode with node runtime should have generated a static 404 page",
+        "react 18 streaming SSR in minimal mode with node runtime should pass correct nextRuntime values",
+        "streaming SSR with custom next configs should match more specific route along with dynamic routes",
+        "streaming SSR with custom next configs should redirect paths without trailing-slash and render when slash is appended",
+        "streaming SSR with custom next configs should render multi-byte characters correctly in streaming",
+        "streaming SSR with custom next configs should render next/router correctly in edge runtime",
+        "streaming SSR with custom next configs should render styled-jsx styles in streaming",
+        "streaming SSR with custom server should render page correctly under custom server"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/styled-jsx/index.test.ts": {
+      "passed": [
+        "styled-jsx should contain styled-jsx styles during SSR",
+        "styled-jsx should render styles during CSR",
+        "styled-jsx should render styles during CSR (AMP)",
+        "styled-jsx should render styles during SSR (AMP)"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/swc-warnings/index.test.ts": {
+      "passed": [
+        "can force swc should not have warning",
+        "swc warnings by default should have warning"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/switchable-runtime/index.test.ts": {
+      "passed": [
+        "Switchable runtime Switchable runtime (prod) should build /api/hello and /api/edge as an api route with edge runtime",
+        "Switchable runtime Switchable runtime (prod) should build /app-valid-runtime as a dynamic page with the edge runtime",
+        "Switchable runtime Switchable runtime (prod) should build /edge as a dynamic page with the edge runtime",
+        "Switchable runtime Switchable runtime (prod) should build /node-ssr as a dynamic page with the nodejs runtime",
+        "Switchable runtime Switchable runtime (prod) should build /static as a static page with the nodejs runtime",
+        "Switchable runtime Switchable runtime (prod) should support etag header in the web server"
+      ],
+      "failed": [],
+      "pending": [
+        "Switchable runtime Switchable runtime (prod) should build /edge-rsc as a dynamic page with the edge runtime",
+        "Switchable runtime Switchable runtime (prod) should build /node as a static page with the nodejs runtime",
+        "Switchable runtime Switchable runtime (prod) should build /node-rsc as a static page with the nodejs runtime",
+        "Switchable runtime Switchable runtime (prod) should build /node-rsc-isr as an isr page with the nodejs runtime",
+        "Switchable runtime Switchable runtime (prod) should build /node-rsc-ssg as a static page with the nodejs runtime",
+        "Switchable runtime Switchable runtime (prod) should build /node-rsc-ssr as a dynamic page with the nodejs runtime",
+        "Switchable runtime Switchable runtime (prod) should build /node-ssg as a static page with the nodejs runtime",
+        "Switchable runtime Switchable runtime (prod) should display correct tree view with page types in terminal",
+        "Switchable runtime Switchable runtime (prod) should prefetch data for static pages",
+        "Switchable runtime Switchable runtime (prod) should support client side navigation to ssg rsc pages",
+        "Switchable runtime Switchable runtime (prod) should support client side navigation to ssr rsc pages",
+        "Switchable runtime Switchable runtime (prod) should support client side navigation to static rsc pages"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/test-template/{{ toFileName name }}/{{ toFileName name }}.test.ts": {
+      "passed": [
+        "{{name}} should work using browser",
+        "{{name}} should work using cheerio",
+        "{{name}} should work with fetch",
+        "{{name}} should work with html"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/test-utils-tests/basic/basic.test.ts": {
+      "passed": ["nextTestSetup should work"],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/testmode/testmode.test.ts": {
+      "passed": [
+        "testmode app router should avoid fetch cache",
+        "testmode app router should fetch real data when Next-Test-* headers are not present",
+        "testmode app router should handle API with fetch in edge function",
+        "testmode app router should handle API with fetch in serverless function",
+        "testmode app router should handle API with http.get in serverless function",
+        "testmode app router should handle RSC with fetch in edge function",
+        "testmode app router should handle RSC with fetch in serverless function",
+        "testmode app router should handle RSC with http.get in serverless function",
+        "testmode middleware should intercept fetchs in middleware",
+        "testmode page router should handle API with fetch",
+        "testmode page router should handle API with http.get",
+        "testmode page router should handle getServerSideProps with fetch",
+        "testmode page router should handle getServerSideProps with http.get",
+        "testmode rewrites should handle rewrites"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/third-parties/index.test.ts": {
+      "passed": [
+        "@next/third-parties basic usage renders GA",
+        "@next/third-parties basic usage renders GTM",
+        "@next/third-parties basic usage renders GoogleMapsEmbed",
+        "@next/third-parties basic usage renders YoutubeEmbed"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/trailingslash-with-rewrite/index.test.ts": {
+      "passed": [
+        "trailingSlash:true with rewrites and getStaticProps should work"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/transpile-packages/index.test.ts": {
+      "passed": [
+        "transpile packages css should handle css modules imports inside transpiled modules",
+        "transpile packages css should handle global css imports inside transpiled modules",
+        "transpile packages css should handle global scss imports inside transpiled modules",
+        "transpile packages css should handle scss modules imports inside transpiled modules",
+        "transpile packages optional deps should hide dynammic module dependency errors from node_modules",
+        "transpile packages optional deps should not throw an error when optional deps are not installed"
+      ],
+      "failed": [],
+      "pending": [
+        "transpile packages should handle optional peer dependencies"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/tsconfig-module-preserve/index.test.ts": {
+      "passed": [
+        "tsconfig module: preserve allows you to skip moduleResolution, esModuleInterop and resolveJsonModule when using \"module: preserve\""
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/type-module-interop/index.test.ts": {
+      "passed": [
+        "Type module interop should render client-side",
+        "Type module interop should render client-side with modules",
+        "Type module interop should render server-side",
+        "Type module interop should render server-side with modules"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/typescript-version-no-warning/typescript-version-no-warning.test.ts": {
+      "passed": [
+        "typescript-version-no-warning should not print warning when new typescript version is used with next build"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/typescript-version-warning/typescript-version-warning.test.ts": {
+      "passed": [
+        "typescript-version-warning should print warning when old typescript version is used with next build"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/undici-fetch/index.test.ts": {
+      "passed": [
+        "undici fetch undici global Headers should return true when undici is used",
+        "undici fetch undici global Request should return true when undici is used",
+        "undici fetch undici global Response should return true when undici is used",
+        "undici fetch undici global fetch should return true when undici is used"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/useselectedlayoutsegment-s-in-pages-router/useselectedlayoutsegment-s-in-pages-router.test.ts": {
+      "passed": [
+        "useSelectedLayoutSegment(s) in Pages Router Should render with `useSelectedLayoutSegment(s) hooks"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/vary-header/test/index.test.ts": {
+      "passed": [
+        "Vary Header Tests should preserve custom vary header and append RSC headers in app route handlers",
+        "Vary Header Tests should preserve custom vary header in API routes",
+        "Vary Header Tests should preserve middleware vary header in combination with route handlers"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/with-router/index.test.ts": {
+      "passed": [
+        "withRouter production mode allows observation of navigation events using top level Router",
+        "withRouter production mode allows observation of navigation events using top level Router deprecated behavior",
+        "withRouter production mode allows observation of navigation events using withRouter"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/yarn-pnp/test/mdx-pages.test.ts": {
+      "passed": [
+        "yarn PnP should compile and serve the index page correctly mdx-pages"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/yarn-pnp/test/with-eslint.test.ts": {
+      "passed": [
+        "yarn PnP should compile and serve the index page correctly with-eslint"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/e2e/yarn-pnp/test/with-sass.test.ts": {
+      "passed": [
+        "yarn PnP should compile and serve the index page correctly with-sass"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/404-page-app/test/index.test.js": {
+      "passed": [
+        "404 Page Support with _app development mode should not show pages/404 GIP error if _app has GIP",
+        "404 Page Support with _app production mode should build successfully",
+        "404 Page Support with _app production mode should not output static 404 if _app has getInitialProps",
+        "404 Page Support with _app production mode should still use 404 page",
+        "404 Page Support with _app production mode specify to use the 404 page still in the routes-manifest"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/404-page-custom-error/test/index.test.js": {
+      "passed": [
+        "Default 404 Page with custom _error development mode should render index page normal",
+        "Default 404 Page with custom _error development mode should respond to 404 correctly",
+        "Default 404 Page with custom _error production mode should build successfully",
+        "Default 404 Page with custom _error production mode should have output 404.html",
+        "Default 404 Page with custom _error production mode should render error correctly",
+        "Default 404 Page with custom _error production mode should render index page normal",
+        "Default 404 Page with custom _error production mode should respond to 404 correctly",
+        "Default 404 Page with custom _error production mode should set pages404 in routes-manifest correctly"
+      ],
+      "failed": [
+        "Default 404 Page with custom _error development mode should render error correctly"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/404-page-ssg/test/index.test.js": {
+      "passed": [
+        "404 Page Support SSG development mode should not show an error in the logs for 404 SSG",
+        "404 Page Support SSG development mode should render index page normal",
+        "404 Page Support SSG development mode should respond to 404 correctly",
+        "404 Page Support SSG production mode should build successfully",
+        "404 Page Support SSG production mode should have 404 page in prerender-manifest",
+        "404 Page Support SSG production mode should not revalidate custom 404 page",
+        "404 Page Support SSG production mode should not show an error in the logs for 404 SSG",
+        "404 Page Support SSG production mode should render error correctly",
+        "404 Page Support SSG production mode should render index page normal",
+        "404 Page Support SSG production mode should respond to 404 correctly",
+        "404 Page Support SSG production mode should set pages404 in routes-manifest correctly"
+      ],
+      "failed": [
+        "404 Page Support SSG development mode should render error correctly"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/404-page/test/index.test.js": {
+      "passed": [
+        "404 Page Support development mode 2 does not show error with getStaticProps in pages/404 dev",
+        "404 Page Support development mode 2 falls back to _error correctly without pages/404",
+        "404 Page Support development mode 2 shows error with getInitialProps in pages/404 dev",
+        "404 Page Support development mode 2 shows error with getServerSideProps in pages/404 dev",
+        "404 Page Support development mode should not error when visited directly",
+        "404 Page Support development mode should set correct status code with pages/404",
+        "404 Page Support development mode should use pages/404",
+        "404 Page Support development mode should use pages/404 for .d.ts file",
+        "404 Page Support production mode does not show error with getStaticProps in pages/404 build",
+        "404 Page Support production mode should add /404 to pages-manifest correctly",
+        "404 Page Support production mode should not cache for custom 404 page with gssp and revalidate disabled",
+        "404 Page Support production mode should not cache for custom 404 page with gssp and revalidate enabled",
+        "404 Page Support production mode should not cache for custom 404 page without gssp",
+        "404 Page Support production mode should not error when visited directly",
+        "404 Page Support production mode should output 404.html during build",
+        "404 Page Support production mode should render _error for a 500 error still",
+        "404 Page Support production mode should set correct status code with pages/404",
+        "404 Page Support production mode should use pages/404",
+        "404 Page Support production mode should use pages/404 for .d.ts file",
+        "404 Page Support production mode shows error with getInitialProps in pages/404 build",
+        "404 Page Support production mode shows error with getServerSideProps in pages/404 build"
+      ],
+      "failed": [
+        "404 Page Support development mode should render _error for a 500 error still"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/500-page/test/gsp-gssp.test.js": {
+      "passed": [
+        "gsp-gssp development mode does not show error with getStaticProps in pages/500 dev",
+        "gsp-gssp development mode shows error with getServerSideProps in pages/500 dev",
+        "gsp-gssp production mode does build 500 statically with getInitialProps in _app and getStaticProps in pages/500",
+        "gsp-gssp production mode does not build 500 statically with no pages/500 and getServerSideProps in _error",
+        "gsp-gssp production mode does not show error with getStaticProps in pages/500 build",
+        "gsp-gssp production mode shows error with getServerSideProps in pages/500 build"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/500-page/test/index.test.js": {
+      "passed": [
+        "500 Page Support development mode 2 shows error with getInitialProps in pages/500 dev",
+        "500 Page Support development mode should not error when visited directly",
+        "500 Page Support development mode should set correct status code with pages/500",
+        "500 Page Support development mode should use pages/500",
+        "500 Page Support production mode 2 builds 500 statically by default with no pages/500",
+        "500 Page Support production mode 2 builds 500 statically by default with no pages/500 and custom _error without getInitialProps",
+        "500 Page Support production mode 2 does not build 500 statically with getInitialProps in _app",
+        "500 Page Support production mode 2 does not build 500 statically with no pages/500 and custom getInitialProps in _error",
+        "500 Page Support production mode 2 does not build 500 statically with no pages/500 and custom getInitialProps in _error and _app",
+        "500 Page Support production mode 2 should have correct cache control for 500 page with getStaticProps",
+        "500 Page Support production mode 2 shows error with getInitialProps in pages/500 build",
+        "500 Page Support production mode should add /500 to pages-manifest correctly",
+        "500 Page Support production mode should not error when visited directly",
+        "500 Page Support production mode should output 500.html during build",
+        "500 Page Support production mode should set correct status code with pages/500",
+        "500 Page Support production mode should use pages/500"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/absolute-assetprefix/test/index.test.js": {
+      "passed": [
+        "absolute assetPrefix with path prefix production mode should fetch from cache correctly",
+        "absolute assetPrefix with path prefix production mode should not fetch static data from a CDN",
+        "absolute assetPrefix with path prefix production mode should work with getServerSideProps",
+        "absolute assetPrefix with path prefix production mode should work with getStaticPaths fallback",
+        "absolute assetPrefix with path prefix production mode should work with getStaticPaths prerendered"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/amp-export-validation/test/index.test.js": {
+      "passed": [
+        "AMP Validation on Export production mode should have shown errors during build"
+      ],
+      "failed": [],
+      "pending": [
+        "AMP Validation on Export production mode shows AMP warning without throwing error",
+        "AMP Validation on Export production mode shows warning and error when throwing error",
+        "AMP Validation on Export production mode throws error on AMP error"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/amphtml-custom-optimizer/test/index.test.js": {
+      "passed": [
+        "AMP Custom Optimizer production mode should build and start for dynamic page",
+        "AMP Custom Optimizer production mode should build and start for static page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/amphtml-custom-validator/test/index.test.js": {
+      "passed": [
+        "AMP Custom Validator development mode should run in development mode successfully",
+        "AMP Custom Validator production mode should build and start successfully"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/amphtml-fragment-style/test/index.test.js": {
+      "passed": [
+        "AMP Fragment Styles production mode adds styles from fragment in AMP mode correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/amphtml-ssg/test/index.test.js": {
+      "passed": [
+        "AMP SSG Support development mode should load a hybrid amp page with query correctly",
+        "AMP SSG Support development mode should load a hybrid amp page without query correctly",
+        "AMP SSG Support development mode should load an amp first page correctly",
+        "AMP SSG Support development mode should load dynamic hybrid SSG/AMP page",
+        "AMP SSG Support development mode should load dynamic hybrid SSG/AMP page with query",
+        "AMP SSG Support development mode should load dynamic hybrid SSG/AMP page with trailing slash",
+        "AMP SSG Support export mode production mode should have copied SSG files correctly",
+        "AMP SSG Support production mode should load a hybrid amp page with query correctly",
+        "AMP SSG Support production mode should load a hybrid amp page without query correctly",
+        "AMP SSG Support production mode should load an amp first page correctly",
+        "AMP SSG Support production mode should load dynamic hybrid SSG/AMP page",
+        "AMP SSG Support production mode should load dynamic hybrid SSG/AMP page with query",
+        "AMP SSG Support production mode should load dynamic hybrid SSG/AMP page with trailing slash",
+        "AMP SSG Support production mode should output prerendered files correctly during build"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/amphtml/test/index.test.js": {
+      "passed": [
+        "AMP Usage AMP dev no-warn should not warn on valid amp",
+        "AMP Usage AMP development mode should add data-ampdevmode to development script tags",
+        "AMP Usage AMP development mode should detect amp validator warning on custom scripts",
+        "AMP Usage AMP development mode should detect amp validator warning on invalid amp",
+        "AMP Usage AMP development mode should navigate from non-AMP to AMP without error",
+        "AMP Usage AMP development mode should not contain missing files warning",
+        "AMP Usage production mode With AMP context should render nested AMP page with AMP hook",
+        "AMP Usage production mode With AMP context should render nested normal page with AMP hook",
+        "AMP Usage production mode With AMP context should render the AMP page that uses the AMP hook",
+        "AMP Usage production mode With AMP context should render the normal page that uses the AMP hook",
+        "AMP Usage production mode With basic AMP usage should auto import extensions",
+        "AMP Usage production mode With basic AMP usage should drop custom scripts",
+        "AMP Usage production mode With basic AMP usage should not drop custom amp scripts",
+        "AMP Usage production mode With basic AMP usage should not output client pages for AMP only",
+        "AMP Usage production mode With basic AMP usage should not output client pages for AMP only with config exported after declaration",
+        "AMP Usage production mode With basic AMP usage should optimize clean",
+        "AMP Usage production mode With basic AMP usage should render the page as valid AMP",
+        "AMP Usage production mode With basic AMP usage should render the page without leaving render target",
+        "AMP Usage production mode With basic usage should render the page",
+        "AMP Usage production mode canonical amphtml should allow manually setting amphtml rel",
+        "AMP Usage production mode canonical amphtml should allow manually setting canonical",
+        "AMP Usage production mode canonical amphtml should not render amphtml link tag with no AMP page",
+        "AMP Usage production mode canonical amphtml should remove conflicting amp tags",
+        "AMP Usage production mode canonical amphtml should render a canonical regardless of amp-only status (explicit)",
+        "AMP Usage production mode canonical amphtml should render amphtml from provided rel link",
+        "AMP Usage production mode canonical amphtml should render link rel amphtml",
+        "AMP Usage production mode canonical amphtml should render link rel amphtml with existing query",
+        "AMP Usage production mode canonical amphtml should render the AMP page that uses the AMP hook",
+        "AMP Usage production mode combined styles should combine style tags",
+        "AMP Usage production mode combined styles should remove sourceMaps from styles",
+        "AMP Usage production mode should have amp optimizer in trace",
+        "AMP Usage production mode should not contain missing files warning"
+      ],
+      "failed": [],
+      "pending": [
+        "AMP Usage AMP development mode should detect changes and refresh a hybrid AMP page",
+        "AMP Usage AMP development mode should detect changes and refresh an AMP page",
+        "AMP Usage AMP development mode should detect changes and refresh an AMP page at root pages/",
+        "AMP Usage AMP development mode should detect changes to component and refresh an AMP page",
+        "AMP Usage AMP development mode should detect the changes and display it",
+        "AMP Usage AMP development mode should not reload unless the page is edited for an AMP page"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/api-body-parser/test/index.test.js": {
+      "passed": [
+        "should not throw if request body is already parsed in custom middleware",
+        "should not throw if request's content-type is invalid",
+        "should parse JSON body"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/api-catch-all/test/index.test.js": {
+      "passed": [
+        "API routes dev support should return data when catch-all",
+        "API routes dev support should return data when catch-all with index and no trailing slash",
+        "API routes dev support should return data when catch-all with index and trailing slash",
+        "API routes dev support should return redirect when catch-all with index and trailing slash",
+        "API routes production mode should return data when catch-all",
+        "API routes production mode should return data when catch-all with index and no trailing slash",
+        "API routes production mode should return data when catch-all with index and trailing slash",
+        "API routes production mode should return redirect when catch-all with index and trailing slash"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/api-support/test/index.test.js": {
+      "passed": [
+        "API routes dev support should 404 on optional dynamic api page",
+        "API routes dev support should compile only server code in development",
+        "API routes dev support should handle 204 status correctly",
+        "API routes dev support should handle proxying to self correctly",
+        "API routes dev support should not conflict with /api routes",
+        "API routes dev support should not show warning if using externalResolver flag",
+        "API routes dev support should not show warning when the API resolves and the response is piped",
+        "API routes dev support should not warn if response body is larger than 4MB with responseLimit config = false",
+        "API routes dev support should parse JSON body",
+        "API routes dev support should parse bigger body then 1mb",
+        "API routes dev support should parse body in handler",
+        "API routes dev support should parse body with config",
+        "API routes dev support should parse query correctly",
+        "API routes dev support should parse urlencoded body",
+        "API routes dev support should prioritize a non-dynamic page",
+        "API routes dev support should redirect to login",
+        "API routes dev support should redirect with status code 301",
+        "API routes dev support should redirect with status code 307",
+        "API routes dev support should render page",
+        "API routes dev support should respond from /api/auth/[...nextauth] correctly",
+        "API routes dev support should return 200 on POST on pages",
+        "API routes dev support should return 404 for undefined path",
+        "API routes dev support should return JSON on post on API",
+        "API routes dev support should return cookies object",
+        "API routes dev support should return custom error",
+        "API routes dev support should return data on dynamic nested route",
+        "API routes dev support should return data on dynamic optional nested route",
+        "API routes dev support should return data on dynamic route",
+        "API routes dev support should return empty cookies object",
+        "API routes dev support should return empty query object",
+        "API routes dev support should return error with invalid JSON",
+        "API routes dev support should set cors headers when adding cors middleware",
+        "API routes dev support should show false positive warning if not using externalResolver flag",
+        "API routes dev support should show friendly error in case of passing null as first argument redirect",
+        "API routes dev support should show warning when the API resolves without ending the request in development mode",
+        "API routes dev support should special-case empty JSON body",
+        "API routes dev support should support boolean for JSON in api page",
+        "API routes dev support should support etag spec",
+        "API routes dev support should support null in JSON response body",
+        "API routes dev support should support string in JSON response body",
+        "API routes dev support should support undefined response body",
+        "API routes dev support should warn if response body is larger than 4MB",
+        "API routes dev support should warn with configured size if response body is larger than configured size",
+        "API routes dev support should work with child_process correctly",
+        "API routes dev support should work with dynamic params and search string",
+        "API routes dev support should work with dynamic params and search string like lambda",
+        "API routes dev support should work with index api",
+        "API routes dev support should work with nullable payload",
+        "API routes production mode should 404 on optional dynamic api page",
+        "API routes production mode should build api routes",
+        "API routes production mode should handle 204 status correctly",
+        "API routes production mode should handle proxying to self correctly",
+        "API routes production mode should not conflict with /api routes",
+        "API routes production mode should not warn if response body is larger than 4MB with responseLimit config = false",
+        "API routes production mode should parse JSON body",
+        "API routes production mode should parse bigger body then 1mb",
+        "API routes production mode should parse body in handler",
+        "API routes production mode should parse body with config",
+        "API routes production mode should parse query correctly",
+        "API routes production mode should parse urlencoded body",
+        "API routes production mode should prioritize a non-dynamic page",
+        "API routes production mode should redirect to login",
+        "API routes production mode should redirect with status code 301",
+        "API routes production mode should redirect with status code 307",
+        "API routes production mode should render page",
+        "API routes production mode should respond from /api/auth/[...nextauth] correctly",
+        "API routes production mode should return 200 on POST on pages",
+        "API routes production mode should return 404 for undefined path",
+        "API routes production mode should return JSON on post on API",
+        "API routes production mode should return cookies object",
+        "API routes production mode should return custom error",
+        "API routes production mode should return data on dynamic nested route",
+        "API routes production mode should return data on dynamic optional nested route",
+        "API routes production mode should return data on dynamic route",
+        "API routes production mode should return empty cookies object",
+        "API routes production mode should return empty query object",
+        "API routes production mode should return error with invalid JSON",
+        "API routes production mode should set cors headers when adding cors middleware",
+        "API routes production mode should show error with output export",
+        "API routes production mode should show friendly error in case of passing null as first argument redirect",
+        "API routes production mode should special-case empty JSON body",
+        "API routes production mode should support boolean for JSON in api page",
+        "API routes production mode should support etag spec",
+        "API routes production mode should support null in JSON response body",
+        "API routes production mode should support string in JSON response body",
+        "API routes production mode should support undefined response body",
+        "API routes production mode should throw Internal Server Error",
+        "API routes production mode should throw Internal Server Error (async)",
+        "API routes production mode should warn if response body is larger than 4MB",
+        "API routes production mode should warn with configured size if response body is larger than configured size",
+        "API routes production mode should work with child_process correctly",
+        "API routes production mode should work with dynamic params and search string",
+        "API routes production mode should work with dynamic params and search string like lambda",
+        "API routes production mode should work with index api",
+        "API routes production mode should work with nullable payload"
+      ],
+      "failed": [
+        "API routes dev support should show friendly error for invalid redirect",
+        "API routes dev support should throw Internal Server Error",
+        "API routes dev support should throw Internal Server Error (async)",
+        "API routes production mode should show friendly error for invalid redirect"
+      ],
+      "pending": [
+        "API routes dev support should return error exceeded body limit",
+        "API routes production mode should return error exceeded body limit"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-aspath/test/index.test.js": {
+      "passed": [
+        "App asPath should not have any changes in asPath after a bundle rebuild"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-config-asset-prefix/test/index.test.js": {
+      "passed": [
+        "App assetPrefix config should render correctly with assetPrefix: \"/\""
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-dir-export/test/config.test.ts": {
+      "passed": [
+        "app dir - with output export (next dev / next build) production mode should correctly emit exported assets to config.distDir",
+        "app dir - with output export (next dev / next build) production mode should error when running next export",
+        "app dir - with output export (next dev / next build) production mode should throw when exportPathMap configured"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-dir-export/test/dev-custom-dist-dir.test.ts": {
+      "passed": [
+        "app dir - with output export and custom distDir (next dev) should render properly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-dir-export/test/dynamic-missing-gsp-dev.test.ts": {
+      "passed": [
+        "app dir - with output export - dynamic missing gsp dev development mode should error when client component has generateStaticParams",
+        "app dir - with output export - dynamic missing gsp dev development mode should error when dynamic route is missing generateStaticParams",
+        "app dir - with output export - dynamic missing gsp dev development mode should error when dynamic route is set to true"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-dir-export/test/dynamic-missing-gsp-prod.test.ts": {
+      "passed": [
+        "app dir - with output export - dynamic missing gsp prod production mode should error when client component has generateStaticParams",
+        "app dir - with output export - dynamic missing gsp prod production mode should error when dynamic route is missing generateStaticParams"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-dir-export/test/dynamicapiroute-dev.test.ts": {
+      "passed": [
+        "app dir - with output export - dynamic api route dev development mode should work in dev with dynamicApiRoute 'error'",
+        "app dir - with output export - dynamic api route dev development mode should work in dev with dynamicApiRoute 'force-static'"
+      ],
+      "failed": [
+        "app dir - with output export - dynamic api route dev development mode should work in dev with dynamicApiRoute 'force-dynamic'",
+        "app dir - with output export - dynamic api route dev development mode should work in dev with dynamicApiRoute undefined"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-dir-export/test/dynamicapiroute-prod.test.ts": {
+      "passed": [
+        "app dir - with output export - dynamic api route prod production mode should work in prod with dynamicApiRoute 'error'",
+        "app dir - with output export - dynamic api route prod production mode should work in prod with dynamicApiRoute 'force-dynamic'",
+        "app dir - with output export - dynamic api route prod production mode should work in prod with dynamicApiRoute 'force-static'",
+        "app dir - with output export - dynamic api route prod production mode should work in prod with dynamicApiRoute undefined"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-dir-export/test/dynamicpage-dev.test.ts": {
+      "passed": [
+        "app dir - with output export - dynamic page dev development mode should work in dev with dynamicPage 'error'",
+        "app dir - with output export - dynamic page dev development mode should work in dev with dynamicPage 'force-dynamic'",
+        "app dir - with output export - dynamic page dev development mode should work in dev with dynamicPage 'force-static'",
+        "app dir - with output export - dynamic page dev development mode should work in dev with dynamicPage undefined"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-dir-export/test/dynamicpage-prod.test.ts": {
+      "passed": [
+        "app dir - with output export - dynamic api route prod production mode should work in prod with dynamicPage 'error'",
+        "app dir - with output export - dynamic api route prod production mode should work in prod with dynamicPage 'force-dynamic'",
+        "app dir - with output export - dynamic api route prod production mode should work in prod with dynamicPage 'force-static'",
+        "app dir - with output export - dynamic api route prod production mode should work in prod with dynamicPage undefined"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-dir-export/test/start.test.ts": {
+      "passed": [
+        "app dir - with output export (next start) production mode should error during next start with output export",
+        "app dir - with output export (next start) production mode should warn during next start with output standalone"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-dir-export/test/trailing-slash-dev.test.ts": {
+      "passed": [
+        "app dir - with output export - trailing slash dev development mode should work in dev with trailingSlash 'false'",
+        "app dir - with output export - trailing slash dev development mode should work in dev with trailingSlash 'true'"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-dir-export/test/trailing-slash-start.test.ts": {
+      "passed": [
+        "app dir - with output export - trailing slash prod production mode should work in prod with trailingSlash 'false'",
+        "app dir - with output export - trailing slash prod production mode should work in prod with trailingSlash 'true'"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-document-add-hmr/test/index.test.js": {
+      "passed": [],
+      "failed": [],
+      "pending": [
+        "_app/_document add HMR should HMR when _app is added",
+        "_app/_document add HMR should HMR when _document is added"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-document-import-order/test/index.test.js": {
+      "passed": [
+        "Root components import order production mode _app chunks should be attached to de dom before page chunks",
+        "Root components import order production mode root components should be imported in this order _document > _app > page in order to respect side effects",
+        "development mode Skipped in Turbopack _app chunks should be attached to de dom before page chunks",
+        "development mode root components should be imported in this order _document > _app > page in order to respect side effects"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-document-remove-hmr/test/index.test.js": {
+      "passed": [
+        "_app removal HMR should HMR when _app is removed",
+        "_app removal HMR should HMR when _document is removed"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-document-style-fragment/test/index.test.js": {
+      "passed": [
+        "Custom Document Fragment Styles production mode correctly adds styles from fragment styles key"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-document/test/index.test.js": {
+      "passed": [
+        "Document and App Client side It should share module state with pages",
+        "Document and App Client side should detect the changes to pages/_app.js and display it",
+        "Document and App Client side should detect the changes to pages/_document.js and display it",
+        "Document and App Client side should keep state between page navigations",
+        "Document and App Rendering via HTTP _app It should share module state with pages",
+        "Document and App Rendering via HTTP _app It should show valid error when thrown in _app getInitialProps",
+        "Document and App Rendering via HTTP _app It shows a custom tag",
+        "Document and App Rendering via HTTP _document Document.getInitialProps returns html prop representing app shell",
+        "Document and App Rendering via HTTP _document It adds a timestamp to link tags with preload attribute to invalidate the cache (DEV only)",
+        "Document and App Rendering via HTTP _document It adds crossOrigin to all scripts and preload links",
+        "Document and App Rendering via HTTP _document It adds nonces to all scripts and preload links",
+        "Document and App Rendering via HTTP _document It renders ctx.renderPage with enhanceApp and enhanceComponent correctly",
+        "Document and App Rendering via HTTP _document It renders ctx.renderPage with enhanceApp correctly",
+        "Document and App Rendering via HTTP _document It renders ctx.renderPage with enhanceComponent correctly",
+        "Document and App Rendering via HTTP _document It renders ctx.renderPage with enhancer correctly",
+        "Document and App Rendering via HTTP _document should include required elements in rendered html",
+        "Document and App With CSP enabled should load inline script by hash",
+        "Document and App With CSP enabled should load inline script by nonce",
+        "Document and App should not have any missing key warnings"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-dynamic-error/test/index.test.ts": {
+      "passed": [
+        "app-dynamic-error production mode throws an error when prerendering a page with config dynamic error"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-functional/test/index.test.js": {
+      "passed": ["Document and App should not have any missing key warnings"],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-tree/test/index.test.js": {
+      "passed": [
+        "AppTree development mode should pass AppTree to NextPageContext",
+        "AppTree development mode should provide router context in AppTree on CSR",
+        "AppTree development mode should provide router context in AppTree on SSR",
+        "AppTree production mode should pass AppTree to NextPageContext",
+        "AppTree production mode should provide router context in AppTree on CSR",
+        "AppTree production mode should provide router context in AppTree on SSR"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/app-types/app-types.test.js": {
+      "passed": [
+        "app type checking production mode should generate route types correctly and report form errors",
+        "app type checking production mode should generate route types correctly and report link error",
+        "app type checking production mode should generate route types correctly and report router API errors",
+        "app type checking production mode should type check invalid entry exports"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/auto-export-error-bail/test/index.test.js": {
+      "passed": [
+        "Auto Export _error bail production mode should not opt-out of auto static optimization from invalid _error"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/auto-export-query-error/test/index.test.js": {
+      "passed": [
+        "Auto Export production mode should show warning for query provided for auto exported page correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/auto-export/test/index.test.js": {
+      "passed": [
+        "Auto Export dev Refreshes query on mount",
+        "Auto Export dev Supports commonjs 1",
+        "Auto Export dev Supports commonjs 2",
+        "Auto Export dev should not replace URL with page name while asPath is delayed",
+        "Auto Export dev should not show hydration warning from mismatching asPath",
+        "Auto Export dev should update asPath after mount",
+        "Auto Export production mode Refreshes query on mount",
+        "Auto Export production mode Supports commonjs 1",
+        "Auto Export production mode Supports commonjs 2",
+        "Auto Export production mode should not replace URL with page name while asPath is delayed",
+        "Auto Export production mode should update asPath after mount"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/babel-custom/test/index.test.js": {
+      "passed": [
+        "Babel should allow babelrc JSON5 syntax",
+        "Babel should allow setting babelrc env",
+        "Babel should allow setting targets to a string",
+        "Babel should allow setting targets.browsers"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/babel-next-image/babel-next-image.test.js": {
+      "passed": ["babel-next-image should work with babel and next/image"],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/babel/test/index.test.js": {
+      "passed": [
+        "Babel Rendering via HTTP Should compile a page with flowtype correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/basepath-root-catch-all/test/index.test.js": {
+      "passed": [
+        "development mode should use correct data URL for root catch-all",
+        "production mode should use correct data URL for root catch-all"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/bigint/test/index.test.js": {
+      "passed": [
+        "bigint API route support development mode should return 200",
+        "bigint API route support development mode should return the BigInt result text",
+        "bigint API route support production mode should return 200",
+        "bigint API route support production mode should return the BigInt result text"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/broken-webpack-plugin/test/index.test.js": {
+      "passed": [
+        "Handles a broken webpack plugin (precompile) should render error correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/build-indicator/test/index.test.js": {
+      "passed": [
+        "Build Activity Indicator Disabled with next.config.js - (app) Does not add the build indicator container",
+        "Build Activity Indicator Disabled with next.config.js - (pages) Does not add the build indicator container",
+        "Build Activity Indicator Enabled - (app) Adds the build indicator container",
+        "Build Activity Indicator Enabled - (app) Shows build indicator when page is built from modifying",
+        "Build Activity Indicator Enabled - (app) webpack only Shows the build indicator when a page is built during navigation",
+        "Build Activity Indicator Enabled - (pages) Adds the build indicator container",
+        "Build Activity Indicator Enabled - (pages) Shows build indicator when page is built from modifying",
+        "Build Activity Indicator Enabled - (pages) webpack only Shows the build indicator when a page is built during navigation",
+        "Build Activity Indicator should validate buildActivityPosition config"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/build-output/test/index.test.js": {
+      "passed": [
+        "Build Output production mode Basic Application Output (experimental: {\"gzipSize\":false}) should not emit extracted comments",
+        "Build Output production mode Basic Application Output (experimental: {\"gzipSize\":false}) should not include internal pages",
+        "Build Output production mode Basic Application Output (experimental: {\"gzipSize\":false}) should print duration when rendering or get static props takes long",
+        "Build Output production mode Basic Application Output (experimental: {}) should not emit extracted comments",
+        "Build Output production mode Basic Application Output (experimental: {}) should not include internal pages",
+        "Build Output production mode Basic Application Output (experimental: {}) should print duration when rendering or get static props takes long",
+        "Build Output production mode Custom App Output should not include custom error",
+        "Build Output production mode Custom Error Output should not include custom app",
+        "Build Output production mode Custom Static Error Output should not specify /404 as lambda when static",
+        "Build Output production mode With AMP Output should not include custom error",
+        "Build Output production mode With Parallel Routes should not have duplicate paths that resolve to the same route"
+      ],
+      "failed": [],
+      "pending": [
+        "Build Output production mode Basic Application Output (experimental: {\"gzipSize\":false}) should not deviate from snapshot",
+        "Build Output production mode Basic Application Output (experimental: {}) should not deviate from snapshot"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/build-trace-extra-entries-turbo/test/index.test.js": {
+      "passed": [
+        "build trace with extra entries production mode should build and trace correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/build-trace-extra-entries/test/index.test.js": {
+      "passed": [
+        "build trace with extra entries production mode should build and trace correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/build-warnings/test/index.test.js": {
+      "passed": [
+        "Build warnings production mode should not shown warning about minification without any modification",
+        "Build warnings production mode should not warn about missing cache in non-CI",
+        "Build warnings production mode should not warn about missing cache on supported platforms",
+        "Build warnings production mode should shown warning about minification for minimize",
+        "Build warnings production mode should shown warning about minification for minimizer",
+        "Build warnings production mode should warn about missing cache in CI"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/catches-missing-getStaticProps/test/index.test.js": {
+      "passed": [
+        "Catches Missing getStaticProps development mode should catch it in development mode",
+        "Catches Missing getStaticProps production mode should catch it in server build mode"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/chunking/test/index.test.js": {
+      "passed": [
+        "Chunking production mode Serving should hydrate with aggressive chunking",
+        "Chunking production mode Serving should load chunks when navigating",
+        "Chunking production mode should create a framework chunk",
+        "Chunking production mode should execute the build manifest",
+        "Chunking production mode should not create a commons chunk",
+        "Chunking production mode should not create a lib chunk for react or react-dom",
+        "Chunking production mode should not include more than one instance of react-dom",
+        "Chunking production mode should not preload the build manifest",
+        "Chunking production mode should use all url friendly names"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/clean-distdir/test/index.test.js": {
+      "passed": [
+        "Cleaning distDir production mode disabled write should not clean up .next before build start",
+        "Cleaning distDir production mode should clean up .next before build start"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/cli/test/index.test.js": {
+      "passed": [
+        "CLI Usage dev --experimental-https",
+        "CLI Usage dev --experimental-https with provided key/cert",
+        "CLI Usage dev --help",
+        "CLI Usage dev --hostname",
+        "CLI Usage dev --port",
+        "CLI Usage dev --port 0",
+        "CLI Usage dev -H",
+        "CLI Usage dev -h",
+        "CLI Usage dev -p",
+        "CLI Usage dev -p conflict",
+        "CLI Usage dev -p reserved",
+        "CLI Usage dev Allow retry if default port is already in use",
+        "CLI Usage dev NODE_OPTIONS='--inspect'",
+        "CLI Usage dev NODE_OPTIONS='--require=file with spaces to --require.js'",
+        "CLI Usage dev NODE_OPTIONS='--require=file with spaces to-require-with-node-require-option.js'",
+        "CLI Usage dev PORT=0",
+        "CLI Usage dev custom directory",
+        "CLI Usage dev invalid directory",
+        "CLI Usage dev should exit when SIGINT is signalled",
+        "CLI Usage dev should exit when SIGTERM is signalled",
+        "CLI Usage dev should format IPv6 addresses correctly",
+        "CLI Usage dev should not throw UnhandledPromiseRejectionWarning",
+        "CLI Usage dev should warn when unknown argument provided",
+        "CLI Usage export --help",
+        "CLI Usage export run export command",
+        "CLI Usage info --help",
+        "CLI Usage info -h",
+        "CLI Usage info should print output",
+        "CLI Usage info should print output with next.config.mjs",
+        "CLI Usage no command --help",
+        "CLI Usage no command --version",
+        "CLI Usage no command -h",
+        "CLI Usage no command -v",
+        "CLI Usage no command detects command typos",
+        "CLI Usage no command invalid directory",
+        "CLI Usage production mode build --help",
+        "CLI Usage production mode build -h",
+        "CLI Usage production mode build invalid directory",
+        "CLI Usage production mode build should exit when SIGINT is signalled",
+        "CLI Usage production mode build should exit when SIGTERM is signalled",
+        "CLI Usage production mode build should not throw UnhandledPromiseRejectionWarning",
+        "CLI Usage production mode build should warn when unknown argument provided",
+        "CLI Usage production mode start --help",
+        "CLI Usage production mode start --keepAliveTimeout Infinity",
+        "CLI Usage production mode start --keepAliveTimeout happy path",
+        "CLI Usage production mode start --keepAliveTimeout negative number",
+        "CLI Usage production mode start --keepAliveTimeout string arg",
+        "CLI Usage production mode start -h",
+        "CLI Usage production mode start duplicate sass deps",
+        "CLI Usage production mode start invalid directory",
+        "CLI Usage production mode start should exit when SIGINT is signalled",
+        "CLI Usage production mode start should exit when SIGTERM is signalled",
+        "CLI Usage production mode start should format IPv6 addresses correctly",
+        "CLI Usage production mode start should not start on a port out of range",
+        "CLI Usage production mode start should not start on a reserved port",
+        "CLI Usage production mode start should not throw UnhandledPromiseRejectionWarning",
+        "CLI Usage production mode start should warn when unknown argument provided",
+        "CLI Usage production mode telemetry --help",
+        "CLI Usage production mode telemetry -h",
+        "CLI Usage production mode telemetry should not throw UnhandledPromiseRejectionWarning",
+        "CLI Usage production mode telemetry should warn when unknown argument provided"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/client-404/test/index.test.js": {
+      "passed": [
+        "Client 404 development mode Client Navigation 404 should hard navigate to URL on failing to load bundle",
+        "Client 404 development mode Client Navigation 404 should show 404 upon client replacestate should navigate the page",
+        "Client 404 production mode Client Navigation 404 should hard navigate to URL on failing to load bundle",
+        "Client 404 production mode Client Navigation 404 should hard navigate to URL on failing to load missing bundle",
+        "Client 404 production mode Client Navigation 404 should show 404 upon client replacestate should navigate the page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/client-navigation-a11y/test/index.test.js": {
+      "passed": [
+        "Client Navigation accessibility <RouteAnnouncer /> There is a title and a h1 tag has the innerText equal to the value of h1",
+        "Client Navigation accessibility <RouteAnnouncer /> There is a title but no h1 tag has the innerText equal to the value of document.title",
+        "Client Navigation accessibility <RouteAnnouncer /> There is no title and no h1 tag has the innerText equal to the value of the pathname",
+        "Client Navigation accessibility <RouteAnnouncer /> There is no title but a h1 tag has the innerText equal to the value of h1",
+        "Client Navigation accessibility <RouteAnnouncer /> has aria-live=\"assertive\" and role=\"alert\"",
+        "Client Navigation accessibility <RouteAnnouncer /> should not have the initial route announced"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/client-shallow-routing/test/index.test.js": {
+      "passed": [
+        "Client Shallow Routing development mode should not shallowly navigate back in history when current page was not shallow",
+        "Client Shallow Routing development mode should not shallowly navigate forwards in history when current page was not shallow",
+        "Client Shallow Routing production mode should not shallowly navigate back in history when current page was not shallow",
+        "Client Shallow Routing production mode should not shallowly navigate forwards in history when current page was not shallow"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/compression/test/index.test.js": {
+      "passed": ["Compression should compress responses by default"],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/config-devtool-dev/test/index.test.js": {
+      "passed": [
+        "devtool set in development mode in next config should warn and revert when a devtool is set in development mode"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/config-experimental-warning/test/index.test.js": {
+      "passed": [
+        "Config Experimental Warning production mode should not show next app info in next start",
+        "Config Experimental Warning production mode should show next app info with all experimental features in next build",
+        "Config Experimental Warning production mode should show unrecognized experimental features in warning but not in start log experiments section",
+        "Config Experimental Warning should not show warning with config from object",
+        "Config Experimental Warning should not show warning with default config from function",
+        "Config Experimental Warning should not show warning with default value",
+        "Config Experimental Warning should show the configured value for numerical features",
+        "Config Experimental Warning should show warning with a symbol indicating that a default `true` value is set to `false`",
+        "Config Experimental Warning should show warning with config from function with experimental",
+        "Config Experimental Warning should show warning with config from object with experimental",
+        "Config Experimental Warning should show warning with config from object with experimental and multiple keys"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/config-mjs/test/index.test.js": {
+      "passed": [
+        "Configuration correctly imports a package that defines `module` but no `main` in package.json",
+        "Configuration renders public config on the server only",
+        "Configuration renders server config on the server only",
+        "Configuration should disable X-Powered-By header support",
+        "Configuration should have config available on the client"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/config-output-export/test/index.test.ts": {
+      "passed": [
+        "config-output-export should error with \"i18n\" config",
+        "config-output-export should error with api routes function",
+        "config-output-export should error with getServerSideProps without fallback",
+        "config-output-export should error with getStaticPaths and fallback blocking",
+        "config-output-export should error with getStaticPaths and fallback true",
+        "config-output-export should error with getStaticProps and revalidate 10 seconds (ISR)",
+        "config-output-export should error with middleware function",
+        "config-output-export should work with getStaticPaths and fallback false",
+        "config-output-export should work with getStaticProps and revalidate false",
+        "config-output-export should work with getStaticProps and without revalidate",
+        "config-output-export should work with static homepage",
+        "config-output-export when hasNextSupport = false should error with \"headers\" config",
+        "config-output-export when hasNextSupport = false should error with \"redirects\" config",
+        "config-output-export when hasNextSupport = false should error with \"rewrites\" config",
+        "config-output-export when hasNextSupport = true should error with \"headers\" config",
+        "config-output-export when hasNextSupport = true should error with \"redirects\" config",
+        "config-output-export when hasNextSupport = true should error with \"rewrites\" config"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/import-attributes/test/index.test.js": {
+      "passed": [
+        "import-attributes dev should handle json attributes",
+        "production mode import-attributes prod should handle json attributes"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/index-index/test/index.test.js": {
+      "passed": [
+        "nested index.js development mode should 404 on /index/index/index",
+        "nested index.js development mode should client render page /",
+        "nested index.js development mode should client render page /index",
+        "nested index.js development mode should client render page /index/index",
+        "nested index.js development mode should client render page /index/project",
+        "nested index.js development mode should client render page /index/user",
+        "nested index.js development mode should follow link to /",
+        "nested index.js development mode should follow link to /index",
+        "nested index.js development mode should follow link to /index/index",
+        "nested index.js development mode should follow link to /index/project",
+        "nested index.js development mode should follow link to /index/user",
+        "nested index.js development mode should not find a link to /index/index/index",
+        "nested index.js development mode should ssr page /",
+        "nested index.js development mode should ssr page /index",
+        "nested index.js development mode should ssr page /index/index",
+        "nested index.js development mode should ssr page /index/project",
+        "nested index.js development mode should ssr page /index/user",
+        "nested index.js production mode should 404 on /index/index/index",
+        "nested index.js production mode should client render page /",
+        "nested index.js production mode should client render page /index",
+        "nested index.js production mode should client render page /index/index",
+        "nested index.js production mode should client render page /index/project",
+        "nested index.js production mode should client render page /index/user",
+        "nested index.js production mode should follow link to /",
+        "nested index.js production mode should follow link to /index",
+        "nested index.js production mode should follow link to /index/index",
+        "nested index.js production mode should follow link to /index/project",
+        "nested index.js production mode should follow link to /index/user",
+        "nested index.js production mode should not find a link to /index/index/index",
+        "nested index.js production mode should ssr page /",
+        "nested index.js production mode should ssr page /index",
+        "nested index.js production mode should ssr page /index/index",
+        "nested index.js production mode should ssr page /index/project",
+        "nested index.js production mode should ssr page /index/user"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/initial-ref/test/index.test.js": {
+      "passed": [
+        "Initial Refs development mode Has correct initial ref values",
+        "Initial Refs production mode Has correct initial ref values"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/invalid-config-values/test/index.test.js": {
+      "passed": [
+        "Handles valid/invalid assetPrefix production mode should not error when assetPrefix is a string",
+        "Handles valid/invalid assetPrefix production mode should not error without usage of assetPrefix"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/invalid-custom-routes/test/index.test.js": {
+      "passed": [
+        "Errors on invalid custom routes development mode should error during next build for invalid headers",
+        "Errors on invalid custom routes development mode should error during next build for invalid redirects",
+        "Errors on invalid custom routes development mode should error during next build for invalid rewrites",
+        "Errors on invalid custom routes development mode should error when empty headers array is present on header item",
+        "Errors on invalid custom routes development mode should error when source and destination length is exceeded",
+        "Errors on invalid custom routes development mode should show formatted error for redirect source parse fail",
+        "Errors on invalid custom routes development mode should show valid error when non-array is returned from headers",
+        "Errors on invalid custom routes development mode should show valid error when non-array is returned from redirects",
+        "Errors on invalid custom routes development mode should show valid error when non-array is returned from rewrites",
+        "Errors on invalid custom routes development mode should show valid error when segments not in source are used in destination",
+        "Errors on invalid custom routes production mode should error during next build for invalid headers",
+        "Errors on invalid custom routes production mode should error during next build for invalid redirects",
+        "Errors on invalid custom routes production mode should error during next build for invalid rewrites",
+        "Errors on invalid custom routes production mode should error when empty headers array is present on header item",
+        "Errors on invalid custom routes production mode should error when source and destination length is exceeded",
+        "Errors on invalid custom routes production mode should show formatted error for redirect source parse fail",
+        "Errors on invalid custom routes production mode should show valid error when non-array is returned from headers",
+        "Errors on invalid custom routes production mode should show valid error when non-array is returned from redirects",
+        "Errors on invalid custom routes production mode should show valid error when non-array is returned from rewrites",
+        "Errors on invalid custom routes production mode should show valid error when segments not in source are used in destination"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/invalid-document-image-import/test/index.test.js": {
+      "passed": [
+        "Invalid static image import in _document production mode Should fail to build when disableStaticImages in next.config.js",
+        "Invalid static image import in _document production mode Should fail to build when no next.config.js"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/invalid-href/test/index.test.js": {
+      "passed": [
+        "Invalid hrefs development mode does not show error when https://google.com is used as href on Link",
+        "Invalid hrefs development mode does not show error when mailto: is used as href on Link",
+        "Invalid hrefs development mode does not throw error when dynamic route mismatch is used on Link and params are manually provided",
+        "Invalid hrefs development mode doesn't fail on invalid url",
+        "Invalid hrefs development mode shows error when dynamic route mismatch is used on Link",
+        "Invalid hrefs development mode shows error when internal href is used with external as",
+        "Invalid hrefs development mode shows warning when dynamic route mismatch is used on Link",
+        "Invalid hrefs production mode does not show error in production when https://google.com is used as href on Link",
+        "Invalid hrefs production mode does not show error in production when mailto: is used as href on Link",
+        "Invalid hrefs production mode does not show error when internal href is used with external as",
+        "Invalid hrefs production mode doesn't fail on invalid url",
+        "Invalid hrefs production mode renders a link with invalid href",
+        "Invalid hrefs production mode renders a link with mailto: href",
+        "Invalid hrefs production mode shows error when dynamic route mismatch is used on Link"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/invalid-middleware-matchers/test/index.test.js": {
+      "passed": [
+        "Errors on invalid custom middleware matchers development mode should error during next build for invalid matchers",
+        "Errors on invalid custom middleware matchers development mode should error when source length is exceeded",
+        "Errors on invalid custom middleware matchers production mode should error during next build for invalid matchers",
+        "Errors on invalid custom middleware matchers production mode should error when source length is exceeded"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/invalid-multi-match/test/index.test.js": {
+      "passed": [
+        "Custom routes invalid multi-match development mode should show error for invalid mulit-match",
+        "Custom routes invalid multi-match production mode should show error for invalid mulit-match"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/invalid-page-automatic-static-optimization/test/index.test.js": {
+      "passed": [
+        "Invalid Page automatic static optimization production mode Fails softly with descriptive error",
+        "Invalid Page automatic static optimization production mode handles non-error correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/invalid-revalidate-values/test/index.test.js": {
+      "passed": [
+        "Invalid revalidate values should not show error for false revalidate value",
+        "Invalid revalidate values should not show error for true revalidate value",
+        "Invalid revalidate values should not show error initially",
+        "Invalid revalidate values should show error for float revalidate value",
+        "Invalid revalidate values should show error for null revalidate value",
+        "Invalid revalidate values should show error for string revalidate value"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/invalid-server-options/test/index.test.js": {
+      "passed": [
+        "Invalid server options next() called with dev as array should send warning",
+        "Invalid server options next() called with dev as function should send warning",
+        "Invalid server options next() called with dev as number should send warning",
+        "Invalid server options next() called with dev as object should send warning",
+        "Invalid server options next() called with dev as string should send warning",
+        "Invalid server options next() called with no parameters should throw error",
+        "Invalid server options next() called with null parameter should throw error",
+        "Invalid server options next() called with undefined parameter should throw error"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/jsconfig-baseurl/test/index.test.js": {
+      "passed": [
+        "jsconfig.json baseurl default behavior should have correct module not found error",
+        "jsconfig.json baseurl default behavior should render the page",
+        "jsconfig.json baseurl should build production mode should trace correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/jsconfig-empty/test/index.test.js": {
+      "passed": [
+        "Empty JSConfig Support production mode should compile successfully"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/jsconfig-paths-wildcard/test/index.test.js": {
+      "passed": [
+        "jsconfig paths wildcard default behavior should resolve a wildcard alias",
+        "jsconfig paths without baseurl wildcard default behavior should resolve a wildcard alias"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/jsconfig-paths/test/index.test.js": {
+      "passed": [
+        "jsconfig paths default behavior should alias components",
+        "jsconfig paths default behavior should have correct module not found error",
+        "jsconfig paths default behavior should resolve a single matching alias",
+        "jsconfig paths default behavior should resolve the first item in the array first",
+        "jsconfig paths default behavior should resolve the second item as fallback",
+        "jsconfig paths should build production mode should trace correctly",
+        "jsconfig paths without baseurl default behavior should alias components",
+        "jsconfig paths without baseurl default behavior should have correct module not found error",
+        "jsconfig paths without baseurl default behavior should resolve a single matching alias",
+        "jsconfig paths without baseurl default behavior should resolve the first item in the array first",
+        "jsconfig paths without baseurl default behavior should resolve the second item as fallback",
+        "jsconfig paths without baseurl should build production mode should trace correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/jsconfig/test/index.test.js": {
+      "passed": [
+        "jsconfig.json production mode should build normally",
+        "jsconfig.json production mode should fail on invalid jsconfig.json"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/json-serialize-original-error/test/index.test.js": {
+      "passed": [
+        "JSON Serialization production mode should fail with original error"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/link-ref-app/test/index.test.js": {
+      "passed": [
+        "Invalid hrefs development mode should handle child ref that is a function",
+        "Invalid hrefs development mode should handle child ref that is a function that returns a cleanup function",
+        "Invalid hrefs development mode should handle child ref with React.createRef",
+        "Invalid hrefs development mode should not have a race condition with a click handler",
+        "Invalid hrefs development mode should not show error for class component as child of next/link",
+        "Invalid hrefs development mode should not show error for function component with forwardRef",
+        "Invalid hrefs production mode should not have a race condition with a click handler",
+        "Invalid hrefs production mode should preload with child ref with React.createRef",
+        "Invalid hrefs production mode should preload with child ref with function",
+        "Invalid hrefs production mode should preload with child ref with function that returns a cleanup function",
+        "Invalid hrefs production mode should preload with forwardRef"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/link-ref-pages/test/index.test.js": {
+      "passed": [
+        "Invalid hrefs development mode should handle child ref that is a function",
+        "Invalid hrefs development mode should handle child ref that is a function that returns a cleanup function",
+        "Invalid hrefs development mode should handle child ref with React.createRef",
+        "Invalid hrefs development mode should not have a race condition with a click handler",
+        "Invalid hrefs development mode should not show error for class component as child of next/link",
+        "Invalid hrefs development mode should not show error for function component with forwardRef",
+        "Invalid hrefs production mode should not have a race condition with a click handler",
+        "Invalid hrefs production mode should preload with child ref with React.createRef",
+        "Invalid hrefs production mode should preload with child ref with function",
+        "Invalid hrefs production mode should preload with child ref with function that returns a cleanup function",
+        "Invalid hrefs production mode should preload with forwardRef"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/link-with-encoding/test/index.test.js": {
+      "passed": [
+        "Link Component with Encoding colon should have correct parsing of url query params",
+        "Link Component with Encoding colon should have correct query on Router#push",
+        "Link Component with Encoding colon should have correct query on SSR",
+        "Link Component with Encoding colon should have correct query on simple client-side <Link>",
+        "Link Component with Encoding double quote should have correct query on Router#push",
+        "Link Component with Encoding double quote should have correct query on SSR",
+        "Link Component with Encoding double quote should have correct query on simple client-side <Link>",
+        "Link Component with Encoding forward slash should have correct query on Router#push",
+        "Link Component with Encoding forward slash should have correct query on SSR",
+        "Link Component with Encoding forward slash should have correct query on simple client-side <Link>",
+        "Link Component with Encoding percent should have correct query on Router#push",
+        "Link Component with Encoding percent should have correct query on SSR",
+        "Link Component with Encoding percent should have correct query on simple client-side <Link>",
+        "Link Component with Encoding spaces should have correct query on Router#push",
+        "Link Component with Encoding spaces should have correct query on SSR",
+        "Link Component with Encoding spaces should have correct query on simple client-side <Link>"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/link-with-multiple-child/test/index.test.js": {
+      "passed": [
+        "multiple child with default legacyBehavior",
+        "multiple child with forced legacyBehavior=false",
+        "single child"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/link-without-router/test/index.test.js": {
+      "passed": [
+        "Link without a router development mode should not throw when rendered",
+        "Link without a router production mode should not throw when rendered"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/middleware-basic/test/index.test.js": {
+      "passed": [
+        "development mode loads a middleware",
+        "production mode loads a middleware"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/middleware-build-errors/test/index.test.js": {
+      "passed": [
+        "Middleware validation during build production mode given a middleware building body with JSON.stringify does not throw an error",
+        "Middleware validation during build production mode given a middleware building response body with a variable does not throw an error",
+        "Middleware validation during build production mode given a middleware building response body with custom code does not throw an error",
+        "Middleware validation during build production mode given a middleware returning a null body builds successfully",
+        "Middleware validation during build production mode given a middleware returning a text body does not throw an error",
+        "Middleware validation during build production mode given a middleware returning a text body with NextResponse does not throw an error",
+        "Middleware validation during build production mode given a middleware returning an undefined body builds successfully"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/middleware-dev-update/test/index.test.js": {
+      "passed": [
+        "Middleware development errors when matcher is added sends response correctly",
+        "Middleware development errors when middleware is added sends response correctly",
+        "Middleware development errors when middleware is removed and re-added sends response correctly",
+        "Middleware development errors when middleware is removed sends response correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/middleware-overrides-node.js-api/test/index.test.ts": {
+      "passed": [
+        "Middleware overriding a Node.js API development mode does not show a warning and allows overriding"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/middleware-prefetch/tests/index.test.js": {
+      "passed": [
+        "Middleware Production Prefetch production mode does not prefetch provided path if it will be rewritten",
+        "Middleware Production Prefetch production mode prefetch correctly for unexistent routes"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/middleware-src/test/index.test.js": {
+      "passed": [
+        "Middleware in src/ and / folders development mode loads and runs only root middleware",
+        "Middleware in src/ and / folders production mode should warn about middleware on export",
+        "Middleware in src/ folder development mode loads an runs src middleware",
+        "Middleware in src/ folder production mode should warn about middleware on export"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/missing-document-component-error/test/index.test.js": {
+      "passed": [
+        "Missing _document components error should detect missing Head component",
+        "Missing _document components error should detect missing Html component",
+        "Missing _document components error should detect missing Main component",
+        "Missing _document components error should detect missing NextScript component",
+        "Missing _document components error should detect multiple missing document components"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/mixed-ssg-serverprops-error/test/index.test.js": {
+      "passed": [
+        "Mixed getStaticProps and getServerSideProps error production mode should error when exporting both getStaticPaths and getServerSideProps",
+        "Mixed getStaticProps and getServerSideProps error production mode should error when exporting both getStaticProps and getServerSideProps",
+        "Mixed getStaticProps and getServerSideProps error production mode should error when exporting getStaticPaths on a non-dynamic page",
+        "Mixed getStaticProps and getServerSideProps error production mode should error with getStaticProps but no default export"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/module-id-strategies/test/index.test.js": {
+      "passed": [],
+      "failed": [],
+      "pending": [
+        "minified module ids development mode should have long module id for the next client runtime module",
+        "minified module ids development mode should have long module ids for async loader modules",
+        "minified module ids development mode should have long module ids for basic modules",
+        "minified module ids development mode should have long module ids for external modules",
+        "minified module ids production mode should have no long module id for the next client runtime module",
+        "minified module ids production mode should have no long module ids for async loader modules",
+        "minified module ids production mode should have no long module ids for basic modules",
+        "minified module ids production mode should have no long module ids for external modules"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-dynamic-css-asset-prefix/test/index.test.js": {
+      "passed": [
+        "next/dynamic with assetPrefix development mode should load a App Router page correctly",
+        "next/dynamic with assetPrefix development mode should load a Pages Router page correctly",
+        "next/dynamic with assetPrefix production mode should load a App Router page correctly",
+        "next/dynamic with assetPrefix production mode should load a Pages Router page correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-dynamic-css/test/index.test.js": {
+      "passed": [
+        "next/dynamic development mode should load a App Router page correctly",
+        "next/dynamic development mode should load a Pages Router page correctly",
+        "next/dynamic production mode should load a App Router page correctly",
+        "next/dynamic production mode should load a Pages Router page correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-dynamic-lazy-compilation/test/index.test.js": {
+      "passed": [
+        "next/dynamic lazy compilation development mode should render dynamic server rendered values before hydration",
+        "next/dynamic lazy compilation development mode should render dynamic server rendered values on client mount",
+        "next/dynamic lazy compilation development mode should render server value",
+        "next/dynamic lazy compilation production mode should render dynamic server rendered values before hydration",
+        "next/dynamic lazy compilation production mode should render dynamic server rendered values on client mount",
+        "next/dynamic lazy compilation production mode should render server value"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-dynamic/test/index.test.js": {
+      "passed": [
+        "next/dynamic development mode should render dynamic server rendered values on client mount",
+        "next/dynamic development mode should render server value",
+        "next/dynamic production mode should render dynamic server rendered values on client mount",
+        "next/dynamic production mode should render server value"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-legacy/asset-prefix/test/index.test.ts": {
+      "passed": [
+        "Image Component assetPrefix Tests development mode should include assetPrefix when placeholder=blur during next dev",
+        "Image Component assetPrefix Tests production mode should use base64 data url with placeholder=blur during next start"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-legacy/base-path/test/index.test.ts": {
+      "passed": [
+        "Image Component basePath Tests development mode should correctly ignore prose styles",
+        "Image Component basePath Tests development mode should load the images",
+        "Image Component basePath Tests development mode should show missing src error",
+        "Image Component basePath Tests development mode should update the image on src change",
+        "Image Component basePath Tests development mode should work when using flexbox",
+        "Image Component basePath Tests development mode should work with layout-fill to fill the parent and stretch with viewport",
+        "Image Component basePath Tests development mode should work with layout-fill to fill the parent but NOT stretch with viewport",
+        "Image Component basePath Tests development mode should work with layout-fixed so resizing window does not resize image",
+        "Image Component basePath Tests development mode should work with layout-intrinsic so resizing window maintains image aspect ratio",
+        "Image Component basePath Tests development mode should work with layout-responsive so resizing window maintains image aspect ratio",
+        "Image Component basePath Tests development mode should work with sizes and automatically use layout-responsive",
+        "Image Component basePath Tests production mode should correctly ignore prose styles",
+        "Image Component basePath Tests production mode should correctly rotate image",
+        "Image Component basePath Tests production mode should load the images",
+        "Image Component basePath Tests production mode should update the image on src change",
+        "Image Component basePath Tests production mode should work when using flexbox",
+        "Image Component basePath Tests production mode should work with layout-fill to fill the parent and stretch with viewport",
+        "Image Component basePath Tests production mode should work with layout-fill to fill the parent but NOT stretch with viewport",
+        "Image Component basePath Tests production mode should work with layout-fixed so resizing window does not resize image",
+        "Image Component basePath Tests production mode should work with layout-intrinsic so resizing window maintains image aspect ratio",
+        "Image Component basePath Tests production mode should work with layout-responsive so resizing window maintains image aspect ratio",
+        "Image Component basePath Tests production mode should work with sizes and automatically use layout-responsive"
+      ],
+      "failed": [
+        "Image Component basePath Tests development mode should show invalid src error",
+        "Image Component basePath Tests development mode should show invalid src error when protocol-relative"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-legacy/base-path/test/static.test.ts": {
+      "passed": [
+        "Build Error Tests for basePath production mode should throw build error when import statement is used with missing file",
+        "Static Image Component Tests for basePath development mode Should add a blur placeholder to statically imported jpg",
+        "Static Image Component Tests for basePath development mode Should add a blur placeholder to statically imported png",
+        "Static Image Component Tests for basePath development mode Should allow an image with a static src to omit height and width",
+        "Static Image Component Tests for basePath development mode Should allow provided width and height to override intrinsic",
+        "Static Image Component Tests for basePath development mode Should automatically provide an image height and width",
+        "Static Image Component Tests for basePath development mode Should use immutable cache-control header for static import",
+        "Static Image Component Tests for basePath production mode Should add a blur placeholder to statically imported jpg",
+        "Static Image Component Tests for basePath production mode Should add a blur placeholder to statically imported png",
+        "Static Image Component Tests for basePath production mode Should allow an image with a static src to omit height and width",
+        "Static Image Component Tests for basePath production mode Should allow provided width and height to override intrinsic",
+        "Static Image Component Tests for basePath production mode Should automatically provide an image height and width",
+        "Static Image Component Tests for basePath production mode Should use immutable cache-control header even when unoptimized",
+        "Static Image Component Tests for basePath production mode Should use immutable cache-control header for static import"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-legacy/basic/test/index.test.ts": {
+      "passed": [
+        "Image Component Tests production mode Client-side Image Component Tests Client-side Errors Should not log an error when an unregistered host is used in production",
+        "Image Component Tests production mode Client-side Image Component Tests should add a srcset based on the loader",
+        "Image Component Tests production mode Client-side Image Component Tests should add a srcset even with preceding slash in prop",
+        "Image Component Tests production mode Client-side Image Component Tests should correctly generate src even if preceding slash is included in prop",
+        "Image Component Tests production mode Client-side Image Component Tests should keep auto parameter if already set",
+        "Image Component Tests production mode Client-side Image Component Tests should keep fit parameter if already set",
+        "Image Component Tests production mode Client-side Image Component Tests should keep width parameter if already set",
+        "Image Component Tests production mode Client-side Image Component Tests should modify src with the loader",
+        "Image Component Tests production mode Client-side Image Component Tests should not add a srcset if unoptimized attribute present",
+        "Image Component Tests production mode Client-side Image Component Tests should only be loaded once if `sizes` is set",
+        "Image Component Tests production mode Client-side Image Component Tests should render an image tag",
+        "Image Component Tests production mode Client-side Image Component Tests should support passing through arbitrary attributes",
+        "Image Component Tests production mode Client-side Image Component Tests should support the unoptimized attribute",
+        "Image Component Tests production mode Client-side Image Component Tests should use imageSizes when width matches, not deviceSizes from next.config.js",
+        "Image Component Tests production mode Client-side Lazy Loading Tests should have loaded the first image immediately",
+        "Image Component Tests production mode Client-side Lazy Loading Tests should load the fifth image eagerly, without scrolling",
+        "Image Component Tests production mode Client-side Lazy Loading Tests should load the fourth image lazily after scrolling down",
+        "Image Component Tests production mode Client-side Lazy Loading Tests should load the second image after scrolling down",
+        "Image Component Tests production mode Client-side Lazy Loading Tests should load the sixth image, which has lazyBoundary property after scrolling down",
+        "Image Component Tests production mode Client-side Lazy Loading Tests should load the third image, which is unoptimized, after scrolling further down",
+        "Image Component Tests production mode Client-side Lazy Loading Tests should not have loaded the second image immediately",
+        "Image Component Tests production mode Client-side Lazy Loading Tests should not have loaded the third image after scrolling down",
+        "Image Component Tests production mode Client-side Lazy Loading Tests should pass through classes on a lazy loaded image",
+        "Image Component Tests production mode SSR Image Component Tests should add a preload tag for a priority image",
+        "Image Component Tests production mode SSR Image Component Tests should add a preload tag for a priority image with preceding slash",
+        "Image Component Tests production mode SSR Image Component Tests should add a preload tag for a priority image, with arbitrary host",
+        "Image Component Tests production mode SSR Image Component Tests should add a preload tag for a priority image, with quality",
+        "Image Component Tests production mode SSR Image Component Tests should add a srcset based on the loader",
+        "Image Component Tests production mode SSR Image Component Tests should add a srcset even with preceding slash in prop",
+        "Image Component Tests production mode SSR Image Component Tests should add data-nimg data attribute based on layout",
+        "Image Component Tests production mode SSR Image Component Tests should correctly generate src even if preceding slash is included in prop",
+        "Image Component Tests production mode SSR Image Component Tests should keep auto parameter if already set",
+        "Image Component Tests production mode SSR Image Component Tests should keep fit parameter if already set",
+        "Image Component Tests production mode SSR Image Component Tests should keep width parameter if already set",
+        "Image Component Tests production mode SSR Image Component Tests should modify src with the loader",
+        "Image Component Tests production mode SSR Image Component Tests should not add a srcset if unoptimized attribute present",
+        "Image Component Tests production mode SSR Image Component Tests should not create any preload tags higher up the page than CSS preload tags",
+        "Image Component Tests production mode SSR Image Component Tests should not pass config to custom loader prop",
+        "Image Component Tests production mode SSR Image Component Tests should render an image tag",
+        "Image Component Tests production mode SSR Image Component Tests should support passing through arbitrary attributes",
+        "Image Component Tests production mode SSR Image Component Tests should support the unoptimized attribute",
+        "Image Component Tests production mode SSR Image Component Tests should use imageSizes when width matches, not deviceSizes from next.config.js",
+        "Image Component Tests production mode SSR Lazy Loading Tests should have loaded the first image immediately",
+        "Image Component Tests production mode SSR Lazy Loading Tests should load the fifth image eagerly, without scrolling",
+        "Image Component Tests production mode SSR Lazy Loading Tests should load the fourth image lazily after scrolling down",
+        "Image Component Tests production mode SSR Lazy Loading Tests should load the second image after scrolling down",
+        "Image Component Tests production mode SSR Lazy Loading Tests should load the sixth image, which has lazyBoundary property after scrolling down",
+        "Image Component Tests production mode SSR Lazy Loading Tests should load the third image, which is unoptimized, after scrolling further down",
+        "Image Component Tests production mode SSR Lazy Loading Tests should not have loaded the second image immediately",
+        "Image Component Tests production mode SSR Lazy Loading Tests should not have loaded the third image after scrolling down",
+        "Image Component Tests production mode SSR Lazy Loading Tests should pass through classes on a lazy loaded image"
+      ],
+      "failed": [],
+      "pending": [
+        "Image Component Tests production mode Client-side Image Component Tests should NOT add a preload tag for a priority image"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-legacy/custom-resolver/test/index.test.ts": {
+      "passed": [
+        "Custom Resolver Tests production mode Client-side Custom Loader Tests Should use a custom resolver for image URL",
+        "Custom Resolver Tests production mode Client-side Custom Loader Tests should add a srcset based on the custom resolver",
+        "Custom Resolver Tests production mode Client-side Custom Loader Tests should support the unoptimized attribute",
+        "Custom Resolver Tests production mode SSR Custom Loader Tests Should use a custom resolver for image URL",
+        "Custom Resolver Tests production mode SSR Custom Loader Tests should add a srcset based on the custom resolver",
+        "Custom Resolver Tests production mode SSR Custom Loader Tests should support the unoptimized attribute"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-legacy/default/test/index.test.ts": {
+      "passed": [
+        "Image Component Tests development mode should apply filter style after image loads",
+        "Image Component Tests development mode should apply style inheritance for img elements but not wrapper elements",
+        "Image Component Tests development mode should be valid HTML",
+        "Image Component Tests development mode should callback native onError when error occurred while loading image",
+        "Image Component Tests development mode should callback native onLoad in most cases",
+        "Image Component Tests development mode should callback onLoadingComplete when image is fully loaded",
+        "Image Component Tests development mode should correctly ignore prose styles",
+        "Image Component Tests development mode should emit image for next/dynamic with non ssr case",
+        "Image Component Tests development mode should handle the styles prop appropriately",
+        "Image Component Tests development mode should have blurry placeholder when enabled",
+        "Image Component Tests development mode should initially load only two of four images using lazyroot",
+        "Image Component Tests development mode should load the images",
+        "Image Component Tests development mode should not pass through user-provided srcset (causing a flash)",
+        "Image Component Tests development mode should not use blurry placeholder for <noscript> image",
+        "Image Component Tests development mode should not warn when Image is child of p",
+        "Image Component Tests development mode should not warn when svg, even if with loader prop or without",
+        "Image Component Tests development mode should preload priority images",
+        "Image Component Tests development mode should re-lazyload images after src changes",
+        "Image Component Tests development mode should remove blurry placeholder after image loads",
+        "Image Component Tests development mode should show missing src error",
+        "Image Component Tests development mode should update the image on src change",
+        "Image Component Tests development mode should warn at most once even after state change",
+        "Image Component Tests development mode should warn when img with layout=fill is inside a container without position relative",
+        "Image Component Tests development mode should warn when img with layout=responsive is inside flex container",
+        "Image Component Tests development mode should warn when loader is missing width",
+        "Image Component Tests development mode should warn when priority prop is missing on LCP image",
+        "Image Component Tests development mode should warn when using a very small image with placeholder=blur",
+        "Image Component Tests development mode should warn when using sizes with incorrect layout",
+        "Image Component Tests development mode should work when using flexbox",
+        "Image Component Tests development mode should work with image with blob src",
+        "Image Component Tests development mode should work with layout-fill to fill the parent and stretch with viewport",
+        "Image Component Tests development mode should work with layout-fill to fill the parent but NOT stretch with viewport",
+        "Image Component Tests development mode should work with layout-fixed so resizing window does not resize image",
+        "Image Component Tests development mode should work with layout-intrinsic so resizing window maintains image aspect ratio",
+        "Image Component Tests development mode should work with layout-responsive so resizing window maintains image aspect ratio",
+        "Image Component Tests development mode should work with sizes and automatically use layout-responsive",
+        "Image Component Tests production mode should apply filter style after image loads",
+        "Image Component Tests production mode should apply style inheritance for img elements but not wrapper elements",
+        "Image Component Tests production mode should be valid HTML",
+        "Image Component Tests production mode should callback native onError when error occurred while loading image",
+        "Image Component Tests production mode should callback native onLoad in most cases",
+        "Image Component Tests production mode should callback onLoadingComplete when image is fully loaded",
+        "Image Component Tests production mode should correctly ignore prose styles",
+        "Image Component Tests production mode should correctly rotate image",
+        "Image Component Tests production mode should emit image for next/dynamic with non ssr case",
+        "Image Component Tests production mode should handle the styles prop appropriately",
+        "Image Component Tests production mode should have blurry placeholder when enabled",
+        "Image Component Tests production mode should initially load only two of four images using lazyroot",
+        "Image Component Tests production mode should load the images",
+        "Image Component Tests production mode should not create an image folder in server/chunks",
+        "Image Component Tests production mode should not pass through user-provided srcset (causing a flash)",
+        "Image Component Tests production mode should not use blurry placeholder for <noscript> image",
+        "Image Component Tests production mode should preload priority images",
+        "Image Component Tests production mode should re-lazyload images after src changes",
+        "Image Component Tests production mode should remove blurry placeholder after image loads",
+        "Image Component Tests production mode should update the image on src change",
+        "Image Component Tests production mode should work when using flexbox",
+        "Image Component Tests production mode should work with image with blob src",
+        "Image Component Tests production mode should work with layout-fill to fill the parent and stretch with viewport",
+        "Image Component Tests production mode should work with layout-fill to fill the parent but NOT stretch with viewport",
+        "Image Component Tests production mode should work with layout-fixed so resizing window does not resize image",
+        "Image Component Tests production mode should work with layout-intrinsic so resizing window maintains image aspect ratio",
+        "Image Component Tests production mode should work with layout-responsive so resizing window maintains image aspect ratio",
+        "Image Component Tests production mode should work with sizes and automatically use layout-responsive"
+      ],
+      "failed": [
+        "Image Component Tests development mode should show error when not numeric string width or height",
+        "Image Component Tests development mode should show error when static import and placeholder=blur and blurDataUrl is missing",
+        "Image Component Tests development mode should show error when string src and placeholder=blur and blurDataURL is missing",
+        "Image Component Tests development mode should show invalid src error",
+        "Image Component Tests development mode should show invalid src error when protocol-relative"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-legacy/default/test/static.test.ts": {
+      "passed": [
+        "Build Error Tests production mode should throw build error when import statement is used with missing file",
+        "Static Image Component Tests production mode Should add a blur placeholder to statically imported jpg",
+        "Static Image Component Tests production mode Should add a blur placeholder to statically imported png",
+        "Static Image Component Tests production mode Should allow an image with a static src to omit height and width",
+        "Static Image Component Tests production mode Should allow provided width and height to override intrinsic",
+        "Static Image Component Tests production mode Should automatically provide an image height and width",
+        "Static Image Component Tests production mode Should use immutable cache-control header even when unoptimized",
+        "Static Image Component Tests production mode Should use immutable cache-control header for static import",
+        "Static Image Component Tests production mode should load direct imported image",
+        "Static Image Component Tests production mode should load staticprops imported image"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-legacy/image-from-node-modules/test/index.test.ts": {
+      "passed": [
+        "Image Component Tests In Prod Mode production mode should apply image config for node_modules",
+        "Image Component Tests In development mode should apply image config for node_modules"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-legacy/no-intersection-observer-fallback/test/index.test.ts": {
+      "passed": [
+        "Image Component No IntersectionObserver test production mode Client-side Lazy Loading Tests should automatically load images if observer does not exist",
+        "Image Component No IntersectionObserver test production mode SSR Lazy Loading Tests should automatically load images if observer does not exist"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-legacy/noscript/test/index.test.ts": {
+      "passed": [
+        "Noscript Tests production mode Noscript page source tests should use loader url for noscript img#image-with-loader src attribute",
+        "Noscript Tests production mode Noscript page source tests should use local API for noscript img#basic-image src attribute"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-legacy/react-virtualized/test/index.test.ts": {
+      "passed": [
+        "react-virtualized wrapping next/legacy/image production mode should not cancel requests for images"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-legacy/svgo-webpack/test/index.test.ts": {
+      "passed": [
+        "svgo-webpack with Image Component development mode should print error when invalid Image usage",
+        "svgo-webpack with Image Component production mode should not fail to build invalid usage of the Image component"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-legacy/trailing-slash/test/index.test.ts": {
+      "passed": [
+        "Image Component Trailing Slash Tests development mode should include trailing slash when trailingSlash is set on config file during next dev",
+        "Image Component Trailing Slash Tests production mode should include trailing slash when trailingSlash is set on config file during next start"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-legacy/typescript/test/index.test.ts": {
+      "passed": [
+        "TypeScript Image Component development mode 2 should remove global image types when disabled (dev)",
+        "TypeScript Image Component development mode should have image types when enabled",
+        "TypeScript Image Component development mode should render the valid Image usage and not print error",
+        "TypeScript Image Component production mode should fail to build invalid usage of the Image component",
+        "TypeScript Image Component production mode should remove global image types when disabled"
+      ],
+      "failed": [
+        "TypeScript Image Component development mode should print error when invalid Image usage"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-legacy/unicode/test/index.test.ts": {
+      "passed": [
+        "Image Component Unicode Image URL development mode should load external image with space",
+        "Image Component Unicode Image URL development mode should load external unicode image",
+        "Image Component Unicode Image URL development mode should load internal image with space",
+        "Image Component Unicode Image URL development mode should load internal unicode image",
+        "Image Component Unicode Image URL development mode should load static unicode image",
+        "Image Component Unicode Image URL production mode should load external image with space",
+        "Image Component Unicode Image URL production mode should load external unicode image",
+        "Image Component Unicode Image URL production mode should load internal image with space",
+        "Image Component Unicode Image URL production mode should load internal unicode image",
+        "Image Component Unicode Image URL production mode should load static unicode image"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-legacy/unoptimized/test/index.test.ts": {
+      "passed": [
+        "Unoptimized Image Tests development mode should not optimize any image",
+        "Unoptimized Image Tests production mode should not optimize any image"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-new/app-dir-image-from-node-modules/test/index.test.ts": {
+      "passed": [
+        "Image Component from node_modules development mode should apply image config for node_modules",
+        "Image Component from node_modules prod mode production mode should apply image config for node_modules"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-new/app-dir-localpatterns/test/index.test.ts": {
+      "passed": [
+        "Image localPatterns config development mode should block unmatched image does-not-exist",
+        "Image localPatterns config development mode should block unmatched image nested-assets-query",
+        "Image localPatterns config development mode should block unmatched image nested-blocked",
+        "Image localPatterns config development mode should block unmatched image top-level",
+        "Image localPatterns config development mode should load matching images",
+        "Image localPatterns config production mode should block unmatched image does-not-exist",
+        "Image localPatterns config production mode should block unmatched image nested-assets-query",
+        "Image localPatterns config production mode should block unmatched image nested-blocked",
+        "Image localPatterns config production mode should block unmatched image top-level",
+        "Image localPatterns config production mode should build correct images-manifest.json",
+        "Image localPatterns config production mode should load matching images"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-new/app-dir-qualities/test/index.test.ts": {
+      "passed": [
+        "Image localPatterns config development mode should fail to load img when quality is 100",
+        "Image localPatterns config development mode should load img when quality 42",
+        "Image localPatterns config development mode should load img when quality 69",
+        "Image localPatterns config development mode should load img when quality 88",
+        "Image localPatterns config development mode should load img when quality is undefined",
+        "Image localPatterns config production mode should build correct images-manifest.json",
+        "Image localPatterns config production mode should fail to load img when quality is 100",
+        "Image localPatterns config production mode should load img when quality 42",
+        "Image localPatterns config production mode should load img when quality 69",
+        "Image localPatterns config production mode should load img when quality 88",
+        "Image localPatterns config production mode should load img when quality is undefined"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-new/app-dir/test/index.test.ts": {
+      "passed": [
+        "Image Component Default Tests development mode Fill-mode tests should add 100% width and height to fill images",
+        "Image Component Default Tests development mode Fill-mode tests should add position styles to fill images",
+        "Image Component Default Tests development mode Fill-mode tests should add position:absolute to fill images",
+        "Image Component Default Tests development mode Fill-mode tests should include a data-attribute on fill images",
+        "Image Component Default Tests development mode Fill-mode tests should log warnings when using fill mode incorrectly",
+        "Image Component Default Tests development mode Fill-mode tests should not log incorrect warnings",
+        "Image Component Default Tests development mode Fill-mode tests should not log warnings when image unmounts",
+        "Image Component Default Tests development mode should apply filter style after image loads",
+        "Image Component Default Tests development mode should apply style inheritance for img elements but not wrapper elements",
+        "Image Component Default Tests development mode should be valid HTML",
+        "Image Component Default Tests development mode should call callback ref cleanups when unmounting",
+        "Image Component Default Tests development mode should callback native onError even when error before hydration",
+        "Image Component Default Tests development mode should callback native onError when error occurred while loading image",
+        "Image Component Default Tests development mode should callback native onLoad with sythetic event",
+        "Image Component Default Tests development mode should callback onLoadingComplete when image is fully loaded",
+        "Image Component Default Tests development mode should correctly ignore prose styles",
+        "Image Component Default Tests development mode should emit image for next/dynamic with non ssr case",
+        "Image Component Default Tests development mode should handle the styles prop appropriately",
+        "Image Component Default Tests development mode should have blurry placeholder when enabled",
+        "Image Component Default Tests development mode should have data url placeholder when enabled",
+        "Image Component Default Tests development mode should lazy load with placeholder=blur",
+        "Image Component Default Tests development mode should load the images",
+        "Image Component Default Tests development mode should not pass through user-provided srcset (causing a flash)",
+        "Image Component Default Tests development mode should not warn when Image is child of p",
+        "Image Component Default Tests development mode should not warn when data url image with fill and sizes props",
+        "Image Component Default Tests development mode should not warn when svg, even if with loader prop or without",
+        "Image Component Default Tests development mode should preload priority images",
+        "Image Component Default Tests development mode should remove blurry placeholder after image loads",
+        "Image Component Default Tests development mode should remove data url placeholder after image loads",
+        "Image Component Default Tests development mode should render correct objectFit when blurDataURL and fill",
+        "Image Component Default Tests development mode should render correct objectFit when data url placeholder and fill",
+        "Image Component Default Tests development mode should render no wrappers or sizers",
+        "Image Component Default Tests development mode should render picture via getImageProps",
+        "Image Component Default Tests development mode should show empty string src error",
+        "Image Component Default Tests development mode should show error when CSS position changed on fill image",
+        "Image Component Default Tests development mode should show error when invalid Infinity width prop",
+        "Image Component Default Tests development mode should show error when invalid height prop",
+        "Image Component Default Tests development mode should show error when invalid width prop",
+        "Image Component Default Tests development mode should show error when missing height prop",
+        "Image Component Default Tests development mode should show error when missing width prop",
+        "Image Component Default Tests development mode should show error when static import and placeholder=blur and blurDataUrl is missing",
+        "Image Component Default Tests development mode should show error when string src and placeholder=blur and blurDataURL is missing",
+        "Image Component Default Tests development mode should show error when width prop on fill image",
+        "Image Component Default Tests development mode should show invalid src error",
+        "Image Component Default Tests development mode should show invalid src error when protocol-relative",
+        "Image Component Default Tests development mode should show invalid src with leading space",
+        "Image Component Default Tests development mode should show invalid src with trailing space",
+        "Image Component Default Tests development mode should show missing alt error",
+        "Image Component Default Tests development mode should show missing src error",
+        "Image Component Default Tests development mode should show null src error",
+        "Image Component Default Tests development mode should update the image on src change",
+        "Image Component Default Tests development mode should warn at most once even after state change",
+        "Image Component Default Tests development mode should warn when legacy prop layout=fill",
+        "Image Component Default Tests development mode should warn when legacy prop layout=responsive",
+        "Image Component Default Tests development mode should warn when loader is missing width",
+        "Image Component Default Tests development mode should warn when priority prop is missing on LCP image",
+        "Image Component Default Tests development mode should warn when using a very small image with placeholder=blur",
+        "Image Component Default Tests development mode should work when using flexbox",
+        "Image Component Default Tests development mode should work when using overrideSrc prop",
+        "Image Component Default Tests development mode should work with image with blob src",
+        "Image Component Default Tests development mode should work with sizes and automatically use responsive srcset",
+        "Image Component Default Tests production mode Fill-mode tests should add 100% width and height to fill images",
+        "Image Component Default Tests production mode Fill-mode tests should add position styles to fill images",
+        "Image Component Default Tests production mode Fill-mode tests should add position:absolute to fill images",
+        "Image Component Default Tests production mode Fill-mode tests should include a data-attribute on fill images",
+        "Image Component Default Tests production mode should apply filter style after image loads",
+        "Image Component Default Tests production mode should apply style inheritance for img elements but not wrapper elements",
+        "Image Component Default Tests production mode should be valid HTML",
+        "Image Component Default Tests production mode should build correct images-manifest.json",
+        "Image Component Default Tests production mode should call callback ref cleanups when unmounting",
+        "Image Component Default Tests production mode should callback native onError even when error before hydration",
+        "Image Component Default Tests production mode should callback native onError when error occurred while loading image",
+        "Image Component Default Tests production mode should callback native onLoad with sythetic event",
+        "Image Component Default Tests production mode should callback onLoadingComplete when image is fully loaded",
+        "Image Component Default Tests production mode should correctly ignore prose styles",
+        "Image Component Default Tests production mode should correctly rotate image",
+        "Image Component Default Tests production mode should emit image for next/dynamic with non ssr case",
+        "Image Component Default Tests production mode should handle the styles prop appropriately",
+        "Image Component Default Tests production mode should have blurry placeholder when enabled",
+        "Image Component Default Tests production mode should have data url placeholder when enabled",
+        "Image Component Default Tests production mode should lazy load with placeholder=blur",
+        "Image Component Default Tests production mode should load the images",
+        "Image Component Default Tests production mode should not create an image folder in server/chunks",
+        "Image Component Default Tests production mode should not pass through user-provided srcset (causing a flash)",
+        "Image Component Default Tests production mode should preload priority images",
+        "Image Component Default Tests production mode should remove blurry placeholder after image loads",
+        "Image Component Default Tests production mode should remove data url placeholder after image loads",
+        "Image Component Default Tests production mode should render as unoptimized with empty string src prop",
+        "Image Component Default Tests production mode should render as unoptimized with missing src prop",
+        "Image Component Default Tests production mode should render correct objectFit when blurDataURL and fill",
+        "Image Component Default Tests production mode should render correct objectFit when data url placeholder and fill",
+        "Image Component Default Tests production mode should render no wrappers or sizers",
+        "Image Component Default Tests production mode should render picture via getImageProps",
+        "Image Component Default Tests production mode should update the image on src change",
+        "Image Component Default Tests production mode should warn when legacy prop layout=fill",
+        "Image Component Default Tests production mode should warn when legacy prop layout=responsive",
+        "Image Component Default Tests production mode should work when using flexbox",
+        "Image Component Default Tests production mode should work when using overrideSrc prop",
+        "Image Component Default Tests production mode should work with image with blob src",
+        "Image Component Default Tests production mode should work with sizes and automatically use responsive srcset"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-new/app-dir/test/static.test.ts": {
+      "passed": [
+        "Build Error Tests production mode should throw build error when import statement is used with missing file",
+        "Static Image Component Tests development mode Should allow an image with a static src to omit height and width",
+        "Static Image Component Tests development mode Should automatically provide an image height and width",
+        "Static Image Component Tests development mode should add a blur placeholder a statically imported jpg",
+        "Static Image Component Tests development mode should add a blur placeholder a statically imported png",
+        "Static Image Component Tests development mode should add a blur placeholder a statically imported png with fill",
+        "Static Image Component Tests development mode should add a data URL placeholder to an image",
+        "Static Image Component Tests development mode should add placeholder even when blurDataURL aspect ratio does not match width/height ratio",
+        "Static Image Component Tests development mode should add placeholder with blurDataURL and fill",
+        "Static Image Component Tests development mode should have <head> containing <meta name=\"viewport\"> followed by <link rel=\"preload\"> for priority image",
+        "Static Image Component Tests development mode should load direct imported image",
+        "Static Image Component Tests development mode should use height prop to adjust both width and height",
+        "Static Image Component Tests development mode should use width and height prop to override import",
+        "Static Image Component Tests development mode should use width prop to adjust both width and height",
+        "Static Image Component Tests production mode Should allow an image with a static src to omit height and width",
+        "Static Image Component Tests production mode Should automatically provide an image height and width",
+        "Static Image Component Tests production mode Should use immutable cache-control header even when unoptimized",
+        "Static Image Component Tests production mode Should use immutable cache-control header for static import",
+        "Static Image Component Tests production mode should add a blur placeholder a statically imported jpg",
+        "Static Image Component Tests production mode should add a blur placeholder a statically imported png",
+        "Static Image Component Tests production mode should add a blur placeholder a statically imported png with fill",
+        "Static Image Component Tests production mode should add a data URL placeholder to an image",
+        "Static Image Component Tests production mode should add placeholder even when blurDataURL aspect ratio does not match width/height ratio",
+        "Static Image Component Tests production mode should add placeholder with blurDataURL and fill",
+        "Static Image Component Tests production mode should have <head> containing <meta name=\"viewport\"> followed by <link rel=\"preload\"> for priority image",
+        "Static Image Component Tests production mode should load direct imported image",
+        "Static Image Component Tests production mode should use height prop to adjust both width and height",
+        "Static Image Component Tests production mode should use width and height prop to override import",
+        "Static Image Component Tests production mode should use width prop to adjust both width and height"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-new/asset-prefix/test/index.test.js": {
+      "passed": [
+        "Image Component assetPrefix Tests development mode should include assetPrefix when placeholder=blur during next dev",
+        "Image Component assetPrefix Tests development mode should not log a deprecation warning about using `images.domains`",
+        "Image Component assetPrefix Tests production mode should not log a deprecation warning about using `images.domains`",
+        "Image Component assetPrefix Tests production mode should use base64 data url with placeholder=blur during next start"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-new/base-path/test/index.test.js": {
+      "passed": [
+        "Image Component basePath Tests development mode should correctly ignore prose styles",
+        "Image Component basePath Tests development mode should load the images",
+        "Image Component basePath Tests development mode should show missing src error",
+        "Image Component basePath Tests development mode should update the image on src change",
+        "Image Component basePath Tests development mode should work when using flexbox",
+        "Image Component basePath Tests production mode should correctly ignore prose styles",
+        "Image Component basePath Tests production mode should load the images",
+        "Image Component basePath Tests production mode should update the image on src change",
+        "Image Component basePath Tests production mode should work when using flexbox"
+      ],
+      "failed": [
+        "Image Component basePath Tests development mode should show invalid src error",
+        "Image Component basePath Tests development mode should show invalid src error when protocol-relative"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-new/base-path/test/static.test.js": {
+      "passed": [
+        "Build Error Tests production mode should throw build error when import statement is used with missing file",
+        "Static Image Component Tests for basePath development mode Should allow an image with a static src to omit height and width",
+        "Static Image Component Tests for basePath development mode Should automatically provide an image height and width",
+        "Static Image Component Tests for basePath development mode should add a blur placeholder a statically imported jpg",
+        "Static Image Component Tests for basePath development mode should add a blur placeholder a statically imported png",
+        "Static Image Component Tests for basePath development mode should add a data URL placeholder to an image",
+        "Static Image Component Tests for basePath development mode should have <head> containing <meta name=\"viewport\"> followed by <link rel=\"preload\"> for priority image",
+        "Static Image Component Tests for basePath development mode should use height prop to adjust both width and height",
+        "Static Image Component Tests for basePath development mode should use width and height prop to override import",
+        "Static Image Component Tests for basePath development mode should use width prop to adjust both width and height",
+        "Static Image Component Tests for basePath production mode Should allow an image with a static src to omit height and width",
+        "Static Image Component Tests for basePath production mode Should automatically provide an image height and width",
+        "Static Image Component Tests for basePath production mode Should use immutable cache-control header even when unoptimized",
+        "Static Image Component Tests for basePath production mode Should use immutable cache-control header for static import",
+        "Static Image Component Tests for basePath production mode should add a blur placeholder a statically imported jpg",
+        "Static Image Component Tests for basePath production mode should add a blur placeholder a statically imported png",
+        "Static Image Component Tests for basePath production mode should add a data URL placeholder to an image",
+        "Static Image Component Tests for basePath production mode should have <head> containing <meta name=\"viewport\"> followed by <link rel=\"preload\"> for priority image",
+        "Static Image Component Tests for basePath production mode should use height prop to adjust both width and height",
+        "Static Image Component Tests for basePath production mode should use width and height prop to override import",
+        "Static Image Component Tests for basePath production mode should use width prop to adjust both width and height"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-new/both-basepath-trailingslash/test/index.test.ts": {
+      "passed": [
+        "Image Component basePath + trailingSlash Tests development mode should correctly load image src from import",
+        "Image Component basePath + trailingSlash Tests development mode should correctly load image src from string",
+        "Image Component basePath + trailingSlash Tests production mode should correctly load image src from import",
+        "Image Component basePath + trailingSlash Tests production mode should correctly load image src from string"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-new/default/test/index.test.ts": {
+      "passed": [
+        "Image Component Default Tests development mode Fill-mode tests should add 100% width and height to fill images",
+        "Image Component Default Tests development mode Fill-mode tests should add position styles to fill images",
+        "Image Component Default Tests development mode Fill-mode tests should add position:absolute to fill images",
+        "Image Component Default Tests development mode Fill-mode tests should include a data-attribute on fill images",
+        "Image Component Default Tests development mode Fill-mode tests should log warnings when using fill mode incorrectly",
+        "Image Component Default Tests development mode Fill-mode tests should not log incorrect warnings",
+        "Image Component Default Tests development mode Fill-mode tests should not log warnings when image unmounts",
+        "Image Component Default Tests development mode should apply filter style after image loads",
+        "Image Component Default Tests development mode should apply style inheritance for img elements but not wrapper elements",
+        "Image Component Default Tests development mode should be valid HTML",
+        "Image Component Default Tests development mode should callback native onError even when error before hydration",
+        "Image Component Default Tests development mode should callback native onError when error occurred while loading image",
+        "Image Component Default Tests development mode should callback native onLoad with sythetic event",
+        "Image Component Default Tests development mode should callback onLoadingComplete when image is fully loaded",
+        "Image Component Default Tests development mode should correctly ignore prose styles",
+        "Image Component Default Tests development mode should emit image for next/dynamic with non ssr case",
+        "Image Component Default Tests development mode should handle the styles prop appropriately",
+        "Image Component Default Tests development mode should have blurry placeholder when enabled",
+        "Image Component Default Tests development mode should have data url placeholder when enabled",
+        "Image Component Default Tests development mode should lazy load with placeholder=blur",
+        "Image Component Default Tests development mode should load the images",
+        "Image Component Default Tests development mode should not pass through user-provided srcset (causing a flash)",
+        "Image Component Default Tests development mode should not warn when Image is child of p",
+        "Image Component Default Tests development mode should not warn when data url image with fill and sizes props",
+        "Image Component Default Tests development mode should not warn when svg, even if with loader prop or without",
+        "Image Component Default Tests development mode should preload priority images",
+        "Image Component Default Tests development mode should remove blurry placeholder after image loads",
+        "Image Component Default Tests development mode should remove data url placeholder after image loads",
+        "Image Component Default Tests development mode should render correct objectFit when blurDataURL and fill",
+        "Image Component Default Tests development mode should render correct objectFit when data url placeholder and fill",
+        "Image Component Default Tests development mode should render no wrappers or sizers",
+        "Image Component Default Tests development mode should render picture via getImageProps",
+        "Image Component Default Tests development mode should show empty string src error",
+        "Image Component Default Tests development mode should show missing alt error",
+        "Image Component Default Tests development mode should show missing src error",
+        "Image Component Default Tests development mode should show null src error",
+        "Image Component Default Tests development mode should update the image on src change",
+        "Image Component Default Tests development mode should warn at most once even after state change",
+        "Image Component Default Tests development mode should warn when legacy prop layout=fill",
+        "Image Component Default Tests development mode should warn when legacy prop layout=responsive",
+        "Image Component Default Tests development mode should warn when loader is missing width",
+        "Image Component Default Tests development mode should warn when priority prop is missing on LCP image",
+        "Image Component Default Tests development mode should warn when using a very small image with placeholder=blur",
+        "Image Component Default Tests development mode should work when using flexbox",
+        "Image Component Default Tests development mode should work when using overrideSrc prop",
+        "Image Component Default Tests development mode should work with image with blob src",
+        "Image Component Default Tests development mode should work with sizes and automatically use responsive srcset",
+        "Image Component Default Tests production mode Fill-mode tests should add 100% width and height to fill images",
+        "Image Component Default Tests production mode Fill-mode tests should add position styles to fill images",
+        "Image Component Default Tests production mode Fill-mode tests should add position:absolute to fill images",
+        "Image Component Default Tests production mode Fill-mode tests should include a data-attribute on fill images",
+        "Image Component Default Tests production mode should apply filter style after image loads",
+        "Image Component Default Tests production mode should apply style inheritance for img elements but not wrapper elements",
+        "Image Component Default Tests production mode should be valid HTML",
+        "Image Component Default Tests production mode should callback native onError even when error before hydration",
+        "Image Component Default Tests production mode should callback native onError when error occurred while loading image",
+        "Image Component Default Tests production mode should callback native onLoad with sythetic event",
+        "Image Component Default Tests production mode should callback onLoadingComplete when image is fully loaded",
+        "Image Component Default Tests production mode should correctly ignore prose styles",
+        "Image Component Default Tests production mode should correctly rotate image",
+        "Image Component Default Tests production mode should create images folder in static/media for edge runtime",
+        "Image Component Default Tests production mode should emit image for next/dynamic with non ssr case",
+        "Image Component Default Tests production mode should handle the styles prop appropriately",
+        "Image Component Default Tests production mode should have blurry placeholder when enabled",
+        "Image Component Default Tests production mode should have data url placeholder when enabled",
+        "Image Component Default Tests production mode should lazy load with placeholder=blur",
+        "Image Component Default Tests production mode should load the images",
+        "Image Component Default Tests production mode should not create an image folder in server/chunks",
+        "Image Component Default Tests production mode should not pass through user-provided srcset (causing a flash)",
+        "Image Component Default Tests production mode should preload priority images",
+        "Image Component Default Tests production mode should remove blurry placeholder after image loads",
+        "Image Component Default Tests production mode should remove data url placeholder after image loads",
+        "Image Component Default Tests production mode should render as unoptimized with empty string src prop",
+        "Image Component Default Tests production mode should render as unoptimized with missing src prop",
+        "Image Component Default Tests production mode should render correct objectFit when blurDataURL and fill",
+        "Image Component Default Tests production mode should render correct objectFit when data url placeholder and fill",
+        "Image Component Default Tests production mode should render no wrappers or sizers",
+        "Image Component Default Tests production mode should render picture via getImageProps",
+        "Image Component Default Tests production mode should update the image on src change",
+        "Image Component Default Tests production mode should warn when legacy prop layout=fill",
+        "Image Component Default Tests production mode should warn when legacy prop layout=responsive",
+        "Image Component Default Tests production mode should work when using flexbox",
+        "Image Component Default Tests production mode should work when using overrideSrc prop",
+        "Image Component Default Tests production mode should work with image with blob src",
+        "Image Component Default Tests production mode should work with sizes and automatically use responsive srcset"
+      ],
+      "failed": [
+        "Image Component Default Tests development mode should show error when CSS position changed on fill image",
+        "Image Component Default Tests development mode should show error when invalid Infinity width prop",
+        "Image Component Default Tests development mode should show error when invalid height prop",
+        "Image Component Default Tests development mode should show error when invalid width prop",
+        "Image Component Default Tests development mode should show error when missing height prop",
+        "Image Component Default Tests development mode should show error when missing width prop",
+        "Image Component Default Tests development mode should show error when static import and placeholder=blur and blurDataUrl is missing",
+        "Image Component Default Tests development mode should show error when string src and placeholder=blur and blurDataURL is missing",
+        "Image Component Default Tests development mode should show error when width prop on fill image",
+        "Image Component Default Tests development mode should show invalid src error",
+        "Image Component Default Tests development mode should show invalid src error when protocol-relative",
+        "Image Component Default Tests development mode should show invalid src with leading space",
+        "Image Component Default Tests development mode should show invalid src with trailing space"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-new/default/test/static.test.ts": {
+      "passed": [
+        "Build Error Tests production mode should throw build error when import statement is used with missing file",
+        "Static Image Component Tests development mode Should allow an image with a static src to omit height and width",
+        "Static Image Component Tests development mode Should automatically provide an image height and width",
+        "Static Image Component Tests development mode should add a blur placeholder a statically imported jpg",
+        "Static Image Component Tests development mode should add a blur placeholder a statically imported png",
+        "Static Image Component Tests development mode should add a blur placeholder a statically imported png with fill",
+        "Static Image Component Tests development mode should add a data URL placeholder to an image",
+        "Static Image Component Tests development mode should add placeholder even when blurDataURL aspect ratio does not match width/height ratio",
+        "Static Image Component Tests development mode should add placeholder with blurDataURL and fill",
+        "Static Image Component Tests development mode should have <head> containing <meta name=\"viewport\"> followed by <link rel=\"preload\"> for priority image",
+        "Static Image Component Tests development mode should load direct imported image",
+        "Static Image Component Tests development mode should load staticprops imported image",
+        "Static Image Component Tests development mode should use height prop to adjust both width and height",
+        "Static Image Component Tests development mode should use width and height prop to override import",
+        "Static Image Component Tests development mode should use width prop to adjust both width and height",
+        "Static Image Component Tests production mode Should allow an image with a static src to omit height and width",
+        "Static Image Component Tests production mode Should automatically provide an image height and width",
+        "Static Image Component Tests production mode Should use immutable cache-control header even when unoptimized",
+        "Static Image Component Tests production mode Should use immutable cache-control header for static import",
+        "Static Image Component Tests production mode should add a blur placeholder a statically imported jpg",
+        "Static Image Component Tests production mode should add a blur placeholder a statically imported png",
+        "Static Image Component Tests production mode should add a blur placeholder a statically imported png with fill",
+        "Static Image Component Tests production mode should add a data URL placeholder to an image",
+        "Static Image Component Tests production mode should add placeholder even when blurDataURL aspect ratio does not match width/height ratio",
+        "Static Image Component Tests production mode should add placeholder with blurDataURL and fill",
+        "Static Image Component Tests production mode should have <head> containing <meta name=\"viewport\"> followed by <link rel=\"preload\"> for priority image",
+        "Static Image Component Tests production mode should load direct imported image",
+        "Static Image Component Tests production mode should load staticprops imported image",
+        "Static Image Component Tests production mode should use height prop to adjust both width and height",
+        "Static Image Component Tests production mode should use width and height prop to override import",
+        "Static Image Component Tests production mode should use width prop to adjust both width and height"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/next-image-new/export-config/test/index.test.ts": {
+      "passed": [],
+      "failed": [
+        "next/image with output export config development mode should error"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/root-optional-revalidate/test/index.test.js": {
+      "passed": [
+        "Root Optional Catch-all Revalidate production mode should render / correctly",
+        "Root Optional Catch-all Revalidate production mode should render /a correctly",
+        "Root Optional Catch-all Revalidate production mode should render /hello/world correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/route-index/test/index.test.js": {
+      "passed": [
+        "Route index handling development mode should handle / correctly",
+        "Route index handling development mode should handle /index correctly",
+        "Route index handling development mode should handle /index/?bar%60%3C%25%22%27%7B%24%2A%25%5C correctly",
+        "Route index handling development mode should handle /index/index correctly",
+        "Route index handling development mode should handle /index?file%3A%5C correctly",
+        "Route index handling production mode should handle / correctly",
+        "Route index handling production mode should handle /index correctly",
+        "Route index handling production mode should handle /index/?bar%60%3C%25%22%27%7B%24%2A%25%5C correctly",
+        "Route index handling production mode should handle /index/index correctly",
+        "Route index handling production mode should handle /index?file%3A%5C correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/route-indexes/test/index.test.js": {
+      "passed": [
+        "Route indexes handling development mode should handle / correctly",
+        "Route indexes handling development mode should handle /api/sub correctly",
+        "Route indexes handling development mode should handle /api/sub/another correctly",
+        "Route indexes handling development mode should handle /api/sub/another/index correctly",
+        "Route indexes handling development mode should handle /api/sub/index correctly",
+        "Route indexes handling development mode should handle /api/sub/index/index correctly",
+        "Route indexes handling development mode should handle /index correctly",
+        "Route indexes handling development mode should handle /index/index correctly",
+        "Route indexes handling development mode should handle /nested-index correctly",
+        "Route indexes handling development mode should handle /nested-index/index correctly",
+        "Route indexes handling development mode should handle /nested-index/index/index correctly",
+        "Route indexes handling development mode should handle /sub correctly",
+        "Route indexes handling development mode should handle /sub/another correctly",
+        "Route indexes handling development mode should handle /sub/another/index correctly",
+        "Route indexes handling development mode should handle /sub/index correctly",
+        "Route indexes handling development mode should handle /sub/index/index correctly",
+        "Route indexes handling production mode should handle / correctly",
+        "Route indexes handling production mode should handle /api/sub correctly",
+        "Route indexes handling production mode should handle /api/sub/another correctly",
+        "Route indexes handling production mode should handle /api/sub/another/index correctly",
+        "Route indexes handling production mode should handle /api/sub/index correctly",
+        "Route indexes handling production mode should handle /api/sub/index/index correctly",
+        "Route indexes handling production mode should handle /index correctly",
+        "Route indexes handling production mode should handle /index/index correctly",
+        "Route indexes handling production mode should handle /nested-index correctly",
+        "Route indexes handling production mode should handle /nested-index/index correctly",
+        "Route indexes handling production mode should handle /nested-index/index/index correctly",
+        "Route indexes handling production mode should handle /sub correctly",
+        "Route indexes handling production mode should handle /sub/another correctly",
+        "Route indexes handling production mode should handle /sub/another/index correctly",
+        "Route indexes handling production mode should handle /sub/index correctly",
+        "Route indexes handling production mode should handle /sub/index/index correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/route-load-cancel-css/test/index.test.js": {
+      "passed": [
+        "route cancel via CSS production mode should cancel slow page loads on re-navigation"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/route-load-cancel/test/index.test.js": {
+      "passed": [
+        "next/dynamic development mode should cancel slow page loads on re-navigation",
+        "next/dynamic production mode should cancel slow page loads on re-navigation"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/router-hash-navigation/test/index.test.js": {
+      "passed": [
+        "router.isReady development mode scrolls to top when href=\"/\" and url already contains a hash",
+        "router.isReady production mode scrolls to top when href=\"/\" and url already contains a hash"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/router-is-ready-app-gip/test/index.test.js": {
+      "passed": [
+        "router.isReady with appGip development mode isReady should be true after query update for getStaticProps page with query",
+        "router.isReady with appGip development mode isReady should be true immediately for getStaticProps page without query",
+        "router.isReady with appGip development mode isReady should be true immediately for pages without getStaticProps",
+        "router.isReady with appGip development mode isReady should be true immediately for pages without getStaticProps, with query",
+        "router.isReady with appGip production mode isReady should be true after query update for getStaticProps page with query",
+        "router.isReady with appGip production mode isReady should be true immediately for getStaticProps page without query",
+        "router.isReady with appGip production mode isReady should be true immediately for pages without getStaticProps",
+        "router.isReady with appGip production mode isReady should be true immediately for pages without getStaticProps, with query"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/router-is-ready/test/index.test.js": {
+      "passed": [
+        "router.isReady development mode isReady should be true after query update for auto-export page with query",
+        "router.isReady development mode isReady should be true after query update for dynamic auto-export page with query",
+        "router.isReady development mode isReady should be true after query update for dynamic auto-export page without query",
+        "router.isReady development mode isReady should be true after query update for getStaticProps page with query",
+        "router.isReady development mode isReady should be true immediately for auto-export page without query",
+        "router.isReady development mode isReady should be true immediately for getInitialProps page",
+        "router.isReady development mode isReady should be true immediately for getInitialProps page with query",
+        "router.isReady development mode isReady should be true immediately for getServerSideProps page",
+        "router.isReady development mode isReady should be true immediately for getServerSideProps page with query",
+        "router.isReady development mode isReady should be true immediately for getStaticProps page without query",
+        "router.isReady production mode isReady should be true after query update for auto-export page with query",
+        "router.isReady production mode isReady should be true after query update for dynamic auto-export page with query",
+        "router.isReady production mode isReady should be true after query update for dynamic auto-export page without query",
+        "router.isReady production mode isReady should be true after query update for getStaticProps page with query",
+        "router.isReady production mode isReady should be true immediately for auto-export page without query",
+        "router.isReady production mode isReady should be true immediately for getInitialProps page",
+        "router.isReady production mode isReady should be true immediately for getInitialProps page with query",
+        "router.isReady production mode isReady should be true immediately for getServerSideProps page",
+        "router.isReady production mode isReady should be true immediately for getServerSideProps page with query",
+        "router.isReady production mode isReady should be true immediately for getStaticProps page without query"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/router-prefetch/test/index.test.js": {
+      "passed": [
+        "Router prefetch development mode should not prefetch",
+        "Router prefetch development mode should resolve prefetch promise",
+        "Router prefetch production mode should resolve prefetch promise with invalid href"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/router-rerender/test/index.test.js": {
+      "passed": [
+        "router rerender development mode with middleware should not trigger unnecessary rerenders when middleware is used",
+        "router rerender production mode with middleware should not trigger unnecessary rerenders when middleware is used"
+      ],
+      "failed": [],
+      "pending": [
+        "router rerender development mode with rewrites should not trigger unnecessary rerenders when rewrites are used",
+        "router rerender development mode with rewrites should rerender with the correct query parameter if present with rewrites",
+        "router rerender production mode with rewrites should not trigger unnecessary rerenders when rewrites are used",
+        "router rerender production mode with rewrites should rerender with the correct query parameter if present with rewrites"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/script-loader/test/index.test.js": {
+      "passed": [
+        "Next.js Script - Primary Strategies - Production Mode production mode Does not duplicate inline scripts",
+        "Next.js Script - Primary Strategies - Production Mode production mode Error message is shown if Partytown is not installed locally",
+        "Next.js Script - Primary Strategies - Production Mode production mode onReady fires after load event and then on every subsequent re-mount",
+        "Next.js Script - Primary Strategies - Production Mode production mode onReady should only fires once after loaded (issue #39993)",
+        "Next.js Script - Primary Strategies - Production Mode production mode onload fires correctly",
+        "Next.js Script - Primary Strategies - Production Mode production mode priority afterInteractive",
+        "Next.js Script - Primary Strategies - Production Mode production mode priority beforeInteractive",
+        "Next.js Script - Primary Strategies - Production Mode production mode priority beforeInteractive - older version",
+        "Next.js Script - Primary Strategies - Production Mode production mode priority beforeInteractive on navigate",
+        "Next.js Script - Primary Strategies - Production Mode production mode priority beforeInteractive with inline script",
+        "Next.js Script - Primary Strategies - Production Mode production mode priority beforeInteractive with inline script should execute",
+        "Next.js Script - Primary Strategies - Production Mode production mode priority lazyOnload",
+        "Next.js Script - Primary Strategies - Strict Mode Does not duplicate inline scripts",
+        "Next.js Script - Primary Strategies - Strict Mode onReady fires after load event and then on every subsequent re-mount",
+        "Next.js Script - Primary Strategies - Strict Mode onReady should only fires once after loaded (issue #39993)",
+        "Next.js Script - Primary Strategies - Strict Mode onload fires correctly",
+        "Next.js Script - Primary Strategies - Strict Mode priority afterInteractive",
+        "Next.js Script - Primary Strategies - Strict Mode priority beforeInteractive",
+        "Next.js Script - Primary Strategies - Strict Mode priority beforeInteractive - older version",
+        "Next.js Script - Primary Strategies - Strict Mode priority beforeInteractive on navigate",
+        "Next.js Script - Primary Strategies - Strict Mode priority beforeInteractive with inline script",
+        "Next.js Script - Primary Strategies - Strict Mode priority beforeInteractive with inline script should execute",
+        "Next.js Script - Primary Strategies - Strict Mode priority lazyOnload"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/scroll-back-restoration/test/index.test.js": {
+      "passed": [
+        "Scroll Back Restoration Support development mode should restore the scroll position on navigating back",
+        "Scroll Back Restoration Support production mode should restore the scroll position on navigating back"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/scroll-forward-restoration/test/index.test.js": {
+      "passed": [
+        "Scroll Forward Restoration Support development mode should restore the scroll position on navigating forward",
+        "Scroll Forward Restoration Support production mode should restore the scroll position on navigating forward"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/server-asset-modules/test/index.test.js": {
+      "passed": [
+        "serverside asset modules development mode should enable reading local files in api routes",
+        "serverside asset modules production mode should enable reading local files in api routes"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/server-side-dev-errors/test/index.test.js": {
+      "passed": [
+        "server-side dev errors should show server-side error for api route correctly",
+        "server-side dev errors should show server-side error for dynamic api route correctly",
+        "server-side dev errors should show server-side error for dynamic gssp page correctly",
+        "server-side dev errors should show server-side error for gsp page correctly",
+        "server-side dev errors should show server-side error for gssp page correctly",
+        "server-side dev errors should show server-side error for uncaught empty exception correctly",
+        "server-side dev errors should show server-side error for uncaught empty rejection correctly",
+        "server-side dev errors should show server-side error for uncaught exception correctly",
+        "server-side dev errors should show server-side error for uncaught rejection correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/sharp-api/test/sharp-api.test.ts": {
+      "passed": ["sharp api should handle custom sharp usage"],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/src-dir-support-double-dir/test/index.test.js": {
+      "passed": [
+        "Dynamic Routing development mode should render from pages",
+        "Dynamic Routing development mode should render not render from src/pages",
+        "Dynamic Routing production mode should render from pages",
+        "Dynamic Routing production mode should render not render from src/pages"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/src-dir-support/test/index.test.js": {
+      "passed": [
+        "Dynamic Routing development mode should navigate to a dynamic page successfully",
+        "Dynamic Routing development mode should navigate to a nested dynamic page successfully",
+        "Dynamic Routing development mode should pass params in getInitialProps during SSR",
+        "Dynamic Routing development mode should prioritize a non-dynamic page",
+        "Dynamic Routing development mode should render another normal route",
+        "Dynamic Routing development mode should render dynamic page",
+        "Dynamic Routing development mode should render nested dynamic page",
+        "Dynamic Routing development mode should render normal route",
+        "Dynamic Routing production mode should navigate to a dynamic page successfully",
+        "Dynamic Routing production mode should navigate to a nested dynamic page successfully",
+        "Dynamic Routing production mode should pass params in getInitialProps during SSR",
+        "Dynamic Routing production mode should prioritize a non-dynamic page",
+        "Dynamic Routing production mode should render another normal route",
+        "Dynamic Routing production mode should render dynamic page",
+        "Dynamic Routing production mode should render nested dynamic page",
+        "Dynamic Routing production mode should render normal route"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/ssg-data-404/test/index.test.js": {
+      "passed": [
+        "SSG data 404 development mode should hard navigate when a new deployment occurs",
+        "SSG data 404 production mode should hard navigate when a new deployment occurs"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/ssg-dynamic-routes-404-page/test/index.test.js": {
+      "passed": [
+        "Custom 404 Page for static site generation with dynamic routes development mode should respond to a not existing page with 404",
+        "Custom 404 Page for static site generation with dynamic routes production mode should build successfully",
+        "Custom 404 Page for static site generation with dynamic routes production mode should respond to a not existing page with 404"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/static-404/test/index.test.js": {
+      "passed": [
+        "Static 404 page With config enabled production mode should export 404 page without custom _error",
+        "Static 404 page With config enabled production mode should not export 404 page with custom _error GIP",
+        "Static 404 page With config enabled production mode should not export 404 page with getInitialProps in _app"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/static-page-name/test/index.test.js": {
+      "passed": [
+        "Static Page Name development mode should navigate to static page name correctly",
+        "Static Page Name development mode should render the page via SSR correctly",
+        "Static Page Name production mode should navigate to static page name correctly",
+        "Static Page Name production mode should render the page via SSR correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/styled-jsx-plugin/test/index.test.js": {
+      "passed": [
+        "styled-jsx using in node_modules production mode should serve a page correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/telemetry/test/config.test.js": {
+      "passed": [
+        "config telemetry production mode detects i18n and image configs for session start",
+        "config telemetry production mode detects output config for session start",
+        "config telemetry production mode detects rewrites, headers, and redirects for next build",
+        "config telemetry production mode emits telemery for usage of image, script & dynamic",
+        "config telemetry production mode emits telemetry for `next lint`",
+        "config telemetry production mode emits telemetry for configured React Compiler options",
+        "config telemetry production mode emits telemetry for default React Compiler options",
+        "config telemetry production mode emits telemetry for enabled React Compiler",
+        "config telemetry production mode emits telemetry for lint during build",
+        "config telemetry production mode emits telemetry for lint during build when '--no-lint' is specified",
+        "config telemetry production mode emits telemetry for lint during build when 'ignoreDuringBuilds' is specified",
+        "config telemetry production mode emits telemetry for middleware related options",
+        "config telemetry production mode emits telemetry for transpilePackages",
+        "config telemetry production mode emits telemetry for usage of @vercel/og",
+        "config telemetry production mode emits telemetry for usage of `experimental/dynamicIO`",
+        "config telemetry production mode emits telemetry for usage of `nextScriptWorkers`",
+        "config telemetry production mode emits telemetry for usage of `optimizeCss`",
+        "config telemetry production mode emits telemetry for usage of middleware",
+        "config telemetry production mode emits telemetry for usage of next/legacy/image",
+        "config telemetry production mode emits telemetry for usage of swc",
+        "config telemetry production mode emits telemetry for usage of swc plugins",
+        "config telemetry production mode emits telemetry for useCache directive"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/telemetry/test/index.test.js": {
+      "passed": [
+        "Telemetry CLI can disable telemetry with env NEXT_TELEMETRY_DISABLED",
+        "Telemetry CLI can disable telemetry with flag",
+        "Telemetry CLI can disable telemetry without flag",
+        "Telemetry CLI can enable telemetry with flag",
+        "Telemetry CLI can enable telemetry without flag",
+        "Telemetry CLI can print telemetry status",
+        "Telemetry CLI can re-disable telemetry",
+        "Telemetry CLI can re-enable telemetry",
+        "Telemetry CLI detects isSrcDir dir correctly for `next dev`",
+        "Telemetry CLI production mode cli session: babel tooling config",
+        "Telemetry CLI production mode cli session: custom babel config (plugin)",
+        "Telemetry CLI production mode cli session: custom babel config (preset)",
+        "Telemetry CLI production mode cli session: next config with webpack",
+        "Telemetry CLI production mode cli session: package.json custom babel config (plugin)",
+        "Telemetry CLI production mode detect page counts correctly for `next build`",
+        "Telemetry CLI production mode detect static 404 correctly for `next build`",
+        "Telemetry CLI production mode detects correct cli session defaults",
+        "Telemetry CLI production mode detects isSrcDir dir correctly for `next build`",
+        "Telemetry CLI production mode detects tests correctly for `next build`",
+        "Telemetry CLI production mode emits event when swc fails to load",
+        "Telemetry CLI production mode logs completed `next build` with warnings"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/telemetry/test/page-features.test.js": {
+      "passed": [
+        "page features telemetry detects correctly for `next dev` stopped (no turbo)",
+        "page features telemetry production mode detect with reportWebVitals correctly for `next build`",
+        "page features telemetry production mode detect without reportWebVitals correctly for `next build`",
+        "page features telemetry production mode detects reportWebVitals with no _app correctly for `next build`",
+        "page features telemetry production mode should detect app page counts"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/trailing-slash-dist/test/index.test.js": {
+      "passed": [
+        "Trailing slash in distDir development mode supports trailing slash"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/trailing-slashes-href-resolving/test/index.test.js": {
+      "passed": [
+        "href resolving trailing-slash development mode should route to /another/ correctly",
+        "href resolving trailing-slash development mode should route to /blog/another/ correctly",
+        "href resolving trailing-slash development mode should route to /blog/first-post/ correctly",
+        "href resolving trailing-slash development mode should route to /catch-all/first/ correctly",
+        "href resolving trailing-slash development mode should route to /catch-all/hello/world/ correctly",
+        "href resolving trailing-slash development mode should route to /top-level-slug/ correctly",
+        "href resolving trailing-slash production mode should preload SSG routes correctly",
+        "href resolving trailing-slash production mode should route to /another/ correctly",
+        "href resolving trailing-slash production mode should route to /blog/another/ correctly",
+        "href resolving trailing-slash production mode should route to /blog/first-post/ correctly",
+        "href resolving trailing-slash production mode should route to /catch-all/first/ correctly",
+        "href resolving trailing-slash production mode should route to /catch-all/hello/world/ correctly",
+        "href resolving trailing-slash production mode should route to /top-level-slug/ correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/trailing-slashes-rewrite/test/index.test.js": {
+      "passed": [
+        "Trailing Slash Rewrite Proxying development mode should proxy non-existent page correctly",
+        "Trailing Slash Rewrite Proxying development mode should resolve a catch-all page correctly",
+        "Trailing Slash Rewrite Proxying development mode should resolve a dynamic page correctly",
+        "Trailing Slash Rewrite Proxying development mode should resolve index page correctly",
+        "Trailing Slash Rewrite Proxying development mode should resolve products page correctly",
+        "Trailing Slash Rewrite Proxying production mode should proxy non-existent page correctly",
+        "Trailing Slash Rewrite Proxying production mode should resolve a catch-all page correctly",
+        "Trailing Slash Rewrite Proxying production mode should resolve a dynamic page correctly",
+        "Trailing Slash Rewrite Proxying production mode should resolve index page correctly",
+        "Trailing Slash Rewrite Proxying production mode should resolve products page correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/trailing-slashes/test/index.test.js": {
+      "passed": [
+        "Trailing slashes development mode, trailingSlash: false / should client side render /index.js, with router path /",
+        "Trailing slashes development mode, trailingSlash: false / should resolve to /index.js, with router path /",
+        "Trailing slashes development mode, trailingSlash: false /about should client side render /about.js, with router path /about",
+        "Trailing slashes development mode, trailingSlash: false /about should resolve to /about.js, with router path /about",
+        "Trailing slashes development mode, trailingSlash: false /about/ should redirect to /about",
+        "Trailing slashes development mode, trailingSlash: false /about?hello=world should client side render /about.js, with router path /about",
+        "Trailing slashes development mode, trailingSlash: false /about?hello=world should resolve to /about.js, with router path /about",
+        "Trailing slashes development mode, trailingSlash: false /catch-all/hello.world/ should redirect to /catch-all/hello.world",
+        "Trailing slashes development mode, trailingSlash: false /catch-all/hello/world should client side render /catch-all/[...slug].js, with router path /catch-all/[...slug]",
+        "Trailing slashes development mode, trailingSlash: false /catch-all/hello/world should resolve to /catch-all/[...slug].js, with router path /catch-all/[...slug]",
+        "Trailing slashes development mode, trailingSlash: false /catch-all/hello/world/ should redirect to /catch-all/hello/world",
+        "Trailing slashes development mode, trailingSlash: false /external-linker?href=https://nextjs.org should have href https://nextjs.org",
+        "Trailing slashes development mode, trailingSlash: false /external-linker?href=https://nextjs.org/ should have href https://nextjs.org/",
+        "Trailing slashes development mode, trailingSlash: false /linker?href=/ should have href /",
+        "Trailing slashes development mode, trailingSlash: false /linker?href=/ should navigate to /",
+        "Trailing slashes development mode, trailingSlash: false /linker?href=/ should push route to /",
+        "Trailing slashes development mode, trailingSlash: false /linker?href=/about should have href /about",
+        "Trailing slashes development mode, trailingSlash: false /linker?href=/about should navigate to /about",
+        "Trailing slashes development mode, trailingSlash: false /linker?href=/about should push route to /about",
+        "Trailing slashes development mode, trailingSlash: false /linker?href=/about/ should have href /about",
+        "Trailing slashes development mode, trailingSlash: false /linker?href=/about/ should navigate to /about",
+        "Trailing slashes development mode, trailingSlash: false /linker?href=/about/ should push route to /about",
+        "Trailing slashes development mode, trailingSlash: false /linker?href=/about/?hello=world should have href /about?hello=world",
+        "Trailing slashes development mode, trailingSlash: false /linker?href=/about/?hello=world should navigate to /about?hello=world",
+        "Trailing slashes development mode, trailingSlash: false /linker?href=/about/?hello=world should push route to /about?hello=world",
+        "Trailing slashes development mode, trailingSlash: false /linker?href=/about?hello=world should have href /about?hello=world",
+        "Trailing slashes development mode, trailingSlash: false /linker?href=/about?hello=world should navigate to /about?hello=world",
+        "Trailing slashes development mode, trailingSlash: false /linker?href=/about?hello=world should push route to /about?hello=world",
+        "Trailing slashes development mode, trailingSlash: false /linker?href=/catch-all/hello.world/ should have href /catch-all/hello.world",
+        "Trailing slashes development mode, trailingSlash: false /linker?href=/catch-all/hello.world/ should navigate to /catch-all/hello.world",
+        "Trailing slashes development mode, trailingSlash: false /linker?href=/catch-all/hello.world/ should push route to /catch-all/hello.world",
+        "Trailing slashes development mode, trailingSlash: false /linker?href=/catch-all/hello/ should have href /catch-all/hello",
+        "Trailing slashes development mode, trailingSlash: false /linker?href=/catch-all/hello/ should navigate to /catch-all/hello",
+        "Trailing slashes development mode, trailingSlash: false /linker?href=/catch-all/hello/ should push route to /catch-all/hello",
+        "Trailing slashes development mode, trailingSlash: true / should client side render /index.js, with router path /",
+        "Trailing slashes development mode, trailingSlash: true / should resolve to /index.js, with router path /",
+        "Trailing slashes development mode, trailingSlash: true /about should redirect to /about/",
+        "Trailing slashes development mode, trailingSlash: true /about/ should client side render /about.js, with router path /about",
+        "Trailing slashes development mode, trailingSlash: true /about/ should resolve to /about.js, with router path /about",
+        "Trailing slashes development mode, trailingSlash: true /about/?hello=world should client side render /about.js, with router path /about",
+        "Trailing slashes development mode, trailingSlash: true /about/?hello=world should resolve to /about.js, with router path /about",
+        "Trailing slashes development mode, trailingSlash: true /catch-all/hello.world/ should redirect to /catch-all/hello.world",
+        "Trailing slashes development mode, trailingSlash: true /catch-all/hello/world should redirect to /catch-all/hello/world/",
+        "Trailing slashes development mode, trailingSlash: true /catch-all/hello/world/ should client side render /catch-all/[...slug].js, with router path /catch-all/[...slug]",
+        "Trailing slashes development mode, trailingSlash: true /catch-all/hello/world/ should resolve to /catch-all/[...slug].js, with router path /catch-all/[...slug]",
+        "Trailing slashes development mode, trailingSlash: true /external-linker?href=https://nextjs.org should have href https://nextjs.org",
+        "Trailing slashes development mode, trailingSlash: true /external-linker?href=https://nextjs.org/ should have href https://nextjs.org/",
+        "Trailing slashes development mode, trailingSlash: true /linker?href=/ should have href /",
+        "Trailing slashes development mode, trailingSlash: true /linker?href=/ should navigate to /",
+        "Trailing slashes development mode, trailingSlash: true /linker?href=/ should push route to /",
+        "Trailing slashes development mode, trailingSlash: true /linker?href=/about should have href /about/",
+        "Trailing slashes development mode, trailingSlash: true /linker?href=/about should navigate to /about/",
+        "Trailing slashes development mode, trailingSlash: true /linker?href=/about should push route to /about/",
+        "Trailing slashes development mode, trailingSlash: true /linker?href=/about/ should have href /about/",
+        "Trailing slashes development mode, trailingSlash: true /linker?href=/about/ should navigate to /about/",
+        "Trailing slashes development mode, trailingSlash: true /linker?href=/about/ should push route to /about/",
+        "Trailing slashes development mode, trailingSlash: true /linker?href=/about/?hello=world should have href /about/?hello=world",
+        "Trailing slashes development mode, trailingSlash: true /linker?href=/about/?hello=world should navigate to /about/?hello=world",
+        "Trailing slashes development mode, trailingSlash: true /linker?href=/about/?hello=world should push route to /about/?hello=world",
+        "Trailing slashes development mode, trailingSlash: true /linker?href=/about?hello=world should have href /about/?hello=world",
+        "Trailing slashes development mode, trailingSlash: true /linker?href=/about?hello=world should navigate to /about/?hello=world",
+        "Trailing slashes development mode, trailingSlash: true /linker?href=/about?hello=world should push route to /about/?hello=world",
+        "Trailing slashes development mode, trailingSlash: true /linker?href=/catch-all/hello.world/ should have href /catch-all/hello.world",
+        "Trailing slashes development mode, trailingSlash: true /linker?href=/catch-all/hello.world/ should navigate to /catch-all/hello.world",
+        "Trailing slashes development mode, trailingSlash: true /linker?href=/catch-all/hello.world/ should push route to /catch-all/hello.world",
+        "Trailing slashes development mode, trailingSlash: true /linker?href=/catch-all/hello/ should have href /catch-all/hello/",
+        "Trailing slashes development mode, trailingSlash: true /linker?href=/catch-all/hello/ should navigate to /catch-all/hello/",
+        "Trailing slashes development mode, trailingSlash: true /linker?href=/catch-all/hello/ should push route to /catch-all/hello/",
+        "Trailing slashes development mode, with basepath, trailingSlash: true /docs should redirect to /docs/",
+        "Trailing slashes development mode, with basepath, trailingSlash: true /docs/about should redirect to /docs/about/",
+        "Trailing slashes development mode, with basepath, trailingSlash: true /docs/catch-all/hello.world/ should redirect to /docs/catch-all/hello.world",
+        "Trailing slashes development mode, with basepath, trailingSlash: true /docs/catch-all/hello/world should redirect to /docs/catch-all/hello/world/",
+        "Trailing slashes development mode, with basepath, trailingSlash: true /docs/linker?href=/ should have href /docs/",
+        "Trailing slashes development mode, with basepath, trailingSlash: true /docs/linker?href=/ should navigate to /docs/",
+        "Trailing slashes development mode, with basepath, trailingSlash: true /docs/linker?href=/ should push route to /docs/",
+        "Trailing slashes development mode, with basepath, trailingSlash: true /docs/linker?href=/about should have href /docs/about/",
+        "Trailing slashes development mode, with basepath, trailingSlash: true /docs/linker?href=/about should navigate to /docs/about/",
+        "Trailing slashes development mode, with basepath, trailingSlash: true /docs/linker?href=/about should push route to /docs/about/",
+        "Trailing slashes production mode, trailingSlash: false / should client side render /index.js, with router path /",
+        "Trailing slashes production mode, trailingSlash: false / should resolve to /index.js, with router path /",
+        "Trailing slashes production mode, trailingSlash: false /about should client side render /about.js, with router path /about",
+        "Trailing slashes production mode, trailingSlash: false /about should resolve to /about.js, with router path /about",
+        "Trailing slashes production mode, trailingSlash: false /about/ should redirect to /about",
+        "Trailing slashes production mode, trailingSlash: false /about?hello=world should client side render /about.js, with router path /about",
+        "Trailing slashes production mode, trailingSlash: false /about?hello=world should resolve to /about.js, with router path /about",
+        "Trailing slashes production mode, trailingSlash: false /catch-all/hello.world/ should redirect to /catch-all/hello.world",
+        "Trailing slashes production mode, trailingSlash: false /catch-all/hello/world should client side render /catch-all/[...slug].js, with router path /catch-all/[...slug]",
+        "Trailing slashes production mode, trailingSlash: false /catch-all/hello/world should resolve to /catch-all/[...slug].js, with router path /catch-all/[...slug]",
+        "Trailing slashes production mode, trailingSlash: false /catch-all/hello/world/ should redirect to /catch-all/hello/world",
+        "Trailing slashes production mode, trailingSlash: false /external-linker?href=https://nextjs.org should have href https://nextjs.org",
+        "Trailing slashes production mode, trailingSlash: false /external-linker?href=https://nextjs.org/ should have href https://nextjs.org/",
+        "Trailing slashes production mode, trailingSlash: false /linker?href=/ should have href /",
+        "Trailing slashes production mode, trailingSlash: false /linker?href=/ should navigate to /",
+        "Trailing slashes production mode, trailingSlash: false /linker?href=/ should push route to /",
+        "Trailing slashes production mode, trailingSlash: false /linker?href=/about should have href /about",
+        "Trailing slashes production mode, trailingSlash: false /linker?href=/about should navigate to /about",
+        "Trailing slashes production mode, trailingSlash: false /linker?href=/about should push route to /about",
+        "Trailing slashes production mode, trailingSlash: false /linker?href=/about/ should have href /about",
+        "Trailing slashes production mode, trailingSlash: false /linker?href=/about/ should navigate to /about",
+        "Trailing slashes production mode, trailingSlash: false /linker?href=/about/ should push route to /about",
+        "Trailing slashes production mode, trailingSlash: false /linker?href=/about/?hello=world should have href /about?hello=world",
+        "Trailing slashes production mode, trailingSlash: false /linker?href=/about/?hello=world should navigate to /about?hello=world",
+        "Trailing slashes production mode, trailingSlash: false /linker?href=/about/?hello=world should push route to /about?hello=world",
+        "Trailing slashes production mode, trailingSlash: false /linker?href=/about?hello=world should have href /about?hello=world",
+        "Trailing slashes production mode, trailingSlash: false /linker?href=/about?hello=world should navigate to /about?hello=world",
+        "Trailing slashes production mode, trailingSlash: false /linker?href=/about?hello=world should push route to /about?hello=world",
+        "Trailing slashes production mode, trailingSlash: false /linker?href=/catch-all/hello.world/ should have href /catch-all/hello.world",
+        "Trailing slashes production mode, trailingSlash: false /linker?href=/catch-all/hello.world/ should navigate to /catch-all/hello.world",
+        "Trailing slashes production mode, trailingSlash: false /linker?href=/catch-all/hello.world/ should push route to /catch-all/hello.world",
+        "Trailing slashes production mode, trailingSlash: false /linker?href=/catch-all/hello/ should have href /catch-all/hello",
+        "Trailing slashes production mode, trailingSlash: false /linker?href=/catch-all/hello/ should navigate to /catch-all/hello",
+        "Trailing slashes production mode, trailingSlash: false /linker?href=/catch-all/hello/ should push route to /catch-all/hello",
+        "Trailing slashes production mode, trailingSlash: false should have a redirect in the routesmanifest",
+        "Trailing slashes production mode, trailingSlash: true / should client side render /index.js, with router path /",
+        "Trailing slashes production mode, trailingSlash: true / should resolve to /index.js, with router path /",
+        "Trailing slashes production mode, trailingSlash: true /about should redirect to /about/",
+        "Trailing slashes production mode, trailingSlash: true /about/ should client side render /about.js, with router path /about",
+        "Trailing slashes production mode, trailingSlash: true /about/ should resolve to /about.js, with router path /about",
+        "Trailing slashes production mode, trailingSlash: true /about/?hello=world should client side render /about.js, with router path /about",
+        "Trailing slashes production mode, trailingSlash: true /about/?hello=world should resolve to /about.js, with router path /about",
+        "Trailing slashes production mode, trailingSlash: true /catch-all/hello.world/ should redirect to /catch-all/hello.world",
+        "Trailing slashes production mode, trailingSlash: true /catch-all/hello/world should redirect to /catch-all/hello/world/",
+        "Trailing slashes production mode, trailingSlash: true /catch-all/hello/world/ should client side render /catch-all/[...slug].js, with router path /catch-all/[...slug]",
+        "Trailing slashes production mode, trailingSlash: true /catch-all/hello/world/ should resolve to /catch-all/[...slug].js, with router path /catch-all/[...slug]",
+        "Trailing slashes production mode, trailingSlash: true /external-linker?href=https://nextjs.org should have href https://nextjs.org",
+        "Trailing slashes production mode, trailingSlash: true /external-linker?href=https://nextjs.org/ should have href https://nextjs.org/",
+        "Trailing slashes production mode, trailingSlash: true /linker?href=/ should have href /",
+        "Trailing slashes production mode, trailingSlash: true /linker?href=/ should navigate to /",
+        "Trailing slashes production mode, trailingSlash: true /linker?href=/ should push route to /",
+        "Trailing slashes production mode, trailingSlash: true /linker?href=/about should have href /about/",
+        "Trailing slashes production mode, trailingSlash: true /linker?href=/about should navigate to /about/",
+        "Trailing slashes production mode, trailingSlash: true /linker?href=/about should push route to /about/",
+        "Trailing slashes production mode, trailingSlash: true /linker?href=/about/ should have href /about/",
+        "Trailing slashes production mode, trailingSlash: true /linker?href=/about/ should navigate to /about/",
+        "Trailing slashes production mode, trailingSlash: true /linker?href=/about/ should push route to /about/",
+        "Trailing slashes production mode, trailingSlash: true /linker?href=/about/?hello=world should have href /about/?hello=world",
+        "Trailing slashes production mode, trailingSlash: true /linker?href=/about/?hello=world should navigate to /about/?hello=world",
+        "Trailing slashes production mode, trailingSlash: true /linker?href=/about/?hello=world should push route to /about/?hello=world",
+        "Trailing slashes production mode, trailingSlash: true /linker?href=/about?hello=world should have href /about/?hello=world",
+        "Trailing slashes production mode, trailingSlash: true /linker?href=/about?hello=world should navigate to /about/?hello=world",
+        "Trailing slashes production mode, trailingSlash: true /linker?href=/about?hello=world should push route to /about/?hello=world",
+        "Trailing slashes production mode, trailingSlash: true /linker?href=/catch-all/hello.world/ should have href /catch-all/hello.world",
+        "Trailing slashes production mode, trailingSlash: true /linker?href=/catch-all/hello.world/ should navigate to /catch-all/hello.world",
+        "Trailing slashes production mode, trailingSlash: true /linker?href=/catch-all/hello.world/ should push route to /catch-all/hello.world",
+        "Trailing slashes production mode, trailingSlash: true /linker?href=/catch-all/hello/ should have href /catch-all/hello/",
+        "Trailing slashes production mode, trailingSlash: true /linker?href=/catch-all/hello/ should navigate to /catch-all/hello/",
+        "Trailing slashes production mode, trailingSlash: true /linker?href=/catch-all/hello/ should push route to /catch-all/hello/",
+        "Trailing slashes production mode, trailingSlash: true should have a trailing redirect in the routesmanifest",
+        "Trailing slashes production mode, with basepath, trailingSlash: true /docs should redirect to /docs/",
+        "Trailing slashes production mode, with basepath, trailingSlash: true /docs/about should redirect to /docs/about/",
+        "Trailing slashes production mode, with basepath, trailingSlash: true /docs/catch-all/hello.world/ should redirect to /docs/catch-all/hello.world",
+        "Trailing slashes production mode, with basepath, trailingSlash: true /docs/catch-all/hello/world should redirect to /docs/catch-all/hello/world/",
+        "Trailing slashes production mode, with basepath, trailingSlash: true /docs/linker?href=/ should have href /docs/",
+        "Trailing slashes production mode, with basepath, trailingSlash: true /docs/linker?href=/ should navigate to /docs/",
+        "Trailing slashes production mode, with basepath, trailingSlash: true /docs/linker?href=/ should push route to /docs/",
+        "Trailing slashes production mode, with basepath, trailingSlash: true /docs/linker?href=/about should have href /docs/about/",
+        "Trailing slashes production mode, with basepath, trailingSlash: true /docs/linker?href=/about should navigate to /docs/about/",
+        "Trailing slashes production mode, with basepath, trailingSlash: true /docs/linker?href=/about should push route to /docs/about/"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/tsconfig-verifier/test/index.test.js": {
+      "passed": [
+        "tsconfig.json verifier Creates a default tsconfig.json when one is missing",
+        "tsconfig.json verifier Updates an existing tsconfig.json without losing comments",
+        "tsconfig.json verifier Works with an empty tsconfig.json (docs)",
+        "tsconfig.json verifier allows you to extend another configuration file",
+        "tsconfig.json verifier allows you to set bundler moduleResolution mode",
+        "tsconfig.json verifier allows you to set commonjs module mode",
+        "tsconfig.json verifier allows you to set es2020 module mode",
+        "tsconfig.json verifier allows you to set node16 module mode",
+        "tsconfig.json verifier allows you to set node16 moduleResolution mode",
+        "tsconfig.json verifier allows you to set target mode",
+        "tsconfig.json verifier allows you to set verbatimModuleSyntax true via extends without adding isolatedModules",
+        "tsconfig.json verifier allows you to set verbatimModuleSyntax true without adding isolatedModules",
+        "tsconfig.json verifier creates compilerOptions when you extend another config"
+      ],
+      "failed": [],
+      "pending": [
+        "tsconfig.json verifier allows you to skip moduleResolution, esModuleInterop and resolveJsonModule when using \"module: preserve\""
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/turbopack-unsupported-log/index.test.ts": {
+      "passed": [],
+      "failed": [],
+      "pending": ["turbopack unsupported features log turbopack only"],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/turborepo-access-trace/test/index.test.js": {
+      "passed": [
+        "build with proxy trace production mode should build and output trace correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/turbotrace-with-webpack-worker/test/index.test.js": {
+      "passed": [
+        "build trace with extra entries production mode should build and trace correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/typeof-window-replace/test/index.test.js": {
+      "passed": [
+        "typeof window replace production mode Does not replace `typeof window` for `node_modules` code",
+        "typeof window replace production mode Replaces `typeof window` with object for client code",
+        "typeof window replace production mode Replaces `typeof window` with undefined for server code"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/typescript-app-type-declarations/test/index.test.js": {
+      "passed": [
+        "TypeScript App Type Declarations should not touch an existing correct next-env.d.ts",
+        "TypeScript App Type Declarations should overwrite next-env.d.ts if an incorrect one exists",
+        "TypeScript App Type Declarations should write a new next-env.d.ts if none exist"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/typescript-baseurl/test/index.test.js": {
+      "passed": ["TypeScript Features default behavior should render the page"],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/typescript-custom-tsconfig/test/index.test.js": {
+      "passed": [
+        "Custom TypeScript Config production mode should warn when using custom typescript path"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/typescript-external-dir/project/test/index.test.js": {
+      "passed": [
+        "TypeScript Features default behavior should render the page with external TS/TSX dependencies"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/typescript-filtered-files/test/index.test.js": {
+      "passed": [
+        "TypeScript filtered files production mode should fail to build the app with a file named con*test*.js"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/typescript-hmr/test/index.test.js": {
+      "passed": [
+        "TypeScript HMR delete a page and add it back should detect the changes to typescript pages and display it",
+        "TypeScript HMR should ignore type errors in development"
+      ],
+      "failed": [],
+      "pending": ["TypeScript HMR should recover from a type error"],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/typescript-ignore-errors/test/index.test.js": {
+      "passed": [
+        "TypeScript with error handling options production mode ignoreBuildErrors: false Next fails to build the application despite type errors in incremental mode",
+        "TypeScript with error handling options production mode ignoreBuildErrors: false Next fails to build the application despite type errors without incremental mode",
+        "TypeScript with error handling options production mode ignoreBuildErrors: true Next builds the application despite type errors in incremental mode",
+        "TypeScript with error handling options production mode ignoreBuildErrors: true Next builds the application despite type errors without incremental mode"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/typescript-only-remove-type-imports/test/index.test.js": {
+      "passed": [
+        "TypeScript onlyRemoveTypeImports development mode should render a normal page correctly",
+        "TypeScript onlyRemoveTypeImports development mode should render a page with type import correctly",
+        "TypeScript onlyRemoveTypeImports production mode should render a normal page correctly",
+        "TypeScript onlyRemoveTypeImports production mode should render a page with type import correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/typescript-paths/test/index.test.js": {
+      "passed": [
+        "typescript paths default behavior should alias components",
+        "typescript paths default behavior should not resolve to .d.ts files",
+        "typescript paths default behavior should resolve a single matching alias",
+        "typescript paths default behavior should resolve the first item in the array first",
+        "typescript paths default behavior should resolve the second item in as a fallback",
+        "typescript paths without baseurl default behavior should alias components",
+        "typescript paths without baseurl default behavior should not resolve to .d.ts files",
+        "typescript paths without baseurl default behavior should resolve a single matching alias",
+        "typescript paths without baseurl default behavior should resolve the first item in the array first",
+        "typescript paths without baseurl default behavior should resolve the second item in as a fallback"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/typescript-workspaces-paths/packages/www/test/index.test.js": {
+      "passed": [
+        "TypeScript Features default behavior should alias components",
+        "TypeScript Features default behavior should not resolve to .d.ts files",
+        "TypeScript Features default behavior should resolve a single matching alias",
+        "TypeScript Features default behavior should resolve the first item in the array first",
+        "TypeScript Features default behavior should resolve the second item in as a fallback"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/typescript/test/index.test.js": {
+      "passed": [
+        "TypeScript Features default behavior should not fail to render when an inactive page has an error",
+        "TypeScript Features default behavior should render the angle bracket type assertions page",
+        "TypeScript Features default behavior should render the cookies page",
+        "TypeScript Features default behavior should render the cookies page with cookies",
+        "TypeScript Features default behavior should render the generics page",
+        "TypeScript Features default behavior should render the page",
+        "TypeScript Features default behavior should resolve files in correct order",
+        "TypeScript Features default behavior should respond to async API route correctly",
+        "TypeScript Features default behavior should respond to sync API route correctly",
+        "TypeScript Features production mode should build the app",
+        "TypeScript Features production mode should build the app with functions in next.config.js",
+        "TypeScript Features production mode should compile with different types should compile async getInitialProps for _error",
+        "TypeScript Features production mode should compile with different types should compile sync getStaticPaths & getStaticProps",
+        "TypeScript Features production mode should not inform when using default tsconfig path"
+      ],
+      "failed": [],
+      "pending": [
+        "TypeScript Features default behavior should report type checking to stdout"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/undefined-webpack-config/test/index.test.js": {
+      "passed": [
+        "undefined webpack config error should show in development mode"
+      ],
+      "failed": [],
+      "pending": [
+        "undefined webpack config error production mode should show in production mode"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/url-imports/test/index.test.js": {
+      "passed": [
+        "Handle url imports with next build should allow url import in css",
+        "Handle url imports with next build should client-render the /ssg page",
+        "Handle url imports with next build should client-render the /ssr page",
+        "Handle url imports with next build should client-render the /static page",
+        "Handle url imports with next build should render a static url image import",
+        "Handle url imports with next build should render the /ssg page",
+        "Handle url imports with next build should render the /ssr page",
+        "Handle url imports with next build should render the /static page",
+        "Handle url imports with next build should respond on value api",
+        "Handle url imports with next dev should allow url import in css",
+        "Handle url imports with next dev should client-render the /ssg page",
+        "Handle url imports with next dev should client-render the /ssr page",
+        "Handle url imports with next dev should client-render the /static page",
+        "Handle url imports with next dev should render a static url image import",
+        "Handle url imports with next dev should render the /ssg page",
+        "Handle url imports with next dev should render the /ssr page",
+        "Handle url imports with next dev should render the /static page",
+        "Handle url imports with next dev should respond on value api"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/url/test/index.test.js": {
+      "passed": [
+        "Handle new URL asset references in next build should client-render the /ssg page",
+        "Handle new URL asset references in next build should client-render the /ssr page",
+        "Handle new URL asset references in next build should client-render the /static page",
+        "Handle new URL asset references in next build should render the /ssg page",
+        "Handle new URL asset references in next build should render the /ssr page",
+        "Handle new URL asset references in next build should render the /static page",
+        "Handle new URL asset references in next build should respond on basename api",
+        "Handle new URL asset references in next build should respond on size api",
+        "Handle new URL asset references in next dev should client-render the /ssg page",
+        "Handle new URL asset references in next dev should client-render the /ssr page",
+        "Handle new URL asset references in next dev should client-render the /static page",
+        "Handle new URL asset references in next dev should render the /ssg page",
+        "Handle new URL asset references in next dev should render the /ssr page",
+        "Handle new URL asset references in next dev should render the /static page",
+        "Handle new URL asset references in next dev should respond on basename api",
+        "Handle new URL asset references in next dev should respond on size api"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/webpack-config-extensionalias/test/index.test.js": {
+      "passed": [
+        "webpack config with extensionAlias setting should run correctly with an tsx file import with .js extension"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/webpack-config-mainjs/test/index.test.js": {
+      "passed": [
+        "Customized webpack config with main.js should run correctly with main.js customized"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/webpack-require-hook/test/index.test.js": {
+      "passed": [
+        "Handles Webpack Require Hook build Does not error during build",
+        "Handles Webpack Require Hook development mode Applies and does not error during development"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/with-electron/test/index.test.js": {
+      "passed": [
+        "Should skip testing electron without process.env.TEST_ELECTRON set"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/integration/worker-webpack5/test/index.test.js": {
+      "passed": [
+        "Web Workers with webpack 5 development mode should pass on both client and worker",
+        "Web Workers with webpack 5 production mode should pass on both client and worker"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/production/allow-development-build/allow-development-build.test.ts": {
+      "passed": [
+        "allow-development-build with NODE_ENV not set to development should fail the build with a message about not setting NODE_ENV",
+        "allow-development-build with NODE_ENV set to development should show React development errors in app-page",
+        "allow-development-build with NODE_ENV set to development should show React development errors in pages-page",
+        "allow-development-build with NODE_ENV set to development should warn about a non-standard NODE_ENV"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/production/app-dir-edge-runtime-with-wasm/index.test.ts": {
+      "passed": ["app-dir edge runtime with wasm should have built"],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/production/app-dir-hide-suppressed-error-during-next-export/index.test.ts": {
+      "passed": [
+        "app-dir-hide-suppressed-error-during-next-export should not log suppressed error when exporting static page"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/production/app-dir-prefetch-non-iso-url/index.test.ts": {
+      "passed": [
+        "app-dir-prefetch-non-iso-url should go to iso url",
+        "app-dir-prefetch-non-iso-url should go to non-iso url"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/production/app-dir-prevent-304-caching/index.test.ts": {
+      "passed": ["app-dir-prevent-304-caching should not cache 304 status"],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/production/app-dir/actions-tree-shaking/basic/basic-edge.test.ts": {
+      "passed": [],
+      "failed": [],
+      "pending": [
+        "actions-tree-shaking - basic should not have the unused action in the manifest"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/production/app-dir/actions-tree-shaking/basic/basic.test.ts": {
+      "passed": [],
+      "failed": [],
+      "pending": [
+        "actions-tree-shaking - basic should not have the unused action in the manifest"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/production/app-dir/actions-tree-shaking/client-actions-tree-shaking/client-actions-tree-shaking.test.ts": {
+      "passed": [
+        "app-dir - client-actions-tree-shaking should not bundle unused server reference id in client bundles",
+        "app-dir - client-actions-tree-shaking should trigger actions correctly"
+      ],
+      "failed": [],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/production/app-dir/actions-tree-shaking/mixed-module-actions/mixed-module-actions-edge.test.ts": {
+      "passed": [],
+      "failed": [],
+      "pending": [
+        "actions-tree-shaking - mixed-module-actions should not do tree shake for cjs module when import server actions"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/production/app-dir/actions-tree-shaking/mixed-module-actions/mixed-module-actions.test.ts": {
+      "passed": [],
+      "failed": [],
+      "pending": [
+        "actions-tree-shaking - mixed-module-actions should not do tree shake for cjs module when import server actions"
+      ],
+      "flakey": [],
+      "runtimeError": false
+    }
+  },
+  "rules": {
+    "include": [
+      "test/integration/**/*.test.{t,j}s{,x}",
+      "test/e2e/**/*.test.{t,j}s{,x}",
+      "test/production/**/*.test.{t,j}s{,x}"
+    ],
+    "exclude": []
+  }
+}

--- a/test/rspack-dev-tests-manifest.json
+++ b/test/rspack-dev-tests-manifest.json
@@ -1,0 +1,192 @@
+{
+  "test/integration/404-page-custom-error/test/index.test.js": {
+    "passed": [
+      "Default 404 Page with custom _error development mode should render index page normal",
+      "Default 404 Page with custom _error development mode should respond to 404 correctly",
+      "Default 404 Page with custom _error production mode should build successfully",
+      "Default 404 Page with custom _error production mode should have output 404.html",
+      "Default 404 Page with custom _error production mode should render error correctly",
+      "Default 404 Page with custom _error production mode should render index page normal",
+      "Default 404 Page with custom _error production mode should respond to 404 correctly",
+      "Default 404 Page with custom _error production mode should set pages404 in routes-manifest correctly"
+    ],
+    "failed": [
+      "Default 404 Page with custom _error development mode should render error correctly"
+    ],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/integration/app-document-style-fragment/test/index.test.js": {
+    "passed": [],
+    "failed": [
+      "Custom Document Fragment Styles production mode correctly adds styles from fragment styles key"
+    ],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/integration/build-trace-extra-entries-turbo/test/index.test.js": {
+    "passed": [],
+    "failed": [
+      "build trace with extra entries production mode should build and trace correctly"
+    ],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/integration/create-next-app/package-manager/bun.test.ts": {
+    "passed": [],
+    "failed": [
+      "create-next-app with package manager bun should use bun for --use-bun flag",
+      "create-next-app with package manager bun should use bun for --use-bun flag with example",
+      "create-next-app with package manager bun should use bun when user-agent is bun",
+      "create-next-app with package manager bun should use bun when user-agent is bun with example"
+    ],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/integration/css/test/valid-invalid-css.test.js": {
+    "passed": [
+      "Valid Global CSS from npm production mode should've emitted a single CSS file"
+    ],
+    "failed": [
+      "Invalid CSS in _document production mode should fail to build",
+      "Invalid Global CSS production mode should fail to build",
+      "Invalid Global CSS with Custom App production mode should fail to build",
+      "Valid and Invalid Global CSS with Custom App production mode should fail to build"
+    ],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/integration/edge-runtime-dynamic-code/test/index.test.js": {
+    "passed": [
+      "Edge route usage of dynamic code evaluation development mode does not show a warning when running WebAssembly.instantiate with a module parameter",
+      "Edge route usage of dynamic code evaluation development mode does not show warning when no code uses eval",
+      "Middleware usage of dynamic code evaluation development mode does not show a warning when running WebAssembly.instantiate with a module parameter",
+      "Middleware usage of dynamic code evaluation development mode does not show warning when no code uses eval",
+      "Page using eval in development mode does issue dynamic code evaluation warnings"
+    ],
+    "failed": [
+      "Edge route usage of dynamic code evaluation development mode shows a warning when running WebAssembly.compile",
+      "Edge route usage of dynamic code evaluation development mode shows a warning when running WebAssembly.instantiate with a buffer parameter",
+      "Edge route usage of dynamic code evaluation development mode shows a warning when running code with eval",
+      "Edge route usage of dynamic code evaluation production mode should have middleware warning during build",
+      "Middleware usage of dynamic code evaluation development mode shows a warning when running WebAssembly.compile",
+      "Middleware usage of dynamic code evaluation development mode shows a warning when running WebAssembly.instantiate with a buffer parameter",
+      "Middleware usage of dynamic code evaluation development mode shows a warning when running code with eval",
+      "Middleware usage of dynamic code evaluation production mode should have middleware warning during build"
+    ],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/integration/externals-pages-bundle/test/externals.test.js": {
+    "passed": [],
+    "failed": [
+      "default should use externals for unvendored node_modules reachable from the project"
+    ],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/integration/invalid-document-image-import/test/index.test.js": {
+    "passed": [],
+    "failed": [
+      "Invalid static image import in _document production mode Should fail to build when disableStaticImages in next.config.js",
+      "Invalid static image import in _document production mode Should fail to build when no next.config.js"
+    ],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/integration/next-dynamic/test/index.test.js": {
+    "passed": [
+      "next/dynamic development mode should render dynamic server rendered values on client mount",
+      "next/dynamic development mode should render server value",
+      "next/dynamic production mode should render server value"
+    ],
+    "failed": [
+      "next/dynamic production mode should render dynamic server rendered values on client mount"
+    ],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/integration/next-image-legacy/typescript/test/index.test.ts": {
+    "passed": [
+      "TypeScript Image Component development mode 2 should remove global image types when disabled (dev)",
+      "TypeScript Image Component development mode should have image types when enabled",
+      "TypeScript Image Component development mode should render the valid Image usage and not print error",
+      "TypeScript Image Component production mode should fail to build invalid usage of the Image component",
+      "TypeScript Image Component production mode should remove global image types when disabled"
+    ],
+    "failed": [
+      "TypeScript Image Component development mode should print error when invalid Image usage"
+    ],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/integration/no-override-next-props/test/index.test.js": {
+    "passed": [],
+    "failed": [
+      "Dynamic require should show error when a Next prop is returned in _app.getInitialProps"
+    ],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/integration/prerender/test/index.test.js": {
+    "passed": [],
+    "failed": [
+      "SSG Prerender development mode getStaticPaths should not cache getStaticPaths errors",
+      "SSG Prerender development mode getStaticPaths should work with firebase import and getStaticPaths"
+    ],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/integration/server-side-dev-errors/test/index.test.js": {
+    "passed": [],
+    "failed": [
+      "server-side dev errors should show server-side error for api route correctly",
+      "server-side dev errors should show server-side error for dynamic api route correctly",
+      "server-side dev errors should show server-side error for dynamic gssp page correctly",
+      "server-side dev errors should show server-side error for gsp page correctly",
+      "server-side dev errors should show server-side error for gssp page correctly",
+      "server-side dev errors should show server-side error for uncaught empty exception correctly",
+      "server-side dev errors should show server-side error for uncaught empty rejection correctly",
+      "server-side dev errors should show server-side error for uncaught exception correctly",
+      "server-side dev errors should show server-side error for uncaught rejection correctly"
+    ],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/integration/turbotrace-with-webpack-worker/test/index.test.js": {
+    "passed": [],
+    "failed": [
+      "build trace with extra entries production mode should build and trace correctly"
+    ],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/integration/typescript-workspaces-paths/packages/www/test/index.test.js": {
+    "passed": [
+      "TypeScript Features default behavior should alias components",
+      "TypeScript Features default behavior should resolve a single matching alias",
+      "TypeScript Features default behavior should resolve the first item in the array first",
+      "TypeScript Features default behavior should resolve the second item in as a fallback"
+    ],
+    "failed": [
+      "TypeScript Features default behavior should not resolve to .d.ts files"
+    ],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  }
+}


### PR DESCRIPTION
These jobs were failing because they first attempt to open the existing file to compare, and there was no pre-existing file:

https://github.com/vercel/next.js/actions/workflows/rspack-update-tests-manifest.yml

Fixed this by running:

```
echo '{}' > /home/bgw.linux/next.js/test/rspack-dev-tests-manifest.json
echo '{}' > /home/bgw.linux/next.js/test/rspack-build-tests-manifest.json
node test/build-rspack-dev-tests-manifest.js
node test/build-rspack-build-tests-manifest.js
```

![Screenshot 2025-02-12 at 3.25.10 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/c6ee98a0-917f-447b-ac53-10996e2c7e7a.png)

Closes PACK-3959