### PR TITLE
[error overlay] fix infinite loop when frames are failed to fetch

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
@@ -78,8 +78,8 @@ export async function getOriginalStackFrames(
   }
 
   let res: Response | undefined = undefined
-  let errored = false
   let reason: string | undefined = undefined
+  let errored = false
   try {
     res = await fetch('/__nextjs_original-stack-frames', {
       method: 'POST',
@@ -93,17 +93,7 @@ export async function getOriginalStackFrames(
   // When fails to fetch the original stack frames, we reject here to be
   // caught at `_getOriginalStackFrame()` and return the stack frames so
   // that the error overlay can render.
-  if (!res) {
-    return Promise.all(
-      frames.map((frame) =>
-        getOriginalStackFrame(frame, {
-          status: 'rejected',
-          reason: 'Failed to fetch the original stack frames: No response',
-        })
-      )
-    )
-  }
-  if (!res.ok || res.status === 204) {
+  if (res && (!res.ok || res.status === 204)) {
     errored = true // if it's 204 the reason is empty, but we still need to mark as errored
     reason = await res.text()
   }

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
@@ -91,7 +91,7 @@ export async function getOriginalStackFrames(
   // When fails to fetch the original stack frames, we reject here to be
   // caught at `_getOriginalStackFrame()` and return the stack frames so
   // that the error overlay can render.
-  if (res && res.ok) {
+  if (res && res.ok && res.status !== 204) {
     const data = await res.json()
     return Promise.all(
       frames.map((frame, index) => getOriginalStackFrame(frame, data[index]))

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
@@ -79,38 +79,35 @@ export async function getOriginalStackFrames(
 
   let res: Response | undefined = undefined
   let reason: string | undefined = undefined
-  let errored = false
   try {
     res = await fetch('/__nextjs_original-stack-frames', {
       method: 'POST',
       body: JSON.stringify(req),
     })
   } catch (e) {
-    errored = true
     reason = e + ''
   }
 
   // When fails to fetch the original stack frames, we reject here to be
   // caught at `_getOriginalStackFrame()` and return the stack frames so
   // that the error overlay can render.
-  if (res && (!res.ok || res.status === 204)) {
-    errored = true // if it's 204 the reason is empty, but we still need to mark as errored
-    reason = await res.text()
-  }
-  if (errored) {
+  if (res && res.ok) {
+    const data = await res.json()
     return Promise.all(
-      frames.map((frame) =>
-        getOriginalStackFrame(frame, {
-          status: 'rejected',
-          reason: `Failed to fetch the original stack frames ${reason ? `: ${reason}` : ''}`,
-        })
-      )
+      frames.map((frame, index) => getOriginalStackFrame(frame, data[index]))
     )
+  } else {
+    if (res) {
+      reason = await res.text()
+    }
   }
-
-  const data = await res.json()
   return Promise.all(
-    frames.map((frame, index) => getOriginalStackFrame(frame, data[index]))
+    frames.map((frame) =>
+      getOriginalStackFrame(frame, {
+        status: 'rejected',
+        reason: `Failed to fetch the original stack frames ${reason ? `: ${reason}` : ''}`,
+      })
+    )
   )
 }
 

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
@@ -77,21 +77,42 @@ export async function getOriginalStackFrames(
     isAppDirectory: isAppDir,
   }
 
-  const res = await fetch('/__nextjs_original-stack-frames', {
-    method: 'POST',
-    body: JSON.stringify(req),
-  })
+  let res: Response | undefined = undefined
+  let errored = false
+  let reason: string | undefined = undefined
+  try {
+    res = await fetch('/__nextjs_original-stack-frames', {
+      method: 'POST',
+      body: JSON.stringify(req),
+    })
+  } catch (e) {
+    errored = true
+    reason = e + ''
+  }
 
   // When fails to fetch the original stack frames, we reject here to be
   // caught at `_getOriginalStackFrame()` and return the stack frames so
   // that the error overlay can render.
-  if (!res.ok || res.status === 204) {
-    const reason = await res.text()
+  if (!res) {
     return Promise.all(
       frames.map((frame) =>
         getOriginalStackFrame(frame, {
           status: 'rejected',
-          reason: `Failed to fetch the original stack frames: ${reason}`,
+          reason: 'Failed to fetch the original stack frames: No response',
+        })
+      )
+    )
+  }
+  if (!res.ok || res.status === 204) {
+    errored = true // if it's 204 the reason is empty, but we still need to mark as errored
+    reason = await res.text()
+  }
+  if (errored) {
+    return Promise.all(
+      frames.map((frame) =>
+        getOriginalStackFrame(frame, {
+          status: 'rejected',
+          reason: `Failed to fetch the original stack frames ${reason ? `: ${reason}` : ''}`,
         })
       )
     )


### PR DESCRIPTION
### What

If the request of fetching for stack frames is failing, then it will throw error in dialog but no more extra catching. We should fallback to empty response and log the error 

Closes NDX-816
Closes #75922 