### PR TITLE
[Segment Cache] Search param fallback handling

### DIFF
--- a/packages/next/src/client/components/segment-cache-impl/cache-key.ts
+++ b/packages/next/src/client/components/segment-cache-impl/cache-key.ts
@@ -3,13 +3,17 @@ type Opaque<K, T> = T & { __brand: K }
 
 // Only functions in this module should be allowed to create CacheKeys.
 export type NormalizedHref = Opaque<'NormalizedHref', string>
+export type NormalizedSearch = Opaque<'NormalizedSearch', string>
 export type NormalizedNextUrl = Opaque<'NormalizedNextUrl', string>
 
 export type RouteCacheKey = Opaque<
   'RouteCacheKey',
   {
     href: NormalizedHref
+    search: NormalizedSearch
     nextUrl: NormalizedNextUrl | null
+
+    // TODO: Eventually the dynamic params will be added here, too.
   }
 >
 
@@ -18,20 +22,10 @@ export function createCacheKey(
   nextUrl: string | null
 ): RouteCacheKey {
   const originalUrl = new URL(originalHref)
-
-  // TODO: As of now, we never include search params in the cache key because
-  // per-segment prefetch requests are always static, and cannot contain search
-  // params. But to support <Link prefetch={true}>, we will sometimes populate
-  // the cache with dynamic data, so this will have to change.
-  originalUrl.search = ''
-
-  const normalizedHref = originalUrl.href as NormalizedHref
-  const normalizedNextUrl = nextUrl as NormalizedNextUrl | null
-
   const cacheKey = {
-    href: normalizedHref,
-    nextUrl: normalizedNextUrl,
+    href: originalHref as NormalizedHref,
+    search: originalUrl.search as NormalizedSearch,
+    nextUrl: nextUrl as NormalizedNextUrl | null,
   } as RouteCacheKey
-
   return cacheKey
 }

--- a/packages/next/src/server/app-render/segment-value-encoding.ts
+++ b/packages/next/src/server/app-render/segment-value-encoding.ts
@@ -1,3 +1,4 @@
+import { PAGE_SEGMENT_KEY } from '../../shared/lib/segment'
 import type { Segment as FlightRouterStateSegment } from './types'
 
 // TypeScript trick to simulate opaque types, like in Flow.
@@ -9,6 +10,18 @@ export function encodeSegment(
   segment: FlightRouterStateSegment
 ): EncodedSegment {
   if (typeof segment === 'string') {
+    if (segment.startsWith(PAGE_SEGMENT_KEY)) {
+      // The Flight Router State type sometimes includes the search params in
+      // the page segment. However, the Segment Cache tracks this as a separate
+      // key. So, we strip the search params here, and then add them back when
+      // the cache entry is turned back into a FlightRouterState. This is an
+      // unfortunate consequence of the FlightRouteState being used both as a
+      // transport type and as a cache key; we'll address this once more of the
+      // Segment Cache implementation has settled.
+      // TODO: We should hoist the search params out of the FlightRouterState
+      // type entirely, This is our plan for dynamic route params, too.
+      return PAGE_SEGMENT_KEY as EncodedSegment
+    }
     const safeName =
       // TODO: FlightRouterState encodes Not Found routes as "/_not-found".
       // But params typically don't include the leading slash. We should use

--- a/test/e2e/app-dir/segment-cache/search-params/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/search-params/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/search-params/app/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/search-params/app/search-params/page.tsx
@@ -1,0 +1,39 @@
+import { LinkAccordion } from '../../components/link-accordion'
+
+export default function SearchParamsPage() {
+  return (
+    <>
+      <p>
+        Demonstrates that we can prefetch a page that reads from search params
+      </p>
+      <ul>
+        <li>
+          <LinkAccordion href="/search-params/target-page?searchParam=a_PPR">
+            searchParam=a_PPR
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion
+            prefetch={true}
+            href="/search-params/target-page?searchParam=b_full"
+          >
+            searchParam=b_full, prefetch=true
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/search-params/target-page?searchParam=c_PPR">
+            searchParam=c_PPR
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion
+            prefetch={true}
+            href="/search-params/target-page?searchParam=d_full"
+          >
+            searchParam=d_full, prefetch=true
+          </LinkAccordion>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/search-params/app/search-params/target-page/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/search-params/app/search-params/target-page/layout.tsx
@@ -1,0 +1,8 @@
+export default function SearchParamsLayout({ children }) {
+  return (
+    <div>
+      <p>Search params shared layout</p>
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/search-params/app/search-params/target-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/search-params/app/search-params/target-page/page.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+
+async function Content({ searchParams }) {
+  const { searchParam } = await searchParams
+  return `Search param: ${searchParam}`
+}
+
+export default async function Target({ searchParams }) {
+  return (
+    <Suspense fallback="Loading...">
+      <div id="target-page-with-search-param">
+        <Content searchParams={searchParams} />
+      </div>
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/search-params/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/search-params/components/link-accordion.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: React.ReactNode
+  prefetch?: boolean
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link prefetch={prefetch} href={href}>
+          {children}
+        </Link>
+      ) : (
+        <>{children} (link is hidden)</>
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/search-params/next.config.js
+++ b/test/e2e/app-dir/segment-cache/search-params/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    ppr: true,
+    dynamicIO: true,
+    clientSegmentCache: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts
+++ b/test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts
@@ -1,0 +1,144 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from '../router-act'
+
+describe('segment cache (search params)', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+  if (isNextDev || skipped) {
+    test('ppr is disabled', () => {})
+    return
+  }
+
+  it('when fetching with PPR, does not include search params in the cache key', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/search-params', {
+      beforePageLoad(page: Playwright.Page) {
+        act = createRouterAct(page)
+      },
+    })
+
+    // Prefetch a page with search param `a_PPR`.
+    const revealA = await browser.elementByCss(
+      'input[data-link-accordion="/search-params/target-page?searchParam=a_PPR"]'
+    )
+    await act(
+      async () => {
+        await revealA.click()
+      },
+      // The response will include a shell of the page, but nothing that is
+      // based on the search param.
+      {
+        includes:
+          // This is the id assigned to a container div
+          'target-page-with-search-param',
+      }
+    )
+
+    // Prefetch the same page but with the search param changed to `c_PPR`.
+    const revealC = await browser.elementByCss(
+      'input[data-link-accordion="/search-params/target-page?searchParam=c_PPR"]'
+    )
+    await act(
+      async () => {
+        await revealC.click()
+      },
+      // This should not issue a new request for the page segment, because
+      // search params are not included in the the PPR shell. So we can reuse
+      // the shell we fetched for `searchParam=a`.
+      { includes: 'target-page-with-search-param', block: 'reject' }
+    )
+
+    // Navigate to one of the links.
+    const linkC = await browser.elementByCss(
+      'a[href="/search-params/target-page?searchParam=c_PPR"]'
+    )
+    await act(
+      async () => {
+        await linkC.click()
+      },
+      // The search param streams in on navigation
+      {
+        includes: 'Search param: c_PPR',
+      }
+    )
+    const result = await browser.elementById('target-page-with-search-param')
+    expect(await result.innerText()).toBe('Search param: c_PPR')
+  })
+
+  it('when fetching without PPR (e.g. prefetch={true}), includes the search params in the cache key', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/search-params', {
+      beforePageLoad(page: Playwright.Page) {
+        act = createRouterAct(page)
+      },
+    })
+
+    // Prefetch a page with search param `b_full`. This link has prefetch={true}
+    // so it will fetch the entire page, including the search param.
+    const revealB = await browser.elementByCss(
+      'input[data-link-accordion="/search-params/target-page?searchParam=b_full"]'
+    )
+    await act(
+      async () => {
+        await revealB.click()
+      },
+      // The response will include the entire page, including the search param.
+      {
+        includes: 'Search param: b_full',
+      }
+    )
+
+    // Prefetch a link with a different search param, and without
+    // prefetch={true}. This must fetch a new shell, because it can't use the
+    // entry we fetched for `searchParam=b_full` (because that one wasn't a
+    // shell — it included the search param).
+    const revealA = await browser.elementByCss(
+      'input[data-link-accordion="/search-params/target-page?searchParam=a_PPR"]'
+    )
+    await act(
+      async () => {
+        await revealA.click()
+      },
+      // The response will include a shell of the page, but nothing that is
+      // based on the search param.
+      { includes: 'target-page-with-search-param' }
+    )
+
+    // Prefetch a different link using prefetch={true}. Again, this must issue
+    // a new request, because it's a full page prefetch and we haven't fetched
+    // this particular search param before.
+    // TODO: As an future optimization, if a navigation to this link occurs
+    // before the prefetch completes, we could render the PPR shell in
+    // the meantime, since it contains no search params. This would effectively
+    // be a "per-segment fallback".
+    const revealD = await browser.elementByCss(
+      'input[data-link-accordion="/search-params/target-page?searchParam=d_full"]'
+    )
+    await act(
+      async () => {
+        await revealD.click()
+      },
+      // The response will include the entire page, including the search param.
+      { includes: 'Search param: d_full' }
+    )
+
+    // Navigate to one of the fully prefetched links.
+    const linkD = await browser.elementByCss(
+      'a[href="/search-params/target-page?searchParam=d_full"]'
+    )
+    await act(
+      async () => {
+        await linkD.click()
+        const result = await browser.elementById(
+          'target-page-with-search-param'
+        )
+        expect(await result.innerText()).toBe('Search param: d_full')
+      },
+      // No requests should be issued, because the page was fully prefetched.
+      'no-requests'
+    )
+  })
+})


### PR DESCRIPTION
This implements search param handling in the Segment Cache.

When a cache entry is fetched via PPR, search params are treated as dynamic data. We can share the same cache entry for every set of search params for a given page segment.

By contrast, when a cache entry is fetched using a dynamic request (e.g. using `<Link prefetch={true}`), the result may vary by the search param values. So we must include the search params in the cache key.

During a navigation, we will first check for the more specific cache entry (i.e. one that includes search params), and then fallback to the PPR version if no such entry exists.