### PR TITLE
[dev-overlay] update overlay toolbar icons

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/copy-button/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/copy-button/index.tsx
@@ -174,7 +174,17 @@ export function CopyButton({
 
   // Assign default icon
   const renderedIcon =
-    copyState.state === 'success' ? <CopySuccessIcon /> : icon || <CopyIcon />
+    copyState.state === 'success' ? (
+      <CopySuccessIcon />
+    ) : (
+      icon || (
+        <CopyIcon
+          width={14}
+          height={14}
+          className="error-overlay-toolbar-button-icon"
+        />
+      )
+    )
 
   return (
     <button
@@ -202,20 +212,19 @@ export function CopyButton({
   )
 }
 
-function CopyIcon() {
+function CopyIcon(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
-      width="16"
-      height="16"
-      viewBox="0 0 16 16"
+      width="14"
+      height="14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      className="error-overlay-toolbar-button-icon"
+      {...props}
     >
       <path
         fillRule="evenodd"
         clipRule="evenodd"
-        d="M2.75 0.5C1.7835 0.5 1 1.2835 1 2.25V9.75C1 10.7165 1.7835 11.5 2.75 11.5H3.75H4.5V10H3.75H2.75C2.61193 10 2.5 9.88807 2.5 9.75V2.25C2.5 2.11193 2.61193 2 2.75 2H8.25C8.38807 2 8.5 2.11193 8.5 2.25V3H10V2.25C10 1.2835 9.2165 0.5 8.25 0.5H2.75ZM7.75 4.5C6.7835 4.5 6 5.2835 6 6.25V13.75C6 14.7165 6.7835 15.5 7.75 15.5H13.25C14.2165 15.5 15 14.7165 15 13.75V6.25C15 5.2835 14.2165 4.5 13.25 4.5H7.75ZM7.5 6.25C7.5 6.11193 7.61193 6 7.75 6H13.25C13.3881 6 13.5 6.11193 13.5 6.25V13.75C13.5 13.8881 13.3881 14 13.25 14H7.75C7.61193 14 7.5 13.8881 7.5 13.75V6.25Z"
+        d="M2.406.438c-.845 0-1.531.685-1.531 1.53v6.563c0 .846.686 1.531 1.531 1.531H3.937V8.75H2.406a.219.219 0 0 1-.219-.219V1.97c0-.121.098-.219.22-.219h4.812c.12 0 .218.098.218.219v.656H8.75v-.656c0-.846-.686-1.532-1.531-1.532H2.406zm4.375 3.5c-.845 0-1.531.685-1.531 1.53v6.563c0 .846.686 1.531 1.531 1.531h4.813c.845 0 1.531-.685 1.531-1.53V5.468c0-.846-.686-1.532-1.531-1.532H6.78zm-.218 1.53c0-.12.097-.218.218-.218h4.813c.12 0 .219.098.219.219v6.562c0 .121-.098.219-.22.219H6.782a.219.219 0 0 1-.218-.219V5.47z"
         fill="currentColor"
       />
     </svg>

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/docs-link-button.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/docs-link-button.tsx
@@ -22,7 +22,11 @@ export function DocsLinkButton({ errorMessage }: { errorMessage: string }) {
   if (!docsURL) {
     return (
       <button className="docs-link-button" disabled>
-        <DocsIcon />
+        <DocsIcon
+          className="error-overlay-toolbar-button-icon"
+          width={14}
+          height={14}
+        />
       </button>
     )
   }
@@ -36,25 +40,28 @@ export function DocsLinkButton({ errorMessage }: { errorMessage: string }) {
       target="_blank"
       rel="noopener noreferrer"
     >
-      <DocsIcon />
+      <DocsIcon
+        className="error-overlay-toolbar-button-icon"
+        width={14}
+        height={14}
+      />
     </a>
   )
 }
 
-function DocsIcon() {
+function DocsIcon(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
-      width="16"
-      height="16"
-      viewBox="0 0 16 16"
+      width="14"
+      height="14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      className="error-overlay-toolbar-button-icon"
+      {...props}
     >
       <path
         fillRule="evenodd"
         clipRule="evenodd"
-        d="M0 1H0.75H5C6.2267 1 7.31583 1.58901 8 2.49963C8.68417 1.58901 9.7733 1 11 1H15.25H16V1.75V13V13.75H15.25H10.7426C10.1459 13.75 9.57361 13.9871 9.15165 14.409L8.53033 15.0303H7.46967L6.84835 14.409C6.42639 13.9871 5.8541 13.75 5.25736 13.75H0.75H0V13V1.75V1ZM7.25 4.75C7.25 3.50736 6.24264 2.5 5 2.5H1.5V12.25H5.25736C5.96786 12.25 6.65758 12.4516 7.25 12.8232V4.75ZM8.75 12.8232V4.75C8.75 3.50736 9.75736 2.5 11 2.5H14.5V12.25H10.7426C10.0321 12.25 9.34242 12.4516 8.75 12.8232Z"
+        d="M0 .875h4.375C5.448.875 6.401 1.39 7 2.187A3.276 3.276 0 0 1 9.625.875H14v11.156H9.4c-.522 0-1.023.208-1.392.577l-.544.543h-.928l-.544-.543c-.369-.37-.87-.577-1.392-.577H0V.875zm6.344 3.281a1.969 1.969 0 0 0-1.969-1.968H1.312v8.53H4.6c.622 0 1.225.177 1.744.502V4.156zm1.312 7.064V4.156c0-1.087.882-1.968 1.969-1.968h3.063v8.53H9.4c-.622 0-1.225.177-1.744.502z"
         fill="currentColor"
       />
     </svg>

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/error-overlay-toolbar.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/error-overlay-toolbar.stories.tsx
@@ -28,10 +28,3 @@ export const WithErrorOnly: Story = {
     debugInfo: undefined,
   },
 }
-
-export const WithoutError: Story = {
-  args: {
-    error: undefined,
-    debugInfo: undefined,
-  },
-}

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/error-overlay-toolbar.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/error-overlay-toolbar.tsx
@@ -16,10 +16,10 @@ export function ErrorOverlayToolbar({
   return (
     <span className="error-overlay-toolbar">
       <CopyStackTraceButton error={error} />
+      <DocsLinkButton errorMessage={error.message} />
       <NodejsInspectorButton
         devtoolsFrontendUrl={debugInfo?.devtoolsFrontendUrl}
       />
-      <DocsLinkButton errorMessage={error.message} />
     </span>
   )
 }
@@ -37,8 +37,8 @@ export const styles = css`
     justify-content: center;
     align-items: center;
 
-    width: 32px;
-    height: 32px;
+    width: 28px;
+    height: 28px;
     background: var(--color-background-100);
     background-clip: padding-box;
     border: 1px solid var(--color-gray-alpha-400);

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/nodejs-inspector-button.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/nodejs-inspector-button.tsx
@@ -19,27 +19,110 @@ const isChromeBrowser = isChrome()
 function NodeJsIcon(props: any) {
   return (
     <svg
-      width="44"
-      height="44"
-      viewBox="0 0 44 44"
+      width="14"
+      height="14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
-      <g clipPath="url(#clip0_1546_2)">
+      <mask
+        id="a"
+        style={{ maskType: 'luminance' }}
+        maskUnits="userSpaceOnUse"
+        x="0"
+        y="0"
+        width="14"
+        height="14"
+      >
         <path
-          d="M22 0L41.0526 11V33L22 44L2.94744 33V11L22 0Z"
-          fill="#71BD55"
+          d="M6.67.089 1.205 3.256a.663.663 0 0 0-.33.573v6.339c0 .237.126.455.33.574l5.466 3.17a.66.66 0 0 0 .66 0l5.465-3.17a.664.664 0 0 0 .329-.574V3.829a.663.663 0 0 0-.33-.573L7.33.089a.663.663 0 0 0-.661 0"
+          fill="#fff"
         />
+      </mask>
+      <g mask="url(#a)">
         <path
-          d="M41.0493 11.0001L41.0493 33L22 1.5583e-07L41.0493 11.0001Z"
-          fill="#A1DF83"
+          d="M18.648 2.717 3.248-4.86-4.648 11.31l15.4 7.58 7.896-16.174z"
+          fill="url(#b)"
         />
       </g>
+      <mask
+        id="c"
+        style={{ maskType: 'luminance' }}
+        maskUnits="userSpaceOnUse"
+        x="1"
+        y="0"
+        width="12"
+        height="14"
+      >
+        <path
+          d="M1.01 10.57a.663.663 0 0 0 .195.17l4.688 2.72.781.45a.66.66 0 0 0 .51.063l5.764-10.597a.653.653 0 0 0-.153-.122L9.216 1.18 7.325.087a.688.688 0 0 0-.171-.07L1.01 10.57z"
+          fill="#fff"
+        />
+      </mask>
+      <g mask="url(#c)">
+        <path
+          d="M-5.647 4.958 5.226 19.734l14.38-10.667L8.734-5.71-5.647 4.958z"
+          fill="url(#d)"
+        />
+      </g>
+      <g>
+        <mask
+          id="e"
+          style={{ maskType: 'luminance' }}
+          maskUnits="userSpaceOnUse"
+          x="1"
+          y="0"
+          width="13"
+          height="14"
+        >
+          <path
+            d="M6.934.004A.665.665 0 0 0 6.67.09L1.22 3.247l5.877 10.746a.655.655 0 0 0 .235-.08l5.465-3.17a.665.665 0 0 0 .319-.453L7.126.015a.684.684 0 0 0-.189-.01"
+            fill="#fff"
+          />
+        </mask>
+        <g mask="url(#e)">
+          <path d="M1.22.002v13.992h11.894V.002H1.22z" fill="url(#f)" />
+        </g>
+      </g>
       <defs>
-        <clipPath id="clip0_1546_2">
-          <rect width="44" height="44" fill="white" />
-        </clipPath>
+        <linearGradient
+          id="b"
+          x1="10.943"
+          y1="-1.084"
+          x2="2.997"
+          y2="15.062"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset=".3" stopColor="#3E863D" />
+          <stop offset=".5" stopColor="#55934F" />
+          <stop offset=".8" stopColor="#5AAD45" />
+        </linearGradient>
+        <linearGradient
+          id="d"
+          x1="-.145"
+          y1="12.431"
+          x2="14.277"
+          y2="1.818"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset=".57" stopColor="#3E863D" />
+          <stop offset=".72" stopColor="#619857" />
+          <stop offset="1" stopColor="#76AC64" />
+        </linearGradient>
+        <linearGradient
+          id="f"
+          x1="1.225"
+          y1="6.998"
+          x2="13.116"
+          y2="6.998"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset=".16" stopColor="#6BBF47" />
+          <stop offset=".38" stopColor="#79B461" />
+          <stop offset=".47" stopColor="#75AC64" />
+          <stop offset=".7" stopColor="#659E5A" />
+          <stop offset=".9" stopColor="#3E863D" />
+        </linearGradient>
       </defs>
     </svg>
   )
@@ -48,26 +131,111 @@ function NodeJsIcon(props: any) {
 function NodeJsDisabledIcon(props: any) {
   return (
     <svg
-      width="44"
-      height="44"
-      viewBox="0 0 44 44"
+      width="14"
+      height="14"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
-      <path
-        d="M4.44744 11.866L22 1.73205L39.5526 11.866V32.134L22 42.2679L4.44744 32.134V11.866Z"
-        stroke="currentColor"
-        fill="transparent"
-        strokeWidth="3"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M22 2L39 32"
-        stroke="currentColor"
-        strokeWidth="3"
-        strokeLinecap="round"
-      />
+      <mask
+        id="a"
+        style={{ maskType: 'luminance' }}
+        maskUnits="userSpaceOnUse"
+        x="0"
+        y="0"
+        width="14"
+        height="14"
+      >
+        <path
+          d="M6.67.089 1.205 3.256a.663.663 0 0 0-.33.573v6.339c0 .237.126.455.33.574l5.466 3.17a.66.66 0 0 0 .66 0l5.465-3.17a.664.664 0 0 0 .329-.574V3.829a.663.663 0 0 0-.33-.573L7.33.089a.663.663 0 0 0-.661 0"
+          fill="#fff"
+        />
+      </mask>
+      <g mask="url(#a)">
+        <path
+          d="M18.648 2.717 3.248-4.86-4.646 11.31l15.399 7.58 7.896-16.174z"
+          fill="url(#b)"
+        />
+      </g>
+      <mask
+        id="c"
+        style={{ maskType: 'luminance' }}
+        maskUnits="userSpaceOnUse"
+        x="1"
+        y="0"
+        width="12"
+        height="15"
+      >
+        <path
+          d="M1.01 10.571a.66.66 0 0 0 .195.172l4.688 2.718.781.451a.66.66 0 0 0 .51.063l5.764-10.597a.653.653 0 0 0-.153-.122L9.216 1.181 7.325.09a.688.688 0 0 0-.171-.07L1.01 10.572z"
+          fill="#fff"
+        />
+      </mask>
+      <g mask="url(#c)">
+        <path
+          d="M-5.647 4.96 5.226 19.736 19.606 9.07 8.734-5.707-5.647 4.96z"
+          fill="url(#d)"
+        />
+      </g>
+      <g>
+        <mask
+          id="e"
+          style={{ maskType: 'luminance' }}
+          maskUnits="userSpaceOnUse"
+          x="1"
+          y="0"
+          width="13"
+          height="14"
+        >
+          <path
+            d="M6.935.003a.665.665 0 0 0-.264.085l-5.45 3.158 5.877 10.747a.653.653 0 0 0 .235-.082l5.465-3.17a.665.665 0 0 0 .319-.452L7.127.014a.684.684 0 0 0-.189-.01"
+            fill="#fff"
+          />
+        </mask>
+        <g mask="url(#e)">
+          <path d="M1.222.001v13.992h11.893V0H1.222z" fill="url(#f)" />
+        </g>
+      </g>
+      <defs>
+        <linearGradient
+          id="b"
+          x1="10.944"
+          y1="-1.084"
+          x2="2.997"
+          y2="15.062"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset=".3" stopColor="#676767" />
+          <stop offset=".5" stopColor="#858585" />
+          <stop offset=".8" stopColor="#989A98" />
+        </linearGradient>
+        <linearGradient
+          id="d"
+          x1="-.145"
+          y1="12.433"
+          x2="14.277"
+          y2="1.819"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset=".57" stopColor="#747474" />
+          <stop offset=".72" stopColor="#707070" />
+          <stop offset="1" stopColor="#929292" />
+        </linearGradient>
+        <linearGradient
+          id="f"
+          x1="1.226"
+          y1="6.997"
+          x2="13.117"
+          y2="6.997"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset=".16" stopColor="#878787" />
+          <stop offset=".38" stopColor="#A9A9A9" />
+          <stop offset=".47" stopColor="#A5A5A5" />
+          <stop offset=".7" stopColor="#8F8F8F" />
+          <stop offset=".9" stopColor="#626262" />
+        </linearGradient>
+      </defs>
     </svg>
   )
 }
@@ -94,8 +262,8 @@ export function NodejsInspectorButton({
       >
         <NodeJsDisabledIcon
           className="error-overlay-toolbar-button-icon"
-          width={16}
-          height={16}
+          width={14}
+          height={14}
         />
       </a>
     )
@@ -110,8 +278,8 @@ export function NodejsInspectorButton({
       icon={
         <NodeJsIcon
           className="error-overlay-toolbar-button-icon"
-          width={16}
-          height={16}
+          width={14}
+          height={14}
         />
       }
     />


### PR DESCRIPTION
Updated the Node.js inspector icon and the sizes of icons from 16 to 14.

| | Enabled | Disabled |
|--------|--------|--------|
| Light | ![CleanShot 2025-02-14 at 00 45 20](https://github.com/user-attachments/assets/e2a93800-ee19-4d6e-9b53-a0cb78827fc8) | ![CleanShot 2025-02-14 at 00 45 43](https://github.com/user-attachments/assets/aeeee354-1fa6-4e80-93a0-bf799791317f) |
| Dark | ![CleanShot 2025-02-14 at 00 45 13](https://github.com/user-attachments/assets/c21ddba6-abbf-45ee-80ed-a7638b6353e3) | ![CleanShot 2025-02-14 at 00 45 48](https://github.com/user-attachments/assets/25b29b09-0735-4b23-a9bc-4047910f6fc9) | 

Closes NDX-642