### PR TITLE
[dev-overlay] add error env name label

### DIFF
--- a/packages/next/src/client/components/errors/console-error.ts
+++ b/packages/next/src/client/components/errors/console-error.ts
@@ -10,12 +10,20 @@ type UnhandledError = Error & {
   environmentName: string
 }
 
-export function createUnhandledError(message: string | Error): UnhandledError {
+export function createUnhandledError(
+  message: string | Error,
+  environmentName?: string | null
+): UnhandledError {
   const error = (
     typeof message === 'string' ? new Error(message) : message
   ) as UnhandledError
   error[digestSym] = 'NEXT_UNHANDLED_ERROR'
   error[consoleTypeSym] = typeof message === 'string' ? 'string' : 'error'
+
+  if (environmentName && !error.environmentName) {
+    error.environmentName = environmentName
+  }
+
   return error
 }
 

--- a/packages/next/src/client/components/errors/console-error.ts
+++ b/packages/next/src/client/components/errors/console-error.ts
@@ -7,6 +7,7 @@ const consoleTypeSym = Symbol.for('next.console.error.type')
 type UnhandledError = Error & {
   [digestSym]: 'NEXT_UNHANDLED_ERROR'
   [consoleTypeSym]: 'string' | 'error'
+  environmentName: string
 }
 
 export function createUnhandledError(message: string | Error): UnhandledError {

--- a/packages/next/src/client/components/errors/use-error-handler.ts
+++ b/packages/next/src/client/components/errors/use-error-handler.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { attachHydrationErrorState } from './attach-hydration-error-state'
 import { isNextRouterError } from '../is-next-router-error'
 import { storeHydrationErrorStateFromConsoleArgs } from './hydration-error-info'
-import { parseConsoleArgs } from '../../lib/console'
+import { formatConsoleArgs, parseConsoleArgs } from '../../lib/console'
 import isError from '../../../lib/is-error'
 import { createUnhandledError } from './console-error'
 import { enqueueConsecutiveDedupedError } from './enqueue-client-error'
@@ -25,9 +25,10 @@ export function handleClientError(
 ) {
   let error: Error
   if (!originError || !isError(originError)) {
-    const { formattedMessage, environmentName } =
-      parseConsoleArgs(consoleErrorArgs)
-    error = createUnhandledError(formattedMessage, environmentName)
+    // If it's not an error, format the args into an error
+    const formattedErrorMessage = formatConsoleArgs(consoleErrorArgs)
+    const { environmentName } = parseConsoleArgs(consoleErrorArgs)
+    error = createUnhandledError(formattedErrorMessage, environmentName)
   } else {
     error = capturedFromConsole
       ? createUnhandledError(originError)

--- a/packages/next/src/client/components/errors/use-error-handler.ts
+++ b/packages/next/src/client/components/errors/use-error-handler.ts
@@ -2,9 +2,12 @@ import { useEffect } from 'react'
 import { attachHydrationErrorState } from './attach-hydration-error-state'
 import { isNextRouterError } from '../is-next-router-error'
 import { storeHydrationErrorStateFromConsoleArgs } from './hydration-error-info'
-import { formatConsoleArgs } from '../../lib/console'
+import { formatConsoleArgs, parseEnvironmentName } from '../../lib/console'
 import isError from '../../../lib/is-error'
-import { createUnhandledError } from './console-error'
+import {
+  createUnhandledError,
+  isUnhandledConsoleOrRejection,
+} from './console-error'
 import { enqueueConsecutiveDedupedError } from './enqueue-client-error'
 import { getReactStitchedError } from '../errors/stitched-error'
 
@@ -34,6 +37,15 @@ export function handleClientError(
       : originError
   }
   error = getReactStitchedError(error)
+
+  if (isUnhandledConsoleOrRejection(error)) {
+    if (!error.environmentName) {
+      const environmentName = parseEnvironmentName(consoleErrorArgs)
+      if (environmentName) {
+        error.environmentName = environmentName
+      }
+    }
+  }
 
   storeHydrationErrorStateFromConsoleArgs(...consoleErrorArgs)
   attachHydrationErrorState(error)

--- a/packages/next/src/client/components/errors/use-error-handler.ts
+++ b/packages/next/src/client/components/errors/use-error-handler.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { attachHydrationErrorState } from './attach-hydration-error-state'
 import { isNextRouterError } from '../is-next-router-error'
 import { storeHydrationErrorStateFromConsoleArgs } from './hydration-error-info'
-import { formatConsoleArgs, parseEnvironmentName } from '../../lib/console'
+import { formatConsoleArgs, parseConsoleArgs } from '../../lib/console'
 import isError from '../../../lib/is-error'
 import {
   createUnhandledError,
@@ -40,7 +40,7 @@ export function handleClientError(
 
   if (isUnhandledConsoleOrRejection(error)) {
     if (!error.environmentName) {
-      const environmentName = parseEnvironmentName(consoleErrorArgs)
+      const { environmentName } = parseConsoleArgs(consoleErrorArgs)
       if (environmentName) {
         error.environmentName = environmentName
       }

--- a/packages/next/src/client/components/errors/use-error-handler.ts
+++ b/packages/next/src/client/components/errors/use-error-handler.ts
@@ -2,12 +2,9 @@ import { useEffect } from 'react'
 import { attachHydrationErrorState } from './attach-hydration-error-state'
 import { isNextRouterError } from '../is-next-router-error'
 import { storeHydrationErrorStateFromConsoleArgs } from './hydration-error-info'
-import { formatConsoleArgs, parseConsoleArgs } from '../../lib/console'
+import { parseConsoleArgs } from '../../lib/console'
 import isError from '../../../lib/is-error'
-import {
-  createUnhandledError,
-  isUnhandledConsoleOrRejection,
-} from './console-error'
+import { createUnhandledError } from './console-error'
 import { enqueueConsecutiveDedupedError } from './enqueue-client-error'
 import { getReactStitchedError } from '../errors/stitched-error'
 
@@ -28,24 +25,15 @@ export function handleClientError(
 ) {
   let error: Error
   if (!originError || !isError(originError)) {
-    // If it's not an error, format the args into an error
-    const formattedErrorMessage = formatConsoleArgs(consoleErrorArgs)
-    error = createUnhandledError(formattedErrorMessage)
+    const { formattedMessage, environmentName } =
+      parseConsoleArgs(consoleErrorArgs)
+    error = createUnhandledError(formattedMessage, environmentName)
   } else {
     error = capturedFromConsole
       ? createUnhandledError(originError)
       : originError
   }
   error = getReactStitchedError(error)
-
-  if (isUnhandledConsoleOrRejection(error)) {
-    if (!error.environmentName) {
-      const { environmentName } = parseConsoleArgs(consoleErrorArgs)
-      if (environmentName) {
-        error.environmentName = environmentName
-      }
-    }
-  }
 
   storeHydrationErrorStateFromConsoleArgs(...consoleErrorArgs)
   attachHydrationErrorState(error)

--- a/packages/next/src/client/components/globals/intercept-console-error.ts
+++ b/packages/next/src/client/components/globals/intercept-console-error.ts
@@ -1,6 +1,7 @@
 import isError from '../../../lib/is-error'
 import { isNextRouterError } from '../is-next-router-error'
 import { handleClientError } from '../errors/use-error-handler'
+import { parseConsoleArgs } from '../../lib/console'
 
 export const originConsoleError = window.console.error
 
@@ -13,7 +14,7 @@ export function patchConsoleError() {
   window.console.error = function error(...args: any[]) {
     let maybeError: unknown
     if (process.env.NODE_ENV !== 'production') {
-      const replayedError = matchReplayedError(...args)
+      const { error: replayedError } = parseConsoleArgs(args)
       if (replayedError) {
         maybeError = replayedError
       } else if (isError(args[0])) {
@@ -40,35 +41,4 @@ export function patchConsoleError() {
       originConsoleError.apply(window.console, args)
     }
   }
-}
-
-function matchReplayedError(...args: unknown[]): Error | null {
-  // See
-  // https://github.com/facebook/react/blob/65a56d0e99261481c721334a3ec4561d173594cd/packages/react-devtools-shared/src/backend/flight/renderer.js#L88-L93
-  //
-  // Logs replayed from the server look like this:
-  // [
-  //   "%c%s%c %o\n\n%s\n\n%s\n",
-  //   "background: #e6e6e6; ...",
-  //   " Server ", // can also be e.g. " Prerender "
-  //   "",
-  //   Error
-  //   "The above error occurred in the <Page> component."
-  //   ...
-  // ]
-  if (
-    args.length > 3 &&
-    typeof args[0] === 'string' &&
-    args[0].startsWith('%c%s%c ') &&
-    typeof args[1] === 'string' &&
-    typeof args[2] === 'string' &&
-    typeof args[3] === 'string'
-  ) {
-    const maybeError = args[4]
-    if (isError(maybeError)) {
-      return maybeError
-    }
-  }
-
-  return null
 }

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/environment-name-label/environment-name-label.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/environment-name-label/environment-name-label.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { EnvironmentNameLabel } from './environment-name-label'
+import { withShadowPortal } from '../../../storybook/with-shadow-portal'
+
+const meta: Meta<typeof EnvironmentNameLabel> = {
+  component: EnvironmentNameLabel,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [withShadowPortal],
+}
+
+export default meta
+type Story = StoryObj<typeof EnvironmentNameLabel>
+
+export const Server: Story = {
+  args: {
+    environmentName: 'Server',
+  },
+}
+
+export const Prerender: Story = {
+  args: {
+    environmentName: 'Prerender',
+  },
+}
+
+export const Cache: Story = {
+  args: {
+    environmentName: 'Cache',
+  },
+}

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/environment-name-label/environment-name-label.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/environment-name-label/environment-name-label.tsx
@@ -1,0 +1,24 @@
+import { noop as css } from '../../../helpers/noop-template'
+
+export function EnvironmentNameLabel({
+  environmentName,
+}: {
+  environmentName: string
+}) {
+  return <span data-nextjs-environment-name-label>{environmentName}</span>
+}
+
+export const ENVIRONMENT_NAME_LABEL_STYLES = css`
+  [data-nextjs-environment-name-label] {
+    padding: var(--size-0_5) var(--size-1_5);
+    margin: 0;
+    /* used --size instead of --rounded because --rounded is missing 6px */
+    border-radius: var(--size-1_5);
+    background: var(--color-gray-300);
+    font-weight: 600;
+    font-size: var(--size-font-11);
+    color: var(--color-gray-900);
+    font-family: var(--font-stack-monospace);
+    line-height: var(--size-5);
+  }
+`

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-layout/error-overlay-layout.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-layout/error-overlay-layout.tsx
@@ -33,13 +33,14 @@ import { OVERLAY_STYLES, ErrorOverlayOverlay } from '../overlay/overlay'
 import { ErrorOverlayBottomStack } from '../error-overlay-bottom-stack'
 import type { ErrorBaseProps } from '../error-overlay/error-overlay'
 import type { ReadyRuntimeError } from '../../../../../internal/helpers/get-error-by-type'
+import { EnvironmentNameLabel } from '../environment-name-label/environment-name-label'
 
 interface ErrorOverlayLayoutProps extends ErrorBaseProps {
   errorMessage: ErrorMessageType
   errorType: ErrorType
   children?: React.ReactNode
   errorCode?: string
-  error: Error
+  error: ReadyRuntimeError['error']
   debugInfo?: DebugInfo
   isBuildError?: boolean
   onClose?: () => void
@@ -51,6 +52,7 @@ interface ErrorOverlayLayoutProps extends ErrorBaseProps {
   dialogResizerRef?: React.RefObject<HTMLDivElement | null>
 }
 
+// TODO: Clean up and improve composition.
 export function ErrorOverlayLayout({
   errorMessage,
   errorType,
@@ -97,7 +99,14 @@ export function ErrorOverlayLayout({
                 // allow assertion in tests before error rating is implemented
                 data-nextjs-error-code={errorCode}
               >
-                <ErrorTypeLabel errorType={errorType} />
+                <span data-nextjs-error-label-group>
+                  <ErrorTypeLabel errorType={errorType} />
+                  {error.environmentName && (
+                    <EnvironmentNameLabel
+                      environmentName={error.environmentName}
+                    />
+                  )}
+                </span>
                 <ErrorOverlayToolbar error={error} debugInfo={debugInfo} />
               </div>
               <ErrorMessage errorMessage={errorMessage} />
@@ -141,4 +150,10 @@ export const styles = css`
   ${errorMessageStyles}
   ${toolbarStyles}
   ${CALL_STACK_STYLES}
+
+  [data-nextjs-error-label-group] {
+    display: flex;
+    align-items: center;
+    gap: var(--size-2);
+  }
 `

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-layout/error-overlay-layout.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-layout/error-overlay-layout.tsx
@@ -52,7 +52,6 @@ interface ErrorOverlayLayoutProps extends ErrorBaseProps {
   dialogResizerRef?: React.RefObject<HTMLDivElement | null>
 }
 
-// TODO: Clean up and improve composition.
 export function ErrorOverlayLayout({
   errorMessage,
   errorType,

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-type-label/error-type-label.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-type-label/error-type-label.tsx
@@ -28,7 +28,7 @@ export const styles = css`
     margin: 0;
     /* used --size instead of --rounded because --rounded is missing 6px */
     border-radius: var(--size-1_5);
-    background: var(--color-red-100);
+    background: var(--color-red-300);
     font-weight: 600;
     font-size: var(--size-font-11);
     color: var(--color-red-900);

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.tsx
@@ -53,11 +53,15 @@ function ErrorDescription({
       ? ''
       : error.name + ': '
 
+  const environmentName =
+    'environmentName' in error ? error.environmentName : ''
+  const envPrefix = environmentName ? `[ ${environmentName} ] ` : ''
+
   // The environment name will be displayed as a label, so remove it
   // from the message (e.g. "[ Server ] hello world" -> "hello world").
   let message = error.message
-  if ('environmentName' in error) {
-    message = message.slice(`[ ${error.environmentName} ] `.length)
+  if (message.startsWith(envPrefix)) {
+    message = message.slice(envPrefix.length)
   }
 
   return (

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.tsx
@@ -53,16 +53,18 @@ function ErrorDescription({
       ? ''
       : error.name + ': '
 
-  // If it's replayed error, display the environment name
-  const environmentName =
-    'environmentName' in error ? error['environmentName'] : ''
-  const envPrefix = environmentName ? `[ ${environmentName} ] ` : ''
+  // The environment name will be displayed as a label, so remove it
+  // from the message (e.g. "[ Server ] hello world" -> "hello world").
+  let message = error.message
+  if ('environmentName' in error) {
+    message = message.slice(`[ ${error.environmentName} ] `.length)
+  }
+
   return (
     <>
-      {envPrefix}
       {title}
       <HotlinkedText
-        text={hydrationWarning || error.message}
+        text={hydrationWarning || message}
         matcher={isNextjsLink}
       />
     </>

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/styles/component-styles.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/styles/component-styles.tsx
@@ -16,13 +16,14 @@ import { CALL_STACK_FRAME_STYLES } from '../components/call-stack-frame/call-sta
 import { styles as devToolsIndicator } from '../components/errors/dev-tools-indicator/styles'
 import { noop as css } from '../helpers/noop-template'
 import { EDITOR_LINK_STYLES } from '../components/terminal/editor-link'
-
+import { ENVIRONMENT_NAME_LABEL_STYLES } from '../components/errors/environment-name-label/environment-name-label'
 export function ComponentStyles() {
   return (
     <style>
       {css`
         ${COPY_BUTTON_STYLES}
         ${CALL_STACK_FRAME_STYLES}
+        ${ENVIRONMENT_NAME_LABEL_STYLES}
         ${overlay}
         ${toast}
         ${dialog}

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
@@ -84,9 +84,10 @@ function ErrorDescription({
   const environmentName =
     'environmentName' in error ? error['environmentName'] : ''
   const envPrefix = environmentName ? `[ ${environmentName} ] ` : ''
+  const isMsgMissingEnvPrefix = !error.message.startsWith(envPrefix)
   return (
     <>
-      {envPrefix}
+      {isMsgMissingEnvPrefix && envPrefix}
       {title}
       <HotlinkedText
         text={hydrationWarning || error.message}

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/get-error-by-type.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/get-error-by-type.ts
@@ -12,7 +12,7 @@ import React from 'react'
 export type ReadyRuntimeError = {
   id: number
   runtime: true
-  error: Error
+  error: Error & { environmentName?: string }
   frames: OriginalStackFrame[] | (() => Promise<OriginalStackFrame[]>)
   componentStackFrames?: ComponentStackFrame[]
 }

--- a/packages/next/src/client/lib/console.ts
+++ b/packages/next/src/client/lib/console.ts
@@ -112,7 +112,6 @@ export function formatConsoleArgs(args: unknown[]): string {
   return result
 }
 
-// TODO: Infer type for `environmentName` if available.
 export function parseConsoleArgs(args: unknown[]): {
   environmentName: string | null
   error: Error | null

--- a/packages/next/src/client/lib/console.ts
+++ b/packages/next/src/client/lib/console.ts
@@ -109,3 +109,33 @@ export function formatConsoleArgs(args: unknown[]): string {
 
   return result
 }
+
+// TODO: Infer type for `environmentName` if available.
+export function parseEnvironmentName(args: unknown[]): string | null {
+  // See
+  // https://github.com/facebook/react/blob/65a56d0e99261481c721334a3ec4561d173594cd/packages/react-devtools-shared/src/backend/flight/renderer.js#L88-L93
+  //
+  // Logs replayed from the server look like this:
+  // [
+  //   "%c%s%c %o\n\n%s\n\n%s\n",
+  //   "background: #e6e6e6; ...",
+  //   " Server ", // can also be e.g. " Prerender "
+  //   "",
+  //   Error
+  //   "The above error occurred in the <Page> component."
+  //   ...
+  // ]
+  if (
+    args.length > 3 &&
+    typeof args[0] === 'string' &&
+    args[0].startsWith('%c%s%c ') &&
+    typeof args[1] === 'string' &&
+    typeof args[2] === 'string' &&
+    typeof args[3] === 'string'
+  ) {
+    const environmentName = args[2]
+    return environmentName.trim()
+  }
+
+  return null
+}

--- a/packages/next/src/client/lib/console.ts
+++ b/packages/next/src/client/lib/console.ts
@@ -115,7 +115,6 @@ export function formatConsoleArgs(args: unknown[]): string {
 export function parseConsoleArgs(args: unknown[]): {
   environmentName: string | null
   error: Error | null
-  formattedMessage: string
 } {
   // See
   // https://github.com/facebook/react/blob/65a56d0e99261481c721334a3ec4561d173594cd/packages/react-devtools-shared/src/backend/flight/renderer.js#L88-L93
@@ -141,18 +140,14 @@ export function parseConsoleArgs(args: unknown[]): {
     const environmentName = args[2]
     const maybeError = args[4]
 
-    const formattedMessage = formatConsoleArgs(args)
-
     return {
       environmentName: environmentName.trim(),
       error: isError(maybeError) ? maybeError : null,
-      formattedMessage,
     }
   }
 
   return {
     environmentName: null,
     error: null,
-    formattedMessage: '',
   }
 }

--- a/packages/next/src/client/lib/console.ts
+++ b/packages/next/src/client/lib/console.ts
@@ -115,6 +115,7 @@ export function formatConsoleArgs(args: unknown[]): string {
 export function parseConsoleArgs(args: unknown[]): {
   environmentName: string | null
   error: Error | null
+  formattedMessage: string
 } {
   // See
   // https://github.com/facebook/react/blob/65a56d0e99261481c721334a3ec4561d173594cd/packages/react-devtools-shared/src/backend/flight/renderer.js#L88-L93
@@ -125,8 +126,8 @@ export function parseConsoleArgs(args: unknown[]): {
   //   "background: #e6e6e6; ...",
   //   " Server ", // can also be e.g. " Prerender "
   //   "",
-  //   Error
-  //   "The above error occurred in the <Page> component."
+  //   Error,
+  //   "The above error occurred in the <Page> component.",
   //   ...
   // ]
   if (
@@ -140,14 +141,18 @@ export function parseConsoleArgs(args: unknown[]): {
     const environmentName = args[2]
     const maybeError = args[4]
 
+    const formattedMessage = formatConsoleArgs(args)
+
     return {
       environmentName: environmentName.trim(),
       error: isError(maybeError) ? maybeError : null,
+      formattedMessage,
     }
   }
 
   return {
     environmentName: null,
     error: null,
+    formattedMessage: '',
   }
 }

--- a/packages/next/src/client/lib/console.ts
+++ b/packages/next/src/client/lib/console.ts
@@ -1,3 +1,5 @@
+import isError from '../../lib/is-error'
+
 function formatObject(arg: unknown, depth: number) {
   switch (typeof arg) {
     case 'object':
@@ -111,7 +113,10 @@ export function formatConsoleArgs(args: unknown[]): string {
 }
 
 // TODO: Infer type for `environmentName` if available.
-export function parseEnvironmentName(args: unknown[]): string | null {
+export function parseConsoleArgs(args: unknown[]): {
+  environmentName: string | null
+  error: Error | null
+} {
   // See
   // https://github.com/facebook/react/blob/65a56d0e99261481c721334a3ec4561d173594cd/packages/react-devtools-shared/src/backend/flight/renderer.js#L88-L93
   //
@@ -134,8 +139,16 @@ export function parseEnvironmentName(args: unknown[]): string | null {
     typeof args[3] === 'string'
   ) {
     const environmentName = args[2]
-    return environmentName.trim()
+    const maybeError = args[4]
+
+    return {
+      environmentName: environmentName.trim(),
+      error: isError(maybeError) ? maybeError : null,
+    }
   }
 
-  return null
+  return {
+    environmentName: null,
+    error: null,
+  }
 }

--- a/test/development/acceptance-app/dynamic-error.test.ts
+++ b/test/development/acceptance-app/dynamic-error.test.ts
@@ -32,7 +32,7 @@ describe('dynamic = "error" in devmode', () => {
     const { session } = sandbox
     await session.assertHasRedbox()
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-      `"[ Server ] Error: Route /server with \`dynamic = "error"\` couldn't be rendered statically because it used \`cookies\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering"`
+      `"${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: Route /server with \`dynamic = "error"\` couldn't be rendered statically because it used \`cookies\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering"`
     )
   })
 })

--- a/test/development/acceptance-app/dynamic-error.test.ts
+++ b/test/development/acceptance-app/dynamic-error.test.ts
@@ -31,8 +31,15 @@ describe('dynamic = "error" in devmode', () => {
     )
     const { session } = sandbox
     await session.assertHasRedbox()
-    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-      `"${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: Route /server with \`dynamic = "error"\` couldn't be rendered statically because it used \`cookies\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering"`
-    )
+    const description = await session.getRedboxDescription()
+    if (process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true') {
+      expect(description).toMatchInlineSnapshot(
+        `"Error: Route /server with \`dynamic = "error"\` couldn't be rendered statically because it used \`cookies\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering"`
+      )
+    } else {
+      expect(description).toMatchInlineSnapshot(
+        `"[ Server ] Error: Route /server with \`dynamic = "error"\` couldn't be rendered statically because it used \`cookies\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering"`
+      )
+    }
   })
 })

--- a/test/development/app-dir/capture-console-error-owner-stack/capture-console-error-owner-stack.test.ts
+++ b/test/development/app-dir/capture-console-error-owner-stack/capture-console-error-owner-stack.test.ts
@@ -204,8 +204,7 @@ describe('app-dir - capture-console-error-owner-stack', () => {
     const result = await getRedboxResult(browser)
 
     if (process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true') {
-      if (process.env.TURBOPACK) {
-        expect(result).toMatchInlineSnapshot(`
+      expect(result).toMatchInlineSnapshot(`
          {
            "callStacks": "Page
          app/rsc/page.js (2:17)
@@ -227,30 +226,6 @@ describe('app-dir - capture-console-error-owner-stack', () => {
          Server",
          }
         `)
-      } else {
-        expect(result).toMatchInlineSnapshot(`
-         {
-           "callStacks": "Page
-         app/rsc/page.js (2:17)
-         JSON.parse
-         <anonymous> (0:0)
-         Page
-         <anonymous> (0:0)",
-           "count": 1,
-           "description": "Error: boom",
-           "source": "app/rsc/page.js (2:17) @ Page
-
-           1 | export default function Page() {
-         > 2 |   console.error(new Error('boom'))
-             |                 ^
-           3 |   return <p>rsc</p>
-           4 | }
-           5 |",
-           "title": "Console Error
-         Server",
-         }
-        `)
-      }
     } else {
       if (process.env.TURBOPACK) {
         expect(result).toMatchInlineSnapshot(`

--- a/test/development/app-dir/capture-console-error-owner-stack/capture-console-error-owner-stack.test.ts
+++ b/test/development/app-dir/capture-console-error-owner-stack/capture-console-error-owner-stack.test.ts
@@ -213,7 +213,7 @@ describe('app-dir - capture-console-error-owner-stack', () => {
        Page
        <anonymous> (0:0)",
          "count": 1,
-         "description": "[ Server ] Error: boom",
+         "description": "${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: boom",
          "source": "app/rsc/page.js (2:17) @ Page
 
          1 | export default function Page() {
@@ -235,7 +235,7 @@ describe('app-dir - capture-console-error-owner-stack', () => {
        Page
        <anonymous> (0:0)",
          "count": 1,
-         "description": "[ Server ] Error: boom",
+         "description": "${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: boom",
          "source": "app/rsc/page.js (2:17) @ Page
 
          1 | export default function Page() {

--- a/test/development/app-dir/capture-console-error-owner-stack/capture-console-error-owner-stack.test.ts
+++ b/test/development/app-dir/capture-console-error-owner-stack/capture-console-error-owner-stack.test.ts
@@ -203,8 +203,9 @@ describe('app-dir - capture-console-error-owner-stack', () => {
 
     const result = await getRedboxResult(browser)
 
-    if (process.env.TURBOPACK) {
-      expect(result).toMatchInlineSnapshot(`
+    if (process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true') {
+      if (process.env.TURBOPACK) {
+        expect(result).toMatchInlineSnapshot(`
        {
          "callStacks": "Page
        app/rsc/page.js (2:17)
@@ -213,7 +214,7 @@ describe('app-dir - capture-console-error-owner-stack', () => {
        Page
        <anonymous> (0:0)",
          "count": 1,
-         "description": "${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: boom",
+         "description": "[ Server ] Error: boom",
          "source": "app/rsc/page.js (2:17) @ Page
 
          1 | export default function Page() {
@@ -225,8 +226,32 @@ describe('app-dir - capture-console-error-owner-stack', () => {
          "title": "Console Error",
        }
       `)
+      } else {
+        expect(result).toMatchInlineSnapshot(`
+       {
+         "callStacks": "Page
+       app/rsc/page.js (2:17)
+       JSON.parse
+       <anonymous> (0:0)
+       Page
+       <anonymous> (0:0)",
+         "count": 1,
+         "description": "[ Server ] Error: boom",
+         "source": "app/rsc/page.js (2:17) @ Page
+
+         1 | export default function Page() {
+       > 2 |   console.error(new Error('boom'))
+           |                 ^
+         3 |   return <p>rsc</p>
+         4 | }
+         5 |",
+         "title": "Console Error",
+       }
+      `)
+      }
     } else {
-      expect(result).toMatchInlineSnapshot(`
+      if (process.env.TURBOPACK) {
+        expect(result).toMatchInlineSnapshot(`
        {
          "callStacks": "Page
        app/rsc/page.js (2:17)
@@ -235,7 +260,7 @@ describe('app-dir - capture-console-error-owner-stack', () => {
        Page
        <anonymous> (0:0)",
          "count": 1,
-         "description": "${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: boom",
+         "description": "[ Server ] Error: boom",
          "source": "app/rsc/page.js (2:17) @ Page
 
          1 | export default function Page() {
@@ -247,6 +272,29 @@ describe('app-dir - capture-console-error-owner-stack', () => {
          "title": "Console Error",
        }
       `)
+      } else {
+        expect(result).toMatchInlineSnapshot(`
+       {
+         "callStacks": "Page
+       app/rsc/page.js (2:17)
+       JSON.parse
+       <anonymous> (0:0)
+       Page
+       <anonymous> (0:0)",
+         "count": 1,
+         "description": "[ Server ] Error: boom",
+         "source": "app/rsc/page.js (2:17) @ Page
+
+         1 | export default function Page() {
+       > 2 |   console.error(new Error('boom'))
+           |                 ^
+         3 |   return <p>rsc</p>
+         4 | }
+         5 |",
+         "title": "Console Error",
+       }
+      `)
+      }
     }
   })
 

--- a/test/development/app-dir/capture-console-error-owner-stack/capture-console-error-owner-stack.test.ts
+++ b/test/development/app-dir/capture-console-error-owner-stack/capture-console-error-owner-stack.test.ts
@@ -206,48 +206,50 @@ describe('app-dir - capture-console-error-owner-stack', () => {
     if (process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true') {
       if (process.env.TURBOPACK) {
         expect(result).toMatchInlineSnapshot(`
-       {
-         "callStacks": "Page
-       app/rsc/page.js (2:17)
-       JSON.parse
-       <anonymous> (0:0)
-       Page
-       <anonymous> (0:0)",
-         "count": 1,
-         "description": "[ Server ] Error: boom",
-         "source": "app/rsc/page.js (2:17) @ Page
+         {
+           "callStacks": "Page
+         app/rsc/page.js (2:17)
+         JSON.parse
+         <anonymous> (0:0)
+         Page
+         <anonymous> (0:0)",
+           "count": 1,
+           "description": "Error: boom",
+           "source": "app/rsc/page.js (2:17) @ Page
 
-         1 | export default function Page() {
-       > 2 |   console.error(new Error('boom'))
-           |                 ^
-         3 |   return <p>rsc</p>
-         4 | }
-         5 |",
-         "title": "Console Error",
-       }
-      `)
+           1 | export default function Page() {
+         > 2 |   console.error(new Error('boom'))
+             |                 ^
+           3 |   return <p>rsc</p>
+           4 | }
+           5 |",
+           "title": "Console Error
+         Server",
+         }
+        `)
       } else {
         expect(result).toMatchInlineSnapshot(`
-       {
-         "callStacks": "Page
-       app/rsc/page.js (2:17)
-       JSON.parse
-       <anonymous> (0:0)
-       Page
-       <anonymous> (0:0)",
-         "count": 1,
-         "description": "[ Server ] Error: boom",
-         "source": "app/rsc/page.js (2:17) @ Page
+         {
+           "callStacks": "Page
+         app/rsc/page.js (2:17)
+         JSON.parse
+         <anonymous> (0:0)
+         Page
+         <anonymous> (0:0)",
+           "count": 1,
+           "description": "Error: boom",
+           "source": "app/rsc/page.js (2:17) @ Page
 
-         1 | export default function Page() {
-       > 2 |   console.error(new Error('boom'))
-           |                 ^
-         3 |   return <p>rsc</p>
-         4 | }
-         5 |",
-         "title": "Console Error",
-       }
-      `)
+           1 | export default function Page() {
+         > 2 |   console.error(new Error('boom'))
+             |                 ^
+           3 |   return <p>rsc</p>
+           4 | }
+           5 |",
+           "title": "Console Error
+         Server",
+         }
+        `)
       }
     } else {
       if (process.env.TURBOPACK) {

--- a/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
+++ b/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
@@ -19,14 +19,23 @@ describe('Dynamic IO Dev Errors', () => {
     files: __dirname,
   })
 
+  const isNewOverlay =
+    process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
+
   it('should show a red box error on the SSR render', async () => {
     const browser = await next.browser('/error')
 
     await openRedbox(browser)
 
-    expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
-      `"${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random"`
-    )
+    if (isNewOverlay) {
+      expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
+        `"Error: Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random"`
+      )
+    } else {
+      expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
+        `"[ Server ] Error: Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random"`
+      )
+    }
   })
 
   it('should show a red box error on client navigations', async () => {
@@ -39,10 +48,15 @@ describe('Dynamic IO Dev Errors', () => {
     await browser.elementByCss("[href='/error']").click()
 
     await openRedbox(browser)
-
-    expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
-      `"${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random"`
-    )
+    if (isNewOverlay) {
+      expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
+        `"Error: Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random"`
+      )
+    } else {
+      expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
+        `"[ Server ] Error: Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random"`
+      )
+    }
   })
 
   it('should not log unhandled rejections for persistently thrown top-level errors', async () => {
@@ -86,9 +100,15 @@ describe('Dynamic IO Dev Errors', () => {
 
     const description = await getRedboxDescription(browser)
 
-    expect(description).toMatchInlineSnapshot(
-      `"${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: Route "/no-accessed-data": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense"`
-    )
+    if (isNewOverlay) {
+      expect(description).toMatchInlineSnapshot(
+        `"Error: Route "/no-accessed-data": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense"`
+      )
+    } else {
+      expect(description).toMatchInlineSnapshot(
+        `"[ Server ] Error: Route "/no-accessed-data": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense"`
+      )
+    }
 
     // Expand the stack frames, since the first frame `Page [Server] <anonymous>` is treated as ignored.
     // TODO: Remove the filter of anonymous frames when we have a better way to handle them.

--- a/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
+++ b/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
@@ -25,7 +25,7 @@ describe('Dynamic IO Dev Errors', () => {
     await openRedbox(browser)
 
     expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
-      `"[ Server ] Error: Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random"`
+      `"${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random"`
     )
   })
 
@@ -41,7 +41,7 @@ describe('Dynamic IO Dev Errors', () => {
     await openRedbox(browser)
 
     expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
-      `"[ Server ] Error: Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random"`
+      `"${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random"`
     )
   })
 
@@ -87,7 +87,7 @@ describe('Dynamic IO Dev Errors', () => {
     const description = await getRedboxDescription(browser)
 
     expect(description).toMatchInlineSnapshot(
-      `"[ Server ] Error: Route "/no-accessed-data": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense"`
+      `"${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: Route "/no-accessed-data": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense"`
     )
 
     // Expand the stack frames, since the first frame `Page [Server] <anonymous>` is treated as ignored.

--- a/test/development/app-dir/serialize-circular-error/serialize-circular-error.test.ts
+++ b/test/development/app-dir/serialize-circular-error/serialize-circular-error.test.ts
@@ -17,7 +17,7 @@ describe('serialize-circular-error', () => {
     const description = await getRedboxDescription(browser)
     // React cannot serialize thrown objects with circular references
     expect(description).toBe(
-      '[ Server ] Error: An error occurred but serializing the error message failed.'
+      `${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: An error occurred but serializing the error message failed.`
     )
 
     const output = next.cliOutput

--- a/test/development/app-dir/serialize-circular-error/serialize-circular-error.test.ts
+++ b/test/development/app-dir/serialize-circular-error/serialize-circular-error.test.ts
@@ -16,9 +16,15 @@ describe('serialize-circular-error', () => {
 
     const description = await getRedboxDescription(browser)
     // React cannot serialize thrown objects with circular references
-    expect(description).toBe(
-      `${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: An error occurred but serializing the error message failed.`
-    )
+    if (process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true') {
+      expect(description).toBe(
+        `Error: An error occurred but serializing the error message failed.`
+      )
+    } else {
+      expect(description).toBe(
+        `[ Server ] Error: An error occurred but serializing the error message failed.`
+      )
+    }
 
     const output = next.cliOutput
     expect(output).toContain(

--- a/test/e2e/app-dir/global-error/basic/index.test.ts
+++ b/test/e2e/app-dir/global-error/basic/index.test.ts
@@ -6,6 +6,9 @@ describe('app dir - global error', () => {
     files: __dirname,
   })
 
+  const isNewOverlay =
+    process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
+
   it('should trigger error component when an error happens during rendering', async () => {
     const browser = await next.browser('/client')
     await browser
@@ -30,9 +33,13 @@ describe('app dir - global error', () => {
     if (isNextDev) {
       await assertHasRedbox(browser)
       const description = await getRedboxDescription(browser)
-      expect(description).toMatchInlineSnapshot(
-        `"${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: server page error"`
-      )
+      if (isNewOverlay) {
+        expect(description).toMatchInlineSnapshot(`"Error: server page error"`)
+      } else {
+        expect(description).toMatchInlineSnapshot(
+          `"[ Server ] Error: server page error"`
+        )
+      }
     }
     // Show original error message in dev mode, but hide with the react fallback RSC error message in production mode
     expect(await browser.elementByCss('#error').text()).toBe(
@@ -74,9 +81,13 @@ describe('app dir - global error', () => {
     if (isNextDev) {
       await assertHasRedbox(browser)
       const description = await getRedboxDescription(browser)
-      expect(description).toMatchInlineSnapshot(
-        `"${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: Metadata error"`
-      )
+      if (isNewOverlay) {
+        expect(description).toMatchInlineSnapshot(`"Error: Metadata error"`)
+      } else {
+        expect(description).toMatchInlineSnapshot(
+          `"[ Server ] Error: Metadata error"`
+        )
+      }
     }
     expect(await browser.elementByCss('h1').text()).toBe('Global Error')
     expect(await browser.elementByCss('#error').text()).toBe(

--- a/test/e2e/app-dir/global-error/basic/index.test.ts
+++ b/test/e2e/app-dir/global-error/basic/index.test.ts
@@ -31,7 +31,7 @@ describe('app dir - global error', () => {
       await assertHasRedbox(browser)
       const description = await getRedboxDescription(browser)
       expect(description).toMatchInlineSnapshot(
-        `"[ Server ] Error: server page error"`
+        `"${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: server page error"`
       )
     }
     // Show original error message in dev mode, but hide with the react fallback RSC error message in production mode
@@ -75,7 +75,7 @@ describe('app dir - global error', () => {
       await assertHasRedbox(browser)
       const description = await getRedboxDescription(browser)
       expect(description).toMatchInlineSnapshot(
-        `"[ Server ] Error: Metadata error"`
+        `"${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: Metadata error"`
       )
     }
     expect(await browser.elementByCss('h1').text()).toBe('Global Error')

--- a/test/e2e/app-dir/global-error/layout-error/index.test.ts
+++ b/test/e2e/app-dir/global-error/layout-error/index.test.ts
@@ -17,9 +17,13 @@ describe('app dir - global error - layout error', () => {
     if (isNextDev) {
       await assertHasRedbox(browser)
       const description = await getRedboxDescription(browser)
-      expect(description).toMatchInlineSnapshot(
-        `"${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: layout error"`
-      )
+      if (process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true') {
+        expect(description).toMatchInlineSnapshot(`"Error: layout error"`)
+      } else {
+        expect(description).toMatchInlineSnapshot(
+          `"[ Server ] Error: layout error"`
+        )
+      }
     }
 
     expect(await browser.elementByCss('h1').text()).toBe('Global Error')

--- a/test/e2e/app-dir/global-error/layout-error/index.test.ts
+++ b/test/e2e/app-dir/global-error/layout-error/index.test.ts
@@ -18,7 +18,7 @@ describe('app dir - global error - layout error', () => {
       await assertHasRedbox(browser)
       const description = await getRedboxDescription(browser)
       expect(description).toMatchInlineSnapshot(
-        `"[ Server ] Error: layout error"`
+        `"${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: layout error"`
       )
     }
 

--- a/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
+++ b/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
@@ -39,7 +39,7 @@ describe('use-cache-close-over-function', () => {
       `)
       } else {
         expect(errorDescription).toMatchInlineSnapshot(`
-        "[ Server ] Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
+        "[ Prerender ] Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
           [function fn]
            ^^^^^^^^^^^"
       `)
@@ -105,7 +105,7 @@ describe('use-cache-close-over-function', () => {
       `)
       } else {
         expect(errorDescription).toMatchInlineSnapshot(`
-        "[ Server ] Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
+        "[ Prerender ] Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
           [function fn]
            ^^^^^^^^^^^"
       `)

--- a/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
+++ b/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
@@ -18,6 +18,9 @@ describe('use-cache-close-over-function', () => {
     return
   }
 
+  const isNewOverlay =
+    process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
+
   if (isNextDev) {
     it('should show an error toast for client-side usage', async () => {
       const outputIndex = next.cliOutput.length
@@ -28,11 +31,19 @@ describe('use-cache-close-over-function', () => {
       const errorDescription = await getRedboxDescription(browser)
       const errorSource = await getRedboxSource(browser)
 
-      expect(errorDescription).toMatchInlineSnapshot(`
-        "${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
+      if (isNewOverlay) {
+        expect(errorDescription).toMatchInlineSnapshot(`
+        "Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
           [function fn]
            ^^^^^^^^^^^"
       `)
+      } else {
+        expect(errorDescription).toMatchInlineSnapshot(`
+        "[ Server ] Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
+          [function fn]
+           ^^^^^^^^^^^"
+      `)
+      }
 
       expect(errorSource).toMatchInlineSnapshot(`
         "app/client/page.tsx (8:3) @ createCachedFn
@@ -86,11 +97,19 @@ describe('use-cache-close-over-function', () => {
       const errorDescription = await getRedboxDescription(browser)
       const errorSource = await getRedboxSource(browser)
 
-      expect(errorDescription).toMatchInlineSnapshot(`
-        "${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
+      if (isNewOverlay) {
+        expect(errorDescription).toMatchInlineSnapshot(`
+        "Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
           [function fn]
            ^^^^^^^^^^^"
       `)
+      } else {
+        expect(errorDescription).toMatchInlineSnapshot(`
+        "[ Server ] Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
+          [function fn]
+           ^^^^^^^^^^^"
+      `)
+      }
 
       expect(errorSource).toMatchInlineSnapshot(`
         "app/server/page.tsx (6:3) @ createCachedFn

--- a/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
+++ b/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
@@ -29,7 +29,7 @@ describe('use-cache-close-over-function', () => {
       const errorSource = await getRedboxSource(browser)
 
       expect(errorDescription).toMatchInlineSnapshot(`
-        "[ Prerender ] Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
+        "${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
           [function fn]
            ^^^^^^^^^^^"
       `)
@@ -87,7 +87,7 @@ describe('use-cache-close-over-function', () => {
       const errorSource = await getRedboxSource(browser)
 
       expect(errorDescription).toMatchInlineSnapshot(`
-        "[ Prerender ] Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
+        "${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
           [function fn]
            ^^^^^^^^^^^"
       `)

--- a/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
@@ -203,9 +203,13 @@ describe('use-cache-hanging-inputs', () => {
           const expectedErrorMessagePpr =
             'Error: Route "/bound-args": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don\'t have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense'
 
-          expect(errorDescription).toBe(
-            `${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}${expectedErrorMessagePpr}`
-          )
+          if (process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true') {
+            expect(errorDescription).toBe(expectedErrorMessagePpr)
+          } else {
+            expect(errorDescription).toBe(
+              `[ Server ] ${expectedErrorMessagePpr}`
+            )
+          }
 
           expect(cliOutput).toContain(
             `${expectedErrorMessagePpr}

--- a/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
@@ -203,7 +203,9 @@ describe('use-cache-hanging-inputs', () => {
           const expectedErrorMessagePpr =
             'Error: Route "/bound-args": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don\'t have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense'
 
-          expect(errorDescription).toBe(`[ Server ] ${expectedErrorMessagePpr}`)
+          expect(errorDescription).toBe(
+            `${process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ? '' : '[ Server ] '}${expectedErrorMessagePpr}`
+          )
 
           expect(cliOutput).toContain(
             `${expectedErrorMessagePpr}

--- a/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
@@ -215,7 +215,7 @@ describe('use-cache-hanging-inputs', () => {
           const expectedErrorMessagePpr =
             'Error: Route "/bound-args": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don\'t have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense'
 
-          if (process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true') {
+          if (isNewDevOverlay) {
             expect(errorDescription).toBe(expectedErrorMessagePpr)
           } else {
             expect(errorDescription).toBe(

--- a/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
@@ -273,13 +273,19 @@ describe('use-cache-hanging-inputs', () => {
         const title = await getRedboxTitle(browser)
         const description = await getRedboxDescription(browser)
 
-        expect({ count, title, description }).toEqual({
-          count: 1,
-          title: 'Unhandled Runtime Error',
-          description: isNewDevOverlay
-            ? 'Error: kaputt!'
-            : '[ Cache ] Error: kaputt!',
-        })
+        if (isNewDevOverlay) {
+          expect({ count, title, description }).toEqual({
+            count: 1,
+            title: 'Unhandled Runtime Error\nCache',
+            description: 'Error: kaputt!',
+          })
+        } else {
+          expect({ count, title, description }).toEqual({
+            count: 1,
+            title: 'Unhandled Runtime Error',
+            description: '[ Cache ] Error: kaputt!',
+          })
+        }
       })
     })
   } else {

--- a/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
@@ -41,7 +41,11 @@ describe('use-cache-hanging-inputs', () => {
         const errorDescription = await getRedboxDescription(browser)
         const errorSource = await getRedboxSource(browser)
 
-        expect(errorDescription).toBe(`[ Cache ] ${expectedErrorMessage}`)
+        if (isNewDevOverlay) {
+          expect(errorDescription).toBe(expectedErrorMessage)
+        } else {
+          expect(errorDescription).toBe(`[ Cache ] ${expectedErrorMessage}`)
+        }
 
         const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
 
@@ -100,7 +104,11 @@ describe('use-cache-hanging-inputs', () => {
         const errorDescription = await getRedboxDescription(browser)
         const errorSource = await getRedboxSource(browser)
 
-        expect(errorDescription).toBe(`[ Cache ] ${expectedErrorMessage}`)
+        if (isNewDevOverlay) {
+          expect(errorDescription).toBe(expectedErrorMessage)
+        } else {
+          expect(errorDescription).toBe(`[ Cache ] ${expectedErrorMessage}`)
+        }
 
         const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
 
@@ -146,7 +154,11 @@ describe('use-cache-hanging-inputs', () => {
         const errorDescription = await getRedboxDescription(browser)
         const errorSource = await getRedboxSource(browser)
 
-        expect(errorDescription).toBe(`[ Cache ] ${expectedErrorMessage}`)
+        if (isNewDevOverlay) {
+          expect(errorDescription).toBe(expectedErrorMessage)
+        } else {
+          expect(errorDescription).toBe(`[ Cache ] ${expectedErrorMessage}`)
+        }
 
         const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
 
@@ -216,7 +228,11 @@ describe('use-cache-hanging-inputs', () => {
     at Page [Server] (<anonymous>)`
           )
         } else {
-          expect(errorDescription).toBe(`[ Cache ] ${expectedErrorMessage}`)
+          if (isNewDevOverlay) {
+            expect(errorDescription).toBe(expectedErrorMessage)
+          } else {
+            expect(errorDescription).toBe(`[ Cache ] ${expectedErrorMessage}`)
+          }
 
           if (isTurbopack) {
             // TODO(veil): For Turbopack, a fix in the React Flight Client, where
@@ -260,7 +276,9 @@ describe('use-cache-hanging-inputs', () => {
         expect({ count, title, description }).toEqual({
           count: 1,
           title: 'Unhandled Runtime Error',
-          description: '[ Cache ] Error: kaputt!',
+          description: isNewDevOverlay
+            ? 'Error: kaputt!'
+            : '[ Cache ] Error: kaputt!',
         })
       })
     })

--- a/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
@@ -11,6 +11,8 @@ import {
 import stripAnsi from 'strip-ansi'
 
 const isExperimentalReact = process.env.__NEXT_EXPERIMENTAL_PPR
+const isNewDevOverlay =
+  process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
 
 const expectedErrorMessage =
   'Error: Filling a cache during prerender timed out, likely because request-specific arguments such as params, searchParams, cookies() or dynamic data were used inside "use cache".'

--- a/test/e2e/app-dir/use-cache-standalone-search-params/use-cache-standalone-search-params.test.ts
+++ b/test/e2e/app-dir/use-cache-standalone-search-params/use-cache-standalone-search-params.test.ts
@@ -39,7 +39,11 @@ describe('use-cache-standalone-search-params', () => {
         const errorSource = await getRedboxSource(browser)
         const expectedErrorMessage = getExpectedErrorMessage(route)
 
-        expect(errorDescription).toBe(`[ Cache ] ${expectedErrorMessage}`)
+        if (process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true') {
+          expect(errorDescription).toBe(expectedErrorMessage)
+        } else {
+          expect(errorDescription).toBe(`[ Cache ] ${expectedErrorMessage}`)
+        }
 
         const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
 


### PR DESCRIPTION
This PR moved the `[ {envName} ]` to a separate label chip at the header for better indication and visibility. Also, slightly changed the label colors.

| -------- | Before | After |
|--------|--------|--------|
| Light | ![CleanShot 2025-02-14 at 04 15 11](https://github.com/user-attachments/assets/be73b740-8b85-48b2-985b-74a76838b0c6) | ![CleanShot 2025-02-14 at 04 12 39](https://github.com/user-attachments/assets/289b80ac-d2b0-4fac-b60d-5286c986cbf9) |
| Dark | ![CleanShot 2025-02-14 at 04 15 18](https://github.com/user-attachments/assets/b94d76eb-17ee-431b-a120-0add64fd217a) | ![CleanShot 2025-02-14 at 04 12 34](https://github.com/user-attachments/assets/9449c3e9-9631-4c0b-977d-7a3d431d02fb) |

Closes NDX-754