### PR TITLE
Built-in app loader plugin for additional bundler

### DIFF
--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -13,7 +13,7 @@ import * as Log from './output/log'
 import type { LoadedEnvFiles } from '@next/env'
 import type { AppLoaderOptions } from './webpack/loaders/next-app-loader'
 
-import { posix, join, dirname, extname } from 'path'
+import { posix, join, dirname, extname, normalize } from 'path'
 import { stringify } from 'querystring'
 import fs from 'fs'
 import {
@@ -474,9 +474,18 @@ export function getInstrumentationEntry(opts: {
   }
 }
 
+export function getAppLoader() {
+  return process.env.BUILTIN_APP_LOADER
+    ? `builtin:next-app-loader`
+    : 'next-app-loader'
+}
+
 export function getAppEntry(opts: Readonly<AppLoaderOptions>) {
+  if (process.env.NEXT_RSPACK && process.env.BUILTIN_APP_LOADER) {
+    ;(opts as any).projectRoot = normalize(join(__dirname, '../../..'))
+  }
   return {
-    import: `next-app-loader?${stringify(opts)}!`,
+    import: `${getAppLoader()}?${stringify(opts)}!`,
     layer: WEBPACK_LAYERS.reactServerComponents,
   }
 }

--- a/packages/next/src/build/webpack/plugins/wellknown-errors-plugin/parseNextAppLoaderError.ts
+++ b/packages/next/src/build/webpack/plugins/wellknown-errors-plugin/parseNextAppLoaderError.ts
@@ -1,6 +1,7 @@
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import { relative } from 'path'
 import { SimpleWebpackError } from './simpleWebpackError'
+import { getAppLoader } from '../../../entries'
 
 export function getNextAppLoaderError(
   err: Error,
@@ -8,7 +9,7 @@ export function getNextAppLoaderError(
   compiler: webpack.Compiler
 ): SimpleWebpackError | false {
   try {
-    if (!module.loaders[0].loader.includes('next-app-loader')) {
+    if (!module.loaders[0].loader.includes(getAppLoader())) {
       return false
     }
 

--- a/packages/next/src/build/webpack/utils.ts
+++ b/packages/next/src/build/webpack/utils.ts
@@ -7,6 +7,7 @@ import type {
   ModuleGraph,
 } from 'webpack'
 import type { ModuleGraphConnection } from 'webpack'
+import { getAppLoader } from '../entries'
 
 export function traverseModules(
   compilation: Compilation,
@@ -61,7 +62,7 @@ export function forEachEntryModule(
     if (
       !request.startsWith('next-edge-ssr-loader?') &&
       !request.startsWith('next-edge-app-route-loader?') &&
-      !request.startsWith('next-app-loader?')
+      !request.startsWith(`${getAppLoader()}?`)
     )
       continue
 
@@ -74,7 +75,7 @@ export function forEachEntryModule(
     ) {
       entryModule.dependencies.forEach((dependency) => {
         const modRequest: string | undefined = (dependency as any).request
-        if (modRequest?.includes('next-app-loader')) {
+        if (modRequest?.includes(getAppLoader())) {
           entryModule = compilation.moduleGraph.getResolvedModule(dependency)
         }
       })


### PR DESCRIPTION
Ported from https://github.com/vercel/next.js/tree/wbinnssmith/try-ci-test, originally by @hardfist.

Adds support for a built-in app loader through the `BUILTIN_APP_LOADER` environment variable.

Closes PACK-3994