### PR TITLE
Fix unisolated tests

### DIFF
--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -154,9 +154,11 @@ async function createNextInstall({
       )
 
       if (beforeInstall !== undefined) {
-        rootSpan.traceChild('beforeInstall').traceAsyncFn(async (span) => {
-          await beforeInstall(span, installDir)
-        })
+        await rootSpan
+          .traceChild('beforeInstall')
+          .traceAsyncFn(async (span) => {
+            await beforeInstall(span, installDir)
+          })
       }
 
       if (installCommand) {


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/75906/files

Fixes `NEXT_SKIP_ISOLATE=1 pnpm test-start test/e2e/app-dir/hello-world`