### PR TITLE
ci: fix version-staleness test

### DIFF
--- a/test/development/acceptance-app/version-staleness.test.ts
+++ b/test/development/acceptance-app/version-staleness.test.ts
@@ -54,23 +54,22 @@ describe('Error Overlay version staleness', () => {
       if (process.env.TURBOPACK) {
         expect(await getStaleness(browser)).toMatchInlineSnapshot(`
          "Next.js 1.0.0 (outdated)
-         (learn more)
          Turbopack"
         `)
       } else {
-        expect(await getStaleness(browser)).toMatchInlineSnapshot(`
-         "Next.js 1.0.0 (outdated)
-         (learn more)"
-        `)
+        expect(await getStaleness(browser)).toMatchInlineSnapshot(
+          `"Next.js 1.0.0 (outdated)"`
+        )
       }
     } else {
       if (process.env.TURBOPACK) {
-        expect(await getStaleness(browser)).toMatchInlineSnapshot(
-          `"Next.js (1.0.0) is outdated (learn more) (Turbopack)"`
-        )
+        expect(await getStaleness(browser)).toMatchInlineSnapshot(`
+         "Next.js 1.0.0 (outdated)
+         Turbopack"
+        `)
       } else {
         expect(await getStaleness(browser)).toMatchInlineSnapshot(
-          `"Next.js (1.0.0) is outdated (learn more)"`
+          `"Next.js 1.0.0 (outdated)"`
         )
       }
     }
@@ -103,14 +102,12 @@ describe('Error Overlay version staleness', () => {
     if (process.env.TURBOPACK) {
       expect(await getStaleness(browser)).toMatchInlineSnapshot(`
        "Next.js 2.0.0 (outdated)
-       (learn more)
        Turbopack"
       `)
     } else {
-      expect(await getStaleness(browser)).toMatchInlineSnapshot(`
-       "Next.js 2.0.0 (outdated)
-       (learn more)"
-      `)
+      expect(await getStaleness(browser)).toMatchInlineSnapshot(
+        `"Next.js 2.0.0 (outdated)"`
+      )
     }
   })
 
@@ -138,14 +135,12 @@ describe('Error Overlay version staleness', () => {
     if (process.env.TURBOPACK) {
       expect(await getStaleness(browser)).toMatchInlineSnapshot(`
        "Next.js 3.0.0 (outdated)
-       (learn more)
        Turbopack"
       `)
     } else {
-      expect(await getStaleness(browser)).toMatchInlineSnapshot(`
-       "Next.js 3.0.0 (outdated)
-       (learn more)"
-      `)
+      expect(await getStaleness(browser)).toMatchInlineSnapshot(
+        `"Next.js 3.0.0 (outdated)"`
+      )
     }
   })
 })


### PR DESCRIPTION
The test failed since https://github.com/vercel/next.js/pull/75882 was merged with a lot of test changes, but https://github.com/vercel/next.js/pull/75768 didn't rebase.