### PR TITLE
example: add next config to hello-world app

### DIFF
--- a/examples/hello-world/next.config.ts
+++ b/examples/hello-world/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  /* config options here */
+};
+
+export default nextConfig;


### PR DESCRIPTION
### Why?

Since the `hello-world` app is also used for the default debugging app, I used to add a config when testing a relevant feature and removed it after. Hence, just added a config.

https://github.com/vercel/next.js/blob/959a31214341d1ea00c0f00bcc8fc6f6a9c7b6fc/.vscode/launch.json#L11