### PR TITLE
Turbopack: codegen EsmAssetReference without turbo tasks

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
@@ -31,19 +31,9 @@ use crate::references::{
     AstPath,
 };
 
-/// impl of code generation inferred from a ModuleReference.
-/// This is rust only and can't be implemented by non-rust plugins.
-#[turbo_tasks::value(
-    shared,
-    serialization = "none",
-    eq = "manual",
-    into = "new",
-    cell = "new"
-)]
 #[derive(Default)]
 pub struct CodeGeneration {
     /// ast nodes matching the span will be visitor by the visitor
-    #[turbo_tasks(debug_ignore, trace_ignore)]
     pub visitors: Vec<(Vec<AstParentKind>, Box<dyn VisitorFactory>)>,
     pub hoisted_stmts: Vec<CodeGenerationHoistedStmt>,
     pub early_hoisted_stmts: Vec<CodeGenerationHoistedStmt>,
@@ -90,11 +80,9 @@ impl CodeGeneration {
     }
 }
 
-#[turbo_tasks::value(shared)]
 #[derive(Clone)]
 pub struct CodeGenerationHoistedStmt {
     pub key: RcStr,
-    #[turbo_tasks(trace_ignore)]
     pub stmt: Stmt,
 }
 
@@ -106,15 +94,6 @@ impl CodeGenerationHoistedStmt {
 
 pub trait VisitorFactory: Send + Sync {
     fn create<'a>(&'a self) -> Box<dyn VisitMut + Send + Sync + 'a>;
-}
-
-#[turbo_tasks::value_trait]
-pub trait CodeGenerateable {
-    fn code_generation(
-        self: Vc<Self>,
-        module_graph: Vc<ModuleGraph>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Vc<CodeGeneration>;
 }
 
 #[derive(PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue)]

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -42,7 +42,7 @@ use std::{
 
 use anyhow::Result;
 use chunk::EcmascriptChunkItem;
-use code_gen::{CodeGenerateable, CodeGeneration, CodeGenerationHoistedStmt};
+use code_gen::{CodeGeneration, CodeGenerationHoistedStmt};
 use either::Either;
 use parse::{parse, ParseResult};
 use path_visitor::ApplyVisitors;
@@ -95,7 +95,9 @@ use crate::{
     chunk::EcmascriptChunkPlaceable,
     code_gen::CodeGens,
     parse::generate_js_source_map,
-    references::{analyse_ecmascript_module, async_module::OptionAsyncModule},
+    references::{
+        analyse_ecmascript_module, async_module::OptionAsyncModule, esm::base::EsmAssetReferences,
+    },
     transform::remove_shebang,
 };
 
@@ -429,7 +431,7 @@ impl EcmascriptAnalyzable for EcmascriptModuleAsset {
             module_type_result.module_type,
             module_graph,
             chunking_context,
-            analyze.references(),
+            (analyze.references(), *analyze_ref.esm_references),
             *analyze_ref.code_generation,
             *analyze_ref.async_module,
             generate_source_map,
@@ -765,7 +767,7 @@ impl EcmascriptModuleContent {
         specified_module_type: SpecifiedModuleType,
         module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-        references: Vc<ModuleReferences>,
+        (references, esm_references): (Vc<ModuleReferences>, Vc<EsmAssetReferences>),
         code_generation: Vc<CodeGens>,
         async_module: Vc<OptionAsyncModule>,
         generate_source_map: Vc<bool>,
@@ -773,13 +775,6 @@ impl EcmascriptModuleContent {
         exports: Vc<EcmascriptExports>,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<Self>> {
-        let mut code_gen_cells = Vec::new();
-        for r in references.await?.iter() {
-            if let Some(code_gen) = ResolvedVc::try_sidecast::<Box<dyn CodeGenerateable>>(*r) {
-                code_gen_cells.push(code_gen.code_generation(module_graph, chunking_context));
-            }
-        }
-
         let additional_code_gens = [
             if let Some(async_module) = &*async_module.await? {
                 Some(
@@ -806,17 +801,21 @@ impl EcmascriptModuleContent {
             },
         ];
 
+        let esm_code_gens = esm_references
+            .await?
+            .iter()
+            .map(|r| r.code_generation(module_graph, chunking_context))
+            .try_join()
+            .await?;
         let code_gens = code_generation
             .await?
             .iter()
             .map(|c| c.code_generation(module_graph, chunking_context))
             .try_join()
             .await?;
-        let code_gen_cells = code_gen_cells.into_iter().try_join().await?;
 
-        let code_gens = code_gen_cells
+        let code_gens = esm_code_gens
             .iter()
-            .map(|c| &**c)
             .chain(additional_code_gens.iter().flatten())
             .chain(code_gens.iter());
         gen_content_with_code_gens(

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -81,14 +81,16 @@ impl Module for EcmascriptModuleFacadeModule {
                     );
                 };
                 let result = module.analyze().await?;
-                let references = result.evaluation_references;
-                let mut references = references.owned().await?;
-                references.push(ResolvedVc::upcast(
-                    EcmascriptModulePartReference::new_part(*self.module, ModulePart::locals())
-                        .to_resolved()
-                        .await?,
-                ));
-                references
+                result
+                    .esm_evaluation_references
+                    .iter()
+                    .map(|r| ResolvedVc::upcast(*r))
+                    .chain(std::iter::once(ResolvedVc::upcast(
+                        EcmascriptModulePartReference::new_part(*self.module, ModulePart::locals())
+                            .to_resolved()
+                            .await?,
+                    )))
+                    .collect()
             }
             ModulePart::Exports => {
                 let Some(module) =
@@ -96,18 +98,20 @@ impl Module for EcmascriptModuleFacadeModule {
                 else {
                     bail!(
                         "Expected EcmascriptModuleAsset for a EcmascriptModuleFacadeModule with \
-                         ModulePart::Evaluation"
+                         ModulePart::Exports"
                     );
                 };
                 let result = module.analyze().await?;
-                let references = result.reexport_references;
-                let mut references = references.owned().await?;
-                references.push(ResolvedVc::upcast(
-                    EcmascriptModulePartReference::new_part(*self.module, ModulePart::locals())
-                        .to_resolved()
-                        .await?,
-                ));
-                references
+                result
+                    .esm_reexport_references
+                    .iter()
+                    .map(|r| ResolvedVc::upcast(*r))
+                    .chain(std::iter::once(ResolvedVc::upcast(
+                        EcmascriptModulePartReference::new_part(*self.module, ModulePart::locals())
+                            .to_resolved()
+                            .await?,
+                    )))
+                    .collect()
             }
             ModulePart::Facade => {
                 vec![

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
@@ -43,7 +43,8 @@ impl EcmascriptChunkItem for EcmascriptModuleLocalsChunkItem {
         let original_module = module.module;
         let parsed = original_module.parse().resolve().await?;
 
-        let analyze_result = original_module.analyze().await?;
+        let analyze = original_module.analyze();
+        let analyze_result = analyze.await?;
         let async_module_options = analyze_result
             .async_module
             .module_options(async_module_info);
@@ -58,7 +59,7 @@ impl EcmascriptChunkItem for EcmascriptModuleLocalsChunkItem {
             module_type_result.module_type,
             *module_graph,
             *chunking_context,
-            *analyze_result.local_references,
+            analyze.references(),
             *analyze_result.code_generation,
             *analyze_result.async_module,
             generate_source_map,

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
@@ -59,7 +59,10 @@ impl EcmascriptChunkItem for EcmascriptModuleLocalsChunkItem {
             module_type_result.module_type,
             *module_graph,
             *chunking_context,
-            analyze.references(),
+            (
+                analyze.local_references(),
+                *analyze_result.esm_local_references,
+            ),
             *analyze_result.code_generation,
             *analyze_result.async_module,
             generate_source_map,

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -50,15 +50,15 @@ impl Module for EcmascriptModuleLocalsModule {
 
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<ModuleReferences>> {
-        let result = self.module.analyze().await?;
-        Ok(*result.local_references)
+        let result = self.module.analyze();
+        Ok(result.references())
     }
 
     #[turbo_tasks::function]
-    async fn is_self_async(&self) -> Result<Vc<bool>> {
-        let analyze = self.module.analyze().await?;
+    async fn is_self_async(self: Vc<Self>) -> Result<Vc<bool>> {
+        let analyze = self.await?.module.analyze().await?;
         if let Some(async_module) = *analyze.async_module.await? {
-            let is_self_async = async_module.is_self_async(*analyze.local_references);
+            let is_self_async = async_module.is_self_async(self.references());
             Ok(is_self_async)
         } else {
             Ok(Vc::cell(false))

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -51,7 +51,7 @@ impl Module for EcmascriptModuleLocalsModule {
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<ModuleReferences>> {
         let result = self.module.analyze();
-        Ok(result.references())
+        Ok(result.local_references())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
@@ -17,10 +17,8 @@ use super::{
     facade::module::EcmascriptModuleFacadeModule, locals::module::EcmascriptModuleLocalsModule,
 };
 use crate::{
-    chunk::EcmascriptChunkPlaceable,
-    code_gen::{CodeGenerateable, CodeGeneration},
-    references::esm::base::ReferencedAsset,
-    runtime_functions::TURBOPACK_IMPORT,
+    chunk::EcmascriptChunkPlaceable, code_gen::CodeGeneration,
+    references::esm::base::ReferencedAsset, runtime_functions::TURBOPACK_IMPORT,
     utils::module_id_to_lit,
 };
 
@@ -111,14 +109,12 @@ impl ChunkableModuleReference for EcmascriptModulePartReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl CodeGenerateable for EcmascriptModulePartReference {
-    #[turbo_tasks::function]
-    async fn code_generation(
+impl EcmascriptModulePartReference {
+    pub async fn code_generation(
         self: Vc<Self>,
         module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<CodeGeneration>> {
+    ) -> Result<CodeGeneration> {
         let referenced_asset = ReferencedAsset::from_resolve_result(self.resolve_reference());
         let referenced_asset = referenced_asset.await?;
         let ident = referenced_asset
@@ -142,7 +138,6 @@ impl CodeGenerateable for EcmascriptModulePartReference {
                 turbopack_import: Expr = TURBOPACK_IMPORT.into(),
                 id: Expr = module_id_to_lit(&id),
             ),
-        )
-        .cell())
+        ))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -292,11 +292,11 @@ impl Module for EcmascriptModulePartAsset {
     async fn references(&self) -> Result<Vc<ModuleReferences>> {
         let split_data = split_module(*self.full_module).await?;
 
-        let analyze = analyze(*self.full_module, self.part.clone()).await?;
+        let analyze = analyze(*self.full_module, self.part.clone());
 
         let deps = match &*split_data {
             SplitResult::Ok { deps, .. } => deps,
-            SplitResult::Failed { .. } => return Ok(*analyze.references),
+            SplitResult::Failed { .. } => return Ok(analyze.references()),
         };
 
         let part_dep = |part: ModulePart| -> Vc<Box<dyn ModuleReference>> {
@@ -306,7 +306,7 @@ impl Module for EcmascriptModulePartAsset {
             ))
         };
 
-        let mut references = analyze.references.await?.to_vec();
+        let mut references = analyze.references().owned().await?;
 
         // Facade depends on evaluation and re-exports
         if self.part == ModulePart::Facade {

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
@@ -66,7 +66,7 @@ impl EcmascriptChunkItem for EcmascriptModulePartChunkItem {
             module_type_result.module_type,
             *self.module_graph,
             *self.chunking_context,
-            analyze.references(),
+            (analyze.references(), *analyze_ref.esm_references),
             *analyze_ref.code_generation,
             *analyze_ref.async_module,
             generate_source_map,

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
@@ -51,8 +51,9 @@ impl EcmascriptChunkItem for EcmascriptModulePartChunkItem {
         let split_data = split_module(*module.full_module);
         let parsed = part_of_module(split_data, module.part.clone());
 
-        let analyze = self.module.analyze().await?;
-        let async_module_options = analyze.async_module.module_options(async_module_info);
+        let analyze = self.module.analyze();
+        let analyze_ref = analyze.await?;
+        let async_module_options = analyze_ref.async_module.module_options(async_module_info);
 
         let module_type_result = *module.full_module.determine_module_type().await?;
         let generate_source_map = self
@@ -65,12 +66,12 @@ impl EcmascriptChunkItem for EcmascriptModulePartChunkItem {
             module_type_result.module_type,
             *self.module_graph,
             *self.chunking_context,
-            *analyze.references,
-            *analyze.code_generation,
-            *analyze.async_module,
+            analyze.references(),
+            *analyze_ref.code_generation,
+            *analyze_ref.async_module,
             generate_source_map,
-            *analyze.source_map,
-            *analyze.exports,
+            *analyze_ref.source_map,
+            *analyze_ref.exports,
             async_module_info,
         );
 


### PR DESCRIPTION
Run `EsmAssetReference::code_generation` without cells/turbo tasks.

```
testing against 0293c96cf32


canary 71d8bfcc1f
14.8gb
529.67s user 81.57s system 883% cpu 1:09.18 total

mischnic/codegen-fewer-tasks 72eba1ead2
14.8gb
533.13s user 82.01s system 874% cpu 1:10.32 total

mischnic/codegen-fewer-tasks don't store twice
14.6gb
529.85s user 82.35s system 875% cpu 1:09.90 total

mischnic/codegen-esm-asset
14.2gb
528.69s user 81.37s system 881% cpu 1:09.17 total
```

Closes PACK-3977