### PR TITLE
ensure test files are populated in next deploy

### DIFF
--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -240,7 +240,7 @@ export class NextInstance {
               recursive: true,
             })
           } else {
-            const { tmpRepoDir } = await createNextInstall({
+            const { installDir, tmpRepoDir } = await createNextInstall({
               parentSpan: rootSpan,
               dependencies: finalDependencies,
               resolutions: this.resolutions ?? null,
@@ -263,9 +263,24 @@ export class NextInstance {
                   })
               },
             })
+            this.testDir = installDir
             this.tmpRepoDir = tmpRepoDir
           }
           require('console').log('created next.js install, writing test files')
+        }
+
+        if (isNextDeploy) {
+          await rootSpan
+            .traceChild('writeInitialFiles')
+            .traceAsyncFn(async () => {
+              await this.writeInitialFiles()
+            })
+
+          await await rootSpan
+            .traceChild('writeOverrideFiles')
+            .traceAsyncFn(async () => {
+              await this.writeOverrideFiles()
+            })
         }
 
         const testDirFiles = await fs.readdir(this.testDir)


### PR DESCRIPTION
We changed how test files are populated in the test dir at https://github.com/vercel/next.js/pull/75906; specifically by moving that work to `beforeInstall`. For next deploy tests, we do not really install anything, resulting in deploy tests to fail due to empty projects. Thus, this PR makes sure that next deploy flow continues to have the test files populated under the test dir.