### PR TITLE
Add basic profiling plugin for alternative bundler

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -93,6 +93,8 @@ import {
   NEXT_PROJECT_ROOT_DIST_CLIENT,
 } from './next-dir-paths'
 import { getRspackReactRefresh } from '../shared/lib/get-rspack'
+import { RspackProfilingPlugin } from './webpack/plugins/rspack-profiling-plugin'
+
 type ExcludesFalse = <T>(x: T | false) => x is T
 type ClientEntries = {
   [key: string]: string | string[]
@@ -1912,7 +1914,9 @@ export default async function getBaseWebpackConfig(
           appDirEnabled: hasAppDir,
           clientRouterFilters,
         }),
-      !isRspack && new ProfilingPlugin({ runWebpackSpan, rootDir: dir }),
+      isRspack
+        ? new RspackProfilingPlugin({ runWebpackSpan })
+        : new ProfilingPlugin({ runWebpackSpan, rootDir: dir }),
       new WellKnownErrorsPlugin(),
       isClient &&
         new CopyFilePlugin({

--- a/packages/next/src/build/webpack/plugins/rspack-profiling-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/rspack-profiling-plugin.ts
@@ -1,0 +1,59 @@
+// A basic implementation to allow loaders access to loaderContext.currentTraceSpan
+
+import type { Span } from '../../../trace'
+
+import { getRspackCore } from '../../../shared/lib/get-rspack'
+
+const pluginName = 'RspackProfilingPlugin'
+const moduleSpansByCompilation = new WeakMap()
+export const compilationSpans: WeakMap<any, Span> = new WeakMap()
+
+export class RspackProfilingPlugin {
+  runWebpackSpan: Span
+
+  constructor({ runWebpackSpan }: { runWebpackSpan: Span }) {
+    this.runWebpackSpan = runWebpackSpan
+  }
+
+  apply(compiler: any) {
+    compiler.hooks.compilation.tap(
+      { name: pluginName, stage: -Infinity },
+      (compilation: any) => {
+        const rspack = getRspackCore()
+
+        moduleSpansByCompilation.set(compilation, new WeakMap())
+        compilationSpans.set(
+          compilation,
+          this.runWebpackSpan.traceChild('compilation-' + compilation.name)
+        )
+
+        const compilationSpan = this.runWebpackSpan.traceChild(
+          `compilation-${compilation.name}`
+        )
+
+        const moduleHooks = rspack.NormalModule.getCompilationHooks(compilation)
+        moduleHooks.loader.tap(
+          pluginName,
+          (loaderContext: any, module: any) => {
+            const moduleSpan = moduleSpansByCompilation
+              .get(compilation)
+              ?.get(module)
+            loaderContext.currentTraceSpan = moduleSpan
+          }
+        )
+
+        compilation.hooks.buildModule.tap(pluginName, (module: any) => {
+          const span = compilationSpan.traceChild('build-module')
+          span.setAttribute('name', module.userRequest)
+          span.setAttribute('layer', module.layer)
+
+          moduleSpansByCompilation?.get(compilation)?.set(module, span)
+        })
+
+        compilation.hooks.succeedModule.tap(pluginName, (module: any) => {
+          moduleSpansByCompilation?.get(compilation)?.get(module)?.stop()
+        })
+      }
+    )
+  }
+}


### PR DESCRIPTION
Adds a profiling plugin for Rspack to enable tracing similar to the existing Webpack profiling plugin. Rspack does not implement all of the hooks necessary to re-use the webpack plugin, so this is a basic implementation that starts and stops spans, and makes them available to our loaders.

Closes PACK-3992