### PR TITLE
[dev-overlay] fix: hydration error style

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.tsx
@@ -267,7 +267,7 @@ export const styles = css`
     margin-bottom: var(--size-3_5);
   }
   .error-overlay-notes-container {
-    padding: 0 var(--size-4);
+    margin: var(--size-2) var(--size-0_5);
   }
   .error-overlay-notes-container p {
     white-space: pre-wrap;

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/component-stack-pseudo-html.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/component-stack-pseudo-html.tsx
@@ -4,8 +4,7 @@ export { PseudoHtmlDiff } from '../../../../hydration-diff/diff-view'
 
 export const PSEUDO_HTML_DIFF_STYLES = css`
   [data-nextjs-container-errors-pseudo-html] {
-    padding: var(--size-3) 0;
-    margin: var(--size-2) var(--size-4) var(--size-4);
+    margin: var(--size-2) 0;
     border: 1px solid var(--color-gray-400);
     background: var(--color-background-200);
     color: var(--color-syntax-constant);


### PR DESCRIPTION
This PR removed unnecessary spacing for hydration error.

| Before | After |
|--------|--------|
| ![CleanShot 2025-02-14 at 23 41 35](https://github.com/user-attachments/assets/5e496159-38ce-4d57-b1ca-d54640439148) | ![CleanShot 2025-02-14 at 23 43 13](https://github.com/user-attachments/assets/84b91e95-04a4-4daa-b6c6-6ed5ca091562) | 

