### PR TITLE
Turbopack: store vectors instead of hashmaps in ResolveResult

### DIFF
--- a/crates/next-core/src/hmr_entry.rs
+++ b/crates/next-core/src/hmr_entry.rs
@@ -132,7 +132,7 @@ impl ValueToString for HmrEntryModuleReference {
 impl ModuleReference for HmrEntryModuleReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        ModuleResolveResult::module(self.module).cell()
+        *ModuleResolveResult::module(self.module)
     }
 }
 

--- a/crates/next-core/src/next_app/include_modules_module.rs
+++ b/crates/next-core/src/next_app/include_modules_module.rs
@@ -162,7 +162,7 @@ impl ValueToString for IncludedModuleReference {
 impl ModuleReference for IncludedModuleReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        ModuleResolveResult::module(self.module).cell()
+        *ModuleResolveResult::module(self.module)
     }
 }
 

--- a/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
@@ -94,7 +94,7 @@ impl ChunkableModuleReference for CssClientReference {
 impl ModuleReference for CssClientReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        ModuleResolveResult::module(self.module).cell()
+        *ModuleResolveResult::module(self.module)
     }
 }
 

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -379,7 +379,7 @@ impl ChunkableModuleReference for EcmascriptClientReference {
 impl ModuleReference for EcmascriptClientReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        ModuleResolveResult::module(self.module).cell()
+        *ModuleResolveResult::module(self.module)
     }
 }
 

--- a/crates/next-core/src/next_edge/unsupported.rs
+++ b/crates/next-core/src/next_edge/unsupported.rs
@@ -64,10 +64,9 @@ impl ImportMappingReplacement for NextEdgeUnsupportedModuleReplacer {
             };
             let content = AssetContent::file(File::from(code).into());
             let source = VirtualSource::new(root_path, content).to_resolved().await?;
-            return Ok(ImportMapResult::Result(
-                ResolveResult::source(ResolvedVc::upcast(source)).resolved_cell(),
-            )
-            .cell());
+            return Ok(
+                ImportMapResult::Result(ResolveResult::source(ResolvedVc::upcast(source))).cell(),
+            );
         };
 
         Ok(ImportMapResult::NoEntry.cell())

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -136,10 +136,7 @@ impl NextFontGoogleReplacer {
             )
             .cell()),
         ).to_resolved().await?;
-        Ok(ImportMapResult::Result(
-            ResolveResult::source(ResolvedVc::upcast(js_asset)).resolved_cell(),
-        )
-        .cell())
+        Ok(ImportMapResult::Result(ResolveResult::source(ResolvedVc::upcast(js_asset))).cell())
     }
 }
 
@@ -268,10 +265,7 @@ impl NextFontGoogleCssModuleReplacer {
         .to_resolved()
         .await?;
 
-        Ok(ImportMapResult::Result(
-            ResolveResult::source(ResolvedVc::upcast(css_asset)).resolved_cell(),
-        )
-        .cell())
+        Ok(ImportMapResult::Result(ResolveResult::source(ResolvedVc::upcast(css_asset))).cell())
     }
 }
 
@@ -380,9 +374,7 @@ impl ImportMappingReplacement for NextFontGoogleFontFileReplacer {
         // really matter either.
         let Some(font) = fetch_from_google_fonts(Vc::cell(url.into()), font_virtual_path).await?
         else {
-            return Ok(
-                ImportMapResult::Result(ResolveResult::unresolvable().resolved_cell()).cell(),
-            );
+            return Ok(ImportMapResult::Result(ResolveResult::unresolvable()).cell());
         };
 
         let font_source = VirtualSource::new(
@@ -392,10 +384,7 @@ impl ImportMappingReplacement for NextFontGoogleFontFileReplacer {
         .to_resolved()
         .await?;
 
-        Ok(ImportMapResult::Result(
-            ResolveResult::source(ResolvedVc::upcast(font_source)).resolved_cell(),
-        )
-        .cell())
+        Ok(ImportMapResult::Result(ResolveResult::source(ResolvedVc::upcast(font_source))).cell())
     }
 }
 

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -122,13 +122,12 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                             .resolved_cell()
                             .emit();
 
-                            return Ok(ResolveResultOption::some(
-                                ResolveResult::primary(ResolveResultItem::Error(ResolvedVc::cell(
+                            return Ok(ResolveResultOption::some(*ResolveResult::primary(
+                                ResolveResultItem::Error(ResolvedVc::cell(
                                     format!("Font file not found: Can't resolve {}'", font_path)
                                         .into(),
-                                )))
-                                .into(),
-                            ));
+                                )),
+                            )));
                         }
                     }
                 }
@@ -180,9 +179,9 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                 .to_resolved()
                 .await?;
 
-                Ok(ResolveResultOption::some(
-                    ResolveResult::source(ResolvedVc::upcast(js_asset)).cell(),
-                ))
+                Ok(ResolveResultOption::some(*ResolveResult::source(
+                    ResolvedVc::upcast(js_asset),
+                )))
             }
             "@vercel/turbopack-next/internal/font/local/cssmodule.module.css" => {
                 let query = query_vc.await?.to_string();
@@ -211,9 +210,9 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                 .to_resolved()
                 .await?;
 
-                Ok(ResolveResultOption::some(
-                    ResolveResult::source(ResolvedVc::upcast(css_asset)).cell(),
-                ))
+                Ok(ResolveResultOption::some(*ResolveResult::source(
+                    ResolvedVc::upcast(css_asset),
+                )))
             }
             "@vercel/turbopack-next/internal/font/local/font" => {
                 let NextFontLocalFontFileOptions {
@@ -243,9 +242,9 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                         .to_resolved()
                         .await?;
 
-                Ok(ResolveResultOption::some(
-                    ResolveResult::source(ResolvedVc::upcast(font_source)).cell(),
-                ))
+                Ok(ResolveResultOption::some(*ResolveResult::source(
+                    ResolvedVc::upcast(font_source),
+                )))
             }
             _ => Ok(ResolveResultOption::none()),
         }

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -415,14 +415,13 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
             }
         };
 
-        Ok(ResolveResultOption::some(
-            ResolveResult::primary(ResolveResultItem::External {
+        Ok(ResolveResultOption::some(*ResolveResult::primary(
+            ResolveResultItem::External {
                 name: request_str.into(),
                 ty: external_type,
                 traced: ExternalTraced::Traced,
-            })
-            .cell(),
-        ))
+            },
+        )))
     }
 }
 

--- a/crates/next-core/src/next_server_component/server_component_reference.rs
+++ b/crates/next-core/src/next_server_component/server_component_reference.rs
@@ -37,7 +37,7 @@ impl ValueToString for NextServerComponentModuleReference {
 impl ModuleReference for NextServerComponentModuleReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        ModuleResolveResult::module(self.asset).cell()
+        *ModuleResolveResult::module(self.asset)
     }
 }
 

--- a/crates/next-core/src/next_server_utility/server_utility_reference.rs
+++ b/crates/next-core/src/next_server_utility/server_utility_reference.rs
@@ -37,7 +37,7 @@ impl ValueToString for NextServerUtilityModuleReference {
 impl ModuleReference for NextServerUtilityModuleReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        ModuleResolveResult::module(self.asset).cell()
+        *ModuleResolveResult::module(self.asset)
     }
 }
 

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -144,12 +144,9 @@ impl BeforeResolvePlugin for InvalidImportResolvePlugin {
         .resolved_cell()
         .emit();
 
-        ResolveResultOption::some(
-            ResolveResult::primary(ResolveResultItem::Error(ResolvedVc::cell(
-                self.message.join("\n").into(),
-            )))
-            .cell(),
-        )
+        ResolveResultOption::some(*ResolveResult::primary(ResolveResultItem::Error(
+            ResolvedVc::cell(self.message.join("\n").into()),
+        )))
     }
 }
 
@@ -245,14 +242,13 @@ impl AfterResolvePlugin for NextExternalResolvePlugin {
         // Replace '/esm/' with '/' to match the CJS version of the file.
         let specifier: RcStr = specifier.replace("/esm/", "/").into();
 
-        Ok(Vc::cell(Some(
-            ResolveResult::primary(ResolveResultItem::External {
+        Ok(Vc::cell(Some(ResolveResult::primary(
+            ResolveResultItem::External {
                 name: specifier.clone(),
                 ty: ExternalType::CommonJs,
                 traced: ExternalTraced::Traced,
-            })
-            .resolved_cell(),
-        )))
+            },
+        ))))
     }
 }
 
@@ -324,12 +320,9 @@ impl AfterResolvePlugin for NextNodeSharedRuntimeResolvePlugin {
             .root()
             .join(format!("{base}/{resource_request}").into());
 
-        Ok(Vc::cell(Some(
-            ResolveResult::source(ResolvedVc::upcast(
-                FileSource::new(new_path).to_resolved().await?,
-            ))
-            .resolved_cell(),
-        )))
+        Ok(Vc::cell(Some(ResolveResult::source(ResolvedVc::upcast(
+            FileSource::new(new_path).to_resolved().await?,
+        )))))
     }
 }
 
@@ -426,11 +419,8 @@ impl AfterResolvePlugin for NextSharedRuntimeResolvePlugin {
         let raw_fs_path = &*fs_path.await?;
         let modified_path = raw_fs_path.path.replace("next/dist/esm/", "next/dist/");
         let new_path = fs_path.root().join(modified_path.into());
-        Ok(Vc::cell(Some(
-            ResolveResult::source(ResolvedVc::upcast(
-                FileSource::new(new_path).to_resolved().await?,
-            ))
-            .resolved_cell(),
-        )))
+        Ok(Vc::cell(Some(ResolveResult::source(ResolvedVc::upcast(
+            FileSource::new(new_path).to_resolved().await?,
+        )))))
     }
 }

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -129,7 +129,7 @@ pub use vc::{
     VcValueTypeCast,
 };
 
-pub type VecMap<K, V> = Box<[(K, V)]>;
+pub type SliceMap<K, V> = Box<[(K, V)]>;
 
 pub type FxIndexSet<T> = indexmap::IndexSet<T, BuildHasherDefault<FxHasher>>;
 pub type FxIndexMap<K, V> = indexmap::IndexMap<K, V, BuildHasherDefault<FxHasher>>;

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -129,6 +129,8 @@ pub use vc::{
     VcValueTypeCast,
 };
 
+pub type VecMap<K, V> = Box<[(K, V)]>;
+
 pub type FxIndexSet<T> = indexmap::IndexSet<T, BuildHasherDefault<FxHasher>>;
 pub type FxIndexMap<K, V> = indexmap::IndexMap<K, V, BuildHasherDefault<FxHasher>>;
 pub type FxDashMap<K, V> = dashmap::DashMap<K, V, BuildHasherDefault<FxHasher>>;

--- a/turbopack/crates/turbo-tasks/src/trace.rs
+++ b/turbopack/crates/turbo-tasks/src/trace.rs
@@ -122,6 +122,14 @@ impl<T: TraceRawVcs> TraceRawVcs for Vec<T> {
     }
 }
 
+impl<T: TraceRawVcs> TraceRawVcs for Box<[T]> {
+    fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
+        for item in self.iter() {
+            TraceRawVcs::trace_raw_vcs(item, trace_context);
+        }
+    }
+}
+
 impl<T: TraceRawVcs, const N: usize> TraceRawVcs for [T; N] {
     fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
         for item in self.iter() {

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -56,7 +56,7 @@ pub struct SingleModuleReference {
 impl ModuleReference for SingleModuleReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        ModuleResolveResult::module(self.asset).cell()
+        *ModuleResolveResult::module(self.asset)
     }
 }
 
@@ -110,7 +110,7 @@ impl ChunkableModuleReference for SingleChunkableModuleReference {
 impl ModuleReference for SingleChunkableModuleReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        ModuleResolveResult::module(self.asset).cell()
+        *ModuleResolveResult::module(self.asset)
     }
 }
 
@@ -133,7 +133,7 @@ pub struct SingleOutputAssetReference {
 impl ModuleReference for SingleOutputAssetReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        ModuleResolveResult::output_asset(RequestKey::default(), self.asset).cell()
+        *ModuleResolveResult::output_asset(RequestKey::default(), self.asset)
     }
 }
 
@@ -210,7 +210,7 @@ pub struct TracedModuleReference {
 impl ModuleReference for TracedModuleReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        ModuleResolveResult::module(self.module).cell()
+        *ModuleResolveResult::module(self.module)
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/reference/source_map.rs
+++ b/turbopack/crates/turbopack-core/src/reference/source_map.rs
@@ -44,14 +44,13 @@ impl ModuleReference for SourceMapReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
         if let Some(file) = self.get_file().await {
-            return Ok(ModuleResolveResult::module(ResolvedVc::upcast(
+            return Ok(*ModuleResolveResult::module(ResolvedVc::upcast(
                 RawModule::new(Vc::upcast(FileSource::new(file)))
                     .to_resolved()
                     .await?,
-            ))
-            .cell());
+            )));
         }
-        Ok(ModuleResolveResult::unresolvable().cell())
+        Ok(*ModuleResolveResult::unresolvable())
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -256,12 +256,14 @@ impl ModuleResolveResult {
         &self,
         source: ResolvedVc<Box<dyn Source>>,
     ) -> Result<Vc<Self>> {
-        let mut affecting_sources = Vec::with_capacity(self.affecting_sources.len() + 1);
-        affecting_sources.extend(self.affecting_sources.iter().copied());
-        affecting_sources.push(source);
         Ok(Self {
             primary: self.primary.clone(),
-            affecting_sources: affecting_sources.into_boxed_slice(),
+            affecting_sources: self
+                .affecting_sources
+                .iter()
+                .copied()
+                .chain(std::iter::once(source))
+                .collect(),
         }
         .cell())
     }
@@ -271,13 +273,14 @@ impl ModuleResolveResult {
         &self,
         sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> Result<Vc<Self>> {
-        let mut affecting_sources =
-            Vec::with_capacity(self.affecting_sources.len() + sources.len());
-        affecting_sources.extend(self.affecting_sources.iter().copied());
-        affecting_sources.extend(sources);
         Ok(Self {
             primary: self.primary.clone(),
-            affecting_sources: affecting_sources.into_boxed_slice(),
+            affecting_sources: self
+                .affecting_sources
+                .iter()
+                .copied()
+                .chain(sources)
+                .collect(),
         }
         .cell())
     }
@@ -867,12 +870,14 @@ impl ResolveResult {
         &self,
         source: ResolvedVc<Box<dyn Source>>,
     ) -> Result<Vc<Self>> {
-        let mut affecting_sources = Vec::with_capacity(self.affecting_sources.len() + 1);
-        affecting_sources.extend(self.affecting_sources.iter().copied());
-        affecting_sources.push(source);
         Ok(Self {
             primary: self.primary.clone(),
-            affecting_sources: affecting_sources.into_boxed_slice(),
+            affecting_sources: self
+                .affecting_sources
+                .iter()
+                .copied()
+                .chain(std::iter::once(source))
+                .collect(),
         }
         .cell())
     }
@@ -882,13 +887,14 @@ impl ResolveResult {
         &self,
         sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> Result<Vc<Self>> {
-        let mut affecting_sources =
-            Vec::with_capacity(self.affecting_sources.len() + sources.len());
-        affecting_sources.extend(self.affecting_sources.iter().copied());
-        affecting_sources.extend(sources);
         Ok(Self {
             primary: self.primary.clone(),
-            affecting_sources: affecting_sources.into_boxed_slice(),
+            affecting_sources: self
+                .affecting_sources
+                .iter()
+                .copied()
+                .chain(sources)
+                .collect(),
         }
         .cell())
     }

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -214,7 +214,7 @@ pub struct ModuleResolveResultBuilder {
 impl From<ModuleResolveResultBuilder> for ModuleResolveResult {
     fn from(v: ModuleResolveResultBuilder) -> Self {
         ModuleResolveResult {
-            primary: v.primary.into_iter().collect::<Vec<_>>().into_boxed_slice(),
+            primary: v.primary.into_iter().collect(),
             affecting_sources: v.affecting_sources.into_boxed_slice(),
         }
     }
@@ -813,7 +813,7 @@ pub struct ResolveResultBuilder {
 impl From<ResolveResultBuilder> for ResolveResult {
     fn from(v: ResolveResultBuilder) -> Self {
         ResolveResult {
-            primary: v.primary.into_iter().collect::<Vec<_>>().into_boxed_slice(),
+            primary: v.primary.into_iter().collect(),
             affecting_sources: v.affecting_sources.into_boxed_slice(),
         }
     }

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -13,7 +13,7 @@ use tracing::{Instrument, Level};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     fxindexmap, trace::TraceRawVcs, FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc,
-    TaskInput, TryJoinIterExt, Value, ValueToString, Vc,
+    TaskInput, TryJoinIterExt, Value, ValueToString, Vc, VecMap,
 };
 use turbo_tasks_fs::{
     util::normalize_request, FileSystemEntryType, FileSystemPath, RealPathResult,
@@ -104,7 +104,7 @@ impl ModuleResolveResultItem {
 #[turbo_tasks::value(shared)]
 #[derive(Clone, Debug)]
 pub struct ModuleResolveResult {
-    pub primary: Box<[(RequestKey, ModuleResolveResultItem)]>,
+    pub primary: VecMap<RequestKey, ModuleResolveResultItem>,
     pub affecting_sources: Box<[ResolvedVc<Box<dyn Source>>]>,
 }
 

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -256,7 +256,8 @@ impl ModuleResolveResult {
         &self,
         source: ResolvedVc<Box<dyn Source>>,
     ) -> Result<Vc<Self>> {
-        let mut affecting_sources = self.affecting_sources.to_vec();
+        let mut affecting_sources = Vec::with_capacity(self.affecting_sources.len() + 1);
+        affecting_sources.extend(self.affecting_sources.iter().copied());
         affecting_sources.push(source);
         Ok(Self {
             primary: self.primary.clone(),
@@ -270,7 +271,9 @@ impl ModuleResolveResult {
         &self,
         sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> Result<Vc<Self>> {
-        let mut affecting_sources = self.affecting_sources.to_vec();
+        let mut affecting_sources =
+            Vec::with_capacity(self.affecting_sources.len() + sources.len());
+        affecting_sources.extend(self.affecting_sources.iter().copied());
         affecting_sources.extend(sources);
         Ok(Self {
             primary: self.primary.clone(),
@@ -864,7 +867,8 @@ impl ResolveResult {
         &self,
         source: ResolvedVc<Box<dyn Source>>,
     ) -> Result<Vc<Self>> {
-        let mut affecting_sources = self.affecting_sources.to_vec();
+        let mut affecting_sources = Vec::with_capacity(self.affecting_sources.len() + 1);
+        affecting_sources.extend(self.affecting_sources.iter().copied());
         affecting_sources.push(source);
         Ok(Self {
             primary: self.primary.clone(),
@@ -878,7 +882,9 @@ impl ResolveResult {
         &self,
         sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> Result<Vc<Self>> {
-        let mut affecting_sources = self.affecting_sources.to_vec();
+        let mut affecting_sources =
+            Vec::with_capacity(self.affecting_sources.len() + sources.len());
+        affecting_sources.extend(self.affecting_sources.iter().copied());
         affecting_sources.extend(sources);
         Ok(Self {
             primary: self.primary.clone(),

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -12,8 +12,8 @@ use serde::{Deserialize, Serialize};
 use tracing::{Instrument, Level};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    trace::TraceRawVcs, FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TaskInput,
-    TryJoinIterExt, Value, ValueToString, Vc, VecMap,
+    trace::TraceRawVcs, FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, SliceMap,
+    TaskInput, TryJoinIterExt, Value, ValueToString, Vc,
 };
 use turbo_tasks_fs::{
     util::normalize_request, FileSystemEntryType, FileSystemPath, RealPathResult,
@@ -104,7 +104,7 @@ impl ModuleResolveResultItem {
 #[turbo_tasks::value(shared)]
 #[derive(Clone)]
 pub struct ModuleResolveResult {
-    pub primary: VecMap<RequestKey, ModuleResolveResultItem>,
+    pub primary: SliceMap<RequestKey, ModuleResolveResultItem>,
     pub affecting_sources: Box<[ResolvedVc<Box<dyn Source>>]>,
 }
 
@@ -514,7 +514,7 @@ impl RequestKey {
 #[turbo_tasks::value(shared)]
 #[derive(Clone)]
 pub struct ResolveResult {
-    pub primary: VecMap<RequestKey, ResolveResultItem>,
+    pub primary: SliceMap<RequestKey, ResolveResultItem>,
     pub affecting_sources: Box<[ResolvedVc<Box<dyn Source>>]>,
 }
 

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -434,12 +434,12 @@ async fn import_mapping_to_result(
             traced: *traced,
             lookup_dir: *lookup_dir,
         },
-        ReplacedImportMapping::Ignore => ImportMapResult::Result(
-            ResolveResult::primary(ResolveResultItem::Ignore).resolved_cell(),
-        ),
-        ReplacedImportMapping::Empty => ImportMapResult::Result(
-            ResolveResult::primary(ResolveResultItem::Empty).resolved_cell(),
-        ),
+        ReplacedImportMapping::Ignore => {
+            ImportMapResult::Result(ResolveResult::primary(ResolveResultItem::Ignore))
+        }
+        ReplacedImportMapping::Empty => {
+            ImportMapResult::Result(ResolveResult::primary(ResolveResultItem::Empty))
+        }
         ReplacedImportMapping::PrimaryAlternative(name, context) => {
             let request = Request::parse(Value::new(name.clone()))
                 .to_resolved()

--- a/turbopack/crates/turbopack-core/src/resolve/origin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/origin.rs
@@ -86,7 +86,7 @@ async fn resolve_asset(
     reference_type: Value<ReferenceType>,
 ) -> Result<Vc<ModuleResolveResult>> {
     if let Some(asset) = *resolve_origin.get_inner_asset(request).await? {
-        return Ok(ModuleResolveResult::module(asset).cell());
+        return Ok(*ModuleResolveResult::module(asset));
     }
     Ok(resolve_origin
         .asset_context()

--- a/turbopack/crates/turbopack-css/src/references/internal.rs
+++ b/turbopack/crates/turbopack-css/src/references/internal.rs
@@ -26,7 +26,7 @@ impl InternalCssAssetReference {
 impl ModuleReference for InternalCssAssetReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        ModuleResolveResult::module(self.module).cell()
+        *ModuleResolveResult::module(self.module)
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -175,12 +175,11 @@ impl ModuleReference for EsmAssetReference {
                         ResolvedVc::try_downcast_type(self.origin)
                             .expect("EsmAssetReference origin should be a EcmascriptModuleAsset");
 
-                    return Ok(ModuleResolveResult::module(
+                    return Ok(*ModuleResolveResult::module(
                         EcmascriptModulePartAsset::select_part(*module, part.clone())
                             .to_resolved()
                             .await?,
-                    )
-                    .cell());
+                    ));
                 }
 
                 bail!("export_name is required for part import")

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -33,12 +33,11 @@ impl PackageJsonReference {
 impl ModuleReference for PackageJsonReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
-        Ok(ModuleResolveResult::module(ResolvedVc::upcast(
+        Ok(*ModuleResolveResult::module(ResolvedVc::upcast(
             RawModule::new(Vc::upcast(FileSource::new(*self.package_json)))
                 .to_resolved()
                 .await?,
-        ))
-        .cell())
+        )))
     }
 }
 
@@ -117,7 +116,7 @@ async fn resolve_reference_from_dir(
             .await?
             .into_iter(),
         ),
-        (None, None) => return Ok(ModuleResolveResult::unresolvable().cell()),
+        (None, None) => return Ok(*ModuleResolveResult::unresolvable()),
     };
     let mut affecting_sources = Vec::new();
     let mut results = Vec::new();
@@ -142,7 +141,10 @@ async fn resolve_reference_from_dir(
             PatternMatch::Directory(..) => {}
         }
     }
-    Ok(ModuleResolveResult::modules_with_affecting_sources(results, affecting_sources).cell())
+    Ok(*ModuleResolveResult::modules_with_affecting_sources(
+        results,
+        affecting_sources,
+    ))
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -411,7 +411,7 @@ impl PatternMapping {
             ))
             .cell()),
             1 => {
-                let resolve_item = result.primary.first().unwrap().1;
+                let resolve_item = &result.primary.first().unwrap().1;
                 let single_pattern_mapping =
                     to_single_pattern_mapping(origin, chunking_context, resolve_item, resolve_type)
                         .await?;

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -264,7 +264,7 @@ impl RequireContextAssetReference {
 impl ModuleReference for RequireContextAssetReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        ModuleResolveResult::module(ResolvedVc::upcast(self.inner)).cell()
+        *ModuleResolveResult::module(ResolvedVc::upcast(self.inner))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
@@ -35,12 +35,11 @@ impl TsConfigReference {
 impl ModuleReference for TsConfigReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
-        Ok(ModuleResolveResult::module(ResolvedVc::upcast(
+        Ok(*ModuleResolveResult::module(ResolvedVc::upcast(
             TsConfigModuleAsset::new(*self.origin, Vc::upcast(FileSource::new(*self.tsconfig)))
                 .to_resolved()
                 .await?,
-        ))
-        .cell())
+        )))
     }
 }
 
@@ -93,9 +92,9 @@ impl ModuleReference for TsReferencePathAssetReference {
                     .module()
                     .to_resolved()
                     .await?;
-                ModuleResolveResult::module(module).cell()
+                *ModuleResolveResult::module(module)
             } else {
-                ModuleResolveResult::unresolvable().cell()
+                *ModuleResolveResult::unresolvable()
             },
         )
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -91,12 +91,11 @@ impl ModuleReference for WorkerAssetReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
         if let Some(worker_loader_module) = self.worker_loader_module().await? {
-            Ok(ModuleResolveResult::module(ResolvedVc::upcast(
+            Ok(*ModuleResolveResult::module(ResolvedVc::upcast(
                 worker_loader_module.to_resolved().await?,
-            ))
-            .cell())
+            )))
         } else {
-            Ok(ModuleResolveResult::unresolvable().cell())
+            Ok(*ModuleResolveResult::unresolvable())
         }
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
@@ -97,7 +97,7 @@ impl ModuleReference for EcmascriptModulePartReference {
         } else {
             ResolvedVc::upcast(self.module)
         };
-        Ok(ModuleResolveResult::module(module).cell())
+        Ok(*ModuleResolveResult::module(module))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -240,12 +240,11 @@ impl TsExtendsReference {
 impl ModuleReference for TsExtendsReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
-        Ok(ModuleResolveResult::module(ResolvedVc::upcast(
+        Ok(*ModuleResolveResult::module(ResolvedVc::upcast(
             RawModule::new(*ResolvedVc::upcast(self.config))
                 .to_resolved()
                 .await?,
-        ))
-        .cell())
+        )))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -100,14 +100,13 @@ impl ModuleReference for WebpackChunkAssetReference {
                 let filename = format!("./chunks/{}.js", chunk_id).into();
                 let source = Vc::upcast(FileSource::new(context_path.join(filename)));
 
-                ModuleResolveResult::module(ResolvedVc::upcast(
+                *ModuleResolveResult::module(ResolvedVc::upcast(
                     WebpackModuleAsset::new(source, *self.runtime, *self.transforms)
                         .to_resolved()
                         .await?,
                 ))
-                .cell()
             }
-            WebpackRuntime::None => ModuleResolveResult::unresolvable().cell(),
+            WebpackRuntime::None => *ModuleResolveResult::unresolvable(),
         })
     }
 }
@@ -136,12 +135,11 @@ pub struct WebpackEntryAssetReference {
 impl ModuleReference for WebpackEntryAssetReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
-        Ok(ModuleResolveResult::module(ResolvedVc::upcast(
+        Ok(*ModuleResolveResult::module(ResolvedVc::upcast(
             WebpackModuleAsset::new(*self.source, *self.runtime, *self.transforms)
                 .to_resolved()
                 .await?,
-        ))
-        .cell())
+        )))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -113,7 +113,7 @@ impl ChunkableModuleReference for WorkerModuleReference {
 impl ModuleReference for WorkerModuleReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        ModuleResolveResult::module(self.module).cell()
+        *ModuleResolveResult::module(self.module)
     }
 }
 

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -197,7 +197,7 @@ pub async fn resolve_node_pre_gyp_files(
                         _ => {}
                     }
                 }
-                return Ok(ModuleResolveResult::modules_with_affecting_sources(
+                return Ok(*ModuleResolveResult::modules_with_affecting_sources(
                     sources
                         .into_iter()
                         .map(|(key, source)| async move {
@@ -215,12 +215,11 @@ pub async fn resolve_node_pre_gyp_files(
                         })
                         .try_join()
                         .await?,
-                )
-                .cell());
+                ));
             }
         };
     }
-    Ok(ModuleResolveResult::unresolvable().cell())
+    Ok(*ModuleResolveResult::unresolvable())
 }
 
 #[turbo_tasks::value]
@@ -305,7 +304,7 @@ pub async fn resolve_node_gyp_build_files(
                         }
                     }
                     if !resolved.is_empty() {
-                        return Ok(ModuleResolveResult::modules_with_affecting_sources(
+                        return Ok(*ModuleResolveResult::modules_with_affecting_sources(
                             resolved
                                 .into_iter()
                                 .map(|(key, source)| async move {
@@ -320,8 +319,7 @@ pub async fn resolve_node_gyp_build_files(
                                 .await?
                                 .into_iter(),
                             merged_affecting_sources,
-                        )
-                        .into());
+                        ));
                     }
                 }
             }
@@ -441,5 +439,5 @@ pub async fn resolve_node_bindings_files(
         .map(|try_dir| try_path(format!("{}/{}", try_dir, &file_name).into()))
         .try_flat_join()
         .await?;
-    Ok(ModuleResolveResult::modules(modules).cell())
+    Ok(*ModuleResolveResult::modules(modules))
 }

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -466,8 +466,7 @@ pub async fn type_resolve(
 #[turbo_tasks::function]
 pub async fn as_typings_result(result: Vc<ModuleResolveResult>) -> Result<Vc<ModuleResolveResult>> {
     let mut result = result.owned().await?;
-    result.primary = take(&mut result.primary)
-        .into_iter()
+    result.primary = IntoIterator::into_iter(take(&mut result.primary))
         .map(|(mut k, v)| {
             k.conditions.insert("types".to_string(), true);
             (k, v)


### PR DESCRIPTION
@bgw 😉 

- We never actually perform any lookup operations on these maps
- While I'm at it, also make that Vec a boxed slice

No perf difference though, do we still want this?

```
testing against 0293c96cf32

canary 0153bc2d61
13,1 GB

538.20s user 78.03s system 843% cpu 1:13.04 total
553.22s user 84.42s system 893% cpu 1:11.37 total
548.03s user 80.97s system 901% cpu 1:09.79 total

mischnic/resolve-result-repr e5618d72ed

13,1 GB
540.10s user 81.18s system 897% cpu 1:09.23 total
542.19s user 80.08s system 896% cpu 1:09.39 total
552.28s user 84.43s system 888% cpu 1:11.63 total
```

Closes PACK-3991