### PR TITLE
[dev-overlay] add aria to disabled docs button

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/copy-stack-trace-button.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/copy-stack-trace-button.stories.tsx
@@ -13,25 +13,14 @@ const meta: Meta<typeof CopyStackTraceButton> = {
 export default meta
 type Story = StoryObj<typeof CopyStackTraceButton>
 
-const errorWithStack = new Error('Test error')
-errorWithStack.stack = `Error: Test error
-    at Context.<anonymous> (test.ts:1:1)
-    at processImmediate (node:internal/timers:466:21)`
-
 export const WithStackTrace: Story = {
   args: {
-    error: errorWithStack,
+    error: new Error('Boom'),
   },
 }
 
 export const WithoutStackTrace: Story = {
   args: {
-    error: new Error('Error without stack'),
-  },
-}
-
-export const Disabled: Story = {
-  args: {
-    error: undefined,
+    error: Object.assign(new Error('Boom'), { stack: undefined }),
   },
 }

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/docs-link-button.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/docs-link-button.tsx
@@ -18,15 +18,15 @@ function getDocsURLFromErrorMessage(text: string): string | null {
 
 export function DocsLinkButton({ errorMessage }: { errorMessage: string }) {
   const docsURL = getDocsURLFromErrorMessage(errorMessage)
-  const commonProps = {
-    title: 'Related Next.js Docs',
-    'aria-label': 'Related Next.js Docs',
-    className: 'docs-link-button',
-  }
 
   if (!docsURL) {
     return (
-      <button {...commonProps} disabled>
+      <button
+        title="No related Next.js docs found"
+        aria-label="No related Next.js docs found"
+        className="docs-link-button"
+        disabled
+      >
         <DocsIcon
           className="error-overlay-toolbar-button-icon"
           width={14}
@@ -38,7 +38,9 @@ export function DocsLinkButton({ errorMessage }: { errorMessage: string }) {
 
   return (
     <a
-      {...commonProps}
+      title="Go to related Next.js docs"
+      aria-label="Go to related Next.js docs"
+      className="docs-link-button"
       href={docsURL}
       target="_blank"
       rel="noopener noreferrer"

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/docs-link-button.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/docs-link-button.tsx
@@ -20,7 +20,7 @@ export function DocsLinkButton({ errorMessage }: { errorMessage: string }) {
   const docsURL = getDocsURLFromErrorMessage(errorMessage)
   const commonProps = {
     title: 'Related Next.js Docs',
-    ariaLabel: 'Related Next.js Docs',
+    'aria-label': 'Related Next.js Docs',
     className: 'docs-link-button',
   }
 

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/docs-link-button.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/docs-link-button.tsx
@@ -18,10 +18,15 @@ function getDocsURLFromErrorMessage(text: string): string | null {
 
 export function DocsLinkButton({ errorMessage }: { errorMessage: string }) {
   const docsURL = getDocsURLFromErrorMessage(errorMessage)
+  const commonProps = {
+    title: 'Related Next.js Docs',
+    ariaLabel: 'Related Next.js Docs',
+    className: 'docs-link-button',
+  }
 
   if (!docsURL) {
     return (
-      <button className="docs-link-button" disabled>
+      <button {...commonProps} disabled>
         <DocsIcon
           className="error-overlay-toolbar-button-icon"
           width={14}
@@ -33,9 +38,7 @@ export function DocsLinkButton({ errorMessage }: { errorMessage: string }) {
 
   return (
     <a
-      title="Related Next.js Docs"
-      aria-label="Related Next.js Docs"
-      className="docs-link-button"
+      {...commonProps}
       href={docsURL}
       target="_blank"
       rel="noopener noreferrer"


### PR DESCRIPTION
The tooltip from the `title` property was missing when the docs button was disabled.

Closes NDX-798