### PR TITLE
[dev-overlay] use `browser` instead of `chrome` for aria in nodejs inspector button

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/nodejs-inspector-button.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-toolbar/nodejs-inspector-button.tsx
@@ -241,7 +241,7 @@ function NodeJsDisabledIcon(props: any) {
 }
 
 const label =
-  'Learn more about enabling Node.js inspector for server code with Chrome DevTools'
+  'Learn more about enabling Node.js inspector for server code with Browser DevTools'
 
 export function NodejsInspectorButton({
   devtoolsFrontendUrl,
@@ -272,7 +272,7 @@ export function NodejsInspectorButton({
     <CopyButton
       data-nextjs-data-runtime-error-copy-devtools-url
       className="nodejs-inspector-button"
-      actionLabel={'Copy Chrome DevTools URL'}
+      actionLabel={'Copy Browser DevTools URL'}
       successLabel="Copied"
       content={content}
       icon={

--- a/packages/next/src/client/components/react-dev-overlay/internal/components/nodejs-inspector.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/nodejs-inspector.tsx
@@ -73,7 +73,7 @@ function NodeJsDisabledIcon(props: any) {
 }
 
 const label =
-  'Learn more about enabling Node.js inspector for server code with Chrome DevTools'
+  'Learn more about enabling Node.js inspector for server code with Browser DevTools'
 
 export function NodejsInspectorCopyButton({
   devtoolsFrontendUrl,
@@ -99,7 +99,7 @@ export function NodejsInspectorCopyButton({
   return (
     <CopyButton
       data-nextjs-data-runtime-error-copy-devtools-url
-      actionLabel={'Copy Chrome DevTools URL'}
+      actionLabel={'Copy Browser DevTools URL'}
       successLabel="Copied"
       content={content}
       icon={<NodeJsIcon width={16} height={16} />}

--- a/test/development/app-dir/devtool-copy-button/devtool-copy-button.test.ts
+++ b/test/development/app-dir/devtool-copy-button/devtool-copy-button.test.ts
@@ -15,6 +15,10 @@ describe('app-dir - devtool-copy-button', () => {
       await browser
         .elementByCss('[data-nextjs-data-runtime-error-copy-devtools-url]')
         .getAttribute('aria-label')
-    ).toBe('Copy Chrome DevTools URL')
+    ).toBe(
+      process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
+        ? 'Copy Browser DevTools URL'
+        : 'Copy Chrome DevTools URL'
+    )
   })
 })

--- a/test/development/app-dir/devtool-copy-button/devtool-copy-button.test.ts
+++ b/test/development/app-dir/devtool-copy-button/devtool-copy-button.test.ts
@@ -15,10 +15,6 @@ describe('app-dir - devtool-copy-button', () => {
       await browser
         .elementByCss('[data-nextjs-data-runtime-error-copy-devtools-url]')
         .getAttribute('aria-label')
-    ).toBe(
-      process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true'
-        ? 'Copy Browser DevTools URL'
-        : 'Copy Chrome DevTools URL'
-    )
+    ).toBe('Copy Browser DevTools URL')
   })
 })


### PR DESCRIPTION
Since we support both `Chrome` and `Firefox` for Node.js inspector, change the label to use "Browser".

Closes NDX-799