### PR TITLE
[Segment Cache] Re-prefetch links on navigation

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -62,6 +62,7 @@ import { prefetch as prefetchWithSegmentCache } from '../components/segment-cach
 import { getRedirectTypeFromError, getURLFromRedirectError } from './redirect'
 import { isRedirectError, RedirectType } from './redirect-error'
 import { prefetchReducer } from './router-reducer/reducers/prefetch-reducer'
+import { pingVisibleLinks } from '../app-dir/link'
 
 const globalMutable: {
   pendingMpaPath?: string
@@ -142,6 +143,17 @@ function HistoryUpdater({
       window.history.replaceState(historyState, '', canonicalUrl)
     }
   }, [appRouterState])
+
+  useEffect(() => {
+    // The Next-Url and the base tree may affect the result of a prefetch
+    // task. Re-prefetch all visible links with the updated values. In most
+    // cases, this will not result in any new network requests, only if
+    // the prefetch result actually varies on one of these inputs.
+    if (process.env.__NEXT_CLIENT_SEGMENT_CACHE) {
+      pingVisibleLinks(appRouterState.nextUrl, appRouterState.tree)
+    }
+  }, [appRouterState.nextUrl, appRouterState.tree])
+
   return null
 }
 

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -123,7 +123,7 @@ export function refreshReducer(
             undefined
           )
           if (process.env.__NEXT_CLIENT_SEGMENT_CACHE) {
-            revalidateEntireCache()
+            revalidateEntireCache(state.nextUrl, newTree)
           } else {
             mutable.prefetchCache = new Map()
           }

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -340,7 +340,7 @@ export function serverActionReducer(
 
           mutable.cache = cache
           if (process.env.__NEXT_CLIENT_SEGMENT_CACHE) {
-            revalidateEntireCache()
+            revalidateEntireCache(state.nextUrl, newTree)
           } else {
             mutable.prefetchCache = new Map()
           }

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -52,6 +52,7 @@ import type {
 } from '../../../server/app-render/types'
 import { normalizeFlightData } from '../../flight-data-helpers'
 import { STATIC_STALETIME_MS } from '../router-reducer/prefetch-cache-utils'
+import { pingVisibleLinks } from '../../app-dir/link'
 
 // A note on async/await when working in the prefetch cache:
 //
@@ -238,13 +239,25 @@ let segmentCacheLru = createLRU<SegmentCacheEntry>(
   onSegmentLRUEviction
 )
 
+// Incrementing counter used to track cache invalidations.
+let currentCacheVersion = 0
+
+export function getCurrentCacheVersion(): number {
+  return currentCacheVersion
+}
+
 /**
  * Used to clear the client prefetch cache when a server action calls
  * revalidatePath or revalidateTag. Eventually we will support only clearing the
  * segments that were actually affected, but there's more work to be done on the
  * server before the client is able to do this correctly.
  */
-export function revalidateEntireCache() {
+export function revalidateEntireCache(
+  nextUrl: string | null,
+  tree: FlightRouterState
+) {
+  currentCacheVersion++
+
   // Clearing the cache also effectively rejects any pending requests, because
   // when the response is received, it gets written into a cache entry that is
   // no longer reachable.
@@ -254,6 +267,9 @@ export function revalidateEntireCache() {
   routeCacheLru = createLRU(maxRouteLruSize, onRouteLRUEviction)
   segmentCacheMap = new Map()
   segmentCacheLru = createLRU(maxSegmentLruSize, onSegmentLRUEviction)
+
+  // Prefetch all the currently visible links again, to re-fill the cache.
+  pingVisibleLinks(nextUrl, tree)
 }
 
 export function readExactRouteCacheEntry(

--- a/test/e2e/app-dir/segment-cache/revalidation/app/refetch-on-new-base-tree/a/page.tsx
+++ b/test/e2e/app-dir/segment-cache/revalidation/app/refetch-on-new-base-tree/a/page.tsx
@@ -1,0 +1,15 @@
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+async function Content() {
+  await connection()
+  return <div id="page-a-content">Page A content</div>
+}
+
+export default async function PageA() {
+  return (
+    <Suspense fallback="Loading...">
+      <Content />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/revalidation/app/refetch-on-new-base-tree/b/page.tsx
+++ b/test/e2e/app-dir/segment-cache/revalidation/app/refetch-on-new-base-tree/b/page.tsx
@@ -1,0 +1,15 @@
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+async function Content() {
+  await connection()
+  return <div id="page-b-content">Page B content</div>
+}
+
+export default async function PageB() {
+  return (
+    <Suspense fallback="Loading...">
+      <Content />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/revalidation/app/refetch-on-new-base-tree/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/revalidation/app/refetch-on-new-base-tree/layout.tsx
@@ -1,0 +1,61 @@
+import { LinkAccordion } from '../../components/link-accordion'
+
+export default function RefetchOnNewBaseTreeLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <>
+      <div style={{ backgroundColor: 'lightgray', padding: '1rem' }}>
+        <p>
+          This demonstrates what happens when a link is prefetched using{' '}
+          <code>{'prefetch={true}'}</code> and the URL changes. Next.js should
+          re-prefetch the link in case the delta between the base tree and the
+          target tree has changed.
+        </p>
+        <p>
+          Everything in this gray section is part of a shared layout. The links
+          below are prefetched using <code>{'prefetch={true}'}</code>. If the
+          first loaded page is "/refetch-on-new-base-tree/a", the prefetch for
+          this link will be empty, because there's no delta between the base
+          tree and the target tree.
+        </p>
+        <p>
+          However, if you then navigate to page B, we should re-prefetch the
+          link to A, because the delta between the base tree and the target tree
+          is now different.
+        </p>
+        <p>Test steps:</p>
+        <ul>
+          <li>Load "/refetch-on-new-base-tree/a" in the browser.</li>
+          <li>
+            Click the checkboxes to reveal the links. (These exist so the e2e
+            test can control the timing of the prefetch.)
+          </li>
+          <li>
+            Observe that the prefetch for page A is empty, i.e. the string "Page
+            A content" should not appear anywhere in the response.
+          </li>
+          <li>Click the link to page B to navigate away.</li>
+          <li>
+            Check the network tab to confirm that a new prefetch for page A was
+            requested.
+          </li>
+          <li>Click the link to page A</li>
+          <li>
+            Observe that no new request was made when navigating to page A,
+            because it was fully prefetched.
+          </li>
+        </ul>
+        <LinkAccordion prefetch={true} href="/refetch-on-new-base-tree/a">
+          Page A
+        </LinkAccordion>
+        <LinkAccordion prefetch={true} href="/refetch-on-new-base-tree/b">
+          Page B
+        </LinkAccordion>
+      </div>
+      <div>{children}</div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/revalidation/app/refetch-on-new-base-tree/page.tsx
+++ b/test/e2e/app-dir/segment-cache/revalidation/app/refetch-on-new-base-tree/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function Page() {
+  redirect('/refetch-on-new-base-tree/a')
+}

--- a/test/e2e/app-dir/segment-cache/revalidation/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/revalidation/components/link-accordion.tsx
@@ -3,7 +3,15 @@
 import Link from 'next/link'
 import { useState } from 'react'
 
-export function LinkAccordion({ href, children }) {
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: React.ReactNode
+  prefetch?: boolean
+}) {
   const [isVisible, setIsVisible] = useState(false)
   return (
     <>
@@ -14,9 +22,11 @@ export function LinkAccordion({ href, children }) {
         data-link-accordion={href}
       />
       {isVisible ? (
-        <Link href={href}>{children}</Link>
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
       ) : (
-        `${children} (link is hidden)`
+        <>{children} (link is hidden)</>
       )}
     </>
   )

--- a/test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts
+++ b/test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts
@@ -13,23 +13,24 @@ describe('segment cache (revalidation)', () => {
 
   let port = -1
   let server
-  let pendingRequests = new Map()
+  let dataVersions = new Map()
   let TestLog = createTestLog()
 
   let next
   beforeAll(async () => {
     port = await findPort()
-    let isFinishedBuilding = false
     server = createTestDataServer(async (key, res) => {
-      if (!isFinishedBuilding) {
-        res.resolve('Initial value during build for: ' + key)
-        return
-      }
-      if (pendingRequests.has(key)) {
-        throw new Error('Request already pending for: ' + key)
-      }
-      pendingRequests.set(key, res)
+      const currentVersion = dataVersions.get(key)
+
+      // Increment the version number each time to track how often the
+      // server renders.
+      const nextVersion = currentVersion === undefined ? 1 : currentVersion + 1
+      dataVersions.set(key, nextVersion)
+
+      // Append the version number to the response
+      const response = `${key} [${nextVersion}]`
       TestLog.log('REQUEST: ' + key)
+      res.resolve(response)
     })
     server.listen(port)
 
@@ -37,11 +38,10 @@ describe('segment cache (revalidation)', () => {
       files: __dirname,
       env: { TEST_DATA_SERVICE_URL: `http://localhost:${port}` },
     })
-    isFinishedBuilding = true
   })
 
-  afterEach(async () => {
-    pendingRequests = new Map()
+  beforeEach(async () => {
+    dataVersions = new Map()
     TestLog = createTestLog()
   })
 
@@ -59,7 +59,7 @@ describe('segment cache (revalidation)', () => {
     })
 
     const linkVisibilityToggle = await browser.elementByCss(
-      'input[type="checkbox"]'
+      'input[data-link-accordion="/greeting"]'
     )
 
     // Reveal the link the target page to trigger a prefetch
@@ -68,37 +68,23 @@ describe('segment cache (revalidation)', () => {
         await linkVisibilityToggle.click()
       },
       {
-        includes: 'Greeting',
+        includes: 'random-greeting',
       }
     )
-
-    // Hide the link so we can reveal it again later to trigger another
-    // prefetch task
-    await linkVisibilityToggle.click()
 
     // Perform an action that calls revalidatePath. This should cause the
-    // corresponding entry to be evicted from the client cache.
-    await act(async () => {
-      const revalidateByPath = await browser.elementById('revalidate-by-path')
-      await revalidateByPath.click()
-    })
-
+    // corresponding entry to be evicted from the client cache, and a new
+    // prefetch to be requested.
     await act(
       async () => {
-        // Reveal the link
-        await linkVisibilityToggle.click()
-
-        // Because the corresponding entry was evicted from the cache, this
-        // should trigger a new prefetch.
-        await TestLog.waitFor(['REQUEST: random-greeting'])
-
-        // Fulfill the prefetch request.
-        await pendingRequests.get('random-greeting').resolve('yo!')
+        const revalidateByPath = await browser.elementById('revalidate-by-path')
+        await revalidateByPath.click()
       },
       {
-        includes: 'yo!',
+        includes: 'random-greeting [1]',
       }
     )
+    TestLog.assert(['REQUEST: random-greeting'])
 
     // Navigate to the target page.
     await act(async () => {
@@ -107,7 +93,7 @@ describe('segment cache (revalidation)', () => {
       // Navigation should finish immedately because the page is
       // fully prefetched.
       const greeting = await browser.elementById('greeting')
-      expect(await greeting.innerHTML()).toBe('yo!')
+      expect(await greeting.innerHTML()).toBe('random-greeting [1]')
     }, 'no-requests')
   })
 
@@ -120,46 +106,32 @@ describe('segment cache (revalidation)', () => {
     })
 
     const linkVisibilityToggle = await browser.elementByCss(
-      'input[type="checkbox"]'
+      'input[data-link-accordion="/greeting"]'
     )
 
-    // Reveal the link the target page to trigger a prefetch
+    // Reveal the link the target page to trigger a prefetch.
     await act(
       async () => {
         await linkVisibilityToggle.click()
       },
       {
-        includes: 'Greeting',
+        includes: 'random-greeting',
       }
     )
-
-    // Hide the link so we can reveal it again later to trigger another
-    // prefetch task
-    await linkVisibilityToggle.click()
 
     // Perform an action that calls revalidateTag. This should cause the
-    // corresponding entry to be evicted from the client cache.
-    await act(async () => {
-      const revalidateByPath = await browser.elementById('revalidate-by-tag')
-      await revalidateByPath.click()
-    })
-
+    // corresponding entry to be evicted from the client cache, and a new
+    // prefetch to be requested.
     await act(
       async () => {
-        // Reveal the link
-        await linkVisibilityToggle.click()
-
-        // Because the corresponding entry was evicted from the cache, this
-        // should trigger a new prefetch.
-        await TestLog.waitFor(['REQUEST: random-greeting'])
-
-        // Fulfill the prefetch request.
-        await pendingRequests.get('random-greeting').resolve('hey!')
+        const revalidateByTag = await browser.elementById('revalidate-by-tag')
+        await revalidateByTag.click()
       },
       {
-        includes: 'hey!',
+        includes: 'random-greeting [1]',
       }
     )
+    TestLog.assert(['REQUEST: random-greeting'])
 
     // Navigate to the target page.
     await act(async () => {
@@ -168,7 +140,75 @@ describe('segment cache (revalidation)', () => {
       // Navigation should finish immedately because the page is
       // fully prefetched.
       const greeting = await browser.elementById('greeting')
-      expect(await greeting.innerHTML()).toBe('hey!')
+      expect(await greeting.innerHTML()).toBe('random-greeting [1]')
     }, 'no-requests')
+  })
+
+  it('re-fetch visible links after a navigation, if needed', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/refetch-on-new-base-tree/a', {
+      beforePageLoad(page: Playwright.Page) {
+        act = createRouterAct(page)
+      },
+    })
+
+    const linkALinkVisibilityToggle = await browser.elementByCss(
+      'input[data-link-accordion="/refetch-on-new-base-tree/a"]'
+    )
+    const linkBLinkVisibilityToggle = await browser.elementByCss(
+      'input[data-link-accordion="/refetch-on-new-base-tree/b"]'
+    )
+
+    // Reveal the links to trigger prefetches
+    await act(async () => {
+      await linkALinkVisibilityToggle.click()
+      await linkBLinkVisibilityToggle.click()
+    }, [
+      // Page B's content should have been prefetched
+      {
+        includes: 'Page B content',
+      },
+      // Page A's content should not be prefetched because we're already on that
+      // page. When prefetching with `prefetch={true}`, we only prefetch the
+      // delta between the current route and the target route.
+      {
+        includes: 'Page A content',
+        block: 'reject',
+      },
+    ])
+
+    // Navigate to page B
+    await act(
+      async () => {
+        const link = await browser.elementByCss(
+          'a[href="/refetch-on-new-base-tree/b"]'
+        )
+        await link.click()
+        const content = await browser.elementById('page-b-content')
+        expect(await content.innerHTML()).toBe('Page B content')
+      },
+      // The link for page A is re-prefetched again, even though it's an
+      // existing link, because the delta between the current route and the
+      // target route has changed.
+      //
+      // This time, the response does include the content for page A.
+      {
+        includes: 'Page A content',
+      }
+    )
+
+    // Navigate to page A
+    await act(
+      async () => {
+        const link = await browser.elementByCss(
+          'a[href="/refetch-on-new-base-tree/a"]'
+        )
+        await link.click()
+        const content = await browser.elementById('page-a-content')
+        expect(await content.innerHTML()).toBe('Page A content')
+      },
+      // There should be no new requests because everything is fully prefetched.
+      'no-requests'
+    )
   })
 })


### PR DESCRIPTION
The result of certain kinds of prefetches may depend on the current URL at the time it is initiated. This is true if for links that are intercepted, or links that are prefetched using a dynamic request (e.g. `prefetch={true}`). So, whenever the location changes, we should re-prefetch all the links using the updated value.

In most cases, this will not result in any new network requests — only if the prefetch result actually varies on one of these inputs.

For similar reasons, we also re-prefetch links whenever the client cache is revalidated by a Server Action.

As part of the implementation, we must be able to enumerate over all the currently visible links. I've added a Set to track this.