### PR TITLE
[dev-overlay] style: improve version staleness indicator version unknown

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/version-staleness-info/version-staleness-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/version-staleness-info/version-staleness-info.tsx
@@ -78,7 +78,9 @@ export function getStaleness({ installed, staleness, expected }: VersionInfo) {
       break
     }
     case 'unknown':
-      text = 'No version data'
+      text = `${versionLabel} (unknown)`
+      title = 'No Next.js version data was found.'
+      indicatorClass = 'unknown'
       break
     default:
       break
@@ -132,6 +134,10 @@ export const styles = css`
   .version-staleness-indicator.outdated {
     fill: var(--color-red-800);
     stroke: var(--color-red-300);
+  }
+  .version-staleness-indicator.unknown {
+    fill: var(--color-gray-800);
+    stroke: var(--color-gray-300);
   }
 
   .nextjs-container-build-error-version-status > .turbopack-text {


### PR DESCRIPTION
This PR added style for no version info found.

| _______ | Before | After |
|--------|--------|--------|
| Light | ![CleanShot 2025-02-15 at 03 00 34](https://github.com/user-attachments/assets/61138303-609d-47cd-b52c-6326b42f8b28) | ![CleanShot 2025-02-15 at 02 59 08](https://github.com/user-attachments/assets/821919fd-7116-48ce-ad00-be467a214f97) |
| Dark | ![CleanShot 2025-02-15 at 03 00 29](https://github.com/user-attachments/assets/2cc219ac-13f5-477f-817d-0cf69a1863cd) | ![CleanShot 2025-02-15 at 02 59 13](https://github.com/user-attachments/assets/89168eaf-9d33-44bd-803e-3d8422c7b251) | 



