### PR TITLE
Add `radix-ui`, `radix-ui/internal` to the default `optimizePackageImports` list

### DIFF
--- a/docs/01-app/04-api-reference/05-config/01-next-config-js/optimizePackageImports.mdx
+++ b/docs/01-app/04-api-reference/05-config/01-next-config-js/optimizePackageImports.mdx
@@ -44,3 +44,5 @@ The following libraries are optimized by default:
 - `@tabler/icons-react`
 - `mui-core`
 - `react-icons/*`
+- `radix-ui`
+- `radix-ui/internal`

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -972,6 +972,8 @@ function assignDefaults(
       '@material-ui/icons',
       '@tabler/icons-react',
       'mui-core',
+      'radix-ui',
+      'radix-ui/internal',
       // We don't support wildcard imports for these configs, e.g. `react-icons/*`
       // so we need to add them manually.
       // In the future, we should consider automatically detecting packages that


### PR DESCRIPTION
### What?

- Add `radix-ui` and `radix-ui/internal` to the default `optimizePackageImports` list in [`packages/next/src/server/config.ts`](packages/next/src/server/config.ts)
- Ref: https://unpkg.com/radix-ui@1.1.3/dist/index.js and https://unpkg.com/radix-ui@1.1.3/dist/internal.js

### Why?

[radix-ui/primitives](https://github.com/radix-ui/primitives) as of [January 22, 2025](https://www.radix-ui.com/primitives/docs/overview/releases#january-22-2025) has a `radix-ui` package that exposes all Radix UI primitives. This was introduced in commit radix-ui/primitives@61479a869266debe9eb017055997ae64468d7e1e.

Without updating `optimizePackageImports`, all imports in `radix-ui` will be brought into client bundle. Example can be seen here: [StackBlitz](https://stackblitz.com/edit/stackblitz-starters-ynj762ww?file=next.config.js)

### How?

- Updates default `optimizePackageImports` list and corresponding docs