### PR TITLE
[dev-overlay] deprecate `devIndicators` options `appIsrStatus` and `buildActivity`

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1098,8 +1098,9 @@ export const defaultConfig: NextConfig = {
   compress: true,
   images: imageConfigDefault,
   devIndicators: {
-    appIsrStatus: false,
-    buildActivity: false,
+    // TODO(jiwon): Change to false once we remove the old overlay and this flag.
+    appIsrStatus: process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY !== 'true',
+    buildActivity: process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY !== 'true',
     buildActivityPosition: 'bottom-right',
   },
   onDemandEntries: {

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1097,8 +1097,8 @@ export const defaultConfig: NextConfig = {
   compress: true,
   images: imageConfigDefault,
   devIndicators: {
-    appIsrStatus: true,
-    buildActivity: true,
+    appIsrStatus: false,
+    buildActivity: false,
     buildActivityPosition: 'bottom-right',
   },
   onDemandEntries: {

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -837,7 +837,9 @@ export interface NextConfig extends Record<string, any> {
 
   /** Configure indicators in development environment */
   devIndicators?: {
-    /** Show "building..."" indicator in development */
+    /** Show "building..."" indicator in development
+     * @deprecated The dev tools indicator has it enabled by default.
+     */
     buildActivity?: boolean
     /** Position of "building..." indicator in browser */
     buildActivityPosition?:
@@ -846,6 +848,9 @@ export interface NextConfig extends Record<string, any> {
       | 'top-right'
       | 'top-left'
 
+    /**
+     * @deprecated The dev tools indicator has it enabled by default.
+     * */
     appIsrStatus?: boolean
   }
 

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -837,7 +837,8 @@ export interface NextConfig extends Record<string, any> {
 
   /** Configure indicators in development environment */
   devIndicators?: {
-    /** Show "building..."" indicator in development
+    /**
+     * Show "building..."" indicator in development
      * @deprecated The dev tools indicator has it enabled by default.
      */
     buildActivity?: boolean

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1098,9 +1098,6 @@ export const defaultConfig: NextConfig = {
   compress: true,
   images: imageConfigDefault,
   devIndicators: {
-    // TODO(jiwon): Change to false once we remove the old overlay and this flag.
-    appIsrStatus: process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY !== 'true',
-    buildActivity: process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY !== 'true',
     buildActivityPosition: 'bottom-right',
   },
   onDemandEntries: {

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -466,14 +466,14 @@ function assignDefaults(
   warnOptionHasBeenDeprecated(
     result,
     'devIndicators.appIsrStatus',
-    `\`devIndicators.appIsrStatus\` is no longer needed, because the new dev tools indicator has it enabled by default. You can remove it from ${configFileName}.`,
+    `\`devIndicators.appIsrStatus\` is no longer needed and is enabled by default. You can remove it from ${configFileName}.`,
     silent
   )
 
   warnOptionHasBeenDeprecated(
     result,
     'devIndicators.buildActivity',
-    `\`devIndicators.buildActivity\` is no longer needed, because the new dev tools indicator has it enabled by default. You can remove it from ${configFileName}.`,
+    `\`devIndicators.buildActivity\` is no longer needed and is enabled by default. You can remove it from ${configFileName}.`,
     silent
   )
 

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -463,6 +463,20 @@ function assignDefaults(
     silent
   )
 
+  warnOptionHasBeenDeprecated(
+    result,
+    'devIndicators.appIsrStatus',
+    `\`devIndicators.appIsrStatus\` is no longer needed, because the new dev tools indicator has it enabled by default. You can remove it from ${configFileName}.`,
+    silent
+  )
+
+  warnOptionHasBeenDeprecated(
+    result,
+    'devIndicators.buildActivity',
+    `\`devIndicators.buildActivity\` is no longer needed, because the new dev tools indicator has it enabled by default. You can remove it from ${configFileName}.`,
+    silent
+  )
+
   warnOptionHasBeenMovedOutOfExperimental(
     result,
     'bundlePagesExternals',

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -938,6 +938,13 @@ function assignDefaults(
   if (process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'false') {
     result.experimental.newDevOverlay = false
   }
+  if (result.experimental.newDevOverlay !== true) {
+    // Preserve the default indicator options for old overlay.
+    result.devIndicators = {
+      appIsrStatus: result.devIndicators?.appIsrStatus ?? true,
+      buildActivity: result.devIndicators?.buildActivity ?? true,
+    }
+  }
 
   result.experimental.optimizePackageImports = [
     ...new Set([

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -938,9 +938,10 @@ function assignDefaults(
   if (process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'false') {
     result.experimental.newDevOverlay = false
   }
+  // Preserve the default indicator options for old overlay.
   if (result.experimental.newDevOverlay !== true) {
-    // Preserve the default indicator options for old overlay.
     result.devIndicators = {
+      ...result.devIndicators,
       appIsrStatus: result.devIndicators?.appIsrStatus ?? true,
       buildActivity: result.devIndicators?.buildActivity ?? true,
     }

--- a/test/integration/next-image-new/svgo-webpack/test/index.test.ts
+++ b/test/integration/next-image-new/svgo-webpack/test/index.test.ts
@@ -52,7 +52,7 @@ let devOutput
           await renderViaHTTP(appPort, '/', {})
           const errors = devOutput.stderr
             .split('\n')
-            .filter((line) => line && !line.trim().startsWith('⚠️'))
+            .filter((line) => line && !line.trim().startsWith('⚠'))
           expect(errors).toEqual([])
         })
       }


### PR DESCRIPTION
### Why?

Since the new dev indicator supersedes the existing `appIsrStatus` (Static Route Indicator) and `buildActivity` (Compilation Indicator), deprecate them before we fully remove the old overlay.

### Follow Up

After removing the old overlay's sources, we can remove any logic that `appIsrStatus ` and `buildActivity` were holding for the old overlay.

Closes NDX-836