### PR TITLE
[dev-overlay] deprecate `devIndicators.buildActivityPosition` and rename to `position`

### DIFF
--- a/crates/next-build-test/nextConfig.json
+++ b/crates/next-build-test/nextConfig.json
@@ -38,7 +38,7 @@
   },
   "devIndicators": {
     "buildActivity": true,
-    "position": "bottom-right"
+    "position": "bottom-left"
   },
   "onDemandEntries": {
     "maxInactiveAge": 60000,

--- a/crates/next-build-test/nextConfig.json
+++ b/crates/next-build-test/nextConfig.json
@@ -38,7 +38,7 @@
   },
   "devIndicators": {
     "buildActivity": true,
-    "position": "bottom-left"
+    "buildActivityPosition": "bottom-right"
   },
   "onDemandEntries": {
     "maxInactiveAge": 60000,

--- a/crates/next-build-test/nextConfig.json
+++ b/crates/next-build-test/nextConfig.json
@@ -38,7 +38,7 @@
   },
   "devIndicators": {
     "buildActivity": true,
-    "buildActivityPosition": "bottom-right"
+    "position": "bottom-right"
   },
   "onDemandEntries": {
     "maxInactiveAge": 60000,

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -202,6 +202,7 @@ pub enum BuildActivityPositions {
 pub struct DevIndicatorsConfig {
     pub build_activity: Option<bool>,
     pub build_activity_position: Option<BuildActivityPositions>,
+    pub position: Option<BuildActivityPositions>,
 }
 
 #[derive(

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -640,5 +640,6 @@
   "639": "unstable_rootParams() can only be used within App Router.",
   "640": "Route %s used \"unstable_rootParams\" inside \\`\"use cache\"\\` or \\`unstable_cache\\`. Support for this API inside cache scopes is planned for a future version of Next.js.",
   "641": "Route %s used \\`unstable_rootParams()\\` in Pages Router. This API is only available within App Router.",
-  "642": "Route %s used \\`unstable_rootParams()\\` inside \\`\"use cache\"\\` or \\`unstable_cache\\`. Support for this API inside cache scopes is planned for a future version of Next.js."
+  "642": "Route %s used \\`unstable_rootParams()\\` inside \\`\"use cache\"\\` or \\`unstable_cache\\`. Support for this API inside cache scopes is planned for a future version of Next.js.",
+  "643": "Invalid \"devIndicator.position\" provided, expected one of %s, received %s"
 }

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2131,7 +2131,7 @@ export default async function getBaseWebpackConfig(
     pageExtensions: pageExtensions,
     trailingSlash: config.trailingSlash,
     buildActivity: config.devIndicators.buildActivity,
-    buildActivityPosition: config.devIndicators.buildActivityPosition,
+    buildActivityPosition: config.devIndicators.position,
     productionBrowserSourceMaps: !!config.productionBrowserSourceMaps,
     reactStrictMode: config.reactStrictMode,
     optimizeCss: config.experimental.optimizeCss,

--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -240,7 +240,7 @@ export function getDefineEnv({
     'process.env.__NEXT_BUILD_INDICATOR':
       config.devIndicators.buildActivity ?? true,
     'process.env.__NEXT_BUILD_INDICATOR_POSITION':
-      config.devIndicators.buildActivityPosition ?? 'bottom-right',
+      config.devIndicators.position ?? 'bottom-right',
     'process.env.__NEXT_STRICT_MODE':
       config.reactStrictMode === null ? false : config.reactStrictMode,
     'process.env.__NEXT_STRICT_MODE_APP':

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -231,6 +231,14 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
       .object({
         appIsrStatus: z.boolean().optional(),
         buildActivity: z.boolean().optional(),
+        buildActivityPosition: z
+          .union([
+            z.literal('bottom-left'),
+            z.literal('bottom-right'),
+            z.literal('top-left'),
+            z.literal('top-right'),
+          ])
+          .optional(),
         position: z
           .union([
             z.literal('bottom-left'),

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -231,14 +231,6 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
       .object({
         appIsrStatus: z.boolean().optional(),
         buildActivity: z.boolean().optional(),
-        buildActivityPosition: z
-          .union([
-            z.literal('bottom-left'),
-            z.literal('bottom-right'),
-            z.literal('top-left'),
-            z.literal('top-right'),
-          ])
-          .optional(),
         position: z
           .union([
             z.literal('bottom-left'),

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -239,6 +239,14 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
             z.literal('top-right'),
           ])
           .optional(),
+        position: z
+          .union([
+            z.literal('bottom-left'),
+            z.literal('bottom-right'),
+            z.literal('top-left'),
+            z.literal('top-right'),
+          ])
+          .optional(),
       })
       .optional(),
     distDir: z.string().min(1).optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -838,10 +838,16 @@ export interface NextConfig extends Record<string, any> {
   /** Configure indicators in development environment */
   devIndicators?: {
     /**
+     * @deprecated The dev tools indicator has it enabled by default.
+     * */
+    appIsrStatus?: boolean
+
+    /**
      * Show "building..."" indicator in development
      * @deprecated The dev tools indicator has it enabled by default.
      */
     buildActivity?: boolean
+
     /**
      * Position of "building..." indicator in browser
      * @deprecated Renamed as `position`.
@@ -852,13 +858,10 @@ export interface NextConfig extends Record<string, any> {
       | 'top-right'
       | 'top-left'
 
-    /** Position of "building..." indicator in browser */
-    position?: 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left'
-
     /**
-     * @deprecated The dev tools indicator has it enabled by default.
+     * Position of "building..." indicator in browser
      * */
-    appIsrStatus?: boolean
+    position?: 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left'
   }
 
   /**
@@ -1104,8 +1107,7 @@ export const defaultConfig: NextConfig = {
   compress: true,
   images: imageConfigDefault,
   devIndicators: {
-    buildActivityPosition: 'bottom-right',
-    position: 'bottom-right',
+    position: 'bottom-left',
   },
   onDemandEntries: {
     maxInactiveAge: 60 * 1000,

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -850,6 +850,7 @@ export interface NextConfig extends Record<string, any> {
 
     /**
      * Position of "building..." indicator in browser
+     * @default "bottom-right"
      * @deprecated Renamed as `position`.
      */
     buildActivityPosition?:
@@ -860,9 +861,9 @@ export interface NextConfig extends Record<string, any> {
 
     /**
      * Position of "building..." indicator in browser
-     * @default "bottom-left"
+     * @default "bottom-right"
      * */
-    position?: 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right'
+    position?: 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left'
   }
 
   /**
@@ -1108,7 +1109,7 @@ export const defaultConfig: NextConfig = {
   compress: true,
   images: imageConfigDefault,
   devIndicators: {
-    position: 'bottom-left',
+    position: 'bottom-right',
   },
   onDemandEntries: {
     maxInactiveAge: 60 * 1000,

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -860,8 +860,9 @@ export interface NextConfig extends Record<string, any> {
 
     /**
      * Position of "building..." indicator in browser
+     * @default "bottom-left"
      * */
-    position?: 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left'
+    position?: 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right'
   }
 
   /**

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -842,12 +842,18 @@ export interface NextConfig extends Record<string, any> {
      * @deprecated The dev tools indicator has it enabled by default.
      */
     buildActivity?: boolean
-    /** Position of "building..." indicator in browser */
+    /**
+     * Position of "building..." indicator in browser
+     * @deprecated Renamed as `position`.
+     */
     buildActivityPosition?:
       | 'bottom-right'
       | 'bottom-left'
       | 'top-right'
       | 'top-left'
+
+    /** Position of "building..." indicator in browser */
+    position?: 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left'
 
     /**
      * @deprecated The dev tools indicator has it enabled by default.
@@ -1099,6 +1105,7 @@ export const defaultConfig: NextConfig = {
   images: imageConfigDefault,
   devIndicators: {
     buildActivityPosition: 'bottom-right',
+    position: 'bottom-right',
   },
   onDemandEntries: {
     maxInactiveAge: 60 * 1000,

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -843,7 +843,7 @@ export interface NextConfig extends Record<string, any> {
     appIsrStatus?: boolean
 
     /**
-     * Show "building..."" indicator in development
+     * Show "building..." indicator in development
      * @deprecated The dev tools indicator has it enabled by default.
      */
     buildActivity?: boolean

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -105,34 +105,6 @@ export function warnOptionHasBeenMovedOutOfExperimental(
   return config
 }
 
-export function warnOptionHasBeenRenamed(
-  config: NextConfig,
-  oldKey: string,
-  newKey: string,
-  configFileName: string,
-  silent: boolean
-) {
-  if (config[oldKey]) {
-    if (!silent) {
-      Log.warnOnce(
-        `\`${oldKey}\` has been renamed to \`${newKey}\`. ` +
-          `Please update your ${configFileName} file accordingly.`
-      )
-    }
-
-    let current = config
-    const newKeys = newKey.split('.')
-    while (newKeys.length > 1) {
-      const key = newKeys.shift()!
-      current[key] = current[key] || {}
-      current = current[key]
-    }
-    current[newKeys.shift()!] = config[oldKey]
-  }
-
-  return config
-}
-
 function warnCustomizedOption(
   config: NextConfig,
   key: string,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -494,6 +494,7 @@ function assignDefaults(
     Log.warnOnce(
       `The \`devIndicators\` option \`buildActivityPosition\` ("${result.devIndicators.buildActivityPosition}") conflicts with \`position\` ("${result.devIndicators.position}"). Using \`buildActivityPosition\` for backwards compatibility.`
     )
+    result.devIndicators.position = result.devIndicators.buildActivityPosition
   }
 
   warnOptionHasBeenMovedOutOfExperimental(

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -492,7 +492,7 @@ function assignDefaults(
     result.devIndicators.buildActivityPosition !== result.devIndicators.position
   ) {
     Log.warnOnce(
-      `The \`devIndicators\` option \`buildActivityPosition\` ("${result.devIndicators.buildActivityPosition}") conflicts with \`position\` ("${result.devIndicators.position}"). Using \`buildActivityPosition\` for backwards compatibility.`
+      `The \`devIndicators\` option \`buildActivityPosition\` ("${result.devIndicators.buildActivityPosition}") conflicts with \`position\` ("${result.devIndicators.position}"). Using \`buildActivityPosition\` for backward compatibility.`
     )
     result.devIndicators.position = result.devIndicators.buildActivityPosition
   }

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -520,7 +520,7 @@ function assignDefaults(
     result.devIndicators.buildActivityPosition !== result.devIndicators.position
   ) {
     Log.warnOnce(
-      `The \`devIndicators\` option \`buildActivityPosition\` ("${result.devIndicators.buildActivityPosition}") conflicts with \`position\` ("${result.devIndicators.position}"). Using \`buildActivityPosition\` for backwardscompatibility.`
+      `The \`devIndicators\` option \`buildActivityPosition\` ("${result.devIndicators.buildActivityPosition}") conflicts with \`position\` ("${result.devIndicators.position}"). Using \`buildActivityPosition\` for backwards compatibility.`
     )
   }
 

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -492,7 +492,7 @@ function assignDefaults(
     result.devIndicators.buildActivityPosition !== result.devIndicators.position
   ) {
     Log.warnOnce(
-      `The \`devIndicators\` option \`buildActivityPosition\` ("${result.devIndicators.buildActivityPosition}") conflicts with \`position\` ("${result.devIndicators.position}"). Using \`buildActivityPosition\` for backward compatibility.`
+      `The \`devIndicators\` option \`buildActivityPosition\` ("${result.devIndicators.buildActivityPosition}") conflicts with \`position\` ("${result.devIndicators.position}"). Using \`buildActivityPosition\` ("${result.devIndicators.buildActivityPosition}") for backward compatibility.`
     )
     result.devIndicators.position = result.devIndicators.buildActivityPosition
   }

--- a/test/integration/build-indicator/test/index.test.js
+++ b/test/integration/build-indicator/test/index.test.js
@@ -67,7 +67,7 @@ describe('Build Activity Indicator', () => {
     await check(
       () => stripAnsi(stderr),
       new RegExp(
-        `Invalid "devIndicator.buildActivityPosition" provided, expected one of top-left, top-right, bottom-left, bottom-right, received ttop-leff`
+        `Invalid "devIndicator.position" provided, expected one of top-left, top-right, bottom-left, bottom-right, received ttop-leff`
       )
     )
 


### PR DESCRIPTION
### Why?

Since the `buildActivity` is deprecated at #76067, `buildActivityPosition` may also be deprecated. However, we are planning to preserve the option to position the dev indicator. Therefore, this PR adds a new option `position` and deprecates and aliases the `buildActivityPosition` to `position`.

### Success Criteria

Deprecation:

- [x] Does using `buildActivityPosition` show a deprecation warning?
- [x] Does `buildActivityPosition` have a deprecation in JSDoc?

Alias:

> Is it backward compatible with the old overlay?

- [x] Does setting `buildActivityPosition` correctly set the build activity indicator position?
- [x] Does it warn if `buildActivityPosition` is set instead of `position`?
- [x] Does `buildActivityPosition` supersede `position` value to prevent breaking change?
- [x] Does setting the `position` correctly set the build activity indicator position?

### Follow Up

In the following PRs, we will add the behavior for `position` to adjust the dev indicator's position. After removing the old overlay's sources, we can remove any logic that `buildActivityPosition` was holding for the old overlay and make it fully an alias for backwards compatibility.

Closes NDX-837