### PR TITLE
[dev-overlay] add false option to disable dev indicator

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -199,10 +199,19 @@ pub enum BuildActivityPositions {
     OperationValue,
 )]
 #[serde(rename_all = "camelCase")]
-pub struct DevIndicatorsConfig {
+pub struct DevIndicatorsOptions {
     pub build_activity: Option<bool>,
     pub build_activity_position: Option<BuildActivityPositions>,
     pub position: Option<BuildActivityPositions>,
+}
+
+#[derive(
+    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+)]
+#[serde(untagged)]
+pub enum DevIndicatorsConfig {
+    WithOptions(DevIndicatorsOptions),
+    Boolean(bool),
 }
 
 #[derive(

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2130,8 +2130,14 @@ export default async function getBaseWebpackConfig(
     crossOrigin: config.crossOrigin,
     pageExtensions: pageExtensions,
     trailingSlash: config.trailingSlash,
-    buildActivity: config.devIndicators.buildActivity,
-    buildActivityPosition: config.devIndicators.position,
+    buildActivity:
+      config.devIndicators === false
+        ? false
+        : config.devIndicators.buildActivity,
+    buildActivityPosition:
+      config.devIndicators === false
+        ? undefined
+        : config.devIndicators.position,
     productionBrowserSourceMaps: !!config.productionBrowserSourceMaps,
     reactStrictMode: config.reactStrictMode,
     optimizeCss: config.experimental.optimizeCss,

--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -239,6 +239,7 @@ export function getDefineEnv({
     'process.env.__NEXT_TRAILING_SLASH': config.trailingSlash,
     'process.env.__NEXT_BUILD_INDICATOR':
       config.devIndicators.buildActivity ?? true,
+    'process.env.__NEXT_DEV_INDICATOR': config.devIndicators !== false,
     'process.env.__NEXT_DEV_INDICATOR_POSITION':
       config.devIndicators.position ?? 'bottom-left',
     'process.env.__NEXT_STRICT_MODE':

--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -186,7 +186,7 @@ export function getDefineEnv({
       config.experimental.appNavFailHandling
     ),
     'process.env.__NEXT_APP_ISR_INDICATOR': Boolean(
-      config.devIndicators.appIsrStatus
+      config.devIndicators === false ? false : config.devIndicators.appIsrStatus
     ),
     'process.env.__NEXT_PPR': isPPREnabled,
     'process.env.__NEXT_DYNAMIC_IO': isDynamicIOEnabled,
@@ -238,10 +238,14 @@ export function getDefineEnv({
       : {}),
     'process.env.__NEXT_TRAILING_SLASH': config.trailingSlash,
     'process.env.__NEXT_BUILD_INDICATOR':
-      config.devIndicators.buildActivity ?? true,
+      config.devIndicators === false
+        ? false
+        : config.devIndicators.buildActivity ?? true,
     'process.env.__NEXT_DEV_INDICATOR': config.devIndicators !== false,
     'process.env.__NEXT_DEV_INDICATOR_POSITION':
-      config.devIndicators.position ?? 'bottom-left',
+      config.devIndicators === false
+        ? 'bottom-left' // This will not be used as the indicator is disabled.
+        : config.devIndicators.position ?? 'bottom-left',
     'process.env.__NEXT_STRICT_MODE':
       config.reactStrictMode === null ? false : config.reactStrictMode,
     'process.env.__NEXT_STRICT_MODE_APP':

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/render-error.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/render-error.tsx
@@ -109,7 +109,18 @@ const RenderRuntimeError = ({ children, state, isAppDir }: Props) => {
     }
   }, [nextError, isAppDir])
 
-  return children({ readyErrors, totalErrorCount: readyErrors.length })
+  // Stringify since __NEXT_DEV_INDICATOR can be set to boolean false.
+  const hasDisabledDevIndicator =
+    process.env.__NEXT_DEV_INDICATOR?.toString() === 'false'
+  const totalErrorCount = readyErrors.length
+
+  // Even if the dev indicator is disabled, we should show it
+  // along with the error overlay when there are errors.
+  if (hasDisabledDevIndicator && !totalErrorCount) {
+    return null
+  }
+
+  return children({ readyErrors, totalErrorCount })
 }
 
 const RenderBuildError = ({ children }: Props) => {

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -228,26 +228,29 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
       .optional(),
     deploymentId: z.string().optional(),
     devIndicators: z
-      .object({
-        appIsrStatus: z.boolean().optional(),
-        buildActivity: z.boolean().optional(),
-        buildActivityPosition: z
-          .union([
-            z.literal('bottom-left'),
-            z.literal('bottom-right'),
-            z.literal('top-left'),
-            z.literal('top-right'),
-          ])
-          .optional(),
-        position: z
-          .union([
-            z.literal('bottom-left'),
-            z.literal('bottom-right'),
-            z.literal('top-left'),
-            z.literal('top-right'),
-          ])
-          .optional(),
-      })
+      .union([
+        z.object({
+          appIsrStatus: z.boolean().optional(),
+          buildActivity: z.boolean().optional(),
+          buildActivityPosition: z
+            .union([
+              z.literal('bottom-left'),
+              z.literal('bottom-right'),
+              z.literal('top-left'),
+              z.literal('top-right'),
+            ])
+            .optional(),
+          position: z
+            .union([
+              z.literal('bottom-left'),
+              z.literal('bottom-right'),
+              z.literal('top-left'),
+              z.literal('top-right'),
+            ])
+            .optional(),
+        }),
+        z.literal(false),
+      ])
       .optional(),
     distDir: z.string().min(1).optional(),
     env: z.record(z.string(), z.union([z.string(), z.undefined()])).optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -258,6 +258,36 @@ export interface LoggingConfig {
   incomingRequests?: boolean | IncomingRequestLoggingConfig
 }
 
+export interface DevIndicatorsConfig {
+  /**
+   * @deprecated The dev tools indicator has it enabled by default.
+   * */
+  appIsrStatus?: boolean
+
+  /**
+   * Show "building..." indicator in development
+   * @deprecated The dev tools indicator has it enabled by default.
+   */
+  buildActivity?: boolean
+
+  /**
+   * Position of "building..." indicator in browser
+   * @default "bottom-right"
+   * @deprecated Renamed as `position`.
+   */
+  buildActivityPosition?:
+    | 'top-left'
+    | 'top-right'
+    | 'bottom-left'
+    | 'bottom-right'
+
+  /**
+   * Position of the development tools indicator in the browser window.
+   * @default "bottom-left"
+   * */
+  position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
+}
+
 export interface ExperimentalConfig {
   nodeMiddleware?: boolean
   cacheHandlers?: {
@@ -836,35 +866,8 @@ export interface NextConfig extends Record<string, any> {
   images?: ImageConfig
 
   /** Configure indicators in development environment */
-  devIndicators?: {
-    /**
-     * @deprecated The dev tools indicator has it enabled by default.
-     * */
-    appIsrStatus?: boolean
-
-    /**
-     * Show "building..." indicator in development
-     * @deprecated The dev tools indicator has it enabled by default.
-     */
-    buildActivity?: boolean
-
-    /**
-     * Position of "building..." indicator in browser
-     * @default "bottom-right"
-     * @deprecated Renamed as `position`.
-     */
-    buildActivityPosition?:
-      | 'top-left'
-      | 'top-right'
-      | 'bottom-left'
-      | 'bottom-right'
-
-    /**
-     * Position of the development tools indicator in the browser window.
-     * @default "bottom-left"
-     * */
-    position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
-  }
+  // Quite a large discriminant union, but is to skip boolean type check.
+  devIndicators?: DevIndicatorsConfig | (DevIndicatorsConfig & false)
 
   /**
    * Next.js exposes some options that give you some control over how the server will dispose or keep in memory built pages in development.

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -258,36 +258,6 @@ export interface LoggingConfig {
   incomingRequests?: boolean | IncomingRequestLoggingConfig
 }
 
-export interface DevIndicatorsConfig {
-  /**
-   * @deprecated The dev tools indicator has it enabled by default.
-   * */
-  appIsrStatus?: boolean
-
-  /**
-   * Show "building..." indicator in development
-   * @deprecated The dev tools indicator has it enabled by default.
-   */
-  buildActivity?: boolean
-
-  /**
-   * Position of "building..." indicator in browser
-   * @default "bottom-right"
-   * @deprecated Renamed as `position`.
-   */
-  buildActivityPosition?:
-    | 'top-left'
-    | 'top-right'
-    | 'bottom-left'
-    | 'bottom-right'
-
-  /**
-   * Position of the development tools indicator in the browser window.
-   * @default "bottom-left"
-   * */
-  position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
-}
-
 export interface ExperimentalConfig {
   nodeMiddleware?: boolean
   cacheHandlers?: {
@@ -866,8 +836,37 @@ export interface NextConfig extends Record<string, any> {
   images?: ImageConfig
 
   /** Configure indicators in development environment */
-  // Quite a large discriminant union, but is to skip boolean type check.
-  devIndicators?: DevIndicatorsConfig | (DevIndicatorsConfig & false)
+  devIndicators?:
+    | false
+    | {
+        /**
+         * @deprecated The dev tools indicator has it enabled by default.
+         * */
+        appIsrStatus?: boolean
+
+        /**
+         * Show "building..." indicator in development
+         * @deprecated The dev tools indicator has it enabled by default.
+         */
+        buildActivity?: boolean
+
+        /**
+         * Position of "building..." indicator in browser
+         * @default "bottom-right"
+         * @deprecated Renamed as `position`.
+         */
+        buildActivityPosition?:
+          | 'top-left'
+          | 'top-right'
+          | 'bottom-left'
+          | 'bottom-right'
+
+        /**
+         * Position of the development tools indicator in the browser window.
+         * @default "bottom-left"
+         * */
+        position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
+      }
 
   /**
    * Next.js exposes some options that give you some control over how the server will dispose or keep in memory built pages in development.

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -488,6 +488,7 @@ function assignDefaults(
   )
   if (
     hasWarnedBuildActivityPosition &&
+    result.devIndicators !== false &&
     result.devIndicators?.buildActivityPosition &&
     result.devIndicators.buildActivityPosition !== result.devIndicators.position
   ) {
@@ -835,7 +836,7 @@ function assignDefaults(
     }
   }
 
-  if (result.devIndicators?.position) {
+  if (result.devIndicators !== false && result.devIndicators?.position) {
     const { position } = result.devIndicators
     const allowedValues = [
       'top-left',
@@ -962,8 +963,14 @@ function assignDefaults(
   if (result.experimental.newDevOverlay !== true) {
     result.devIndicators = {
       ...result.devIndicators,
-      appIsrStatus: result.devIndicators?.appIsrStatus ?? true,
-      buildActivity: result.devIndicators?.buildActivity ?? true,
+      appIsrStatus:
+        result.devIndicators === false
+          ? false
+          : result.devIndicators?.appIsrStatus ?? true,
+      buildActivity:
+        result.devIndicators === false
+          ? false
+          : result.devIndicators?.buildActivity ?? true,
     }
 
     // If the user didn't explicitly set `position` or `buildActivityPosition` option,


### PR DESCRIPTION
### Why?

Since the dev indicator is visible by default, there could be a case where a user might want to disable it.
However, the indicator needs to be brought back if there is an error since it's tied to the error overlay.

### What?

Added an option `devIndicators: false` to disable the dev indicator.

### Success Criteria

- [x] Does it hide the indicator when there is no error?
- [x] Does it show the indicator when there is an error?
- [x] Does it show the error overlay when there is an error?

Closes NDX-840