### PR TITLE
[dev-overlay] Stop hiding `rsc:` protocol

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/helpers/webpack-module-path.test.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/helpers/webpack-module-path.test.ts
@@ -9,26 +9,7 @@ describe('webpack-module-path', () => {
       expect(
         isWebpackInternalResource('webpack-internal:///./src/hello.tsx')
       ).toBe(true)
-      expect(
-        isWebpackInternalResource(
-          'rsc://React/Server/webpack-internal:///(rsc)/./src/hello.tsx?42'
-        )
-      ).toBe(true)
-      expect(
-        isWebpackInternalResource(
-          'rsc://React/Server/webpack:///(rsc)/./src/hello.tsx?42'
-        )
-      ).toBe(true)
-      expect(
-        isWebpackInternalResource(
-          'rsc://React/Server/webpack:///(app-pages-browser)/./src/hello.tsx?42'
-        )
-      ).toBe(true)
-      expect(
-        isWebpackInternalResource(
-          'rsc://React/Server/webpack:///(app-pages-browser)/./src/hello.tsx?42dc'
-        )
-      ).toBe(true)
+
       expect(isWebpackInternalResource('webpack://_N_E/./src/hello.tsx')).toBe(
         true
       )
@@ -47,31 +28,6 @@ describe('webpack-module-path', () => {
       expect(formatFrameSourceFile('webpack-internal:///./src/hello.tsx')).toBe(
         './src/hello.tsx'
       )
-      expect(
-        formatFrameSourceFile(
-          'rsc://React/Server/webpack-internal:///(rsc)/./src/hello.tsx?42'
-        )
-      ).toBe('./src/hello.tsx')
-      expect(
-        formatFrameSourceFile(
-          'rsc://React/Server/webpack:///(rsc)/./src/hello.tsx?42'
-        )
-      ).toBe('./src/hello.tsx')
-      expect(
-        formatFrameSourceFile(
-          'rsc://React/Server/webpack:///(app-pages-browser)/./src/hello.tsx?42'
-        )
-      ).toBe('./src/hello.tsx')
-      expect(
-        formatFrameSourceFile(
-          'rsc://React/Server/webpack:///(app-pages-browser)/./src/hello.tsx?42?0'
-        )
-      ).toBe('./src/hello.tsx')
-      expect(
-        formatFrameSourceFile(
-          'rsc://React/Server/webpack:///(app-pages-browser)/./src/hello.tsx?42dc'
-        )
-      ).toBe('./src/hello.tsx')
       expect(formatFrameSourceFile('webpack://_N_E/./src/hello.tsx')).toBe(
         './src/hello.tsx'
       )

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/helpers/webpack-module-path.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/helpers/webpack-module-path.ts
@@ -1,9 +1,6 @@
 const replacementRegExes = [
-  /^(rsc:\/\/React\/[^/]+\/)/,
   /^webpack-internal:\/\/\/(\([\w-]+\)\/)?/,
   /^(webpack:\/\/\/|webpack:\/\/(_N_E\/)?)(\([\w-]+\)\/)?/,
-  /\?\w+(\?\d+)?$/, // React replay error query param, .e.g. ?c69d?0, ?c69d
-  /\?\d+$/, // React's fakeFunctionIdx query param
 ]
 
 export function isWebpackInternalResource(file: string) {
@@ -20,8 +17,6 @@ export function isWebpackInternalResource(file: string) {
  * Format the webpack internal id to original file path
  *
  * webpack-internal:///./src/hello.tsx => ./src/hello.tsx
- * rsc://React/Server/webpack-internal:///(rsc)/./src/hello.tsx?42 => ./src/hello.tsx
- * rsc://React/Server/webpack:///app/indirection.tsx?14cb?0 => app/indirection.tsx
  * webpack://_N_E/./src/hello.tsx => ./src/hello.tsx
  * webpack://./src/hello.tsx => ./src/hello.tsx
  * webpack:///./src/hello.tsx => ./src/hello.tsx

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/webpack-module-path.test.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/webpack-module-path.test.ts
@@ -9,26 +9,6 @@ describe('webpack-module-path', () => {
       expect(
         isWebpackInternalResource('webpack-internal:///./src/hello.tsx')
       ).toBe(true)
-      expect(
-        isWebpackInternalResource(
-          'rsc://React/Server/webpack-internal:///(rsc)/./src/hello.tsx?42'
-        )
-      ).toBe(true)
-      expect(
-        isWebpackInternalResource(
-          'rsc://React/Server/webpack:///(rsc)/./src/hello.tsx?42'
-        )
-      ).toBe(true)
-      expect(
-        isWebpackInternalResource(
-          'rsc://React/Server/webpack:///(app-pages-browser)/./src/hello.tsx?42'
-        )
-      ).toBe(true)
-      expect(
-        isWebpackInternalResource(
-          'rsc://React/Server/webpack:///(app-pages-browser)/./src/hello.tsx?42dc'
-        )
-      ).toBe(true)
       expect(isWebpackInternalResource('webpack://_N_E/./src/hello.tsx')).toBe(
         true
       )
@@ -47,31 +27,6 @@ describe('webpack-module-path', () => {
       expect(formatFrameSourceFile('webpack-internal:///./src/hello.tsx')).toBe(
         './src/hello.tsx'
       )
-      expect(
-        formatFrameSourceFile(
-          'rsc://React/Server/webpack-internal:///(rsc)/./src/hello.tsx?42'
-        )
-      ).toBe('./src/hello.tsx')
-      expect(
-        formatFrameSourceFile(
-          'rsc://React/Server/webpack:///(rsc)/./src/hello.tsx?42'
-        )
-      ).toBe('./src/hello.tsx')
-      expect(
-        formatFrameSourceFile(
-          'rsc://React/Server/webpack:///(app-pages-browser)/./src/hello.tsx?42'
-        )
-      ).toBe('./src/hello.tsx')
-      expect(
-        formatFrameSourceFile(
-          'rsc://React/Server/webpack:///(app-pages-browser)/./src/hello.tsx?42?0'
-        )
-      ).toBe('./src/hello.tsx')
-      expect(
-        formatFrameSourceFile(
-          'rsc://React/Server/webpack:///(app-pages-browser)/./src/hello.tsx?42dc'
-        )
-      ).toBe('./src/hello.tsx')
       expect(formatFrameSourceFile('webpack://_N_E/./src/hello.tsx')).toBe(
         './src/hello.tsx'
       )

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/webpack-module-path.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/webpack-module-path.ts
@@ -1,9 +1,6 @@
 const replacementRegExes = [
-  /^(rsc:\/\/React\/[^/]+\/)/,
   /^webpack-internal:\/\/\/(\([\w-]+\)\/)?/,
   /^(webpack:\/\/\/|webpack:\/\/(_N_E\/)?)(\([\w-]+\)\/)?/,
-  /\?\w+(\?\d+)?$/, // React replay error query param, .e.g. ?c69d?0, ?c69d
-  /\?\d+$/, // React's fakeFunctionIdx query param
 ]
 
 export function isWebpackInternalResource(file: string) {
@@ -20,8 +17,6 @@ export function isWebpackInternalResource(file: string) {
  * Format the webpack internal id to original file path
  *
  * webpack-internal:///./src/hello.tsx => ./src/hello.tsx
- * rsc://React/Server/webpack-internal:///(rsc)/./src/hello.tsx?42 => ./src/hello.tsx
- * rsc://React/Server/webpack:///app/indirection.tsx?14cb?0 => app/indirection.tsx
  * webpack://_N_E/./src/hello.tsx => ./src/hello.tsx
  * webpack://./src/hello.tsx => ./src/hello.tsx
  * webpack:///./src/hello.tsx => ./src/hello.tsx


### PR DESCRIPTION
It's indicative that there's a sourcemapping issue.

It was hiding the bug we fixed by supporting `rsc:` protocol in the stacktrace parser: https://github.com/vercel/next.js/pull/76086