### PR TITLE
[metadata] fix ppr deployment by not disabling ppr

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2166,8 +2166,7 @@ export default abstract class Server<
     const couldSupportPPR: boolean =
       this.isAppPPREnabled &&
       typeof routeModule !== 'undefined' &&
-      isAppPageRouteModule(routeModule) &&
-      !isHtmlBot
+      isAppPageRouteModule(routeModule)
 
     // When enabled, this will allow the use of the `?__nextppronly` query to
     // enable debugging of the static shell.
@@ -3228,8 +3227,7 @@ export default abstract class Server<
 
     const didPostpone =
       cacheEntry.value?.kind === CachedRouteKind.APP_PAGE &&
-      typeof cacheEntry.value.postponed === 'string' &&
-      !isHtmlBot
+      typeof cacheEntry.value.postponed === 'string'
 
     if (
       isSSG &&


### PR DESCRIPTION
### What

For PPR deployment we shouldn't disbale the PPR config inside of Next.js but let infra determine when to pass down the PPR cache. If we disable it inside Next.js it could lead to other error when the infra tries to get the cache in dynamic-resume.