### PR TITLE
docs: add download badge

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -9,6 +9,7 @@
 
 <a href="https://vercel.com"><img alt="Vercel logo" src="https://img.shields.io/badge/MADE%20BY%20Vercel-000000.svg?style=for-the-badge&logo=Vercel&labelColor=000"></a>
 <a href="https://www.npmjs.com/package/next"><img alt="NPM version" src="https://img.shields.io/npm/v/next.svg?style=for-the-badge&labelColor=000000"></a>
+<a href="https://npm-compare.com/next/#timeRange=FIVE_YEARS"><img alt="NPM downloads" src="https://img.shields.io/npm/dw/next?style=for-the-badge&labelColor=000000"></a>
 <a href="https://github.com/vercel/next.js/blob/canary/license.md"><img alt="License" src="https://img.shields.io/npm/l/next.svg?style=for-the-badge&labelColor=000000"></a>
 <a href="https://github.com/vercel/next.js/discussions"><img alt="Join the community on GitHub" src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&logo=Next.js&labelColor=000000&logoWidth=20"></a>
 


### PR DESCRIPTION
Hi, I’ve added a new NPM download trend badge to the [next](https://npm-compare.com/next/#timeRange=FIVE_YEARS) README. This badge links to a dynamic chart on npm-compare.com that shows the download trends for next over the past five years. By providing this trend data, new users can gain insight into the popularity and growth of `next`.

Here’s the badge I added:

<a href="https://npm-compare.com/next/#timeRange=FIVE_YEARS">
  <img alt="NPM downloads" src="https://img.shields.io/npm/dw/next?style=for-the-badge&labelColor=000000">
</a>

As a maintainer of npm-compare.com, I’m happy to assist with any additional features or insights from our site if needed.

Thanks for considering my suggestion!