### PR TITLE
test: replace explicit `padding-bottom` with  `devIndicators: false` for scroll position testing

### DIFF
--- a/test/development/pages-dir/client-navigation/fixture/next.config.js
+++ b/test/development/pages-dir/client-navigation/fixture/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   onDemandEntries: {
     // Make sure entries are not getting disposed.
@@ -6,4 +7,7 @@ module.exports = {
   experimental: {
     strictNextHead: process.env.TEST_STRICT_NEXT_HEAD !== 'false',
   },
+  // scroll position can be finicky with the
+  // indicators showing so hide by default
+  devIndicators: false,
 }

--- a/test/development/pages-dir/client-navigation/fixture/pages/nav/shallow-routing.js
+++ b/test/development/pages-dir/client-navigation/fixture/pages/nav/shallow-routing.js
@@ -41,7 +41,7 @@ export default withRouter(
 
     render() {
       return (
-        <div className="shallow-routing" style={{ paddingBottom: 60 }}>
+        <div className="shallow-routing">
           <Link href="/nav" id="home-link" style={linkStyle}>
             Home
           </Link>

--- a/test/e2e/app-dir/navigation/app/scroll-restoration/page.tsx
+++ b/test/e2e/app-dir/navigation/app/scroll-restoration/page.tsx
@@ -7,8 +7,7 @@ export default function Page() {
   const { items, loadMoreItems } = useContext(ItemsContext)
 
   return (
-    // Dev Indicator blocking the click.
-    <div style={{ paddingBottom: 60 }}>
+    <div>
       <h1>Page</h1>
       <ul>
         {items.map((item) => (

--- a/test/e2e/app-dir/navigation/next.config.js
+++ b/test/e2e/app-dir/navigation/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   redirects: () => {
     return [
@@ -10,7 +11,5 @@ module.exports = {
   },
   // scroll position can be finicky with the
   // indicators showing so hide by default
-  devIndicators: {
-    appIsrStatus: false,
-  },
+  devIndicators: false,
 }


### PR DESCRIPTION
### Why?

There were explicit `paddingBottom: 60` set to fixtures due to the dev indicator blocking the scroll position. Since an option to disable it was added at https://github.com/vercel/next.js/pull/76079, this PR replaced them with `devIndicators: false`.

x-ref: https://github.com/vercel/next.js/pull/76077#discussion_r1957164641