### PR TITLE
Clean module path if Fast Refresh full reload was caused by files outside project

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -524,9 +524,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
                 if (file) {
                   // `file` is filepath in `pages/` but it can be a webpack url.
                   // If it's a webpack loader URL, it will include the app-pages layer
-                  if (
-                    file.startsWith(`(${WEBPACK_LAYERS.appPagesBrowser})/./`)
-                  ) {
+                  if (file.startsWith(`(${WEBPACK_LAYERS.appPagesBrowser})/`)) {
                     const fileUrl = new URL(file, 'file://')
                     const cwd = process.cwd()
                     const modules = fileUrl.searchParams

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -541,7 +541,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
                     }
                   } else if (
                     // Handle known webpack layers
-                    file.startsWith(`(${WEBPACK_LAYERS.pagesDirBrowser})/./`)
+                    file.startsWith(`(${WEBPACK_LAYERS.pagesDirBrowser})/`)
                   ) {
                     const cleanedFilePath = file.slice(
                       `(${WEBPACK_LAYERS.pagesDirBrowser})/`.length


### PR DESCRIPTION
```diff
-⚠ Fast Refresh had to perform a full reload when (pages-dir-browser)/../../../packages/next/dist/client/add-base-path.js changed
+⚠ Fast Refresh had to perform a full reload when ../../../packages/next/dist/client/add-base-path.js changed
```