### PR TITLE
[dev-overlay] fix: overlay is located relatively low when long content

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/overlay/overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/overlay/overlay.tsx
@@ -7,6 +7,7 @@ export function ErrorOverlayOverlay({ children, ...props }: OverlayProps) {
 
 export const OVERLAY_STYLES = css`
   [data-nextjs-dialog-overlay] {
-    top: var(--size-8_5);
+    padding: initial;
+    top: 10vh;
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Errors } from './errors'
 import { withShadowPortal } from '../storybook/with-shadow-portal'
 import type { ReadyRuntimeError } from '../../../internal/helpers/get-error-by-type'
+import { lorem } from '../../../internal/utils/lorem'
 
 const meta: Meta<typeof Errors> = {
   component: Errors,
@@ -169,9 +170,15 @@ export const Turbopack: Story = {
   },
 }
 
-export const Minimized: Story = {
+export const VeryLongErrorMessage: Story = {
   args: {
     ...Default.args,
+    readyErrors: [
+      {
+        ...readyErrors[0],
+        error: Object.assign(new Error(lorem)),
+      },
+    ],
   },
 }
 

--- a/packages/next/src/client/components/react-dev-overlay/internal/utils/lorem.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/utils/lorem.ts
@@ -1,0 +1,38 @@
+export const lorem = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec euismod blandit ante non 
+malesuada. Nunc congue urna id laoreet tempor. Nunc rhoncus nec ante eu dapibus. Sed egestas neque vel 
+vehicula ullamcorper. Phasellus quis accumsan turpis, et condimentum nibh. Sed dignissim diam ex, consectetur 
+aliquet lectus feugiat a. Etiam tempor varius massa, sed suscipit nulla. Pellentesque orci est, porta a massa 
+ac, pretium pulvinar mi. Praesent ac placerat leo, tempus hendrerit ipsum. Phasellus felis ex, blandit et 
+nibh at, tincidunt gravida est.
+
+In non orci vel libero sollicitudin ornare. Nunc quis augue id velit venenatis posuere. Aenean et velit 
+fermentum, facilisis nunc vel, cursus purus. Integer tempus velit et diam vulputate, in convallis nisi 
+feugiat. Sed euismod aliquet neque, ac fermentum risus dapibus et. Donec sodales dui in semper consequat. 
+Suspendisse potenti. Aliquam augue dolor, tincidunt quis sem a, rhoncus porttitor eros. Sed molestie leo 
+eget elementum vehicula.
+
+Praesent velit turpis, blandit non ex et, lacinia elementum dolor. Aliquam erat volutpat. Proin varius odio 
+sit amet arcu fermentum, eu consectetur enim laoreet. Nullam id arcu hendrerit leo bibendum consequat. 
+Quisque purus nibh, bibendum sed ullamcorper eget, blandit eu enim. Morbi et nulla eu lectus tempor blandit. 
+Aliquam finibus turpis porttitor, ullamcorper lectus in, luctus augue. Sed efficitur ipsum sapien, id 
+rutrum magna ultricies sed. Phasellus sit amet sapien accumsan tortor mattis sodales. Vestibulum vulputate 
+vehicula nisi ut imperdiet. Aliquam magna mauris, elementum vel risus id, ultricies accumsan justo. 
+Phasellus facilisis interdum ante eu hendrerit. Aenean maximus risus eget leo convallis, id consectetur 
+sapien placerat. Phasellus non enim erat. Praesent sapien massa, rhoncus in ipsum eget, rutrum pharetra est. 
+Vestibulum ipsum augue, fringilla at ligula quis, auctor consectetur orci.
+
+Vivamus sed sapien et felis tincidunt semper non et turpis. Nulla quis velit sit amet magna scelerisque 
+eleifend ac quis sapien. Phasellus sit amet elementum nunc, vel sollicitudin ante. Phasellus bibendum 
+blandit velit, vitae volutpat felis fringilla sit amet. Phasellus dictum nisi dui, ac semper magna 
+vestibulum ut. Suspendisse commodo finibus augue ut vehicula. Curabitur molestie eros at varius dapibus. 
+Suspendisse eu ligula interdum, consequat ante non, faucibus est. Nunc erat nibh, malesuada quis justo ut, 
+mattis rhoncus velit. Vestibulum ullamcorper rutrum gravida. Fusce commodo eget elit blandit euismod. Aenean 
+facilisis dui sed cursus cursus.
+
+Praesent odio ex, pulvinar a lobortis a, elementum sit amet mi. Proin molestie non orci vitae sodales. 
+Morbi a elit viverra, luctus ex sed, condimentum nulla. Quisque laoreet mauris id mauris elementum, nec 
+auctor metus pellentesque. Integer aliquet volutpat leo, a varius est molestie in. Praesent congue aliquam 
+dolor non sodales. Aliquam blandit consequat eros ut luctus. Nunc sodales semper semper. Integer varius quam 
+a arcu efficitur lacinia. Phasellus lobortis aliquam tortor dapibus laoreet. Integer ac mi quam. Nunc vitae 
+purus et odio malesuada mattis. Proin pellentesque mauris tristique magna imperdiet venenatis. Phasellus 
+scelerisque, lectus et efficitur varius, ipsum risus rutrum tortor, nec egestas odio arcu nec tellus.`


### PR DESCRIPTION
### Why?

The overlay seemed too low when the content was long since it had both `padding` and `top` values. Adjust to have only the `top` and preserve the `padding` value.

### Before

https://github.com/user-attachments/assets/e2172a7b-1275-4647-88e2-7b91fc4c8d98

### After

https://github.com/user-attachments/assets/182cfa7b-d532-4bb7-aa0c-69911720b370

Closes NDX-845