### PR TITLE
Fix on-demand revalidation with `"use cache"` in dev mode

### DIFF
--- a/packages/next/src/server/api-utils/node/api-resolver.ts
+++ b/packages/next/src/server/api-utils/node/api-resolver.ts
@@ -43,6 +43,7 @@ type ApiContext = __ApiPreviewProps & {
   hostname?: string
   revalidate?: RevalidateFn
   multiZoneDraftMode?: boolean
+  dev: boolean
 }
 
 function getMaxContentLength(responseLimit?: ResponseLimit) {
@@ -271,10 +272,15 @@ async function revalidate(
   }
   const allowedRevalidateHeaderKeys = [
     ...(context.allowedRevalidateHeaderKeys || []),
-    ...(context.trustHostHeader
-      ? ['cookie', 'x-vercel-protection-bypass']
-      : []),
   ]
+
+  if (context.trustHostHeader || context.dev) {
+    allowedRevalidateHeaderKeys.push('cookie')
+  }
+
+  if (context.trustHostHeader) {
+    allowedRevalidateHeaderKeys.push('x-vercel-protection-bypass')
+  }
 
   for (const key of Object.keys(req.headers)) {
     if (allowedRevalidateHeaderKeys.includes(key)) {

--- a/packages/next/src/server/api-utils/node/api-resolver.ts
+++ b/packages/next/src/server/api-utils/node/api-resolver.ts
@@ -302,6 +302,7 @@ async function revalidate(
 
       if (
         cacheHeader?.toUpperCase() !== 'REVALIDATED' &&
+        res.status !== 200 &&
         !(res.status === 404 && opts.unstable_onlyGenerated)
       ) {
         throw new Error(`Invalid response ${res.status}`)

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2080,7 +2080,10 @@ export default abstract class Server<
       // this signals revalidation in deploy environments
       // TODO: make this more generic
       req.headers['x-now-route-matches'] ||
-      req.headers[PRERENDER_REVALIDATE_HEADER]
+      // In dev mode, we don't know for sure whether a route could be
+      // prerendered. But if the prerender revalidate header is set because the
+      // user triggered an on-demand revalidation, we can assume so.
+      (this.renderOpts.dev && req.headers[PRERENDER_REVALIDATE_HEADER])
     ) {
       isSSG = true
     } else if (!this.renderOpts.dev) {

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2328,13 +2328,8 @@ export default abstract class Server<
       stripFlightHeaders(req.headers)
     }
 
-    let isOnDemandRevalidate = false
-    let revalidateOnlyGenerated = false
-
-    if (isSSG) {
-      ;({ isOnDemandRevalidate, revalidateOnlyGenerated } =
-        checkIsOnDemandRevalidate(req, this.renderOpts.previewProps))
-    }
+    let { isOnDemandRevalidate, revalidateOnlyGenerated } =
+      checkIsOnDemandRevalidate(req, this.renderOpts.previewProps)
 
     if (isSSG && this.minimalMode && req.headers[MATCHED_PATH_HEADER]) {
       // the url value is already correct when the matched-path header is set

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -138,7 +138,6 @@ import {
   NEXT_CACHE_REVALIDATED_TAGS_HEADER,
   NEXT_CACHE_TAGS_HEADER,
   NEXT_RESUME_HEADER,
-  PRERENDER_REVALIDATE_HEADER,
 } from '../lib/constants'
 import { normalizeLocalePath } from '../shared/lib/i18n/normalize-locale-path'
 import {
@@ -2079,11 +2078,7 @@ export default abstract class Server<
       staticPaths?.includes(resolvedUrlPathname) ||
       // this signals revalidation in deploy environments
       // TODO: make this more generic
-      req.headers['x-now-route-matches'] ||
-      // In dev mode, we don't know for sure whether a route could be
-      // prerendered. But if the prerender revalidate header is set because the
-      // user triggered an on-demand revalidation, we can assume so.
-      (this.renderOpts.dev && req.headers[PRERENDER_REVALIDATE_HEADER])
+      req.headers['x-now-route-matches']
     ) {
       isSSG = true
     } else if (!this.renderOpts.dev) {

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -138,6 +138,7 @@ import {
   NEXT_CACHE_REVALIDATED_TAGS_HEADER,
   NEXT_CACHE_TAGS_HEADER,
   NEXT_RESUME_HEADER,
+  PRERENDER_REVALIDATE_HEADER,
 } from '../lib/constants'
 import { normalizeLocalePath } from '../shared/lib/i18n/normalize-locale-path'
 import {
@@ -2078,7 +2079,8 @@ export default abstract class Server<
       staticPaths?.includes(resolvedUrlPathname) ||
       // this signals revalidation in deploy environments
       // TODO: make this more generic
-      req.headers['x-now-route-matches']
+      req.headers['x-now-route-matches'] ||
+      req.headers[PRERENDER_REVALIDATE_HEADER]
     ) {
       isSSG = true
     } else if (!this.renderOpts.dev) {

--- a/packages/next/src/server/lib/dev-bundler-service.ts
+++ b/packages/next/src/server/lib/dev-bundler-service.ts
@@ -75,6 +75,7 @@ export class DevBundlerService {
 
     if (
       mocked.res.getHeader('x-nextjs-cache') !== 'REVALIDATED' &&
+      mocked.res.statusCode !== 200 &&
       !(mocked.res.statusCode === 404 && revalidateOpts.unstable_onlyGenerated)
     ) {
       throw new Error(`Invalid response ${mocked.res.statusCode}`)

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1224,6 +1224,7 @@ export default class NextNodeServer extends BaseServer<
 
     if (
       mocked.res.getHeader('x-nextjs-cache') !== 'REVALIDATED' &&
+      mocked.res.statusCode !== 200 &&
       !(mocked.res.statusCode === 404 && opts.unstable_onlyGenerated)
     ) {
       throw new Error(`Invalid response ${mocked.res.statusCode}`)

--- a/packages/next/src/server/route-modules/pages-api/module.ts
+++ b/packages/next/src/server/route-modules/pages-api/module.ts
@@ -154,6 +154,7 @@ export class PagesAPIRouteModule extends RouteModule<
         allowedRevalidateHeaderKeys: context.allowedRevalidateHeaderKeys,
         hostname: context.hostname,
         multiZoneDraftMode: context.multiZoneDraftMode,
+        dev: context.dev,
       },
       context.minimalMode,
       context.dev,

--- a/test/e2e/app-dir/use-cache/app/on-demand-revalidate/revalidate-buttons.tsx
+++ b/test/e2e/app-dir/use-cache/app/on-demand-revalidate/revalidate-buttons.tsx
@@ -1,10 +1,14 @@
 'use client'
 
+import { useTransition } from 'react'
+
 export function RevalidateButtons({
   revalidatePath,
 }: {
   revalidatePath: () => Promise<void>
 }) {
+  const [isPending, startTransition] = useTransition()
+
   return (
     <form>
       <button id="revalidate-path" formAction={revalidatePath}>
@@ -12,9 +16,12 @@ export function RevalidateButtons({
       </button>{' '}
       <button
         id="revalidate-api-route"
+        disabled={isPending}
         formAction={async () => {
-          await fetch('/api/revalidate?path=/on-demand-revalidate', {
-            method: 'POST',
+          startTransition(async () => {
+            await fetch('/api/revalidate?path=/on-demand-revalidate', {
+              method: 'POST',
+            })
           })
         }}
       >

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -318,7 +318,7 @@ describe('use-cache', () => {
     const value = await browser.elementById('value').text()
 
     await browser.elementById('revalidate-api-route').click()
-    await browser.waitForIdleNetwork()
+    await browser.waitForElementByCss('#revalidate-api-route:enabled')
 
     await retry(async () => {
       await browser.refresh()

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -303,31 +303,30 @@ describe('use-cache', () => {
     })
   }
 
-  if (isNextStart) {
-    // res.revalidate does not work in dev mode
-    it('should revalidate caches during on-demand revalidation', async () => {
-      const browser = await next.browser('/on-demand-revalidate')
-      const initial = await browser.elementById('value').text()
+  it('should revalidate caches during on-demand revalidation', async () => {
+    const browser = await next.browser('/on-demand-revalidate')
+    const initial = await browser.elementById('value').text()
 
-      // Bust the ISR cache first to populate the "use cache" in-memory cache for
-      // the subsequent on-demand revalidation.
-      await browser.elementById('revalidate-path').click()
+    // Bust the ISR cache first to populate the "use cache" in-memory cache for
+    // the subsequent on-demand revalidation.
+    await browser.elementById('revalidate-path').click()
 
-      await retry(async () => {
-        expect(await browser.elementById('value').text()).not.toBe(initial)
-      })
-
-      const value = await browser.elementById('value').text()
-
-      await browser.elementById('revalidate-api-route').click()
-      await browser.waitForIdleNetwork()
-
-      await retry(async () => {
-        await browser.refresh()
-        expect(await browser.elementById('value').text()).not.toBe(value)
-      })
+    await retry(async () => {
+      expect(await browser.elementById('value').text()).not.toBe(initial)
     })
 
+    const value = await browser.elementById('value').text()
+
+    await browser.elementById('revalidate-api-route').click()
+    await browser.waitForIdleNetwork()
+
+    await retry(async () => {
+      await browser.refresh()
+      expect(await browser.elementById('value').text()).not.toBe(value)
+    })
+  })
+
+  if (isNextStart) {
     it('should prerender fully cacheable pages as static HTML', async () => {
       const prerenderManifest = JSON.parse(
         await next.readFile('.next/prerender-manifest.json')

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -1877,7 +1877,6 @@ describe('Prerender', () => {
         })
 
         expect(res.status).toBe(200)
-        expect(await res.json()).toEqual({ revalidated: false })
         expect(stripAnsi(next.cliOutput)).not.toContain('hasHeader')
       })
 


### PR DESCRIPTION
This PR is a follow-up to #76100 that enables on-demand revalidation via an API route in development mode. This is accomplished by implementing three changes:
1. We need to forward the user cookies, including the `__next_hmr_refresh_hash__` value, which is required to generate the same cache key _during_ the revalidation as _before_ and, more importantly, _after_ the revalidation. Otherwise the revalidated cache entries will use a different cache key (without the refresh hash), and on subsequent page reload, the stale cached data would still be shown (using the cache key with refresh hash).
2. When checking if a `revalidate()` call succeeded, we allow `200` responses in general, and only check the `'x-nextjs-cache'` header for `404` response. This matches the historic intent of the feature. ([x-ref-1](https://github.com/vercel/next.js/pull/36108/files#diff-8d464ed8b3d6ed08deabeaa05180900c38f8943d75368798861d1734103512fcR338-R342), [x-ref-2](https://github.com/vercel/next.js/pull/34826/files#diff-8d464ed8b3d6ed08deabeaa05180900c38f8943d75368798861d1734103512fcR318-R324)).
3. The `isOnDemandRevalidate` status is now also set for non-`isSSG` pages, based on the `'x-prerender-revalidate'` header. This matches the logic in the incremental cache handler, which enables cache revalidation in dev mode when using `unstable_cache`.