### PR TITLE
[dev-overlay] handle ssrd nextjs internal errors in overlay

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -27,6 +27,7 @@ import { MissingSlotContext } from '../shared/lib/app-router-context.shared-runt
 import { setAppBuildId } from './app-build-id'
 import { shouldRenderRootLevelErrorOverlay } from './lib/is-error-thrown-while-rendering-rsc'
 import { handleClientError } from './components/errors/use-error-handler'
+import { isNextRouterError } from './components/is-next-router-error'
 
 /// <reference types="react-dom/experimental" />
 
@@ -304,7 +305,15 @@ function devQueueSsrError(): Error | undefined {
       'data-next-error-message'
     )!
     const stack = ssrErrorTemplateTag.getAttribute('data-next-error-stack')
+    const digest = ssrErrorTemplateTag.getAttribute('data-next-error-digest')
     const error = new Error(message)
+    if (digest) {
+      ;(error as any).digest = digest
+    }
+    // Skip Next.js SSR'd internal errors that which will be handled by the error boundaries.
+    if (isNextRouterError(error)) {
+      return
+    }
     error.stack = stack || ''
     return error
   }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -994,6 +994,7 @@ async function getErrorRSCPayload(
         {process.env.NODE_ENV !== 'production' && err ? (
           <template
             data-next-error-message={err.message}
+            data-next-error-digest={'digest' in err ? err.digest : ''}
             data-next-error-stack={err.stack}
           />
         ) : null}

--- a/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
+++ b/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
@@ -54,7 +54,7 @@ describe('error-ignored-frames', () => {
        at OuterLayoutRouter (../src/client/components/layout-router.tsx (607:20))
        at Router (../src/client/components/app-router.tsx (633:8))
        at AppRouter (../src/client/components/app-router.tsx (679:8))
-       at ServerRoot (../src/client/app-index.tsx (200:6))"
+       at ServerRoot (../src/client/app-index.tsx (201:6))"
       `)
     }
   })
@@ -85,7 +85,7 @@ describe('error-ignored-frames', () => {
        at ClientPageRoot (../src/client/components/client-page.tsx (60:13))
        at Router (../src/client/components/app-router.tsx (633:8))
        at AppRouter (../src/client/components/app-router.tsx (679:8))
-       at ServerRoot (../src/client/app-index.tsx (200:6))"
+       at ServerRoot (../src/client/app-index.tsx (201:6))"
       `)
     }
   })
@@ -123,12 +123,12 @@ describe('error-ignored-frames', () => {
     } else {
       expect(expendedStack).toMatchInlineSnapshot(`
        "at eval (app/interleaved/page.tsx (7:11))
-       at invokeCallback (node_modules/interleave/index.js (2:1))
        at Page (app/interleaved/page.tsx (6:37))
+       at invokeCallback (node_modules/interleave/index.js (2:1))
        at ClientPageRoot (../src/client/components/client-page.tsx (60:13))
        at Router (../src/client/components/app-router.tsx (633:8))
        at AppRouter (../src/client/components/app-router.tsx (679:8))
-       at ServerRoot (../src/client/app-index.tsx (200:6))"
+       at ServerRoot (../src/client/app-index.tsx (201:6))"
       `)
     }
   })

--- a/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
+++ b/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
@@ -123,8 +123,8 @@ describe('error-ignored-frames', () => {
     } else {
       expect(expendedStack).toMatchInlineSnapshot(`
        "at eval (app/interleaved/page.tsx (7:11))
-       at Page (app/interleaved/page.tsx (6:37))
        at invokeCallback (node_modules/interleave/index.js (2:1))
+       at Page (app/interleaved/page.tsx (6:37))
        at ClientPageRoot (../src/client/components/client-page.tsx (60:13))
        at Router (../src/client/components/app-router.tsx (633:8))
        at AppRouter (../src/client/components/app-router.tsx (679:8))

--- a/test/development/app-dir/ssr-only-error/app/notfound/page.tsx
+++ b/test/development/app-dir/ssr-only-error/app/notfound/page.tsx
@@ -1,0 +1,7 @@
+import { notFound } from 'next/navigation'
+
+export default async function Home() {
+  notFound()
+}
+
+export const dynamic = 'force-dynamic'

--- a/test/development/app-dir/ssr-only-error/ssr-only-error.test.ts
+++ b/test/development/app-dir/ssr-only-error/ssr-only-error.test.ts
@@ -53,15 +53,18 @@ describe('ssr-only-error', () => {
     const text = await browser.elementByCss('body').text()
     expect(text).toBe('404\nThis page could not be found.')
 
-    // Assert if there's no console.error related to the notFound error
-    // Since there's already one error log containing "404" from browser:
-    // "Failed to load resource: the server responded with a status of 404 (Not Found)"
-    // We assert there's no error text in the error log
-    expect(await browser.log()).not.toContainEqual(
+    // Assert there's only one console.error from browser itself
+    const errorLogs = (await browser.log()).filter(
+      (log) => log.source === 'error'
+    )
+
+    expect(errorLogs).toEqual([
       expect.objectContaining({
         source: 'error',
-        message: expect.stringContaining('NEXT_HTTP_ERROR_FALLBACK;404'),
-      })
-    )
+        message: expect.stringContaining(
+          'the server responded with a status of 404'
+        ),
+      }),
+    ])
   })
 })

--- a/test/development/app-dir/ssr-only-error/ssr-only-error.test.ts
+++ b/test/development/app-dir/ssr-only-error/ssr-only-error.test.ts
@@ -43,12 +43,20 @@ describe('ssr-only-error', () => {
   })
 
   it('should not handle internal nextjs errors that will be handled by error boundaries', async () => {
-    const browser = await next.browser('/notfound')
+    const browser = await next.browser('/notfound', {
+      pushErrorAsConsoleLog: true,
+    })
 
     await assertNoRedbox(browser)
     expect(await hasErrorToast(browser)).toBe(false)
 
     const text = await browser.elementByCss('body').text()
     expect(text).toBe('404\nThis page could not be found.')
+
+    expect(await browser.log()).not.toContainEqual(
+      expect.objectContaining({
+        source: 'error',
+      })
+    )
   })
 })

--- a/test/development/app-dir/ssr-only-error/ssr-only-error.test.ts
+++ b/test/development/app-dir/ssr-only-error/ssr-only-error.test.ts
@@ -1,5 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 import {
+  assertNoRedbox,
   getRedboxDescription,
   getRedboxSource,
   hasErrorToast,
@@ -39,5 +40,15 @@ describe('ssr-only-error', () => {
        8 | }",
      }
     `)
+  })
+
+  it('should not handle internal nextjs errors that will be handled by error boundaries', async () => {
+    const browser = await next.browser('/notfound')
+
+    await assertNoRedbox(browser)
+    expect(await hasErrorToast(browser)).toBe(false)
+
+    const text = await browser.elementByCss('body').text()
+    expect(text).toBe('404\nThis page could not be found.')
   })
 })

--- a/test/development/app-dir/ssr-only-error/ssr-only-error.test.ts
+++ b/test/development/app-dir/ssr-only-error/ssr-only-error.test.ts
@@ -53,9 +53,14 @@ describe('ssr-only-error', () => {
     const text = await browser.elementByCss('body').text()
     expect(text).toBe('404\nThis page could not be found.')
 
+    // Assert if there's no console.error related to the notFound error
+    // Since there's already one error log containing "404" from browser:
+    // "Failed to load resource: the server responded with a status of 404 (Not Found)"
+    // We assert there's no error text in the error log
     expect(await browser.log()).not.toContainEqual(
       expect.objectContaining({
         source: 'error',
+        message: expect.stringContaining('NEXT_HTTP_ERROR_FALLBACK;404'),
       })
     )
   })


### PR DESCRIPTION
### What

We were consuming SSR'd error and showing them in the error overlay in #74983. But we need to filter out the Next.js internal errors such as notFound or redirect as they're not designed to be unhandled runtime errors. Those will be caught by proper error boundaries and display the error. When we consume the SSR'd errors from the error template in dev, we can check the `disget` property and skip those.

We don't need to handle any other errors like client bailout as they won't be SSR'd and they're not showing up in dev due to it's always dynamic rendering. Hence we only test the navigation errors