### PR TITLE
docs: Remove `switcher` from MDX code fence

### DIFF
--- a/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
@@ -607,7 +607,7 @@ Frontmatter is a YAML like key/value pairing that can be used to store data abou
 
 `@next/mdx` **does** allow you to use exports like any other JavaScript component:
 
-```mdx filename="content/blog-post.mdx" switcher
+```mdx filename="content/blog-post.mdx"
 export const metadata = {
   author: 'John Doe',
 }


### PR DESCRIPTION
Currently, the [live docs](https://nextjs.org/docs/app/building-your-application/configuring/mdx#frontmatter) do not render the affected MDX snippet:

![next-docs-missing-mdx-snippet](https://github.com/user-attachments/assets/7bdea063-eea4-40c7-9684-04aea3a8634f)

This PR attempts to fix that.  Unfortunately, the code that renders the docs does not seem to be public.  Which means that I can't render the docs to verify this actually fixes the issue, and I can't inspect the code to verify the root cause.

Can that code be open sourced?  If so, I can submit a PR that improves how such cases are handled (e.g. trigger a build error, or properly render the snippet but log a warning).
