### PR TITLE
[dev-overlay] feat: dev indicator menu turbopack info popover

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/copy-button/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/copy-button/index.tsx
@@ -194,11 +194,11 @@ export function CopyButton({
       aria-label={label}
       aria-disabled={isDisabled}
       disabled={isDisabled}
-      data-nextjs-data-runtime-error-copy-button
+      data-nextjs-copy-button
       className={cx(
         props.className,
-        'nextjs-data-runtime-error-copy-button',
-        `nextjs-data-runtime-error-copy-button--${copyState.state}`
+        'nextjs-data-copy-button',
+        `nextjs-data-copy-button--${copyState.state}`
       )}
       onClick={() => {
         if (!isDisabled) {
@@ -247,28 +247,17 @@ function CopySuccessIcon() {
 }
 
 export const COPY_BUTTON_STYLES = css`
-  [data-nextjs-data-runtime-error-copy-button],
-  [data-nextjs-data-runtime-error-copy-button]:focus:not(:focus-visible) {
-    position: relative;
-    padding: 0;
-    border: none;
-    background: none;
-    outline: none;
-  }
-  [data-nextjs-data-runtime-error-copy-button] > svg {
-    vertical-align: middle;
-  }
-  .nextjs-data-runtime-error-copy-button {
+  .nextjs-data-copy-button {
     color: inherit;
   }
-  .nextjs-data-runtime-error-copy-button--initial:hover {
+  .nextjs-data-copy-button--initial:hover {
     cursor: pointer;
   }
-  .nextjs-data-runtime-error-copy-button--error,
-  .nextjs-data-runtime-error-copy-button--error:hover {
+  .nextjs-data-copy-button--error,
+  .nextjs-data-copy-button--error:hover {
     color: var(--color-ansi-red);
   }
-  .nextjs-data-runtime-error-copy-button--success {
+  .nextjs-data-copy-button--success {
     color: var(--color-ansi-green);
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/dialog/dialog.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/dialog/dialog.tsx
@@ -17,6 +17,7 @@ const CSS_SELECTORS_TO_EXCLUDE_ON_CLICK_OUTSIDE = [
   '[data-issues-open]',
   '#nextjs-dev-tools-menu',
   '[data-nextjs-error-overlay-nav]',
+  '[data-info-popover]',
 ]
 
 const Dialog: React.FC<DialogProps> = function Dialog({

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -307,7 +307,7 @@ function DevToolsPopover({
                 <MenuItem
                   index={1}
                   label="Try Turbopack"
-                  value={<ExternalIcon />}
+                  value={isTurbopack ? 'Enabled' : 'Disabled'}
                   onClick={() => setIsTurbopackInfoOpen(true)}
                 />
               )}
@@ -478,26 +478,6 @@ function useClickOutside(
 }
 
 //////////////////////////////////////////////////////////////////////////////////////
-
-function ExternalIcon() {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 16 16"
-      fill="none"
-      role="img"
-      aria-label="External link"
-    >
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M13.5 10.25V13.25C13.5 13.3881 13.3881 13.5 13.25 13.5H2.75C2.61193 13.5 2.5 13.3881 2.5 13.25L2.5 2.75C2.5 2.61193 2.61193 2.5 2.75 2.5H5.75H6.5V1H5.75H2.75C1.7835 1 1 1.7835 1 2.75V13.25C1 14.2165 1.7835 15 2.75 15H13.25C14.2165 15 15 14.2165 15 13.25V10.25V9.5H13.5V10.25ZM9 1H9.75H14.2495C14.6637 1 14.9995 1.33579 14.9995 1.75V6.25V7H13.4995V6.25V3.56066L8.53033 8.52978L8 9.06011L6.93934 7.99945L7.46967 7.46912L12.4388 2.5H9.75H9V1Z"
-        fill="currentColor"
-      />
-    </svg>
-  )
-}
 
 export const DEV_TOOLS_INDICATOR_STYLES = css`
   .dev-tools-indicator-menu {

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -307,7 +307,7 @@ function DevToolsPopover({
                 <MenuItem
                   index={1}
                   label="Try Turbopack"
-                  value={isTurbopack ? 'Enabled' : 'Disabled'}
+                  value={<ChevronRight />}
                   onClick={() => setIsTurbopackInfoOpen(true)}
                 />
               )}
@@ -326,6 +326,19 @@ function DevToolsPopover({
         </div>
       )}
     </Toast>
+  )
+}
+
+function ChevronRight() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none">
+      <path
+        fill="#666"
+        fillRule="evenodd"
+        d="m7.5 3.94.53.53 4.824 4.823a1 1 0 0 1 0 1.414L8.03 15.53l-.53.53L6.44 15l.53-.53L11.44 10 6.97 5.53 6.44 5 7.5 3.94Z"
+        clipRule="evenodd"
+      />
+    </svg>
   )
 }
 

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
@@ -1,0 +1,137 @@
+import { noop as css } from '../../../../helpers/noop-template'
+
+export function DevToolsInfo({
+  title,
+  children,
+  learnMoreLink,
+  setIsOpen,
+  setPreviousOpen,
+  ...props
+}: {
+  title: string
+  children: React.ReactNode
+  learnMoreLink: string
+  setIsOpen: (isOpen: boolean) => void
+  setPreviousOpen: (isOpen: boolean) => void
+}) {
+  return (
+    <div className="dev-tools-info-popover" {...props}>
+      <div className="dev-tools-info-container">
+        <h1 className="dev-tools-info-title">{title}</h1>
+        {children}
+        <div className="dev-tools-info-button-container">
+          <button
+            className="dev-tools-info-close-button"
+            onClick={() => {
+              setIsOpen(false)
+              setPreviousOpen(true)
+            }}
+          >
+            Close
+          </button>
+          <a
+            className="dev-tools-info-learn-more-button"
+            href={learnMoreLink}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Learn More
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const DEV_TOOLS_INFO_STYLES = css`
+  .dev-tools-info-popover {
+    -webkit-font-smoothing: antialiased;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    background: var(--color-background-100);
+    border: 1px solid var(--color-gray-alpha-400);
+    background-clip: padding-box;
+    box-shadow: var(--shadow-menu);
+    border-radius: var(--rounded-xl);
+    position: absolute;
+    font-family: var(--font-stack-sans);
+    z-index: 1000;
+    overflow: hidden;
+    opacity: 0;
+    outline: 0;
+    min-width: 248px;
+    transition: opacity var(--animate-out-duration-ms)
+      var(--animate-out-timing-function);
+
+    &[data-rendered='true'] {
+      opacity: 1;
+      scale: 1;
+    }
+  }
+
+  .dev-tools-info-container {
+    padding: var(--size-1_5);
+  }
+
+  .dev-tools-info-title {
+    padding: var(--size-2) var(--size-1_5);
+    color: var(--color-gray-1000);
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 20px;
+    margin: 0;
+  }
+
+  .dev-tools-info-paragraph {
+    padding: var(--size-2) var(--size-1_5);
+    color: var(--color-gray-1000);
+    font-size: 14px;
+    line-height: 20px;
+    margin: 0;
+  }
+
+  .dev-tools-info-button-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: var(--size-2) var(--size-1_5);
+  }
+
+  .dev-tools-info-close-button {
+    padding: 0 var(--size-2);
+    height: 28px;
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 20px;
+    transition: background var(--duration-short) ease;
+    color: var(--color-gray-1000);
+    border-radius: var(--rounded-md-2);
+    border: 1px solid var(--color-gray-alpha-400);
+    background: var(--color-background-200);
+  }
+
+  .dev-tools-info-close-button:hover {
+    background: var(--color-gray-400);
+  }
+
+  .dev-tools-info-learn-more-button {
+    align-content: center;
+    padding: 0 var(--size-2);
+    height: 28px;
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 20px;
+    transition: background var(--duration-short) ease;
+    color: var(--color-background-100);
+    border-radius: var(--rounded-md-2);
+    border: 1px solid var(--color-gray-1000);
+    background: var(--color-gray-1000);
+  }
+
+  .dev-tools-info-learn-more-button:hover {
+    text-decoration: none;
+    color: var(--color-background-100);
+    opacity: 0.9;
+  }
+`

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
@@ -33,7 +33,7 @@ export function DevToolsInfo({
             className="dev-tools-info-learn-more-button"
             href={learnMoreLink}
             target="_blank"
-            rel="noreferrer"
+            rel="noreferrer noopener"
           >
             Learn More
           </a>

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
@@ -15,7 +15,7 @@ export function DevToolsInfo({
   setPreviousOpen: (isOpen: boolean) => void
 }) {
   return (
-    <div className="dev-tools-info-popover" {...props}>
+    <div data-info-popover {...props}>
       <div className="dev-tools-info-container">
         <h1 className="dev-tools-info-title">{title}</h1>
         {children}
@@ -44,7 +44,7 @@ export function DevToolsInfo({
 }
 
 export const DEV_TOOLS_INFO_STYLES = css`
-  .dev-tools-info-popover {
+  [data-info-popover] {
     -webkit-font-smoothing: antialiased;
     display: flex;
     flex-direction: column;
@@ -60,7 +60,7 @@ export const DEV_TOOLS_INFO_STYLES = css`
     overflow: hidden;
     opacity: 0;
     outline: 0;
-    min-width: 248px;
+    min-width: 350px;
     transition: opacity var(--animate-out-duration-ms)
       var(--animate-out-timing-function);
 

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
@@ -83,12 +83,17 @@ export const DEV_TOOLS_INFO_STYLES = css`
     margin: 0;
   }
 
-  .dev-tools-info-paragraph {
+  .dev-tools-info-article {
     padding: var(--size-2) var(--size-1_5);
     color: var(--color-gray-1000);
     font-size: 14px;
     line-height: 20px;
     margin: 0;
+  }
+  .dev-tools-info-paragraph {
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 
   .dev-tools-info-button-container {

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
@@ -60,7 +60,7 @@ export const DEV_TOOLS_INFO_STYLES = css`
     overflow: hidden;
     opacity: 0;
     outline: 0;
-    min-width: 350px;
+    min-width: 248px;
     transition: opacity var(--animate-out-duration-ms)
       var(--animate-out-timing-function);
 

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/turbopack-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/turbopack-info.tsx
@@ -22,13 +22,23 @@ export function TurbopackInfo({
       setPreviousOpen={setPreviousOpen}
       {...props}
     >
-      <p className="dev-tools-info-paragraph">
-        Turbopack is an incremental bundler optimized for JavaScript and
-        TypeScript, written in Rust, and built into Next.js. To enable, include
-        the following flag in your next config file:
-      </p>
+      <article className="dev-tools-info-article">
+        <p className="dev-tools-info-paragraph">
+          Turbopack is an incremental bundler optimized for JavaScript and
+          TypeScript, written in Rust, and built into Next.js. Turbopack can be
+          used in Next.js in both the{' '}
+          <code className="dev-tools-info-code">pages</code> and{' '}
+          <code className="dev-tools-info-code">app</code> directories for
+          faster local development.
+        </p>
+        <p className="dev-tools-info-paragraph">
+          To enable Turbopack, use the{' '}
+          <code className="dev-tools-info-code">--turbopack</code> flag when
+          running the Next.js development server.
+        </p>
+      </article>
 
-      <div className="dev-tools-info-code-container">
+      <div className="dev-tools-info-code-block-container">
         <div className="dev-tools-info-code-block">
           <CopyButton
             actionLabel="Copy Next.js Turbopack Command"
@@ -38,56 +48,61 @@ export function TurbopackInfo({
           />
           <pre className="dev-tools-info-code-block-pre">
             <code>
-              <div className="dev-tools-info-code-line">{'  '}</div>
-              <div className="dev-tools-info-code-line">{'{'}</div>
-              <div className="dev-tools-info-code-line">
+              <div className="dev-tools-info-code-block-line">{'  '}</div>
+              <div className="dev-tools-info-code-block-line">{'{'}</div>
+              <div className="dev-tools-info-code-block-line">
                 {'  '}
-                <span className="dev-tools-info-code-json-key">
+                <span className="dev-tools-info-code-block-json-key">
                   "scripts"
-                </span>: {'{'}
+                </span>
+                : {'{'}
               </div>
-              <div className="dev-tools-info-code-line dev-tools-info-highlight">
+              <div className="dev-tools-info-code-block-line dev-tools-info-highlight">
                 {'    '}
-                <span className="dev-tools-info-code-json-key">
+                <span className="dev-tools-info-code-block-json-key">
                   "dev"
-                </span>:{' '}
-                <span className="dev-tools-info-code-json-value">
+                </span>
+                :{' '}
+                <span className="dev-tools-info-code-block-json-value">
                   "next dev --turbopack"
                 </span>
                 ,
               </div>
-              <div className="dev-tools-info-code-line">
+              <div className="dev-tools-info-code-block-line">
                 {'    '}
-                <span className="dev-tools-info-code-json-key">
+                <span className="dev-tools-info-code-block-json-key">
                   "build"
-                </span>:{' '}
-                <span className="dev-tools-info-code-json-value">
+                </span>
+                :{' '}
+                <span className="dev-tools-info-code-block-json-value">
                   "next build"
                 </span>
                 ,
               </div>
-              <div className="dev-tools-info-code-line">
+              <div className="dev-tools-info-code-block-line">
                 {'    '}
-                <span className="dev-tools-info-code-json-key">
+                <span className="dev-tools-info-code-block-json-key">
                   "start"
-                </span>:{' '}
-                <span className="dev-tools-info-code-json-value">
+                </span>
+                :{' '}
+                <span className="dev-tools-info-code-block-json-value">
                   "next start"
                 </span>
                 ,
               </div>
-              <div className="dev-tools-info-code-line">
+              <div className="dev-tools-info-code-block-line">
                 {'    '}
-                <span className="dev-tools-info-code-json-key">
+                <span className="dev-tools-info-code-block-json-key">
                   "lint"
-                </span>:{' '}
-                <span className="dev-tools-info-code-json-value">
+                </span>
+                :{' '}
+                <span className="dev-tools-info-code-block-json-value">
                   "next lint"
                 </span>
               </div>
-              <div className="dev-tools-info-code-line">{'  }'}</div>
-              <div className="dev-tools-info-code-line">{'}'}</div>
-              <div className="dev-tools-info-code-line">{'  '}</div>
+              <div className="dev-tools-info-code-block-line">{'  }'}</div>
+              <div className="dev-tools-info-code-block-line">{'}'}</div>
+              <div className="dev-tools-info-code-block-line">{'  '}</div>
             </code>
           </pre>
         </div>
@@ -97,7 +112,18 @@ export function TurbopackInfo({
 }
 
 export const DEV_TOOLS_INFO_TURBOPACK_INFO_STYLES = css`
-  .dev-tools-info-code-container {
+  .dev-tools-info-code {
+    background: var(--color-gray-400);
+    color: var(--color-gray-1000);
+    font-family: var(--font-stack-mono);
+    padding: var(--size-0_5) var(--size-1);
+    margin: 0;
+    font-size: 13px;
+    white-space: break-spaces;
+    border-radius: var(--rounded-md-2);
+  }
+
+  .dev-tools-info-code-block-container {
     padding: var(--size-1_5);
   }
 
@@ -131,22 +157,22 @@ export const DEV_TOOLS_INFO_TURBOPACK_INFO_STYLES = css`
     background: var(--color-background-100);
   }
 
-  .dev-tools-info-code-line {
+  .dev-tools-info-code-block-line {
     display: block;
     line-height: 1.5;
     padding: 0 1rem;
   }
 
-  .dev-tools-info-code-line.dev-tools-info-highlight {
+  .dev-tools-info-code-block-line.dev-tools-info-highlight {
     border-left: 2px solid var(--color-blue-900);
     background: var(--color-blue-400);
   }
 
-  .dev-tools-info-code-json-key {
+  .dev-tools-info-code-block-json-key {
     color: var(--color-syntax-keyword);
   }
 
-  .dev-tools-info-code-json-value {
+  .dev-tools-info-code-block-json-value {
     color: var(--color-syntax-link);
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/turbopack-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/turbopack-info.tsx
@@ -1,0 +1,152 @@
+import { DevToolsInfo } from './dev-tools-info'
+import { CopyButton } from '../../../copy-button'
+import { noop as css } from '../../../../helpers/noop-template'
+
+export function TurbopackInfo({
+  isOpen,
+  setIsOpen,
+  setPreviousOpen,
+  ...props
+}: {
+  isOpen: boolean
+  setIsOpen: (isOpen: boolean) => void
+  setPreviousOpen: (isOpen: boolean) => void
+  style?: React.CSSProperties
+  ref?: React.RefObject<HTMLElement | null>
+}) {
+  return (
+    <DevToolsInfo
+      title="Turbopack"
+      learnMoreLink="https://nextjs.org/docs/app/api-reference/turbopack"
+      setIsOpen={setIsOpen}
+      setPreviousOpen={setPreviousOpen}
+      {...props}
+    >
+      <p className="dev-tools-info-paragraph">
+        Turbopack is an incremental bundler optimized for JavaScript and
+        TypeScript, written in Rust, and built into Next.js. To enable, include
+        the following flag in your next config file:
+      </p>
+
+      <div className="dev-tools-info-code-container">
+        <div className="dev-tools-info-code-block">
+          <CopyButton
+            actionLabel="Copy Next.js Turbopack Command"
+            successLabel="Next.js Turbopack Command Copied"
+            content={'--turbopack'}
+            className="dev-tools-info-copy-button"
+          />
+          <pre className="dev-tools-info-code-block-pre">
+            <code>
+              <div className="dev-tools-info-code-line">{'  '}</div>
+              <div className="dev-tools-info-code-line">{'{'}</div>
+              <div className="dev-tools-info-code-line">
+                {'  '}
+                <span className="dev-tools-info-code-json-key">
+                  "scripts"
+                </span>: {'{'}
+              </div>
+              <div className="dev-tools-info-code-line dev-tools-info-highlight">
+                {'    '}
+                <span className="dev-tools-info-code-json-key">
+                  "dev"
+                </span>:{' '}
+                <span className="dev-tools-info-code-json-value">
+                  "next dev --turbopack"
+                </span>
+                ,
+              </div>
+              <div className="dev-tools-info-code-line">
+                {'    '}
+                <span className="dev-tools-info-code-json-key">
+                  "build"
+                </span>:{' '}
+                <span className="dev-tools-info-code-json-value">
+                  "next build"
+                </span>
+                ,
+              </div>
+              <div className="dev-tools-info-code-line">
+                {'    '}
+                <span className="dev-tools-info-code-json-key">
+                  "start"
+                </span>:{' '}
+                <span className="dev-tools-info-code-json-value">
+                  "next start"
+                </span>
+                ,
+              </div>
+              <div className="dev-tools-info-code-line">
+                {'    '}
+                <span className="dev-tools-info-code-json-key">
+                  "lint"
+                </span>:{' '}
+                <span className="dev-tools-info-code-json-value">
+                  "next lint"
+                </span>
+              </div>
+              <div className="dev-tools-info-code-line">{'  }'}</div>
+              <div className="dev-tools-info-code-line">{'}'}</div>
+              <div className="dev-tools-info-code-line">{'  '}</div>
+            </code>
+          </pre>
+        </div>
+      </div>
+    </DevToolsInfo>
+  )
+}
+
+export const DEV_TOOLS_INFO_TURBOPACK_INFO_STYLES = css`
+  .dev-tools-info-code-container {
+    padding: var(--size-1_5);
+  }
+
+  .dev-tools-info-code-block {
+    position: relative;
+    background: var(--color-background-200);
+    border: 1px solid var(--color-gray-alpha-400);
+    border-radius: var(--rounded-md-2);
+    min-width: 326px;
+  }
+
+  .dev-tools-info-code-block-pre {
+    margin: 0;
+    font-family: var(--font-stack-mono);
+    font-size: 12px;
+  }
+
+  .dev-tools-info-copy-button {
+    position: absolute;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    right: var(--size-2);
+    top: var(--size-2);
+    padding: var(--size-1);
+    height: var(--size-6);
+    width: var(--size-6);
+    border-radius: var(--rounded-md-2);
+    border: 1px solid var(--color-gray-alpha-400);
+    background: var(--color-background-100);
+  }
+
+  .dev-tools-info-code-line {
+    display: block;
+    line-height: 1.5;
+    padding: 0 1rem;
+  }
+
+  .dev-tools-info-code-line.dev-tools-info-highlight {
+    border-left: 2px solid var(--color-blue-900);
+    background: var(--color-blue-400);
+  }
+
+  .dev-tools-info-code-json-key {
+    color: var(--color-syntax-keyword);
+  }
+
+  .dev-tools-info-code-json-value {
+    color: var(--color-syntax-link);
+  }
+`

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/toast/toast.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/toast/toast.tsx
@@ -16,7 +16,9 @@ export const Toast: React.FC<ToastProps> = function Toast({
     <div
       {...props}
       onClick={(e) => {
-        e.preventDefault()
+        if (!(e.target as HTMLElement).closest('a')) {
+          e.preventDefault()
+        }
         return onClick?.()
       }}
       className={cx('nextjs-toast', className)}

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/styles/base.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/styles/base.tsx
@@ -83,6 +83,7 @@ export function Base() {
           --rounded-none: 0px;
           --rounded-sm: 0.125rem; /* 2px */
           --rounded-md: 0.25rem; /* 4px */
+          --rounded-md-2: 0.375rem; /* 6px */
           --rounded-lg: 0.5rem; /* 8px */
           --rounded-xl: 0.75rem; /* 12px */
           --rounded-2xl: 1rem; /* 16px */

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/styles/component-styles.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/styles/component-styles.tsx
@@ -17,6 +17,9 @@ import { DEV_TOOLS_INDICATOR_STYLES } from '../components/errors/dev-tools-indic
 import { noop as css } from '../helpers/noop-template'
 import { EDITOR_LINK_STYLES } from '../components/terminal/editor-link'
 import { ENVIRONMENT_NAME_LABEL_STYLES } from '../components/errors/environment-name-label/environment-name-label'
+import { DEV_TOOLS_INFO_STYLES } from '../components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info'
+import { DEV_TOOLS_INFO_TURBOPACK_INFO_STYLES } from '../components/errors/dev-tools-indicator/dev-tools-info/turbopack-info'
+
 export function ComponentStyles() {
   return (
     <style>
@@ -39,6 +42,8 @@ export function ComponentStyles() {
         ${containerRuntimeErrorStyles}
         ${versionStaleness}
         ${DEV_TOOLS_INDICATOR_STYLES}
+        ${DEV_TOOLS_INFO_STYLES}
+        ${DEV_TOOLS_INFO_TURBOPACK_INFO_STYLES}
       `}
     </style>
   )


### PR DESCRIPTION
### What?

This PR added a menu item's specific info popover for Turbopack.

https://github.com/user-attachments/assets/48b56436-8183-425e-be5a-b5091142abb0

### Success Criteria

Open/Close:

- [x] Does it open when on click Turbopack menu?
- [x] Does it close when on click outside?
- [x] Does it close when on click "Close" button?
- [x] Does it close and open menu when on click indicator?

Behaviors:

- [x] Does it open Turbopack docs on another window when on click "Learn More" button?
- [x] Does it copy "--turbopack" text when on click the copy button?
- [x] Does it have all the content as expected?
- [x] Does it go along with the position of the indicator?

Closes NDX-848