### PR TITLE
refactor(turbopack): Simplify `minify()`

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -2,7 +2,7 @@ use std::{io::Write, sync::Arc};
 
 use anyhow::{bail, Context, Result};
 use swc_core::{
-    base::{try_with_handler, Compiler},
+    base::try_with_handler,
     common::{
         comments::{Comments, SingleThreadedComments},
         BytePos, FileName, FilePathMapping, LineCol, Mark, SourceMap as SwcSourceMap, GLOBALS,
@@ -41,8 +41,7 @@ pub async fn minify(
 
     let cm = Arc::new(SwcSourceMap::new(FilePathMapping::empty()));
     let (src, mut src_map_buf) = {
-        let compiler = Arc::new(Compiler::new(cm.clone()));
-        let fm = compiler.cm.new_source_file(
+        let fm = cm.new_source_file(
             FileName::Custom(path.path.to_string()).into(),
             code.source_code().to_str()?.into_owned(),
         );
@@ -71,48 +70,46 @@ pub async fn minify(
                 let unresolved_mark = Mark::new();
                 let top_level_mark = Mark::new();
 
-                Ok(compiler.run_transform(handler, false, || {
-                    let program = program.apply(paren_remover(Some(&comments)));
+                let program = program.apply(paren_remover(Some(&comments)));
 
-                    let mut program = program.apply(swc_core::ecma::transforms::base::resolver(
-                        unresolved_mark,
-                        top_level_mark,
-                        false,
-                    ));
+                let mut program = program.apply(swc_core::ecma::transforms::base::resolver(
+                    unresolved_mark,
+                    top_level_mark,
+                    false,
+                ));
 
-                    program = swc_core::ecma::minifier::optimize(
-                        program,
-                        cm.clone(),
-                        Some(&comments),
-                        None,
-                        &MinifyOptions {
-                            compress: Some(CompressOptions {
-                                // Only run 2 passes, this is a tradeoff between performance and
-                                // compression size. Default is 3 passes.
-                                passes: 2,
-                                ..Default::default()
-                            }),
-                            mangle: if mangle {
-                                Some(MangleOptions {
-                                    reserved: vec!["AbortSignal".into()],
-                                    ..Default::default()
-                                })
-                            } else {
-                                None
-                            },
+                program = swc_core::ecma::minifier::optimize(
+                    program,
+                    cm.clone(),
+                    Some(&comments),
+                    None,
+                    &MinifyOptions {
+                        compress: Some(CompressOptions {
+                            // Only run 2 passes, this is a tradeoff between performance and
+                            // compression size. Default is 3 passes.
+                            passes: 2,
                             ..Default::default()
+                        }),
+                        mangle: if mangle {
+                            Some(MangleOptions {
+                                reserved: vec!["AbortSignal".into()],
+                                ..Default::default()
+                            })
+                        } else {
+                            None
                         },
-                        &ExtraOptions {
-                            top_level_mark,
-                            unresolved_mark,
-                            mangle_name_cache: None,
-                        },
-                    );
+                        ..Default::default()
+                    },
+                    &ExtraOptions {
+                        top_level_mark,
+                        unresolved_mark,
+                        mangle_name_cache: None,
+                    },
+                );
 
-                    program.apply(ecma::transforms::base::fixer::fixer(Some(
-                        &comments as &dyn Comments,
-                    )))
-                }))
+                Ok(program.apply(ecma::transforms::base::fixer::fixer(Some(
+                    &comments as &dyn Comments,
+                ))))
             })
         })?;
 


### PR DESCRIPTION
### What?

Simplify `minify()` of turbopack. `swc::Compiler` is not required for the minification, considering that we are not using the minification API of it.

### Why?

It has some tiny overheads, and it disturbs future refactoring for source maps.

Closes PACK-3979