### PR TITLE
perf(turbopack): Use `triomphe::Arc` for `Rope`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9317,6 +9317,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "triomphe 0.1.12",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -9324,6 +9325,7 @@ dependencies = [
  "turbo-tasks-memory",
  "turbo-tasks-testing",
  "unicode-segmentation",
+ "unsize",
  "urlencoding",
 ]
 

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -47,6 +47,7 @@ serde_json = { workspace = true }
 serde_path_to_error = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+triomphe = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-hash = { workspace = true }

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -47,7 +47,8 @@ serde_json = { workspace = true }
 serde_path_to_error = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-triomphe = { workspace = true }
+unsize = "1.1.0"
+triomphe = { workspace = true, features = ["unsize"] }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-hash = { workspace = true }

--- a/turbopack/crates/turbo-tasks-fs/src/rope.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/rope.rs
@@ -6,7 +6,6 @@ use std::{
     mem,
     ops::{AddAssign, Deref},
     pin::Pin,
-    sync::Arc,
     task::{Context as TaskContext, Poll},
 };
 
@@ -16,7 +15,9 @@ use futures::Stream;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_bytes::ByteBuf;
 use tokio::io::{AsyncRead, ReadBuf};
+use triomphe::Arc;
 use turbo_tasks_hash::{DeterministicHash, DeterministicHasher};
+use unsize::{CoerceUnsize, Coercion};
 use RopeElem::{Local, Shared};
 
 static EMPTY_BUF: &[u8] = &[];
@@ -141,7 +142,7 @@ impl<T: Into<Bytes>> From<T> for Rope {
         } else {
             Rope {
                 length: bytes.len(),
-                data: InnerRope(Arc::from([Local(bytes)])),
+                data: InnerRope(Arc::from([Local(bytes)]).unsize(Coercion::to_slice())),
             }
         }
     }
@@ -539,7 +540,7 @@ impl InnerRope {
 
 impl Default for InnerRope {
     fn default() -> Self {
-        InnerRope(Arc::from([]))
+        InnerRope(Arc::new([]).unsize(Coercion::to_slice()))
     }
 }
 


### PR DESCRIPTION
### What?

I tried using `triomphe::Arc` for `Rope`, although there was no big performance difference on my device (mac, M3 Max)

### Why?

It's a clear win, even if it's very small.

Closes PACK-3989