### PR TITLE
build: Reduce binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,130 @@ opt-level = 1
 [profile.dev.build-override]
 opt-level = 3
 
+[profile.release]
+
+[profile.release.package]
+
+[profile.release.package.turbopack-ecmascript]
+opt-level = 3
+
+[profile.release.package.turbopack-core]
+opt-level = 3
+
+[profile.release.package.next-core]
+opt-level = 3
+
+[profile.release.package.lightningcss]
+opt-level = "s"
+
+[profile.release.package.std]
+opt-level = 3
+
+[profile.release.package.lightningcss-napi]
+opt-level = "s"
+
+[profile.release.package.swc_ecma_ast]
+opt-level = 3
+
+[profile.release.package.next-api]
+opt-level = 3
+
+[profile.release.package.wasmer-wasix]
+opt-level = "s"
+
+[profile.release.package.cranelift-codegen]
+opt-level = "s"
+
+[profile.release.package.turbo-tasks]
+opt-level = 3
+
+[profile.release.package.turbopack-node]
+opt-level = 3
+
+[profile.release.package.turbopack-dev-server]
+opt-level = 3
+
+[profile.release.package.swc_ecma_minifier]
+opt-level = 3
+
+[profile.release.package.swc]
+opt-level = 3
+
+[profile.release.package.turbopack-css]
+opt-level = 3
+
+[profile.release.package.swc_ecma_compat_es2015]
+opt-level = "s"
+
+[profile.release.package.turbo-tasks-fs]
+opt-level = 3
+
+[profile.release.package.swc_ecma_parser]
+opt-level = 3
+
+[profile.release.package.turbopack]
+opt-level = 3
+
+[profile.release.package.turbopack-browser]
+opt-level = 3
+
+[profile.release.package.turbo-tasks-backend]
+opt-level = 3
+
+[profile.release.package.styled_jsx]
+opt-level = "s"
+
+[profile.release.package.next-custom-transforms]
+opt-level = 3
+
+[profile.release.package.wast]
+opt-level = "s"
+
+[profile.release.package.wasmparser]
+opt-level = "s"
+
+[profile.release.package.browserslist-rs]
+opt-level = "s"
+
+[profile.release.package.tokio]
+opt-level = 3
+
+[profile.release.package.reqwest]
+opt-level = "s"
+
+[profile.release.package.swc_ecma_transforms_proposal]
+opt-level = "s"
+
+[profile.release.package.turbopack-resolve]
+opt-level = 3
+
+[profile.release.package.swc_ecma_transforms_optimization]
+opt-level = 3
+
+[profile.release.package.swc_ecma_transforms_base]
+opt-level = 3
+
+[profile.release.package.regex-automata]
+opt-level = 3
+
+[profile.release.package.auto-hash-map]
+opt-level = 3
+
+[profile.release.package.webc]
+opt-level = "s"
+
+[profile.release.package.turbopack-nodejs]
+opt-level = 3
+
+[profile.release.package.turbopack-trace-server]
+opt-level = 3
+
+[profile.release.package.swc_ecma_transforms_module]
+opt-level = "s"
+
+[profile.release.package.swc_ecma_transforms_typescript]
+opt-level = 3
+
 [workspace.dependencies]
 # Workspace crates
 next-api = { path = "crates/next-api" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,90 @@ opt-level = "s"
 [profile.release.package.swc_ecma_transforms_typescript]
 opt-level = 3
 
+[profile.release.package.swc_css_prefixer]
+opt-level = "s"
+
+[profile.release.package.zstd-sys]
+opt-level = 3
+
+[profile.release.package.sourcemap]
+opt-level = 3
+
+[profile.release.package.turbopack-wasm]
+opt-level = 3
+
+[profile.release.package.rustls]
+opt-level = "s"
+
+[profile.release.package.turbopack-ecmascript-plugins]
+opt-level = 3
+
+[profile.release.package.handlebars]
+opt-level = "s"
+
+[profile.release.package.swc_ecma_compat_bugfixes]
+opt-level = "s"
+
+[profile.release.package.h2]
+opt-level = "s"
+
+[profile.release.package.swc_ecma_compat_es2022]
+opt-level = "s"
+
+[profile.release.package.wasmer-config]
+opt-level = "s"
+
+[profile.release.package.wasmer-compiler]
+opt-level = "s"
+
+[profile.release.package.swc_ecma_utils]
+opt-level = 3
+
+[profile.release.package.regex-syntax]
+opt-level = "s"
+
+[profile.release.package.turbopack-image]
+opt-level = 3
+
+[profile.release.package.turbo-tasks-env]
+opt-level = 3
+
+[profile.release.package.napi]
+opt-level = 3
+
+[profile.release.package.mdxjs]
+opt-level = "s"
+
+[profile.release.package.serde_json]
+opt-level = 3
+
+[profile.release.package.swc_plugin_runner]
+opt-level = "s"
+
+[profile.release.package.markdown]
+opt-level = "s"
+
+[profile.release.package.swc_ecma_preset_env]
+opt-level = "s"
+
+[profile.release.package.turbo-tasks-fetch]
+opt-level = 3
+
+[profile.release.package.swc_ecma_visit]
+opt-level = 3
+
+[profile.release.package.turbopack-mdx]
+opt-level = "s"
+
+[profile.release.package.autocfg]
+opt-level = "s"
+
+[profile.release.package.image]
+opt-level = 3
+
+[profile.release.package.serde]
+opt-level = 3
+
 [workspace.dependencies]
 # Workspace crates
 next-api = { path = "crates/next-api" }


### PR DESCRIPTION
### What?

Configures optimization levels for each crate by using `ddt cargo bin-size select-per-crate --compare --features plugin --release` from `crates/napi`.

### Why?

To reduce binary size. We don't want to `wasmer` to be optimized as much as possible. Rather, it should use less space.


### How?



Closes PACK-3999