### PR TITLE
[dev-overlay] fix: line number handling for cursor editor

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/helpers/launch-editor.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/helpers/launch-editor.ts
@@ -85,7 +85,7 @@ const COMMON_EDITORS_MACOS = {
   '/Applications/Rider.app/Contents/MacOS/rider':
     '/Applications/Rider.app/Contents/MacOS/rider',
   '/Applications/Cursor.app/Contents/MacOS/Cursor':
-  '/Applications/Cursor.app/Contents/MacOS/Cursor',
+    '/Applications/Cursor.app/Contents/MacOS/Cursor',
 }
 
 const COMMON_EDITORS_LINUX = {

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/helpers/launch-editor.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/helpers/launch-editor.ts
@@ -84,6 +84,8 @@ const COMMON_EDITORS_MACOS = {
     '/Applications/GoLand.app/Contents/MacOS/goland',
   '/Applications/Rider.app/Contents/MacOS/rider':
     '/Applications/Rider.app/Contents/MacOS/rider',
+  '/Applications/Cursor.app/Contents/MacOS/Cursor':
+  '/Applications/Cursor.app/Contents/MacOS/Cursor',
 }
 
 const COMMON_EDITORS_LINUX = {
@@ -181,6 +183,7 @@ function getArgumentsForLineNumber(
     case 'Code':
     case 'code-insiders':
     case 'Code - Insiders':
+    case 'Cursor':
     case 'vscodium':
     case 'VSCodium': {
       return ['-g', fileName + ':' + lineNumber + ':' + colNumber]


### PR DESCRIPTION
#### What?
Fix line number handling for Cursor editor by adding proper command line arguments
#### Why?
Cursor editor was not properly handling line and column numbers when opening files, which prevented accurate navigation to specific code locations when clicking error stack traces. Without a specific case for Cursor, it was falling back to the default case which only opens the file without line number information.
#### How?
Added Cursor editor support to getArgumentsForLineNumber function with the correct command line argument format:
```ts
case 'Cursor': {
  return ['-g', fileName + ':' + lineNumber + ':' + colNumber]
}
```
This matches VSCode's argument format since Cursor is a fork of VSCode and uses the same underlying editor technology.