### PR TITLE
[dev-overlay] Fix off-by-one column sourcemapping in Webpack

### DIFF
--- a/packages/next/src/build/webpack/plugins/wellknown-errors-plugin/parseNotFoundError.ts
+++ b/packages/next/src/build/webpack/plugins/wellknown-errors-plugin/parseNotFoundError.ts
@@ -76,7 +76,8 @@ async function getSourceFrame(
           file: fileName,
           methodName: '',
           lineNumber: loc.start.line,
-          column: loc.start.column,
+          // loc is 0-based but columns in stack frames are 1-based.
+          column: (loc.start.column ?? 0) + 1,
         },
       })
 

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
@@ -232,6 +232,9 @@ function findApplicableSourceMapPayload(
   }
 }
 
+/**
+ * @returns 1-based lines and 0-based columns
+ */
 async function nativeTraceSource(
   frame: TurbopackStackFrame
 ): Promise<{ frame: IgnorableStackFrame; source: string | null } | undefined> {
@@ -264,7 +267,8 @@ async function nativeTraceSource(
     try {
       const originalPosition = consumer.originalPositionFor({
         line: frame.line ?? 1,
-        column: frame.column ?? 1,
+        // 0-based columns out requires 0-based columns in.
+        column: (frame.column ?? 1) - 1,
       })
 
       if (originalPosition.source === null) {

--- a/test/development/app-dir/capture-console-error-owner-stack/capture-console-error-owner-stack.test.ts
+++ b/test/development/app-dir/capture-console-error-owner-stack/capture-console-error-owner-stack.test.ts
@@ -41,54 +41,28 @@ describe('app-dir - capture-console-error-owner-stack', () => {
 
     const result = await getRedboxResult(browser)
 
-    // TODO(veil): Inconsistent cursor position for the "Page" frame
-    if (process.env.TURBOPACK) {
-      expect(result).toMatchInlineSnapshot(`
-       {
-         "callStacks": "onClick
-       app/browser/event/page.js (7:17)
-       button
-       <anonymous> (0:0)
-       Page
-       app/browser/event/page.js (5:5)",
-         "count": 1,
-         "description": "trigger an console <error>",
-         "source": "app/browser/event/page.js (7:17) @ onClick
+    expect(result).toMatchInlineSnapshot(`
+     {
+       "callStacks": "onClick
+     app/browser/event/page.js (7:17)
+     button
+     <anonymous> (0:0)
+     Page
+     app/browser/event/page.js (5:5)",
+       "count": 1,
+       "description": "trigger an console <error>",
+       "source": "app/browser/event/page.js (7:17) @ onClick
 
-          5 |     <button
-          6 |       onClick={() => {
-       >  7 |         console.error('trigger an console <%s>', 'error')
-            |                 ^
-          8 |       }}
-          9 |     >
-         10 |       click to error",
-         "title": "Console Error",
-       }
-      `)
-    } else {
-      expect(result).toMatchInlineSnapshot(`
-       {
-         "callStacks": "onClick
-       app/browser/event/page.js (7:17)
-       button
-       <anonymous> (0:0)
-       Page
-       app/browser/event/page.js (5:6)",
-         "count": 1,
-         "description": "trigger an console <error>",
-         "source": "app/browser/event/page.js (7:17) @ onClick
-
-          5 |     <button
-          6 |       onClick={() => {
-       >  7 |         console.error('trigger an console <%s>', 'error')
-            |                 ^
-          8 |       }}
-          9 |     >
-         10 |       click to error",
-         "title": "Console Error",
-       }
-      `)
-    }
+        5 |     <button
+        6 |       onClick={() => {
+     >  7 |         console.error('trigger an console <%s>', 'error')
+          |                 ^
+        8 |       }}
+        9 |     >
+       10 |       click to error",
+       "title": "Console Error",
+     }
+    `)
   })
 
   it('should capture browser console error in render and dedupe if necessary', async () => {
@@ -227,8 +201,7 @@ describe('app-dir - capture-console-error-owner-stack', () => {
          }
         `)
     } else {
-      if (process.env.TURBOPACK) {
-        expect(result).toMatchInlineSnapshot(`
+      expect(result).toMatchInlineSnapshot(`
        {
          "callStacks": "Page
        app/rsc/page.js (2:17)
@@ -249,29 +222,6 @@ describe('app-dir - capture-console-error-owner-stack', () => {
          "title": "Console Error",
        }
       `)
-      } else {
-        expect(result).toMatchInlineSnapshot(`
-       {
-         "callStacks": "Page
-       app/rsc/page.js (2:17)
-       JSON.parse
-       <anonymous> (0:0)
-       Page
-       <anonymous> (0:0)",
-         "count": 1,
-         "description": "[ Server ] Error: boom",
-         "source": "app/rsc/page.js (2:17) @ Page
-
-         1 | export default function Page() {
-       > 2 |   console.error(new Error('boom'))
-           |                 ^
-         3 |   return <p>rsc</p>
-         4 | }
-         5 |",
-         "title": "Console Error",
-       }
-      `)
-      }
     }
   })
 

--- a/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
+++ b/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
@@ -6,7 +6,7 @@ import {
 } from 'next-test-utils'
 
 describe('error-ignored-frames', () => {
-  const { next } = nextTestSetup({
+  const { isTurbopack, next } = nextTestSetup({
     files: __dirname,
   })
 
@@ -30,7 +30,7 @@ describe('error-ignored-frames', () => {
     await toggleCollapseCallStackFrames(browser)
 
     const expendedStack = await getStackFramesContent(browser)
-    if (process.env.TURBOPACK) {
+    if (isTurbopack) {
       expect(expendedStack).toMatchInlineSnapshot(`
        "at Page (app/page.tsx (2:9))
        at resolveErrorDev ()
@@ -50,11 +50,11 @@ describe('error-ignored-frames', () => {
        at processFullStringRow ()
        at processFullBinaryRow ()
        at progress ()
-       at InnerLayoutRouter (../src/client/components/layout-router.tsx (408:6))
-       at OuterLayoutRouter (../src/client/components/layout-router.tsx (607:20))
-       at Router (../src/client/components/app-router.tsx (633:8))
-       at AppRouter (../src/client/components/app-router.tsx (679:8))
-       at ServerRoot (../src/client/app-index.tsx (201:6))"
+       at InnerLayoutRouter (../src/client/components/layout-router.tsx (408:5))
+       at OuterLayoutRouter (../src/client/components/layout-router.tsx (607:19))
+       at Router (../src/client/components/app-router.tsx (633:7))
+       at AppRouter (../src/client/components/app-router.tsx (679:7))
+       at ServerRoot (../src/client/app-index.tsx (201:5))"
       `)
     }
   })
@@ -71,7 +71,7 @@ describe('error-ignored-frames', () => {
     await toggleCollapseCallStackFrames(browser)
 
     const expendedStack = await getStackFramesContent(browser)
-    if (process.env.TURBOPACK) {
+    if (isTurbopack) {
       expect(expendedStack).toMatchInlineSnapshot(`
        "at Page (app/client/page.tsx (4:9))
        at ClientPageRoot ()
@@ -82,10 +82,10 @@ describe('error-ignored-frames', () => {
     } else {
       expect(expendedStack).toMatchInlineSnapshot(`
        "at Page (app/client/page.tsx (4:9))
-       at ClientPageRoot (../src/client/components/client-page.tsx (60:13))
-       at Router (../src/client/components/app-router.tsx (633:8))
-       at AppRouter (../src/client/components/app-router.tsx (679:8))
-       at ServerRoot (../src/client/app-index.tsx (201:6))"
+       at ClientPageRoot (../src/client/components/client-page.tsx (60:12))
+       at Router (../src/client/components/app-router.tsx (633:7))
+       at AppRouter (../src/client/components/app-router.tsx (679:7))
+       at ServerRoot (../src/client/app-index.tsx (201:5))"
       `)
     }
   })
@@ -95,7 +95,7 @@ describe('error-ignored-frames', () => {
     await assertHasRedbox(browser)
 
     const defaultStack = await getStackFramesContent(browser)
-    if (process.env.TURBOPACK) {
+    if (isTurbopack) {
       expect(defaultStack).toMatchInlineSnapshot(`
        "at <unknown> (app/interleaved/page.tsx (7:11))
        at Page (app/interleaved/page.tsx (6:35))"
@@ -103,18 +103,18 @@ describe('error-ignored-frames', () => {
     } else {
       expect(defaultStack).toMatchInlineSnapshot(`
        "at eval (app/interleaved/page.tsx (7:11))
-       at Page (app/interleaved/page.tsx (6:37))"
+       at Page (app/interleaved/page.tsx (6:36))"
       `)
     }
 
     await toggleCollapseCallStackFrames(browser)
 
     const expendedStack = await getStackFramesContent(browser)
-    if (process.env.TURBOPACK) {
+    if (isTurbopack) {
       expect(expendedStack).toMatchInlineSnapshot(`
        "at <unknown> (app/interleaved/page.tsx (7:11))
-       at invokeCallback ()
        at Page (app/interleaved/page.tsx (6:35))
+       at invokeCallback ()
        at ClientPageRoot ()
        at Router ()
        at AppRouter ()
@@ -124,11 +124,11 @@ describe('error-ignored-frames', () => {
       expect(expendedStack).toMatchInlineSnapshot(`
        "at eval (app/interleaved/page.tsx (7:11))
        at invokeCallback (node_modules/interleave/index.js (2:1))
-       at Page (app/interleaved/page.tsx (6:37))
-       at ClientPageRoot (../src/client/components/client-page.tsx (60:13))
-       at Router (../src/client/components/app-router.tsx (633:8))
-       at AppRouter (../src/client/components/app-router.tsx (679:8))
-       at ServerRoot (../src/client/app-index.tsx (201:6))"
+       at Page (app/interleaved/page.tsx (6:36))
+       at ClientPageRoot (../src/client/components/client-page.tsx (60:12))
+       at Router (../src/client/components/app-router.tsx (633:7))
+       at AppRouter (../src/client/components/app-router.tsx (679:7))
+       at ServerRoot (../src/client/app-index.tsx (201:5))"
       `)
     }
   })
@@ -145,7 +145,7 @@ describe('error-ignored-frames', () => {
     await toggleCollapseCallStackFrames(browser)
 
     const expendedStack = await getStackFramesContent(browser)
-    if (process.env.TURBOPACK) {
+    if (isTurbopack) {
       expect(expendedStack).toMatchInlineSnapshot(`
        "at Page (pages/pages.tsx (2:9))
        at react-stack-bottom-frame ()

--- a/test/development/app-dir/owner-stack-invalid-element-type/owner-stack-invalid-element-type.test.ts
+++ b/test/development/app-dir/owner-stack-invalid-element-type/owner-stack-invalid-element-type.test.ts
@@ -17,41 +17,22 @@ describe('app-dir - owner-stack-invalid-element-type', () => {
     const source = await getRedboxSource(browser)
 
     const stackFramesContent = await getStackFramesContent(browser)
-    if (process.env.TURBOPACK) {
-      expect(stackFramesContent).toMatchInlineSnapshot(`
-         "at BrowserOnly (app/browser/browser-only.js (8:7))
-         at Inner (app/browser/page.js (11:10))
-         at Page (app/browser/page.js (15:10))"
-        `)
-      expect(source).toMatchInlineSnapshot(`
-          "app/browser/browser-only.js (8:7) @ BrowserOnly
+    expect(stackFramesContent).toMatchInlineSnapshot(`
+     "at BrowserOnly (app/browser/browser-only.js (8:7))
+     at Inner (app/browser/page.js (11:10))
+     at Page (app/browser/page.js (15:10))"
+    `)
+    expect(source).toMatchInlineSnapshot(`
+     "app/browser/browser-only.js (8:7) @ BrowserOnly
 
-             6 |   return (
-             7 |     <div>
-          >  8 |       <Foo />
-               |       ^
-             9 |     </div>
-            10 |   )
-            11 | }"
-        `)
-    } else {
-      expect(stackFramesContent).toMatchInlineSnapshot(`
-         "at BrowserOnly (app/browser/browser-only.js (8:8))
-         at Inner (app/browser/page.js (11:11))
-         at Page (app/browser/page.js (15:11))"
-        `)
-      expect(source).toMatchInlineSnapshot(`
-         "app/browser/browser-only.js (8:8) @ BrowserOnly
-
-            6 |   return (
-            7 |     <div>
-         >  8 |       <Foo />
-              |        ^
-            9 |     </div>
-           10 |   )
-           11 | }"
-        `)
-    }
+        6 |   return (
+        7 |     <div>
+     >  8 |       <Foo />
+          |       ^
+        9 |     </div>
+       10 |   )
+       11 | }"
+    `)
   })
 
   it('should catch invalid element from a rsc component', async () => {
@@ -61,39 +42,21 @@ describe('app-dir - owner-stack-invalid-element-type', () => {
     const stackFramesContent = await getStackFramesContent(browser)
     const source = await getRedboxSource(browser)
 
-    if (process.env.TURBOPACK) {
-      expect(stackFramesContent).toMatchInlineSnapshot(`
-         "at Inner (app/rsc/page.js (5:11))
-         at Page (app/rsc/page.js (11:8))"
-        `)
-      expect(source).toMatchInlineSnapshot(`
-          "app/rsc/page.js (5:11) @ Inner
+    expect(stackFramesContent).toMatchInlineSnapshot(`
+     "at Inner (app/rsc/page.js (5:10))
+     at Page (app/rsc/page.js (11:7))"
+    `)
+    expect(source).toMatchInlineSnapshot(`
+     "app/rsc/page.js (5:10) @ Inner
 
-            3 | // Intermediate component for testing owner stack
-            4 | function Inner() {
-          > 5 |   return <Foo />
-              |           ^
-            6 | }
-            7 |
-            8 | export default function Page() {"
-        `)
-    } else {
-      expect(stackFramesContent).toMatchInlineSnapshot(`
-         "at Inner (app/rsc/page.js (5:11))
-         at Page (app/rsc/page.js (11:8))"
-        `)
-      expect(source).toMatchInlineSnapshot(`
-         "app/rsc/page.js (5:11) @ Inner
-
-           3 | // Intermediate component for testing owner stack
-           4 | function Inner() {
-         > 5 |   return <Foo />
-             |           ^
-           6 | }
-           7 |
-           8 | export default function Page() {"
-        `)
-    }
+       3 | // Intermediate component for testing owner stack
+       4 | function Inner() {
+     > 5 |   return <Foo />
+         |          ^
+       6 | }
+       7 |
+       8 | export default function Page() {"
+    `)
   })
 
   it('should catch invalid element from on ssr client component', async () => {
@@ -103,38 +66,20 @@ describe('app-dir - owner-stack-invalid-element-type', () => {
 
     const stackFramesContent = await getStackFramesContent(browser)
     const source = await getRedboxSource(browser)
-    if (process.env.TURBOPACK) {
-      expect(stackFramesContent).toMatchInlineSnapshot(`
-         "at Inner (app/ssr/page.js (7:10))
-         at Page (app/ssr/page.js (13:7))"
-        `)
-      expect(source).toMatchInlineSnapshot(`
-          "app/ssr/page.js (7:10) @ Inner
+    expect(stackFramesContent).toMatchInlineSnapshot(`
+     "at Inner (app/ssr/page.js (7:10))
+     at Page (app/ssr/page.js (13:7))"
+    `)
+    expect(source).toMatchInlineSnapshot(`
+     "app/ssr/page.js (7:10) @ Inner
 
-             5 | // Intermediate component for testing owner stack
-             6 | function Inner() {
-          >  7 |   return <Foo />
-               |          ^
-             8 | }
-             9 |
-            10 | export default function Page() {"
-        `)
-    } else {
-      expect(stackFramesContent).toMatchInlineSnapshot(`
-         "at Inner (app/ssr/page.js (7:11))
-         at Page (app/ssr/page.js (13:8))"
-        `)
-      expect(source).toMatchInlineSnapshot(`
-         "app/ssr/page.js (7:11) @ Inner
-
-            5 | // Intermediate component for testing owner stack
-            6 | function Inner() {
-         >  7 |   return <Foo />
-              |           ^
-            8 | }
-            9 |
-           10 | export default function Page() {"
-        `)
-    }
+        5 | // Intermediate component for testing owner stack
+        6 | function Inner() {
+     >  7 |   return <Foo />
+          |          ^
+        8 | }
+        9 |
+       10 | export default function Page() {"
+    `)
   })
 })

--- a/test/development/app-dir/owner-stack-react-missing-key-prop/owner-stack-react-missing-key-prop.test.ts
+++ b/test/development/app-dir/owner-stack-react-missing-key-prop/owner-stack-react-missing-key-prop.test.ts
@@ -6,7 +6,7 @@ import {
 } from 'next-test-utils'
 
 describe('app-dir - owner-stack-react-missing-key-prop', () => {
-  const { next } = nextTestSetup({
+  const { isTurbopack, next } = nextTestSetup({
     files: __dirname,
   })
 
@@ -17,19 +17,19 @@ describe('app-dir - owner-stack-react-missing-key-prop', () => {
     const stackFramesContent = await getStackFramesContent(browser)
     const source = await getRedboxSource(browser)
 
-    if (process.env.TURBOPACK) {
+    if (isTurbopack) {
       expect(stackFramesContent).toMatchInlineSnapshot(`
          "at span ()
-         at <anonymous> (app/rsc/page.tsx (7:10))
+         at <anonymous> (app/rsc/page.tsx (7:9))
          at Page (app/rsc/page.tsx (6:13))"
         `)
       expect(source).toMatchInlineSnapshot(`
-         "app/rsc/page.tsx (7:10) @ <anonymous>
+         "app/rsc/page.tsx (7:9) @ <anonymous>
 
             5 |     <div>
             6 |       {list.map((item, index) => (
          >  7 |         <span>{item}</span>
-              |          ^
+              |         ^
             8 |       ))}
             9 |     </div>
            10 |   )"
@@ -37,16 +37,16 @@ describe('app-dir - owner-stack-react-missing-key-prop', () => {
     } else {
       expect(stackFramesContent).toMatchInlineSnapshot(`
          "at span ()
-         at eval (app/rsc/page.tsx (7:10))
+         at eval (app/rsc/page.tsx (7:9))
          at Page (app/rsc/page.tsx (6:13))"
         `)
       expect(source).toMatchInlineSnapshot(`
-          "app/rsc/page.tsx (7:10) @ eval
+          "app/rsc/page.tsx (7:9) @ eval
 
              5 |     <div>
              6 |       {list.map((item, index) => (
           >  7 |         <span>{item}</span>
-               |          ^
+               |         ^
              8 |       ))}
              9 |     </div>
             10 |   )"
@@ -60,7 +60,7 @@ describe('app-dir - owner-stack-react-missing-key-prop', () => {
 
     const stackFramesContent = await getStackFramesContent(browser)
     const source = await getRedboxSource(browser)
-    if (process.env.TURBOPACK) {
+    if (isTurbopack) {
       expect(stackFramesContent).toMatchInlineSnapshot(`
          "at p ()
          at <unknown> (app/ssr/page.tsx (9:9))
@@ -81,17 +81,17 @@ describe('app-dir - owner-stack-react-missing-key-prop', () => {
     } else {
       expect(stackFramesContent).toMatchInlineSnapshot(`
          "at p ()
-         at eval (app/ssr/page.tsx (9:10))
+         at eval (app/ssr/page.tsx (9:9))
          at Array.map ()
          at Page (app/ssr/page.tsx (8:13))"
         `)
       expect(source).toMatchInlineSnapshot(`
-          "app/ssr/page.tsx (9:10) @ eval
+          "app/ssr/page.tsx (9:9) @ eval
 
              7 |     <div>
              8 |       {list.map((item, index) => (
           >  9 |         <p>{item}</p>
-               |          ^
+               |         ^
             10 |       ))}
             11 |     </div>
             12 |   )"

--- a/test/development/app-dir/owner-stack/owner-stack.test.ts
+++ b/test/development/app-dir/owner-stack/owner-stack.test.ts
@@ -47,7 +47,7 @@ async function getStackFramesContent(browser) {
 }
 
 describe('app-dir - owner-stack', () => {
-  const { isTurbopack, next } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
 
@@ -168,23 +168,14 @@ describe('app-dir - owner-stack', () => {
     await openRedbox(browser)
 
     const stackFramesContent = await getStackFramesContent(browser)
-    if (isTurbopack) {
-      expect(stackFramesContent).toMatchInlineSnapshot(`
-       "at useThrowError (app/browser/caught/page.js (34:11))
-       at useErrorHook (app/browser/caught/page.js (39:3))
-       at Thrower (app/browser/caught/page.js (29:3))
-       at Inner (app/browser/caught/page.js (23:7))
-       at Page (app/browser/caught/page.js (43:10))"
-      `)
-    } else {
-      expect(stackFramesContent).toMatchInlineSnapshot(`
-       "at useThrowError (app/browser/caught/page.js (34:11))
-       at useErrorHook (app/browser/caught/page.js (39:3))
-       at Thrower (app/browser/caught/page.js (29:3))
-       at Inner (app/browser/caught/page.js (23:8))
-       at Page (app/browser/caught/page.js (43:11))"
-      `)
-    }
+
+    expect(stackFramesContent).toMatchInlineSnapshot(`
+     "at useThrowError (app/browser/caught/page.js (34:11))
+     at useErrorHook (app/browser/caught/page.js (39:3))
+     at Thrower (app/browser/caught/page.js (29:3))
+     at Inner (app/browser/caught/page.js (23:7))
+     at Page (app/browser/caught/page.js (43:10))"
+    `)
 
     expect(normalizeStackTrace(errorLog)).toMatchInlineSnapshot(`
       "%o

--- a/test/development/app-dir/server-navigation-error/server-navigation-error.test.ts
+++ b/test/development/app-dir/server-navigation-error/server-navigation-error.test.ts
@@ -6,7 +6,7 @@ import {
 } from 'next-test-utils'
 
 describe('server-navigation-error', () => {
-  const { next } = nextTestSetup({
+  const { isTurbopack, next } = nextTestSetup({
     files: __dirname,
   })
 
@@ -18,7 +18,7 @@ describe('server-navigation-error', () => {
         `Next.js navigation API is not allowed to be used in Pages Router.`
       )
       const source = await getRedboxSource(browser)
-      if (process.env.TURBOPACK) {
+      if (isTurbopack) {
         expect(source).toMatchInlineSnapshot(`
           "pages/pages/redirect.tsx (4:10) @ Page
 
@@ -31,12 +31,12 @@ describe('server-navigation-error', () => {
         `)
       } else {
         expect(source).toMatchInlineSnapshot(`
-          "pages/pages/redirect.tsx (4:12) @ Page
+          "pages/pages/redirect.tsx (4:11) @ Page
 
             2 |
             3 | export default function Page() {
           > 4 |   redirect('/')
-              |            ^
+              |           ^
             5 | }
             6 |"
         `)
@@ -50,7 +50,7 @@ describe('server-navigation-error', () => {
         `Next.js navigation API is not allowed to be used in Pages Router.`
       )
       const source = await getRedboxSource(browser)
-      if (process.env.TURBOPACK) {
+      if (isTurbopack) {
         expect(source).toMatchInlineSnapshot(`
           "pages/pages/not-found.tsx (4:10) @ Page
 
@@ -86,7 +86,7 @@ describe('server-navigation-error', () => {
         `Next.js navigation API is not allowed to be used in Middleware.`
       )
       const source = await getRedboxSource(browser)
-      if (process.env.TURBOPACK) {
+      if (isTurbopack) {
         expect(source).toMatchInlineSnapshot(`
           "middleware.ts (8:12) @ middleware
 
@@ -100,12 +100,12 @@ describe('server-navigation-error', () => {
         `)
       } else {
         expect(source).toMatchInlineSnapshot(`
-          "middleware.ts (8:14) @ middleware
+          "middleware.ts (8:13) @ middleware
 
              6 |     notFound()
              7 |   } else if (req.nextUrl.pathname === '/middleware/redirect') {
           >  8 |     redirect('/')
-               |              ^
+               |             ^
              9 |   }
             10 | }
             11 |"
@@ -121,7 +121,7 @@ describe('server-navigation-error', () => {
       )
       const source = await getRedboxSource(browser)
 
-      if (process.env.TURBOPACK) {
+      if (isTurbopack) {
         expect(source).toMatchInlineSnapshot(`
           "middleware.ts (6:12) @ middleware
 

--- a/test/e2e/app-dir/use-cache-standalone-search-params/use-cache-standalone-search-params.test.ts
+++ b/test/e2e/app-dir/use-cache-standalone-search-params/use-cache-standalone-search-params.test.ts
@@ -56,12 +56,12 @@ describe('use-cache-standalone-search-params', () => {
     at Page (file:/`)
         } else {
           expect(errorSource).toMatchInlineSnapshot(`
-           "app/search-params-used/page.tsx (8:18) @ Page
+           "app/search-params-used/page.tsx (8:17) @ Page
 
               6 |   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
               7 | }) {
            >  8 |   const param = (await searchParams).foo
-                |                  ^
+                |                 ^
               9 |
              10 |   return <p>param: {param}</p>
              11 | }"


### PR DESCRIPTION
The sourcemapping of `source-map` outputs 0-based columns in the version we're using in the middleware. It also requires 0-based columns as inputs. We're were given it 1-based columns. This caused off-by-one mappings in Webpack. Turbopack only incidentally worked.

