### PR TITLE
[dev-overlay] feat: dev indicator menu route info popover

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.stories.tsx
@@ -59,7 +59,7 @@ const state: OverlayState = {
   rootLayoutMissingTags: [],
   versionInfo: mockVersionInfo,
   notFound: false,
-  staticIndicator: false,
+  staticIndicator: true,
   debugInfo: { devtoolsFrontendUrl: undefined },
 }
 
@@ -67,6 +67,17 @@ export const NoErrors: Story = {
   args: {
     errorCount: 0,
     state,
+    setIsErrorOverlayOpen: () => {},
+  },
+}
+
+export const DynamicRoute: Story = {
+  args: {
+    errorCount: 0,
+    state: {
+      ...state,
+      staticIndicator: false,
+    },
     setIsErrorOverlayOpen: () => {},
   },
 }
@@ -84,18 +95,5 @@ export const MultipleErrors: Story = {
     errorCount: 3,
     state,
     setIsErrorOverlayOpen: () => {},
-  },
-}
-
-export const WithStaticIndicator: Story = {
-  args: {
-    errorCount: 3,
-    state: {
-      ...state,
-      staticIndicator: true,
-    },
-    setIsErrorOverlayOpen: () => {
-      console.log('setIsErrorOverlayOpen called')
-    },
   },
 }

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.stories.tsx
@@ -63,7 +63,7 @@ const state: OverlayState = {
   debugInfo: { devtoolsFrontendUrl: undefined },
 }
 
-export const NoErrors: Story = {
+export const StaticRoute: Story = {
   args: {
     errorCount: 0,
     state,

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -88,6 +88,7 @@ function DevToolsPopover({
   const turbopackRef = useRef<HTMLElement>(null)
   const triggerTurbopackRef = useRef<HTMLButtonElement | null>(null)
   const routeInfoRef = useRef<HTMLElement>(null)
+  const triggerRouteInfoRef = useRef<HTMLButtonElement | null>(null)
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [isTurbopackInfoOpen, setIsTurbopackInfoOpen] = useState(false)
   const [isRouteInfoOpen, setIsRouteInfoOpen] = useState(false)
@@ -124,8 +125,13 @@ function DevToolsPopover({
     isTurbopackInfoOpen,
     closeTurbopackInfo
   )
-  useFocusTrap(routeInfoRef, triggerRef, isRouteInfoOpen)
-  useClickOutside(routeInfoRef, triggerRef, isRouteInfoOpen, closeRouteInfo)
+  useFocusTrap(routeInfoRef, triggerRouteInfoRef, isRouteInfoOpen)
+  useClickOutside(
+    routeInfoRef,
+    triggerRouteInfoRef,
+    isRouteInfoOpen,
+    closeRouteInfo
+  )
 
   function select(index: number | 'first' | 'last') {
     if (index === 'first') {

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
@@ -60,7 +60,7 @@ export const DEV_TOOLS_INFO_STYLES = css`
     overflow: hidden;
     opacity: 0;
     outline: 0;
-    min-width: 248px;
+    min-width: 300px;
     transition: opacity var(--animate-out-duration-ms)
       var(--animate-out-timing-function);
 

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
@@ -60,7 +60,7 @@ export const DEV_TOOLS_INFO_STYLES = css`
     overflow: hidden;
     opacity: 0;
     outline: 0;
-    min-width: 300px;
+    min-width: 350px;
     transition: opacity var(--animate-out-duration-ms)
       var(--animate-out-timing-function);
 

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/route-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/route-info.tsx
@@ -1,0 +1,61 @@
+import { DevToolsInfo } from './dev-tools-info'
+import { noop as css } from '../../../../helpers/noop-template'
+
+export function RouteInfo({
+  routeType,
+  isOpen,
+  setIsOpen,
+  setPreviousOpen,
+  ...props
+}: {
+  routeType: 'Static' | 'Dynamic'
+  isOpen: boolean
+  setIsOpen: (isOpen: boolean) => void
+  setPreviousOpen: (isOpen: boolean) => void
+  style?: React.CSSProperties
+  ref?: React.RefObject<HTMLElement | null>
+}) {
+  return (
+    <DevToolsInfo
+      title={`${routeType} Route`}
+      learnMoreLink="https://nextjs.org/docs/app/building-your-application/rendering/server-components#static-rendering-default"
+      setIsOpen={setIsOpen}
+      setPreviousOpen={setPreviousOpen}
+      {...props}
+    >
+      <article className="dev-tools-info-article">
+        <p className="dev-tools-info-paragraph">
+          The path{' '}
+          <code className="dev-tools-info-code">
+            {window.location.pathname}
+          </code>{' '}
+          is marked as "static" since it will be prerendered during the build
+          time.
+        </p>
+        <p className="dev-tools-info-paragraph">
+          With Static Rendering, routes are rendered at build time, or in the
+          background after{' '}
+          <a
+            className="dev-tools-info-link"
+            href="https://nextjs.org/docs/app/building-your-application/data-fetching/incremental-static-regeneration"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            data revalidation
+          </a>
+          .
+        </p>
+        <p className="dev-tools-info-paragraph">
+          Static rendering is useful when a route has data that is not
+          personalized to the user and can be known at build time, such as a
+          static blog post or a product page.
+        </p>
+      </article>
+    </DevToolsInfo>
+  )
+}
+
+export const DEV_TOOLS_INFO_ROUTE_INFO_STYLES = css`
+  .dev-tools-info-link {
+  }
+`

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/route-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-info/route-info.tsx
@@ -1,6 +1,79 @@
 import { DevToolsInfo } from './dev-tools-info'
 import { noop as css } from '../../../../helpers/noop-template'
 
+function StaticRouteContent() {
+  return (
+    <article className="dev-tools-info-article">
+      <p className="dev-tools-info-paragraph">
+        The path{' '}
+        <code className="dev-tools-info-code">{window.location.pathname}</code>{' '}
+        is marked as "static" since it will be prerendered during the build
+        time.
+      </p>
+      <p className="dev-tools-info-paragraph">
+        With Static Rendering, routes are rendered at build time, or in the
+        background after{' '}
+        <a
+          className="dev-tools-info-link"
+          href="https://nextjs.org/docs/app/building-your-application/data-fetching/incremental-static-regeneration"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          data revalidation
+        </a>
+        .
+      </p>
+      <p className="dev-tools-info-paragraph">
+        Static rendering is useful when a route has data that is not
+        personalized to the user and can be known at build time, such as a
+        static blog post or a product page.
+      </p>
+    </article>
+  )
+}
+
+function DynamicRouteContent() {
+  return (
+    <article className="dev-tools-info-article">
+      <p className="dev-tools-info-paragraph">
+        The path{' '}
+        <code className="dev-tools-info-code">{window.location.pathname}</code>{' '}
+        is marked as "dynamic" since it will be rendered for each user at{' '}
+        <strong>request time</strong>.
+      </p>
+      <p className="dev-tools-info-paragraph">
+        Dynamic rendering is useful when a route has data that is personalized
+        to the user or has information that can only be known at request time,
+        such as cookies or the URL's search params.
+      </p>
+      <p className="dev-tools-info-paragraph">
+        During rendering, if a{' '}
+        <a
+          className="dev-tools-info-link"
+          href="https://nextjs.org/docs/app/building-your-application/rendering/server-components#dynamic-apis"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Dynamic API
+        </a>{' '}
+        or a{' '}
+        <a
+          className="dev-tools-info-link"
+          href="https://nextjs.org/docs/app/api-reference/functions/fetch"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          fetch
+        </a>{' '}
+        option of{' '}
+        <code className="dev-tools-info-code">{`{ cache: 'no-store' }`}</code>{' '}
+        is discovered, Next.js will switch to dynamically rendering the whole
+        route.
+      </p>
+    </article>
+  )
+}
+
 export function RouteInfo({
   routeType,
   isOpen,
@@ -15,42 +88,19 @@ export function RouteInfo({
   style?: React.CSSProperties
   ref?: React.RefObject<HTMLElement | null>
 }) {
+  const isStaticRoute = routeType === 'Static'
+  const learnMoreLink = isStaticRoute
+    ? 'https://nextjs.org/docs/app/building-your-application/rendering/server-components#static-rendering-default'
+    : 'https://nextjs.org/docs/app/building-your-application/rendering/server-components#dynamic-rendering'
   return (
     <DevToolsInfo
+      {...props}
       title={`${routeType} Route`}
-      learnMoreLink="https://nextjs.org/docs/app/building-your-application/rendering/server-components#static-rendering-default"
+      learnMoreLink={learnMoreLink}
       setIsOpen={setIsOpen}
       setPreviousOpen={setPreviousOpen}
-      {...props}
     >
-      <article className="dev-tools-info-article">
-        <p className="dev-tools-info-paragraph">
-          The path{' '}
-          <code className="dev-tools-info-code">
-            {window.location.pathname}
-          </code>{' '}
-          is marked as "static" since it will be prerendered during the build
-          time.
-        </p>
-        <p className="dev-tools-info-paragraph">
-          With Static Rendering, routes are rendered at build time, or in the
-          background after{' '}
-          <a
-            className="dev-tools-info-link"
-            href="https://nextjs.org/docs/app/building-your-application/data-fetching/incremental-static-regeneration"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            data revalidation
-          </a>
-          .
-        </p>
-        <p className="dev-tools-info-paragraph">
-          Static rendering is useful when a route has data that is not
-          personalized to the user and can be known at build time, such as a
-          static blog post or a product page.
-        </p>
-      </article>
+      {isStaticRoute ? <StaticRouteContent /> : <DynamicRouteContent />}
     </DevToolsInfo>
   )
 }

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/styles/component-styles.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/styles/component-styles.tsx
@@ -19,6 +19,7 @@ import { EDITOR_LINK_STYLES } from '../components/terminal/editor-link'
 import { ENVIRONMENT_NAME_LABEL_STYLES } from '../components/errors/environment-name-label/environment-name-label'
 import { DEV_TOOLS_INFO_STYLES } from '../components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info'
 import { DEV_TOOLS_INFO_TURBOPACK_INFO_STYLES } from '../components/errors/dev-tools-indicator/dev-tools-info/turbopack-info'
+import { DEV_TOOLS_INFO_ROUTE_INFO_STYLES } from '../components/errors/dev-tools-indicator/dev-tools-info/route-info'
 
 export function ComponentStyles() {
   return (
@@ -44,6 +45,7 @@ export function ComponentStyles() {
         ${DEV_TOOLS_INDICATOR_STYLES}
         ${DEV_TOOLS_INFO_STYLES}
         ${DEV_TOOLS_INFO_TURBOPACK_INFO_STYLES}
+        ${DEV_TOOLS_INFO_ROUTE_INFO_STYLES}
       `}
     </style>
   )


### PR DESCRIPTION
### What?

This PR added a menu item's specific info popover for Route.

https://github.com/user-attachments/assets/63a3df65-f367-471a-a33a-30a7c6377485

| Static | Dynamic |
|--------|--------|
| ![CleanShot 2025-02-18 at 21 48 38@2x](https://github.com/user-attachments/assets/70e0d7c1-9390-43f2-9fd2-92f1477c8028) | ![CleanShot 2025-02-18 at 21 48 10@2x](https://github.com/user-attachments/assets/353404d4-2c9a-46f3-9beb-c8eb26bd0f79) | 

Closes NDX-815
Closes NDX-849