### PR TITLE
15.2 Docs: Add note about `devIndicators` no longer being required

### DIFF
--- a/docs/01-app/04-api-reference/05-config/01-next-config-js/devIndicators.mdx
+++ b/docs/01-app/04-api-reference/05-config/01-next-config-js/devIndicators.mdx
@@ -7,7 +7,7 @@ version: legacy
 {/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
 
 
-In Next.js 15.2, the `devIndicators` config has been replaced with an enhanced error overlay that provides the same information. To use it, simply update to Next.js 15.2 or later and start the development server with `next dev`.
+In Next.js 15.2, the `devIndicators` config has been replaced with an enhanced error overlay that provides the same information. To use it, update to version 15.2 or later and start the development server with `next dev`.
 
 <AppOnly>
 

--- a/docs/01-app/04-api-reference/05-config/01-next-config-js/devIndicators.mdx
+++ b/docs/01-app/04-api-reference/05-config/01-next-config-js/devIndicators.mdx
@@ -1,9 +1,13 @@
 ---
 title: devIndicators
 description: Optimized pages include an indicator to let you know if it's being statically optimized. You can opt-out of it here.
+version: legacy
 ---
 
 {/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
+
+
+In Next.js 15.2, the `devIndicators` config has been replaced with an enhanced error overlay that provides the same information. To use it, simply update to Next.js 15.2 or later and start the development server with `next dev`.
 
 <AppOnly>
 


### PR DESCRIPTION
Do not merge yet 🙏🏼 

Closes: https://linear.app/vercel/issue/DOC-4216/redesigned-error-overlay-devindicators-deprecation