### PR TITLE
Fix: Encode catch-all segment parameters in parallel routes

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -397,7 +397,13 @@ function makeGetDynamicParamFromSegment(
             const param = parseParameter(pathSegment)
             // if the segment matches a param, return the param value
             // otherwise, it's a static segment, so just return that
-            return params[param.key] ?? param.key
+            const currentValue = params[param.key]
+            if (Array.isArray(currentValue)) {
+              return currentValue.map((i) => encodeURIComponent(i))
+            } else if (typeof currentValue === 'string') {
+              return encodeURIComponent(currentValue)
+            }
+            return encodeURIComponent(param.key)
           })
 
         return {

--- a/test/e2e/app-dir/parallel-routes-breadcrumbs/app/fizz/[...buzz]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-breadcrumbs/app/fizz/[...buzz]/page.tsx
@@ -1,7 +1,10 @@
-export default function Page() {
+export default async function Page({ params }) {
+  const { buzz = [] } = await params
   return (
     <div>
       <h2>/fizz/[...buzz] Page!</h2>
+      <h3>buzz[0]: {buzz[0]}</h3>
+      <h4>buzz[1]: {buzz[1]}</h4>
     </div>
   )
 }

--- a/test/e2e/app-dir/parallel-routes-breadcrumbs/parallel-routes-breadcrumbs.test.ts
+++ b/test/e2e/app-dir/parallel-routes-breadcrumbs/parallel-routes-breadcrumbs.test.ts
@@ -75,6 +75,25 @@ describe('parallel-routes-breadcrumbs', () => {
     expect(await slot.text()).toContain('Track: b')
   })
 
+  it('should render the breadcrumbs correctly with catchall route segments for non-ascii path', async () => {
+    const browser = await next.browser(`/fizz/${encodeURIComponent('あ')}/b`)
+    const slot = await browser.waitForElementByCss('#slot')
+
+    expect(await browser.elementByCss('h1').text()).toBe('Parallel Route!')
+    expect(await browser.elementByCss('h2').text()).toBe(
+      '/fizz/[...buzz] Page!'
+    )
+    expect(await browser.elementByCss('h3').text()).toBe(
+      `buzz[0]: ${encodeURIComponent('あ')}`
+    )
+    expect(await browser.elementByCss('h4').text()).toBe('buzz[1]: b')
+
+    // verify slot is rendering the params
+    expect(await slot.text()).toContain('Artist: fizz')
+    expect(await slot.text()).toContain(`Album: ${encodeURIComponent('あ')}`)
+    expect(await slot.text()).toContain('Track: b')
+  })
+
   it('should render the breadcrumbs correctly with optional catchall route segments', async () => {
     const browser = await next.browser('/buzz/a/b')
     const slot = await browser.waitForElementByCss('#slot')


### PR DESCRIPTION
### What?

- Fixed an issue where clicking links to non-ASCII paths with a catch-all segment in parallel routes would cause an error like t below. This cause a hard navigation.

<img width="912" alt="image" src="https://github.com/user-attachments/assets/af8fb9b7-c263-459c-8867-95fc73b59a41" />

This behavior can be reproduced by adding codes like below to `test/e2e/app-dir/parallel-routes-breadcrumbs/app/fizz/[...buzz]/page.tsx`

```typescript
import Link from "next/link"

export default async function Page({ params }) {
  const { buzz = [] } = await params
  return (
    <div>
      <h2>/fizz/[...buzz] Page!</h2>
      <h3>buzz[0]: {buzz[0]}</h3>
      <h4>buzz[1]: {buzz[1]}</h4>
      <div>
        <Link href="/fizz/あ/b?size=小" >non ascii link 小</Link>
      </div>
      <div>
        <Link href="/fizz/い/b?size=中" >non ascii link 中</Link>
      </div>
      <div>
        <Link href="/fizz/う/b?size=大" >non ascii link 大</Link>
      </div>
    </div>
  )
}

```


- Ensured that catch-all segment parameters in parallel routes are properly encoded, matching the behavior of normal pages.


### How?

- Added proper encoding for catch-all segment parameters in parallel routes.

