### PR TITLE
[Segment Cache] Hard nav when root layout changes

### DIFF
--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -14,6 +14,7 @@ import { DEFAULT_SEGMENT_KEY } from '../../../shared/lib/segment'
 import { matchSegment } from '../match-segments'
 import { createRouterCacheKey } from './create-router-cache-key'
 import type { FetchServerResponseResult } from './fetch-server-response'
+import { isNavigatingToNewRootLayout } from './is-navigating-to-new-root-layout'
 
 // This is yet another tree type that is used to track pending promises that
 // need to be fulfilled once the dynamic data is received. The terminal nodes of
@@ -21,7 +22,7 @@ import type { FetchServerResponseResult } from './fetch-server-response'
 // request. We can't use the Cache Node tree or Route State tree directly
 // because those include reused nodes, too. This tree is discarded as soon as
 // the navigation response is received.
-export type Task = {
+type SPANavigationTask = {
   // The router state that corresponds to the tree that this Task represents.
   route: FlightRouterState
   // The CacheNode that corresponds to the tree that this Task represents. If
@@ -34,8 +35,26 @@ export type Task = {
   // If all the segments are static, then this will be null, and no server
   // request is required.
   dynamicRequestTree: FlightRouterState | null
-  children: Map<string, Task> | null
+  children: Map<string, SPANavigationTask> | null
 }
+
+// A special type used to bail out and trigger a full-page navigation.
+type MPANavigationTask = {
+  // MPA tasks are distinguised from SPA tasks by having a null `route`.
+  route: null
+  node: null
+  dynamicRequestTree: null
+  children: null
+}
+
+const MPA_NAVIGATION_TASK: MPANavigationTask = {
+  route: null,
+  node: null,
+  dynamicRequestTree: null,
+  children: null,
+}
+
+export type Task = SPANavigationTask | MPANavigationTask
 
 // Creates a new Cache Node tree (i.e. copy-on-write) that represents the
 // optimistic result of a navigation, using both the current Cache Node tree and
@@ -66,10 +85,30 @@ export type Task = {
 //
 // A return value of `null` means there were no changes, and the previous tree
 // can be reused without initiating a server request.
-export function updateCacheNodeOnNavigation(
+export function startPPRNavigation(
   oldCacheNode: CacheNode,
   oldRouterState: FlightRouterState,
   newRouterState: FlightRouterState,
+  prefetchData: CacheNodeSeedData | null,
+  prefetchHead: HeadData | null,
+  isPrefetchHeadPartial: boolean
+): Task | null {
+  return updateCacheNodeOnNavigation(
+    oldCacheNode,
+    oldRouterState,
+    newRouterState,
+    false,
+    prefetchData,
+    prefetchHead,
+    isPrefetchHeadPartial
+  )
+}
+
+function updateCacheNodeOnNavigation(
+  oldCacheNode: CacheNode,
+  oldRouterState: FlightRouterState,
+  newRouterState: FlightRouterState,
+  didFindRootLayout: boolean,
   prefetchData: CacheNodeSeedData | null,
   prefetchHead: HeadData | null,
   isPrefetchHeadPartial: boolean
@@ -78,6 +117,17 @@ export function updateCacheNodeOnNavigation(
   const oldRouterStateChildren = oldRouterState[1]
   const newRouterStateChildren = newRouterState[1]
   const prefetchDataChildren = prefetchData !== null ? prefetchData[2] : null
+
+  if (!didFindRootLayout) {
+    // We're currently traversing the part of the tree that was also part of
+    // the previous route. If we discover a root layout, then we don't need to
+    // trigger an MPA navigation. See beginRenderingNewRouteTree for context.
+    const isRootLayout = newRouterState[4] === true
+    if (isRootLayout) {
+      // Found a matching root layout.
+      didFindRootLayout = true
+    }
+  }
 
   const oldParallelRoutes = oldCacheNode.parallelRoutes
 
@@ -163,14 +213,17 @@ export function updateCacheNodeOnNavigation(
         taskChild = spawnReusedTask(oldRouterStateChild)
       } else {
         // There's no currently active segment. Switch to the "create" path.
-        taskChild = createCacheNodeOnNavigation(
+        taskChild = beginRenderingNewRouteTree(
+          oldRouterStateChild,
           newRouterStateChild,
+          didFindRootLayout,
           prefetchDataChild !== undefined ? prefetchDataChild : null,
           prefetchHead,
           isPrefetchHeadPartial
         )
       }
     } else if (
+      oldRouterStateChild !== undefined &&
       oldSegmentChild !== undefined &&
       matchSegment(newSegmentChild, oldSegmentChild)
     ) {
@@ -184,16 +237,18 @@ export function updateCacheNodeOnNavigation(
           oldCacheNodeChild,
           oldRouterStateChild,
           newRouterStateChild,
+          didFindRootLayout,
           prefetchDataChild,
           prefetchHead,
           isPrefetchHeadPartial
         )
       } else {
-        // Either there's no existing Cache Node for this segment, or this
-        // segment doesn't exist in the old Router State tree. Switch to the
+        // There's no existing Cache Node for this segment. Switch to the
         // "create" path.
-        taskChild = createCacheNodeOnNavigation(
+        taskChild = beginRenderingNewRouteTree(
+          oldRouterStateChild,
           newRouterStateChild,
+          didFindRootLayout,
           prefetchDataChild !== undefined ? prefetchDataChild : null,
           prefetchHead,
           isPrefetchHeadPartial
@@ -201,8 +256,10 @@ export function updateCacheNodeOnNavigation(
       }
     } else {
       // This is a new tree. Switch to the "create" path.
-      taskChild = createCacheNodeOnNavigation(
+      taskChild = beginRenderingNewRouteTree(
+        oldRouterStateChild,
         newRouterStateChild,
+        didFindRootLayout,
         prefetchDataChild !== undefined ? prefetchDataChild : null,
         prefetchHead,
         isPrefetchHeadPartial
@@ -210,7 +267,14 @@ export function updateCacheNodeOnNavigation(
     }
 
     if (taskChild !== null) {
-      // Something changed in the child tree. Keep track of the child task.
+      // Recursively propagate up the child tasks.
+
+      if (taskChild.route === null) {
+        // One of the child tasks discovered a change to the root layout.
+        // Immediately unwind from this recursive traversal.
+        return MPA_NAVIGATION_TASK
+      }
+
       if (taskChildren === null) {
         taskChildren = new Map()
       }
@@ -283,12 +347,56 @@ export function updateCacheNodeOnNavigation(
   }
 }
 
+function beginRenderingNewRouteTree(
+  oldRouterState: FlightRouterState | void,
+  newRouterState: FlightRouterState,
+  didFindRootLayout: boolean,
+  prefetchData: CacheNodeSeedData | null,
+  possiblyPartialPrefetchHead: HeadData | null,
+  isPrefetchHeadPartial: boolean
+): Task {
+  if (!didFindRootLayout) {
+    // The route tree changed before we reached a layout. (The highest-level
+    // layout in a route tree is referred to as the "root" layout.) This could
+    // mean that we're navigating between two different root layouts. When this
+    // happens, we perform a full-page (MPA-style) navigation.
+    //
+    // However, the algorithm for deciding where to start rendering a route
+    // (i.e. the one performed in order to reach this function) is stricter
+    // than the one used to detect a change in the root layout. So just because
+    // we're re-rendering a segment outside of the root layout does not mean we
+    // should trigger a full-page navigation.
+    //
+    // Specifically, we handle dynamic parameters differently: two segments are
+    // considered the same even if their parameter values are different.
+    //
+    // Refer to isNavigatingToNewRootLayout for details.
+    //
+    // Note that we only have to perform this extra traversal if we didn't
+    // already discover a root layout in the part of the tree that is unchanged.
+    // In the common case, this branch is skipped completely.
+    if (
+      oldRouterState === undefined ||
+      isNavigatingToNewRootLayout(oldRouterState, newRouterState)
+    ) {
+      // The root layout changed. Perform a full-page navigation.
+      return MPA_NAVIGATION_TASK
+    }
+  }
+  return createCacheNodeOnNavigation(
+    newRouterState,
+    prefetchData,
+    possiblyPartialPrefetchHead,
+    isPrefetchHeadPartial
+  )
+}
+
 function createCacheNodeOnNavigation(
   routerState: FlightRouterState,
   prefetchData: CacheNodeSeedData | null,
   possiblyPartialPrefetchHead: HeadData | null,
   isPrefetchHeadPartial: boolean
-): Task {
+): SPANavigationTask {
   // Same traversal as updateCacheNodeNavigation, but we switch to this path
   // once we reach the part of the tree that was not in the previous route. We
   // don't need to diff against the old tree, we just need to create a new one.
@@ -424,7 +532,7 @@ function spawnPendingTask(
   prefetchData: CacheNodeSeedData | null,
   prefetchHead: HeadData | null,
   isPrefetchHeadPartial: boolean
-): Task {
+): SPANavigationTask {
   // Create a task that will later be fulfilled by data from the server.
 
   // Clone the prefetched route tree and the `refetch` marker to it. We'll send
@@ -480,7 +588,7 @@ function spawnReusedTask(reusedRouterState: FlightRouterState): Task {
 // This does _not_ create a new tree; it modifies the existing one in place.
 // Which means it must follow the Suspense rules of cache safety.
 export function listenForDynamicRequest(
-  task: Task,
+  task: SPANavigationTask,
   responsePromise: Promise<FetchServerResponseResult>
 ) {
   responsePromise.then(
@@ -528,7 +636,7 @@ export function listenForDynamicRequest(
 }
 
 function writeDynamicDataIntoPendingTask(
-  rootTask: Task,
+  rootTask: SPANavigationTask,
   segmentPath: FlightSegmentPath,
   serverRouterState: FlightRouterState,
   dynamicData: CacheNodeSeedData,
@@ -576,7 +684,7 @@ function writeDynamicDataIntoPendingTask(
 }
 
 function finishTaskUsingDynamicDataPayload(
-  task: Task,
+  task: SPANavigationTask,
   serverRouterState: FlightRouterState,
   dynamicData: CacheNodeSeedData,
   dynamicHead: HeadData
@@ -802,7 +910,7 @@ function finishPendingCacheNode(
   }
 }
 
-export function abortTask(task: Task, error: any): void {
+export function abortTask(task: SPANavigationTask, error: any): void {
   const cacheNode = task.node
   if (cacheNode === null) {
     // This indicates the task is already complete.

--- a/test/e2e/app-dir/segment-cache/mpa-navigations/app/(group1)/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/mpa-navigations/app/(group1)/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/mpa-navigations/app/(group1)/page.tsx
+++ b/test/e2e/app-dir/segment-cache/mpa-navigations/app/(group1)/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export default async function Page() {
+  return (
+    <>
+      <p>
+        This link <em>should</em> trigger an MPA navigation, because it
+        navigates to a different root layout:
+      </p>
+      <p>
+        <Link href="/foo">/foo</Link>
+      </p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/mpa-navigations/app/(group2)/[rootParam]/(groupA)/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/mpa-navigations/app/(group2)/[rootParam]/(groupA)/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/mpa-navigations/app/(group2)/[rootParam]/(groupA)/page.tsx
+++ b/test/e2e/app-dir/segment-cache/mpa-navigations/app/(group2)/[rootParam]/(groupA)/page.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+
+export function generateStaticParams() {
+  return [{ rootParam: 'foo' }, { rootParam: 'bar' }]
+}
+
+export default async function Page({ params }) {
+  const { rootParam } = params
+  const otherRootParam = rootParam === 'foo' ? 'bar' : 'foo'
+  return (
+    <>
+      <p>
+        <p>
+          This link <em>should not</em> trigger an MPA navigation, because it
+          only changes a root param:
+        </p>
+        <Link href={`/${otherRootParam}`}>/{otherRootParam}</Link>
+      </p>
+      <p>
+        <p>
+          This link <em>should</em> trigger an MPA navigation, because in
+          addition to changing a root param, it also navigates to a different
+          root layout:
+        </p>
+        <Link href={`/${otherRootParam}/inner`}>/{otherRootParam}/inner</Link>
+      </p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/mpa-navigations/app/(group2)/[rootParam]/(groupB)/inner/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/mpa-navigations/app/(group2)/[rootParam]/(groupB)/inner/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/mpa-navigations/app/(group2)/[rootParam]/(groupB)/inner/page.tsx
+++ b/test/e2e/app-dir/segment-cache/mpa-navigations/app/(group2)/[rootParam]/(groupB)/inner/page.tsx
@@ -1,0 +1,6 @@
+export function generateStaticParams() {
+  return [{ rootParam: 'foo' }, { rootParam: 'bar' }]
+}
+export default async function Page() {
+  return <p>Content of inner page</p>
+}

--- a/test/e2e/app-dir/segment-cache/mpa-navigations/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/mpa-navigations/components/link-accordion.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: React.ReactNode
+  prefetch?: boolean
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        <>{children} (link is hidden)</>
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/mpa-navigations/mpa-navigations.test.ts
+++ b/test/e2e/app-dir/segment-cache/mpa-navigations/mpa-navigations.test.ts
@@ -1,0 +1,55 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('segment cache (MPA navigations)', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+  if (isNextDev || skipped) {
+    test('ppr is disabled', () => {})
+    return
+  }
+
+  it('triggers MPA navigation when navigating to a different root layout', async () => {
+    const browser = await next.browser('/')
+
+    // Set an expando on the html element so we can detect if the page
+    // gets unloaded.
+    const html = await browser.elementByCss('html')
+    await html.evaluate((el) => (el.__expando = true))
+
+    // Navigate to a page with a different root layout.
+    const link = await browser.elementByCss(`a[href="/foo"]`)
+    await link.click()
+
+    // The expando should not be present because we did a full-page navigation.
+    const htmlAfterNav = await browser.elementByCss('html')
+    expect(await htmlAfterNav.evaluate((el) => el.__expando)).toBe(undefined)
+  })
+
+  it(
+    'triggers MPA navigation when navigating to a different root layout, ' +
+      'during a navigation where a root param also changed',
+    async () => {
+      // Testing this scenario because a root param change alone does not
+      // trigger an MPA navigation, but if an inner segment changes before the
+      // root layout, then we should trigger an MPA navigation. This case is
+      // handled slightly differently in the implementation than the case where
+      // there's no root param change.
+      const browser = await next.browser('/foo')
+
+      // Set an expando on the html element so we can detect if the page
+      // gets unloaded.
+      const html = await browser.elementByCss('html')
+      await html.evaluate((el) => (el.__expando = true))
+
+      // Navigate to a page with a different root layout.
+      const link = await browser.elementByCss(`a[href="/bar/inner"]`)
+      await link.click()
+
+      // The expando should not be present because we did a full-page navigation.
+      const htmlAfterNav = await browser.elementByCss('html')
+      expect(await htmlAfterNav.evaluate((el) => el.__expando)).toBe(undefined)
+    }
+  )
+})

--- a/test/e2e/app-dir/segment-cache/mpa-navigations/next.config.js
+++ b/test/e2e/app-dir/segment-cache/mpa-navigations/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    ppr: true,
+    dynamicIO: true,
+    clientSegmentCache: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
The highest-level layout in a route tree is referred to as the "root" layout. When it changes, we perform a full-page (MPA-style) navigation.

To implement this for the Segment Cache, I moved the `isNavigatingToNewRootLayout` check from `navigateReducer` into `startPPRNavigation`.

Rather than run the `isNavigatingToNewRootLayout` check on every navigation, I combined it with the route tree traversal we already perform when diffing the tree on navigation. In the common case, navigation happens inside the root layout. If we discover a root layout before the first new segment is reached, we don't have to do anything extra.

The only special case is when a root parameter changes. Although this triggers a re-render of that segment, it shouldn't cause the root layout to be treated as different for the purposes of deciding whether to trigger an MPA navigation. It's only in this case where we need to switch to a different tree traversal (isNavigatingToNewRootLayout).