### PR TITLE
chore(github): add Error Overlay area

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -84,6 +84,7 @@ body:
         - 'dynamicIO'
         - 'Dynamic Routes'
         - 'Error Handling'
+        - 'Error Overlay'
         - 'Lazy Loading'
         - 'Font (next/font)'
         - 'Form (next/form)'


### PR DESCRIPTION
## Why?

Adding an `Error Overlay` area (will add label as well) so we can start tracking issues with the new Error Overlay.