### PR TITLE
[Segment Cache] Implement scroll-to-new-page

### DIFF
--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -91,8 +91,10 @@ export function startPPRNavigation(
   newRouterState: FlightRouterState,
   prefetchData: CacheNodeSeedData | null,
   prefetchHead: HeadData | null,
-  isPrefetchHeadPartial: boolean
+  isPrefetchHeadPartial: boolean,
+  scrollableSegmentsResult: Array<FlightSegmentPath>
 ): Task | null {
+  const segmentPath: Array<FlightSegmentPath> = []
   return updateCacheNodeOnNavigation(
     oldCacheNode,
     oldRouterState,
@@ -100,7 +102,9 @@ export function startPPRNavigation(
     false,
     prefetchData,
     prefetchHead,
-    isPrefetchHeadPartial
+    isPrefetchHeadPartial,
+    segmentPath,
+    scrollableSegmentsResult
   )
 }
 
@@ -111,7 +115,9 @@ function updateCacheNodeOnNavigation(
   didFindRootLayout: boolean,
   prefetchData: CacheNodeSeedData | null,
   prefetchHead: HeadData | null,
-  isPrefetchHeadPartial: boolean
+  isPrefetchHeadPartial: boolean,
+  segmentPath: FlightSegmentPath,
+  scrollableSegmentsResult: Array<FlightSegmentPath>
 ): Task | null {
   // Diff the old and new trees to reuse the shared layouts.
   const oldRouterStateChildren = oldRouterState[1]
@@ -187,6 +193,10 @@ function updateCacheNodeOnNavigation(
         : null
 
     const newSegmentChild = newRouterStateChild[0]
+    const newSegmentPathChild = segmentPath.concat([
+      parallelRouteKey,
+      newSegmentChild,
+    ])
     const newSegmentKeyChild = createRouterCacheKey(newSegmentChild)
 
     const oldSegmentChild =
@@ -219,7 +229,9 @@ function updateCacheNodeOnNavigation(
           didFindRootLayout,
           prefetchDataChild !== undefined ? prefetchDataChild : null,
           prefetchHead,
-          isPrefetchHeadPartial
+          isPrefetchHeadPartial,
+          newSegmentPathChild,
+          scrollableSegmentsResult
         )
       }
     } else if (
@@ -240,7 +252,9 @@ function updateCacheNodeOnNavigation(
           didFindRootLayout,
           prefetchDataChild,
           prefetchHead,
-          isPrefetchHeadPartial
+          isPrefetchHeadPartial,
+          newSegmentPathChild,
+          scrollableSegmentsResult
         )
       } else {
         // There's no existing Cache Node for this segment. Switch to the
@@ -251,7 +265,9 @@ function updateCacheNodeOnNavigation(
           didFindRootLayout,
           prefetchDataChild !== undefined ? prefetchDataChild : null,
           prefetchHead,
-          isPrefetchHeadPartial
+          isPrefetchHeadPartial,
+          newSegmentPathChild,
+          scrollableSegmentsResult
         )
       }
     } else {
@@ -262,7 +278,9 @@ function updateCacheNodeOnNavigation(
         didFindRootLayout,
         prefetchDataChild !== undefined ? prefetchDataChild : null,
         prefetchHead,
-        isPrefetchHeadPartial
+        isPrefetchHeadPartial,
+        newSegmentPathChild,
+        scrollableSegmentsResult
       )
     }
 
@@ -353,7 +371,9 @@ function beginRenderingNewRouteTree(
   didFindRootLayout: boolean,
   prefetchData: CacheNodeSeedData | null,
   possiblyPartialPrefetchHead: HeadData | null,
-  isPrefetchHeadPartial: boolean
+  isPrefetchHeadPartial: boolean,
+  segmentPath: FlightSegmentPath,
+  scrollableSegmentsResult: Array<FlightSegmentPath>
 ): Task {
   if (!didFindRootLayout) {
     // The route tree changed before we reached a layout. (The highest-level
@@ -387,7 +407,9 @@ function beginRenderingNewRouteTree(
     newRouterState,
     prefetchData,
     possiblyPartialPrefetchHead,
-    isPrefetchHeadPartial
+    isPrefetchHeadPartial,
+    segmentPath,
+    scrollableSegmentsResult
   )
 }
 
@@ -395,7 +417,9 @@ function createCacheNodeOnNavigation(
   routerState: FlightRouterState,
   prefetchData: CacheNodeSeedData | null,
   possiblyPartialPrefetchHead: HeadData | null,
-  isPrefetchHeadPartial: boolean
+  isPrefetchHeadPartial: boolean,
+  segmentPath: FlightSegmentPath,
+  scrollableSegmentsResult: Array<FlightSegmentPath>
 ): SPANavigationTask {
   // Same traversal as updateCacheNodeNavigation, but we switch to this path
   // once we reach the part of the tree that was not in the previous route. We
@@ -409,7 +433,9 @@ function createCacheNodeOnNavigation(
       routerState,
       null,
       possiblyPartialPrefetchHead,
-      isPrefetchHeadPartial
+      isPrefetchHeadPartial,
+      segmentPath,
+      scrollableSegmentsResult
     )
   }
 
@@ -435,7 +461,9 @@ function createCacheNodeOnNavigation(
       routerState,
       prefetchData,
       possiblyPartialPrefetchHead,
-      isPrefetchHeadPartial
+      isPrefetchHeadPartial,
+      segmentPath,
+      scrollableSegmentsResult
     )
   }
 
@@ -449,35 +477,51 @@ function createCacheNodeOnNavigation(
     [parallelRouteKey: string]: FlightRouterState
   } = {}
   let needsDynamicRequest = false
-  for (let parallelRouteKey in routerStateChildren) {
-    const routerStateChild: FlightRouterState =
-      routerStateChildren[parallelRouteKey]
-    const prefetchDataChild: CacheNodeSeedData | void | null =
-      prefetchDataChildren !== null
-        ? prefetchDataChildren[parallelRouteKey]
-        : null
-    const segmentChild = routerStateChild[0]
-    const segmentKeyChild = createRouterCacheKey(segmentChild)
-    const taskChild = createCacheNodeOnNavigation(
-      routerStateChild,
-      prefetchDataChild,
-      possiblyPartialPrefetchHead,
-      isPrefetchHeadPartial
-    )
-    taskChildren.set(parallelRouteKey, taskChild)
-    const dynamicRequestTreeChild = taskChild.dynamicRequestTree
-    if (dynamicRequestTreeChild !== null) {
-      // Something in the child tree is dynamic.
-      needsDynamicRequest = true
-      dynamicRequestTreeChildren[parallelRouteKey] = dynamicRequestTreeChild
-    } else {
-      dynamicRequestTreeChildren[parallelRouteKey] = routerStateChild
-    }
-    const newCacheNodeChild = taskChild.node
-    if (newCacheNodeChild !== null) {
-      const newSegmentMapChild: ChildSegmentMap = new Map()
-      newSegmentMapChild.set(segmentKeyChild, newCacheNodeChild)
-      cacheNodeChildren.set(parallelRouteKey, newSegmentMapChild)
+  if (isLeafSegment) {
+    // The segment path of every leaf segment (i.e. page) is collected into
+    // a result array. This is used by the LayoutRouter to scroll to ensure that
+    // new pages are visible after a navigation.
+    // TODO: We should use a string to represent the segment path instead of
+    // an array. We already use a string representation for the path when
+    // accessing the Segment Cache, so we can use the same one.
+    scrollableSegmentsResult.push(segmentPath)
+  } else {
+    for (let parallelRouteKey in routerStateChildren) {
+      const routerStateChild: FlightRouterState =
+        routerStateChildren[parallelRouteKey]
+      const prefetchDataChild: CacheNodeSeedData | void | null =
+        prefetchDataChildren !== null
+          ? prefetchDataChildren[parallelRouteKey]
+          : null
+      const segmentChild = routerStateChild[0]
+      const segmentPathChild = segmentPath.concat([
+        parallelRouteKey,
+        segmentChild,
+      ])
+      const segmentKeyChild = createRouterCacheKey(segmentChild)
+      const taskChild = createCacheNodeOnNavigation(
+        routerStateChild,
+        prefetchDataChild,
+        possiblyPartialPrefetchHead,
+        isPrefetchHeadPartial,
+        segmentPathChild,
+        scrollableSegmentsResult
+      )
+      taskChildren.set(parallelRouteKey, taskChild)
+      const dynamicRequestTreeChild = taskChild.dynamicRequestTree
+      if (dynamicRequestTreeChild !== null) {
+        // Something in the child tree is dynamic.
+        needsDynamicRequest = true
+        dynamicRequestTreeChildren[parallelRouteKey] = dynamicRequestTreeChild
+      } else {
+        dynamicRequestTreeChildren[parallelRouteKey] = routerStateChild
+      }
+      const newCacheNodeChild = taskChild.node
+      if (newCacheNodeChild !== null) {
+        const newSegmentMapChild: ChildSegmentMap = new Map()
+        newSegmentMapChild.set(segmentKeyChild, newCacheNodeChild)
+        cacheNodeChildren.set(parallelRouteKey, newSegmentMapChild)
+      }
     }
   }
 
@@ -531,7 +575,9 @@ function spawnPendingTask(
   routerState: FlightRouterState,
   prefetchData: CacheNodeSeedData | null,
   prefetchHead: HeadData | null,
-  isPrefetchHeadPartial: boolean
+  isPrefetchHeadPartial: boolean,
+  segmentPath: FlightSegmentPath,
+  scrollableSegmentsResult: Array<FlightSegmentPath>
 ): SPANavigationTask {
   // Create a task that will later be fulfilled by data from the server.
 
@@ -551,7 +597,9 @@ function spawnPendingTask(
       routerState,
       prefetchData,
       prefetchHead,
-      isPrefetchHeadPartial
+      isPrefetchHeadPartial,
+      segmentPath,
+      scrollableSegmentsResult
     ),
     // Because this is non-null, and it gets propagated up through the parent
     // tasks, the root task will know that it needs to perform a server request.
@@ -754,7 +802,9 @@ function createPendingCacheNode(
   routerState: FlightRouterState,
   prefetchData: CacheNodeSeedData | null,
   prefetchHead: HeadData | null,
-  isPrefetchHeadPartial: boolean
+  isPrefetchHeadPartial: boolean,
+  segmentPath: FlightSegmentPath,
+  scrollableSegmentsResult: Array<FlightSegmentPath>
 ): ReadyCacheNode {
   const routerStateChildren = routerState[1]
   const prefetchDataChildren = prefetchData !== null ? prefetchData[2] : null
@@ -769,13 +819,19 @@ function createPendingCacheNode(
         : null
 
     const segmentChild = routerStateChild[0]
+    const segmentPathChild = segmentPath.concat([
+      parallelRouteKey,
+      segmentChild,
+    ])
     const segmentKeyChild = createRouterCacheKey(segmentChild)
 
     const newCacheNodeChild = createPendingCacheNode(
       routerStateChild,
       prefetchDataChild === undefined ? null : prefetchDataChild,
       prefetchHead,
-      isPrefetchHeadPartial
+      isPrefetchHeadPartial,
+      segmentPathChild,
+      scrollableSegmentsResult
     )
 
     const newSegmentMapChild: ChildSegmentMap = new Map()
@@ -786,6 +842,17 @@ function createPendingCacheNode(
   // The head is assigned to every leaf segment delivered by the server. Based
   // on corresponding logic in fill-lazy-items-till-leaf-with-head.ts
   const isLeafSegment = parallelRoutes.size === 0
+
+  if (isLeafSegment) {
+    // The segment path of every leaf segment (i.e. page) is collected into
+    // a result array. This is used by the LayoutRouter to scroll to ensure that
+    // new pages are visible after a navigation.
+    // TODO: We should use a string to represent the segment path instead of
+    // an array. We already use a string representation for the path when
+    // accessing the Segment Cache, so we can use the same one.
+    scrollableSegmentsResult.push(segmentPath)
+  }
+
   const maybePrefetchRsc = prefetchData !== null ? prefetchData[1] : null
   const maybePrefetchLoading = prefetchData !== null ? prefetchData[3] : null
   return {

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -120,10 +120,10 @@ function handleNavigationResult(
       mutable.cache = result.data.cacheNode
       mutable.patchedTree = result.data.flightRouterState
       mutable.canonicalUrl = result.data.canonicalUrl
+      mutable.scrollableSegments = result.data.scrollableSegments
+      mutable.shouldScroll = result.data.shouldScroll
       // TODO: Not yet implemented
-      // mutable.scrollableSegments = scrollableSegments
       // mutable.hashFragment = hash
-      // mutable.shouldScroll = shouldScroll
       return handleMutable(state, mutable)
     }
     case NavigationResultTag.Async: {
@@ -186,7 +186,8 @@ export function navigateReducer(
       url,
       state.cache,
       state.tree,
-      state.nextUrl
+      state.nextUrl,
+      shouldScroll
     )
     return handleNavigationResult(state, mutable, pendingPush, result)
   }
@@ -311,7 +312,8 @@ export function navigateReducer(
               treePatch,
               seedData,
               head,
-              isHeadPartial
+              isHeadPartial,
+              scrollableSegments
             )
 
             if (task !== null) {
@@ -437,20 +439,23 @@ export function navigateReducer(
               // segments in the FlightDataPath will be able to reference the updated cache.
               currentCache = cache
             }
+
+            for (const subSegment of generateSegmentsFromPatch(treePatch)) {
+              const scrollableSegmentPath = [
+                ...flightSegmentPath,
+                ...subSegment,
+              ]
+              // Filter out the __DEFAULT__ paths as they shouldn't be scrolled to in this case.
+              if (
+                scrollableSegmentPath[scrollableSegmentPath.length - 1] !==
+                DEFAULT_SEGMENT_KEY
+              ) {
+                scrollableSegments.push(scrollableSegmentPath)
+              }
+            }
           }
 
           currentTree = newTree
-
-          for (const subSegment of generateSegmentsFromPatch(treePatch)) {
-            const scrollableSegmentPath = [...flightSegmentPath, ...subSegment]
-            // Filter out the __DEFAULT__ paths as they shouldn't be scrolled to in this case.
-            if (
-              scrollableSegmentPath[scrollableSegmentPath.length - 1] !==
-              DEFAULT_SEGMENT_KEY
-            ) {
-              scrollableSegments.push(scrollableSegmentPath)
-            }
-          }
         }
       }
 


### PR DESCRIPTION
This implements Next's scroll-to-new-page behavior in the Segment Cache.

The LayoutRouter expects an array of segment paths that represents every page in the new route tree. In the old implementation, this is generated by the `generateSegmentsFromPatch` function. In the new implementation, I've chosen to generate this array during the main tree traversal that happens in `startPPRNavigation`.

As a future improvement, we should use the same segment path type that we use to access Segment Cache entries; there's no reason to have two representations of the same concept.