### PR TITLE
[dev-overlay] fix the code frame title alignment

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/code-frame/code-frame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/code-frame/code-frame.tsx
@@ -69,12 +69,16 @@ export function CodeFrame({ stackFrame, codeFrame }: CodeFrameProps) {
         onClick={open}
       >
         <p className="code-frame-link">
-          <span className="code-frame-icon">
+          <span className="code-frame-icon" data-icon="left">
             <FileIcon lang={fileExtension} />
-            {getFrameSource(stackFrame)} @{' '}
-            <HotlinkedText text={stackFrame.methodName} />
           </span>
-          <ExternalIcon width={16} height={16} />
+          <span data-text>
+            <HotlinkedText text={stackFrame.methodName} />
+            {getFrameSource(stackFrame)} @{' '}
+          </span>
+          <span className="code-frame-icon" data-icon="right">
+            <ExternalIcon width={16} height={16} />
+          </span>
         </p>
       </button>
       <pre className="code-frame-pre">
@@ -120,6 +124,16 @@ export const CODE_FRAME_STYLES = css`
     padding: 12px;
   }
 
+  .code-frame-link svg {
+    flex-shrink: 0;
+  }
+
+  .code-frame-link [data-text] {
+    display: inline-flex;
+    text-align: left;
+    margin: auto 6px;
+  }
+
   .code-frame-pre {
     white-space: pre-wrap;
   }
@@ -141,12 +155,6 @@ export const CODE_FRAME_STYLES = css`
     }
   }
 
-  .code-frame-icon {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-  }
-
   [data-nextjs-codeframe]::selection,
   [data-nextjs-codeframe] *::selection {
     background-color: var(--color-ansi-selection);
@@ -164,10 +172,11 @@ export const CODE_FRAME_STYLES = css`
 
   .code-frame-link {
     display: flex;
-    align-items: center;
-    justify-content: space-between;
     margin: 0;
     outline: 0;
+  }
+  .code-frame-link [data-icon='right'] {
+    margin-left: auto;
   }
 
   [data-nextjs-codeframe] div > pre {

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/code-frame/code-frame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/code-frame/code-frame.tsx
@@ -73,8 +73,8 @@ export function CodeFrame({ stackFrame, codeFrame }: CodeFrameProps) {
             <FileIcon lang={fileExtension} />
           </span>
           <span data-text>
-            <HotlinkedText text={stackFrame.methodName} />
             {getFrameSource(stackFrame)} @{' '}
+            <HotlinkedText text={stackFrame.methodName} />
           </span>
           <span className="code-frame-icon" data-icon="right">
             <ExternalIcon width={16} height={16} />

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/terminal/terminal.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/terminal/terminal.tsx
@@ -102,10 +102,14 @@ export const Terminal: React.FC<TerminalProps> = function Terminal({
         <div className="code-frame-link">
           <span className="code-frame-icon">
             <FileIcon lang={fileExtension} />
-            {getFrameSource(stackFrame)}
-            {/* TODO: Unlike the CodeFrame component, the `methodName` is unavailable. */}
           </span>
-          <ExternalIcon width={16} height={16} />
+          <span data-text>
+            {/* TODO: Unlike the CodeFrame component, the `methodName` is unavailable. */}
+            {getFrameSource(stackFrame)}
+          </span>
+          <span className="code-frame-icon" data-icon="right">
+            <ExternalIcon width={16} height={16} />
+          </span>
         </div>
       </button>
       <pre className="code-frame-pre">


### PR DESCRIPTION
### What

Aligb the text to left and avoid icon being shrinked

| after | before |
|:-----|:-------|
| ![image](https://github.com/user-attachments/assets/bb39379d-ec52-4f2e-9a6b-ccf102e40556) | ![image](https://github.com/user-attachments/assets/cc495680-18b8-4380-b577-23891023b204) |
| ![image](https://github.com/user-attachments/assets/db32427e-103f-4304-9d3b-931a0bccc001) | ![image](https://github.com/user-attachments/assets/fa8921ed-1f13-48d7-9313-8944596eda56) |

Closes NDX-826