### PR TITLE
[Segment Cache] Implement hash-only navigations

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -101,6 +101,7 @@ function triggerLazyFetchForLeafSegments(
 }
 
 function handleNavigationResult(
+  url: URL,
   state: ReadonlyReducerState,
   mutable: Mutable,
   pendingPush: boolean,
@@ -112,9 +113,32 @@ function handleNavigationResult(
       const newUrl = result.data
       return handleExternalUrl(state, mutable, newUrl, pendingPush)
     }
-    case NavigationResultTag.NoOp:
-      // The server responded with no change to the current page.
+    case NavigationResultTag.NoOp: {
+      // The server responded with no change to the current page. However, if
+      // the URL changed, we still need to update that.
+      const newCanonicalUrl = result.data.canonicalUrl
+      mutable.canonicalUrl = newCanonicalUrl
+
+      // Check if the only thing that changed was the hash fragment.
+      const oldUrl = new URL(state.canonicalUrl, url)
+      const onlyHashChange =
+        // We don't need to compare the origins, because client-driven
+        // navigations are always same-origin.
+        url.pathname === oldUrl.pathname &&
+        url.search === oldUrl.search &&
+        url.hash !== oldUrl.hash
+      if (onlyHashChange) {
+        // The only updated part of the URL is the hash.
+        mutable.onlyHashChange = true
+        mutable.shouldScroll = result.data.shouldScroll
+        mutable.hashFragment = url.hash
+        // Setting this to an empty array triggers a scroll for all new and
+        // updated segments. See `ScrollAndFocusHandler` for more details.
+        mutable.scrollableSegments = []
+      }
+
       return handleMutable(state, mutable)
+    }
     case NavigationResultTag.Success: {
       // Received a new result.
       mutable.cache = result.data.cacheNode
@@ -122,14 +146,13 @@ function handleNavigationResult(
       mutable.canonicalUrl = result.data.canonicalUrl
       mutable.scrollableSegments = result.data.scrollableSegments
       mutable.shouldScroll = result.data.shouldScroll
-      // TODO: Not yet implemented
-      // mutable.hashFragment = hash
+      mutable.hashFragment = result.data.hash
       return handleMutable(state, mutable)
     }
     case NavigationResultTag.Async: {
       return result.data.then(
         (asyncResult) =>
-          handleNavigationResult(state, mutable, pendingPush, asyncResult),
+          handleNavigationResult(url, state, mutable, pendingPush, asyncResult),
         // If the navigation failed, return the current state.
         // TODO: This matches the current behavior but we need to do something
         // better here if the network fails.
@@ -138,9 +161,10 @@ function handleNavigationResult(
         }
       )
     }
-    default:
-      const _exhaustiveCheck: never = result
+    default: {
+      result satisfies never
       return state
+    }
   }
 }
 
@@ -189,7 +213,7 @@ export function navigateReducer(
       state.nextUrl,
       shouldScroll
     )
-    return handleNavigationResult(state, mutable, pendingPush, result)
+    return handleNavigationResult(url, state, mutable, pendingPush, result)
   }
 
   const prefetchValues = getOrCreatePrefetchCacheEntry({


### PR DESCRIPTION
When a navigation happens and the only thing that changes is the hash fragment, we must do some special handling to ensure that the hash is correctly scrolled into view.

Nearly all of this is handled by ScrollAndFocusHandler; for the Segment Cache, the only thing we need to do is update a few of the fields on the router state object, like `scrollableSegments` and `onlyHashChange`.