### PR TITLE
build: Update `swc_core` to `v14.0.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7225,9 +7225,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "14.0.0"
+version = "14.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80006194dd33cfa1af6f5371b371b6fc4c234adea327c4d0d1f9cec70eba2ca6"
+checksum = "624749807c67a0ceebbe6b8fce07b96186cd855ae3c4fb6be546634de91bd79b"
 dependencies = [
  "binding_macros",
  "swc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 
 # SWC crates
-swc_core = { version = "14.0.0", features = [
+swc_core = { version = "14.0.1", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }


### PR DESCRIPTION
### What?

Apply https://github.com/swc-project/swc/pull/10047

### Why?

To reduce memory usage.



Closes PACK-3987