### PR TITLE
[dev-overlay] refactor to group the middleware response utils

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/font/get-dev-overlay-font-middleware.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/font/get-dev-overlay-font-middleware.ts
@@ -1,9 +1,8 @@
-import { internalServerError } from '../../server/shared'
-import { notFound } from '../../../not-found'
 import type { ServerResponse, IncomingMessage } from 'http'
 import path from 'path'
 import * as fs from 'fs/promises'
 import { constants } from 'fs'
+import { middlewareResponse } from '../../server/middleware-response'
 
 const FONT_PREFIX = '/__nextjs_font/'
 
@@ -34,14 +33,14 @@ export function getDevOverlayFontMiddleware() {
 
       const fontFile = pathname.replace(FONT_PREFIX, '')
       if (!VALID_FONTS.includes(fontFile)) {
-        return notFound()
+        return middlewareResponse.notFound(res)
       }
 
       const fontPath = path.resolve(__dirname, fontFile)
       const fileExists = await checkFileExists(fontPath)
 
       if (!fileExists) {
-        return notFound()
+        return middlewareResponse.notFound(res)
       }
 
       const fontData = await fs.readFile(fontPath)
@@ -54,7 +53,7 @@ export function getDevOverlayFontMiddleware() {
         'Failed to serve font:',
         err instanceof Error ? err.message : err
       )
-      return internalServerError(res)
+      return middlewareResponse.internalServerError(res)
     }
   }
 }

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/font/get-dev-overlay-font-middleware.ts
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/font/get-dev-overlay-font-middleware.ts
@@ -2,6 +2,7 @@ import type { ServerResponse, IncomingMessage } from 'http'
 import path from 'path'
 import * as fs from 'fs/promises'
 import { constants } from 'fs'
+import * as Log from '../../../../../build/output/log'
 import { middlewareResponse } from '../../server/middleware-response'
 
 const FONT_PREFIX = '/__nextjs_font/'
@@ -49,7 +50,7 @@ export function getDevOverlayFontMiddleware() {
       })
       res.end(fontData)
     } catch (err) {
-      console.error(
+      Log.error(
         'Failed to serve font:',
         err instanceof Error ? err.message : err
       )

--- a/packages/next/src/client/components/react-dev-overlay/server/get-next-error-feedback-middleware.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/get-next-error-feedback-middleware.ts
@@ -1,6 +1,5 @@
 import { eventErrorFeedback } from '../../../../telemetry/events/error-feedback'
-import { badRequest, internalServerError, noContent } from './shared'
-
+import { middlewareResponse } from './middleware-response'
 import type { ServerResponse, IncomingMessage } from 'http'
 import type { Telemetry } from '../../../../telemetry/storage'
 
@@ -22,7 +21,7 @@ export function getNextErrorFeedbackMiddleware(telemetry: Telemetry) {
       const wasHelpful = searchParams.get('wasHelpful')
 
       if (!errorCode || !wasHelpful) {
-        return badRequest(res)
+        return middlewareResponse.badRequest(res)
       }
 
       await telemetry.record(
@@ -32,9 +31,9 @@ export function getNextErrorFeedbackMiddleware(telemetry: Telemetry) {
         })
       )
 
-      return noContent(res)
+      return middlewareResponse.noContent(res)
     } catch (error) {
-      return internalServerError(res)
+      return middlewareResponse.internalServerError(res)
     }
   }
 }

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-response.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-response.ts
@@ -1,0 +1,34 @@
+import type { ServerResponse } from 'http'
+import { inspect } from 'util'
+
+export const middlewareResponse = {
+  noContent(res: ServerResponse) {
+    res.statusCode = 204
+    res.end('No Content')
+  },
+  notFound(res: ServerResponse) {
+    res.statusCode = 404
+    res.end('Not Found')
+  },
+  badRequest(res: ServerResponse) {
+    res.statusCode = 400
+    res.end('Bad Request')
+  },
+  internalServerError(res: ServerResponse, error?: unknown) {
+    res.statusCode = 500
+    res.setHeader('Content-Type', 'text/plain')
+    res.end(
+      error !== undefined
+        ? inspect(error, { colors: false })
+        : 'Internal Server Error'
+    )
+  },
+  json(res: ServerResponse, data: any) {
+    res
+      .setHeader('Content-Type', 'application/json')
+      .end(Buffer.from(JSON.stringify(data)))
+  },
+  jsonString(res: ServerResponse, data: string) {
+    res.setHeader('Content-Type', 'application/json').end(Buffer.from(data))
+  },
+}

--- a/packages/next/src/client/components/react-dev-overlay/server/shared.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/shared.ts
@@ -1,6 +1,4 @@
 import type { StackFrame } from 'stacktrace-parser'
-import type { ServerResponse } from 'http'
-import { inspect } from 'util'
 import { codeFrameColumns } from 'next/dist/compiled/babel/code-frame'
 import isInternal, {
   nextInternalsRe,
@@ -81,39 +79,4 @@ export function getOriginalCodeFrame(
     },
     { forceColor: colors }
   )
-}
-
-export function noContent(res: ServerResponse) {
-  res.statusCode = 204
-  res.end('No Content')
-}
-
-export function badRequest(res: ServerResponse) {
-  res.statusCode = 400
-  res.end('Bad Request')
-}
-
-export function notFound(res: ServerResponse) {
-  res.statusCode = 404
-  res.end('Not Found')
-}
-
-export function internalServerError(res: ServerResponse, error?: unknown) {
-  res.statusCode = 500
-  res.setHeader('Content-Type', 'text/plain')
-  res.end(
-    error !== undefined
-      ? inspect(error, { colors: false })
-      : 'Internal Server Error'
-  )
-}
-
-export function json(res: ServerResponse, data: any) {
-  res
-    .setHeader('Content-Type', 'application/json')
-    .end(Buffer.from(JSON.stringify(data)))
-}
-
-export function jsonString(res: ServerResponse, data: string) {
-  res.setHeader('Content-Type', 'application/json').end(Buffer.from(data))
 }


### PR DESCRIPTION
### What

Noticed that the `notFound` in middleware font serving route actually imports the wrong API rather from `next/navigation` than the simple notFound response one for sending the 404 response status. Introduced in #76166

Bad log observed while developing
```
 ✓ Compiled in 966ms (793 modules)
 GET /bad-nesting 200 in 90ms
Failed to serve font: NEXT_HTTP_ERROR_FALLBACK;404
Failed to serve font: NEXT_HTTP_ERROR_FALLBACK;404
 ✓ Compiled in 1101ms (793 modules)
 ✓ Compiled /_not-found in 230ms (797 modules)
```

Hence I group those dev middleware response API utils into one namespace and will be more explict and easy to use them without confusion.
Replacing with the correct API will avoid the unexpected logging in the output

