### PR TITLE
[dev-overlay] fix: dev indicator menu closing after tab access

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -191,6 +191,7 @@ function DevToolsPopover({
 
     // Open with first item focused
     if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
       setIsMenuOpen(true)
       // Run on next tick because querying DOM after state change
       setTimeout(() => {
@@ -200,6 +201,7 @@ function DevToolsPopover({
 
     // Open with last item focused
     if (e.key === 'ArrowUp') {
+      e.preventDefault()
       setIsMenuOpen(true)
       // Run on next tick because querying DOM after state change
       setTimeout(() => {


### PR DESCRIPTION
### Why?

After the tab access via `onTriggerKeydown()`, the `onTriggerClick()` was triggered, which closed the menu right after it was opened.

https://github.com/vercel/next.js/blob/f984d1f6812345e9f079f5a37aae6239bc5aa338/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx#L217-L219

### Before

https://github.com/user-attachments/assets/b5c2b1b9-68e8-4a7c-b8a5-06ca82c26255

### After

https://github.com/user-attachments/assets/48ab32ab-aec8-4a9b-93c5-bbe3957162e0

Closes NDX-790