### PR TITLE
[dev-overlay] rename `readyErrors` to `runtimeErrors`

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/app/react-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/app/react-dev-overlay.tsx
@@ -36,7 +36,7 @@ export default function ReactDevOverlay({
         <ComponentStyles />
 
         <RenderError state={state} isAppDir={true}>
-          {({ readyErrors, totalErrorCount }) => {
+          {({ runtimeErrors, totalErrorCount }) => {
             return (
               <>
                 <DevToolsIndicator
@@ -47,7 +47,7 @@ export default function ReactDevOverlay({
 
                 <ErrorOverlay
                   state={state}
-                  readyErrors={readyErrors}
+                  runtimeErrors={runtimeErrors}
                   isErrorOverlayOpen={isErrorOverlayOpen}
                   setIsErrorOverlayOpen={setIsErrorOverlayOpen}
                 />

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-layout/error-overlay-layout.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-layout/error-overlay-layout.tsx
@@ -45,7 +45,7 @@ interface ErrorOverlayLayoutProps extends ErrorBaseProps {
   isBuildError?: boolean
   onClose?: () => void
   // TODO: better handle receiving
-  readyErrors?: ReadyRuntimeError[]
+  runtimeErrors?: ReadyRuntimeError[]
   activeIdx?: number
   setActiveIndex?: (index: number) => void
   footerMessage?: string
@@ -62,7 +62,7 @@ export function ErrorOverlayLayout({
   isBuildError,
   onClose,
   versionInfo,
-  readyErrors,
+  runtimeErrors,
   activeIdx,
   setActiveIndex,
   footerMessage,
@@ -122,12 +122,12 @@ export function ErrorOverlayLayout({
             </DialogFooter>
           )}
           <ErrorOverlayBottomStack
-            count={readyErrors?.length ?? 0}
+            count={runtimeErrors?.length ?? 0}
             activeIdx={activeIdx ?? 0}
           />
         </ErrorOverlayDialog>
         <ErrorOverlayNav
-          readyErrors={readyErrors}
+          runtimeErrors={runtimeErrors}
           activeIdx={activeIdx}
           setActiveIndex={setActiveIndex}
           versionInfo={versionInfo}

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-nav/error-overlay-nav.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-nav/error-overlay-nav.stories.tsx
@@ -15,7 +15,7 @@ type Story = StoryObj<typeof ErrorOverlayNav>
 
 export const Default: Story = {
   args: {
-    readyErrors: [
+    runtimeErrors: [
       {
         id: 0,
         runtime: true,

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-nav/error-overlay-nav.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-nav/error-overlay-nav.tsx
@@ -6,7 +6,7 @@ import { noop as css } from '../../../helpers/noop-template'
 import type { ReadyRuntimeError } from '../../../../../internal/helpers/get-error-by-type'
 
 type ErrorOverlayNavProps = {
-  readyErrors?: ReadyRuntimeError[]
+  runtimeErrors?: ReadyRuntimeError[]
   activeIdx?: number
   setActiveIndex?: (index: number) => void
   versionInfo?: VersionInfo
@@ -14,7 +14,7 @@ type ErrorOverlayNavProps = {
 }
 
 export function ErrorOverlayNav({
-  readyErrors,
+  runtimeErrors,
   activeIdx,
   setActiveIndex,
   versionInfo,
@@ -25,7 +25,7 @@ export function ErrorOverlayNav({
       <Notch side="left">
         {/* TODO: better passing data instead of nullish coalescing */}
         <ErrorOverlayPagination
-          readyErrors={readyErrors ?? []}
+          runtimeErrors={runtimeErrors ?? []}
           activeIdx={activeIdx ?? 0}
           onActiveIndexChange={setActiveIndex ?? (() => {})}
         />

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-pagination/error-overlay-pagination.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-pagination/error-overlay-pagination.stories.tsx
@@ -42,7 +42,7 @@ export const SingleError: Story = {
     return (
       <ErrorOverlayPagination
         activeIdx={activeIdx}
-        readyErrors={[mockErrors[0]]}
+        runtimeErrors={[mockErrors[0]]}
         onActiveIndexChange={setActiveIdx}
       />
     )
@@ -55,7 +55,7 @@ export const MultipleErrors: Story = {
     return (
       <ErrorOverlayPagination
         activeIdx={activeIdx}
-        readyErrors={mockErrors}
+        runtimeErrors={mockErrors}
         onActiveIndexChange={setActiveIdx}
       />
     )
@@ -68,7 +68,7 @@ export const LastError: Story = {
     return (
       <ErrorOverlayPagination
         activeIdx={activeIdx}
-        readyErrors={mockErrors}
+        runtimeErrors={mockErrors}
         onActiveIndexChange={setActiveIdx}
       />
     )
@@ -81,7 +81,7 @@ export const VeryManyErrors: Story = {
     return (
       <ErrorOverlayPagination
         activeIdx={activeIdx}
-        readyErrors={Array(780).fill(mockErrors).flat()}
+        runtimeErrors={Array(780).fill(mockErrors).flat()}
         onActiveIndexChange={setActiveIdx}
       />
     )

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-pagination/error-overlay-pagination.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay-pagination/error-overlay-pagination.tsx
@@ -11,13 +11,13 @@ import { RightArrow } from '../../../icons/right-arrow'
 import type { ReadyRuntimeError } from '../../../../../internal/helpers/get-error-by-type'
 
 type ErrorPaginationProps = {
-  readyErrors: ReadyRuntimeError[]
+  runtimeErrors: ReadyRuntimeError[]
   activeIdx: number
   onActiveIndexChange: (index: number) => void
 }
 
 export function ErrorOverlayPagination({
-  readyErrors,
+  runtimeErrors,
   activeIdx,
   onActiveIndexChange,
 }: ErrorPaginationProps) {
@@ -34,13 +34,13 @@ export function ErrorOverlayPagination({
   const handleNext = useCallback(
     () =>
       startTransition(() => {
-        if (activeIdx < readyErrors.length - 1) {
+        if (activeIdx < runtimeErrors.length - 1) {
           onActiveIndexChange(
-            Math.max(0, Math.min(readyErrors.length - 1, activeIdx + 1))
+            Math.max(0, Math.min(runtimeErrors.length - 1, activeIdx + 1))
           )
         }
       }),
-    [activeIdx, readyErrors.length, onActiveIndexChange]
+    [activeIdx, runtimeErrors.length, onActiveIndexChange]
   )
 
   const buttonLeft = useRef<HTMLButtonElement | null>(null)
@@ -99,13 +99,13 @@ export function ErrorOverlayPagination({
         if (buttonLeft.current && a === buttonLeft.current) {
           buttonLeft.current.blur()
         }
-      } else if (activeIdx === readyErrors.length - 1) {
+      } else if (activeIdx === runtimeErrors.length - 1) {
         if (buttonRight.current && a === buttonRight.current) {
           buttonRight.current.blur()
         }
       }
     }
-  }, [nav, activeIdx, readyErrors.length])
+  }, [nav, activeIdx, runtimeErrors.length])
 
   return (
     <nav
@@ -130,15 +130,15 @@ export function ErrorOverlayPagination({
         <span data-nextjs-dialog-error-index={activeIdx}>{activeIdx + 1}/</span>
         <span data-nextjs-dialog-header-total-count>
           {/* Display 1 out of 1 if there are no errors (e.g. for build errors). */}
-          {readyErrors.length || 1}
+          {runtimeErrors.length || 1}
         </span>
       </div>
       <button
         ref={buttonRight}
         type="button"
         // If no errors or the last error is active, disable the button.
-        disabled={activeIdx >= readyErrors.length - 1}
-        aria-disabled={activeIdx >= readyErrors.length - 1}
+        disabled={activeIdx >= runtimeErrors.length - 1}
+        aria-disabled={activeIdx >= runtimeErrors.length - 1}
         onClick={handleNext}
         data-nextjs-dialog-error-next
         className="error-overlay-pagination-button"

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay/error-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/error-overlay/error-overlay.tsx
@@ -17,12 +17,12 @@ export interface ErrorBaseProps {
 
 export function ErrorOverlay({
   state,
-  readyErrors,
+  runtimeErrors,
   isErrorOverlayOpen,
   setIsErrorOverlayOpen,
 }: {
   state: OverlayState
-  readyErrors: ReadyRuntimeError[]
+  runtimeErrors: ReadyRuntimeError[]
   isErrorOverlayOpen: boolean
   setIsErrorOverlayOpen: (value: boolean) => void
 }) {
@@ -63,7 +63,7 @@ export function ErrorOverlay({
   }
 
   // No Runtime Errors.
-  if (!readyErrors.length) {
+  if (!runtimeErrors.length) {
     return null
   }
 
@@ -75,7 +75,7 @@ export function ErrorOverlay({
     <Errors
       {...commonProps}
       debugInfo={state.debugInfo}
-      readyErrors={readyErrors}
+      runtimeErrors={runtimeErrors}
       onClose={() => {
         setIsErrorOverlayOpen(false)
       }}

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.stories.tsx
@@ -70,7 +70,7 @@ const ignoredFrame = {
   ignored: true,
 }
 
-const readyErrors: ReadyRuntimeError[] = [
+const runtimeErrors: ReadyRuntimeError[] = [
   {
     id: 1,
     runtime: true,
@@ -152,7 +152,7 @@ const readyErrors: ReadyRuntimeError[] = [
 
 export const Default: Story = {
   args: {
-    readyErrors,
+    runtimeErrors,
     versionInfo: {
       installed: '15.0.0',
       staleness: 'fresh',
@@ -173,9 +173,9 @@ export const Turbopack: Story = {
 export const VeryLongErrorMessage: Story = {
   args: {
     ...Default.args,
-    readyErrors: [
+    runtimeErrors: [
       {
-        ...readyErrors[0],
+        ...runtimeErrors[0],
         error: Object.assign(new Error(lorem)),
       },
     ],
@@ -184,7 +184,7 @@ export const VeryLongErrorMessage: Story = {
 
 export const WithHydrationWarning: Story = {
   args: {
-    readyErrors: [
+    runtimeErrors: [
       {
         id: 1,
         runtime: true,

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/errors.tsx
@@ -20,7 +20,7 @@ import type { ReadyRuntimeError } from '../../../internal/helpers/get-error-by-t
 import type { ErrorBaseProps } from '../components/errors/error-overlay/error-overlay'
 
 export interface ErrorsProps extends ErrorBaseProps {
-  readyErrors: ReadyRuntimeError[]
+  runtimeErrors: ReadyRuntimeError[]
   debugInfo: DebugInfo
   onClose: () => void
 }
@@ -76,7 +76,7 @@ function ErrorDescription({
 }
 
 export function Errors({
-  readyErrors,
+  runtimeErrors,
   debugInfo,
   onClose,
   ...props
@@ -96,14 +96,14 @@ export function Errors({
   }, [onClose])
 
   const isLoading = useMemo<boolean>(() => {
-    return readyErrors.length < 1
-  }, [readyErrors.length])
+    return runtimeErrors.length < 1
+  }, [runtimeErrors.length])
 
   const [activeIdx, setActiveIndex] = useState<number>(0)
 
   const activeError = useMemo<ReadyErrorEvent | null>(
-    () => readyErrors[activeIdx] ?? null,
-    [activeIdx, readyErrors]
+    () => runtimeErrors[activeIdx] ?? null,
+    [activeIdx, runtimeErrors]
   )
 
   if (isLoading) {
@@ -158,7 +158,7 @@ export function Errors({
       onClose={isServerError ? undefined : onClose}
       debugInfo={debugInfo}
       error={error}
-      readyErrors={readyErrors}
+      runtimeErrors={runtimeErrors}
       activeIdx={activeIdx}
       setActiveIndex={setActiveIndex}
       footerMessage={footerMessage}

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/render-error.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/container/runtime-error/render-error.tsx
@@ -32,7 +32,7 @@ function getErrorSignature(ev: SupportedErrorEvent): string {
 
 type Props = {
   children: (params: {
-    readyErrors: ReadyRuntimeError[]
+    runtimeErrors: ReadyRuntimeError[]
     totalErrorCount: number
   }) => React.ReactNode
   state: OverlayState
@@ -58,7 +58,7 @@ const RenderRuntimeError = ({ children, state, isAppDir }: Props) => {
     [eventId: string]: ReadyRuntimeError
   }>({})
 
-  const [readyErrors, nextError] = useMemo<
+  const [runtimeErrors, nextError] = useMemo<
     [ReadyRuntimeError[], SupportedErrorEvent | null]
   >(() => {
     let ready: ReadyRuntimeError[] = []
@@ -109,14 +109,14 @@ const RenderRuntimeError = ({ children, state, isAppDir }: Props) => {
     }
   }, [nextError, isAppDir])
 
-  const totalErrorCount = readyErrors.length
+  const totalErrorCount = runtimeErrors.length
 
-  return children({ readyErrors, totalErrorCount })
+  return children({ runtimeErrors, totalErrorCount })
 }
 
 const RenderBuildError = ({ children }: Props) => {
   return children({
-    readyErrors: [],
+    runtimeErrors: [],
     // Build errors and missing root layout tags persist until fixed,
     // so we can set a fixed error count of 1
     totalErrorCount: 1,

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/pages/react-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/pages/react-dev-overlay.tsx
@@ -41,7 +41,7 @@ export default function ReactDevOverlay({ children }: ReactDevOverlayProps) {
         <ComponentStyles />
 
         <RenderError state={state} isAppDir={false}>
-          {({ readyErrors, totalErrorCount }) => (
+          {({ runtimeErrors, totalErrorCount }) => (
             <>
               <DevToolsIndicator
                 state={state}
@@ -52,7 +52,7 @@ export default function ReactDevOverlay({ children }: ReactDevOverlayProps) {
               {(hasRuntimeErrors || hasBuildError) && (
                 <ErrorOverlay
                   state={state}
-                  readyErrors={readyErrors}
+                  runtimeErrors={runtimeErrors}
                   isErrorOverlayOpen={isErrorOverlayOpen}
                   setIsErrorOverlayOpen={setIsErrorOverlayOpen}
                 />


### PR DESCRIPTION
### Why?

The variable name `readyErrors` should be `runtimeErrors`, but was left as is for a while due to low priority. For the following PRs, renamed it to distinguish between build error vs runtime error.