### PR TITLE
[dev-overlay] do not allow dismissing build error for dev indicator

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/app/react-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/app/react-dev-overlay.tsx
@@ -37,11 +37,13 @@ export default function ReactDevOverlay({
 
         <RenderError state={state} isAppDir={true}>
           {({ runtimeErrors, totalErrorCount }) => {
+            const isBuildError = runtimeErrors.length === 0
             return (
               <>
                 <DevToolsIndicator
                   state={state}
                   errorCount={totalErrorCount}
+                  isBuildError={isBuildError}
                   setIsErrorOverlayOpen={setIsErrorOverlayOpen}
                 />
 

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -23,11 +23,13 @@ type DevToolsIndicatorPosition = typeof INDICATOR_POSITION
 export function DevToolsIndicator({
   state,
   errorCount,
+  isBuildError,
   setIsErrorOverlayOpen,
   position = INDICATOR_POSITION,
 }: {
   state: OverlayState
   errorCount: number
+  isBuildError: boolean
   setIsErrorOverlayOpen: Dispatch<SetStateAction<boolean>>
   // Technically this prop isn't needed, but useful for testing.
   position?: DevToolsIndicatorPosition
@@ -47,6 +49,7 @@ export function DevToolsIndicator({
         isTurbopack={!!process.env.TURBOPACK}
         position={position}
         disabled={state.disableDevIndicator}
+        isBuildError={isBuildError}
       />
     )
   )
@@ -71,6 +74,7 @@ function DevToolsPopover({
   isStaticRoute,
   isTurbopack,
   position,
+  isBuildError,
   hide,
   setIsErrorOverlayOpen,
 }: {
@@ -80,6 +84,7 @@ function DevToolsPopover({
   semver: string | undefined
   isTurbopack: boolean
   position: DevToolsIndicatorPosition
+  isBuildError: boolean
   hide: () => void
   setIsErrorOverlayOpen: Dispatch<SetStateAction<boolean>>
 }) {
@@ -263,6 +268,7 @@ function DevToolsPopover({
         openErrorOverlay={openErrorOverlay}
         isDevBuilding={useIsDevBuilding()}
         isDevRendering={useIsDevRendering()}
+        isBuildError={isBuildError}
       />
 
       {routeInfoMounted && (

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/errors/dev-tools-indicator/internal/next-logo.tsx
@@ -7,6 +7,7 @@ interface Props extends React.ComponentProps<'button'> {
   issueCount: number
   isDevBuilding: boolean
   isDevRendering: boolean
+  isBuildError: boolean
   onTriggerClick: () => void
   openErrorOverlay: () => void
 }
@@ -62,6 +63,7 @@ export const NextLogo = forwardRef(function NextLogo(
     issueCount,
     isDevBuilding,
     isDevRendering,
+    isBuildError,
     onTriggerClick,
     openErrorOverlay,
     ...props
@@ -224,7 +226,9 @@ export const NextLogo = forwardRef(function NextLogo(
             gap: var(--padding);
             align-items: center;
             padding-left: 8px;
-            padding-right: ${disabled ? '8px' : 'calc(var(--padding) * 2)'};
+            padding-right: ${disabled || isBuildError
+              ? '8px'
+              : 'calc(var(--padding) * 2)'};
             height: 32px;
             margin: 0 var(--padding);
             border-radius: 9999px;
@@ -462,7 +466,7 @@ export const NextLogo = forwardRef(function NextLogo(
                   )}
                 </div>
               </button>
-              {!disabled && (
+              {!disabled && !isBuildError && (
                 <button
                   data-issues-collapse
                   aria-label="Collapse issues badge"

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/pages/react-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/pages/react-dev-overlay.tsx
@@ -41,24 +41,28 @@ export default function ReactDevOverlay({ children }: ReactDevOverlayProps) {
         <ComponentStyles />
 
         <RenderError state={state} isAppDir={false}>
-          {({ runtimeErrors, totalErrorCount }) => (
-            <>
-              <DevToolsIndicator
-                state={state}
-                errorCount={totalErrorCount}
-                setIsErrorOverlayOpen={setIsErrorOverlayOpen}
-              />
-
-              {(hasRuntimeErrors || hasBuildError) && (
-                <ErrorOverlay
+          {({ runtimeErrors, totalErrorCount }) => {
+            const isBuildError = runtimeErrors.length === 0
+            return (
+              <>
+                <DevToolsIndicator
                   state={state}
-                  runtimeErrors={runtimeErrors}
-                  isErrorOverlayOpen={isErrorOverlayOpen}
+                  errorCount={totalErrorCount}
+                  isBuildError={isBuildError}
                   setIsErrorOverlayOpen={setIsErrorOverlayOpen}
                 />
-              )}
-            </>
-          )}
+
+                {(hasRuntimeErrors || hasBuildError) && (
+                  <ErrorOverlay
+                    state={state}
+                    runtimeErrors={runtimeErrors}
+                    isErrorOverlayOpen={isErrorOverlayOpen}
+                    setIsErrorOverlayOpen={setIsErrorOverlayOpen}
+                  />
+                )}
+              </>
+            )
+          }}
         </RenderError>
       </ShadowPortal>
     </>

--- a/test/e2e/app-dir/hello-world/app/page.tsx
+++ b/test/e2e/app-dir/hello-world/app/page.tsx
@@ -1,5 +1,3 @@
-import 'not'
-
 export default function Page() {
   return <p>hello world</p>
 }

--- a/test/e2e/app-dir/hello-world/app/page.tsx
+++ b/test/e2e/app-dir/hello-world/app/page.tsx
@@ -1,3 +1,5 @@
+import 'not'
+
 export default function Page() {
   return <p>hello world</p>
 }


### PR DESCRIPTION
### Why?

Since the build error, including missing tags, cannot be dismissed until resolved, the "Close Icon" on the indicator does nothing but confuse the user, so remove it.

| Before | After |
|--------|--------|
| ![CleanShot 2025-02-19 at 22 33 44](https://github.com/user-attachments/assets/b64d7a5e-7e8e-428e-a35f-21d49cac6425) | ![CleanShot 2025-02-19 at 22 34 29](https://github.com/user-attachments/assets/8f2f754c-e24d-430e-86c0-edd21ab9c073) | 

Closes NDX-857