### PR TITLE
Turbopack: replace AvailableModules with single bitmap

### DIFF
--- a/turbopack/crates/turbopack-core/src/chunk/available_chunk_groups.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/available_chunk_groups.rs
@@ -1,0 +1,101 @@
+use anyhow::Result;
+use roaring::RoaringBitmap;
+use turbo_tasks::{ResolvedVc, Vc};
+
+use crate::module_graph::{
+    chunk_group_info::{ChunkGroupInfo, RoaringBitmapWrapper},
+    module_batch::ChunkableModuleOrBatch,
+};
+
+/// Allows to gather information about which assets are already available.
+#[turbo_tasks::value]
+pub struct AvailableChunkGroups {
+    chunk_groups: RoaringBitmapWrapper,
+}
+
+#[turbo_tasks::value_impl]
+impl AvailableChunkGroups {
+    #[turbo_tasks::function]
+    pub async fn new(chunk_group: u32) -> Result<Vc<Self>> {
+        Ok(AvailableChunkGroups {
+            chunk_groups: RoaringBitmapWrapper::new(
+                RoaringBitmap::from_sorted_iter(std::iter::once(chunk_group)).unwrap(),
+            ),
+        }
+        .cell())
+    }
+
+    #[turbo_tasks::function]
+    pub async fn with_chunk_group(&self, chunk_group: u32) -> Result<Vc<Self>> {
+        let mut chunk_groups = self.chunk_groups.clone();
+        chunk_groups.insert(chunk_group);
+        Ok(AvailableChunkGroups { chunk_groups }.cell())
+    }
+
+    #[turbo_tasks::function]
+    pub async fn hash(&self, chunk_group_info: Vc<ChunkGroupInfo>) -> Result<Vc<u64>> {
+        Ok(Vc::cell(
+            chunk_group_info
+                .await?
+                .hash_chunk_groups(&self.chunk_groups)
+                .await?,
+        ))
+    }
+
+    #[turbo_tasks::function]
+    pub async fn is_available(
+        &self,
+        chunk_group_info: Vc<ChunkGroupInfo>,
+        module_or_batch: ChunkableModuleOrBatch,
+    ) -> Result<Vc<bool>> {
+        Ok(Vc::cell(match module_or_batch {
+            ChunkableModuleOrBatch::Module(module) => {
+                let chunk_group_info = chunk_group_info.await?;
+                let chunk_groups = chunk_group_info.get_individual(ResolvedVc::upcast(module))?;
+                is_chunk_group_available(&self.chunk_groups, chunk_groups)
+            }
+            ChunkableModuleOrBatch::Batch(batch) => {
+                let batch = batch.await?;
+                let chunk_groups = batch.chunk_groups.as_ref().unwrap();
+                is_chunk_group_available(&self.chunk_groups, chunk_groups)
+            }
+            ChunkableModuleOrBatch::None(_) => unreachable!(),
+        }))
+    }
+}
+
+impl AvailableChunkGroups {
+    pub async fn is_available_individual(
+        &self,
+        chunk_group_info: &ChunkGroupInfo,
+        module_or_batch: ChunkableModuleOrBatch,
+    ) -> Result<bool> {
+        Ok(match module_or_batch {
+            ChunkableModuleOrBatch::Module(module) => {
+                let chunk_groups = chunk_group_info.get_individual(ResolvedVc::upcast(module))?;
+                is_chunk_group_available(&self.chunk_groups, chunk_groups)
+            }
+            ChunkableModuleOrBatch::Batch(batch) => {
+                let batch = batch.await?;
+                let chunk_groups = batch.chunk_groups.as_ref().unwrap();
+                is_chunk_group_available(&self.chunk_groups, chunk_groups)
+            }
+            ChunkableModuleOrBatch::None(_) => unreachable!(),
+        })
+    }
+}
+
+fn is_chunk_group_available(
+    available_chunk_groups: &RoaringBitmapWrapper,
+    module_chunk_groups: &RoaringBitmapWrapper,
+) -> bool {
+    // `self.chunk_groups` is the union of all parent chunk groups (i.e. a single chunking path
+    // leading to this module)
+    //
+    // `module_chunk_groups` is the union of all chunk groups of the module (i.e. the union of
+    // all paths leading to this module)
+    //
+    // The module is available, if there is at least one parent chunk group (bit is set in
+    // `self.chunk_groups`) that contains the module (bit is set in `module`)
+    !available_chunk_groups.is_disjoint(module_chunk_groups)
+}

--- a/turbopack/crates/turbopack-core/src/chunk/available_chunk_groups.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/available_chunk_groups.rs
@@ -59,7 +59,6 @@ impl AvailableChunkGroups {
                 let chunk_groups = batch.chunk_groups.as_ref().unwrap();
                 is_chunk_group_available(&self.chunk_groups, chunk_groups)
             }
-            ChunkableModuleOrBatch::None(_) => unreachable!(),
         }))
     }
 }
@@ -80,7 +79,6 @@ impl AvailableChunkGroups {
                 let chunk_groups = batch.chunk_groups.as_ref().unwrap();
                 is_chunk_group_available(&self.chunk_groups, chunk_groups)
             }
-            ChunkableModuleOrBatch::None(_) => unreachable!(),
         })
     }
 }

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_item_batch.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_item_batch.rs
@@ -87,7 +87,6 @@ impl ChunkItemOrBatchWithAsyncModuleInfo {
                 .to_resolved()
                 .await?,
             )),
-            ChunkableModuleOrBatch::None(_) => None,
         })
     }
 

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/production.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/production.rs
@@ -625,7 +625,7 @@ fn merge_chunk_groups<'l>(
     if let (Some(chunk_groups), Some(chunk_groups2)) = (chunk_groups, chunk_groups2) {
         let l = &**chunk_groups.as_ref();
         let r = &**chunk_groups2.as_ref();
-        Some(Cow::Owned(RoaringBitmapWrapper(l & r)))
+        Some(Cow::Owned(RoaringBitmapWrapper::new(l & r)))
     } else {
         None
     }

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -1,4 +1,5 @@
 pub mod availability_info;
+pub mod available_chunk_groups;
 pub mod available_modules;
 pub mod chunk_group;
 pub(crate) mod chunk_item_batch;

--- a/turbopack/crates/turbopack-core/src/module_graph/module_batch.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batch.rs
@@ -47,7 +47,6 @@ pub enum ModuleOrBatch {
 pub enum ChunkableModuleOrBatch {
     Module(ResolvedVc<Box<dyn ChunkableModule>>),
     Batch(ResolvedVc<ModuleBatch>),
-    None(usize),
 }
 
 impl ChunkableModuleOrBatch {
@@ -55,7 +54,7 @@ impl ChunkableModuleOrBatch {
         match module_or_batch {
             ModuleOrBatch::Module(module) => ResolvedVc::try_downcast(module).map(Self::Module),
             ModuleOrBatch::Batch(batch) => Some(Self::Batch(batch)),
-            ModuleOrBatch::None(i) => Some(Self::None(i)),
+            ModuleOrBatch::None(_) => None,
         }
     }
 
@@ -67,7 +66,6 @@ impl ChunkableModuleOrBatch {
             ChunkableModuleOrBatch::Batch(batch) => {
                 IdentStrings::Multiple(batch.ident_strings().await?)
             }
-            ChunkableModuleOrBatch::None(_) => IdentStrings::None,
         })
     }
 }
@@ -77,7 +75,6 @@ impl From<ChunkableModuleOrBatch> for ModuleOrBatch {
         match chunkable_module_or_batch {
             ChunkableModuleOrBatch::Module(module) => Self::Module(ResolvedVc::upcast(module)),
             ChunkableModuleOrBatch::Batch(batch) => Self::Batch(batch),
-            ChunkableModuleOrBatch::None(i) => Self::None(i),
         }
     }
 }

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
@@ -94,36 +94,38 @@ pub async fn compute_style_groups(
         }
         let mut visited = FxHashSet::default();
         let mut items_in_postorder = FxIndexSet::default();
-        batches_graph.traverse_edges_from_entries_topological(
-            entries.iter().copied(),
-            &mut (),
-            |parent_info, module, _| {
-                if let Some((_, ModuleBatchesGraphEdge { ty, .. })) = parent_info {
-                    if !matches!(
-                        ty,
-                        ChunkingType::Parallel | ChunkingType::ParallelInheritAsync
-                    ) {
-                        return Ok(GraphTraversalAction::Exclude);
+        batches_graph
+            .traverse_edges_from_entries_topological(
+                entries.iter().copied(),
+                &mut (),
+                |parent_info, module, _| {
+                    if let Some((_, ModuleBatchesGraphEdge { ty, .. })) = parent_info {
+                        if !matches!(
+                            ty,
+                            ChunkingType::Parallel | ChunkingType::ParallelInheritAsync
+                        ) {
+                            return Ok(GraphTraversalAction::Exclude);
+                        }
                     }
-                }
-                if visited.insert(module) {
-                    Ok(GraphTraversalAction::Continue)
-                } else {
-                    Ok(GraphTraversalAction::Exclude)
-                }
-            },
-            |parent_info, item, _| {
-                if let Some((_, ModuleBatchesGraphEdge { ty, .. })) = parent_info {
-                    if !matches!(
-                        ty,
-                        ChunkingType::Parallel | ChunkingType::ParallelInheritAsync
-                    ) {
-                        return;
+                    if visited.insert(module) {
+                        Ok(GraphTraversalAction::Continue)
+                    } else {
+                        Ok(GraphTraversalAction::Exclude)
                     }
-                }
-                items_in_postorder.insert(*item);
-            },
-        )?;
+                },
+                |parent_info, item, _| {
+                    if let Some((_, ModuleBatchesGraphEdge { ty, .. })) = parent_info {
+                        if !matches!(
+                            ty,
+                            ChunkingType::Parallel | ChunkingType::ParallelInheritAsync
+                        ) {
+                            return;
+                        }
+                    }
+                    items_in_postorder.insert(*item);
+                },
+            )
+            .await?;
 
         let mut styles = FxIndexSet::default();
         let mut handle_module = async |module| {

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
@@ -97,8 +97,8 @@ pub async fn compute_style_groups(
         batches_graph
             .traverse_edges_from_entries_topological(
                 entries.iter().copied(),
-                &mut (),
-                |parent_info, module, _| {
+                &mut visited,
+                async |parent_info, module, visited| {
                     if let Some((_, ModuleBatchesGraphEdge { ty, .. })) = parent_info {
                         if !matches!(
                             ty,
@@ -122,7 +122,7 @@ pub async fn compute_style_groups(
                             return;
                         }
                     }
-                    items_in_postorder.insert(*item);
+                    items_in_postorder.insert(item);
                 },
             )
             .await?;


### PR DESCRIPTION
Replace `AvailableModules(HashSet<Box<dyn Module>>)` with `AvailableChunkGroups(RoaringBitMap)`

TODO:
- [x] workers are currently broken, they load but are not evaluated anymore. 
- [x] Verify that CSS client references are ignored for SSR.
Yep, there are no `ChunkGroup::IsolatedMerged` entries with a `ssr` merge tag and  CSS entries

```
testing against 0293c96cf32

canary be228419ce
12,7gb
509.15s user 78.26s system 892% cpu 1:05.84 total
512.90s user 77.15s system 905% cpu 1:05.14 total

mischnic/evaluated_chunk_group_chunk_group eef92cdfa7
12,7
509.05s user 76.17s system 903% cpu 1:04.80 total

mischnic/graph-chunk-groups-client-refs 21dd2e5d9b
13,0
522.09s user 81.00s system 900% cpu 1:06.95 total
516.98s user 77.41s system 901% cpu 1:05.92 total

mischnic/availability-info-module-graph d5b94c2536
12,7gb
508.63s user 74.80s system 896% cpu 1:05.08 total
```