### PR TITLE
Turbopack: ignore invalid sourcemaps for now

### DIFF
--- a/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/input/index.js
@@ -1,0 +1,2 @@
+console.log("test")
+//# sourceMappingURL=index.js.map

--- a/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/input/index.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/input/index.js.map
@@ -1,0 +1,4 @@
+"use client";
+{
+  "version": 3
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/output/4e721_crates_turbopack-tests_tests_snapshot_source_maps_invalid_input_index_66486b.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/output/4e721_crates_turbopack-tests_tests_snapshot_source_maps_invalid_input_index_66486b.js
@@ -1,0 +1,6 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
+    "output/4e721_crates_turbopack-tests_tests_snapshot_source_maps_invalid_input_index_66486b.js",
+    {},
+    {"otherChunks":["output/4e721_crates_turbopack-tests_tests_snapshot_source_maps_invalid_input_index_fc734e.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/input/index.js [test] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/output/4e721_crates_turbopack-tests_tests_snapshot_source_maps_invalid_input_index_66486b.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/output/4e721_crates_turbopack-tests_tests_snapshot_source_maps_invalid_input_index_66486b.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/output/4e721_crates_turbopack-tests_tests_snapshot_source_maps_invalid_input_index_fc734e.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/output/4e721_crates_turbopack-tests_tests_snapshot_source_maps_invalid_input_index_fc734e.js
@@ -1,0 +1,12 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push(["output/4e721_crates_turbopack-tests_tests_snapshot_source_maps_invalid_input_index_fc734e.js", {
+
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/input/index.js [test] (ecmascript)": (function(__turbopack_context__) {
+
+var { g: global, d: __dirname, m: module, e: exports } = __turbopack_context__;
+{
+console.log("test") //# sourceMappingURL=index.js.map
+;
+}}),
+}]);
+
+//# sourceMappingURL=4e721_crates_turbopack-tests_tests_snapshot_source_maps_invalid_input_index_fc734e.js.map

--- a/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/output/4e721_crates_turbopack-tests_tests_snapshot_source_maps_invalid_input_index_fc734e.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/output/4e721_crates_turbopack-tests_tests_snapshot_source_maps_invalid_input_index_fc734e.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 6, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/input/index.js"],"sourcesContent":["console.log(\"test\")\n//# sourceMappingURL=index.js.map\n"],"names":[],"mappings":"AAAA,QAAQ,GAAG,CAAC,QACZ,iCAAiC"}},
+    {"offset": {"line": 8, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
+}


### PR DESCRIPTION
https://github.com/vercel/next.js/pull/75791 made the sourcemap handling stricter, it caused this when encountering invalid input source maps (i.e. the ones that are published to npm).
Let's keep the old behavior for now (which is also what Webpack does). 
```
Caused by:
    0: Execution of run_inner_operation failed
    1: Execution of run_test_operation failed
    2: Execution of ModuleGraph::from_modules failed
    3: Execution of SingleModuleGraph::new_with_entries failed
    4: [project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/input/index.js [test] (ecmascript)
    5: Execution of primary_chunkable_referenced_modules failed
    6: Execution of <EcmascriptModuleAsset as Module>::references failed
    7: Execution of analyse_ecmascript_module failed
    8: failed to analyse ecmascript module '[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/input/index.js [test] (ecmascript)'
    9: Execution of <SourceMapReference as GenerateSourceMap>::generate_source_map failed
   10: invalid type: string "use client", expected struct SourceMapJson at line 1 column 12
```


Closes PACK-4008