### PR TITLE
[Turbopack] remove ChunkingType::Passthrough

### DIFF
--- a/turbopack/crates/turbopack-core/src/chunk/chunking/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/mod.rs
@@ -9,8 +9,7 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, ReadRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 
 use super::{
-    AsyncModuleInfo, Chunk, ChunkItem, ChunkItemTy, ChunkItemWithAsyncModuleInfo, ChunkType,
-    ChunkingContext,
+    AsyncModuleInfo, Chunk, ChunkItem, ChunkItemWithAsyncModuleInfo, ChunkType, ChunkingContext,
 };
 use crate::{
     chunk::{
@@ -88,7 +87,6 @@ pub async fn make_chunks(
                 .map(
                     async |(
                         ChunkItemWithAsyncModuleInfo {
-                            ty,
                             chunk_item,
                             module,
                             async_info,
@@ -96,7 +94,6 @@ pub async fn make_chunks(
                         chunk_item_info,
                     )| {
                         Ok(ChunkItemWithInfo {
-                            ty: *ty,
                             chunk_item: *chunk_item,
                             module: *module,
                             async_info: *async_info,
@@ -156,7 +153,6 @@ pub async fn make_chunks(
 }
 
 struct ChunkItemWithInfo {
-    ty: ChunkItemTy,
     chunk_item: ResolvedVc<Box<dyn ChunkItem>>,
     module: Option<ResolvedVc<Box<dyn ChunkableModule>>>,
     async_info: Option<ResolvedVc<AsyncModuleInfo>>,
@@ -186,13 +182,11 @@ async fn make_chunk(
                 .into_iter()
                 .map(
                     |ChunkItemWithInfo {
-                         ty,
                          chunk_item,
                          module,
                          async_info,
                          ..
                      }| ChunkItemWithAsyncModuleInfo {
-                        ty,
                         chunk_item,
                         module,
                         async_info,

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -286,31 +286,10 @@ impl AsyncModuleInfo {
 }
 
 #[derive(
-    Copy,
-    Debug,
-    Clone,
-    Serialize,
-    Deserialize,
-    PartialEq,
-    Eq,
-    Hash,
-    TraceRawVcs,
-    TaskInput,
-    NonLocalValue,
-)]
-pub enum ChunkItemTy {
-    /// The ChunkItem should be included as content in the chunk.
-    Included,
-    /// The ChunkItem should be used to trace references but should not included in the chunk.
-    Passthrough,
-}
-
-#[derive(
     Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, TraceRawVcs, TaskInput, NonLocalValue,
 )]
 // #[turbo_tasks::value]
 pub struct ChunkItemWithAsyncModuleInfo {
-    pub ty: ChunkItemTy,
     pub chunk_item: ResolvedVc<Box<dyn ChunkItem>>,
     pub module: Option<ResolvedVc<Box<dyn ChunkableModule>>>,
     pub async_info: Option<ResolvedVc<AsyncModuleInfo>>,

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -179,9 +179,6 @@ pub enum ChunkingType {
         _ty: ChunkGroupType,
         merge_tag: Option<RcStr>,
     },
-    /// Module not placed in chunk group, but its references are still followed and placed into the
-    /// chunk group.
-    Passthrough,
     // Module not placed in chunk group, but its references are still followed.
     Traced,
 }
@@ -207,7 +204,6 @@ pub struct ChunkGroupContent {
     pub chunkable_modules: FxIndexSet<ResolvedVc<Box<dyn ChunkableModule>>>,
     pub async_modules: FxIndexSet<ResolvedVc<Box<dyn ChunkableModule>>>,
     pub traced_modules: FxIndexSet<ResolvedVc<Box<dyn Module>>>,
-    pub passthrough_modules: FxIndexSet<ResolvedVc<Box<dyn ChunkableModule>>>,
 }
 
 #[turbo_tasks::value_trait]

--- a/turbopack/crates/turbopack-core/src/introspect/utils.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/utils.rs
@@ -34,11 +34,6 @@ fn async_reference_ty() -> Vc<RcStr> {
 }
 
 #[turbo_tasks::function]
-fn passthrough_reference_ty() -> Vc<RcStr> {
-    Vc::cell("passthrough reference".into())
-}
-
-#[turbo_tasks::function]
 fn isolated_reference_ty() -> Vc<RcStr> {
     Vc::cell("isolated reference".into())
 }
@@ -87,7 +82,6 @@ pub async fn children_from_module_references(
                 }
                 Some(ChunkingType::Async) => key = async_reference_ty(),
                 Some(ChunkingType::Isolated { .. }) => key = isolated_reference_ty(),
-                Some(ChunkingType::Passthrough) => key = passthrough_reference_ty(),
                 Some(ChunkingType::Traced) => key = traced_reference_ty(),
             }
         }

--- a/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
@@ -96,7 +96,6 @@ async fn compute_async_module_info_single(
                 ChunkingType::Parallel
                 | ChunkingType::Async
                 | ChunkingType::Isolated { .. }
-                | ChunkingType::Passthrough
                 | ChunkingType::Traced => {
                     // Nothing to propagate
                 }

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -193,9 +193,7 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraph) -> Result<Vc<ChunkGro
                 let chunk_groups =
                     if let Some((parent, chunking_type)) = parent_info {
                         match chunking_type {
-                            ChunkingType::Parallel
-                            | ChunkingType::ParallelInheritAsync
-                            | ChunkingType::Passthrough => {
+                            ChunkingType::Parallel | ChunkingType::ParallelInheritAsync => {
                                 ChunkGroupInheritance::Inherit(parent.module)
                             }
                             ChunkingType::Async => ChunkGroupInheritance::ChunkGroup(Either::Left(

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueDefault, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, ValueDefault, ValueToString, Vc};
 use turbopack_core::{
     chunk::{
         round_chunk_item_size, AsyncModuleInfo, Chunk, ChunkItem, ChunkItemWithAsyncModuleInfo,
@@ -45,33 +45,32 @@ impl ChunkType for EcmascriptChunkType {
         else {
             bail!("Ecmascript chunking context not found");
         };
+        fn to_ecmascript_chunk_item(
+            chunk_item: &ChunkItemWithAsyncModuleInfo,
+        ) -> Result<EcmascriptChunkItemWithAsyncInfo> {
+            let ChunkItemWithAsyncModuleInfo {
+                chunk_item,
+                module: _,
+                async_info,
+            } = chunk_item;
+            let Some(chunk_item) =
+                ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkItem>>(*chunk_item)
+            else {
+                bail!(
+                    "Chunk item is not an ecmascript chunk item but reporting chunk type \
+                     ecmascript"
+                );
+            };
+            Ok(EcmascriptChunkItemWithAsyncInfo {
+                chunk_item,
+                async_info: *async_info,
+            })
+        }
         let content = EcmascriptChunkContent {
             chunk_items: chunk_items
                 .iter()
-                .map(
-                    async |ChunkItemWithAsyncModuleInfo {
-                               ty,
-                               chunk_item,
-                               module: _,
-                               async_info,
-                           }| {
-                        let Some(chunk_item) =
-                            ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkItem>>(*chunk_item)
-                        else {
-                            bail!(
-                                "Chunk item is not an ecmascript chunk item but reporting chunk \
-                                 type ecmascript"
-                            );
-                        };
-                        Ok(EcmascriptChunkItemWithAsyncInfo {
-                            ty: *ty,
-                            chunk_item,
-                            async_info: *async_info,
-                        })
-                    },
-                )
-                .try_join()
-                .await?,
+                .map(to_ecmascript_chunk_item)
+                .collect::<Result<Vec<_>>>()?,
             referenced_output_assets: referenced_output_assets.owned().await?,
         }
         .cell();

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/content.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/content.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::{
-    chunk::{ChunkItem, ChunkItemTy, ChunkItems},
+    chunk::{ChunkItem, ChunkItems},
     output::OutputAsset,
 };
 
@@ -20,13 +20,7 @@ impl EcmascriptChunkContent {
         Ok(ChunkItems(
             self.chunk_items
                 .iter()
-                .filter_map(|EcmascriptChunkItemWithAsyncInfo { ty, chunk_item, .. }| {
-                    if matches!(ty, ChunkItemTy::Included) {
-                        Some(chunk_item)
-                    } else {
-                        None
-                    }
-                })
+                .map(|EcmascriptChunkItemWithAsyncInfo { chunk_item, .. }| chunk_item)
                 .map(|item| ResolvedVc::upcast::<Box<dyn ChunkItem>>(*item))
                 .collect(),
         )

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -7,7 +7,7 @@ use turbo_tasks::{
 };
 use turbo_tasks_fs::{rope::Rope, FileSystemPath};
 use turbopack_core::{
-    chunk::{AsyncModuleInfo, ChunkItem, ChunkItemTy, ChunkingContext},
+    chunk::{AsyncModuleInfo, ChunkItem, ChunkingContext},
     code_builder::{Code, CodeBuilder},
     error::PrettyPrintError,
     issue::{code_gen::CodeGenerationIssue, IssueExt, IssueSeverity, StyledString},
@@ -188,7 +188,6 @@ pub struct EcmascriptChunkItemOptions {
     Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, TraceRawVcs, TaskInput, NonLocalValue,
 )]
 pub struct EcmascriptChunkItemWithAsyncInfo {
-    pub ty: ChunkItemTy,
     pub chunk_item: ResolvedVc<Box<dyn EcmascriptChunkItem>>,
     pub async_info: Option<ResolvedVc<AsyncModuleInfo>>,
 }

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -173,11 +173,6 @@ impl EcmascriptChunk {
     pub fn chunk_content(&self) -> Vc<EcmascriptChunkContent> {
         *self.content
     }
-
-    #[turbo_tasks::function]
-    pub async fn chunk_items_count(&self) -> Result<Vc<usize>> {
-        Ok(Vc::cell(self.content.await?.chunk_items.len()))
-    }
 }
 
 #[turbo_tasks::function]


### PR DESCRIPTION
### What?

The feature can be removed since it's no longer used.

Closes PACK-4002