### PR TITLE
[dev-overlay] use absolute font src url

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/font/font-styles.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/font/font-styles.tsx
@@ -11,7 +11,7 @@ export const FontStyles = () => {
         font-style: normal;
         font-weight: 400 600;
         font-display: swap;
-        src: url(__nextjs_font/geist-latin-ext.woff2) format('woff2');
+        src: url(/__nextjs_font/geist-latin-ext.woff2) format('woff2');
         unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7,
           U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F,
           U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F,
@@ -23,7 +23,7 @@ export const FontStyles = () => {
         font-style: normal;
         font-weight: 400 600;
         font-display: swap;
-        src: url(__nextjs_font/geist-mono-latin-ext.woff2) format('woff2');
+        src: url(/__nextjs_font/geist-mono-latin-ext.woff2) format('woff2');
         unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7,
           U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F,
           U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F,
@@ -35,7 +35,7 @@ export const FontStyles = () => {
         font-style: normal;
         font-weight: 400 600;
         font-display: swap;
-        src: url(__nextjs_font/geist-latin.woff2) format('woff2');
+        src: url(/__nextjs_font/geist-latin.woff2) format('woff2');
         unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
           U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
           U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
@@ -46,7 +46,7 @@ export const FontStyles = () => {
         font-style: normal;
         font-weight: 400 600;
         font-display: swap;
-        src: url(__nextjs_font/geist-mono-latin.woff2) format('woff2');
+        src: url(/__nextjs_font/geist-mono-latin.woff2) format('woff2');
         unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
           U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
           U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;


### PR DESCRIPTION
Fix font loading from a non-root URL:

Repro:
```
pnpm next dev test/development/app-dir/owner-stack/
```
and Visit http://localhost:3000/browser/uncaught

Shows
```
GET /browser/__nextjs_font/geist-latin.woff2 404 in 330ms
```