### PR TITLE
[dev-overlay] use unique font name

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/font/font-styles.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/font/font-styles.tsx
@@ -7,7 +7,7 @@ export const FontStyles = () => {
     style.textContent = css`
       /* latin-ext */
       @font-face {
-        font-family: 'Geist';
+        font-family: '__nextjs-Geist';
         font-style: normal;
         font-weight: 400 600;
         font-display: swap;
@@ -19,7 +19,7 @@ export const FontStyles = () => {
       }
       /* latin-ext */
       @font-face {
-        font-family: 'Geist Mono';
+        font-family: '__nextjs-Geist Mono';
         font-style: normal;
         font-weight: 400 600;
         font-display: swap;
@@ -31,7 +31,7 @@ export const FontStyles = () => {
       }
       /* latin */
       @font-face {
-        font-family: 'Geist';
+        font-family: '__nextjs-Geist';
         font-style: normal;
         font-weight: 400 600;
         font-display: swap;
@@ -42,7 +42,7 @@ export const FontStyles = () => {
       }
       /* latin */
       @font-face {
-        font-family: 'Geist Mono';
+        font-family: '__nextjs-Geist Mono';
         font-style: normal;
         font-weight: 400 600;
         font-display: swap;

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/styles/base.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/styles/base.tsx
@@ -46,9 +46,9 @@ export function Base() {
           --color-text-color-red-1: #ff5555;
           --color-text-background-red-1: #fff9f9;
 
-          --font-stack-monospace: 'Geist Mono', 'SFMono-Regular', Consolas,
-            'Liberation Mono', Menlo, Courier, monospace;
-          --font-stack-sans: 'Geist', -apple-system, 'Source Sans Pro',
+          --font-stack-monospace: '__nextjs-Geist Mono', 'SFMono-Regular',
+            Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+          --font-stack-sans: '__nextjs-Geist', -apple-system, 'Source Sans Pro',
             sans-serif;
 
           font-family: var(--font-stack-sans);


### PR DESCRIPTION
We [inject a style tag](https://github.com/vercel/next.js/pull/76225) that downloads Geist fonts from local file system. However, that style tag is injected to the main DOM because of an [issue](https://issues.chromium.org/issues/41085401) in Chrome that the fonts do not work in shadow DOM. We worry that this injected style would interfere with user's styles, or vice versa. Hence, we are going to name them with unique prefix to avoid most collision.