### PR TITLE
[dev-overlay] fix extraneous recoverable error

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
@@ -575,7 +575,7 @@ export default function HotReload({
   const shouldRenderErrorOverlay = useSyncExternalStore(
     () => () => {},
     () => !shouldRenderRootLevelErrorOverlay(),
-    () => true
+    () => false
   )
 
   const handleOnUnhandledError = useCallback(

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -219,7 +219,7 @@ describe('app-dir - server source maps', () => {
       // TODO(veil): Should be a single error
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 2,
+         "count": 1,
          "description": "Error: Boom",
          "environmentLabel": null,
          "label": "Unhandled Runtime Error",


### PR DESCRIPTION
We see an additional recoverable error `Switched to client rendering because the server rendering errored` when we render any suspense boundary inside `ShadowPortal`. Changing the default server snapshot to not render the dev overlay puts the render of dev overlay to an effect which somehow circumvents that recoverable error. This is a workaround.