### PR TITLE
[dev-overlay]: make open in editor button a separate click region

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/call-stack-frame/call-stack-frame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/call-stack-frame/call-stack-frame.tsx
@@ -38,34 +38,27 @@ export const CallStackFrame: React.FC<{
     return null
   }
 
-  const props = {
-    ...(hasSource && {
-      role: 'button',
-      tabIndex: 0,
-      'aria-label': 'Click to open in your editor',
-      title: 'Click to open in your editor',
-      onClick: open,
-    }),
-  }
-
   return (
     <div
       data-nextjs-call-stack-frame
       data-nextjs-call-stack-frame-ignored={!hasSource}
-      {...props}
       style={
         {
           '--index': index,
         } as React.CSSProperties
       }
     >
-      <span
+      <div
         data-nextjs-frame-expanded={!frame.ignored}
         className="call-stack-frame-method-name"
       >
         <HotlinkedText text={formattedMethod} />
-        {hasSource && <ExternalIcon width={16} height={16} />}
-      </span>
+        {hasSource && (
+          <button onClick={open} className="open-in-editor-button">
+            <ExternalIcon width={16} height={16} />
+          </button>
+        )}
+      </div>
       <span
         className="call-stack-frame-file-source"
         data-has-source={hasSource}
@@ -101,20 +94,6 @@ export const CALL_STACK_FRAME_STYLES = css`
     padding: 6px 8px;
 
     border-radius: var(--rounded-lg);
-    transition: background 100ms ease-out;
-
-    &:not(:disabled)[role='button']:hover {
-      background: var(--color-gray-alpha-100);
-      cursor: pointer;
-    }
-
-    &:not(:disabled)[role='button']:active {
-      background: var(--color-gray-alpha-200);
-    }
-
-    &:focus-visible {
-      outline: var(--focus-ring);
-    }
   }
 
   .call-stack-frame-method-name {
@@ -129,6 +108,24 @@ export const CALL_STACK_FRAME_STYLES = css`
     font-size: var(--size-font-small);
     font-weight: 500;
     line-height: var(--size-5);
+  }
+
+  .open-in-editor-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--rounded-full);
+    padding: 4px;
+    color: var(--color-font);
+
+    &:focus-visible {
+      outline: var(--focus-ring);
+      outline-offset: -2px;
+    }
+
+    &:hover {
+      background: var(--color-gray-100);
+    }
   }
 
   .call-stack-frame-file-source {

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/code-frame/code-frame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/code-frame/code-frame.tsx
@@ -64,7 +64,12 @@ export function CodeFrame({ stackFrame, codeFrame }: CodeFrameProps) {
   return (
     <div data-nextjs-codeframe>
       <div className="code-frame-header">
-        <div className="code-frame-link">
+        {/* TODO: This is <div> in `Terminal` component.
+        Changing now will require multiple test snapshots updates.
+        Leaving as <div> as is trivial and does not affect the UI.
+        Change when the new redbox matcher `toDisplayRedbox` is used.
+        */}
+        <p className="code-frame-link">
           <span className="code-frame-icon">
             <FileIcon lang={fileExtension} />
           </span>
@@ -81,7 +86,7 @@ export function CodeFrame({ stackFrame, codeFrame }: CodeFrameProps) {
               <ExternalIcon width={16} height={16} />
             </span>
           </button>
-        </div>
+        </p>
       </div>
       <pre className="code-frame-pre">
         {decoded.map((entry, index) => (

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/code-frame/code-frame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/code-frame/code-frame.tsx
@@ -63,24 +63,26 @@ export function CodeFrame({ stackFrame, codeFrame }: CodeFrameProps) {
   // TODO: make the caret absolute
   return (
     <div data-nextjs-codeframe>
-      <button
-        aria-label="Open error location in editor"
-        className="code-frame-header"
-        onClick={open}
-      >
-        <p className="code-frame-link">
-          <span className="code-frame-icon" data-icon="left">
+      <div className="code-frame-header">
+        <div className="code-frame-link">
+          <span className="code-frame-icon">
             <FileIcon lang={fileExtension} />
           </span>
           <span data-text>
             {getFrameSource(stackFrame)} @{' '}
             <HotlinkedText text={stackFrame.methodName} />
           </span>
-          <span className="code-frame-icon" data-icon="right">
-            <ExternalIcon width={16} height={16} />
-          </span>
-        </p>
-      </button>
+          <button
+            aria-label="Open in editor"
+            data-with-open-in-editor-link-source-file
+            onClick={open}
+          >
+            <span className="code-frame-icon" data-icon="right">
+              <ExternalIcon width={16} height={16} />
+            </span>
+          </button>
+        </div>
+      </div>
       <pre className="code-frame-pre">
         {decoded.map((entry, index) => (
           <span
@@ -140,11 +142,16 @@ export const CODE_FRAME_STYLES = css`
 
   .code-frame-header {
     width: 100%;
-    cursor: pointer;
     transition: background 100ms ease-out;
     border-radius: 8px 8px 0 0;
     border-bottom: 1px solid var(--color-gray-400);
+  }
 
+  [data-with-open-in-editor-link-source-file] {
+    padding: 4px;
+    margin: -4px 0 -4px auto;
+    border-radius: var(--rounded-full);
+    margin-left: auto;
     &:focus-visible {
       outline: var(--focus-ring);
       outline-offset: -2px;

--- a/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/terminal/terminal.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/_experimental/internal/components/terminal/terminal.tsx
@@ -93,12 +93,7 @@ export const Terminal: React.FC<TerminalProps> = function Terminal({
 
   return (
     <div data-nextjs-codeframe>
-      <button
-        aria-label="Open in editor"
-        className="code-frame-header"
-        data-with-open-in-editor-link-source-file
-        onClick={open}
-      >
+      <div className="code-frame-header">
         <div className="code-frame-link">
           <span className="code-frame-icon">
             <FileIcon lang={fileExtension} />
@@ -107,11 +102,17 @@ export const Terminal: React.FC<TerminalProps> = function Terminal({
             {/* TODO: Unlike the CodeFrame component, the `methodName` is unavailable. */}
             {getFrameSource(stackFrame)}
           </span>
-          <span className="code-frame-icon" data-icon="right">
-            <ExternalIcon width={16} height={16} />
-          </span>
+          <button
+            aria-label="Open in editor"
+            data-with-open-in-editor-link-source-file
+            onClick={open}
+          >
+            <span className="code-frame-icon" data-icon="right">
+              <ExternalIcon width={16} height={16} />
+            </span>
+          </button>
         </div>
-      </button>
+      </div>
       <pre className="code-frame-pre">
         {decoded.map((entry, index) => (
           <span


### PR DESCRIPTION
Currently the code frame/terminal headers are treated as a clickable region to open in your editor. However, the editor integration might not always work or be desired, and folks might instead want to copy the file path for other reasons. 

This moves the "open in editor" functionality to be a specific click area around the icon, removing interactivity from the header & call stack frames.


https://github.com/user-attachments/assets/e7e1c282-233f-4ca1-9668-f520f0b7bbe8



Closes NDX-794
Closes NDX-802