### PR TITLE
Disable turbo daemon by default

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -167,7 +167,7 @@ jobs:
       - run: rustc --version
         if: ${{ inputs.skipNativeBuild != 'yes' || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}
 
-      - run: corepack prepare --activate yarn@1.22.19 && npm i -g "turbo@${TURBO_VERSION}" "@napi-rs/cli@${NAPI_CLI_VERSION}"
+      - run: corepack prepare --activate yarn@1.22.19 && killall turbo && npm i -g "turbo@${TURBO_VERSION}" "@napi-rs/cli@${NAPI_CLI_VERSION}"
 
       - name: Cache on ${{ github.ref_name }}
         uses: ijjk/rust-cache@turbo-cache-v1.0.8

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -167,7 +167,7 @@ jobs:
       - run: rustc --version
         if: ${{ inputs.skipNativeBuild != 'yes' || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}
 
-      - run: corepack prepare --activate yarn@1.22.19 && killall turbo && npm i -g "turbo@${TURBO_VERSION}" "@napi-rs/cli@${NAPI_CLI_VERSION}"
+      - run: corepack prepare --activate yarn@1.22.19 && (killall turbo || echo 'no turbo') && npm i -g "turbo@${TURBO_VERSION}" "@napi-rs/cli@${NAPI_CLI_VERSION}"
 
       - name: Cache on ${{ github.ref_name }}
         uses: ijjk/rust-cache@turbo-cache-v1.0.8

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turborepo.org/schema.json",
   "globalEnv": ["NEXT_CI_RUNNER"],
+  "daemon": false,
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
This attempts to resolve turbo global failing to install sometimes which current hypothesis is that the turbo process is still running preventing the directory from being wiped/written to. 

x-ref: [slack thread](https://vercel.slack.com/archives/C04KC8A53T7/p1740004625721209)
x-ref: https://github.com/vercel/next.js/actions/runs/13423189899/job/37500545320?pr=76239