### PR TITLE
[dev-overlay] clean up `__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY` feature flag

### DIFF
--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -289,8 +289,6 @@ export function getDefineEnv({
             needsExperimentalReact(config),
         }
       : undefined),
-    'process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY':
-      config.experimental.newDevOverlay || false,
   }
 
   const userDefines = config.compiler?.define ?? {}

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -955,10 +955,6 @@ function assignDefaults(
     result.experimental = {}
   }
 
-  // TODO(jiwon): remove once we've made new UI default
-  if (process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'false') {
-    result.experimental.newDevOverlay = false
-  }
   // Preserve the default indicator options for old overlay.
   if (result.experimental.newDevOverlay !== true) {
     // If the user didn't explicitly set `position` or `buildActivityPosition` option,

--- a/run-tests.js
+++ b/run-tests.js
@@ -50,12 +50,6 @@ const ENDGROUP = process.env.CI ? '##[endgroup]' : ''
 
 const externalTestsFilter = getTestFilter()
 
-// TODO(new-dev-overlay): Remove this once old dev overlay fork is removed
-if (!process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY) {
-  console.log('Setting __NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY to true')
-  process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY = 'true'
-}
-
 const timings = []
 const DEFAULT_NUM_RETRIES = 2
 const DEFAULT_CONCURRENCY = 2

--- a/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
+++ b/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
@@ -11,8 +11,6 @@ describe('error-ignored-frames', () => {
   })
 
   if (
-    // TODO(new-dev-overlay): Remove this once old dev overlay fork is removed
-    process.env.__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY === 'true' ||
     // Skip react 18 test as the call stacks are different
     process.env.NEXT_TEST_REACT_VERSION === '18.3.1'
   ) {
@@ -108,8 +106,8 @@ describe('error-ignored-frames', () => {
     } else {
       expect(expendedStack).toMatchInlineSnapshot(`
        "at eval (app/interleaved/page.tsx (7:11))
-       at invokeCallback (node_modules/interleave/index.js (2:1))
        at Page (app/interleaved/page.tsx (6:36))
+       at invokeCallback (node_modules/interleave/index.js (2:1))
        at ClientPageRoot (../src/client/components/client-page.tsx (60:12))"
       `)
     }


### PR DESCRIPTION
This PR cleaned up the `__NEXT_EXPERIMENTAL_NEW_DEV_OVERLAY` feature flag and its assertions.