### PR TITLE
Unflake `ppr-full` tests

### DIFF
--- a/test/e2e/app-dir/ppr-full/app/dynamic-data/force-static/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/dynamic-data/force-static/page.jsx
@@ -3,7 +3,7 @@ import { Optimistic } from '../../../components/optimistic'
 import { ServerHtml } from '../../../components/server-html'
 
 export const dynamic = 'force-static'
-export const revalidate = 60
+export const revalidate = 120
 
 export default async (props) => {
   const searchParams = await props.searchParams

--- a/test/e2e/app-dir/ppr-full/app/dynamic/force-static/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/dynamic/force-static/page.jsx
@@ -2,7 +2,7 @@ import React, { Suspense } from 'react'
 import { Dynamic } from '../../../components/dynamic'
 
 export const dynamic = 'force-static'
-export const revalidate = 60
+export const revalidate = 120
 
 export default () => {
   return (

--- a/test/e2e/app-dir/ppr-full/app/loading/[slug]/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/loading/[slug]/page.jsx
@@ -1,7 +1,7 @@
 import React, { Suspense } from 'react'
 import { Dynamic } from '../../../components/dynamic'
 
-export const revalidate = 60
+export const revalidate = 120
 
 export default async (props) => {
   const params = await props.params

--- a/test/e2e/app-dir/ppr-full/app/metadata/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/metadata/page.jsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { Dynamic } from '../../components/dynamic'
 import { unstable_noStore } from 'next/cache'
 
-export const revalidate = 60
+export const revalidate = 120
 
 export async function generateMetadata() {
   unstable_noStore()

--- a/test/e2e/app-dir/ppr-full/app/nested/[slug]/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/nested/[slug]/page.jsx
@@ -1,7 +1,7 @@
 import React, { Suspense } from 'react'
 import { Dynamic } from '../../../components/dynamic'
 
-export const revalidate = 60
+export const revalidate = 120
 
 export default async (props) => {
   const params = await props.params

--- a/test/e2e/app-dir/ppr-full/ppr-full.test.ts
+++ b/test/e2e/app-dir/ppr-full/ppr-full.test.ts
@@ -20,16 +20,16 @@ type Page = {
 
 const pages: Page[] = [
   { pathname: '/', dynamic: true },
-  { pathname: '/nested/a', dynamic: true, revalidate: 60 },
-  { pathname: '/nested/b', dynamic: true, revalidate: 60 },
-  { pathname: '/nested/c', dynamic: true, revalidate: 60 },
-  { pathname: '/metadata', dynamic: true, revalidate: 60 },
+  { pathname: '/nested/a', dynamic: true, revalidate: 120 },
+  { pathname: '/nested/b', dynamic: true, revalidate: 120 },
+  { pathname: '/nested/c', dynamic: true, revalidate: 120 },
+  { pathname: '/metadata', dynamic: true, revalidate: 120 },
   { pathname: '/on-demand/a', dynamic: true },
   { pathname: '/on-demand/b', dynamic: true },
   { pathname: '/on-demand/c', dynamic: true },
-  { pathname: '/loading/a', dynamic: true, revalidate: 60 },
-  { pathname: '/loading/b', dynamic: true, revalidate: 60 },
-  { pathname: '/loading/c', dynamic: true, revalidate: 60 },
+  { pathname: '/loading/a', dynamic: true, revalidate: 120 },
+  { pathname: '/loading/b', dynamic: true, revalidate: 120 },
+  { pathname: '/loading/c', dynamic: true, revalidate: 120 },
   { pathname: '/static', dynamic: false },
   { pathname: '/no-suspense', dynamic: true, emptyStaticPart: true },
   { pathname: '/no-suspense/nested/a', dynamic: true, emptyStaticPart: true },
@@ -42,7 +42,7 @@ const pages: Page[] = [
   {
     pathname: '/dynamic/force-static',
     dynamic: 'force-static',
-    revalidate: 60,
+    revalidate: 120,
   },
 ]
 
@@ -154,7 +154,7 @@ describe('ppr-full', () => {
           }
         })
 
-        if (dynamic === true && !isNextDev) {
+        if (dynamic === true && !isNextDev && !isNextDeploy) {
           it('should cache the static part', async () => {
             const delay = 500
 
@@ -618,7 +618,7 @@ describe('ppr-full', () => {
           }
         })
 
-        if (pathname.endsWith('/dynamic')) {
+        if (pathname.endsWith('/dynamic') && !isNextDeploy) {
           it('should cache the static part', async () => {
             const {
               timings: { streamFirstChunk, streamEnd, start },


### PR DESCRIPTION
[flakiness metric](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20env%3Aci%20%40git.repository.id%3Agithub.com%2Fvercel%2Fnext.js%20%40test.service%3Anextjs%20%40test.status%3Afail%20%40test.name%3A%2Appr-full%2A%20%28-%40git.branch%3A%2A%3F%2A%20OR%20%40git.branch%3Acanary%29&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=timestamp%2Casc&cols=%40test.status%2Ctimestamp%2C%40test.suite%3A83%2C%40test.name%3A607%2C%40git.branch&currentTab=overview&eventStack=&fromUser=false&graphType=flamegraph&index=citest&start=1737457116609&end=1740049116609&paused=false)

This attempts to fix the flakiness of two things in the `ppr-full` test suite (there might be more):

- Omit tests that rely on a route shell being cached from deploy tests, similar to #72428.
- Increase revalidate times from 60 to 120 to avoid the headers tests from receiving a `STALE` response instead of the expected `HIT` response.