### PR TITLE
[dev-overlay] Isolate overlay from user space Components

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/app/app-dev-overlay-error-boundary.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/app-dev-overlay-error-boundary.tsx
@@ -5,7 +5,6 @@ import { RuntimeErrorHandler } from '../../errors/runtime-error-handler'
 
 type AppDevOverlayErrorBoundaryProps = {
   children: React.ReactNode
-  devOverlay: React.ReactNode
   globalError: [GlobalErrorComponent, React.ReactNode]
   onError: (value: boolean) => void
 }
@@ -62,18 +61,13 @@ export class AppDevOverlayErrorBoundary extends PureComponent<
   }
 
   render() {
-    const { children, globalError, devOverlay } = this.props
+    const { children, globalError } = this.props
     const { isReactError, reactError } = this.state
 
     const fallback = (
       <ErroredHtml globalError={globalError} error={reactError} />
     )
 
-    return (
-      <>
-        {isReactError ? fallback : children}
-        {devOverlay}
-      </>
-    )
+    return isReactError ? fallback : children
   }
 }

--- a/packages/next/src/client/components/react-dev-overlay/app/app-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/app-dev-overlay.tsx
@@ -16,8 +16,16 @@ export function AppDevOverlay({
   children: React.ReactNode
 }) {
   const [isErrorOverlayOpen, setIsErrorOverlayOpen] = useState(false)
-  const devOverlay = (
+
+  return (
     <>
+      <AppDevOverlayErrorBoundary
+        globalError={globalError}
+        onError={setIsErrorOverlayOpen}
+      >
+        {children}
+      </AppDevOverlayErrorBoundary>
+
       {/* Fonts can only be loaded outside the Shadow DOM. */}
       <FontStyles />
       <DevOverlay
@@ -26,15 +34,5 @@ export function AppDevOverlay({
         setIsErrorOverlayOpen={setIsErrorOverlayOpen}
       />
     </>
-  )
-
-  return (
-    <AppDevOverlayErrorBoundary
-      devOverlay={devOverlay}
-      globalError={globalError}
-      onError={setIsErrorOverlayOpen}
-    >
-      {children}
-    </AppDevOverlayErrorBoundary>
   )
 }

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay/error-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay/error-overlay.tsx
@@ -1,5 +1,6 @@
 import type { OverlayState } from '../../../../shared'
 
+import { Suspense } from 'react'
 import { BuildError } from '../../../container/build-error'
 import { Errors } from '../../../container/errors'
 import { RootLayoutMissingTagsError } from '../../../container/root-layout-missing-tags-error'
@@ -64,11 +65,15 @@ export function ErrorOverlay({
 
   // No Runtime Errors.
   if (!runtimeErrors.length) {
-    return null
+    // Workaround React quirk that triggers "Switch to client-side rendering" if
+    // we return no Suspense boundary here.
+    return <Suspense />
   }
 
   if (!mounted) {
-    return null
+    // Workaround React quirk that triggers "Switch to client-side rendering" if
+    // we return no Suspense boundary here.
+    return <Suspense />
   }
 
   return (

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -216,7 +216,7 @@ describe('Error overlay for hydration errors in App router', () => {
        "...
            <HotReload assetPrefix="" globalError={[...]}>
              <AppDevOverlay state={{nextId:1, ...}} globalError={[...]}>
-               <AppDevOverlayErrorBoundary devOverlay={<Fragment>} globalError={[...]} onError={function bound dispatchSetState}>
+               <AppDevOverlayErrorBoundary globalError={[...]} onError={function bound dispatchSetState}>
                  <DevRootHTTPAccessFallbackBoundary>
                    <HTTPAccessFallbackBoundary notFound={<NotAllowedRootHTTPFallbackError>}>
                      <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<NotAllowedRootHTTPFallbackError>} ...>
@@ -232,14 +232,14 @@ describe('Error overlay for hydration errors in App router', () => {
        -                         className="server-html"
                                >
                            ...
-                 ..."
+               ..."
       `)
     } else {
       expect(pseudoHtml).toMatchInlineSnapshot(`
        "...
            <HotReload assetPrefix="" globalError={[...]}>
              <AppDevOverlay state={{nextId:1, ...}} globalError={[...]}>
-               <AppDevOverlayErrorBoundary devOverlay={<Fragment>} globalError={[...]} onError={function bound dispatchSetState}>
+               <AppDevOverlayErrorBoundary globalError={[...]} onError={function bound dispatchSetState}>
                  <DevRootHTTPAccessFallbackBoundary>
                    <HTTPAccessFallbackBoundary notFound={<NotAllowedRootHTTPFallbackError>}>
                      <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<NotAllowedRootHTTPFallbackError>} ...>
@@ -252,7 +252,7 @@ describe('Error overlay for hydration errors in App router', () => {
        -                         className="server-html"
                                >
                            ...
-                 ..."
+               ..."
       `)
     }
 

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -216,10 +216,9 @@ describe('app-dir - server source maps', () => {
       )
       expect(cliOutput).toMatch(/digest: '\d+'/)
 
-      // TODO(veil): Should be a single error
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 2,
+         "count": 1,
          "description": "Error: Boom",
          "environmentLabel": null,
          "label": "Unhandled Runtime Error",


### PR DESCRIPTION
Fixes an erroneous "Switched to client rendering" error due to a React quirk when new Suspense boundaries are rendered.

React bug: https://github.com/facebook/react/pull/32436