### PR TITLE
[metadata] fix streaming metadata triggering error boundaries

### DIFF
--- a/packages/next/src/client/components/http-access-fallback/error-boundary.tsx
+++ b/packages/next/src/client/components/http-access-fallback/error-boundary.tsx
@@ -136,7 +136,7 @@ class HTTPAccessFallbackErrorBoundary extends React.Component<
           <meta name="robots" content="noindex" />
           {process.env.NODE_ENV === 'development' && (
             <meta
-              name="next-error"
+              name="boundary-next-error"
               content={getAccessFallbackErrorTypeByStatus(triggeredStatus)}
             />
           )}

--- a/packages/next/src/lib/metadata/async-metadata.tsx
+++ b/packages/next/src/lib/metadata/async-metadata.tsx
@@ -27,7 +27,10 @@ function BrowserResolvedMetadata({
 }: {
   promise: Promise<StreamingMetadataResolvedState>
 }) {
-  const { metadata } = use(promise)
+  const { metadata, error } = use(promise)
+  // If there's metadata error on client, discard the browser metadata
+  // and let metadata outlet deal with the error. This will avoid the duplication metadata.
+  if (error) return null
   return metadata
 }
 

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -522,7 +522,11 @@ async function createComponentTreeInternal({
             preloadCallbacks,
             authInterrupts,
             StreamingMetadata,
-            StreamingMetadataOutlet,
+            // `StreamingMetadataOutlet` is used to conditionally throw. In the case of parallel routes we will have more than one page
+            // but we only want to throw on the first one.
+            StreamingMetadataOutlet: isChildrenRouteKey
+              ? StreamingMetadataOutlet
+              : () => null,
           })
 
           childCacheNodeSeedData = seedData
@@ -709,8 +713,12 @@ async function createComponentTreeInternal({
         {layerAssets}
         <OutletBoundary>
           <MetadataOutlet ready={getViewportReady} />
+          {/* Blocking metadata outlet */}
           <MetadataOutlet ready={getMetadataReady} />
-          <StreamingMetadataOutlet />
+          {/* Streaming metadata outlet */}
+          {actualSegment !== DEFAULT_SEGMENT_KEY ? (
+            <StreamingMetadataOutlet />
+          ) : undefined}
         </OutletBoundary>
       </React.Fragment>,
       parallelRouteCacheNodeSeedData,

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -93,7 +93,7 @@ async function createComponentTreeInternal({
   preloadCallbacks: PreloadCallbacks
   authInterrupts: boolean
   StreamingMetadata: React.ComponentType<{}> | null
-  StreamingMetadataOutlet: React.ComponentType
+  StreamingMetadataOutlet: React.ComponentType | null
 }): Promise<CacheNodeSeedData> {
   const {
     renderOpts: { nextConfigOutput, experimental },
@@ -397,9 +397,15 @@ async function createComponentTreeInternal({
 
   // Only render metadata on the actual SSR'd segment not the `default` segment,
   // as it's used as a placeholder for navigation.
+  const isNotDefaultSegment = actualSegment !== DEFAULT_SEGMENT_KEY
+
   const metadata =
-    actualSegment !== DEFAULT_SEGMENT_KEY && StreamingMetadata ? (
-      <StreamingMetadata />
+    isNotDefaultSegment && StreamingMetadata ? <StreamingMetadata /> : undefined
+
+  // Use the same condition to render metadataOutlet as metadata
+  const metadataOutlet =
+    isNotDefaultSegment && StreamingMetadataOutlet ? (
+      <StreamingMetadataOutlet />
     ) : undefined
 
   const notFoundElement = NotFound ? (
@@ -526,7 +532,7 @@ async function createComponentTreeInternal({
             // but we only want to throw on the first one.
             StreamingMetadataOutlet: isChildrenRouteKey
               ? StreamingMetadataOutlet
-              : () => null,
+              : null,
           })
 
           childCacheNodeSeedData = seedData
@@ -716,9 +722,7 @@ async function createComponentTreeInternal({
           {/* Blocking metadata outlet */}
           <MetadataOutlet ready={getMetadataReady} />
           {/* Streaming metadata outlet */}
-          {actualSegment !== DEFAULT_SEGMENT_KEY ? (
-            <StreamingMetadataOutlet />
-          ) : undefined}
+          {metadataOutlet}
         </OutletBoundary>
       </React.Fragment>,
       parallelRouteCacheNodeSeedData,

--- a/test/e2e/app-dir/metadata-streaming/app/notfound/boundary/not-found.tsx
+++ b/test/e2e/app-dir/metadata-streaming/app/notfound/boundary/not-found.tsx
@@ -1,0 +1,7 @@
+export default function NotFound() {
+  return <h1>Custom Not Found</h1>
+}
+
+export const metadata = {
+  title: 'notfound title',
+}

--- a/test/e2e/app-dir/metadata-streaming/app/notfound/boundary/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming/app/notfound/boundary/page.tsx
@@ -2,12 +2,12 @@ import { connection } from 'next/server'
 import { notFound } from 'next/navigation'
 
 export default function Page() {
-  return <p>boundary notfound page</p>
+  return <p>notfound page</p>
 }
 
 export async function generateMetadata() {
   await connection()
-  await new Promise((resolve) => setTimeout(resolve, 500))
+  await new Promise((resolve) => setTimeout(resolve, 2 * 1000))
   notFound()
 }
 

--- a/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
+++ b/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
@@ -121,6 +121,19 @@ describe('app-dir - metadata-streaming', () => {
       expect(await browser.elementByCss('p').text()).toBe('index page')
     })
 
+    it('should trigger custom not-found in the boundary', async () => {
+      const browser = await next.browser('/notfound/boundary')
+
+      expect(await browser.elementByCss('h1').text()).toBe('Custom Not Found')
+    })
+
+    it('should not duplicate metadata with navigation API', async () => {
+      const browser = await next.browser('/notfound/boundary')
+
+      const titleTags = await browser.elementsByCss('title')
+      expect(titleTags.length).toBe(1)
+    })
+
     it('should render blocking 404 response status when html limited bots access notFound', async () => {
       const { status } = await next.fetch('/notfound', {
         headers: {


### PR DESCRIPTION
### What

Found out the error boundary was not triggering the correct error boundary and when the not-found error boundary gets triggered the not-found metadata might get rendered twice. These bugs are discovered while enabling streamingMetadata by default in #76221 

### Why

* When we stream the metadata and it encounters a navigation error, we don't need to inject it again on client side as the navigation error was handled on server side already. So we skip the browser metadata when encounter error. This would avoid the duplication.
* When we pass down the `StreamingMetadataOutlet` down to the parallel routes layout router, it shouldn't only render in the 1st one like our existing metadata outlet. This can ensure we hit the correct error boundary