### PR TITLE
Revert null check in mountLinkInstance

### DIFF
--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -245,9 +245,6 @@ function mountLinkInstance(
   router: AppRouterInstance,
   kind: PrefetchKind.AUTO | PrefetchKind.FULL
 ) {
-  // element can be falsy which can break WeakMap and observing
-  if (!element) return
-
   let prefetchUrl: URL | null = null
   try {
     prefetchUrl = createPrefetchURL(href)


### PR DESCRIPTION
This null check was added as an incidental change in #75981 but I'm not convinced it's actually necessary. Even if it is, it needs to be fixed in the caller, because it means the type is incorrect.

I have a suspicion that it was added before the fix to `useMergedRef` landed here: https://github.com/vercel/next.js/pull/75088

If it turns out that this argument is still sometimes `null`, it suggests that there's  a bug in `useMergedRef` and we need to fix it there.