### PR TITLE
Add canary warning for node middleware

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -647,5 +647,6 @@
   "646": "No span found for compilation",
   "647": "@rspack/core is not available. Please make sure `@next/plugin-rspack` is correctly installed.",
   "648": "@rspack/plugin-react-refresh is not available. Please make sure `@next/plugin-rspack` is correctly installed.",
-  "649": "Cache handlers not initialized"
+  "649": "Cache handlers not initialized",
+  "650": "experimental.nodeMiddleware"
 }

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -255,6 +255,8 @@ function assignDefaults(
       throw new CanaryOnlyError('experimental.dynamicIO')
     } else if (result.experimental?.turbo?.unstablePersistentCaching) {
       throw new CanaryOnlyError('experimental.turbo.unstablePersistentCaching')
+    } else if (result.experimental?.nodeMiddleware) {
+      throw new CanaryOnlyError('experimental.nodeMiddleware')
     }
   }
 


### PR DESCRIPTION
This matches our PPR warning for node middleware while we experiment/validate it further. 