### PR TITLE
Ensure middleware layer is applied for node

### DIFF
--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -407,7 +407,10 @@ export function getEdgeServerEntry(opts: {
       ).toString('base64'),
     }
 
-    return `next-middleware-loader?${stringify(loaderParams)}!`
+    return {
+      import: `next-middleware-loader?${stringify(loaderParams)}!`,
+      layer: WEBPACK_LAYERS.middleware,
+    }
   }
 
   if (isAPIRoute(opts.page)) {

--- a/test/e2e/middleware-general/app/lib/some-data.js
+++ b/test/e2e/middleware-general/app/lib/some-data.js
@@ -1,0 +1,5 @@
+import 'server-only'
+
+export async function getSomeData() {
+  return 'some data'
+}

--- a/test/e2e/middleware-general/app/middleware-node.js
+++ b/test/e2e/middleware-general/app/middleware-node.js
@@ -1,5 +1,6 @@
 /* global globalThis */
 import { NextRequest, NextResponse } from 'next/server'
+import { getSomeData } from './lib/some-data'
 import magicValue from 'shared-package'
 
 export const config = {
@@ -24,6 +25,8 @@ const params = (url) => {
 }
 
 export async function middleware(request) {
+  getSomeData()
+
   const url = request.nextUrl
 
   if (process.env.NEXT_RUNTIME === 'nodejs') {

--- a/test/e2e/middleware-general/app/middleware.js
+++ b/test/e2e/middleware-general/app/middleware.js
@@ -1,5 +1,6 @@
 /* global globalThis */
 import { NextRequest, NextResponse, URLPattern } from 'next/server'
+import { getSomeData } from './lib/some-data'
 import magicValue from 'shared-package'
 
 export const config = {
@@ -38,6 +39,8 @@ const params = (url) => {
 }
 
 export async function middleware(request) {
+  getSomeData()
+
   const url = request.nextUrl
 
   if (request.headers.get('x-prerender-revalidate')) {

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -37,6 +37,7 @@ describe('Middleware Runtime', () => {
               isNodeMiddleware ? 'middleware-node.js' : 'middleware.js'
             )
           ),
+          lib: new FileRef(join(__dirname, '../api/lib')),
           pages: new FileRef(join(__dirname, '../app/pages')),
           'shared-package': new FileRef(
             join(__dirname, '../app/node_modules/shared-package')

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -37,7 +37,7 @@ describe('Middleware Runtime', () => {
               isNodeMiddleware ? 'middleware-node.js' : 'middleware.js'
             )
           ),
-          lib: new FileRef(join(__dirname, '../api/lib')),
+          lib: new FileRef(join(__dirname, '../app/lib')),
           pages: new FileRef(join(__dirname, '../app/pages')),
           'shared-package': new FileRef(
             join(__dirname, '../app/node_modules/shared-package')


### PR DESCRIPTION
This ensures we apply the middleware layer when in the node runtime so that `server-only` imports are properly handled. Also ensures our test suite includes this condition for `edge` and `node` runtimes. 

Fixes: https://github.com/vercel/next.js/issues/75904 