### PR TITLE
[errors]: default export error should distinguish between layout/page

### DIFF
--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -178,7 +178,7 @@ async function createComponentTreeInternal({
 
   const isLayout = typeof layout !== 'undefined'
   const isPage = typeof page !== 'undefined'
-  const { mod: layoutOrPageMod } = await getTracer().trace(
+  const { mod: layoutOrPageMod, modType } = await getTracer().trace(
     NextNodeServerSpan.getLayoutOrPageModule,
     {
       hideSpan: !(isLayout || isPage),
@@ -347,10 +347,10 @@ async function createComponentTreeInternal({
   if (process.env.NODE_ENV === 'development') {
     const { isValidElementType } = require('next/dist/compiled/react-is')
     if (
-      (isPage || typeof MaybeComponent !== 'undefined') &&
+      typeof MaybeComponent !== 'undefined' &&
       !isValidElementType(MaybeComponent)
     ) {
-      errorMissingDefaultExport(pagePath, 'page')
+      errorMissingDefaultExport(pagePath, modType ?? 'page')
     }
 
     if (

--- a/test/development/acceptance-app/undefined-default-export.test.ts
+++ b/test/development/acceptance-app/undefined-default-export.test.ts
@@ -23,6 +23,25 @@ describe('Undefined default export', () => {
     )
   })
 
+  it('should error if layout component does not have default export', async () => {
+    await using sandbox = await createSandbox(
+      next,
+      new Map([
+        ['app/(group)/specific-path/server/layout.js', 'export const a = 123'],
+        [
+          'app/(group)/specific-path/server/page.js',
+          'export default function Page() { return <div>Hello</div> }',
+        ],
+      ]),
+      '/specific-path/server'
+    )
+    const { session } = sandbox
+    await session.assertHasRedbox()
+    expect(await session.getRedboxDescription()).toInclude(
+      'The default export is not a React Component in "/specific-path/server/layout"'
+    )
+  })
+
   it('should error if not-found component does not have default export when trigger not-found boundary', async () => {
     await using sandbox = await createSandbox(
       next,


### PR DESCRIPTION
When you forget to export a component in the layout, the error message points you to the page component, which is confusing.

This ensures the error points to the module that's missing the export. 

Closes NDX-874