### PR TITLE
Update error-recovery test snapshots for alternative bundler

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -382,6 +382,7 @@ jobs:
     with:
       afterBuild: node scripts/test-new-tests.mjs --flake-detection --mode dev --group ${{ matrix.group }}
       stepName: 'test-new-tests-dev-${{matrix.group}}'
+      timeout_minutes: 60 # Increase the default timeout as tests are intentionally run multiple times to detect flakes
 
     secrets: inherit
 
@@ -399,6 +400,7 @@ jobs:
     with:
       afterBuild: node scripts/test-new-tests.mjs --flake-detection --mode start --group ${{ matrix.group }}
       stepName: 'test-new-tests-start-${{matrix.group}}'
+      timeout_minutes: 60 # Increase the default timeout as tests are intentionally run multiple times to detect flakes
 
     secrets: inherit
 

--- a/test/development/basic/hmr/error-recovery.test.ts
+++ b/test/development/basic/hmr/error-recovery.test.ts
@@ -10,6 +10,7 @@ import {
   renderViaHTTP,
   retry,
   waitFor,
+  trimEndMultiline,
 } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 import { outdent } from 'outdent'
@@ -169,31 +170,8 @@ describe.each([
       const source = next.normalizeTestDirContent(
         await getRedboxSource(browser)
       )
-      if (basePath === '' && !process.env.TURBOPACK) {
-        expect(source).toMatchInlineSnapshot(`
-          "./pages/hmr/about2.js
-          Error:   x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
-             ,-[7:1]
-           4 |       <p>This is the about page.</p>
-           5 |     div
-           6 |   )
-           7 | }
-             : ^
-             \`----
-            x Unexpected eof
-             ,-[7:3]
-           5 |     div
-           6 |   )
-           7 | }
-             \`----
 
-          Caused by:
-              Syntax Error
-
-          Import trace for requested module:
-          ./pages/hmr/about2.js"
-        `)
-      } else if (basePath === '' && process.env.TURBOPACK) {
+      if (basePath === '' && process.env.TURBOPACK) {
         expect(source).toMatchInlineSnapshot(`
          "./pages/hmr/about2.js (7:1)
          Parsing ecmascript source code failed
@@ -205,7 +183,34 @@ describe.each([
 
          Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?"
         `)
-      } else if (basePath === '/docs' && !process.env.TURBOPACK) {
+      } else if (basePath === '' && process.env.NEXT_RSPACK) {
+        expect(trimEndMultiline(source)).toMatchInlineSnapshot(`
+         "./pages/hmr/about2.js
+           × Module build failed:
+           ├─▶   ×
+           │     │   x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
+           │     │    ,-[TEST_DIR/pages/hmr/about2.js:7:1]
+           │     │  4 |       <p>This is the about page.</p>
+           │     │  5 |     div
+           │     │  6 |   )
+           │     │  7 | }
+           │     │    : ^
+           │     │    \`----
+           │     │
+           │     │   x Unexpected eof
+           │     │    ,-[TEST_DIR/pages/hmr/about2.js:7:3]
+           │     │  5 |     div
+           │     │  6 |   )
+           │     │  7 | }
+           │     │    \`----
+           │     │
+           │
+           ╰─▶ Syntax Error
+
+         Import trace for requested module:
+         ./pages/hmr/about2.js"
+        `)
+      } else if (basePath === '') {
         expect(source).toMatchInlineSnapshot(`
           "./pages/hmr/about2.js
           Error:   x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
@@ -241,6 +246,57 @@ describe.each([
 
             Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?"
           `)
+      } else if (basePath === '/docs' && process.env.NEXT_RSPACK) {
+        expect(trimEndMultiline(source)).toMatchInlineSnapshot(`
+         "./pages/hmr/about2.js
+           × Module build failed:
+           ├─▶   ×
+           │     │   x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
+           │     │    ,-[TEST_DIR/pages/hmr/about2.js:7:1]
+           │     │  4 |       <p>This is the about page.</p>
+           │     │  5 |     div
+           │     │  6 |   )
+           │     │  7 | }
+           │     │    : ^
+           │     │    \`----
+           │     │
+           │     │   x Unexpected eof
+           │     │    ,-[TEST_DIR/pages/hmr/about2.js:7:3]
+           │     │  5 |     div
+           │     │  6 |   )
+           │     │  7 | }
+           │     │    \`----
+           │     │
+           │
+           ╰─▶ Syntax Error
+
+         Import trace for requested module:
+         ./pages/hmr/about2.js"
+        `)
+      } else if (basePath === '/docs') {
+        expect(source).toMatchInlineSnapshot(`
+          "./pages/hmr/about2.js
+          Error:   x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
+             ,-[7:1]
+           4 |       <p>This is the about page.</p>
+           5 |     div
+           6 |   )
+           7 | }
+             : ^
+             \`----
+            x Unexpected eof
+             ,-[7:3]
+           5 |     div
+           6 |   )
+           7 | }
+             \`----
+
+          Caused by:
+              Syntax Error
+
+          Import trace for requested module:
+          ./pages/hmr/about2.js"
+        `)
       }
 
       await next.patchFile(aboutPage, aboutContent)
@@ -529,6 +585,28 @@ describe.each([
 
               Read more: https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders"
             `)
+        } else if (process.env.NEXT_RSPACK) {
+          expect(trimEndMultiline(await getRedboxSource(browser)))
+            .toMatchInlineSnapshot(`
+           "./components/parse-error.xyz
+             × Module parse failed:
+             ╰─▶   × JavaScript parsing error: Expression expected
+                    ╭─[3:0]
+                  1 │ This
+                  2 │ is
+                  3 │ }}}
+                    · ─
+                  4 │ invalid
+                  5 │ js
+                    ╰────
+
+             help:
+                   You may need an appropriate loader to handle this file type.
+
+           Import trace for requested module:
+           ./components/parse-error.xyz
+           ./pages/hmr/about8.js"
+          `)
         } else {
           expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
                       "./components/parse-error.xyz
@@ -545,6 +623,7 @@ describe.each([
                       ./pages/hmr/about8.js"
                   `)
         }
+
         await next.patchFile(aboutPage, aboutContent)
 
         await retry(async () => {
@@ -604,6 +683,29 @@ describe.each([
              5 | js
 
            Expression expected"
+          `)
+        } else if (process.env.NEXT_RSPACK) {
+          expect(trimEndMultiline(next.normalizeTestDirContent(redboxSource)))
+            .toMatchInlineSnapshot(`
+           "./components/parse-error.js
+             × Module build failed:
+             ├─▶   ×
+             │     │   x Expression expected
+             │     │    ,-[./components/parse-error.js:3:1]
+             │     │  1 | This
+             │     │  2 | is
+             │     │  3 | }}}
+             │     │    : ^
+             │     │  4 | invalid
+             │     │  5 | js
+             │     │    \`----
+             │     │
+             │
+             ╰─▶ Syntax Error
+
+           Import trace for requested module:
+           ./components/parse-error.js
+           ./pages/hmr/about9.js"
           `)
         } else {
           redboxSource = redboxSource.substring(

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1740,3 +1740,10 @@ export async function getHighlightedDiffLines(
     ])
   )
 }
+
+export function trimEndMultiline(str: string) {
+  return str
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .join('\n')
+}


### PR DESCRIPTION
Passes an additional 4 tests for Rspack. Rspack error messages included trailing whitespace when written to the DOM, so these are stripped out.


Closes PACK-4016