### PR TITLE
feat: option to disable next types plugin

### DIFF
--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -466,7 +466,10 @@ function createServer(
     'typescript' in options &&
     'version' in (options as any).typescript
   ) {
-    return require('./next-typescript').createTSPlugin(options)
+    const pluginMod: typeof import('./next-typescript') = require('./next-typescript')
+    return pluginMod.createTSPlugin(
+      options as any
+    ) as unknown as NextWrapperServer
   }
 
   if (options == null) {

--- a/packages/next/src/server/typescript/index.ts
+++ b/packages/next/src/server/typescript/index.ts
@@ -28,6 +28,10 @@ import metadata from './rules/metadata'
 import errorEntry from './rules/error'
 import type tsModule from 'typescript/lib/tsserverlibrary'
 
+type NextTypePluginOptions = {
+  enabled?: boolean
+}
+
 export const createTSPlugin: tsModule.server.PluginModuleFactory = ({
   typescript: ts,
 }) => {
@@ -42,6 +46,13 @@ export const createTSPlugin: tsModule.server.PluginModuleFactory = ({
     for (let k of Object.keys(info.languageService)) {
       const x = (info.languageService as any)[k]
       proxy[k] = (...args: Array<{}>) => x.apply(info.languageService, args)
+    }
+
+    const pluginOptions: NextTypePluginOptions = info.config ?? {
+      enabled: true,
+    }
+    if (!pluginOptions.enabled) {
+      return proxy
     }
 
     // Auto completion


### PR DESCRIPTION
### What

Add option `{ enabled?: boolean }` to Next.js TypeScript plugin, if you want to disable it you can add `enabled: false` into your next plugin option, by default it's always enabled.

Disable plugin
```json5
// tsconfig.json
{ 
  "compilerOptions": {
    "plugins": [
      {
        "name": "next",
        "enabled": false
      }
    ]
  }
}
```

### Why

Next.js tsconfig writer will always modify the `tsconfig.json` to add the "next" plugin if you don't have it, this is to ensure you can always have the best DX in VSCode. This option will allow you be able to unload the plugin manually and let Next.js leave your `tsconfig.json` untouched during dev/build

Close NDX-774