### PR TITLE
docs(cookies): update good-to-know for cookie.delete

### DIFF
--- a/docs/01-app/04-api-reference/04-functions/cookies.mdx
+++ b/docs/01-app/04-api-reference/04-functions/cookies.mdx
@@ -71,7 +71,7 @@ To learn more about these options, see the [MDN docs](https://developer.mozilla.
 - `cookies` is a [Dynamic API](/docs/app/building-your-application/rendering/server-components#dynamic-apis) whose returned values cannot be known ahead of time. Using it in a layout or page will opt a route into [dynamic rendering](/docs/app/building-your-application/rendering/server-components#dynamic-rendering).
 - The `.delete` method can only be called:
   - In a [Server Action](/docs/app/building-your-application/data-fetching/server-actions-and-mutations) or [Route Handler](/docs/app/building-your-application/routing/route-handlers).
-  - If it belongs to the same domain from which `.set` is called. Additionally, the code must be executed on the same protocol (HTTP or HTTPS) as the cookie you want to delete.
+  - If it belongs to the same domain from which `.set` is called. For wildcard domains, the specific subdomain must be an exact match. Additionally, the code must be executed on the same protocol (HTTP or HTTPS) as the cookie you want to delete.
 - HTTP does not allow setting cookies after streaming starts, so you must use `.set` in a [Server Action](/docs/app/building-your-application/data-fetching/server-actions-and-mutations) or [Route Handler](/docs/app/building-your-application/routing/route-handlers).
 
 ## Understanding Cookie Behavior in Server Components


### PR DESCRIPTION
## Why?

We should also clarify that the exact subdomain must be specified when using wildcard domains.

- Fixes https://github.com/vercel/next.js/issues/76275