### PR TITLE
[Turbopack] smarter merging of small chunks in production chunking

### DIFF
--- a/turbopack/crates/turbopack-core/src/chunk/chunking/production.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/production.rs
@@ -293,7 +293,7 @@ fn overlap(
     chunk_groups2: &Option<Cow<'_, RoaringBitmapWrapper>>,
 ) -> u64 {
     if let (Some(chunk_groups), Some(chunk_groups2)) = (chunk_groups, chunk_groups2) {
-        chunk_groups.intersection_len(&**chunk_groups2)
+        chunk_groups.intersection_len(chunk_groups2)
     } else {
         0
     }

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -30,7 +30,7 @@ use crate::{
 #[derive(
     Clone, Debug, Default, PartialEq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat,
 )]
-pub struct RoaringBitmapWrapper(#[turbo_tasks(trace_ignore)] RoaringBitmap);
+pub struct RoaringBitmapWrapper(#[turbo_tasks(trace_ignore)] pub RoaringBitmap);
 
 impl TaskInput for RoaringBitmapWrapper {
     fn is_transient(&self) -> bool {

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -29,6 +29,7 @@ use turbopack::{
     ModuleAssetContext,
 };
 use turbopack_core::{
+    chunk::ChunkingConfig,
     compile_time_defines,
     compile_time_info::CompileTimeInfo,
     condition::ContextCondition,
@@ -415,6 +416,10 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
         env,
         RuntimeType::Development,
     )
+    .ecmascript_chunking_config(ChunkingConfig {
+        min_chunk_size: 20_000,
+        ..Default::default()
+    })
     .build();
 
     let jest_entry_source = FileSource::new(jest_entry_path);


### PR DESCRIPTION
### What?

Instead of merging the smallest chunks to get over the min chunk size, choose chunks with the biggest overlap in chunk groups to merge.
This makes it more likely to have these merged chunks to be shared between chunk groups.

Closes PACK-4012