### PR TITLE
[Turbopack] merged chunks need to have min overlap of 2 merge remainers into chunk

### DIFF
--- a/turbopack/crates/turbopack-core/src/chunk/chunking/production.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/production.rs
@@ -200,6 +200,9 @@ pub async fn make_production_chunks(
                         }
                     } else {
                         // No merges possible
+                        for unused in selection {
+                            chunks_to_merge.push(unused);
+                        }
                         break;
                     }
                 }


### PR DESCRIPTION
### What?

only merge small chunks when they occur in multiple overlapping chunk groups.
All unmergable small chunks will go into a leftover chunk which combines all non-shared chunks.

Closes PACK-4013