### PR TITLE
[Turbopack] allow to merge into big enough chunk candidate when 100% overlap

### DIFF
--- a/turbopack/crates/turbopack-core/src/chunk/chunking/production.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/production.rs
@@ -218,9 +218,6 @@ pub async fn make_production_chunks(
                     }
                     if best_combination.is_none() {
                         // No merges possible
-                        for unused in selection {
-                            chunks_to_merge.push(unused);
-                        }
                         break;
                     }
                 }


### PR DESCRIPTION
### What?

Instead of not looking for further merge candiates when the min chunk size has reached, continue to merge with small chunks that are in all of these chunk groups.

Closes PACK-4014