### PR TITLE
Include module path in "Missing default export" errors

### DIFF
--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -91,6 +91,7 @@ function errorMissingDefaultExportDEV(
       `\n//# sourceMappingURL=${sourceMappingURL}` +
       `\n//# sourceURL=${pathToFileURL(filePath)}`
     // TODO: Remove the "eval" method name from the stack.
+    // TODO: Switch to `vm.runInThisContext` once is https://github.com/nodejs/node/issues/52102 resolved.
     // eslint-disable-next-line no-eval
     eval(source)
   }

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -66,7 +66,7 @@ export function createComponentTree(props: {
   )
 }
 
-function errorMissingDefaultExport(
+function errorMissingDefaultExportDEV(
   pagePath: string,
   filePath: string | undefined,
   convention: string
@@ -403,33 +403,37 @@ async function createComponentTreeInternal(
       typeof MaybeComponent !== 'undefined' &&
       !isValidElementType(MaybeComponent)
     ) {
-      errorMissingDefaultExport(pagePath, layoutOrPagePath, modType ?? 'page')
+      errorMissingDefaultExportDEV(
+        pagePath,
+        layoutOrPagePath,
+        modType ?? 'page'
+      )
     }
 
     if (
       typeof ErrorComponent !== 'undefined' &&
       !isValidElementType(ErrorComponent)
     ) {
-      errorMissingDefaultExport(pagePath, error?.[1], 'error')
+      errorMissingDefaultExportDEV(pagePath, error?.[1], 'error')
     }
 
     if (typeof Loading !== 'undefined' && !isValidElementType(Loading)) {
-      errorMissingDefaultExport(pagePath, loading?.[1], 'loading')
+      errorMissingDefaultExportDEV(pagePath, loading?.[1], 'loading')
     }
 
     if (typeof NotFound !== 'undefined' && !isValidElementType(NotFound)) {
-      errorMissingDefaultExport(pagePath, notFound?.[1], 'not-found')
+      errorMissingDefaultExportDEV(pagePath, notFound?.[1], 'not-found')
     }
 
     if (typeof Forbidden !== 'undefined' && !isValidElementType(Forbidden)) {
-      errorMissingDefaultExport(pagePath, forbidden?.[1], 'forbidden')
+      errorMissingDefaultExportDEV(pagePath, forbidden?.[1], 'forbidden')
     }
 
     if (
       typeof Unauthorized !== 'undefined' &&
       !isValidElementType(Unauthorized)
     ) {
-      errorMissingDefaultExport(pagePath, unauthorized?.[1], 'unauthorized')
+      errorMissingDefaultExportDEV(pagePath, unauthorized?.[1], 'unauthorized')
     }
   }
 

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -4,6 +4,7 @@ import type {
 } from '../../shared/lib/app-router-types'
 import type { PreloadCallbacks } from './types'
 import React from 'react'
+import { pathToFileURL } from 'url'
 import {
   isClientReference,
   isUseCacheFunction,
@@ -67,8 +68,32 @@ export function createComponentTree(props: {
 
 function errorMissingDefaultExport(
   pagePath: string,
+  filePath: string | undefined,
   convention: string
 ): never {
+  if (filePath !== undefined) {
+    const sourcemap = {
+      version: 3,
+      names: [],
+      sources: [pathToFileURL(filePath)],
+      sourcesContent: [
+        // TODO: Would the actual source here be more helpful?
+        // Would only need to read the first lines to get a codeframe.
+        '// Check the content of this module for missing export.',
+      ],
+      mappings: 'AAAA',
+    }
+    const sourceMappingURL = `data:application/json;charset=utf-8;base64,${Buffer.from(
+      JSON.stringify(sourcemap)
+    ).toString('base64')}`
+    const source =
+      'throw new Error("The default export is not a React Component.")' +
+      `\n//# sourceMappingURL=${sourceMappingURL}` +
+      `\n//# sourceURL=${pathToFileURL(filePath)}`
+    // TODO: Remove the "eval" method name from the stack.
+    // eslint-disable-next-line no-eval
+    eval(source)
+  }
   const normalizedPagePath = pagePath === '/' ? '' : pagePath
   throw new Error(
     `The default export is not a React Component in "${normalizedPagePath}/${convention}"`
@@ -378,33 +403,33 @@ async function createComponentTreeInternal(
       typeof MaybeComponent !== 'undefined' &&
       !isValidElementType(MaybeComponent)
     ) {
-      errorMissingDefaultExport(pagePath, modType ?? 'page')
+      errorMissingDefaultExport(pagePath, layoutOrPagePath, modType ?? 'page')
     }
 
     if (
       typeof ErrorComponent !== 'undefined' &&
       !isValidElementType(ErrorComponent)
     ) {
-      errorMissingDefaultExport(pagePath, 'error')
+      errorMissingDefaultExport(pagePath, error?.[1], 'error')
     }
 
     if (typeof Loading !== 'undefined' && !isValidElementType(Loading)) {
-      errorMissingDefaultExport(pagePath, 'loading')
+      errorMissingDefaultExport(pagePath, loading?.[1], 'loading')
     }
 
     if (typeof NotFound !== 'undefined' && !isValidElementType(NotFound)) {
-      errorMissingDefaultExport(pagePath, 'not-found')
+      errorMissingDefaultExport(pagePath, notFound?.[1], 'not-found')
     }
 
     if (typeof Forbidden !== 'undefined' && !isValidElementType(Forbidden)) {
-      errorMissingDefaultExport(pagePath, 'forbidden')
+      errorMissingDefaultExport(pagePath, forbidden?.[1], 'forbidden')
     }
 
     if (
       typeof Unauthorized !== 'undefined' &&
       !isValidElementType(Unauthorized)
     ) {
-      errorMissingDefaultExport(pagePath, 'unauthorized')
+      errorMissingDefaultExport(pagePath, unauthorized?.[1], 'unauthorized')
     }
   }
 

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -92,8 +92,9 @@ function errorMissingDefaultExportDEV(
       `\n//# sourceURL=${pathToFileURL(filePath)}`
     // TODO: Remove the "eval" method name from the stack.
     // TODO: Switch to `vm.runInThisContext` once is https://github.com/nodejs/node/issues/52102 resolved.
-    // eslint-disable-next-line no-eval
-    eval(source)
+    // @ts-expect-error -- Need to trick Webpack
+    // eslint-disable-next-line no-useless-concat
+    globalThis['eval' + ''](source)
   }
   const normalizedPagePath = pagePath === '/' ? '' : pagePath
   throw new Error(

--- a/test/development/acceptance-app/undefined-default-export.test.ts
+++ b/test/development/acceptance-app/undefined-default-export.test.ts
@@ -17,14 +17,17 @@ describe('Undefined default export', () => {
       '/specific-path/server'
     )
     const { browser } = sandbox
-
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "The default export is not a React Component in "/specific-path/server/page"",
+       "description": "Error: The default export is not a React Component.",
        "environmentLabel": null,
        "label": "Runtime Error",
-       "source": null,
-       "stack": [],
+       "source": "app/(group)/specific-path/server/page.js (1:1) @ eval
+     > 1 | // Check the content of this module for missing export.
+         | ^",
+       "stack": [
+         "eval app/(group)/specific-path/server/page.js (1:1)",
+       ],
      }
     `)
   })
@@ -41,15 +44,19 @@ describe('Undefined default export', () => {
       ]),
       '/specific-path/server'
     )
-    const { browser } = sandbox
 
+    const { browser } = sandbox
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "The default export is not a React Component in "/specific-path/server/layout"",
+       "description": "Error: The default export is not a React Component.",
        "environmentLabel": null,
        "label": "Runtime Error",
-       "source": null,
-       "stack": [],
+       "source": "app/(group)/specific-path/server/layout.js (1:1) @ eval
+     > 1 | // Check the content of this module for missing export.
+         | ^",
+       "stack": [
+         "eval app/(group)/specific-path/server/layout.js (1:1)",
+       ],
      }
     `)
   })
@@ -70,14 +77,17 @@ describe('Undefined default export', () => {
       '/will-not-found'
     )
     const { browser } = sandbox
-
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "The default export is not a React Component in "/will-not-found/not-found"",
+       "description": "Error: The default export is not a React Component.",
        "environmentLabel": null,
        "label": "Runtime Error",
-       "source": null,
-       "stack": [],
+       "source": "app/will-not-found/not-found.js (1:1) @ eval
+     > 1 | // Check the content of this module for missing export.
+         | ^",
+       "stack": [
+         "eval app/will-not-found/not-found.js (1:1)",
+       ],
      }
     `)
   })
@@ -85,7 +95,6 @@ describe('Undefined default export', () => {
   it('should error when page component export is not valid', async () => {
     await using sandbox = await createSandbox(next, undefined, '/')
     const { browser } = sandbox
-    const cliOutputLength = next.cliOutput.length
 
     await next.patchFile('app/page.js', 'const a = 123')
 
@@ -99,11 +108,15 @@ describe('Undefined default export', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "The default export is not a React Component in "/page"",
+       "description": "Error: The default export is not a React Component.",
        "environmentLabel": null,
        "label": "Runtime Error",
-       "source": null,
-       "stack": [],
+       "source": "app/page.js (1:1) @ eval
+     > 1 | // Check the content of this module for missing export.
+         | ^",
+       "stack": [
+         "eval app/page.js (1:1)",
+       ],
      }
     `)
   })
@@ -119,15 +132,19 @@ describe('Undefined default export', () => {
       ]),
       '/server-with-errors/page-export-initial-error'
     )
-    const { browser } = sandbox
 
+    const { browser } = sandbox
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "The default export is not a React Component in "/server-with-errors/page-export-initial-error/page"",
+       "description": "Error: The default export is not a React Component.",
        "environmentLabel": null,
        "label": "Runtime Error",
-       "source": null,
-       "stack": [],
+       "source": "app/server-with-errors/page-export-initial-error/page.js (1:1) @ eval
+     > 1 | // Check the content of this module for missing export.
+         | ^",
+       "stack": [
+         "eval app/server-with-errors/page-export-initial-error/page.js (1:1)",
+       ],
      }
     `)
   })

--- a/tsec-exemptions.json
+++ b/tsec-exemptions.json
@@ -18,6 +18,9 @@
   "ban-script-appendchild-calls": [
     "packages/next/src/next-devtools/dev-overlay.browser.tsx"
   ],
+  "ban-eval-calls": [
+    "packages/next/src/server/app-render/create-component-tree.tsx"
+  ],
   "ban-script-content-assignments": ["packages/next/src/client/script.tsx"],
   "ban-script-src-assignments": [
     "packages/next/src/client/script.tsx",


### PR DESCRIPTION
We now add an additional synthetic stackframe that points to the actual module path.
That way the stack points into actual userspace code and not just Next.js internals.

The next step would be to actually inject an error into the page and sourcemap that to the likeliest location where the mistake was made. Then we could get a stack from that error instead of creating a fake one on-the-fly. That would still include the the `eval` method name though in Webpack.

Closes https://linear.app/vercel/issue/NDX-869/workshop-the-default-export-is-not-a-react-component-error