### PR TITLE
[ci]: skip use-cache deployment test

### DIFF
--- a/test/e2e/app-dir/app-root-params/use-cache.test.ts
+++ b/test/e2e/app-dir/app-root-params/use-cache.test.ts
@@ -5,10 +5,14 @@ import { createSandbox } from 'development-sandbox'
 const isPPREnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
 
 describe('app-root-params - cache - at runtime', () => {
-  const { next, isNextDev } = nextTestSetup({
+  const { next, isNextDev, skipped } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'use-cache-runtime'),
     skipStart: true,
+    // this test asserts on build failure logs, which aren't currently observable in `next.cliOutput`.
+    skipDeployment: true,
   })
+
+  if (skipped) return
 
   if (isNextDev) {
     it('should error when using rootParams within a "use cache" - dev', async () => {


### PR DESCRIPTION
When Vercel builds fail, they aren't piped to next.cliOutput. A separate command would have to be run to retrieve build logs.

This skips deployment since it's expected to fail in favor of only asserting during `next start` where we have access to build logs. 