### PR TITLE
Flight loader: use `normalModule.type` to determine module type

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -648,5 +648,6 @@
   "647": "@rspack/core is not available. Please make sure `@next/plugin-rspack` is correctly installed.",
   "648": "@rspack/plugin-react-refresh is not available. Please make sure `@next/plugin-rspack` is correctly installed.",
   "649": "Cache handlers not initialized",
-  "650": "experimental.nodeMiddleware"
+  "650": "experimental.nodeMiddleware",
+  "651": "Unexpected module type %s"
 }

--- a/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
@@ -1,4 +1,4 @@
-import type { webpack } from 'next/dist/compiled/webpack/webpack'
+import type { NormalModule, webpack } from 'next/dist/compiled/webpack/webpack'
 import { RSC_MOD_REF_PROXY_ALIAS } from '../../../../lib/constants'
 import {
   BARREL_OPTIMIZATION_PREFIX,
@@ -97,7 +97,7 @@ export default function transformSource(
   if (buildInfo.rsc?.type === RSC_MODULE_TYPES.client) {
     const assumedSourceType = getAssumedSourceType(
       module,
-      (module.parser as javascript.JavascriptParser).sourceType
+      sourceTypeFromModule(module)
     )
 
     const clientRefs = buildInfo.rsc.clientRefs!
@@ -170,4 +170,18 @@ module.exports = createProxy(${stringifiedResourceKey})
     MODULE_PROXY_PATH
   )
   this.callback(null, replacedSource, sourceMap)
+}
+
+function sourceTypeFromModule(module: NormalModule): SourceType {
+  const moduleType = module.type
+  switch (moduleType) {
+    case 'javascript/auto':
+      return 'auto'
+    case 'javascript/dynamic':
+      return 'script'
+    case 'javascript/esm':
+      return 'module'
+    default:
+      throw new Error('Unexpected module type ' + moduleType)
+  }
 }


### PR DESCRIPTION
This uses `normalModule.type` to determine the source module’s type rather than accessing a value on `normalModule.parser`, which doesn’t exist with rspack.

Closes PACK-4020