### PR TITLE
[global-error] fallback to default error when user one fails

### DIFF
--- a/packages/next/src/client/components/error-boundary.tsx
+++ b/packages/next/src/client/components/error-boundary.tsx
@@ -28,7 +28,9 @@ const styles = {
 
 export type ErrorComponent = React.ComponentType<{
   error: Error
-  reset: () => void
+  // global-error, there's no `reset` function;
+  // regular error boundary, there's a `reset` function.
+  reset?: () => void
 }>
 
 export interface ErrorBoundaryProps {

--- a/packages/next/src/client/components/react-dev-overlay/app/app-dev-overlay-error-boundary.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/app-dev-overlay-error-boundary.tsx
@@ -1,7 +1,10 @@
-import type { GlobalErrorComponent } from '../../error-boundary'
-
 import { PureComponent } from 'react'
 import { RuntimeErrorHandler } from '../../errors/runtime-error-handler'
+import {
+  ErrorBoundary,
+  type GlobalErrorComponent,
+  GlobalError as DefaultGlobalError,
+} from '../../error-boundary'
 
 type AppDevOverlayErrorBoundaryProps = {
   children: React.ReactNode
@@ -31,10 +34,10 @@ function ErroredHtml({
     )
   }
   return (
-    <>
+    <ErrorBoundary errorComponent={DefaultGlobalError}>
       {globalErrorStyles}
       <GlobalError error={error} />
-    </>
+    </ErrorBoundary>
   )
 }
 

--- a/test/e2e/app-dir/global-error/error-in-global-error/app/global-error.js
+++ b/test/e2e/app-dir/global-error/error-in-global-error/app/global-error.js
@@ -1,0 +1,17 @@
+'use client'
+
+export default function GlobalError({ error }) {
+  return (
+    <html>
+      <head></head>
+      <body>
+        <h1>Global Error</h1>
+        <p id="error">{`Global error: ${error?.message}`}</p>
+        {error?.digest && <p id="digest">{error?.digest}</p>}
+      </body>
+    </html>
+  )
+}
+
+// for inspecting purpose
+GlobalError.displayName = 'GlobalError'

--- a/test/e2e/app-dir/global-error/error-in-global-error/app/global-error.js
+++ b/test/e2e/app-dir/global-error/error-in-global-error/app/global-error.js
@@ -1,17 +1,29 @@
 'use client'
 
-export default function GlobalError({ error }) {
+import { useRouter, useSearchParams } from 'next/navigation'
+import { Suspense } from 'react'
+
+function InnerGlobalError({ error }) {
+  useRouter() // do nothing but ensure the call won't fail
+  const searchParams = useSearchParams()
+  if (searchParams.get('error-in-global-error') === '1') {
+    throw new Error('error in global error')
+  }
+
   return (
     <html>
       <head></head>
       <body>
-        <h1>Global Error</h1>
-        <p id="error">{`Global error: ${error?.message}`}</p>
-        {error?.digest && <p id="digest">{error?.digest}</p>}
+        <h1>Custom Global Error</h1>
       </body>
     </html>
   )
 }
 
-// for inspecting purpose
-GlobalError.displayName = 'GlobalError'
+export default function GlobalError({ error }) {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <InnerGlobalError error={error} />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/global-error/error-in-global-error/app/layout.js
+++ b/test/e2e/app-dir/global-error/error-in-global-error/app/layout.js
@@ -1,0 +1,10 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <head></head>
+      <body>{children}</body>
+    </html>
+  )
+}
+
+export const revalidate = 0

--- a/test/e2e/app-dir/global-error/error-in-global-error/app/layout.js
+++ b/test/e2e/app-dir/global-error/error-in-global-error/app/layout.js
@@ -6,5 +6,3 @@ export default function Layout({ children }) {
     </html>
   )
 }
-
-export const revalidate = 0

--- a/test/e2e/app-dir/global-error/error-in-global-error/app/page.js
+++ b/test/e2e/app-dir/global-error/error-in-global-error/app/page.js
@@ -1,0 +1,10 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export default function Page() {
+  useEffect(() => {
+    throw new Error('error in page')
+  }, [])
+  return <p>index page</p>
+}

--- a/test/e2e/app-dir/global-error/error-in-global-error/error-in-global-error.test.ts
+++ b/test/e2e/app-dir/global-error/error-in-global-error/error-in-global-error.test.ts
@@ -1,97 +1,59 @@
-import { assertHasRedbox, getRedboxDescription } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
+import { assertHasRedbox } from 'next-test-utils'
 
 describe('app dir - global-error - error-in-global-error', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,
   })
 
-  it('should trigger error component when an error happens during rendering', async () => {
-    const browser = await next.browser('/client')
-    await browser
-      .waitForElementByCss('#error-trigger-button')
-      .elementByCss('#error-trigger-button')
-      .click()
+  it('should be able to use nextjs navigation hook in global-error', async () => {
+    const browser = await next.browser('/')
+    const text = await browser.elementByCss('h1').text()
+    expect(text).toBe('Custom Global Error')
 
     if (isNextDev) {
       await assertHasRedbox(browser)
-      const description = await getRedboxDescription(browser)
-      expect(description).toMatchInlineSnapshot(`"Error: Client error"`)
+      await expect(browser).toDisplayRedbox(`
+       {
+         "count": 1,
+         "description": "Error: error in page",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": "app/page.js (7:11) @ Page.useEffect
+       >  7 |     throw new Error('error in page')
+            |           ^",
+         "stack": [
+           "Page.useEffect app/page.js (7:11)",
+         ],
+       }
+      `)
     }
-    expect(await browser.elementByCss('#error').text()).toBe(
-      'Global error: Client error'
-    )
   })
 
-  it('should render global error for error in server components', async () => {
-    const browser = await next.browser('/rsc')
-    expect(await browser.elementByCss('h1').text()).toBe('Global Error')
+  it('should render fallback UI when error occurs in global-error', async () => {
+    const browser = await next.browser('/?error-in-global-error=1')
+    const text = await browser.elementByCss('h2').text()
+    expect(text).toBe(
+      'Application error: a client-side exception has occurred while loading localhost (see the browser console for more information).'
+    )
 
     if (isNextDev) {
       await assertHasRedbox(browser)
-      const description = await getRedboxDescription(browser)
-      expect(description).toMatchInlineSnapshot(`"Error: server page error"`)
+      await expect(browser).toDisplayRedbox(`
+       {
+         "count": 2,
+         "description": "Error: error in global error",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": "app/global-error.js (10:11) @ InnerGlobalError
+       > 10 |     throw new Error("error in global error")
+            |           ^",
+         "stack": [
+           "InnerGlobalError app/global-error.js (10:11)",
+           "GlobalError app/global-error.js (26:7)",
+         ],
+       }
+      `)
     }
-    // Show original error message in dev mode, but hide with the react fallback RSC error message in production mode
-    expect(await browser.elementByCss('#error').text()).toBe(
-      isNextDev
-        ? 'Global error: server page error'
-        : 'Global error: An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
-    )
-    expect(await browser.elementByCss('#digest').text()).toMatch(/\w+/)
-  })
-
-  it('should render global error for error in client components during SSR', async () => {
-    const browser = await next.browser('/ssr')
-
-    if (isNextDev) {
-      await assertHasRedbox(browser)
-      const description = await getRedboxDescription(browser)
-      expect(description).toMatchInlineSnapshot(`"Error: client page error"`)
-    }
-    expect(await browser.elementByCss('h1').text()).toBe('Global Error')
-    expect(await browser.elementByCss('#error').text()).toBe(
-      'Global error: client page error'
-    )
-
-    expect(await browser.hasElementByCssSelector('#digest')).toBeFalsy()
-  })
-
-  it('should catch metadata error in error boundary if presented', async () => {
-    const browser = await next.browser('/metadata-error-with-boundary')
-
-    expect(await browser.elementByCss('#error').text()).toBe(
-      'Local error boundary'
-    )
-    expect(await browser.hasElementByCssSelector('#digest')).toBeFalsy()
-  })
-
-  it('should catch metadata error in global-error if no error boundary is presented', async () => {
-    const browser = await next.browser('/metadata-error-without-boundary')
-
-    if (isNextDev) {
-      await assertHasRedbox(browser)
-      const description = await getRedboxDescription(browser)
-      expect(description).toMatchInlineSnapshot(`"Error: Metadata error"`)
-    }
-    expect(await browser.elementByCss('h1').text()).toBe('Global Error')
-    expect(await browser.elementByCss('#error').text()).toBe(
-      isNextDev
-        ? 'Global error: Metadata error'
-        : 'Global error: An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
-    )
-  })
-
-  it('should catch the client error thrown in the nested routes', async () => {
-    const browser = await next.browser('/nested/nested')
-    if (isNextDev) {
-      await assertHasRedbox(browser)
-      const description = await getRedboxDescription(browser)
-      expect(description).toMatchInlineSnapshot(`"Error: nested error"`)
-    }
-    expect(await browser.elementByCss('h1').text()).toBe('Global Error')
-    expect(await browser.elementByCss('#error').text()).toBe(
-      'Global error: nested error'
-    )
   })
 })

--- a/test/e2e/app-dir/global-error/error-in-global-error/error-in-global-error.test.ts
+++ b/test/e2e/app-dir/global-error/error-in-global-error/error-in-global-error.test.ts
@@ -33,8 +33,8 @@ describe('app dir - global-error - error-in-global-error', () => {
   it('should render fallback UI when error occurs in global-error', async () => {
     const browser = await next.browser('/?error-in-global-error=1')
     const text = await browser.elementByCss('h2').text()
-    expect(text).toBe(
-      'Application error: a client-side exception has occurred while loading localhost (see the browser console for more information).'
+    expect(text).toMatch(
+      /Application error: a client-side exception has occurred while loading [\w.-]+ \(see the browser console for more information\)./
     )
 
     if (isNextDev) {

--- a/test/e2e/app-dir/global-error/error-in-global-error/error-in-global-error.test.ts
+++ b/test/e2e/app-dir/global-error/error-in-global-error/error-in-global-error.test.ts
@@ -46,7 +46,7 @@ describe('app dir - global-error - error-in-global-error', () => {
          "environmentLabel": null,
          "label": "Unhandled Runtime Error",
          "source": "app/global-error.js (10:11) @ InnerGlobalError
-       > 10 |     throw new Error("error in global error")
+       > 10 |     throw new Error('error in global error')
             |           ^",
          "stack": [
            "InnerGlobalError app/global-error.js (10:11)",

--- a/test/e2e/app-dir/global-error/error-in-global-error/error-in-global-error.test.ts
+++ b/test/e2e/app-dir/global-error/error-in-global-error/error-in-global-error.test.ts
@@ -1,7 +1,7 @@
 import { assertHasRedbox, getRedboxDescription } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 
-describe('app dir - global-error', () => {
+describe('app dir - global-error - error-in-global-error', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,
   })


### PR DESCRIPTION
### What

* Allow users to call next navigation APIs for `global-error.js`, put it under the Next.js App Router contexts
* Fallback to the **built-in** `global-error.js` when user customized one fails with user error.

### Why

This way we provides more ability to users for customizing their `global-error.js`, meanwhile also ensure we will not end up as a blank screen when there's sth wrong with `global-error.js`.

Closes NDX-862