### PR TITLE
[metadata] promote streaming metadata configs to stable

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2757,8 +2757,8 @@ export default async function build(
                 : undefined
 
             const htmlBotsRegexString =
-              config.experimental.htmlLimitedBots ||
-              HTML_LIMITED_BOT_UA_RE_STRING
+              // The htmlLimitedBots has been converted to a string during loadConfig
+              config.htmlLimitedBots || HTML_LIMITED_BOT_UA_RE_STRING
 
             // this flag is used to selectively bypass the static cache and invoke the lambda directly
             // to enable server actions on static routes
@@ -2774,8 +2774,7 @@ export default async function build(
               ...(isRoutePPREnabled &&
               // Disable streaming metadata for PPR on deployment where we don't have the special env.
               // TODO: enable streaming metadata in PPR mode by default once it's ready.
-              process.env.__NEXT_EXPERIMENTAL_PPR === 'true' &&
-              config.experimental.streamingMetadata
+              process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
                 ? [
                     {
                       type: 'header',

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -380,6 +380,12 @@ async function exportAppImpl(
       : {}),
     strictNextHead: nextConfig.experimental.strictNextHead ?? true,
     deploymentId: nextConfig.deploymentId,
+    htmlLimitedBots: nextConfig.htmlLimitedBots.source,
+    streamingMetadata:
+      // Disable streaming metadata when dynamic IO is enabled.
+      // FIXME: remove dynamic IO guard once we fixed the dynamic indicator case.
+      // test/e2e/app-dir/dynamic-io/dynamic-io.test.ts - should not have static indicator on not-found route
+      !nextConfig.experimental.dynamicIO,
     experimental: {
       clientTraceMetadata: nextConfig.experimental.clientTraceMetadata,
       expireTime: nextConfig.expireTime,
@@ -387,13 +393,6 @@ async function exportAppImpl(
       clientSegmentCache: nextConfig.experimental.clientSegmentCache ?? false,
       inlineCss: nextConfig.experimental.inlineCss ?? false,
       authInterrupts: !!nextConfig.experimental.authInterrupts,
-      streamingMetadata:
-        // Disable streaming metadata when dynamic IO is enabled.
-        // FIXME: remove dynamic IO guard once we fixed the dynamic indicator case.
-        // test/e2e/app-dir/dynamic-io/dynamic-io.test.ts - should not have static indicator on not-found route
-        !nextConfig.experimental.dynamicIO &&
-        !!nextConfig.experimental.streamingMetadata,
-      htmlLimitedBots: nextConfig.experimental.htmlLimitedBots,
     },
     reactMaxHeadersLength: nextConfig.reactMaxHeadersLength,
   }

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -257,7 +257,7 @@ async function exportPageImpl(
   // when it's available. When we're building the PPR rendering result, we don't need to rely
   // on the user agent. The result can be determined to serve streaming on infrastructure level.
   const serveStreamingMetadata = Boolean(
-    isRoutePPREnabled && input.streamingMetadata
+    isRoutePPREnabled && input.renderOpts.serveStreamingMetadata
   )
 
   const renderOpts: WorkerRenderOpts = {
@@ -429,8 +429,7 @@ export async function exportPages(
               // Disable streaming metadata when dynamic IO is enabled.
               // FIXME: remove dynamic IO guard once we fixed the dynamic indicator case.
               // test/e2e/app-dir/dynamic-io/dynamic-io.test.ts - should not have static indicator on not-found route
-              !nextConfig.experimental.dynamicIO &&
-              !!nextConfig.experimental.streamingMetadata,
+              !nextConfig.experimental.dynamicIO,
           }),
           // If exporting the page takes longer than the timeout, reject the promise.
           new Promise((_, reject) => {

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -257,7 +257,7 @@ async function exportPageImpl(
   // when it's available. When we're building the PPR rendering result, we don't need to rely
   // on the user agent. The result can be determined to serve streaming on infrastructure level.
   const serveStreamingMetadata = Boolean(
-    isRoutePPREnabled && input.renderOpts.serveStreamingMetadata
+    isRoutePPREnabled && input.streamingMetadata
   )
 
   const renderOpts: WorkerRenderOpts = {

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -204,6 +204,8 @@ export interface RenderOptsPartial {
   }
   params?: ParsedUrlQuery
   isPrefetch?: boolean
+  htmlLimitedBots: string | undefined
+  streamingMetadata: boolean
   experimental: {
     /**
      * When true, it indicates that the current page supports partial
@@ -216,8 +218,6 @@ export interface RenderOptsPartial {
     clientSegmentCache: boolean
     inlineCss: boolean
     authInterrupts: boolean
-    streamingMetadata: boolean
-    htmlLimitedBots: string | undefined
   }
   postponed?: string
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1770,7 +1770,6 @@ export default abstract class Server<
         supportsDynamicResponse: !isBotRequest,
         botType: getBotType(ua),
         serveStreamingMetadata: shouldServeStreamingMetadata(ua, {
-          dynamicIO: !!this.nextConfig.experimental.dynamicIO,
           streamingMetadata: !!this.renderOpts.streamingMetadata,
           htmlLimitedBots: this.nextConfig.htmlLimitedBots,
         }),

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -602,6 +602,13 @@ export default abstract class Server<
 
       // @ts-expect-error internal field not publicly exposed
       isExperimentalCompile: this.nextConfig.experimental.isExperimentalCompile,
+      // `htmlLimitedBots` is passed to server as serialized config in string format
+      htmlLimitedBots: this.nextConfig.htmlLimitedBots,
+      streamingMetadata:
+        // Disable streaming metadata when dynamic IO is enabled.
+        // FIXME: remove dynamic IO guard once we fixed the dynamic indicator case.
+        // test/e2e/app-dir/dynamic-io/dynamic-io.test.ts - should not have static indicator on not-found route
+        !this.nextConfig.experimental.dynamicIO,
       experimental: {
         expireTime: this.nextConfig.expireTime,
         clientTraceMetadata: this.nextConfig.experimental.clientTraceMetadata,
@@ -610,13 +617,6 @@ export default abstract class Server<
           this.nextConfig.experimental.clientSegmentCache ?? false,
         inlineCss: this.nextConfig.experimental.inlineCss ?? false,
         authInterrupts: !!this.nextConfig.experimental.authInterrupts,
-        streamingMetadata:
-          // Disable streaming metadata when dynamic IO is enabled.
-          // FIXME: remove dynamic IO guard once we fixed the dynamic indicator case.
-          // test/e2e/app-dir/dynamic-io/dynamic-io.test.ts - should not have static indicator on not-found route
-          !this.nextConfig.experimental.dynamicIO &&
-          !!this.nextConfig.experimental.streamingMetadata,
-        htmlLimitedBots: this.nextConfig.experimental.htmlLimitedBots,
       },
       onInstrumentationRequestError:
         this.instrumentationOnRequestError.bind(this),
@@ -1769,10 +1769,11 @@ export default abstract class Server<
         ...this.renderOpts,
         supportsDynamicResponse: !isBotRequest,
         botType: getBotType(ua),
-        serveStreamingMetadata: shouldServeStreamingMetadata(
-          ua,
-          this.renderOpts.experimental
-        ),
+        serveStreamingMetadata: shouldServeStreamingMetadata(ua, {
+          dynamicIO: !!this.nextConfig.experimental.dynamicIO,
+          streamingMetadata: !!this.renderOpts.streamingMetadata,
+          htmlLimitedBots: this.nextConfig.htmlLimitedBots,
+        }),
       },
     }
 

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -448,7 +448,6 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         typedEnv: z.boolean().optional(),
         serverComponentsHmrCache: z.boolean().optional(),
         authInterrupts: z.boolean().optional(),
-        newDevOverlay: z.boolean().optional(),
         useCache: z.boolean().optional(),
         slowModuleDetection: z
           .object({

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -448,8 +448,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         typedEnv: z.boolean().optional(),
         serverComponentsHmrCache: z.boolean().optional(),
         authInterrupts: z.boolean().optional(),
-        streamingMetadata: z.boolean().optional(),
-        htmlLimitedBots: z.instanceof(RegExp).optional(),
+        newDevOverlay: z.boolean().optional(),
         useCache: z.boolean().optional(),
         slowModuleDetection: z
           .object({
@@ -489,6 +488,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
       .args()
       .returns(z.promise(z.array(zHeader)))
       .optional(),
+    htmlLimitedBots: z.instanceof(RegExp).optional(),
     httpAgentOptions: z
       .strictObject({ keepAlive: z.boolean().optional() })
       .optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1069,7 +1069,7 @@ export interface NextConfig extends Record<string, any> {
   }
 
   /**
-   * User agent of bots that can't handle streaming metadata.
+   * User agent of bots that should opt-out streaming metadata.
    * User agents that pass this regex will block rendering until metadata has resolved, to ensure it's available in the `head` of the document.
    */
   htmlLimitedBots?: RegExp

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1069,8 +1069,8 @@ export interface NextConfig extends Record<string, any> {
   }
 
   /**
-   * User Agent of bots that can handle streaming metadata.
-   * Besides the default behavior, Next.js act differently on serving metadata to bots based on their capability.
+   * User agent of bots that can't handle streaming metadata.
+   * User agents that pass this regex will block rendering until metadata has resolved, to ensure it's available in the `head` of the document.
    */
   htmlLimitedBots?: RegExp
 }

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -587,11 +587,6 @@ export interface ExperimentalConfig {
   authInterrupts?: boolean
 
   /**
-   * Enables the new dev overlay.
-   */
-  newDevOverlay?: boolean
-
-  /**
    * Enables the use of the `"use cache"` directive.
    */
   useCache?: boolean
@@ -1257,7 +1252,6 @@ export const defaultConfig: NextConfig = {
     staticGenerationMinPagesPerWorker: 25,
     dynamicIO: false,
     inlineCss: false,
-    newDevOverlay: true,
     useCache: undefined,
     slowModuleDetection: undefined,
   },

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -23,9 +23,8 @@ export type NextConfigComplete = Required<NextConfig> & {
   configFileName: string
   // override NextConfigComplete.experimental.htmlLimitedBots to string
   // because it's not defined in NextConfigComplete.experimental
-  experimental: Omit<ExperimentalConfig, 'htmlLimitedBots'> & {
-    htmlLimitedBots: string | undefined
-  }
+  htmlLimitedBots: string | undefined
+  experimental: ExperimentalConfig
 }
 
 export type I18NDomains = readonly DomainLocale[]
@@ -588,15 +587,9 @@ export interface ExperimentalConfig {
   authInterrupts?: boolean
 
   /**
-   * When enabled will cause async metadata calls to stream rather than block the render.
+   * Enables the new dev overlay.
    */
-  streamingMetadata?: boolean
-
-  /**
-   * User Agent of bots that can handle streaming metadata.
-   * Besides the default behavior, Next.js act differently on serving metadata to bots based on their capability.
-   */
-  htmlLimitedBots?: RegExp
+  newDevOverlay?: boolean
 
   /**
    * Enables the use of the `"use cache"` directive.
@@ -1079,6 +1072,12 @@ export interface NextConfig extends Record<string, any> {
   watchOptions?: {
     pollIntervalMs?: number
   }
+
+  /**
+   * User Agent of bots that can handle streaming metadata.
+   * Besides the default behavior, Next.js act differently on serving metadata to bots based on their capability.
+   */
+  htmlLimitedBots?: RegExp
 }
 
 export const defaultConfig: NextConfig = {
@@ -1258,11 +1257,11 @@ export const defaultConfig: NextConfig = {
     staticGenerationMinPagesPerWorker: 25,
     dynamicIO: false,
     inlineCss: false,
-    streamingMetadata: true,
-    htmlLimitedBots: undefined,
+    newDevOverlay: true,
     useCache: undefined,
     slowModuleDetection: undefined,
   },
+  htmlLimitedBots: undefined,
   bundlePagesRouterDependencies: false,
 }
 

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1043,9 +1043,9 @@ function assignDefaults(
     ]),
   ]
 
-  if (!result.experimental.htmlLimitedBots) {
+  if (!result.htmlLimitedBots) {
     // @ts-expect-error: override the htmlLimitedBots with default string, type covert: RegExp -> string
-    result.experimental.htmlLimitedBots = HTML_LIMITED_BOT_UA_RE_STRING
+    result.htmlLimitedBots = HTML_LIMITED_BOT_UA_RE_STRING
   }
 
   // "use cache" was originally implicitly enabled with the dynamicIO flag, so
@@ -1169,10 +1169,10 @@ export default async function loadConfig(
       throw err
     }
 
-    const userConfig = await normalizeConfig(
+    const userConfig = (await normalizeConfig(
       phase,
       userConfigModule.default || userConfigModule
-    )
+    )) as NextConfig
 
     if (!process.env.NEXT_MINIMAL) {
       // We only validate the config against schema in non minimal mode
@@ -1221,7 +1221,7 @@ export default async function loadConfig(
       const { canonicalBase } = userConfig.amp || ({} as any)
       userConfig.amp = userConfig.amp || {}
       userConfig.amp.canonicalBase =
-        (canonicalBase.endsWith('/')
+        (canonicalBase?.endsWith('/')
           ? canonicalBase.slice(0, -1)
           : canonicalBase) || ''
     }
@@ -1264,9 +1264,9 @@ export default async function loadConfig(
     }
 
     // serialize the regex config into string
-    if (userConfig.experimental?.htmlLimitedBots instanceof RegExp) {
-      userConfig.experimental.htmlLimitedBots =
-        userConfig.experimental.htmlLimitedBots.source
+    if (userConfig?.htmlLimitedBots instanceof RegExp) {
+      // @ts-expect-error: override the htmlLimitedBots with default string, type covert: RegExp -> string
+      userConfig.htmlLimitedBots = userConfig.htmlLimitedBots.source
     }
 
     onLoadUserConfig?.(userConfig)

--- a/test/e2e/app-dir/metadata-streaming-static-generation/next.config.js
+++ b/test/e2e/app-dir/metadata-streaming-static-generation/next.config.js
@@ -1,10 +1,6 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {
-  experimental: {
-    streamingMetadata: true,
-  },
-}
+const nextConfig = {}
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/metadata-streaming/metadata-streaming-customized-rule.test.ts
+++ b/test/e2e/app-dir/metadata-streaming/metadata-streaming-customized-rule.test.ts
@@ -6,10 +6,7 @@ describe('app-dir - metadata-streaming-customized-rule', () => {
     overrideFiles: {
       'next.config.js': `
         module.exports = {
-          experimental: {
-            streamingMetadata: true,
-            htmlLimitedBots: /Minibot/i,
-          }
+          htmlLimitedBots: /Minibot/i,
         }
       `,
     },

--- a/test/e2e/app-dir/metadata-streaming/next.config.js
+++ b/test/e2e/app-dir/metadata-streaming/next.config.js
@@ -1,10 +1,6 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {
-  experimental: {
-    streamingMetadata: true,
-  },
-}
+const nextConfig = {}
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/ppr-metadata-streaming/next.config.js
+++ b/test/e2e/app-dir/ppr-metadata-streaming/next.config.js
@@ -1,6 +1,10 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {}
+const nextConfig = {
+  experimental: {
+    ppr: true,
+  },
+}
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/ppr-metadata-streaming/next.config.js
+++ b/test/e2e/app-dir/ppr-metadata-streaming/next.config.js
@@ -1,11 +1,6 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {
-  experimental: {
-    ppr: true,
-    streamingMetadata: true,
-  },
-}
+const nextConfig = {}
 
 module.exports = nextConfig

--- a/test/production/app-dir/metadata-streaming-config/metadata-streaming-config-customized.test.ts
+++ b/test/production/app-dir/metadata-streaming-config/metadata-streaming-config-customized.test.ts
@@ -10,10 +10,9 @@ describe('app-dir - metadata-streaming-config-customized', () => {
     overrideFiles: {
       'next.config.js': `
         module.exports = {
-          experimental: {
+          htmlLimitedBots: /MyBot/i,
+            experimental: {
             ppr: 'incremental',
-            streamingMetadata: true,
-            htmlLimitedBots: /MyBot/i,
           }
         }
       `,

--- a/test/production/app-dir/metadata-streaming-config/metadata-streaming-config.test.ts
+++ b/test/production/app-dir/metadata-streaming-config/metadata-streaming-config.test.ts
@@ -16,9 +16,7 @@ describe('app-dir - metadata-streaming-config', () => {
       await next.readFile('.next/required-server-files.json')
     )
 
-    expect(
-      requiredServerFiles.config.experimental.htmlLimitedBots
-    ).toMatchInlineSnapshot(
+    expect(requiredServerFiles.config.htmlLimitedBots).toMatchInlineSnapshot(
       `"Mediapartners-Google|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview"`
     )
 

--- a/test/production/app-dir/metadata-streaming-config/next.config.js
+++ b/test/production/app-dir/metadata-streaming-config/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     ppr: 'incremental',
-    streamingMetadata: true,
   },
 }
 

--- a/test/production/app-dir/ppr-disable-streaming-metadata/next.config.js
+++ b/test/production/app-dir/ppr-disable-streaming-metadata/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     ppr: 'incremental',
-    streamingMetadata: true,
   },
 }
 


### PR DESCRIPTION
### What

- Promote `htmlLimitedBots` to stable configuration. 
- Remove `experimental.streamingMetadata` as it's enabeld by default now

