### PR TITLE
[app i18n]: warn about i18n configuration deprecation in app router

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -28,6 +28,7 @@ import { transpileConfig } from '../build/next-config-ts/transpile-config'
 import { dset } from '../shared/lib/dset'
 import { normalizeZodErrors } from '../shared/lib/zod'
 import { HTML_LIMITED_BOT_UA_RE_STRING } from '../shared/lib/router/utils/is-bot'
+import { findDir } from '../lib/find-pages-dir'
 
 export { normalizeConfig } from './config-shared'
 export type { DomainLocale, NextConfig } from './config-shared'
@@ -679,6 +680,17 @@ function assignDefaults(
   setHttpClientAndAgentOptions(result || defaultConfig)
 
   if (result.i18n) {
+    const hasAppDir = Boolean(findDir(dir, 'app'))
+
+    if (hasAppDir) {
+      warnOptionHasBeenDeprecated(
+        result,
+        'i18n',
+        `i18n configuration in ${configFileName} is unsupported in App Router.\nLearn more about internationalization in App Router: https://nextjs.org/docs/app/building-your-application/routing/internationalization`,
+        silent
+      )
+    }
+
     const { i18n } = result
     const i18nType = typeof i18n
 

--- a/test/e2e/app-dir/i18n-hybrid/i18n-hybrid.test.js
+++ b/test/e2e/app-dir/i18n-hybrid/i18n-hybrid.test.js
@@ -52,6 +52,12 @@ describe('i18n-hybrid', () => {
     files: __dirname,
   })
 
+  it('should warn about i18n in app dir', async () => {
+    expect(next.cliOutput).toContain(
+      'i18n configuration in next.config.js is unsupported in App Router.'
+    )
+  })
+
   it.each(urls.filter((url) => !url.expected))(
     'does not resolve $pathname',
     async (url) => {


### PR DESCRIPTION
The `i18n` configuration was supported in app router to assist with incremental migration, but it's only meant to be used for pages router. There are some bugs that can pop up when attempting to use it with app router. 

Disabling `i18n` configuration entirely for any app router paths will be handled in a separate PR: the goal for this PR is to signal that it's unsupported in app router. 