### PR TITLE
[dev-overlay] do not attach hydration info to non hydration errors

### DIFF
--- a/packages/next/src/client/components/errors/attach-hydration-error-state.ts
+++ b/packages/next/src/client/components/errors/attach-hydration-error-state.ts
@@ -73,7 +73,7 @@ export function attachHydrationErrorState(error: Error) {
     }
   }
   // If it's a hydration error, store the hydration error state into the error object
-  if (isHydrationRuntimeError) {
+  if (isHydrationRuntimeError || isHydrationWarning) {
     ;(error as any).details = parsedHydrationErrorState
   }
 }

--- a/packages/next/src/client/components/errors/attach-hydration-error-state.ts
+++ b/packages/next/src/client/components/errors/attach-hydration-error-state.ts
@@ -9,12 +9,18 @@ import {
 } from './hydration-error-info'
 
 export function attachHydrationErrorState(error: Error) {
-  const reactHydrationDiffSegments = getReactHydrationDiffSegments(
-    error.message
-  )
   let parsedHydrationErrorState: typeof hydrationErrorState = {}
   const isHydrationWarning = testReactHydrationWarning(error.message)
   const isHydrationRuntimeError = isHydrationError(error)
+
+  // If it's not hydration warnings or errors, skip
+  if (!(isHydrationRuntimeError || isHydrationWarning)) {
+    return
+  }
+
+  const reactHydrationDiffSegments = getReactHydrationDiffSegments(
+    error.message
+  )
   // If the reactHydrationDiffSegments exists
   // and the diff (reactHydrationDiffSegments[1]) exists
   // e.g. the hydration diff log error.
@@ -73,7 +79,5 @@ export function attachHydrationErrorState(error: Error) {
     }
   }
   // If it's a hydration error, store the hydration error state into the error object
-  if (isHydrationRuntimeError || isHydrationWarning) {
-    ;(error as any).details = parsedHydrationErrorState
-  }
+  ;(error as any).details = parsedHydrationErrorState
 }

--- a/packages/next/src/client/components/errors/attach-hydration-error-state.ts
+++ b/packages/next/src/client/components/errors/attach-hydration-error-state.ts
@@ -72,5 +72,8 @@ export function attachHydrationErrorState(error: Error) {
         hydrationErrorState.reactOutputComponentDiff
     }
   }
-  ;(error as any).details = parsedHydrationErrorState
+  // If it's a hydration error, store the hydration error state into the error object
+  if (isHydrationRuntimeError) {
+    ;(error as any).details = parsedHydrationErrorState
+  }
 }

--- a/test/development/app-dir/hydration-error-count/app/hydration-with-runtime-errors/page.tsx
+++ b/test/development/app-dir/hydration-error-count/app/hydration-with-runtime-errors/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export default function Page() {
+  useEffect(() => {
+    throw new Error('runtime error')
+  }, [])
+
+  return (
+    <p>
+      sneaky <p>very sneaky</p>
+    </p>
+  )
+}

--- a/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
+++ b/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
@@ -9,6 +9,7 @@ import {
   goToNextErrorView,
   getRedboxDescriptionWarning,
   getHighlightedDiffLines,
+  assertHasRedbox,
 } from 'next-test-utils'
 import { BrowserInterface } from 'next-webdriver'
 
@@ -128,6 +129,47 @@ describe('hydration-error-count', () => {
      - Invalid HTML tag nesting.
 
      It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.",
+     }
+    `)
+  })
+
+  it('should display runtime error separately from hydration errors', async () => {
+    const browser = await next.browser('/hydration-with-runtime-errors')
+    await assertHasRedbox(browser)
+    expect(await getToastErrorCount(browser)).toBe(3)
+
+    // Move to the last hydration error
+    await goToNextErrorView(browser)
+    expect(browser).toDisplayRedbox(`
+     {
+       "count": 3,
+       "description": "In HTML, <p> cannot be a descendant of <p>.
+     This will cause a hydration error.",
+       "environmentLabel": null,
+       "label": "Unhandled Runtime Error",
+       "source": "app/hydration-with-runtime-errors/page.tsx (12:14) @ Page
+     > 12 |       sneaky <p>very sneaky</p>
+          |              ^",
+       "stack": [
+         "p <anonymous> (0:0)",
+         "Page app/hydration-with-runtime-errors/page.tsx (12:14)",
+       ],
+     }
+    `)
+
+    await goToNextErrorView(browser)
+    expect(browser).toDisplayRedbox(`
+     {
+       "count": 3,
+       "description": "Error: runtime error",
+       "environmentLabel": null,
+       "label": "Unhandled Runtime Error",
+       "source": "app/hydration-with-runtime-errors/page.tsx (7:11) @ Page.useEffect
+     >  7 |     throw new Error('runtime error')
+          |           ^",
+       "stack": [
+         "Page.useEffect app/hydration-with-runtime-errors/page.tsx (7:11)",
+       ],
      }
     `)
   })


### PR DESCRIPTION
### What

We should only attach the hydration error information to the hydration errors, not the normal runtime errors 

Closes NDX-878