### PR TITLE
[test] Use new Redbox matchers in pages/ hydration-error test

### DIFF
--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -483,12 +483,16 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
     const { browser } = sandbox
 
+    await retry(async () => {
+      expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
+    })
+
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
          "componentStack": "<Page>
        >   <table>",
-         "count": 2,
+         "count": 3,
          "description": "Expected server HTML to contain a matching <table> in <div>.",
          "environmentLabel": null,
          "label": "Unhandled Runtime Error",
@@ -548,6 +552,11 @@ describe('Error overlay for hydration errors in Pages router', () => {
       ])
     )
     const { browser } = sandbox
+
+    await retry(async () => {
+      expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
+    })
+
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
@@ -555,7 +564,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
        >   <div>
              <Suspense>
        >       <main>",
-         "count": 2,
+         "count": 3,
          "description": "Expected server HTML to contain a matching <main> in <div>.",
          "environmentLabel": null,
          "label": "Unhandled Runtime Error",

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -8,7 +8,7 @@ const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 // https://github.com/facebook/react/blob/main/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js used as a reference
 
 describe('Error overlay for hydration errors in Pages router', () => {
-  const { next, isTurbopack } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
     skipStart: true,
   })
@@ -73,52 +73,27 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
     const { session, browser } = sandbox
 
-    await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 2 : 1)
-
+    // Pages Router uses React version without Owner Stacks hence the empty `stack`
     if (isReact18) {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-        `"Text content did not match. Server: "server" Client: "client""`
-      )
-    } else {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-        `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:"`
-      )
-    }
-
-    if (isReact18) {
-      expect(await session.getRedboxDescriptionWarning()).toMatchInlineSnapshot(
-        `null`
-      )
-    } else {
-      expect(await session.getRedboxDescriptionWarning())
-        .toMatchInlineSnapshot(`
-          "- A server/client branch \`if (typeof window !== 'undefined')\`.
-          - Variable input such as \`Date.now()\` or \`Math.random()\` which changes each time it's called.
-          - Date formatting in a user's locale which doesn't match the server.
-          - External changing data without sending a snapshot of it along with the HTML.
-          - Invalid HTML tag nesting.
-
-          It can also happen if the client has a browser extension installed which messes with the HTML before React loaded."
-        `)
-    }
-    expect(await session.getRedboxErrorLink()).toMatchInlineSnapshot(
-      `"See more info here: https://nextjs.org/docs/messages/react-hydration-error"`
-    )
-
-    const pseudoHtml = await session.getRedboxComponentStack()
-
-    if (isReact18) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "<Mismatch>
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "<Mismatch>
            <div>
              <main>
        +       "server"
-       -       "client""
+       -       "client"",
+         "count": 2,
+         "description": "Text content did not match. Server: "server" Client: "client"",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
     } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "...
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "...
            <AppContainer>
              <Container fn={function fn}>
                <PagesDevOverlay>
@@ -131,9 +106,17 @@ describe('Error overlay for hydration errors in Pages router', () => {
        +                     client
        -                     server
                      ...
-                 ..."
+                 ...",
+         "count": 1,
+         "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
     }
+
     await session.patch(
       'index.js',
       outdent`
@@ -171,24 +154,30 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-    const { session, browser } = sandbox
-    await session.assertHasRedbox()
+    const { browser } = sandbox
+
     await retry(async () => {
-      await expect(await getRedboxTotalErrorCount(browser)).toBe(
-        isReact18 ? 3 : 1
-      )
+      expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
     })
 
-    const pseudoHtml = await session.getRedboxComponentStack()
     if (isReact18) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "<Mismatch>
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "<Mismatch>
        >   <div>
-       >     <main>"
+       >     <main>",
+         "count": 3,
+         "description": "Expected server HTML to contain a matching <main> in <div>.",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
     } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "...
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "...
            <AppContainer>
              <Container fn={function fn}>
                <PagesDevOverlay>
@@ -199,18 +188,15 @@ describe('Error overlay for hydration errors in Pages router', () => {
                          <div className="parent">
        +                   <main className="only">
                      ...
-                 ..."
+                 ...",
+         "count": 1,
+         "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
-    }
-
-    if (isReact18) {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-        `"Expected server HTML to contain a matching <main> in <div>."`
-      )
-    } else {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-        `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:"`
-      )
     }
   })
 
@@ -235,25 +221,31 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-    const { session, browser } = sandbox
-    await session.assertHasRedbox()
+    const { browser } = sandbox
+
     await retry(async () => {
-      await expect(await getRedboxTotalErrorCount(browser)).toBe(
-        isReact18 ? 3 : 1
-      )
+      expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
     })
 
-    const pseudoHtml = await session.getRedboxComponentStack()
     if (isReact18) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "<Mismatch>
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "<Mismatch>
            <div>
        >     <div>
-       >       "second""
+       >       "second"",
+         "count": 3,
+         "description": "Expected server HTML to contain a matching text node for "second" in <div>.",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
     } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "...
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "...
            <AppContainer>
              <Container fn={function fn}>
                <PagesDevOverlay>
@@ -267,18 +259,15 @@ describe('Error overlay for hydration errors in Pages router', () => {
        -                   <footer className="3">
                            ...
                      ...
-                 ..."
+                 ...",
+         "count": 1,
+         "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
-    }
-
-    if (isReact18) {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-        `"Expected server HTML to contain a matching text node for "second" in <div>."`
-      )
-    } else {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-        `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:"`
-      )
     }
   })
 
@@ -301,19 +290,25 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-    const { session, browser } = sandbox
-    await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 2 : 1)
+    const { browser } = sandbox
 
-    const pseudoHtml = await session.getRedboxComponentStack()
     if (isReact18) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "<Mismatch>
-       >   <div>"
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "<Mismatch>
+       >   <div>",
+         "count": 2,
+         "description": "Did not expect server HTML to contain a <main> in <div>.",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
     } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "<Root callbacks={[...]}>
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "<Root callbacks={[...]}>
            <Head>
            <AppContainer>
              <Container fn={function fn}>
@@ -325,18 +320,15 @@ describe('Error overlay for hydration errors in Pages router', () => {
                          <div className="parent">
        -                   <main className="only">
                      ...
-                 ..."
+                 ...",
+         "count": 1,
+         "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
-    }
-
-    if (isReact18) {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-        `"Did not expect server HTML to contain a <main> in <div>."`
-      )
-    } else {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-        `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:"`
-      )
     }
   })
 
@@ -355,32 +347,27 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-    const { session, browser } = sandbox
-    await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 2 : 1)
+    const { browser } = sandbox
 
     if (isReact18) {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-        `"Did not expect server HTML to contain the text node "only" in <div>."`
-      )
-    } else {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-        `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:"`
-      )
-    }
-
-    const pseudoHtml = await session.getRedboxComponentStack()
-
-    if (isReact18) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "<Mismatch>
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "<Mismatch>
            <div>
        >     <div>
-       >       "only""
+       >       "only"",
+         "count": 2,
+         "description": "Did not expect server HTML to contain the text node "only" in <div>.",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
     } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "<Root callbacks={[...]}>
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "<Root callbacks={[...]}>
            <Head>
            <AppContainer>
              <Container fn={function fn}>
@@ -392,7 +379,14 @@ describe('Error overlay for hydration errors in Pages router', () => {
                          <div className="parent">
        -                   only
                      ...
-                 ..."
+                 ...",
+         "count": 1,
+         "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
     }
   })
@@ -417,11 +411,10 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-    const { session, browser } = sandbox
-    await session.assertHasRedbox()
+    const { browser } = sandbox
 
     await retry(async () => {
-      await expect(await getRedboxTotalErrorCount(browser)).toBe(
+      expect(await getRedboxTotalErrorCount(browser)).toBe(
         isReact18
           ? 3
           : // FIXME: Should be 2
@@ -430,25 +423,22 @@ describe('Error overlay for hydration errors in Pages router', () => {
     })
 
     if (isReact18) {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-        `"Expected server HTML to contain a matching <table> in <div>."`
-      )
-    } else {
-      // FIXME: should show "Expected server HTML to contain a matching <table> in <div>." first
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-        `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:"`
-      )
-    }
-
-    const pseudoHtml = await session.getRedboxComponentStack()
-    if (isReact18) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "<Page>
-       >   <table>"
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "<Page>
+       >   <table>",
+         "count": 3,
+         "description": "Expected server HTML to contain a matching <table> in <div>.",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
     } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "<Root callbacks={[...]}>
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "<Root callbacks={[...]}>
            <Head>
            <AppContainer>
              <Container fn={function fn}>
@@ -460,7 +450,14 @@ describe('Error overlay for hydration errors in Pages router', () => {
        +                 <table>
        -                 test
                      ...
-                 ..."
+                 ...",
+         "count": 1,
+         "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
     }
   })
@@ -484,62 +481,45 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-    const { session, browser } = sandbox
-
-    await session.assertHasRedbox()
+    const { browser } = sandbox
 
     if (isReact18) {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-        `"Expected server HTML to contain a matching <table> in <div>."`
-      )
-
-      const pseudoHtml = await session.getRedboxComponentStack()
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "<Page>
-       >   <table>"
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "<Page>
+       >   <table>",
+         "count": 2,
+         "description": "Expected server HTML to contain a matching <table> in <div>.",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
-
-      expect(await getRedboxTotalErrorCount(browser)).toBe(3)
     } else {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-        `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:"`
-      )
-
-      const pseudoHtml = await session.getRedboxComponentStack()
-      if (isTurbopack) {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-         "<Root callbacks={[...]}>
-             <Head>
-             <AppContainer>
-               <Container fn={function fn}>
-                 <PagesDevOverlay>
-                   <PagesDevOverlayErrorBoundary onError={function usePagesDevOverlay.useCallback[onComponentError]}>
-                     <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                       <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
-                         <Page>
-         +                 <table>
-         -                 {" 123"}
-                       ...
-                   ..."
-        `)
-      } else {
-        expect(pseudoHtml).toMatchInlineSnapshot(`
-         "<Root callbacks={[...]}>
-             <Head>
-             <AppContainer>
-               <Container fn={function fn}>
-                 <PagesDevOverlay>
-                   <PagesDevOverlayErrorBoundary onError={function usePagesDevOverlay.useCallback[onComponentError]}>
-                     <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                       <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
-                         <Page>
-         +                 <table>
-         -                 {" 123"}
-                       ...
-                   ..."
-        `)
-      }
-      expect(await getRedboxTotalErrorCount(browser)).toBe(1)
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "<Root callbacks={[...]}>
+           <Head>
+           <AppContainer>
+             <Container fn={function fn}>
+               <PagesDevOverlay>
+                 <PagesDevOverlayErrorBoundary onError={function usePagesDevOverlay.useCallback[onComponentError]}>
+                   <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
+                     <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+                       <Page>
+       +                 <table>
+       -                 {" 123"}
+                     ...
+                 ...",
+         "count": 1,
+         "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
+      `)
     }
   })
 
@@ -567,19 +547,26 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-    const { session } = sandbox
-    await session.assertHasRedbox()
-    const pseudoHtml = await session.getRedboxComponentStack()
+    const { browser } = sandbox
     if (isReact18) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "<Mismatch>
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "<Mismatch>
        >   <div>
              <Suspense>
-       >       <main>"
+       >       <main>",
+         "count": 2,
+         "description": "Expected server HTML to contain a matching <main> in <div>.",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
     } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "...
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "...
            <PagesDevOverlay>
              <PagesDevOverlayErrorBoundary onError={function usePagesDevOverlay.useCallback[onComponentError]}>
                <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
@@ -592,18 +579,15 @@ describe('Error overlay for hydration errors in Pages router', () => {
        -                 <footer className="3">
                          ...
                  ...
-             ..."
+             ...",
+         "count": 1,
+         "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
-    }
-
-    if (isReact18) {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-        `"Expected server HTML to contain a matching <main> in <div>."`
-      )
-    } else {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-        `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:"`
-      )
     }
   })
 
@@ -658,36 +642,30 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-    const { session, browser } = sandbox
-    await session.assertHasRedbox()
+    const { browser } = sandbox
+
     await retry(async () => {
       expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
     })
 
-    const description = await session.getRedboxDescription()
     if (isReact18) {
-      expect(description).toMatchInlineSnapshot(
-        `"Expected server HTML to contain a matching <p> in <p>."`
-      )
-    } else {
-      expect(description).toMatchInlineSnapshot(`
-        "In HTML, <p> cannot be a descendant of <p>.
-        This will cause a hydration error."
-      `)
-    }
-
-    await session.assertHasRedbox()
-    const pseudoHtml = await session.getRedboxComponentStack()
-
-    if (isReact18) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "<Page>
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "<Page>
        >   <p>
-       >     <p>"
+       >     <p>",
+         "count": 3,
+         "description": "Expected server HTML to contain a matching <p> in <p>.",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
     } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "<Root callbacks={[...]}>
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "<Root callbacks={[...]}>
            <Head>
            <AppContainer>
              <Container fn={function fn}>
@@ -699,7 +677,15 @@ describe('Error overlay for hydration errors in Pages router', () => {
        >                 <p>
        >                   <p>
                      ...
-                 ..."
+                 ...",
+         "count": 1,
+         "description": "In HTML, <p> cannot be a descendant of <p>.
+       This will cause a hydration error.",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
     }
   })
@@ -726,37 +712,32 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-    const { session, browser } = sandbox
-    await session.assertHasRedbox()
+    const { browser } = sandbox
+
     await retry(async () => {
       expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
     })
 
-    const description = await session.getRedboxDescription()
     if (isReact18) {
-      expect(description).toMatchInlineSnapshot(
-        `"Expected server HTML to contain a matching <div> in <p>."`
-      )
-    } else {
-      expect(description).toMatchInlineSnapshot(`
-        "In HTML, <div> cannot be a descendant of <p>.
-        This will cause a hydration error."
-      `)
-    }
-
-    const pseudoHtml = await session.getRedboxComponentStack()
-
-    if (isReact18) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "<Page>
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "<Page>
            <div>
              <div>
        >       <p>
-       >         <div>"
+       >         <div>",
+         "count": 3,
+         "description": "Expected server HTML to contain a matching <div> in <p>.",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
     } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "...
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "...
            <Container fn={function fn}>
              <PagesDevOverlay>
                <PagesDevOverlayErrorBoundary onError={function usePagesDevOverlay.useCallback[onComponentError]}>
@@ -768,7 +749,15 @@ describe('Error overlay for hydration errors in Pages router', () => {
        >                   <p>
        >                     <div>
                    ...
-               ..."
+               ...",
+         "count": 1,
+         "description": "In HTML, <div> cannot be a descendant of <p>.
+       This will cause a hydration error.",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
     }
   })
@@ -787,35 +776,30 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-    const { session, browser } = sandbox
-    await session.assertHasRedbox()
+    const { browser } = sandbox
+
     await retry(async () => {
       expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
     })
 
-    const description = await session.getRedboxDescription()
     if (isReact18) {
-      expect(description).toMatchInlineSnapshot(
-        `"Expected server HTML to contain a matching <tr> in <div>."`
-      )
-    } else {
-      expect(description).toMatchInlineSnapshot(`
-        "In HTML, <tr> cannot be a child of <div>.
-        This will cause a hydration error."
-      `)
-    }
-
-    const pseudoHtml = await session.getRedboxComponentStack()
-
-    if (isReact18) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "<Page>
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "<Page>
        >   <div>
-       >     <tr>"
+       >     <tr>",
+         "count": 3,
+         "description": "Expected server HTML to contain a matching <tr> in <div>.",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
     } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "<Root callbacks={[...]}>
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "<Root callbacks={[...]}>
            <Head>
            <AppContainer>
              <Container fn={function fn}>
@@ -827,7 +811,15 @@ describe('Error overlay for hydration errors in Pages router', () => {
        >                 <div>
        >                   <tr>
                      ...
-                 ..."
+                 ...",
+         "count": 1,
+         "description": "In HTML, <tr> cannot be a child of <div>.
+       This will cause a hydration error.",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
     }
   })
@@ -848,39 +840,34 @@ describe('Error overlay for hydration errors in Pages router', () => {
         ],
       ])
     )
-    const { session, browser } = sandbox
-    await session.assertHasRedbox()
+    const { browser } = sandbox
+
     await retry(async () => {
       expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
     })
 
-    const description = await session.getRedboxDescription()
     if (isReact18) {
-      expect(description).toMatchInlineSnapshot(
-        `"Expected server HTML to contain a matching <p> in <span>."`
-      )
-    } else {
-      expect(description).toMatchInlineSnapshot(`
-        "In HTML, <p> cannot be a descendant of <p>.
-        This will cause a hydration error."
-      `)
-    }
-
-    const pseudoHtml = await session.getRedboxComponentStack()
-
-    if (isReact18) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "<Page>
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "<Page>
            <p>
              <span>
                <span>
                  <span>
        >           <span>
-       >             <p>"
+       >             <p>",
+         "count": 3,
+         "description": "Expected server HTML to contain a matching <p> in <span>.",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
     } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-       "<Root callbacks={[...]}>
+      await expect(browser).toDisplayRedbox(`
+       {
+         "componentStack": "<Root callbacks={[...]}>
            <Head>
            <AppContainer>
              <Container fn={function fn}>
@@ -896,7 +883,15 @@ describe('Error overlay for hydration errors in Pages router', () => {
                                  <span>
        >                           <p>
                      ...
-                 ..."
+                 ...",
+         "count": 1,
+         "description": "In HTML, <p> cannot be a descendant of <p>.
+       This will cause a hydration error.",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": undefined,
+         "stack": [],
+       }
       `)
     }
   })


### PR DESCRIPTION
Adds a `componentStack` property to the Redbox snapshot but only if a component stack exists. The component stack is only displayed for hydration errors at the moment so it's just noise for 99% of tests.