### PR TITLE
[ci] Fix `test-turbopack-integration` not having any shards 

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -249,11 +249,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        exclude:
-          # Excluding React 18 tests unless on `canary` branch until budget is approved.
-          - react: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-react-18-tests') && '18.3.1' }}
         group: [1/6, 2/6, 3/6, 4/6, 5/6, 6/6]
         # Empty value uses default
+        # TODO: Run with React 18.
+        # Integration tests use the installed React version in next/package.json.include:
+        # We can't easily switch like we do for e2e tests.
+        # Skipping this dimensions until we can figure out a way to test multiple React versions.
         react: ['']
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -543,9 +544,9 @@ jobs:
           - 11/13
           - 12/13
           - 13/13
-          # Empty value uses default
-          # TODO: Run with React 18.
-          # Integration tests use the installed React version in next/package.json.include:
+        # Empty value uses default
+        # TODO: Run with React 18.
+        # Integration tests use the installed React version in next/package.json.include:
         # We can't easily switch like we do for e2e tests.
         # Skipping this dimensions until we can figure out a way to test multiple React versions.
         react: ['']


### PR DESCRIPTION
Noticed that this job was the largest contributor to wall time by far
![CleanShot 2025-02-22 at 00 25 39](https://github.com/user-attachments/assets/52ec106c-ac14-4f9d-b4ad-a90f16d7d828)


I guess this broke in [#70541 (files)](https://github.com/vercel/next.js/pull/70541/files#diff-48c0ee97c53013d18d6bbae44648f7fab9af2e0bf5b0dc1ca761e18ec5c478f2R224-R226) which is odd because it still sharded on the PR job. Seems like GH Actions opts out of any sharding if you try to exclude a value that doesn't exist.

Especially odd since it currently sometimes [does shard](https://github.com/vercel/next.js/actions/runs/13479624778/job/37663291940?pr=76384) and sometimes [doesn't shard](https://github.com/vercel/next.js/actions/runs/13481493569/job/37667294030?pr=76392).