### PR TITLE
docs(lazy-loading): add caveat to importing client components section

### DIFF
--- a/docs/01-app/03-building-your-application/06-optimizing/07-lazy-loading.mdx
+++ b/docs/01-app/03-building-your-application/06-optimizing/07-lazy-loading.mdx
@@ -55,6 +55,8 @@ export default function ClientComponentExample() {
 }
 ```
 
+> **Note:** When a Server Component dynamically imports a Client Component, automatic [code splitting](https://developer.mozilla.org/docs/Glossary/Code_splitting) is currently **not** supported.
+
 ### Skipping SSR
 
 When using `React.lazy()` and Suspense, Client Components will be [prerendered](https://github.com/reactwg/server-components/discussions/4) (SSR) by default.


### PR DESCRIPTION
## Why?

Automatic code-splitting is currently not supported when a Server Component dynamically imports a Client Component.

- x-ref: https://github.com/vercel/next.js/issues/61066
- Fixes https://github.com/vercel/next.js/issues/60656