### PR TITLE
[dev-overlay] fix: restore the missing Cursor editor case in dev-overlay 

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/utils/launch-editor.ts
+++ b/packages/next/src/client/components/react-dev-overlay/utils/launch-editor.ts
@@ -181,6 +181,7 @@ function getArgumentsForLineNumber(
     }
     case 'code':
     case 'Code':
+    case 'Cursor':
     case 'code-insiders':
     case 'Code - Insiders':
     case 'vscodium':


### PR DESCRIPTION
### What?
Restore the missing Cursor editor case in dev-overlay code that was accidentally dropped during code migration.

### Why?
The Cursor editor support (for the "Open in Editor" feature when clicking error line numbers) that was previously added in PR (#76151) was inadvertently omitted during the code migration process in commit [b20b272](https://github.com/vercel/next.js/pull/76291/commits/b20b272c1b3206de827905d21865381c499f487f). This case was originally present around line 186 but was accidentally dropped during the dev-overlay restructuring.

### How?
Add back the missing 'Cursor' case in launch-editor.ts to ensure error line numbers can properly open in Cursor editor:
