### PR TITLE
[dev-overlay] use css var for `<a>` tag focus ring

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/container/build-error.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/container/build-error.stories.tsx
@@ -24,7 +24,9 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor i
   4 | }
   5 |
 
-Expected identError: Failed to resolve import "./missing-module"`,
+Expected identError: Failed to resolve import "./missing-module"
+
+https://nextjs.org/docs/messages/module-not-found`,
     versionInfo: {
       installed: '15.0.0',
       staleness: 'fresh',

--- a/packages/next/src/client/components/react-dev-overlay/ui/styles/base.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/styles/base.tsx
@@ -153,6 +153,12 @@ export function Base() {
           font-weight: 500;
           line-height: 1.5;
         }
+
+        a {
+          &:focus {
+            outline: var(--focus-ring);
+          }
+        }
       `}
     </style>
   )


### PR DESCRIPTION
### Why?

When clicking the dialog and tabbing, the `<a>` tag inside the Terminal component was focusable but was missing an outline.

### How?

To have a unified outline for the focused `<a>` tag, use the css var `--focus-ring`. This gives a unified style and also fixes this issue.

### Before

https://github.com/user-attachments/assets/7a3b7e45-c9e8-42f5-84fb-9ac4cf203d24

### After

https://github.com/user-attachments/assets/6309f153-1fe2-4087-a81e-49ff0e51e3fd

Closes NDX-856