### PR TITLE
[dev-overlay] fix: bottom stack count

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-bottom-stack/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-bottom-stack/index.tsx
@@ -1,40 +1,41 @@
 export function ErrorOverlayBottomStack({
-  count,
+  errorCount,
   activeIdx,
 }: {
-  count: number
+  errorCount: number
   activeIdx: number
 }) {
-  let stackCount = '0'
+  let stackCount = errorCount
 
-  if (count > 1) {
-    stackCount = '1'
-  }
+  // Add one since the `activeIdx` is 0-based, but
+  // the `stackCount` (number of errors) is 1-based.
+  stackCount -= activeIdx + 1
 
-  if (count > 2) {
-    stackCount = '2'
-  }
-
-  if (activeIdx === 1) {
-    stackCount = '1'
-  }
-
-  if (activeIdx > 1) {
-    stackCount = '0'
+  // If there are more than 2 errors to navigate,
+  // the stack should remain at 2.
+  if (stackCount > 2) {
+    stackCount = 2
   }
 
   return (
     <div aria-hidden className="error-overlay-bottom-stack">
-      <div className="stack" data-stack-count={stackCount}>
-        <div className="layer layer1">1</div>
-        <div className="layer layer2">2</div>
+      <div
+        className="error-overlay-bottom-stack-stack"
+        data-stack-count={stackCount}
+      >
+        <div className="error-overlay-bottom-stack-layer error-overlay-bottom-stack-layer-1">
+          1
+        </div>
+        <div className="error-overlay-bottom-stack-layer error-overlay-bottom-stack-layer-2">
+          2
+        </div>
       </div>
     </div>
   )
 }
 
 export const styles = `
-  .layer {
+  .error-overlay-bottom-stack-layer {
     width: 100%;
     height: var(--stack-layer-height);
     position: relative;
@@ -46,11 +47,11 @@ export const styles = `
       box-shadow 350ms var(--timing-swift);
   }
 
-  .layer1 {
+  .error-overlay-bottom-stack-layer-1 {
     width: calc(100% - var(--size-6));
   }
 
-  .layer2 {
+  .error-overlay-bottom-stack-layer-2 {
     width: calc(100% - var(--size-12));
     z-index: -1;
   }
@@ -63,7 +64,7 @@ export const styles = `
     overflow: visible;
   }
 
-  .stack {
+  .error-overlay-bottom-stack-stack {
     --stack-layer-height: 44px;
     --stack-layer-height-half: calc(var(--stack-layer-height) / 2);
     --stack-layer-trim: 13px;
@@ -79,7 +80,7 @@ export const styles = `
     z-index: -1;
     max-width: var(--next-dialog-max-width);
 
-    .layer {
+    .error-overlay-bottom-stack-layer {
       grid-area: 1 / 1;
       /* Hide */
       translate: 0 calc(var(--stack-layer-height) * -1);
@@ -87,32 +88,32 @@ export const styles = `
 
     &[data-stack-count='1'],
     &[data-stack-count='2'] {
-      .layer1 {
+      .error-overlay-bottom-stack-layer-1 {
         translate: 0
           calc(var(--stack-layer-height-half) * -1 - var(--stack-layer-trim));
       }
     }
 
     &[data-stack-count='2'] {
-      .layer2 {
+      .error-overlay-bottom-stack-layer-2 {
         translate: 0 calc(var(--stack-layer-trim) * -1 * 2);
       }
     }
 
     /* Only the bottom stack should have the shadow */
-    &[data-stack-count='1'] .layer1 {
+    &[data-stack-count='1'] .error-overlay-bottom-stack-layer-1 {
       box-shadow: var(--shadow);
     }
 
     &[data-stack-count='2'] {
-      .layer2 {
+      .error-overlay-bottom-stack-layer-2 {
         box-shadow: var(--shadow);
       }
     }
   }
 
   @media (prefers-color-scheme: dark) {
-    .layer {
+    .error-overlay-bottom-stack-layer {
       border-color: var(--color-gray-400);
     }
   }

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-bottom-stack/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-bottom-stack/index.tsx
@@ -5,18 +5,8 @@ export function ErrorOverlayBottomStack({
   errorCount: number
   activeIdx: number
 }) {
-  let stackCount = errorCount
-
-  // Add one since the `activeIdx` is 0-based, but
-  // the `stackCount` (number of errors) is 1-based.
-  stackCount -= activeIdx + 1
-
-  // If there are more than 2 errors to navigate,
-  // the stack should remain at 2.
-  if (stackCount > 2) {
-    stackCount = 2
-  }
-
+  // If there are more than 2 errors to navigate, the stack count should remain at 2.
+  const stackCount = Math.min(errorCount - activeIdx - 1, 2)
   return (
     <div aria-hidden className="error-overlay-bottom-stack">
       <div

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-layout/error-overlay-layout.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-layout/error-overlay-layout.tsx
@@ -121,7 +121,7 @@ export function ErrorOverlayLayout({
             </DialogFooter>
           )}
           <ErrorOverlayBottomStack
-            count={runtimeErrors?.length ?? 0}
+            errorCount={runtimeErrors?.length ?? 0}
             activeIdx={activeIdx ?? 0}
           />
         </ErrorOverlayDialog>


### PR DESCRIPTION
### Why?

The error overlay's bottom stack count was wrong.

### Before

https://github.com/user-attachments/assets/24f09416-38a9-4b47-8a59-269e9855f851

### After

https://github.com/user-attachments/assets/9f0dff66-e40c-4e68-afda-d149d1b8d895

Closes NDX-827