### PR TITLE
[dev-overlay] fix: fallback to local machine's Geist Font if applicable

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/styles/base.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/styles/base.tsx
@@ -39,10 +39,11 @@ export function Base() {
           --color-accents-2: #222222;
           --color-accents-3: #404040;
 
-          --font-stack-monospace: '__nextjs-Geist Mono', 'SFMono-Regular',
-            Consolas, 'Liberation Mono', Menlo, Courier, monospace;
-          --font-stack-sans: '__nextjs-Geist', -apple-system, 'Source Sans Pro',
-            sans-serif;
+          --font-stack-monospace: '__nextjs-Geist Mono', 'Geist Mono',
+            'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier,
+            monospace;
+          --font-stack-sans: '__nextjs-Geist', 'Geist', -apple-system,
+            'Source Sans Pro', sans-serif;
 
           font-family: var(--font-stack-sans);
 


### PR DESCRIPTION
### Why?

When the request for `__nextjs_font/` fails, it's safer to fall back to the local Geist Font if applicable. For example, in a storybook, the request will always fail.

| Before | After |
|--------|--------|
| ![CleanShot 2025-02-23 at 00 45 53](https://github.com/user-attachments/assets/bb8b9e36-d646-4602-a67b-5a96ec68992d) | ![CleanShot 2025-02-23 at 00 45 39](https://github.com/user-attachments/assets/05545bef-c05f-4b52-8c53-a0826f5e17aa) | 

Closes NDX-885