### PR TITLE
Turbopack: fix graph chunk groups

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -838,8 +838,9 @@ impl AppProject {
                             (
                                 server_utils
                                     .iter()
-                                    .map(|m| ResolvedVc::upcast(*m))
-                                    .collect(),
+                                    .map(async |m| Ok(ResolvedVc::upcast(m.await?.module)))
+                                    .try_join()
+                                    .await?,
                                 ChunkGroupType::Entry,
                             ),
                             (client_shared_entries, ChunkGroupType::Evaluated),

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -813,13 +813,14 @@ impl AppProject {
         &self,
         endpoint: Vc<AppEndpoint>,
         rsc_entry: ResolvedVc<Box<dyn Module>>,
-        extra_entries: Vc<EvaluatableAssets>,
+        client_shared_entries: Vc<EvaluatableAssets>,
         has_layout_segments: bool,
     ) -> Result<Vc<ModuleGraphs>> {
-        let extra_entries = extra_entries
+        let client_shared_entries = client_shared_entries
             .await?
             .into_iter()
-            .map(|m| ResolvedVc::upcast(*m));
+            .map(|m| ResolvedVc::upcast(*m))
+            .collect();
 
         if *self.project.per_page_module_graph().await? {
             // Implements layout segment optimization to compute a graph "chain" for each layout
@@ -833,14 +834,16 @@ impl AppProject {
                     } = &*find_server_entries(*rsc_entry).await?;
 
                     let graph = SingleModuleGraph::new_with_entries_visited(
-                        vec![(
-                            server_utils
-                                .iter()
-                                .map(|m| ResolvedVc::upcast(*m))
-                                .chain(extra_entries)
-                                .collect(),
-                            ChunkGroupType::Entry,
-                        )],
+                        vec![
+                            (
+                                server_utils
+                                    .iter()
+                                    .map(|m| ResolvedVc::upcast(*m))
+                                    .collect(),
+                                ChunkGroupType::Entry,
+                            ),
+                            (client_shared_entries, ChunkGroupType::Evaluated),
+                        ],
                         VisitedModules::empty(),
                     );
                     graphs.push(graph);
@@ -869,7 +872,7 @@ impl AppProject {
                     visited_modules
                 } else {
                     let graph = SingleModuleGraph::new_with_entries_visited(
-                        vec![(extra_entries.collect(), ChunkGroupType::Entry)],
+                        vec![(client_shared_entries, ChunkGroupType::Evaluated)],
                         VisitedModules::empty(),
                     );
                     graphs.push(graph);

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1475,7 +1475,11 @@ impl Endpoint for PageEndpoint {
 
         if let PageEndpointType::Html = this.ty {
             modules.push((
-                vec![self.client_module().to_resolved().await?],
+                self.client_evaluatable_assets()
+                    .await?
+                    .iter()
+                    .map(|m| ResolvedVc::upcast(*m))
+                    .collect(),
                 ChunkGroupType::Evaluated,
             ));
         }

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -22,8 +22,8 @@ use crate::{
     chunk::{ChunkGroupType, ChunkingType},
     module::Module,
     module_graph::{
-        get_node, GraphNodeIndex, GraphTraversalAction, ModuleGraph, SingleModuleGraphModuleNode,
-        SingleModuleGraphNode,
+        get_node, get_node_idx, GraphNodeIndex, GraphTraversalAction, ModuleGraph,
+        SingleModuleGraphModuleNode, SingleModuleGraphNode,
     },
 };
 
@@ -446,8 +446,8 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraph) -> Result<Vc<ChunkGro
             }
             while let Some(NodeWithPriority { node, .. }) = queue.pop() {
                 queue_set.remove(&node);
+                let (node_weight, node) = get_node_idx!(graphs, node)?;
                 let graph = &graphs[node.graph_idx].graph;
-                let node_weight = get_node!(graphs, node)?;
                 let neighbors = iter_neighbors(graph, node.node_idx);
 
                 visit_count += 1;
@@ -457,7 +457,7 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraph) -> Result<Vc<ChunkGro
                         graph_idx: node.graph_idx,
                         node_idx: succ,
                     };
-                    let succ_weight = get_node!(graphs, succ)?;
+                    let (succ_weight, succ) = get_node_idx!(graphs, succ)?;
                     let edge_weight = graph.edge_weight(edge).unwrap();
                     let action = visitor(
                         Some((node_weight, edge_weight)),

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -692,7 +692,7 @@ macro_rules! get_node {
             Some(SingleModuleGraphNode::Module(node)) => ::anyhow::Ok(node),
             Some(SingleModuleGraphNode::VisitedModule { idx, .. }) => {
                 match $graphs[idx.graph_idx].graph.node_weight(idx.node_idx) {
-                    Some(SingleModuleGraphNode::Module(node)) => anyhow::Ok(node),
+                    Some(SingleModuleGraphNode::Module(node)) => ::anyhow::Ok(node),
                     Some(SingleModuleGraphNode::VisitedModule { .. }) => Err(::anyhow::anyhow!(
                         "Expected visited target node to be module"
                     )),
@@ -704,6 +704,28 @@ macro_rules! get_node {
     }};
 }
 pub(crate) use get_node;
+macro_rules! get_node_idx {
+    ($graphs:expr, $node:expr) => {{
+        let node_idx = $node;
+        match $graphs[node_idx.graph_idx]
+            .graph
+            .node_weight(node_idx.node_idx)
+        {
+            Some(SingleModuleGraphNode::Module(node)) => ::anyhow::Ok((node, node_idx)),
+            Some(SingleModuleGraphNode::VisitedModule { idx, .. }) => {
+                match $graphs[idx.graph_idx].graph.node_weight(idx.node_idx) {
+                    Some(SingleModuleGraphNode::Module(node)) => ::anyhow::Ok((node, *idx)),
+                    Some(SingleModuleGraphNode::VisitedModule { .. }) => Err(::anyhow::anyhow!(
+                        "Expected visited target node to be module"
+                    )),
+                    None => Err(::anyhow::anyhow!("Expected visited target node")),
+                }
+            }
+            None => Err(::anyhow::anyhow!("Expected graph node")),
+        }
+    }};
+}
+pub(crate) use get_node_idx;
 
 // pub struct AllNodesIterator {
 //     inner: Vec<ReadRef<SingleModuleGraph>>,


### PR DESCRIPTION
### What?

* Fix pages graph entrypoints
* Fix chunk_group_info computation for merged
* Fix client_shared_entries in graph
* chunk_group_info: continue walking across graphs

Closes PACK-4022