### PR TITLE
[dev-overlay] sync suffix `N` of `--size-N` with `px` value of base font `16px`

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/call-stack-frame/call-stack-frame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/call-stack-frame/call-stack-frame.tsx
@@ -70,8 +70,8 @@ export const CallStackFrame: React.FC<{
 
 export const CALL_STACK_FRAME_STYLES = `
   [data-nextjs-call-stack-frame-ignored] {
-    padding: var(--rem-px-6) var(--rem-px-8);
-    margin-bottom: var(--rem-px-4);
+    padding: var(--size-6) var(--size-8);
+    margin-bottom: var(--size-4);
 
     border-radius: var(--rounded-lg);
   }
@@ -98,15 +98,15 @@ export const CALL_STACK_FRAME_STYLES = `
   .call-stack-frame-method-name {
     display: flex;
     align-items: center;
-    gap: var(--rem-px-4);
+    gap: var(--size-4);
 
-    margin-bottom: var(--rem-px-4);
+    margin-bottom: var(--size-4);
     font-family: var(--font-stack-monospace);
 
     color: var(--color-gray-1000);
     font-size: var(--size-font-small);
     font-weight: 500;
-    line-height: var(--rem-px-20);
+    line-height: var(--size-20);
   }
 
   .open-in-editor-button {
@@ -130,6 +130,6 @@ export const CALL_STACK_FRAME_STYLES = `
   .call-stack-frame-file-source {
     color: var(--color-gray-900);
     font-size: var(--size-font-small);
-    line-height: var(--rem-px-20);
+    line-height: var(--size-20);
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/call-stack-frame/call-stack-frame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/call-stack-frame/call-stack-frame.tsx
@@ -70,8 +70,8 @@ export const CallStackFrame: React.FC<{
 
 export const CALL_STACK_FRAME_STYLES = `
   [data-nextjs-call-stack-frame-ignored] {
-    padding: var(--size-1_5) var(--size-2);
-    margin-bottom: var(--size-1);
+    padding: var(--rem-px-6) var(--rem-px-8);
+    margin-bottom: var(--rem-px-4);
 
     border-radius: var(--rounded-lg);
   }
@@ -98,15 +98,15 @@ export const CALL_STACK_FRAME_STYLES = `
   .call-stack-frame-method-name {
     display: flex;
     align-items: center;
-    gap: var(--size-1);
+    gap: var(--rem-px-4);
 
-    margin-bottom: var(--size-1);
+    margin-bottom: var(--rem-px-4);
     font-family: var(--font-stack-monospace);
 
     color: var(--color-gray-1000);
     font-size: var(--size-font-small);
     font-weight: 500;
-    line-height: var(--size-5);
+    line-height: var(--rem-px-20);
   }
 
   .open-in-editor-button {
@@ -130,6 +130,6 @@ export const CALL_STACK_FRAME_STYLES = `
   .call-stack-frame-file-source {
     color: var(--color-gray-900);
     font-size: var(--size-font-small);
-    line-height: var(--size-5);
+    line-height: var(--rem-px-20);
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/call-stack-frame/call-stack-frame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/call-stack-frame/call-stack-frame.tsx
@@ -104,7 +104,7 @@ export const CALL_STACK_FRAME_STYLES = `
     font-family: var(--font-stack-monospace);
 
     color: var(--color-gray-1000);
-    font-size: var(--size-font-small);
+    font-size: var(--size-14);
     font-weight: 500;
     line-height: var(--size-20);
   }
@@ -129,7 +129,7 @@ export const CALL_STACK_FRAME_STYLES = `
 
   .call-stack-frame-file-source {
     color: var(--color-gray-900);
-    font-size: var(--size-font-small);
+    font-size: var(--size-14);
     line-height: var(--size-20);
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/code-frame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/code-frame.tsx
@@ -122,7 +122,7 @@ export const CODE_FRAME_STYLES = `
     font-family: var(--font-stack-monospace);
     font-size: 12px;
     line-height: 16px;
-    margin: var(--size-2) 0;
+    margin: var(--rem-px-8) 0;
   }
 
   .code-frame-link,

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/code-frame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/code-frame.tsx
@@ -122,7 +122,7 @@ export const CODE_FRAME_STYLES = `
     font-family: var(--font-stack-monospace);
     font-size: 12px;
     line-height: 16px;
-    margin: var(--rem-px-8) 0;
+    margin: var(--size-8) 0;
   }
 
   .code-frame-link,

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/dialog/styles.ts
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/dialog/styles.ts
@@ -54,7 +54,7 @@ const styles = `
     display: flex;
     flex-direction: column;
     position: relative;
-    padding: var(--size-4) var(--size-3);
+    padding: var(--rem-px-16) var(--rem-px-12);
   }
 
   /* Account for the footer height, when present */
@@ -64,7 +64,7 @@ const styles = `
 
   [data-nextjs-dialog-content] > [data-nextjs-dialog-header] {
     flex-shrink: 0;
-    margin-bottom: var(--size-2);
+    margin-bottom: var(--rem-px-8);
   }
 
   [data-nextjs-dialog-content] > [data-nextjs-dialog-body] {

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/dialog/styles.ts
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/dialog/styles.ts
@@ -54,7 +54,7 @@ const styles = `
     display: flex;
     flex-direction: column;
     position: relative;
-    padding: var(--rem-px-16) var(--rem-px-12);
+    padding: var(--size-16) var(--size-12);
   }
 
   /* Account for the footer height, when present */
@@ -64,7 +64,7 @@ const styles = `
 
   [data-nextjs-dialog-content] > [data-nextjs-dialog-header] {
     flex-shrink: 0;
-    margin-bottom: var(--rem-px-8);
+    margin-bottom: var(--size-8);
   }
 
   [data-nextjs-dialog-content] > [data-nextjs-dialog-body] {

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/call-stack/call-stack.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/call-stack/call-stack.tsx
@@ -142,7 +142,7 @@ export const CALL_STACK_STYLES = `
     margin: 0;
 
     color: var(--color-gray-1000);
-    font-size: var(--size-font);
+    font-size: var(--size-16);
     font-weight: 500;
     line-height: var(--size-20);
   }
@@ -158,7 +158,7 @@ export const CALL_STACK_STYLES = `
 
     color: var(--color-gray-1000);
     text-align: center;
-    font-size: var(--size-font-11);
+    font-size: var(--size-11);
     font-weight: 500;
     line-height: var(--size-16);
 
@@ -172,7 +172,7 @@ export const CALL_STACK_STYLES = `
     align-items: center;
     gap: 6px;
     color: var(--color-gray-900);
-    font-size: var(--size-font-small);
+    font-size: var(--size-14);
     line-height: var(--size-20);
     border-radius: 6px;
     padding: 4px 6px;

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/call-stack/call-stack.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/call-stack/call-stack.tsx
@@ -121,7 +121,7 @@ function ChevronUpDown() {
 export const CALL_STACK_STYLES = `
   .error-overlay-call-stack-container {
     position: relative;
-    margin-top: var(--size-2);
+    margin-top: var(--rem-px-8);
   }
 
   .error-overlay-call-stack-header {
@@ -129,7 +129,7 @@ export const CALL_STACK_STYLES = `
     justify-content: space-between;
     align-items: center;
     min-height: 28px;
-    padding: var(--size-2) var(--size-2) var(--size-3) var(--size-1);
+    padding: var(--rem-px-8) var(--rem-px-8) var(--rem-px-12) var(--rem-px-4);
     width: 100%;
   }
 
@@ -137,14 +137,14 @@ export const CALL_STACK_STYLES = `
     display: flex;
     justify-content: space-between;
     align-items: center;
-    gap: var(--size-2);
+    gap: var(--rem-px-8);
 
     margin: 0;
 
     color: var(--color-gray-1000);
     font-size: var(--size-font);
     font-weight: 500;
-    line-height: var(--size-5);
+    line-height: var(--rem-px-20);
   }
 
   .error-overlay-call-stack-count {
@@ -154,13 +154,13 @@ export const CALL_STACK_STYLES = `
 
     width: 20px;
     height: 20px;
-    gap: var(--size-1);
+    gap: var(--rem-px-4);
 
     color: var(--color-gray-1000);
     text-align: center;
     font-size: var(--size-font-11);
     font-weight: 500;
-    line-height: var(--size-4);
+    line-height: var(--rem-px-16);
 
     border-radius: var(--rounded-full);
     background: var(--color-gray-300);
@@ -173,7 +173,7 @@ export const CALL_STACK_STYLES = `
     gap: 6px;
     color: var(--color-gray-900);
     font-size: var(--size-font-small);
-    line-height: var(--size-5);
+    line-height: var(--rem-px-20);
     border-radius: 6px;
     padding: 4px 6px;
     margin-right: -6px;

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/call-stack/call-stack.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/call-stack/call-stack.tsx
@@ -121,7 +121,7 @@ function ChevronUpDown() {
 export const CALL_STACK_STYLES = `
   .error-overlay-call-stack-container {
     position: relative;
-    margin-top: var(--rem-px-8);
+    margin-top: var(--size-8);
   }
 
   .error-overlay-call-stack-header {
@@ -129,7 +129,7 @@ export const CALL_STACK_STYLES = `
     justify-content: space-between;
     align-items: center;
     min-height: 28px;
-    padding: var(--rem-px-8) var(--rem-px-8) var(--rem-px-12) var(--rem-px-4);
+    padding: var(--size-8) var(--size-8) var(--size-12) var(--size-4);
     width: 100%;
   }
 
@@ -137,14 +137,14 @@ export const CALL_STACK_STYLES = `
     display: flex;
     justify-content: space-between;
     align-items: center;
-    gap: var(--rem-px-8);
+    gap: var(--size-8);
 
     margin: 0;
 
     color: var(--color-gray-1000);
     font-size: var(--size-font);
     font-weight: 500;
-    line-height: var(--rem-px-20);
+    line-height: var(--size-20);
   }
 
   .error-overlay-call-stack-count {
@@ -154,13 +154,13 @@ export const CALL_STACK_STYLES = `
 
     width: 20px;
     height: 20px;
-    gap: var(--rem-px-4);
+    gap: var(--size-4);
 
     color: var(--color-gray-1000);
     text-align: center;
     font-size: var(--size-font-11);
     font-weight: 500;
-    line-height: var(--rem-px-16);
+    line-height: var(--size-16);
 
     border-radius: var(--rounded-full);
     background: var(--color-gray-300);
@@ -173,7 +173,7 @@ export const CALL_STACK_STYLES = `
     gap: 6px;
     color: var(--color-gray-900);
     font-size: var(--size-font-small);
-    line-height: var(--rem-px-20);
+    line-height: var(--size-20);
     border-radius: 6px;
     padding: 4px 6px;
     margin-right: -6px;

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -607,13 +607,13 @@ export const DEV_TOOLS_INDICATOR_STYLES = `
   }
 
   .dev-tools-indicator-label {
-    font-size: var(--size-font-small);
+    font-size: var(--size-14);
     line-height: var(--size-20);
     color: var(--color-gray-1000);
   }
 
   .dev-tools-indicator-value {
-    font-size: var(--size-font-small);
+    font-size: var(--size-14);
     line-height: var(--size-20);
     color: var(--color-gray-900);
     margin-left: auto;
@@ -670,7 +670,7 @@ export const DEV_TOOLS_INDICATOR_STYLES = `
       background: var(--color-background-100);
       color: var(--color-gray-1000);
       text-align: center;
-      font-size: var(--size-font-smaller);
+      font-size: var(--size-12);
       line-height: var(--size-16);
     }
   }

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -262,8 +262,8 @@ function DevToolsPopover({
         // Reset the toast component's default positions.
         bottom: 'initial',
         left: 'initial',
-        [vertical]: 'var(--size-2_5)',
-        [horizontal]: 'var(--size-5)',
+        [vertical]: 'var(--rem-px-10)',
+        [horizontal]: 'var(--rem-px-20)',
       }}
     >
       <NextLogo
@@ -608,13 +608,13 @@ export const DEV_TOOLS_INDICATOR_STYLES = `
 
   .dev-tools-indicator-label {
     font-size: var(--size-font-small);
-    line-height: var(--size-5);
+    line-height: var(--rem-px-20);
     color: var(--color-gray-1000);
   }
 
   .dev-tools-indicator-value {
     font-size: var(--size-font-small);
-    line-height: var(--size-5);
+    line-height: var(--rem-px-20);
     color: var(--color-gray-900);
     margin-left: auto;
   }
@@ -656,11 +656,11 @@ export const DEV_TOOLS_INDICATOR_STYLES = `
 
   .dev-tools-indicator-shortcut {
     display: flex;
-    gap: var(--size-1);
+    gap: var(--rem-px-4);
 
     kbd {
-      width: var(--size-5);
-      height: var(--size-5);
+      width: var(--rem-px-20);
+      height: var(--rem-px-20);
       display: flex;
       justify-content: center;
       align-items: center;
@@ -671,7 +671,7 @@ export const DEV_TOOLS_INDICATOR_STYLES = `
       color: var(--color-gray-1000);
       text-align: center;
       font-size: var(--size-font-smaller);
-      line-height: var(--size-4);
+      line-height: var(--rem-px-16);
     }
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -262,8 +262,8 @@ function DevToolsPopover({
         // Reset the toast component's default positions.
         bottom: 'initial',
         left: 'initial',
-        [vertical]: 'var(--rem-px-10)',
-        [horizontal]: 'var(--rem-px-20)',
+        [vertical]: 'var(--size-10)',
+        [horizontal]: 'var(--size-20)',
       }}
     >
       <NextLogo
@@ -608,13 +608,13 @@ export const DEV_TOOLS_INDICATOR_STYLES = `
 
   .dev-tools-indicator-label {
     font-size: var(--size-font-small);
-    line-height: var(--rem-px-20);
+    line-height: var(--size-20);
     color: var(--color-gray-1000);
   }
 
   .dev-tools-indicator-value {
     font-size: var(--size-font-small);
-    line-height: var(--rem-px-20);
+    line-height: var(--size-20);
     color: var(--color-gray-900);
     margin-left: auto;
   }
@@ -656,11 +656,11 @@ export const DEV_TOOLS_INDICATOR_STYLES = `
 
   .dev-tools-indicator-shortcut {
     display: flex;
-    gap: var(--rem-px-4);
+    gap: var(--size-4);
 
     kbd {
-      width: var(--rem-px-20);
-      height: var(--rem-px-20);
+      width: var(--size-20);
+      height: var(--size-20);
       display: flex;
       justify-content: center;
       align-items: center;
@@ -671,7 +671,7 @@ export const DEV_TOOLS_INDICATOR_STYLES = `
       color: var(--color-gray-1000);
       text-align: center;
       font-size: var(--size-font-smaller);
-      line-height: var(--rem-px-16);
+      line-height: var(--size-16);
     }
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -292,7 +292,7 @@ function DevToolsPopover({
           setIsOpen={setIsRouteInfoOpen}
           setPreviousOpen={setIsMenuOpen}
           style={{
-            [vertical]: 'calc(100% + var(--size-gap))',
+            [vertical]: 'calc(100% + 8px)',
             [horizontal]: 0,
           }}
           data-rendered={routeInfoRendered}
@@ -306,7 +306,7 @@ function DevToolsPopover({
           setIsOpen={setIsTurbopackInfoOpen}
           setPreviousOpen={setIsMenuOpen}
           style={{
-            [vertical]: 'calc(100% + var(--size-gap))',
+            [vertical]: 'calc(100% + 8px)',
             [horizontal]: 0,
           }}
           data-rendered={turbopackInfoRendered}
@@ -329,7 +329,7 @@ function DevToolsPopover({
             {
               '--animate-out-duration-ms': `${ANIMATE_OUT_DURATION_MS}ms`,
               '--animate-out-timing-function': ANIMATE_OUT_TIMING_FUNCTION,
-              [vertical]: 'calc(100% + var(--size-gap))',
+              [vertical]: 'calc(100% + 8px)',
               [horizontal]: 0,
             } as React.CSSProperties
           }

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
@@ -69,11 +69,11 @@ export const DEV_TOOLS_INFO_STYLES = `
   }
 
   .dev-tools-info-container {
-    padding: var(--size-1_5);
+    padding: var(--rem-px-6);
   }
 
   .dev-tools-info-title {
-    padding: var(--size-2) var(--size-1_5);
+    padding: var(--rem-px-8) var(--rem-px-6);
     color: var(--color-gray-1000);
     font-size: 14px;
     font-weight: 500;
@@ -82,7 +82,7 @@ export const DEV_TOOLS_INFO_STYLES = `
   }
 
   .dev-tools-info-article {
-    padding: var(--size-2) var(--size-1_5);
+    padding: var(--rem-px-8) var(--rem-px-6);
     color: var(--color-gray-1000);
     font-size: 14px;
     line-height: 20px;
@@ -98,11 +98,11 @@ export const DEV_TOOLS_INFO_STYLES = `
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: var(--size-2) var(--size-1_5);
+    padding: var(--rem-px-8) var(--rem-px-6);
   }
 
   .dev-tools-info-close-button {
-    padding: 0 var(--size-2);
+    padding: 0 var(--rem-px-8);
     height: 28px;
     font-size: 14px;
     font-weight: 500;
@@ -120,7 +120,7 @@ export const DEV_TOOLS_INFO_STYLES = `
 
   .dev-tools-info-learn-more-button {
     align-content: center;
-    padding: 0 var(--size-2);
+    padding: 0 var(--rem-px-8);
     height: 28px;
     font-size: 14px;
     font-weight: 500;

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
@@ -69,11 +69,11 @@ export const DEV_TOOLS_INFO_STYLES = `
   }
 
   .dev-tools-info-container {
-    padding: var(--rem-px-6);
+    padding: var(--size-6);
   }
 
   .dev-tools-info-title {
-    padding: var(--rem-px-8) var(--rem-px-6);
+    padding: var(--size-8) var(--size-6);
     color: var(--color-gray-1000);
     font-size: 14px;
     font-weight: 500;
@@ -82,7 +82,7 @@ export const DEV_TOOLS_INFO_STYLES = `
   }
 
   .dev-tools-info-article {
-    padding: var(--rem-px-8) var(--rem-px-6);
+    padding: var(--size-8) var(--size-6);
     color: var(--color-gray-1000);
     font-size: 14px;
     line-height: 20px;
@@ -98,11 +98,11 @@ export const DEV_TOOLS_INFO_STYLES = `
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: var(--rem-px-8) var(--rem-px-6);
+    padding: var(--size-8) var(--size-6);
   }
 
   .dev-tools-info-close-button {
-    padding: 0 var(--rem-px-8);
+    padding: 0 var(--size-8);
     height: 28px;
     font-size: 14px;
     font-weight: 500;
@@ -120,7 +120,7 @@ export const DEV_TOOLS_INFO_STYLES = `
 
   .dev-tools-info-learn-more-button {
     align-content: center;
-    padding: 0 var(--rem-px-8);
+    padding: 0 var(--size-8);
     height: 28px;
     font-size: 14px;
     font-weight: 500;

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/turbopack-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/turbopack-info.tsx
@@ -115,7 +115,7 @@ export const DEV_TOOLS_INFO_TURBOPACK_INFO_STYLES = `
     background: var(--color-gray-400);
     color: var(--color-gray-1000);
     font-family: var(--font-stack-mono);
-    padding: var(--size-0_5) var(--rem-px-4);
+    padding: var(--rem-px-2) var(--rem-px-4);
     margin: 0;
     font-size: 13px;
     white-space: break-spaces;

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/turbopack-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/turbopack-info.tsx
@@ -115,7 +115,7 @@ export const DEV_TOOLS_INFO_TURBOPACK_INFO_STYLES = `
     background: var(--color-gray-400);
     color: var(--color-gray-1000);
     font-family: var(--font-stack-mono);
-    padding: var(--size-0_5) var(--size-1);
+    padding: var(--size-0_5) var(--rem-px-4);
     margin: 0;
     font-size: 13px;
     white-space: break-spaces;
@@ -123,7 +123,7 @@ export const DEV_TOOLS_INFO_TURBOPACK_INFO_STYLES = `
   }
 
   .dev-tools-info-code-block-container {
-    padding: var(--size-1_5);
+    padding: var(--rem-px-6);
   }
 
   .dev-tools-info-code-block {
@@ -146,11 +146,11 @@ export const DEV_TOOLS_INFO_TURBOPACK_INFO_STYLES = `
     display: flex;
     justify-content: center;
     align-items: center;
-    right: var(--size-2);
-    top: var(--size-2);
-    padding: var(--size-1);
-    height: var(--size-6);
-    width: var(--size-6);
+    right: var(--rem-px-8);
+    top: var(--rem-px-8);
+    padding: var(--rem-px-4);
+    height: var(--rem-px-24);
+    width: var(--rem-px-24);
     border-radius: var(--rounded-md-2);
     border: 1px solid var(--color-gray-alpha-400);
     background: var(--color-background-100);

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/turbopack-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/turbopack-info.tsx
@@ -115,7 +115,7 @@ export const DEV_TOOLS_INFO_TURBOPACK_INFO_STYLES = `
     background: var(--color-gray-400);
     color: var(--color-gray-1000);
     font-family: var(--font-stack-mono);
-    padding: var(--rem-px-2) var(--rem-px-4);
+    padding: var(--size-2) var(--size-4);
     margin: 0;
     font-size: 13px;
     white-space: break-spaces;
@@ -123,7 +123,7 @@ export const DEV_TOOLS_INFO_TURBOPACK_INFO_STYLES = `
   }
 
   .dev-tools-info-code-block-container {
-    padding: var(--rem-px-6);
+    padding: var(--size-6);
   }
 
   .dev-tools-info-code-block {
@@ -146,11 +146,11 @@ export const DEV_TOOLS_INFO_TURBOPACK_INFO_STYLES = `
     display: flex;
     justify-content: center;
     align-items: center;
-    right: var(--rem-px-8);
-    top: var(--rem-px-8);
-    padding: var(--rem-px-4);
-    height: var(--rem-px-24);
-    width: var(--rem-px-24);
+    right: var(--size-8);
+    top: var(--size-8);
+    padding: var(--size-4);
+    height: var(--size-24);
+    width: var(--size-24);
     border-radius: var(--rounded-md-2);
     border: 1px solid var(--color-gray-alpha-400);
     background: var(--color-background-100);

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dialog/header.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dialog/header.tsx
@@ -44,7 +44,7 @@ export const DIALOG_HEADER_STYLES = `
   .nextjs-container-errors-header
     > .nextjs-container-build-error-version-status {
     position: absolute;
-    top: var(--rem-px-16);
-    right: var(--rem-px-16);
+    top: var(--size-16);
+    right: var(--size-16);
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dialog/header.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dialog/header.tsx
@@ -44,7 +44,7 @@ export const DIALOG_HEADER_STYLES = `
   .nextjs-container-errors-header
     > .nextjs-container-build-error-version-status {
     position: absolute;
-    top: var(--size-4);
-    right: var(--size-4);
+    top: var(--rem-px-16);
+    right: var(--rem-px-16);
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dialog/header.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dialog/header.tsx
@@ -19,14 +19,14 @@ export const DIALOG_HEADER_STYLES = `
     position: relative;
   }
   .nextjs-container-errors-header > h1 {
-    font-size: var(--size-font-big);
-    line-height: var(--size-font-bigger);
+    font-size: var(--size-20);
+    line-height: var(--size-24);
     font-weight: bold;
     margin: calc(var(--size-gap-double) * 1.5) 0;
     color: var(--color-title-h1);
   }
   .nextjs-container-errors-header small {
-    font-size: var(--size-font-small);
+    font-size: var(--size-14);
     color: var(--color-accents-1);
     margin-left: var(--size-gap-double);
   }

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dialog/header.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dialog/header.tsx
@@ -22,20 +22,20 @@ export const DIALOG_HEADER_STYLES = `
     font-size: var(--size-20);
     line-height: var(--size-24);
     font-weight: bold;
-    margin: calc(var(--size-gap-double) * 1.5) 0;
+    margin: calc(16px * 1.5) 0;
     color: var(--color-title-h1);
   }
   .nextjs-container-errors-header small {
     font-size: var(--size-14);
     color: var(--color-accents-1);
-    margin-left: var(--size-gap-double);
+    margin-left: 16px;
   }
   .nextjs-container-errors-header small > span {
     font-family: var(--font-stack-monospace);
   }
   .nextjs-container-errors-header > div > small {
     margin: 0;
-    margin-top: var(--size-gap-half);
+    margin-top: 4px;
   }
   .nextjs-container-errors-header > p > a {
     color: inherit;

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/environment-name-label/environment-name-label.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/environment-name-label/environment-name-label.tsx
@@ -14,7 +14,7 @@ export const ENVIRONMENT_NAME_LABEL_STYLES = `
     border-radius: var(--size-6);
     background: var(--color-gray-300);
     font-weight: 600;
-    font-size: var(--size-font-11);
+    font-size: var(--size-11);
     color: var(--color-gray-900);
     font-family: var(--font-stack-monospace);
     line-height: var(--size-20);

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/environment-name-label/environment-name-label.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/environment-name-label/environment-name-label.tsx
@@ -8,15 +8,15 @@ export function EnvironmentNameLabel({
 
 export const ENVIRONMENT_NAME_LABEL_STYLES = `
   [data-nextjs-environment-name-label] {
-    padding: var(--size-0_5) var(--size-1_5);
+    padding: var(--size-0_5) var(--rem-px-6);
     margin: 0;
     /* used --size instead of --rounded because --rounded is missing 6px */
-    border-radius: var(--size-1_5);
+    border-radius: var(--rem-px-6);
     background: var(--color-gray-300);
     font-weight: 600;
     font-size: var(--size-font-11);
     color: var(--color-gray-900);
     font-family: var(--font-stack-monospace);
-    line-height: var(--size-5);
+    line-height: var(--rem-px-20);
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/environment-name-label/environment-name-label.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/environment-name-label/environment-name-label.tsx
@@ -8,7 +8,7 @@ export function EnvironmentNameLabel({
 
 export const ENVIRONMENT_NAME_LABEL_STYLES = `
   [data-nextjs-environment-name-label] {
-    padding: var(--size-0_5) var(--rem-px-6);
+    padding: var(--rem-px-2) var(--rem-px-6);
     margin: 0;
     /* used --size instead of --rounded because --rounded is missing 6px */
     border-radius: var(--rem-px-6);

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/environment-name-label/environment-name-label.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/environment-name-label/environment-name-label.tsx
@@ -8,15 +8,15 @@ export function EnvironmentNameLabel({
 
 export const ENVIRONMENT_NAME_LABEL_STYLES = `
   [data-nextjs-environment-name-label] {
-    padding: var(--rem-px-2) var(--rem-px-6);
+    padding: var(--size-2) var(--size-6);
     margin: 0;
     /* used --size instead of --rounded because --rounded is missing 6px */
-    border-radius: var(--rem-px-6);
+    border-radius: var(--size-6);
     background: var(--color-gray-300);
     font-weight: 600;
     font-size: var(--size-font-11);
     color: var(--color-gray-900);
     font-family: var(--font-stack-monospace);
-    line-height: var(--rem-px-20);
+    line-height: var(--size-20);
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-message/error-message.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-message/error-message.tsx
@@ -50,12 +50,12 @@ export const styles = `
 
   .nextjs__container_errors_desc {
     margin: 0;
-    margin-left: var(--rem-px-4);
+    margin-left: var(--size-4);
     color: var(--color-red-900);
     font-weight: 500;
     font-size: var(--size-font);
     letter-spacing: -0.32px;
-    line-height: var(--rem-px-24);
+    line-height: var(--size-24);
     overflow-wrap: break-word;
     white-space: pre-wrap;
   }

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-message/error-message.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-message/error-message.tsx
@@ -50,12 +50,12 @@ export const styles = `
 
   .nextjs__container_errors_desc {
     margin: 0;
-    margin-left: var(--size-1);
+    margin-left: var(--rem-px-4);
     color: var(--color-red-900);
     font-weight: 500;
     font-size: var(--size-font);
     letter-spacing: -0.32px;
-    line-height: var(--size-6);
+    line-height: var(--rem-px-24);
     overflow-wrap: break-word;
     white-space: pre-wrap;
   }

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-message/error-message.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-message/error-message.tsx
@@ -53,7 +53,7 @@ export const styles = `
     margin-left: var(--size-4);
     color: var(--color-red-900);
     font-weight: 500;
-    font-size: var(--size-font);
+    font-size: var(--size-16);
     letter-spacing: -0.32px;
     line-height: var(--size-24);
     overflow-wrap: break-word;

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-bottom-stack/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-bottom-stack/index.tsx
@@ -38,11 +38,11 @@ export const styles = `
   }
 
   .error-overlay-bottom-stack-layer-1 {
-    width: calc(100% - var(--size-6));
+    width: calc(100% - var(--rem-px-24));
   }
 
   .error-overlay-bottom-stack-layer-2 {
-    width: calc(100% - var(--size-12));
+    width: calc(100% - var(--rem-px-48));
     z-index: -1;
   }
 

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-bottom-stack/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-bottom-stack/index.tsx
@@ -38,11 +38,11 @@ export const styles = `
   }
 
   .error-overlay-bottom-stack-layer-1 {
-    width: calc(100% - var(--rem-px-24));
+    width: calc(100% - var(--size-24));
   }
 
   .error-overlay-bottom-stack-layer-2 {
-    width: calc(100% - var(--rem-px-48));
+    width: calc(100% - var(--size-48));
     z-index: -1;
   }
 

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-footer/error-feedback/error-feedback.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-footer/error-feedback/error-feedback.tsx
@@ -107,7 +107,7 @@ export const styles = `
   .error-feedback {
     display: flex;
     align-items: center;
-    gap: var(--size-gap);
+    gap: 8px;
     white-space: nowrap;
     color: var(--color-gray-900);
   }

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-footer/error-overlay-footer.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-footer/error-overlay-footer.tsx
@@ -28,7 +28,7 @@ export const styles = `
     flex-direction: row;
     justify-content: space-between;
 
-    gap: var(--size-gap);
+    gap: 8px;
     padding: var(--size-12);
     background: var(--color-background-200);
     border-top: 1px solid var(--color-gray-400);

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-footer/error-overlay-footer.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-footer/error-overlay-footer.tsx
@@ -29,7 +29,7 @@ export const styles = `
     justify-content: space-between;
 
     gap: var(--size-gap);
-    padding: var(--rem-px-12);
+    padding: var(--size-12);
     background: var(--color-background-200);
     border-top: 1px solid var(--color-gray-400);
   }

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-footer/error-overlay-footer.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-footer/error-overlay-footer.tsx
@@ -29,7 +29,7 @@ export const styles = `
     justify-content: space-between;
 
     gap: var(--size-gap);
-    padding: var(--size-3);
+    padding: var(--rem-px-12);
     background: var(--color-background-200);
     border-top: 1px solid var(--color-gray-400);
   }

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-footer/error-overlay-footer.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-footer/error-overlay-footer.tsx
@@ -49,7 +49,7 @@ export const styles = `
     margin: 0;
     font-size: 14px;
     font-weight: 400;
-    line-height: var(--size-font-big);
+    line-height: var(--size-20);
   }
 
   ${feedbackStyles}

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-layout/error-overlay-layout.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-layout/error-overlay-layout.tsx
@@ -152,6 +152,6 @@ export const styles = `
   [data-nextjs-error-label-group] {
     display: flex;
     align-items: center;
-    gap: var(--size-2);
+    gap: var(--rem-px-8);
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-layout/error-overlay-layout.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-layout/error-overlay-layout.tsx
@@ -152,6 +152,6 @@ export const styles = `
   [data-nextjs-error-label-group] {
     display: flex;
     align-items: center;
-    gap: var(--rem-px-8);
+    gap: var(--size-8);
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-nav/error-overlay-nav.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-nav/error-overlay-nav.stories.tsx
@@ -49,7 +49,7 @@ export const Default: Story = {
   decorators: [
     (Story) => (
       // Offset the translateY applied to the floating header.
-      <div style={{ paddingTop: 'var(--rem-px-42)' }}>
+      <div style={{ paddingTop: 'var(--size-42)' }}>
         <Story />
       </div>
     ),

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-nav/error-overlay-nav.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-nav/error-overlay-nav.stories.tsx
@@ -49,7 +49,7 @@ export const Default: Story = {
   decorators: [
     (Story) => (
       // Offset the translateY applied to the floating header.
-      <div style={{ paddingTop: 'var(--size-10_5)' }}>
+      <div style={{ paddingTop: 'var(--rem-px-42)' }}>
         <Story />
       </div>
     ),

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-pagination/error-overlay-pagination.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-pagination/error-overlay-pagination.tsx
@@ -164,7 +164,7 @@ export const styles = `
   .error-overlay-pagination-count {
     color: var(--color-gray-900);
     text-align: center;
-    font-size: var(--size-font-small);
+    font-size: var(--size-14);
     font-weight: 500;
     line-height: 16px;
     font-variant-numeric: tabular-nums;

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-toolbar/error-overlay-toolbar.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-toolbar/error-overlay-toolbar.tsx
@@ -26,7 +26,7 @@ export function ErrorOverlayToolbar({
 export const styles = `
   .error-overlay-toolbar {
     display: flex;
-    gap: var(--size-1_5);
+    gap: var(--rem-px-6);
   }
 
   .nodejs-inspector-button,

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-toolbar/error-overlay-toolbar.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-toolbar/error-overlay-toolbar.tsx
@@ -26,7 +26,7 @@ export function ErrorOverlayToolbar({
 export const styles = `
   .error-overlay-toolbar {
     display: flex;
-    gap: var(--rem-px-6);
+    gap: var(--size-6);
   }
 
   .nodejs-inspector-button,

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-type-label/error-type-label.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-type-label/error-type-label.tsx
@@ -22,15 +22,15 @@ export function ErrorTypeLabel({ errorType }: ErrorTypeLabelProps) {
 
 export const styles = `
   .nextjs__container_errors_label {
-    padding: var(--size-0_5) var(--size-1_5);
+    padding: var(--size-0_5) var(--rem-px-6);
     margin: 0;
     /* used --size instead of --rounded because --rounded is missing 6px */
-    border-radius: var(--size-1_5);
+    border-radius: var(--rem-px-6);
     background: var(--color-red-100);
     font-weight: 600;
     font-size: var(--size-font-11);
     color: var(--color-red-900);
     font-family: var(--font-stack-monospace);
-    line-height: var(--size-5);
+    line-height: var(--rem-px-20);
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-type-label/error-type-label.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-type-label/error-type-label.tsx
@@ -28,7 +28,7 @@ export const styles = `
     border-radius: var(--size-6);
     background: var(--color-red-100);
     font-weight: 600;
-    font-size: var(--size-font-11);
+    font-size: var(--size-11);
     color: var(--color-red-900);
     font-family: var(--font-stack-monospace);
     line-height: var(--size-20);

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-type-label/error-type-label.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-type-label/error-type-label.tsx
@@ -22,15 +22,15 @@ export function ErrorTypeLabel({ errorType }: ErrorTypeLabelProps) {
 
 export const styles = `
   .nextjs__container_errors_label {
-    padding: var(--rem-px-2) var(--rem-px-6);
+    padding: var(--size-2) var(--size-6);
     margin: 0;
     /* used --size instead of --rounded because --rounded is missing 6px */
-    border-radius: var(--rem-px-6);
+    border-radius: var(--size-6);
     background: var(--color-red-100);
     font-weight: 600;
     font-size: var(--size-font-11);
     color: var(--color-red-900);
     font-family: var(--font-stack-monospace);
-    line-height: var(--rem-px-20);
+    line-height: var(--size-20);
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-type-label/error-type-label.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-type-label/error-type-label.tsx
@@ -22,7 +22,7 @@ export function ErrorTypeLabel({ errorType }: ErrorTypeLabelProps) {
 
 export const styles = `
   .nextjs__container_errors_label {
-    padding: var(--size-0_5) var(--rem-px-6);
+    padding: var(--rem-px-2) var(--rem-px-6);
     margin: 0;
     /* used --size instead of --rounded because --rounded is missing 6px */
     border-radius: var(--rem-px-6);

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/terminal/editor-link.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/terminal/editor-link.tsx
@@ -47,7 +47,7 @@ export const EDITOR_LINK_STYLES = `
   [data-with-open-in-editor-link] svg {
     width: auto;
     height: var(--size-14);
-    margin-left: var(--size-gap);
+    margin-left: 8px;
   }
   [data-with-open-in-editor-link] {
     cursor: pointer;
@@ -56,6 +56,6 @@ export const EDITOR_LINK_STYLES = `
     text-decoration: underline dotted;
   }
   [data-with-open-in-editor-link-import-trace] {
-    margin-left: var(--size-gap-double);
+    margin-left: 16px;
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/terminal/editor-link.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/terminal/editor-link.tsx
@@ -46,7 +46,7 @@ export function EditorLink({ file, location }: EditorLinkProps) {
 export const EDITOR_LINK_STYLES = `
   [data-with-open-in-editor-link] svg {
     width: auto;
-    height: var(--size-font-small);
+    height: var(--size-14);
     margin-left: var(--size-gap);
   }
   [data-with-open-in-editor-link] {

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/toast/styles.ts
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/toast/styles.ts
@@ -1,11 +1,11 @@
 const styles = `
   .nextjs-toast {
     position: fixed;
-    bottom: var(--size-gap-double);
-    left: var(--size-gap-double);
+    bottom: 16px;
+    left: 16px;
     max-width: 420px;
     z-index: 9000;
-    box-shadow: 0px var(--size-gap-double) var(--size-gap-quad)
+    box-shadow: 0px 16px 32px
       rgba(0, 0, 0, 0.25);
   }
 
@@ -18,7 +18,7 @@ const styles = `
 
   .nextjs-toast-errors-parent {
     padding: 16px;
-    border-radius: var(--size-gap-quad);
+    border-radius: 32px;
     font-weight: 500;
     color: var(--color-ansi-bright-white);
     background-color: var(--color-ansi-red);
@@ -29,7 +29,7 @@ const styles = `
     height: 30px;
     overflow: hidden;
     border: 0;
-    border-radius: var(--size-gap-triple);
+    border-radius: 24px;
     background: var(--color-background);
     color: var(--color-font);
     transition: all 0.3s ease-in-out;

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/version-staleness-info/version-staleness-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/version-staleness-info/version-staleness-info.tsx
@@ -93,7 +93,7 @@ export const styles = `
     display: flex;
     justify-content: center;
     align-items: center;
-    gap: var(--size-1);
+    gap: var(--rem-px-4);
 
     height: 26px;
     padding: 6px 8px 6px 6px;
@@ -106,7 +106,7 @@ export const styles = `
     color: var(--color-gray-900);
     font-size: 12px;
     font-weight: 500;
-    line-height: var(--size-4);
+    line-height: var(--rem-px-16);
   }
 
   a.nextjs-container-build-error-version-status {

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/version-staleness-info/version-staleness-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/version-staleness-info/version-staleness-info.tsx
@@ -93,7 +93,7 @@ export const styles = `
     display: flex;
     justify-content: center;
     align-items: center;
-    gap: var(--rem-px-4);
+    gap: var(--size-4);
 
     height: 26px;
     padding: 6px 8px 6px 6px;
@@ -106,7 +106,7 @@ export const styles = `
     color: var(--color-gray-900);
     font-size: 12px;
     font-weight: 500;
-    line-height: var(--rem-px-16);
+    line-height: var(--size-16);
   }
 
   a.nextjs-container-build-error-version-status {

--- a/packages/next/src/client/components/react-dev-overlay/ui/container/errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/container/errors.tsx
@@ -212,7 +212,7 @@ export function Errors({
 
 export const styles = `
   .nextjs-error-with-static {
-    bottom: calc(var(--size-gap-double) * 4.5);
+    bottom: calc(16px * 4.5);
   }
   p.nextjs__container_errors__link {
     font-size: 14px;
@@ -223,11 +223,11 @@ export const styles = `
     line-height: 1.5;
   }
   .nextjs-container-errors-body > h2:not(:first-child) {
-    margin-top: calc(var(--size-gap-double) + var(--size-gap));
+    margin-top: calc(16px + 8px);
   }
   .nextjs-container-errors-body > h2 {
     color: var(--color-title-color);
-    margin-bottom: var(--size-gap);
+    margin-bottom: 8px;
     font-size: var(--size-20);
   }
   .nextjs-toast-errors-parent {
@@ -243,10 +243,10 @@ export const styles = `
     justify-content: flex-start;
   }
   .nextjs-toast-errors > svg {
-    margin-right: var(--size-gap);
+    margin-right: 8px;
   }
   .nextjs-toast-hide-button {
-    margin-left: var(--size-gap-triple);
+    margin-left: 24px;
     border: none;
     background: none;
     color: var(--color-ansi-bright-white);
@@ -265,7 +265,7 @@ export const styles = `
     font-size: 1.5rem;
     padding: 0;
     margin: 0;
-    margin-left: var(--size-gap);
+    margin-left: 8px;
     transition: opacity 0.25s ease;
   }
   .nextjs__container_errors__error_title {

--- a/packages/next/src/client/components/react-dev-overlay/ui/container/errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/container/errors.tsx
@@ -275,7 +275,7 @@ export const styles = `
     margin-bottom: var(--rem-px-14);
   }
   .error-overlay-notes-container {
-    margin: var(--rem-px-8) var(--size-0_5);
+    margin: var(--rem-px-8) var(--rem-px-2);
   }
   .error-overlay-notes-container p {
     white-space: pre-wrap;

--- a/packages/next/src/client/components/react-dev-overlay/ui/container/errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/container/errors.tsx
@@ -228,7 +228,7 @@ export const styles = `
   .nextjs-container-errors-body > h2 {
     color: var(--color-title-color);
     margin-bottom: var(--size-gap);
-    font-size: var(--size-font-big);
+    font-size: var(--size-20);
   }
   .nextjs-toast-errors-parent {
     cursor: pointer;

--- a/packages/next/src/client/components/react-dev-overlay/ui/container/errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/container/errors.tsx
@@ -272,10 +272,10 @@ export const styles = `
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: var(--rem-px-14);
+    margin-bottom: var(--size-14);
   }
   .error-overlay-notes-container {
-    margin: var(--rem-px-8) var(--rem-px-2);
+    margin: var(--size-8) var(--size-2);
   }
   .error-overlay-notes-container p {
     white-space: pre-wrap;

--- a/packages/next/src/client/components/react-dev-overlay/ui/container/errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/container/errors.tsx
@@ -272,10 +272,10 @@ export const styles = `
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: var(--size-3_5);
+    margin-bottom: var(--rem-px-14);
   }
   .error-overlay-notes-container {
-    margin: var(--size-2) var(--size-0_5);
+    margin: var(--rem-px-8) var(--size-0_5);
   }
   .error-overlay-notes-container p {
     white-space: pre-wrap;

--- a/packages/next/src/client/components/react-dev-overlay/ui/container/runtime-error/component-stack-pseudo-html.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/container/runtime-error/component-stack-pseudo-html.tsx
@@ -8,7 +8,7 @@ export const PSEUDO_HTML_DIFF_STYLES = `
     background: var(--color-background-200);
     color: var(--color-syntax-constant);
     font-family: var(--font-stack-monospace);
-    font-size: var(--size-font-smaller);
+    font-size: var(--size-12);
     line-height: var(--size-16);
     border-radius: var(--size-8);
   }

--- a/packages/next/src/client/components/react-dev-overlay/ui/container/runtime-error/component-stack-pseudo-html.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/container/runtime-error/component-stack-pseudo-html.tsx
@@ -2,20 +2,20 @@ export { PseudoHtmlDiff } from '../../components/hydration-diff/diff-view'
 
 export const PSEUDO_HTML_DIFF_STYLES = `
   [data-nextjs-container-errors-pseudo-html] {
-    padding: var(--size-2) 0;
-    margin: var(--size-2) 0;
+    padding: var(--rem-px-8) 0;
+    margin: var(--rem-px-8) 0;
     border: 1px solid var(--color-gray-400);
     background: var(--color-background-200);
     color: var(--color-syntax-constant);
     font-family: var(--font-stack-monospace);
     font-size: var(--size-font-smaller);
-    line-height: var(--size-4);
-    border-radius: var(--size-2);
+    line-height: var(--rem-px-16);
+    border-radius: var(--rem-px-8);
   }
   [data-nextjs-container-errors-pseudo-html-line] {
     display: inline-block;
     width: 100%;
-    padding-left: var(--size-10);
+    padding-left: var(--rem-px-40);
     line-height: calc(5 / 3);
   }
   [data-nextjs-container-errors-pseudo-html--diff='error'] {
@@ -24,7 +24,7 @@ export const PSEUDO_HTML_DIFF_STYLES = `
   }
   [data-nextjs-container-errors-pseudo-html-collapse-button] {
     all: unset;
-    margin-left: var(--size-3);
+    margin-left: var(--rem-px-12);
     &:focus {
       outline: none;
     }
@@ -33,8 +33,8 @@ export const PSEUDO_HTML_DIFF_STYLES = `
     background: var(--color-green-300);
   }
   [data-nextjs-container-errors-pseudo-html-line-sign] {
-    margin-left: calc(var(--size-6) * -1);
-    margin-right: var(--size-6);
+    margin-left: calc(var(--rem-px-24) * -1);
+    margin-right: var(--rem-px-24);
   }
   [data-nextjs-container-errors-pseudo-html--diff='add']
     [data-nextjs-container-errors-pseudo-html-line-sign] {
@@ -46,8 +46,8 @@ export const PSEUDO_HTML_DIFF_STYLES = `
   [data-nextjs-container-errors-pseudo-html--diff='remove']
     [data-nextjs-container-errors-pseudo-html-line-sign] {
     color: var(--color-red-900);
-    margin-left: calc(var(--size-6) * -1);
-    margin-right: var(--size-6);
+    margin-left: calc(var(--rem-px-24) * -1);
+    margin-right: var(--rem-px-24);
   }
   [data-nextjs-container-errors-pseudo-html--diff='error']
     [data-nextjs-container-errors-pseudo-html-line-sign] {

--- a/packages/next/src/client/components/react-dev-overlay/ui/container/runtime-error/component-stack-pseudo-html.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/container/runtime-error/component-stack-pseudo-html.tsx
@@ -2,20 +2,20 @@ export { PseudoHtmlDiff } from '../../components/hydration-diff/diff-view'
 
 export const PSEUDO_HTML_DIFF_STYLES = `
   [data-nextjs-container-errors-pseudo-html] {
-    padding: var(--rem-px-8) 0;
-    margin: var(--rem-px-8) 0;
+    padding: var(--size-8) 0;
+    margin: var(--size-8) 0;
     border: 1px solid var(--color-gray-400);
     background: var(--color-background-200);
     color: var(--color-syntax-constant);
     font-family: var(--font-stack-monospace);
     font-size: var(--size-font-smaller);
-    line-height: var(--rem-px-16);
-    border-radius: var(--rem-px-8);
+    line-height: var(--size-16);
+    border-radius: var(--size-8);
   }
   [data-nextjs-container-errors-pseudo-html-line] {
     display: inline-block;
     width: 100%;
-    padding-left: var(--rem-px-40);
+    padding-left: var(--size-40);
     line-height: calc(5 / 3);
   }
   [data-nextjs-container-errors-pseudo-html--diff='error'] {
@@ -24,7 +24,7 @@ export const PSEUDO_HTML_DIFF_STYLES = `
   }
   [data-nextjs-container-errors-pseudo-html-collapse-button] {
     all: unset;
-    margin-left: var(--rem-px-12);
+    margin-left: var(--size-12);
     &:focus {
       outline: none;
     }
@@ -33,8 +33,8 @@ export const PSEUDO_HTML_DIFF_STYLES = `
     background: var(--color-green-300);
   }
   [data-nextjs-container-errors-pseudo-html-line-sign] {
-    margin-left: calc(var(--rem-px-24) * -1);
-    margin-right: var(--rem-px-24);
+    margin-left: calc(var(--size-24) * -1);
+    margin-right: var(--size-24);
   }
   [data-nextjs-container-errors-pseudo-html--diff='add']
     [data-nextjs-container-errors-pseudo-html-line-sign] {
@@ -46,8 +46,8 @@ export const PSEUDO_HTML_DIFF_STYLES = `
   [data-nextjs-container-errors-pseudo-html--diff='remove']
     [data-nextjs-container-errors-pseudo-html-line-sign] {
     color: var(--color-red-900);
-    margin-left: calc(var(--rem-px-24) * -1);
-    margin-right: var(--rem-px-24);
+    margin-left: calc(var(--size-24) * -1);
+    margin-right: var(--size-24);
   }
   [data-nextjs-container-errors-pseudo-html--diff='error']
     [data-nextjs-container-errors-pseudo-html-line-sign] {

--- a/packages/next/src/client/components/react-dev-overlay/ui/styles/base.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/styles/base.tsx
@@ -5,14 +5,14 @@ export function Base() {
     <style>
       {css`
         :host {
-          ${
-            // Although the style applied to the shadow host is isolated,
-            // the element that attached the shadow host (i.e. `nextjs-portal`)
-            // is still affected by the parent's style (e.g. `body`). This may
-            // occur style conflicts like `display: flex`, with other children
-            // elements therefore give the shadow host an absolute position.
-            'position: absolute;'
-          }
+          /* 
+            Although the style applied to the shadow host is isolated,
+            the element that attached the shadow host (i.e. "nextjs-portal")
+            is still affected by the parent's style (e.g. "body"). This may
+            occur style conflicts like "display: flex", with other children
+            elements therefore give the shadow host an absolute position.
+          */
+          position: absolute;
 
           --color-font: #757575;
           --color-backdrop: rgba(250, 250, 250, 0.8);
@@ -69,11 +69,14 @@ export function Base() {
           --rounded-4xl: 32px;
           --rounded-full: 9999px;
 
-          /* Suffix N of --size-N as px value when the base font size is 16px. */
-          --size-1: 0.0625rem;
-          --size-2: 0.125rem;
-          --size-3: 0.1875rem;
-          --size-4: 0.25rem;
+          /* 
+            Suffix N of --size-N as px value when the base font size is 16px.
+            Example: --size-1 is 1px, --size-2 is 2px, --size-3 is 3px, etc.
+          */
+          --size-1: 0.0625rem; /* 1px */
+          --size-2: 0.125rem; /* 2px */
+          --size-3: 0.1875rem; /* 3px */
+          --size-4: 0.25rem; /* ...and more */
           --size-5: 0.3125rem;
           --size-6: 0.375rem;
           --size-7: 0.4375rem;

--- a/packages/next/src/client/components/react-dev-overlay/ui/styles/base.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/styles/base.tsx
@@ -82,32 +82,43 @@ export function Base() {
           --rounded-3xl: 1.5rem; /* 24px */
           --rounded-full: 9999px;
 
-          --size-0: 0px;
-          --size-px: 1px;
-          --size-0_5: 0.125rem; /* 2px */
-          --size-1: 0.25rem; /* 4px */
-          --size-1_5: 0.375rem; /* 6px */
-          --size-2: 0.5rem; /* 8px */
-          --size-2_5: 0.625rem; /* 10px */
-          --size-3: 0.75rem; /* 12px */
-          --size-3_5: 0.875rem; /* 14px */
-          --size-4: 1rem; /* 16px */
-          --size-4_5: 1.125rem; /* 18px */
-          --size-5: 1.25rem; /* 20px */
-          --size-5_5: 1.375rem; /* 22px */
-          --size-6: 1.5rem; /* 24px */
-          --size-6_5: 1.625rem; /* 26px */
-          --size-7: 1.75rem; /* 28px */
-          --size-7_5: 1.875rem; /* 30px */
-          --size-8: 2rem; /* 32px */
-          --size-8_5: 2.125rem; /* 34px */
-          --size-9: 2.25rem; /* 36px */
-          --size-9_5: 2.375rem; /* 38px */
-          --size-10: 2.5rem; /* 40px */
-          --size-10_5: 2.625rem; /* 42px */
-          --size-11: 2.75rem; /* 44px */
-          --size-11_5: 2.875rem; /* 46px */
-          --size-12: 3rem; /* 48px */
+          /* 
+            Values to be used where responsive behavior is desirable.        
+            E.g. we generally want to scale font sizes, but not radii or padding which would make things feel more cramped.
+          */
+          --rem-px-1: 0.0625rem;
+          --rem-px-2: 0.125rem;
+          --rem-px-3: 0.1875rem;
+          --rem-px-4: 0.25rem;
+          --rem-px-5: 0.3125rem;
+          --rem-px-6: 0.375rem;
+          --rem-px-7: 0.4375rem;
+          --rem-px-8: 0.5rem;
+          --rem-px-9: 0.5625rem;
+          --rem-px-10: 0.625rem;
+          --rem-px-11: 0.6875rem;
+          --rem-px-12: 0.75rem;
+          --rem-px-13: 0.8125rem;
+          --rem-px-14: 0.875rem;
+          --rem-px-15: 0.9375rem;
+          --rem-px-16: 1rem;
+          --rem-px-17: 1.0625rem;
+          --rem-px-18: 1.125rem;
+          --rem-px-20: 1.25rem;
+          --rem-px-22: 1.375rem;
+          --rem-px-24: 1.5rem;
+          --rem-px-26: 1.625rem;
+          --rem-px-28: 1.75rem;
+          --rem-px-30: 1.875rem;
+          --rem-px-32: 2rem;
+          --rem-px-34: 2.125rem;
+          --rem-px-36: 2.25rem;
+          --rem-px-38: 2.375rem;
+          --rem-px-40: 2.5rem;
+          --rem-px-42: 2.625rem;
+          --rem-px-44: 2.75rem;
+          --rem-px-46: 2.875rem;
+          --rem-px-48: 3rem;
 
           @media print {
             display: none;

--- a/packages/next/src/client/components/react-dev-overlay/ui/styles/base.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/styles/base.tsx
@@ -14,14 +14,6 @@ export function Base() {
             'position: absolute;'
           }
 
-          --size-font-11: var(--size-11);
-          --size-font-smaller: var(--size-12);
-          --size-font-13: var(--size-13);
-          --size-font-small: var(--size-14);
-          --size-font: var(--size-16);
-          --size-font-big: var(--size-20);
-          --size-font-bigger: var(--size-24);
-
           --color-font: #757575;
           --color-backdrop: rgba(250, 250, 250, 0.8);
           --color-border-shadow: rgba(0, 0, 0, 0.145);

--- a/packages/next/src/client/components/react-dev-overlay/ui/styles/base.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/styles/base.tsx
@@ -82,10 +82,7 @@ export function Base() {
           --rounded-3xl: 1.5rem; /* 24px */
           --rounded-full: 9999px;
 
-          /* 
-            Values to be used where responsive behavior is desirable.        
-            E.g. we generally want to scale font sizes, but not radii or padding which would make things feel more cramped.
-          */
+          /* --rem-px-N: rem value of Npx in base font size 16px. */
           --rem-px-1: 0.0625rem;
           --rem-px-2: 0.125rem;
           --rem-px-3: 0.1875rem;

--- a/packages/next/src/client/components/react-dev-overlay/ui/styles/base.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/styles/base.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import { css } from '../../utils/css'
 
 export function Base() {
@@ -15,18 +14,13 @@ export function Base() {
             'position: absolute;'
           }
 
-          --size-gap-half: 4px;
-          --size-gap: 8px;
-          --size-gap-double: 16px;
-          --size-gap-triple: 24px;
-          --size-gap-quad: 32px;
-
-          --size-font-11: 11px;
-          --size-font-smaller: 12px;
-          --size-font-small: 14px;
-          --size-font: 16px;
-          --size-font-big: 20px;
-          --size-font-bigger: 24px;
+          --size-font-11: var(--size-11);
+          --size-font-smaller: var(--size-12);
+          --size-font-13: var(--size-13);
+          --size-font-small: var(--size-14);
+          --size-font: var(--size-16);
+          --size-font-big: var(--size-20);
+          --size-font-bigger: var(--size-24);
 
           --color-font: #757575;
           --color-backdrop: rgba(250, 250, 250, 0.8);
@@ -73,49 +67,52 @@ export function Base() {
           --timing-overlay: cubic-bezier(0.175, 0.885, 0.32, 1.1);
 
           --rounded-none: 0px;
-          --rounded-sm: 0.125rem; /* 2px */
-          --rounded-md: 0.25rem; /* 4px */
-          --rounded-md-2: 0.375rem; /* 6px */
-          --rounded-lg: 0.5rem; /* 8px */
-          --rounded-xl: 0.75rem; /* 12px */
-          --rounded-2xl: 1rem; /* 16px */
-          --rounded-3xl: 1.5rem; /* 24px */
+          --rounded-sm: 2px;
+          --rounded-md: 4px;
+          --rounded-md-2: 6px;
+          --rounded-lg: 8px;
+          --rounded-xl: 12px;
+          --rounded-2xl: 16px;
+          --rounded-3xl: 24px;
+          --rounded-4xl: 32px;
           --rounded-full: 9999px;
 
-          /* --rem-px-N: rem value of Npx in base font size 16px. */
-          --rem-px-1: 0.0625rem;
-          --rem-px-2: 0.125rem;
-          --rem-px-3: 0.1875rem;
-          --rem-px-4: 0.25rem;
-          --rem-px-5: 0.3125rem;
-          --rem-px-6: 0.375rem;
-          --rem-px-7: 0.4375rem;
-          --rem-px-8: 0.5rem;
-          --rem-px-9: 0.5625rem;
-          --rem-px-10: 0.625rem;
-          --rem-px-11: 0.6875rem;
-          --rem-px-12: 0.75rem;
-          --rem-px-13: 0.8125rem;
-          --rem-px-14: 0.875rem;
-          --rem-px-15: 0.9375rem;
-          --rem-px-16: 1rem;
-          --rem-px-17: 1.0625rem;
-          --rem-px-18: 1.125rem;
-          --rem-px-20: 1.25rem;
-          --rem-px-22: 1.375rem;
-          --rem-px-24: 1.5rem;
-          --rem-px-26: 1.625rem;
-          --rem-px-28: 1.75rem;
-          --rem-px-30: 1.875rem;
-          --rem-px-32: 2rem;
-          --rem-px-34: 2.125rem;
-          --rem-px-36: 2.25rem;
-          --rem-px-38: 2.375rem;
-          --rem-px-40: 2.5rem;
-          --rem-px-42: 2.625rem;
-          --rem-px-44: 2.75rem;
-          --rem-px-46: 2.875rem;
-          --rem-px-48: 3rem;
+          /* Suffix N of --size-N as px value when the base font size is 16px. */
+          --size-1: 0.0625rem;
+          --size-2: 0.125rem;
+          --size-3: 0.1875rem;
+          --size-4: 0.25rem;
+          --size-5: 0.3125rem;
+          --size-6: 0.375rem;
+          --size-7: 0.4375rem;
+          --size-8: 0.5rem;
+          --size-9: 0.5625rem;
+          --size-10: 0.625rem;
+          --size-11: 0.6875rem;
+          --size-12: 0.75rem;
+          --size-13: 0.8125rem;
+          --size-14: 0.875rem;
+          --size-15: 0.9375rem;
+          /* If the base font size of the dev overlay changes e.g. 18px, 
+          just slide the window and make --size-18 as 1rem. */
+          --size-16: 1rem;
+          --size-17: 1.0625rem;
+          --size-18: 1.125rem;
+          --size-20: 1.25rem;
+          --size-22: 1.375rem;
+          --size-24: 1.5rem;
+          --size-26: 1.625rem;
+          --size-28: 1.75rem;
+          --size-30: 1.875rem;
+          --size-32: 2rem;
+          --size-34: 2.125rem;
+          --size-36: 2.25rem;
+          --size-38: 2.375rem;
+          --size-40: 2.5rem;
+          --size-42: 2.625rem;
+          --size-44: 2.75rem;
+          --size-46: 2.875rem;
+          --size-48: 3rem;
 
           @media print {
             display: none;
@@ -139,7 +136,7 @@ export function Base() {
         h4,
         h5,
         h6 {
-          margin-bottom: var(--size-gap);
+          margin-bottom: 8px;
           font-weight: 500;
           line-height: 1.5;
         }


### PR DESCRIPTION
### Why?

Previously, `--size-4` was 16px in rem, but it wasn't intuitive. Therefore, changed to `--size-16`.