### PR TITLE
[dev-overlay] toggle overlay when clicking `N issues` section

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -30,7 +30,7 @@ export function DevToolsIndicator({
   state: OverlayState
   errorCount: number
   isBuildError: boolean
-  setIsErrorOverlayOpen: (isOverlayOpen: boolean) => void
+  setIsErrorOverlayOpen: () => void
   // Technically this prop isn't needed, but useful for testing.
   position?: DevToolsIndicatorPosition
 }) {
@@ -86,7 +86,9 @@ function DevToolsPopover({
   position: DevToolsIndicatorPosition
   isBuildError: boolean
   hide: () => void
-  setIsErrorOverlayOpen: (isOverlayOpen: boolean) => void
+  setIsErrorOverlayOpen: (
+    isOverlayOpen: boolean | ((prev: boolean) => boolean)
+  ) => void
 }) {
   const menuRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLButtonElement | null>(null)
@@ -221,6 +223,10 @@ function DevToolsPopover({
     }
   }
 
+  function toggleErrorOverlay() {
+    setIsErrorOverlayOpen((prev) => !prev)
+  }
+
   function onTriggerClick() {
     setIsMenuOpen((prev) => !prev)
   }
@@ -267,7 +273,7 @@ function DevToolsPopover({
         issueCount={issueCount}
         onTriggerClick={onTriggerClick}
         onKeyDown={onTriggerKeydown}
-        openErrorOverlay={openErrorOverlay}
+        toggleErrorOverlay={toggleErrorOverlay}
         isDevBuilding={useIsDevBuilding()}
         isDevRendering={useIsDevRendering()}
         isBuildError={isBuildError}

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -30,7 +30,9 @@ export function DevToolsIndicator({
   state: OverlayState
   errorCount: number
   isBuildError: boolean
-  setIsErrorOverlayOpen: () => void
+  setIsErrorOverlayOpen: (
+    isErrorOverlayOpen: boolean | ((prev: boolean) => boolean)
+  ) => void
   // Technically this prop isn't needed, but useful for testing.
   position?: DevToolsIndicatorPosition
 }) {

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/next-logo.tsx
@@ -9,7 +9,7 @@ interface Props extends React.ComponentProps<'button'> {
   isDevRendering: boolean
   isBuildError: boolean
   onTriggerClick: () => void
-  openErrorOverlay: () => void
+  toggleErrorOverlay: () => void
 }
 
 const SIZE = 36
@@ -65,7 +65,7 @@ export const NextLogo = forwardRef(function NextLogo(
     isDevRendering,
     isBuildError,
     onTriggerClick,
-    openErrorOverlay,
+    toggleErrorOverlay,
     ...props
   }: Props,
   propRef: React.Ref<HTMLButtonElement>
@@ -442,7 +442,7 @@ export const NextLogo = forwardRef(function NextLogo(
               <button
                 data-issues-open
                 aria-label="Open issues overlay"
-                onClick={openErrorOverlay}
+                onClick={toggleErrorOverlay}
               >
                 {disabled && (
                   <div data-disabled-icon>

--- a/packages/next/src/client/components/react-dev-overlay/ui/dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/dev-overlay.tsx
@@ -16,7 +16,9 @@ export function DevOverlay({
 }: {
   state: OverlayState
   isErrorOverlayOpen: boolean
-  setIsErrorOverlayOpen: (isErrorOverlayOpen: boolean) => void
+  setIsErrorOverlayOpen: (
+    isErrorOverlayOpen: boolean | ((prev: boolean) => boolean)
+  ) => void
 }) {
   return (
     <ShadowPortal>


### PR DESCRIPTION
### Why?

As there is no "X" close button on the overlay, users may naturally expect to close it by clicking the same button that opened it. Thus, toggle the overlay when clicking the `N issues` section.

https://github.com/user-attachments/assets/ec8d4d56-b61f-49e0-8d42-f5cd25c4ab49

Closes NDX-888