### PR TITLE
[dev-overlay]: hiding devtools shouldn't hide errors

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -34,24 +34,23 @@ export function DevToolsIndicator({
   // Technically this prop isn't needed, but useful for testing.
   position?: DevToolsIndicatorPosition
 }) {
-  const [isDevToolsIndicatorOpen, setIsDevToolsIndicatorOpen] = useState(true)
+  const [isDevToolsIndicatorVisible, setIsDevToolsIndicatorVisible] =
+    useState(true)
 
   return (
-    isDevToolsIndicatorOpen && (
-      <DevToolsPopover
-        semver={state.versionInfo.installed}
-        issueCount={errorCount}
-        isStaticRoute={state.staticIndicator}
-        hide={() => {
-          setIsDevToolsIndicatorOpen(false)
-        }}
-        setIsErrorOverlayOpen={setIsErrorOverlayOpen}
-        isTurbopack={!!process.env.TURBOPACK}
-        position={position}
-        disabled={state.disableDevIndicator}
-        isBuildError={isBuildError}
-      />
-    )
+    <DevToolsPopover
+      semver={state.versionInfo.installed}
+      issueCount={errorCount}
+      isStaticRoute={state.staticIndicator}
+      hide={() => {
+        setIsDevToolsIndicatorVisible(false)
+      }}
+      setIsErrorOverlayOpen={setIsErrorOverlayOpen}
+      isTurbopack={!!process.env.TURBOPACK}
+      position={position}
+      disabled={state.disableDevIndicator || !isDevToolsIndicatorVisible}
+      isBuildError={isBuildError}
+    />
   )
 }
 

--- a/test/development/client-dev-overlay/index.test.ts
+++ b/test/development/client-dev-overlay/index.test.ts
@@ -2,7 +2,7 @@ import { createNext, FileRef } from 'e2e-utils'
 import webdriver, { BrowserInterface } from 'next-webdriver'
 import { NextInstance } from 'e2e-utils'
 import { join } from 'path'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('client-dev-overlay', () => {
   let next: NextInstance
@@ -30,6 +30,7 @@ describe('client-dev-overlay', () => {
     fullScreenDialog: '[data-nextjs-dialog]',
     toast: '[data-nextjs-toast]',
     popover: '[data-nextjs-dev-tools-button]',
+    indicator: '[data-next-badge-root]',
     minimizeButton: 'body',
     hideButton: '[data-hide-dev-tools]',
   }
@@ -50,13 +51,11 @@ describe('client-dev-overlay', () => {
     await getMinimizeButton().click()
     await getToast().click()
 
-    await check(async () => {
-      return (await elementExistsInNextJSPortalShadowDOM(
-        selectors.fullScreenDialog
-      ))
-        ? 'success'
-        : 'missing'
-    }, 'success')
+    await retry(async () => {
+      expect(
+        await elementExistsInNextJSPortalShadowDOM(selectors.fullScreenDialog)
+      ).toBe(true)
+    })
   })
 
   it('should be able to minimize the fullscreen overlay', async () => {
@@ -66,22 +65,46 @@ describe('client-dev-overlay', () => {
     )
   })
 
-  it('should be able to hide the minimized overlay', async () => {
+  it('should keep the error indicator visible when there are errors', async () => {
     await getMinimizeButton().click()
     await getPopover().click()
     await getHideButton().click()
 
-    await check(async () => {
-      const exists = await elementExistsInNextJSPortalShadowDOM(selectors.toast)
-      return exists ? 'found' : 'success'
-    }, 'success')
+    await retry(async () => {
+      const display = await browser.eval(
+        `getComputedStyle(document.querySelector('nextjs-portal').shadowRoot.querySelector('${selectors.indicator}')).display`
+      )
+      expect(display).toBe('block')
+    })
+  })
+
+  it('should be possible to hide the minimized overlay when there are no errors', async () => {
+    const originalContent = await next.readFile('pages/index.js')
+    try {
+      await next.patchFile('pages/index.js', (content) => {
+        return content.replace(`throw Error('example runtime error')`, '')
+      })
+
+      await getMinimizeButton().click()
+      await getPopover().click()
+      await getHideButton().click()
+
+      await retry(async () => {
+        const display = await browser.eval(
+          `getComputedStyle(document.querySelector('nextjs-portal').shadowRoot.querySelector('${selectors.indicator}')).display`
+        )
+        expect(display).toBe('none')
+      })
+    } finally {
+      await next.patchFile('pages/index.js', originalContent)
+    }
   })
 
   it('should have a role of "dialog" if the page is focused', async () => {
-    await check(async () => {
-      return (await elementExistsInNextJSPortalShadowDOM('[role="dialog"]'))
-        ? 'exists'
-        : 'missing'
-    }, 'exists')
+    await retry(async () => {
+      expect(
+        await elementExistsInNextJSPortalShadowDOM('[role="dialog"]')
+      ).toBe(true)
+    })
   })
 })


### PR DESCRIPTION
Currently when you select "Hide Dev Tools", if an error comes in you won't see the error indicator anymore.

This follows the same treatment as when the indicator is disabled in next config, which is to only show you errors, and not the regular indicator/popover.