### PR TITLE
docs: update 09-authentication to explicitly show 'use server'

### DIFF
--- a/docs/01-app/03-building-your-application/09-authentication/index.mdx
+++ b/docs/01-app/03-building-your-application/09-authentication/index.mdx
@@ -674,6 +674,8 @@ export async function createSession(userId) {
 Back in your Server Action, you can invoke the `createSession()` function, and use the [`redirect()`](/docs/app/building-your-application/routing/redirecting) API to redirect the user to the appropriate page:
 
 ```ts filename="app/actions/auth.ts" switcher
+'use server'
+
 import { createSession } from '@/app/lib/session'
 
 export async function signup(state: FormState, formData: FormData) {
@@ -691,6 +693,8 @@ export async function signup(state: FormState, formData: FormData) {
 ```
 
 ```js filename="app/actions/auth.js" switcher
+'use server'
+
 import { createSession } from '@/app/lib/session'
 
 export async function signup(state, formData) {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change



Closes NEXT-
Fixes #

-->

### What?

Adding 'use server' to the authentication example.

https://nextjs.org/docs/app/building-your-application/authentication#3-setting-cookies-recommended-options

### Why?

Without the 'use server', the app throws the following error

```
Invalid import
'server-only' cannot be imported from a Client Component module. It should only be used from a Server Component.
```


The Vercel lab repo also contains the 'use server'

https://github.com/vercel-labs/app-router-auth/blob/main/app/auth/01-auth.ts


