### PR TITLE
update type for next/dynamic `loading` option to accept `ReactNode`

### DIFF
--- a/packages/next/src/shared/lib/dynamic.tsx
+++ b/packages/next/src/shared/lib/dynamic.tsx
@@ -1,4 +1,4 @@
-import React, { type JSX } from 'react'
+import React from 'react'
 import Loadable from './loadable.shared-runtime'
 
 const isServerSide = typeof window === 'undefined'
@@ -36,7 +36,7 @@ function convertModule<P>(mod: React.ComponentType<P> | ComponentModule<P>) {
 }
 
 export type DynamicOptions<P = {}> = LoadableGeneratedOptions & {
-  loading?: (loadingProps: DynamicOptionsLoadingProps) => JSX.Element | null
+  loading?: (loadingProps: DynamicOptionsLoadingProps) => React.ReactNode
   loader?: Loader<P> | LoaderMap
   loadableGenerated?: LoadableGeneratedOptions
   ssr?: boolean


### PR DESCRIPTION
the `loading` option for `next/dynamic` should accept any react component which returns a `ReactNode`.

with the current `JSX.Element | null` i see a type error when providing:

```tsx
function LoadingIndicator(): ReactNode {
  return <p>Loading...</p>
}
```