### PR TITLE
`toDisplayRedbox()` matcher: trim line endings

### DIFF
--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -345,7 +345,7 @@ describe('pages/ error recovery', () => {
          "source": "./index.js
        Error:   x Expected '{', got 'return'
           ,-[5:1]
-        2 | 
+        2 |
         3 | class ClassDefault extends React.Component {
         4 |   render()
         5 |     return <h1>Default Export</h1>;
@@ -404,7 +404,7 @@ describe('pages/ error recovery', () => {
          "source": "./index.js
        Error:   x Expected '{', got 'throw'
           ,-[5:1]
-        2 | 
+        2 |
         3 | class ClassDefault extends React.Component {
         4 |   render()
         5 |     throw new Error('nooo');

--- a/test/lib/add-redbox-matchers.ts
+++ b/test/lib/add-redbox-matchers.ts
@@ -113,7 +113,7 @@ async function createRedboxSnapshot(
     focusedSource = ''
     const sourceFrameLines = source.split('\n')
     for (let i = 0; i < sourceFrameLines.length; i++) {
-      const sourceFrameLine = sourceFrameLines[i]
+      const sourceFrameLine = sourceFrameLines[i].trimEnd()
       if (sourceFrameLine === '') {
         continue
       }


### PR DESCRIPTION
Webpack and Rspack message line endings currently have trailing whitespace (should be fixed separately). Prettier’s auto formatting trims this whitespace and makes it very difficult to keep the snapshot in sync while editing other parts of test files.

This automatically trims line endings before creating the snapshot.

Test Plan: CI


Closes PACK-4024