### PR TITLE
fix(turbopack): Fix pure span check in advanced tree shaking

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -10,7 +10,7 @@ use petgraph::{
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::{
-    common::{comments::Comments, util::take::Take, Spanned, SyntaxContext, DUMMY_SP},
+    common::{comments::Comments, util::take::Take, BytePos, Spanned, SyntaxContext, DUMMY_SP},
     ecma::{
         ast::{
             op, ClassDecl, Decl, DefaultDecl, EsReserved, ExportAll, ExportDecl,
@@ -1222,7 +1222,10 @@ impl DepGraph {
                         ids.push(id.clone());
 
                         let has_explicit_pure = match &decl.init {
-                            Some(e) => comments.has_flag(e.span().lo, "PURE"),
+                            Some(e) => {
+                                e.span().lo == BytePos::PURE
+                                    || comments.has_flag(e.span().lo, "PURE")
+                            }
                             _ => false,
                         };
 


### PR DESCRIPTION
### What?

Prepend `PURE_SP` check to `has_flag("PURE")` check.

### Why?

`PURE_SP` is also pure.

Closes PACK-4021