### PR TITLE
Docs: Fix link to ESLint Plugin Page

### DIFF
--- a/docs/01-app/01-getting-started/01-installation.mdx
+++ b/docs/01-app/01-getting-started/01-installation.mdx
@@ -276,7 +276,7 @@ If either of the two configuration options are selected, Next.js will automatica
 
 You can now run `next lint` every time you want to run ESLint to catch errors. Once ESLint has been set up, it will also automatically run during every build (`next build`). Errors will fail the build, while warnings will not.
 
-See the [ESLint Plugin](/docs/app/api-reference/config/next-config-js/eslint) page for more information on how to configure ESLint in your project.
+See the [ESLint Plugin](/docs/app/api-reference/config/eslint) page for more information on how to configure ESLint in your project.
 
 ## Set up Absolute Imports and Module Path Aliases
 


### PR DESCRIPTION
The link text and context suggest that this link should link to https://nextjs.org/docs/app/api-reference/config/eslint

It does, however, link to https://nextjs.org/docs/app/api-reference/config/next-config-js/eslint