### PR TITLE
build: Update `swc_core` to `v16.0.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e8c74ca48fccafb593e6390b1ca2b060a2bb0d51db9216b559d0f249e8caa6"
+checksum = "6db78dd6826824cfac1ed01683b5206f790404cf3416f852b26ce032591a96d6"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -4108,7 +4108,7 @@ dependencies = [
  "markdown",
  "rustc-hash 2.1.0",
  "serde",
- "swc_core",
+ "swc_core 15.0.1",
 ]
 
 [[package]]
@@ -4264,9 +4264,9 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.78.0"
+version = "0.79.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2199249f0fcaa4136c6d58a7c64fca3ef6a6f435d43a2580613ca6cb9f404a"
+checksum = "d0ae55cf268ce5558c0ee4fd5c0d8ac216e5549f9b82e518099a94c7e6219f01"
 dependencies = [
  "convert_case",
  "handlebars",
@@ -4428,7 +4428,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shadow-rs",
- "swc_core",
+ "swc_core 16.0.0",
  "tracing",
  "turbo-rcstr",
  "turbo-tasks",
@@ -4517,7 +4517,7 @@ dependencies = [
  "rustc-hash 2.1.0",
  "serde",
  "serde_json",
- "swc_core",
+ "swc_core 16.0.0",
  "swc_relay",
  "thiserror",
  "tracing",
@@ -4571,7 +4571,7 @@ dependencies = [
  "sha1",
  "styled_components",
  "styled_jsx",
- "swc_core",
+ "swc_core 16.0.0",
  "swc_emotion",
  "swc_relay",
  "testing",
@@ -4609,7 +4609,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shadow-rs",
- "swc_core",
+ "swc_core 16.0.0",
  "tokio",
  "tracing",
  "tracing-chrome",
@@ -5749,9 +5749,9 @@ dependencies = [
 
 [[package]]
 name = "react_remove_properties"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a4f9776eaf1e6f8ccdb27ddb22c5b1ecd252772e3dd999f723e44b52478d93"
+checksum = "72d372e993feb533a8bd7442355935c1a53836f84aa7c2a0b944b46741ce1859"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -5867,9 +5867,9 @@ checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 
 [[package]]
 name = "remove_console"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d9169abfabed42aece26c39bc3fb729202367282a073199ff90964ae44f42d"
+checksum = "71a95efdbb653b6e197da56284edd453ba7616b523ef0f934a7001f6ec0bcefb"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6939,9 +6939,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "styled_components"
-version = "0.106.0"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd94aa1369f866c777b044d489f3f058f35748a301d45b9a722d3f8448f93e73"
+checksum = "98799a352aadd02069c3620ed154f6fdb4323789a64828cf3db32c23d3b30202"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -6958,9 +6958,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.82.0"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417235f4fd39cc6b563ffec2d303c524d10ae023932f72c882352e37b057d1d3"
+checksum = "7991fd3e939e5093d5d58fca4f70821f5d4bb384a66c41e53f5c8e41c1e7ec89"
 dependencies = [
  "anyhow",
  "lightningcss",
@@ -6995,9 +6995,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "swc"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74075a4bbd32aac7e4fb6b23db22f5bac5ef22ab7d107189c240de973c9a2cbe"
+checksum = "908e306e4abcb0bdcf42ffa08325b178e4a27d9ed62d24208cd8f2e5d456a3d6"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7056,7 +7056,7 @@ dependencies = [
  "clap",
  "owo-colors 3.5.0",
  "regex",
- "swc_core",
+ "swc_core 16.0.0",
 ]
 
 [[package]]
@@ -7230,6 +7230,23 @@ name = "swc_core"
 version = "15.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a622dbfdda214d472e8da044d5bd5975c831d6e17c5016fcde4b2681c2be1cf2"
+dependencies = [
+ "swc_allocator",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "swc_ecma_visit",
+ "vergen 9.0.1",
+]
+
+[[package]]
+name = "swc_core"
+version = "16.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78a1b29d23d2c215a9cd55cd821e3383f64694b4a3172317c13162cfd3763074"
 dependencies = [
  "binding_macros",
  "swc",
@@ -7710,9 +7727,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "12.0.0"
+version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3602b7df679021ebb5a42dfbc3ecd2dfb5b7cedac20488af68c126840eccd7"
+checksum = "5fc1b838f90630f1c620113c3517eed44f1b36b09274ada47ed7e4cb4ec10899"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.7.1",
@@ -7770,9 +7787,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025195d58d38ca0a9022d55bdd2370b233f3f61d7c9aa207ecdd19129f5c5139"
+checksum = "71fa37f57f20e5641bdc5b728955e254b7cbc4dcc4313f6e8e088dd9ec62775d"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -7826,9 +7843,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66edf11a95e4eeaac12c30bb59f4d9a922f2f3ac81373639c17b20aaec9be42f"
+checksum = "243295ffdee377b2ee66c94145017f0f60f28f70353d1c02047c9e409f7cd0e2"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7846,9 +7863,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "11.0.0"
+version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13897adabc6ba621560a5898e752e02fb328f4c9797309ead6209d8db55d0e1"
+checksum = "04434877d7529c9067def1a15ad436d6f65d0997657bd1c56430af70914064dc"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.5.0",
@@ -8007,9 +8024,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc1707dd7cf4699336e081a9a764409532139990b4e9f733feb74a17c647606a"
+checksum = "311218980029ea376a1f53292418d852d50b461d15d9d39f830abf0d1c3bdd6c"
 dependencies = [
  "base64 0.21.4",
  "dashmap 5.5.3",
@@ -8061,9 +8078,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06b455ded4b426c1d8016807b8fab11bd36607d5f1dabeb07e3ab94976e6b528"
+checksum = "19c32ebb3dd1942d35142de60c9dc0f3c034d26567de7eb8b3ad6de426f5b0e9"
 dependencies = [
  "once_cell",
  "rustc-hash 2.1.0",
@@ -8134,9 +8151,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.82.0"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c51b659312dcc2817308e395b2609d346df4fbc562df4299a045e481240689b"
+checksum = "d0dd2e7271511175deb3709040ebb9c966c5b518e929b2dad183f9e8ab3d22ed"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -8311,9 +8328,9 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8558f3d73b4405ad117de3b3b30a3c6a2e50ba4fa06e28a03a2fd76fd1aed5c1"
+checksum = "6bf1a6f992aa020764af0dcb4f88931554043268e9eba4a507983ea39c619aa9"
 dependencies = [
  "once_cell",
  "regex",
@@ -9625,7 +9642,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "sourcemap",
- "swc_core",
+ "swc_core 16.0.0",
  "tokio",
  "tracing",
  "turbo-prehash",
@@ -9664,7 +9681,7 @@ dependencies = [
  "rustc-hash 2.1.0",
  "serde",
  "smallvec",
- "swc_core",
+ "swc_core 16.0.0",
  "tracing",
  "turbo-rcstr",
  "turbo-tasks",
@@ -9737,7 +9754,7 @@ dependencies = [
  "serde_json",
  "sourcemap",
  "strsim 0.11.1",
- "swc_core",
+ "swc_core 16.0.0",
  "tokio",
  "tracing",
  "turbo-rcstr",
@@ -9778,7 +9795,7 @@ dependencies = [
  "serde_json",
  "styled_components",
  "styled_jsx",
- "swc_core",
+ "swc_core 16.0.0",
  "swc_emotion",
  "swc_relay",
  "tracing",
@@ -9970,7 +9987,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "parking_lot",
- "swc_core",
+ "swc_core 16.0.0",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -10639,7 +10656,7 @@ dependencies = [
  "next-custom-transforms",
  "serde-wasm-bindgen",
  "serde_json",
- "swc_core",
+ "swc_core 16.0.0",
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293d12b8b4ba1b04834ec96daeb8425dd828f4b82d01eb46defb4f7999abc5b8"
+checksum = "07e8c74ca48fccafb593e6390b1ca2b060a2bb0d51db9216b559d0f249e8caa6"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2856,9 +2856,9 @@ dependencies = [
 
 [[package]]
 name = "hstr"
-version = "0.3.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e963d8fe690aa5ecd16d270b18362b28643862474f7fceabf105fd4c9b3a6a42"
+checksum = "71399f53a92ef72ee336a4b30201c6e944827e14e0af23204c291aad9c24cc85"
 dependencies = [
  "hashbrown 0.14.5",
  "new_debug_unreachable",
@@ -4102,8 +4102,8 @@ dependencies = [
 
 [[package]]
 name = "mdxjs"
-version = "0.3.1"
-source = "git+https://github.com/kdy1/mdxjs-rs.git?branch=swc-core-14#bd1a7dd6115578d59f7189a050ca39ca6a6b063d"
+version = "0.3.2"
+source = "git+https://github.com/kdy1/mdxjs-rs.git?branch=swc-core-15#2113f02a46ef0299a94248fe3ae064306888fc56"
 dependencies = [
  "markdown",
  "rustc-hash 2.1.0",
@@ -4264,9 +4264,9 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.77.0"
+version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd346f0b4eb3cd672dea37962fa965c2aceea8ed6944c3bd12627ecd82bc6f61"
+checksum = "bb2199249f0fcaa4136c6d58a7c64fca3ef6a6f435d43a2580613ca6cb9f404a"
 dependencies = [
  "convert_case",
  "handlebars",
@@ -5749,9 +5749,9 @@ dependencies = [
 
 [[package]]
 name = "react_remove_properties"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02fffcdd54b3ae860ffd9ef220cf1efc431f0fbbd618b5c3f95017fcae408aa"
+checksum = "43a4f9776eaf1e6f8ccdb27ddb22c5b1ecd252772e3dd999f723e44b52478d93"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -5867,9 +5867,9 @@ checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 
 [[package]]
 name = "remove_console"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86a6305be6ecf5c8e8aed43a3d30bd9ffcba4c0f388cdfc86a3632937013714"
+checksum = "74d9169abfabed42aece26c39bc3fb729202367282a073199ff90964ae44f42d"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6939,9 +6939,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "styled_components"
-version = "0.105.0"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f16ff198516c69753be147093eb4f13cc1b151b54d89be1b223895a852724"
+checksum = "bd94aa1369f866c777b044d489f3f058f35748a301d45b9a722d3f8448f93e73"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -6958,9 +6958,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.81.0"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74eb6cae7158d17dd0d58d43a797014ebe14f4f1c3275cec6da40217faa960a4"
+checksum = "417235f4fd39cc6b563ffec2d303c524d10ae023932f72c882352e37b057d1d3"
 dependencies = [
  "anyhow",
  "lightningcss",
@@ -6995,9 +6995,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "swc"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef0eb9ca180bfbee79cb080174eceee04850b42a06a8ad4d180b94a657d10edb"
+checksum = "74075a4bbd32aac7e4fb6b23db22f5bac5ef22ab7d107189c240de973c9a2cbe"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7061,10 +7061,11 @@ dependencies = [
 
 [[package]]
 name = "swc_allocator"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a1f988452cab8c4e25776e5a855ba088cdb38fbe9714f9b9d2a6ff345824858"
+checksum = "cc6b926f0d94bbb34031fe5449428cfa1268cdc0b31158d6ad9c97e0fc1e79dd"
 dependencies = [
+ "allocator-api2",
  "bumpalo",
  "hashbrown 0.14.5",
  "ptr_meta 0.3.0",
@@ -7074,9 +7075,9 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26769479f9cb4248b9c4a9ebde709e2657bb38d612576786680a2eed35c22549"
+checksum = "9d7077ba879f95406459bc0c81f3141c529b34580bc64d7ab7bd15e7118a0391"
 dependencies = [
  "bytecheck 0.8.0",
  "hstr",
@@ -7090,9 +7091,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "762dd20b7fda7952482a8017665f023daf8f7bfe886179f325b9cfc9f080ef58"
+checksum = "452694eeb8bcbe98dc55557757ad0385e5126746c499dfe194b9690a80506086"
 dependencies = [
  "anyhow",
  "crc",
@@ -7137,9 +7138,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601632c554875758657246e4971735d82ab59cfe13dcf496f70e5d9270f4c6f4"
+checksum = "26fbd21a1179166b5635d4b7a6b5930cf34b803a7361e0297b04f84dc820db04"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -7171,9 +7172,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a11ce0e86d6e510505ef24f945ffb689d3631209324c85de0850a36ddd462a80"
+checksum = "4cc6e0eaba5b6410fda9c3189145616b3146ac14328ffc000cfe8319e0dea530"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7226,9 +7227,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "14.0.1"
+version = "15.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624749807c67a0ceebbe6b8fce07b96186cd855ae3c4fb6be546634de91bd79b"
+checksum = "a622dbfdda214d472e8da044d5bd5975c831d6e17c5016fcde4b2681c2be1cf2"
 dependencies = [
  "binding_macros",
  "swc",
@@ -7263,9 +7264,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0993d78718d6e9e1820bb674961d8644128254d30b83dcf28389005d531024"
+checksum = "f9482f1ab79c5de548a8872421a6625fbf7a70102a354bb16da280689edd1768"
 dependencies = [
  "is-macro",
  "string_enum",
@@ -7275,9 +7276,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1259e6cbcaa400fc0aef00f8fb5533b0939081454f289143d3c236eac846d9"
+checksum = "0f75578c97d9338cb6ae4007bda693690bac1c5b5d0bf817d43cd0b0e08632a1"
 dependencies = [
  "auto_impl",
  "bitflags 2.5.0",
@@ -7304,9 +7305,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_compat"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde71f9c13bba7ff9b499a62e8c55174f0628be1ad0ea44723173ee86bfd86b1"
+checksum = "fbfec0694cca0950515b8d87dd8dda991e45d36e257f5efd8cb7682e7617c125"
 dependencies = [
  "bitflags 2.5.0",
  "once_cell",
@@ -7321,9 +7322,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_minifier"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a70a915cf0fe27f0d979c349f0ab25fce782a341466b03a68224d77206dc78"
+checksum = "6183c2b64cc58c0d9fccc993c7084360242c08ec9a1e3f93e798bf99fcd37a23"
 dependencies = [
  "rustc-hash 2.1.0",
  "serde",
@@ -7336,9 +7337,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e37088852126afc7381765b4c04851202a24921a294dbfac4019d8791b13a33"
+checksum = "d445ed47fad61fa7f0a60c1bfd6364c6686d5f3482959f8c13bed2789e98ee26"
 dependencies = [
  "lexical",
  "serde",
@@ -7349,9 +7350,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_prefixer"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe1f8c265eeb9732363f7451443bfe422c3204a6bd1b47ea918fec99ad866f18"
+checksum = "bac1e4bfc032749c2521ea63972e59bf3472a2897d6bbfa7747566eb7ccf7b89"
 dependencies = [
  "once_cell",
  "preset_env_base",
@@ -7367,9 +7368,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bf241d1531bf55ca1a7cb5cdb96232e7b119c3908592c742b985b0abe270cc3"
+checksum = "0976acf568ddc227f407ade30677f4e36122bd9906cc4c3997796bf76fb773cd"
 dependencies = [
  "once_cell",
  "rustc-hash 2.1.0",
@@ -7383,9 +7384,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8645f20a9202e53c40c5410b71a9cdb44e1eb814dd931e3fda451def8a727eea"
+checksum = "f2b941b45c434b6875146a0675a4c60c65a79d8c41a37457f8a33c05519d5c7f"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7396,9 +7397,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d856e3b85126e83d806b8d327ff6dc3708a4f512137510a210b8b0aaa2b1588b"
+checksum = "c66db1e9b31f0f91ee0964aba014b4d2dfdc6c558732d106d762b43bedad2c4a"
 dependencies = [
  "bitflags 2.5.0",
  "bytecheck 0.8.0",
@@ -7419,9 +7420,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "7.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a16d8fe0b81c3856cbd82c6bb7d28c21bd3891a387c9f1f862f545ce9b8a6e88"
+checksum = "874889c00e41e5ae487886ff4af2533944584e8b479bc469a3f9708cab7ecdb7"
 dependencies = [
  "ascii",
  "compact_str",
@@ -7442,9 +7443,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen_macros"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9a42f479a6475647e248fa9750982c87cd985e19d1016a1fc18a70682305d1"
+checksum = "4ac2ff0957329e0dfcde86a1ac465382e189bf42a5989720d3476bea78eaa31a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7454,9 +7455,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ebbda8bf33b91b0bc0fbcd015987fd9adb5fd321d9f0ce2daa7024c1387231"
+checksum = "3fbf52155fac8dbf8b13cf412da46e81f8bbe57467334a4e9434837f7bd61506"
 dependencies = [
  "rustc-hash 2.1.0",
  "swc_atoms",
@@ -7472,9 +7473,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a33d7e0fb5e3db15c25d3292e2551f81a6866b21a995d7c424e25d0f53c714"
+checksum = "09054aad2b52da3e6cf72089237700ff43fc5e6ab3ee1c521583c2c549522a38"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -7485,9 +7486,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940c2073a7aa8bc3dc7d4893a02995f1e7313dc3193e5e1a656851f4ca96695b"
+checksum = "124d5fdcdc9973b7dba1eb18874c5a7a40b9fadb32bc7c5e2fc4f30c69129fa1"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.7.1",
@@ -7512,9 +7513,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff26ec16caad6e17c9991fdb3cacba7bc2be4d77f0f95b6157f344d42fdf5f9"
+checksum = "1d557bc5bc9242e07d16e5d42fb1882856d9bafcd26eab77ba124b9e68444e83"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7529,9 +7530,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a388d6699ce0a6489b2d8d0426df6888735cad712274632f4e3ddad88d77dbd1"
+checksum = "3ce9c93d6a0780fa84eab113083259228557bcd7ce3d27e0479e0d8de143012b"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7547,9 +7548,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740690174e2a1b348cb32b23a90169fef598b289ef7696aa6abf3917fb3b9bc6"
+checksum = "b926094b18e30780c231032ce8ad6240842d0b0cca01938c61370b67ed8911fc"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7566,9 +7567,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aaffce6df422b148acb45cde227228b6b5d629fd1342fe54d28281686f481be"
+checksum = "658ab6efb4ff84a91429d90f5add80c1cf19d9d720cb8e0a47863fc2628e3564"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7582,9 +7583,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42edd65b182b49c324780558a1c78447eae3f49dd6ea862f6de473eeaec3b90a"
+checksum = "e3e0eac482a0ed60af3b7de78ca85e664095dfbd96a21dbafc8dff43e2f13b66"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7600,9 +7601,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a738cf851535907a4d321e026f9249e1e053ce8bd04d33abbe235b59c59da04"
+checksum = "89dd2f25812eab659bd088c2ace9837d5b6f064e7a184f27d7199d5aae493b20"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7616,9 +7617,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb3f197a0cda537b120f0405778eca7c3dad1c06ac9018d2e8377c3a4f5b125"
+checksum = "fa9e163b2badafc208995f771524492f8b003e52b82e0dff6c11fcb06662dc99"
 dependencies = [
  "rustc-hash 2.1.0",
  "swc_atoms",
@@ -7636,9 +7637,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfba8605f88eb317b1a2b840fc509c5aa1ef5eb48ac55df6518330541d777a5f"
+checksum = "0e5bce31592c053191996262d502f219a23edd53ae87ae7f54204bbdd94e5fcc"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -7651,9 +7652,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42bf1a5a4719dfee4a9ae2dfacff37999a55362a1b245dde0adc4d5e4b3354"
+checksum = "111d812c5e61ffc4f2e18573b0f09bcd870463b7eaa0a0419014d88cc7fc084b"
 dependencies = [
  "phf",
  "swc_atoms",
@@ -7665,9 +7666,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fffffcae6d072cc8a0b1843c77aa30ef738b815d70f78c2ae56e4a7b88e0fcd"
+checksum = "5aa46331be775b9ab6f114251ceb79cf7adb8e43d27183673615752a7ac828e5"
 dependencies = [
  "auto_impl",
  "dashmap 5.5.3",
@@ -7686,9 +7687,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40cbfcb05386162e1ab3a6ca34cc2e53917e8203dae2ad89ba100c6bc1c9050b"
+checksum = "a801462c997b71e4add7684ce4953c7d6200c75b5552b8d594783da84ad9564c"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -7709,9 +7710,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7341e3096840638df82572d5d51ec57959cb78751c8aab9e7817c35418ea7f"
+checksum = "7c3602b7df679021ebb5a42dfbc3ecd2dfb5b7cedac20488af68c126840eccd7"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.7.1",
@@ -7746,9 +7747,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee398e6093d6816e060d44013f1b8111e2043367899bc05d01cac3fdce12301"
+checksum = "f9e336f2b460882df2c132328b3c29ab3e680e1db681a05ec3e406940d98320a"
 dependencies = [
  "either",
  "new_debug_unreachable",
@@ -7769,9 +7770,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e024fa429985938b6fd78fa432953e40b9acca41af4bf6988d5b32a3bcc2ec"
+checksum = "025195d58d38ca0a9022d55bdd2370b233f3f61d7c9aa207ecdd19129f5c5139"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -7794,9 +7795,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353013c02bd03faa96db8bd980bbf3c3beb6a3c1559678aaa2bd9189b069ab6c"
+checksum = "e4822fc4052681e583cbac5f823351d38de3347b59edd56bebface11dc05e863"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -7812,9 +7813,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8337a466d19da1d3bfcb6f8b12113fb8c82cf6664602b1183ef46ca9d7a8c66e"
+checksum = "5e72a43b7acd904fa0c6d244a72aeda66febbc5a9720975481cb836d6804b604"
 dependencies = [
  "anyhow",
  "hex",
@@ -7825,9 +7826,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22c16d480e79ac3a5396029bd1d3134e84eac635386269b8e96cfa8d6122786"
+checksum = "66edf11a95e4eeaac12c30bb59f4d9a922f2f3ac81373639c17b20aaec9be42f"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7845,9 +7846,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f73624c31126342dd5b53938a1a4a405ce73ce60b2498af86b432793e58b9e7"
+checksum = "f13897adabc6ba621560a5898e752e02fb328f4c9797309ead6209d8db55d0e1"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.5.0",
@@ -7870,9 +7871,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f20b955ed625edec528810d947074f78baa7abc1079e8a950175660f52def737"
+checksum = "2111a904b8f3c5dd63f56e7c8048851fcd8f748691a162a5d19a5da49f4a9d35"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7884,9 +7885,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ab4c2d155ea8786853e333532fcc3f7f7727d7844be62696656c0bced14461"
+checksum = "d9e25a5cc997638fd050e5e1ddccb49688300f13940ade79ee9bbe584158697b"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.7.1",
@@ -7933,9 +7934,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f793efb5f5d2198dc0779e5dce3f4b0883b800df14804a735b58fc46b5e1ef3"
+checksum = "2911ff76a54c74eaf29518f15861326595f8f9d98a3086edcad30d3d46bea957"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -7961,9 +7962,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec13de01856f03c701291251f84b259dba49204f07903cb5126c8fe351cd655"
+checksum = "93e98cb0e4e10a839c553d610082b4b920a430019a0150067ac415e6049f12b2"
 dependencies = [
  "dashmap 5.5.3",
  "indexmap 2.7.1",
@@ -7986,9 +7987,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fb64dabfb5b04538e7a80a520939f742c657de672666197a06fcac04182fbb"
+checksum = "6eecc30b94780216450f9389ee63854882b1b3c8ec95790497d123cda7888104"
 dependencies = [
  "either",
  "rustc-hash 2.1.0",
@@ -8006,9 +8007,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4795f4c8ef4f591248c987f5ce6d94e699587ee43847b40b2453186b93f748"
+checksum = "bc1707dd7cf4699336e081a9a764409532139990b4e9f733feb74a17c647606a"
 dependencies = [
  "base64 0.21.4",
  "dashmap 5.5.3",
@@ -8033,9 +8034,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfbda9a6efd41c8fe47f0800913bb5c092313d2bdeb9ede8d6006701e4b3d1cb"
+checksum = "7dce5bbd4417919ff4e7a15500c18d88fc135e57b512f3ebd59cf82439d80ef9"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -8060,9 +8061,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5596e4e5e114a33313c7dd696ab3a32cdee2746d7bd9928c3ab885763720ee7f"
+checksum = "06b455ded4b426c1d8016807b8fab11bd36607d5f1dabeb07e3ab94976e6b528"
 dependencies = [
  "once_cell",
  "rustc-hash 2.1.0",
@@ -8079,9 +8080,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca1e7b5e340cd752eddae7fbb30012f03737f52e5d25347dd407c938bbed725"
+checksum = "3ed536f224b5dd9c6c9431c3fca48f572324c485a15d865fa84a22a639e6be59"
 dependencies = [
  "indexmap 2.7.1",
  "rustc-hash 2.1.0",
@@ -8096,9 +8097,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f3f5232b8fb1c756d428a36f09df1dac2f44d77951d7f946cab809757deab6"
+checksum = "721dc779e7de200da96ac4002c710bc32c988e3e1ebf62b39d32bf99f14d9765"
 dependencies = [
  "indexmap 2.7.1",
  "num_cpus",
@@ -8117,9 +8118,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "195a418699326c6a4be906ecd3144d58335bef9c166f07ecfa1b7399028733aa"
+checksum = "2f7a65fa06d0c0f709f1df4e820ccdc4eca7b3db7f9d131545e20c2ac2f1cd23"
 dependencies = [
  "new_debug_unreachable",
  "num-bigint",
@@ -8133,9 +8134,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.81.0"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcaeb62e49080aec49bc7bd763fa66179028fc8064a48917f32d4de9fc8adcc"
+checksum = "1c51b659312dcc2817308e395b2609d346df4fbc562df4299a045e481240689b"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -8169,9 +8170,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d89a68d5725643421457eb8cde1f6d05c4d704bbb884044c889fb7e729effd"
+checksum = "10ad5f4690758cedc202cf0f4c9d2369372c6692307f65bd40031de494662cfa"
 dependencies = [
  "anyhow",
  "miette",
@@ -8182,9 +8183,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2455d78f59b32202c806f0ceeb4c25e5034eb49874e312353962b4fde1414bdf"
+checksum = "bd24b9798b0538803d0a69cffa5f5e051087fa2bd0d23e5a2f05d32edf9ab671"
 dependencies = [
  "indexmap 2.7.1",
  "petgraph",
@@ -8194,9 +8195,9 @@ dependencies = [
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba79d1930ee1adb69c843a8ee76063a4cdac003b6ab861b9fccf2b5524de184"
+checksum = "ed1b3b564c8316500be98cd8ba3dbd604070958d30494b31e8333a472d011f0b"
 dependencies = [
  "auto_impl",
  "petgraph",
@@ -8219,9 +8220,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7873c166c8fa3c015a2c68840a27da4b9030e89d5810346fb0c5f82e7347dbc3"
+checksum = "f97dba66fc5f0df68c706dc99ade59bcba4ce55c585117eefccafe1337ca270f"
 dependencies = [
  "dashmap 5.5.3",
  "rustc-hash 2.1.0",
@@ -8266,9 +8267,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac6c5059fba4db71d99d1df451f57ddc8c01a150c04662075ac1b20acd1c858"
+checksum = "a18c199683d9f946db8dfca444212a3551e74a7c563196b154d5ac30f3bf9de6"
 dependencies = [
  "better_scoped_tls",
  "bytecheck 0.8.0",
@@ -8283,9 +8284,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee01ac8c598d4933b877db3df13b91c428776545a9cfed8eb7131f3cabd9ce32"
+checksum = "72ff89ad36e3a28870dcf64fdc55fff1b8e3c0fad3c01af4cafdf8f2e0472eab"
 dependencies = [
  "anyhow",
  "enumset",
@@ -8310,9 +8311,9 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.51.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560c0d4fa79849bad1be806a7d92b99ae0859d7a84a1d1f65ce02a099d2a6c5c"
+checksum = "8558f3d73b4405ad117de3b3b30a3c6a2e50ba4fa06e28a03a2fd76fd1aed5c1"
 dependencies = [
  "once_cell",
  "regex",
@@ -8361,9 +8362,9 @@ dependencies = [
 
 [[package]]
 name = "swc_typescript"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd416e8edb59ab953ab273f4fb94fd685ec5107bb8ff386f2c9fd8f806dfef4c"
+checksum = "8facec2d8504b0e38195d60de884056d0d2365ffdc78cd2300ee595fcf9c625d"
 dependencies = [
  "petgraph",
  "rustc-hash 2.1.0",
@@ -8538,9 +8539,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357b1e3ef6414c8a97e0d4701a67ee52ea65095f7afb7fcc8a3609efdc0e7cf4"
+checksum = "8d32ddc0e2ebd072cbffe7424087267da990708a5bc3ae29e075904468450275"
 dependencies = [
  "ansi_term",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -299,7 +299,7 @@ turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 
 # SWC crates
-swc_core = { version = "15.0.1", features = [
+swc_core = { version = "16.0.0", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }
@@ -309,11 +309,11 @@ testing = { version = "8.0.0" }
 browserslist-rs = { version = "0.17.0" }
 miette = { version = "5.10.0", features = ["fancy"] }
 mdxjs = "0.3"
-modularize_imports = { version = "0.78.0" }
-styled_components = { version = "0.106.0" }
-styled_jsx = { version = "0.82.0" }
-swc_emotion = { version = "0.82.0" }
-swc_relay = { version = "0.52.0" }
+modularize_imports = { version = "0.79.0" }
+styled_components = { version = "0.107.0" }
+styled_jsx = { version = "0.83.0" }
+swc_emotion = { version = "0.83.0" }
+swc_relay = { version = "0.53.0" }
 
 # General Deps
 chromiumoxide = { version = "0.5.4", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -299,21 +299,21 @@ turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 
 # SWC crates
-swc_core = { version = "14.0.1", features = [
+swc_core = { version = "15.0.1", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }
-testing = { version = "7.0.0" }
+testing = { version = "8.0.0" }
 
 # Keep consistent with preset_env_base through swc_core
 browserslist-rs = { version = "0.17.0" }
 miette = { version = "5.10.0", features = ["fancy"] }
 mdxjs = "0.3"
-modularize_imports = { version = "0.77.0" }
-styled_components = { version = "0.105.0" }
-styled_jsx = { version = "0.81.0" }
-swc_emotion = { version = "0.81.0" }
-swc_relay = { version = "0.51.0" }
+modularize_imports = { version = "0.78.0" }
+styled_components = { version = "0.106.0" }
+styled_jsx = { version = "0.82.0" }
+swc_emotion = { version = "0.82.0" }
+swc_relay = { version = "0.52.0" }
 
 # General Deps
 chromiumoxide = { version = "0.5.4", features = [
@@ -435,4 +435,4 @@ wasmer-cache = { git = "https://github.com/kdy1/wasmer", branch = "build-deps" }
 wasmer-compiler-cranelift = { git = "https://github.com/kdy1/wasmer", branch = "build-deps" }
 wasmer-wasix = { git = "https://github.com/kdy1/wasmer", branch = "build-deps" }
 
-mdxjs={git="https://github.com/kdy1/mdxjs-rs.git",branch = "swc-core-14"}
+mdxjs = { git="https://github.com/kdy1/mdxjs-rs.git", branch = "swc-core-15" }

--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -32,8 +32,8 @@ lazy_static = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 rustc-hash = { workspace = true }
-react_remove_properties = "0.32.0"
-remove_console = "0.33.0"
+react_remove_properties = "0.33.0"
+remove_console = "0.34.0"
 
 auto-hash-map = { workspace = true }
 

--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -32,8 +32,8 @@ lazy_static = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 rustc-hash = { workspace = true }
-react_remove_properties = "0.31.0"
-remove_console = "0.32.0"
+react_remove_properties = "0.32.0"
+remove_console = "0.33.0"
 
 auto-hash-map = { workspace = true }
 

--- a/crates/next-core/src/next_shared/transforms/next_font.rs
+++ b/crates/next-core/src/next_shared/transforms/next_font.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::fonts::*;
-use swc_core::ecma::{ast::Program, atoms::JsWord, visit::VisitMutWith};
+use swc_core::ecma::{ast::Program, atoms::Atom, visit::VisitMutWith};
 use turbo_tasks::ResolvedVc;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
@@ -33,7 +33,7 @@ pub fn get_next_font_transform_rule(enable_mdx_rs: bool) -> ModuleRule {
 
 #[derive(Debug)]
 struct NextJsFont {
-    font_loaders: Vec<JsWord>,
+    font_loaders: Vec<Atom>,
 }
 
 #[async_trait]

--- a/crates/next-custom-transforms/Cargo.toml
+++ b/crates/next-custom-transforms/Cargo.toml
@@ -60,8 +60,8 @@ swc_relay = { workspace = true }
 turbopack-ecmascript-plugins = { workspace = true, optional = true }
 turbo-rcstr = { workspace = true }
 
-react_remove_properties = "0.32.0"
-remove_console = "0.33.0"
+react_remove_properties = "0.33.0"
+remove_console = "0.34.0"
 preset_env_base = "2.0.1"
 
 [dev-dependencies]

--- a/crates/next-custom-transforms/Cargo.toml
+++ b/crates/next-custom-transforms/Cargo.toml
@@ -60,8 +60,8 @@ swc_relay = { workspace = true }
 turbopack-ecmascript-plugins = { workspace = true, optional = true }
 turbo-rcstr = { workspace = true }
 
-react_remove_properties = "0.31.0"
-remove_console = "0.32.0"
+react_remove_properties = "0.32.0"
+remove_console = "0.33.0"
 preset_env_base = "2.0.1"
 
 [dev-dependencies]

--- a/crates/next-custom-transforms/src/transforms/amp_attributes.rs
+++ b/crates/next-custom-transforms/src/transforms/amp_attributes.rs
@@ -3,7 +3,7 @@ use swc_core::ecma::{
         Ident, IdentName, JSXAttr, JSXAttrName, JSXAttrOrSpread, JSXElementName, JSXOpeningElement,
         Pass,
     },
-    atoms::JsWord,
+    atoms::Atom,
     visit::{fold_pass, Fold},
 };
 
@@ -37,7 +37,7 @@ impl Fold for AmpAttributePatcher {
                         if sym as &str == "className" {
                             *i = JSXAttrOrSpread::JSXAttr(JSXAttr {
                                 name: JSXAttrName::Ident(IdentName {
-                                    sym: JsWord::from("class"),
+                                    sym: Atom::from("class"),
                                     span: *s,
                                 }),
                                 span: *span,

--- a/crates/next-custom-transforms/src/transforms/fonts/font_functions_collector.rs
+++ b/crates/next-custom-transforms/src/transforms/fonts/font_functions_collector.rs
@@ -2,13 +2,13 @@ use swc_core::{
     common::errors::HANDLER,
     ecma::{
         ast::*,
-        atoms::JsWord,
+        atoms::Atom,
         visit::{noop_visit_type, Visit},
     },
 };
 
 pub struct FontFunctionsCollector<'a> {
-    pub font_loaders: &'a [JsWord],
+    pub font_loaders: &'a [Atom],
     pub state: &'a mut super::State,
 }
 

--- a/crates/next-custom-transforms/src/transforms/fonts/font_imports_generator.rs
+++ b/crates/next-custom-transforms/src/transforms/fonts/font_imports_generator.rs
@@ -3,7 +3,7 @@ use swc_core::{
     common::{errors::HANDLER, Spanned, DUMMY_SP},
     ecma::{
         ast::*,
-        atoms::JsWord,
+        atoms::Atom,
         visit::{noop_visit_type, Visit},
     },
 };
@@ -66,7 +66,7 @@ impl FontImportsGenerator<'_> {
 
                         return Some(ImportDecl {
                             src: Box::new(Str {
-                                value: JsWord::from(format!(
+                                value: Atom::from(format!(
                                     "{}/target.css?{}",
                                     font_function.loader, query_json
                                 )),

--- a/crates/next-custom-transforms/src/transforms/fonts/mod.rs
+++ b/crates/next-custom-transforms/src/transforms/fonts/mod.rs
@@ -4,7 +4,7 @@ use swc_core::{
     common::{BytePos, Spanned},
     ecma::{
         ast::{Id, ModuleItem, Pass},
-        atoms::JsWord,
+        atoms::Atom,
         visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitWith},
     },
 };
@@ -16,8 +16,8 @@ mod font_imports_generator;
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct Config {
-    pub font_loaders: Vec<JsWord>,
-    pub relative_file_path_from_root: JsWord,
+    pub font_loaders: Vec<Atom>,
+    pub relative_file_path_from_root: Atom,
 }
 
 pub fn next_font_loaders(config: Config) -> impl Pass + VisitMut {
@@ -31,8 +31,8 @@ pub fn next_font_loaders(config: Config) -> impl Pass + VisitMut {
 
 #[derive(Debug)]
 pub struct FontFunction {
-    loader: JsWord,
-    function_name: Option<JsWord>,
+    loader: Atom,
+    function_name: Option<Atom>,
 }
 #[derive(Debug, Default)]
 pub struct State {

--- a/crates/next-custom-transforms/src/transforms/import_analyzer.rs
+++ b/crates/next-custom-transforms/src/transforms/import_analyzer.rs
@@ -1,6 +1,6 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::{
-    atoms::JsWord,
+    atoms::Atom,
     ecma::{
         ast::{
             Expr, Id, ImportDecl, ImportNamedSpecifier, ImportSpecifier, MemberExpr, MemberProp,
@@ -13,16 +13,16 @@ use swc_core::{
 #[derive(Debug, Default)]
 pub(crate) struct ImportMap {
     /// Map from module name to (module path, exported symbol)
-    imports: FxHashMap<Id, (JsWord, JsWord)>,
+    imports: FxHashMap<Id, (Atom, Atom)>,
 
-    namespace_imports: FxHashMap<Id, JsWord>,
+    namespace_imports: FxHashMap<Id, Atom>,
 
-    imported_modules: FxHashSet<JsWord>,
+    imported_modules: FxHashSet<Atom>,
 }
 
 #[allow(unused)]
 impl ImportMap {
-    pub fn is_module_imported(&mut self, module: &JsWord) -> bool {
+    pub fn is_module_imported(&mut self, module: &Atom) -> bool {
         self.imported_modules.contains(module)
     }
 
@@ -96,7 +96,7 @@ impl Visit for Analyzer<'_> {
     }
 }
 
-fn orig_name(n: &ModuleExportName) -> JsWord {
+fn orig_name(n: &ModuleExportName) -> Atom {
     match n {
         ModuleExportName::Ident(v) => v.sym.clone(),
         ModuleExportName::Str(v) => v.value.clone(),

--- a/crates/next-custom-transforms/src/transforms/shake_exports.rs
+++ b/crates/next-custom-transforms/src/transforms/shake_exports.rs
@@ -3,7 +3,7 @@ use swc_core::{
     common::Mark,
     ecma::{
         ast::*,
-        atoms::{js_word, JsWord},
+        atoms::{atom, Atom},
         transforms::optimization::simplify::dce::{dce, Config as DCEConfig},
         visit::{fold_pass, Fold, FoldWith, VisitMutWith},
     },
@@ -11,7 +11,7 @@ use swc_core::{
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Config {
-    pub ignore: Vec<JsWord>,
+    pub ignore: Vec<Atom>,
 }
 
 pub fn shake_exports(config: Config) -> impl Pass {
@@ -23,7 +23,7 @@ pub fn shake_exports(config: Config) -> impl Pass {
 
 #[derive(Debug, Default)]
 struct ExportShaker {
-    ignore: Vec<JsWord>,
+    ignore: Vec<Atom>,
     remove_export: bool,
 }
 
@@ -108,14 +108,14 @@ impl Fold for ExportShaker {
     }
 
     fn fold_export_default_decl(&mut self, decl: ExportDefaultDecl) -> ExportDefaultDecl {
-        if !self.ignore.contains(&js_word!("default")) {
+        if !self.ignore.contains(&atom!("default")) {
             self.remove_export = true
         }
         decl
     }
 
     fn fold_export_default_expr(&mut self, expr: ExportDefaultExpr) -> ExportDefaultExpr {
-        if !self.ignore.contains(&js_word!("default")) {
+        if !self.ignore.contains(&atom!("default")) {
             self.remove_export = true
         }
         expr

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/styled_components.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/styled_components.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use swc_core::{
     common::comments::NoopComments,
-    ecma::{ast::Program, atoms::JsWord},
+    ecma::{ast::Program, atoms::Atom},
 };
 use turbo_tasks::{ValueDefault, Vc};
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
@@ -71,7 +71,7 @@ impl StyledComponentsTransformer {
         if !top_level_import_paths.is_empty() {
             options.top_level_import_paths = top_level_import_paths
                 .iter()
-                .map(|s| JsWord::from(s.clone()))
+                .map(|s| Atom::from(s.clone()))
                 .collect();
         }
         let meaningless_file_names = &config.meaningless_file_names;

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/builtin.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/builtin.rs
@@ -1,6 +1,6 @@
 use std::mem::take;
 
-use swc_core::ecma::atoms::js_word;
+use swc_core::ecma::atoms::atom;
 
 use super::{ConstantNumber, ConstantValue, JsValue, LogicalOperator, LogicalProperty, ObjectPart};
 use crate::analyzer::JsValueUrlKind;
@@ -303,7 +303,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                             }
                         }
                         if potential_values.is_empty() {
-                            *value = JsValue::FreeVar(js_word!("undefined"));
+                            *value = JsValue::FreeVar(atom!("undefined"));
                         } else {
                             *value = potential_values_to_alternatives(
                                 potential_values,

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -9,7 +9,7 @@ use swc_core::{
     common::{comments::Comments, pass::AstNodePath, Mark, Span, Spanned, SyntaxContext, GLOBALS},
     ecma::{
         ast::*,
-        atoms::js_word,
+        atoms::atom,
         utils::contains_ident_ref,
         visit::{fields::*, *},
     },
@@ -658,7 +658,7 @@ impl EvalContext {
                 }
                 let args = args.iter().map(|arg| self.eval(&arg.expr)).collect();
 
-                let callee = Box::new(JsValue::FreeVar(js_word!("import")));
+                let callee = Box::new(JsValue::FreeVar(atom!("import")));
 
                 JsValue::call(callee, args)
             }
@@ -673,7 +673,7 @@ impl EvalContext {
                     .iter()
                     .map(|e| match e {
                         Some(e) => self.eval(&e.expr),
-                        _ => JsValue::FreeVar(js_word!("undefined")),
+                        _ => JsValue::FreeVar(atom!("undefined")),
                     })
                     .collect();
                 JsValue::array(arr)
@@ -1127,7 +1127,7 @@ impl Analyzer<'_> {
         match callee {
             Callee::Import(_) => {
                 self.add_effect(Effect::Call {
-                    func: Box::new(JsValue::FreeVar(js_word!("import"))),
+                    func: Box::new(JsValue::FreeVar(atom!("import"))),
                     args,
                     ast_path: as_parent_path(ast_path),
                     span,
@@ -1213,7 +1213,7 @@ impl Analyzer<'_> {
         let values = self.cur_fn_return_values.take().unwrap();
 
         Box::new(match values.len() {
-            0 => JsValue::FreeVar(js_word!("undefined")),
+            0 => JsValue::FreeVar(atom!("undefined")),
             1 => values.into_iter().next().unwrap(),
             _ => JsValue::alternatives(values),
         })
@@ -1793,7 +1793,7 @@ impl VisitAstPath for Analyzer<'_> {
                 .arg
                 .as_deref()
                 .map(|e| self.eval_context.eval(e))
-                .unwrap_or(JsValue::FreeVar(js_word!("undefined")));
+                .unwrap_or(JsValue::FreeVar(atom!("undefined")));
 
             values.push(return_value);
         }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -6,7 +6,7 @@ use swc_core::{
     common::{comments::Comments, source_map::SmallPos, BytePos, Span, Spanned},
     ecma::{
         ast::*,
-        atoms::{js_word, JsWord},
+        atoms::{atom, Atom},
         visit::{Visit, VisitWith},
     },
 };
@@ -26,19 +26,19 @@ use crate::{
 pub struct ImportAnnotations {
     // TODO store this in more structured way
     #[turbo_tasks(trace_ignore)]
-    map: BTreeMap<JsWord, JsWord>,
+    map: BTreeMap<Atom, Atom>,
 }
 
 /// Enables a specified transition for the annotated import
-static ANNOTATION_TRANSITION: Lazy<JsWord> =
+static ANNOTATION_TRANSITION: Lazy<Atom> =
     Lazy::new(|| crate::annotations::ANNOTATION_TRANSITION.into());
 
 /// Changes the chunking type for the annotated import
-static ANNOTATION_CHUNKING_TYPE: Lazy<JsWord> =
+static ANNOTATION_CHUNKING_TYPE: Lazy<Atom> =
     Lazy::new(|| crate::annotations::ANNOTATION_CHUNKING_TYPE.into());
 
 /// Changes the type of the resolved module (only "json" is supported currently)
-static ATTRIBUTE_MODULE_TYPE: Lazy<JsWord> = Lazy::new(|| "type".into());
+static ATTRIBUTE_MODULE_TYPE: Lazy<Atom> = Lazy::new(|| "type".into());
 
 impl ImportAnnotations {
     pub fn parse(with: Option<&ObjectLit>) -> ImportAnnotations {
@@ -113,7 +113,7 @@ impl ImportAnnotations {
         self.get(&ATTRIBUTE_MODULE_TYPE)
     }
 
-    pub fn get(&self, key: &JsWord) -> Option<&str> {
+    pub fn get(&self, key: &Atom) -> Option<&str> {
         self.map.get(key).map(|w| w.as_str())
     }
 }
@@ -136,8 +136,8 @@ impl Display for ImportAnnotations {
 #[derive(Debug)]
 pub(crate) enum Reexport {
     Star,
-    Namespace { exported: JsWord },
-    Named { imported: JsWord, exported: JsWord },
+    Namespace { exported: Atom },
+    Named { imported: Atom, exported: Atom },
 }
 
 /// The storage for all kinds of imports.
@@ -147,7 +147,7 @@ pub(crate) enum Reexport {
 #[derive(Default, Debug)]
 pub(crate) struct ImportMap {
     /// Map from identifier to (index in references, exported symbol)
-    imports: FxIndexMap<Id, (usize, JsWord)>,
+    imports: FxIndexMap<Id, (usize, Atom)>,
 
     /// Map from identifier to index in references
     namespace_imports: FxIndexMap<Id, usize>,
@@ -177,7 +177,7 @@ pub(crate) struct ImportMap {
 
     /// The module specifiers of star imports that are accessed dynamically and should be imported
     /// as a whole.
-    full_star_imports: FxHashSet<JsWord>,
+    full_star_imports: FxHashSet<Atom>,
 }
 
 /// Represents a collection of [webpack-style "magic comments"][magic] that override import
@@ -226,7 +226,7 @@ impl Default for &ImportAttributes {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum ImportedSymbol {
     ModuleEvaluation,
-    Symbol(JsWord),
+    Symbol(Atom),
     Exports,
     Part(u32),
     PartEvaluation(u32),
@@ -234,7 +234,7 @@ pub(crate) enum ImportedSymbol {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct ImportMapReference {
-    pub module_path: JsWord,
+    pub module_path: Atom,
     pub imported_symbol: ImportedSymbol,
     pub annotations: ImportAnnotations,
     pub issue_source: Option<IssueSource>,
@@ -353,8 +353,8 @@ impl ImportMap {
 
 struct StarImportAnalyzer<'a> {
     /// The local identifiers of the star imports
-    candidates: FxIndexMap<Id, JsWord>,
-    full_star_imports: &'a mut FxHashSet<JsWord>,
+    candidates: FxIndexMap<Id, Atom>,
+    full_star_imports: &'a mut FxHashSet<Atom>,
 }
 
 impl Visit for StarImportAnalyzer<'_> {
@@ -420,7 +420,7 @@ impl Analyzer<'_> {
     fn ensure_reference(
         &mut self,
         span: Span,
-        module_path: JsWord,
+        module_path: Atom,
         imported_symbol: ImportedSymbol,
         annotations: ImportAnnotations,
     ) -> Option<usize> {
@@ -444,7 +444,7 @@ impl Analyzer<'_> {
     }
 }
 
-fn to_word(name: &ModuleExportName) -> JsWord {
+fn to_word(name: &ModuleExportName) -> Atom {
     match name {
         ModuleExportName::Ident(ident) => ident.sym.clone(),
         ModuleExportName::Str(str) => str.value.clone(),
@@ -580,7 +580,7 @@ impl Visit for Analyzer<'_> {
                     self.data.reexports.push((
                         i,
                         Reexport::Named {
-                            imported: js_word!("default"),
+                            imported: atom!("default"),
                             exported: d.exported.sym.clone(),
                         },
                     ));
@@ -718,7 +718,7 @@ fn parse_ignore_directive(comments: &dyn Comments, value: Option<&ExprOrSpread>)
         .next()
 }
 
-pub(crate) fn orig_name(n: &ModuleExportName) -> JsWord {
+pub(crate) fn orig_name(n: &ModuleExportName) -> Atom {
     match n {
         ModuleExportName::Ident(v) => v.sym.clone(),
         ModuleExportName::Str(v) => v.value.clone(),
@@ -743,7 +743,7 @@ fn get_import_symbol_from_import(specifier: &ImportSpecifier) -> ImportedSymbol 
             Some(imported) => orig_name(imported),
             _ => local.sym.clone(),
         }),
-        ImportSpecifier::Default(..) => ImportedSymbol::Symbol(js_word!("default")),
+        ImportSpecifier::Default(..) => ImportedSymbol::Symbol(atom!("default")),
         ImportSpecifier::Namespace(..) => ImportedSymbol::Exports,
     }
 }
@@ -753,7 +753,7 @@ fn get_import_symbol_from_export(specifier: &ExportSpecifier) -> ImportedSymbol 
         ExportSpecifier::Named(ExportNamedSpecifier { orig, .. }) => {
             ImportedSymbol::Symbol(orig_name(orig))
         }
-        ExportSpecifier::Default(..) => ImportedSymbol::Symbol(js_word!("default")),
+        ExportSpecifier::Default(..) => ImportedSymbol::Symbol(atom!("default")),
         ExportSpecifier::Namespace(..) => ImportedSymbol::Exports,
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -22,7 +22,7 @@ use swc_core::{
     common::Mark,
     ecma::{
         ast::{Id, Ident, Lit},
-        atoms::{Atom, JsWord},
+        atoms::Atom,
     },
 };
 use turbo_rcstr::RcStr;
@@ -275,7 +275,7 @@ impl Display for ConstantValue {
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct ModuleValue {
-    pub module: JsWord,
+    pub module: Atom,
     pub annotations: ImportAnnotations,
 }
 
@@ -500,9 +500,9 @@ pub enum JsValue {
     /// A reference to an function argument.
     /// (func_ident, arg_index)
     Argument(u32, usize),
-    // TODO no predefined kinds, only JsWord
+    // TODO no predefined kinds, only Atom
     /// A reference to a free variable.
-    FreeVar(JsWord),
+    FreeVar(Atom),
     /// This is a reference to a imported module.
     Module(ModuleValue),
 }
@@ -3799,9 +3799,9 @@ pub enum WellKnownFunctionKind {
     RequireContextRequireKeys(RequireContextValue),
     RequireContextRequireResolve(RequireContextValue),
     Define,
-    FsReadMethod(JsWord),
+    FsReadMethod(Atom),
     PathToFileUrl,
-    ChildProcessSpawnMethod(JsWord),
+    ChildProcessSpawnMethod(Atom),
     ChildProcessFork,
     OsArch,
     OsPlatform,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -32,7 +32,7 @@ use regex::Regex;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use swc_core::{
-    atoms::JsWord,
+    atoms::Atom,
     common::{
         comments::{CommentKind, Comments},
         errors::{DiagnosticId, Handler, HANDLER},
@@ -3176,7 +3176,7 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
 
         if export.src.is_none() {
             for spec in export.specifiers.iter() {
-                fn to_string(name: &ModuleExportName) -> &JsWord {
+                fn to_string(name: &ModuleExportName) -> &Atom {
                     name.atom()
                 }
                 match spec {
@@ -3445,7 +3445,7 @@ impl From<Vec<AstParentKind>> for AstPath {
     }
 }
 
-pub static TURBOPACK_HELPER: Lazy<JsWord> = Lazy::new(|| "__turbopack-helper__".into());
+pub static TURBOPACK_HELPER: Lazy<Atom> = Lazy::new(|| "__turbopack-helper__".into());
 
 pub fn is_turbopack_helper_import(import: &ImportDecl) -> bool {
     let annotations = ImportAnnotations::parse(import.with.as_deref());

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -19,7 +19,7 @@ use swc_core::{
             Lit, Module, ModuleDecl, ModuleExportName, ModuleItem, NamedExport, ObjectLit, Prop,
             PropName, PropOrSpread, Stmt, Str, VarDecl, VarDeclKind, VarDeclarator,
         },
-        atoms::JsWord,
+        atoms::Atom,
         utils::{find_pat_ids, private_ident, quote_ident, ExprCtx, ExprExt},
     },
 };
@@ -46,7 +46,7 @@ pub(crate) enum ItemId {
 pub(crate) enum ItemIdGroupKind {
     ModuleEvaluation,
     /// `(local, export_name)``
-    Export(Id, JsWord),
+    Export(Id, Atom),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -109,7 +109,7 @@ pub(crate) struct ItemData {
 
     pub content: ModuleItem,
 
-    pub export: Option<JsWord>,
+    pub export: Option<Atom>,
 
     /// This value denotes the module specifier of the [ImportDecl] that declares this
     /// [ItemId].
@@ -1642,7 +1642,7 @@ pub(crate) fn find_turbopack_part_id_in_asserts(asserts: &ObjectLit) -> Option<P
 }
 /// givin a number, return a base54 encoded string
 /// `usize -> [a-zA-Z$_][a-zA-Z$_0-9]*`
-pub(crate) fn encode_base54(init: &mut usize, skip_reserved: bool) -> JsWord {
+pub(crate) fn encode_base54(init: &mut usize, skip_reserved: bool) -> Atom {
     static BASE54_CHARS: &[u8; 64] =
         b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789$_";
 
@@ -1674,8 +1674,8 @@ pub(crate) fn encode_base54(init: &mut usize, skip_reserved: bool) -> JsWord {
 
     let s = unsafe {
         // Safety: We are only using ascii characters
-        // Safety: The stack memory for ret is alive while creating JsWord
-        JsWord::from(std::str::from_utf8_unchecked(&ret))
+        // Safety: The stack memory for ret is alive while creating Atom
+        Atom::from(std::str::from_utf8_unchecked(&ret))
     };
 
     if skip_reserved

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/merge.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/merge.rs
@@ -2,7 +2,7 @@ use anyhow::Error;
 use rustc_hash::FxHashSet;
 use swc_core::ecma::{
     ast::{Module, ModuleDecl, ModuleItem},
-    atoms::JsWord,
+    atoms::Atom,
 };
 
 use super::{graph::find_turbopack_part_id_in_asserts, PartId};
@@ -22,7 +22,7 @@ where
 {
     loader: L,
 
-    done: FxHashSet<(JsWord, u32)>,
+    done: FxHashSet<(Atom, u32)>,
 }
 
 impl<L> Merger<L>

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/tests.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/tests.rs
@@ -6,7 +6,7 @@ use swc_core::{
     common::{comments::SingleThreadedComments, util::take::Take, Mark, SourceMap, SyntaxContext},
     ecma::{
         ast::{EsVersion, Id, Module},
-        atoms::JsWord,
+        atoms::Atom,
         codegen::text_writer::JsWriter,
         parser::{parse_file_as_module, EsSyntax},
         visit::VisitMutWith,
@@ -176,7 +176,7 @@ fn run(input: PathBuf) {
         )
         .unwrap();
 
-        let uri_of_module: JsWord = "entry.js".into();
+        let uri_of_module: Atom = "entry.js".into();
 
         let mut describe =
             |is_debug: bool, title: &str, entries: Vec<ItemIdGroupKind>, skip_parts: bool| {


### PR DESCRIPTION
### What?

Update `swc_core` to `v16.0.0`. This is a Wasm-breaking change, and changelog is at https://github.com/swc-project/swc/compare/swc_core%40v14.0.1...swc_core%40v16.0.0

To elaborate: Wasm-breaking change means the authors of SWC Wasm plugins will need to update `swc_core`.

### Why?

To apply various fixes.



Closes PACK-4042