### PR TITLE
Turbopack: handle removed assets similar to non-existing assets

### DIFF
--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -221,12 +221,6 @@ impl VersionedContentMap {
         {
             if let Some(&asset) = path_to_asset.get(&path) {
                 return Ok(Vc::cell(Some(asset)));
-            } else {
-                let path = path.to_string().await?;
-                bail!(
-                    "could not find asset for path {} (asset has been removed)",
-                    path,
-                );
             }
         }
 


### PR DESCRIPTION
### What?

When assets are removed from the compilation, they should be treated as not existing again

Closes PACK-4026