### PR TITLE
[dev-overlay] Disable error feedback in UI if `NEXT_TELEMETRY_DISABLED` is set

### DIFF
--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -275,6 +275,9 @@ export function getDefineEnv({
     'process.env.__NEXT_ASSET_PREFIX': config.assetPrefix,
     'process.env.__NEXT_EXPERIMENTAL_AUTH_INTERRUPTS':
       !!config.experimental.authInterrupts,
+    'process.env.__NEXT_TELEMETRY_DISABLED': Boolean(
+      process.env.NEXT_TELEMETRY_DISABLED
+    ),
     ...(isNodeOrEdgeCompilation
       ? {
           // Fix bad-actors in the npm ecosystem (e.g. `node-formidable`)

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-footer/error-feedback/error-feedback.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-footer/error-feedback/error-feedback.tsx
@@ -11,6 +11,7 @@ export function ErrorFeedback({ errorCode, className }: ErrorFeedbackProps) {
   const [votedMap, setVotedMap] = useState<Record<string, boolean>>({})
   const voted = votedMap[errorCode]
   const hasVoted = voted !== undefined
+  const disabled = process.env.__NEXT_TELEMETRY_DISABLED
 
   const handleFeedback = useCallback(
     async (wasHelpful: boolean) => {
@@ -63,16 +64,26 @@ export function ErrorFeedback({ errorCode, className }: ErrorFeedbackProps) {
             </a>
           </p>
           <button
-            aria-label="Mark as helpful"
-            onClick={() => handleFeedback(true)}
+            aria-disabled={disabled ? 'true' : undefined}
+            aria-label={
+              disabled
+                ? 'Feedback disabled due to setting NEXT_TELEMETRY_DISABLED'
+                : 'Mark as helpful'
+            }
+            onClick={disabled ? undefined : () => handleFeedback(true)}
             className={cx('feedback-button', voted === true && 'voted')}
             type="button"
           >
             <ThumbsUp aria-hidden="true" />
           </button>
           <button
-            aria-label="Mark as not helpful"
-            onClick={() => handleFeedback(false)}
+            aria-disabled={disabled ? 'true' : undefined}
+            aria-label={
+              disabled
+                ? 'Feedback disabled due to setting NEXT_TELEMETRY_DISABLED'
+                : 'Mark as not helpful'
+            }
+            onClick={disabled ? undefined : () => handleFeedback(false)}
             className={cx('feedback-button', voted === false && 'voted')}
             type="button"
           >
@@ -130,7 +141,7 @@ export const styles = `
     }
   }
 
-  .feedback-button:disabled {
+  .feedback-button[aria-disabled='true'] {
     opacity: 0.7;
     cursor: not-allowed;
   }

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-footer/error-feedback/error-feedback.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-footer/error-feedback/error-feedback.tsx
@@ -65,26 +65,28 @@ export function ErrorFeedback({ errorCode, className }: ErrorFeedbackProps) {
           </p>
           <button
             aria-disabled={disabled ? 'true' : undefined}
-            aria-label={
-              disabled
-                ? 'Feedback disabled due to setting NEXT_TELEMETRY_DISABLED'
-                : 'Mark as helpful'
-            }
+            aria-label="Mark as helpful"
             onClick={disabled ? undefined : () => handleFeedback(true)}
             className={cx('feedback-button', voted === true && 'voted')}
+            title={
+              disabled
+                ? 'Feedback disabled due to setting NEXT_TELEMETRY_DISABLED'
+                : undefined
+            }
             type="button"
           >
             <ThumbsUp aria-hidden="true" />
           </button>
           <button
             aria-disabled={disabled ? 'true' : undefined}
-            aria-label={
-              disabled
-                ? 'Feedback disabled due to setting NEXT_TELEMETRY_DISABLED'
-                : 'Mark as not helpful'
-            }
+            aria-label="Mark as not helpful"
             onClick={disabled ? undefined : () => handleFeedback(false)}
             className={cx('feedback-button', voted === false && 'voted')}
+            title={
+              disabled
+                ? 'Feedback disabled due to setting NEXT_TELEMETRY_DISABLED'
+                : undefined
+            }
             type="button"
           >
             <ThumbsDown


### PR DESCRIPTION
Closes https://linear.app/vercel/issue/NDX-746

It wasn't obvious from the UI that `NEXT_TELEMETRY_DISABLED` had any effect on the error feedback. It even send a request to the backend even though the backend did not forward the feedback.

Now we disable these buttons while leaving them accessible to help their discovery. 

## Test plan

`pnpm debug dev test/e2e/app-dir/server-source-maps/fixtures/default`


https://github.com/user-attachments/assets/6ec46f49-7adc-4de6-9afe-fbf6f7a1b25b

Setting `NEXT_TELEMETRY_DISABLED=` in `package.json` and running same command again allows sending telemetry.