### PR TITLE
[dev-overlay] Link to section explaining opt-in error feedback

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-footer/error-feedback/error-feedback.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-footer/error-feedback/error-feedback.tsx
@@ -53,7 +53,15 @@ export function ErrorFeedback({ errorCode, className }: ErrorFeedbackProps) {
         </p>
       ) : (
         <>
-          <p>Was this helpful?</p>
+          <p>
+            <a
+              href="https://nextjs.org/telemetry#error-feedback"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Was this helpful?
+            </a>
+          </p>
           <button
             aria-label="Mark as helpful"
             onClick={() => handleFeedback(true)}


### PR DESCRIPTION
Might not be the most obvious link but adding an icon makes the UI too busy IMO.
Docs: https://github.com/vercel/front/pull/42157