### PR TITLE
Turbopack: rename reverse topological to postorder topological, fix async referenced modules

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1678,7 +1678,7 @@ async fn any_output_changed(
         .await
         .completed()?
         .into_inner()
-        .into_reverse_topological()
+        .into_postorder_topological()
         .map(|m| async move {
             let asset_path = m.path().await?;
             if !asset_path.path.ends_with(".map")

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -112,7 +112,7 @@ pub async fn all_assets_from_entries(entries: Vc<OutputAssets>) -> Result<Vc<Out
             .await
             .completed()?
             .into_inner()
-            .into_reverse_topological()
+            .into_postorder_topological()
             .collect::<FxHashSet<_>>()
             .into_iter()
             .collect(),

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -174,7 +174,7 @@ pub async fn find_server_entries(entry: ResolvedVc<Box<dyn Module>>) -> Result<V
 
         let mut server_component_entries = vec![];
         let mut server_utils = vec![];
-        for node in graph.reverse_topological() {
+        for node in graph.postorder_topological() {
             match &node.ty {
                 VisitClientReferenceNodeType::ServerUtilEntry(server_util, _) => {
                     server_utils.push(*server_util);

--- a/turbopack/crates/turbo-tasks/src/graph/adjacency_map.rs
+++ b/turbopack/crates/turbo-tasks/src/graph/adjacency_map.rs
@@ -88,10 +88,10 @@ impl<T> AdjacencyMap<T>
 where
     T: Eq + Hash + Clone,
 {
-    /// Returns an owned iterator over the nodes in reverse topological order,
+    /// Returns an owned iterator over the nodes in postorder topological order,
     /// starting from the roots.
-    pub fn into_reverse_topological(self) -> IntoReverseTopologicalIter<T> {
-        IntoReverseTopologicalIter {
+    pub fn into_postorder_topological(self) -> IntoPostorderTopologicalIter<T> {
+        IntoPostorderTopologicalIter {
             adjacency_map: self.adjacency_map,
             stack: self
                 .roots
@@ -108,7 +108,7 @@ where
     pub fn into_breadth_first_edges(self) -> IntoBreadthFirstEdges<T> {
         IntoBreadthFirstEdges {
             adjacency_map: self.adjacency_map,
-            stack: self
+            queue: self
                 .roots
                 .into_iter()
                 .rev()
@@ -118,10 +118,10 @@ where
         }
     }
 
-    /// Returns an iterator over the nodes in reverse topological order,
+    /// Returns an iterator over the nodes in postorder topological order,
     /// starting from the roots.
-    pub fn reverse_topological(&self) -> ReverseTopologicalIter<T> {
-        ReverseTopologicalIter {
+    pub fn postorder_topological(&self) -> PostorderTopologicalIter<T> {
+        PostorderTopologicalIter {
             adjacency_map: &self.adjacency_map,
             stack: self
                 .roots
@@ -133,13 +133,13 @@ where
         }
     }
 
-    /// Returns an iterator over the nodes in reverse topological order,
+    /// Returns an iterator over the nodes in postorder topological order,
     /// starting from the given node.
-    pub fn reverse_topological_from_node<'graph>(
+    pub fn postorder_topological_from_node<'graph>(
         &'graph self,
         node: &'graph T,
-    ) -> ReverseTopologicalIter<'graph, T> {
-        ReverseTopologicalIter {
+    ) -> PostorderTopologicalIter<'graph, T> {
+        PostorderTopologicalIter {
             adjacency_map: &self.adjacency_map,
             stack: vec![(ReverseTopologicalPass::Pre, node)],
             visited: FxHashSet::default(),
@@ -153,9 +153,9 @@ enum ReverseTopologicalPass {
     Post,
 }
 
-/// An iterator over the nodes of a graph in reverse topological order, starting
+/// An iterator over the nodes of a graph in postorder topological order, starting
 /// from the roots.
-pub struct IntoReverseTopologicalIter<T>
+pub struct IntoPostorderTopologicalIter<T>
 where
     T: Eq + Hash + Clone,
 {
@@ -164,7 +164,7 @@ where
     visited: FxHashSet<T>,
 }
 
-impl<T> Iterator for IntoReverseTopologicalIter<T>
+impl<T> Iterator for IntoPostorderTopologicalIter<T>
 where
     T: Eq + Hash + Clone,
 {
@@ -209,7 +209,7 @@ where
     T: Eq + std::hash::Hash + Clone,
 {
     adjacency_map: FxHashMap<T, Vec<T>>,
-    stack: VecDeque<(Option<T>, T)>,
+    queue: VecDeque<(Option<T>, T)>,
     expanded: FxHashSet<T>,
 }
 
@@ -220,14 +220,14 @@ where
     type Item = (Option<T>, T);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (parent, current) = self.stack.pop_front()?;
+        let (parent, current) = self.queue.pop_front()?;
 
         let Some(neighbors) = self.adjacency_map.get(&current) else {
             return Some((parent, current));
         };
 
         if self.expanded.insert(current.clone()) {
-            self.stack.extend(
+            self.queue.extend(
                 neighbors
                     .iter()
                     .map(|neighbor| (Some(current.clone()), neighbor.clone())),
@@ -238,9 +238,9 @@ where
     }
 }
 
-/// An iterator over the nodes of a graph in reverse topological order, starting
+/// An iterator over the nodes of a graph in postorder topological order, starting
 /// from the roots.
-pub struct ReverseTopologicalIter<'graph, T>
+pub struct PostorderTopologicalIter<'graph, T>
 where
     T: Eq + Hash + Clone,
 {
@@ -249,7 +249,7 @@ where
     visited: FxHashSet<&'graph T>,
 }
 
-impl<'graph, T> Iterator for ReverseTopologicalIter<'graph, T>
+impl<'graph, T> Iterator for PostorderTopologicalIter<'graph, T>
 where
     T: Eq + Hash + Clone,
 {

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -191,6 +191,19 @@ pub enum ChunkingType {
     Traced,
 }
 
+impl ChunkingType {
+    pub fn is_inherit_async(&self) -> bool {
+        match self {
+            ChunkingType::Parallel => false,
+            ChunkingType::ParallelInheritAsync => true,
+            ChunkingType::Async => true,
+            ChunkingType::Isolated { .. } => false,
+            ChunkingType::Shared { inherit_async, .. } => *inherit_async,
+            ChunkingType::Traced => false,
+        }
+    }
+}
+
 #[turbo_tasks::value(transparent)]
 pub struct ChunkingTypeOption(Option<ChunkingType>);
 

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -196,7 +196,7 @@ impl ChunkingType {
         match self {
             ChunkingType::Parallel => false,
             ChunkingType::ParallelInheritAsync => true,
-            ChunkingType::Async => true,
+            ChunkingType::Async => false,
             ChunkingType::Isolated { .. } => false,
             ChunkingType::Shared { inherit_async, .. } => *inherit_async,
             ChunkingType::Traced => false,

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -21,7 +21,7 @@ use crate::{
     chunk::{ChunkGroupType, ChunkingType},
     module::Module,
     module_graph::{
-        get_node, get_node_idx, traced_di_graph::iter_neighbors, GraphNodeIndex,
+        get_node, get_node_idx, traced_di_graph::iter_neighbors_rev, GraphNodeIndex,
         GraphTraversalAction, ModuleGraph, SingleModuleGraphModuleNode, SingleModuleGraphNode,
     },
 };
@@ -439,7 +439,7 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraph) -> Result<Vc<ChunkGro
                 queue_set.remove(&node);
                 let (node_weight, node) = get_node_idx!(graphs, node)?;
                 let graph = &graphs[node.graph_idx].graph;
-                let neighbors = iter_neighbors(graph, node.node_idx);
+                let neighbors = iter_neighbors_rev(graph, node.node_idx);
 
                 visit_count += 1;
 

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -7,7 +7,6 @@ use std::{
 use anyhow::{bail, Result};
 use either::Either;
 use indexmap::map::Entry;
-use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
 use roaring::RoaringBitmap;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -22,8 +22,8 @@ use crate::{
     chunk::{ChunkGroupType, ChunkingType},
     module::Module,
     module_graph::{
-        get_node, get_node_idx, GraphNodeIndex, GraphTraversalAction, ModuleGraph,
-        SingleModuleGraphModuleNode, SingleModuleGraphNode,
+        get_node, get_node_idx, traced_di_graph::iter_neighbors, GraphNodeIndex,
+        GraphTraversalAction, ModuleGraph, SingleModuleGraphModuleNode, SingleModuleGraphNode,
     },
 };
 
@@ -176,14 +176,6 @@ impl Deref for ChunkGroupId {
     fn deref(&self) -> &Self::Target {
         &self.0
     }
-}
-
-fn iter_neighbors<N, E>(
-    graph: &DiGraph<N, E>,
-    node: NodeIndex,
-) -> impl Iterator<Item = (EdgeIndex, NodeIndex)> + '_ {
-    let mut walker = graph.neighbors(node).detach();
-    std::iter::from_fn(move || walker.next(graph))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     module_graph::{
         async_module_info::{compute_async_module_info, AsyncModulesInfo},
         chunk_group_info::{compute_chunk_group_info, ChunkGroupInfo},
-        traced_di_graph::TracedDiGraph,
+        traced_di_graph::{iter_neighbors, TracedDiGraph},
     },
     reference::primary_chunkable_referenced_modules,
 };
@@ -1276,12 +1276,4 @@ impl Visit<SingleModuleGraphBuilderNode> for SingleModuleGraphBuilder<'_> {
             }
         }
     }
-}
-
-fn iter_neighbors<N, E>(
-    graph: &DiGraph<N, E>,
-    node: NodeIndex,
-) -> impl Iterator<Item = (EdgeIndex, NodeIndex)> + '_ {
-    let mut walker = graph.neighbors(node).detach();
-    std::iter::from_fn(move || walker.next(graph))
 }

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -655,7 +655,14 @@ impl ModuleGraph {
         let async_modules_info = self.async_module_info().await?;
 
         let entry = ModuleGraph::get_entry(&graphs, module).await?;
-        let referenced_modules = iter_neighbors(&graphs[entry.graph_idx].graph, entry.node_idx)
+        let referenced_modules = iter_neighbors_rev(&graphs[entry.graph_idx].graph, entry.node_idx)
+            .filter(|(edge_idx, _)| {
+                let ty = graphs[entry.graph_idx]
+                    .graph
+                    .edge_weight(*edge_idx)
+                    .unwrap();
+                ty.is_inherit_async()
+            })
             .map(|(_, child_idx)| {
                 anyhow::Ok(
                     get_node!(

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     module_graph::{
         async_module_info::{compute_async_module_info, AsyncModulesInfo},
         chunk_group_info::{compute_chunk_group_info, ChunkGroupInfo},
-        traced_di_graph::{iter_neighbors, TracedDiGraph},
+        traced_di_graph::{iter_neighbors_rev, TracedDiGraph},
     },
     reference::primary_chunkable_referenced_modules,
 };
@@ -528,18 +528,14 @@ impl SingleModuleGraph {
         let graph = &self.graph;
         let entries = entries.into_iter().map(|e| self.get_module(e).unwrap());
 
-        enum ReverseTopologicalPass {
+        enum TopologicalPass {
             Visit,
             ExpandAndVisit,
         }
 
         #[allow(clippy::type_complexity)] // This is a temporary internal structure
-        let mut stack: Vec<(
-            ReverseTopologicalPass,
-            Option<(NodeIndex, EdgeIndex)>,
-            NodeIndex,
-        )> = entries
-            .map(|e| (ReverseTopologicalPass::ExpandAndVisit, None, e))
+        let mut stack: Vec<(TopologicalPass, Option<(NodeIndex, EdgeIndex)>, NodeIndex)> = entries
+            .map(|e| (TopologicalPass::ExpandAndVisit, None, e))
             .collect();
         let mut expanded = HashSet::new();
         while let Some((pass, parent, current)) = stack.pop() {
@@ -555,36 +551,33 @@ impl SingleModuleGraph {
                 )
             });
             match pass {
-                ReverseTopologicalPass::Visit => {
+                TopologicalPass::Visit => {
                     visit_postorder(parent_arg, graph.node_weight(current).unwrap(), state);
                 }
-                ReverseTopologicalPass::ExpandAndVisit => {
-                    match graph.node_weight(current).unwrap() {
-                        current_node @ SingleModuleGraphNode::Module(_) => {
-                            let action = visit_preorder(parent_arg, current_node, state)?;
-                            if action == GraphTraversalAction::Exclude {
-                                continue;
-                            }
-                            stack.push((ReverseTopologicalPass::Visit, parent, current));
-                            if action == GraphTraversalAction::Continue && expanded.insert(current)
-                            {
-                                stack.extend(iter_neighbors(graph, current).map(
-                                    |(edge, child)| {
-                                        (
-                                            ReverseTopologicalPass::ExpandAndVisit,
-                                            Some((current, edge)),
-                                            child,
-                                        )
-                                    },
-                                ));
-                            }
+                TopologicalPass::ExpandAndVisit => match graph.node_weight(current).unwrap() {
+                    current_node @ SingleModuleGraphNode::Module(_) => {
+                        let action = visit_preorder(parent_arg, current_node, state)?;
+                        if action == GraphTraversalAction::Exclude {
+                            continue;
                         }
-                        current_node @ SingleModuleGraphNode::VisitedModule { .. } => {
-                            visit_preorder(parent_arg, current_node, state)?;
-                            visit_postorder(parent_arg, current_node, state);
+                        stack.push((TopologicalPass::Visit, parent, current));
+                        if action == GraphTraversalAction::Continue && expanded.insert(current) {
+                            stack.extend(iter_neighbors_rev(graph, current).map(
+                                |(edge, child)| {
+                                    (
+                                        TopologicalPass::ExpandAndVisit,
+                                        Some((current, edge)),
+                                        child,
+                                    )
+                                },
+                            ));
                         }
                     }
-                }
+                    current_node @ SingleModuleGraphNode::VisitedModule { .. } => {
+                        visit_preorder(parent_arg, current_node, state)?;
+                        visit_postorder(parent_arg, current_node, state);
+                    }
+                },
             }
         }
 
@@ -677,6 +670,7 @@ impl ModuleGraph {
             })
             .collect::<Result<Vec<_>>>()?
             .into_iter()
+            .rev()
             .filter(|m| async_modules_info.contains(m))
             .map(|m| *m)
             .collect();
@@ -815,7 +809,7 @@ impl ModuleGraph {
             let graph = &graphs[node.graph_idx].graph;
             let node_weight = get_node!(graphs, node)?;
             if visited.insert(node) {
-                let neighbors = iter_neighbors(graph, node.node_idx);
+                let neighbors = iter_neighbors_rev(graph, node.node_idx);
 
                 for (edge, succ) in neighbors {
                     let succ = GraphNodeIndex {
@@ -868,7 +862,7 @@ impl ModuleGraph {
             let graph = &graphs[node.graph_idx].graph;
             let node_weight = get_node!(graphs, node)?;
             if visited.insert(node) {
-                let neighbors = iter_neighbors(graph, node.node_idx);
+                let neighbors = iter_neighbors_rev(graph, node.node_idx);
 
                 for (edge, succ) in neighbors {
                     let succ = GraphNodeIndex {
@@ -960,19 +954,19 @@ impl ModuleGraph {
 
         let entries = entries.into_iter().collect::<Vec<_>>();
 
-        enum ReverseTopologicalPass {
+        enum TopologicalPass {
             Visit,
             ExpandAndVisit,
         }
         #[allow(clippy::type_complexity)] // This is a temporary internal structure
         let mut stack: Vec<(
-            ReverseTopologicalPass,
+            TopologicalPass,
             Option<(GraphNodeIndex, EdgeIndex)>,
             GraphNodeIndex,
         )> = Vec::with_capacity(entries.len());
         for entry in entries.into_iter().rev() {
             stack.push((
-                ReverseTopologicalPass::ExpandAndVisit,
+                TopologicalPass::ExpandAndVisit,
                 None,
                 ModuleGraph::get_entry(&graphs, entry).await?,
             ));
@@ -991,31 +985,31 @@ impl ModuleGraph {
             };
             let current_node = get_node!(graphs, current)?;
             match pass {
-                ReverseTopologicalPass::Visit => {
+                TopologicalPass::Visit => {
                     visit_postorder(parent_arg, current_node, state);
                 }
-                ReverseTopologicalPass::ExpandAndVisit => {
+                TopologicalPass::ExpandAndVisit => {
                     let action = visit_preorder(parent_arg, current_node, state)?;
                     if action == GraphTraversalAction::Exclude {
                         continue;
                     }
-                    stack.push((ReverseTopologicalPass::Visit, parent, current));
+                    stack.push((TopologicalPass::Visit, parent, current));
                     if action == GraphTraversalAction::Continue && expanded.insert(current) {
                         let graph = &graphs[current.graph_idx].graph;
-                        let (neighbors, current) =
+                        let (neighbors_rev, current) =
                             match graph.node_weight(current.node_idx).unwrap() {
                                 SingleModuleGraphNode::Module(_) => {
-                                    (iter_neighbors(graph, current.node_idx), current)
+                                    (iter_neighbors_rev(graph, current.node_idx), current)
                                 }
                                 SingleModuleGraphNode::VisitedModule { idx, .. } => (
                                     // We switch graphs
-                                    iter_neighbors(&graphs[idx.graph_idx].graph, idx.node_idx),
+                                    iter_neighbors_rev(&graphs[idx.graph_idx].graph, idx.node_idx),
                                     *idx,
                                 ),
                             };
-                        stack.extend(neighbors.map(|(edge, child)| {
+                        stack.extend(neighbors_rev.map(|(edge, child)| {
                             (
-                                ReverseTopologicalPass::ExpandAndVisit,
+                                TopologicalPass::ExpandAndVisit,
                                 Some((current, edge)),
                                 GraphNodeIndex {
                                     graph_idx: current.graph_idx,

--- a/turbopack/crates/turbopack-core/src/module_graph/traced_di_graph.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/traced_di_graph.rs
@@ -51,7 +51,8 @@ where
 {
 }
 
-pub fn iter_neighbors<N, E>(
+/// Iterate the edges of a node REVERSED!
+pub fn iter_neighbors_rev<N, E>(
     graph: &DiGraph<N, E>,
     node: NodeIndex,
 ) -> impl Iterator<Item = (EdgeIndex, NodeIndex)> + '_ {

--- a/turbopack/crates/turbopack-core/src/module_graph/traced_di_graph.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/traced_di_graph.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use petgraph::graph::DiGraph;
+use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{
     debug::ValueDebugFormat,
@@ -49,4 +49,12 @@ where
     N: NonLocalValue,
     E: NonLocalValue,
 {
+}
+
+pub fn iter_neighbors<N, E>(
+    graph: &DiGraph<N, E>,
+    node: NodeIndex,
+) -> impl Iterator<Item = (EdgeIndex, NodeIndex)> + '_ {
+    let mut walker = graph.neighbors(node).detach();
+    std::iter::from_fn(move || walker.next(graph))
 }

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -323,7 +323,7 @@ pub async fn all_assets_from_entries(entries: Vc<OutputAssets>) -> Result<Vc<Out
             .await
             .completed()?
             .into_inner()
-            .into_reverse_topological()
+            .into_postorder_topological()
             .collect(),
     ))
 }

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -166,7 +166,7 @@ async fn separate_assets_operation(
     let mut internal_assets = FxIndexSet::default();
     let mut external_asset_entrypoints = FxIndexSet::default();
 
-    for item in graph.into_reverse_topological() {
+    for item in graph.into_postorder_topological() {
         match item {
             Type::Internal(asset) => {
                 internal_assets.insert(asset);


### PR DESCRIPTION
### What?

* move iter_neighbors into shared file, rename to iter_neighbors_rev
* fix async referenced modules by filtering by chunking type
* rename reverse topological to postorder topological


Closes PACK-4025