### PR TITLE
[dev-overlay] polish component stack mask css

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/container/runtime-error/component-stack-pseudo-html.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/container/runtime-error/component-stack-pseudo-html.tsx
@@ -68,8 +68,9 @@ export const PSEUDO_HTML_DIFF_STYLES = `
   [data-nextjs-container-errors-pseudo-html-collapse='true']
     .nextjs__container_errors__component-stack
     code {
-    max-height: 100px;
-    mask-image: linear-gradient(to top, rgba(0, 0, 0, 0) 0%, black 50%);
+    max-height: 120px;
+    mask-image: linear-gradient(to bottom,rgba(0,0,0,0) 0%,black 10%);
+    padding-bottom: 40px;
   }
   .nextjs__container_errors__component-stack code {
     display: block;
@@ -78,8 +79,7 @@ export const PSEUDO_HTML_DIFF_STYLES = `
     scroll-snap-type: y mandatory;
     overflow-y: hidden;
   }
-  [data-nextjs-container-errors-pseudo-html--diff],
-  [data-nextjs-container-errors-pseudo-html--diff='error'] {
+  [data-nextjs-container-errors-pseudo-html--diff] {
     scroll-snap-align: center;
   }
   .error-overlay-hydration-error-diff-plus-icon {


### PR DESCRIPTION
### What

* Move the mask to the top when hydration diff is collapsed
* increase the height and bottom space a little bit

| After | Before |
|:--|:--|
| ![image](https://github.com/user-attachments/assets/b4eacb73-9572-4038-91de-bc7c4ed20eae) | ![image](https://github.com/user-attachments/assets/8c9ba719-f30a-4e66-94b2-3b14ee6b2504) |
