### PR TITLE
[dev-overlay] replace the react hydration error link with nextjs one

### DIFF
--- a/packages/next/src/client/components/is-hydration-error.ts
+++ b/packages/next/src/client/components/is-hydration-error.ts
@@ -10,7 +10,10 @@ const reactHydrationStartMessages = [
   `A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:`,
 ]
 
-const reactHydrationErrorDocLink = 'https://react.dev/link/hydration-mismatch'
+export const REACT_HYDRATION_ERROR_LINK =
+  'https://react.dev/link/hydration-mismatch'
+export const NEXTJS_HYDRATION_ERROR_LINK =
+  'https://nextjs.org/docs/messages/react-hydration-error'
 
 export const getDefaultHydrationErrorMessage = () => {
   return reactUnifiedMismatchWarning
@@ -48,7 +51,6 @@ export function testReactHydrationWarning(msg: string): boolean {
 
 export function getHydrationErrorStackInfo(rawMessage: string): {
   message: string | null
-  link?: string
   stack?: string
   diff?: string
 } {
@@ -59,7 +61,6 @@ export function getHydrationErrorStackInfo(rawMessage: string): {
   if (!isReactHydrationErrorMessage(rawMessage) && !isReactHydrationWarning) {
     return {
       message: null,
-      link: '',
       stack: rawMessage,
       diff: '',
     }
@@ -69,7 +70,6 @@ export function getHydrationErrorStackInfo(rawMessage: string): {
     const [message, diffLog] = rawMessage.split('\n\n')
     return {
       message: message.trim(),
-      link: reactHydrationErrorDocLink,
       stack: '',
       diff: (diffLog || '').trim(),
     }
@@ -78,7 +78,7 @@ export function getHydrationErrorStackInfo(rawMessage: string): {
   const firstLineBreak = rawMessage.indexOf('\n')
   rawMessage = rawMessage.slice(firstLineBreak + 1).trim()
 
-  const [message, trailing] = rawMessage.split(`${reactHydrationErrorDocLink}`)
+  const [message, trailing] = rawMessage.split(`${REACT_HYDRATION_ERROR_LINK}`)
   const trimmedMessage = message.trim()
   // React built-in hydration diff starts with a newline, checking if length is > 1
   if (trailing && trailing.length > 1) {
@@ -95,14 +95,12 @@ export function getHydrationErrorStackInfo(rawMessage: string): {
 
     return {
       message: trimmedMessage,
-      link: reactHydrationErrorDocLink,
       diff: diffs.join('\n'),
       stack: stacks.join('\n'),
     }
   } else {
     return {
       message: trimmedMessage,
-      link: reactHydrationErrorDocLink,
       stack: trailing, // without hydration diff
     }
   }

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-toolbar/docs-link-button.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-toolbar/docs-link-button.tsx
@@ -1,3 +1,7 @@
+import {
+  NEXTJS_HYDRATION_ERROR_LINK,
+  REACT_HYDRATION_ERROR_LINK,
+} from '../../../../../is-hydration-error'
 import { parseUrlFromText } from '../../../utils/parse-url-from-text'
 
 const docsURLAllowlist = ['https://nextjs.org', 'https://react.dev']
@@ -13,7 +17,14 @@ function getDocsURLFromErrorMessage(text: string): string | null {
     return null
   }
 
-  return urls[0]
+  const href = urls[0]
+
+  // Replace react hydration error link with nextjs hydration error link
+  if (href === REACT_HYDRATION_ERROR_LINK) {
+    return NEXTJS_HYDRATION_ERROR_LINK
+  }
+
+  return href
 }
 
 export function DocsLinkButton({ errorMessage }: { errorMessage: string }) {

--- a/packages/next/src/client/components/react-dev-overlay/ui/container/errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/container/errors.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../../errors/console-error'
 import { extractNextErrorCode } from '../../../../../lib/error-telemetry-utils'
 import { ErrorOverlayLayout } from '../components/errors/error-overlay-layout/error-overlay-layout'
+import { NEXTJS_HYDRATION_ERROR_LINK } from '../../../is-hydration-error'
 import type { ReadyRuntimeError } from '../../utils/get-error-by-type'
 import type { ErrorBaseProps } from '../components/errors/error-overlay/error-overlay'
 
@@ -180,7 +181,9 @@ export function Errors({
             id="nextjs__container_errors__link"
             className="nextjs__container_errors__link"
           >
-            <HotlinkedText text="See more info here: https://nextjs.org/docs/messages/react-hydration-error" />
+            <HotlinkedText
+              text={`See more info here: ${NEXTJS_HYDRATION_ERROR_LINK}`}
+            />
           </p>
         ) : null}
       </div>


### PR DESCRIPTION
### What

Always display the nextjs hydration error link on both docs button and overlay description side.

Closes NDX-737