### PR TITLE
[test] fix client navigation error count in react 18

### DIFF
--- a/test/development/pages-dir/client-navigation/index.test.ts
+++ b/test/development/pages-dir/client-navigation/index.test.ts
@@ -1,6 +1,12 @@
 /* eslint-env jest */
 
-import { assertNoRedbox, fetchViaHTTP, waitFor, check } from 'next-test-utils'
+import {
+  assertNoRedbox,
+  fetchViaHTTP,
+  waitFor,
+  check,
+  retry,
+} from 'next-test-utils'
 import webdriver, { BrowserInterface } from 'next-webdriver'
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
@@ -331,13 +337,11 @@ describe('Client Navigation', () => {
       const defaultCount = await browser.elementByCss('p').text()
       expect(defaultCount).toBe('COUNT: 0')
 
-      const countAfterClicked = await browser
-        .elementByCss('#self-reload-link')
-        .click()
-        .elementByCss('p')
-        .text()
+      await browser.elementByCss('#self-reload-link').click()
 
-      expect(countAfterClicked).toBe('COUNT: 1')
+      await retry(async () => {
+        expect(await browser.elementByCss('p').text()).toBe('COUNT: 1')
+      })
       await browser.close()
     })
 

--- a/test/development/pages-dir/client-navigation/index.test.ts
+++ b/test/development/pages-dir/client-navigation/index.test.ts
@@ -1393,7 +1393,7 @@ describe('Client Navigation', () => {
         })
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
+           "count": ${isReact18 ? 3 : 1},
            "description": "Error: An Expected error occurred",
            "environmentLabel": null,
            "label": "Unhandled Runtime Error",


### PR DESCRIPTION
fix snapshot for react 18

x-ref: https://github.com/vercel/next.js/actions/runs/13503594271/job/37731266375