### PR TITLE
Webpack: handle file:// urls when finding sourcemaps

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-webpack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-webpack.ts
@@ -287,6 +287,9 @@ async function getSource(
 ): Promise<Source | undefined> {
   const { getCompilations } = options
 
+  // Rspack is now using file:// URLs for source maps. Remove the rsc prefix to produce the file:/// url.
+  sourceURL = sourceURL.replace(/(.*)\/(?=file:\/\/)/, '')
+
   let nativeSourceMap: SourceMap | undefined
   try {
     nativeSourceMap = findSourceMap(sourceURL)


### PR DESCRIPTION
Previously we only handled the eval sourcemaps case where the module id was encoded into the source url. This handles cases when the `file://` protocol is used, such as with Rspack.
    
Test Plan: `pnpm test-dev-rspack test/development/acceptance-app/rsc-runtime-errors.test.ts`

Closes PACK-4035