### PR TITLE
Update error-recovery test snapshots for alternative bundler [3/n]

### DIFF
--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -56,6 +56,29 @@ describe('pages/ error recovery', () => {
          "stack": [],
        }
       `)
+    } else if (process.env.NEXT_RSPACK) {
+      await expect({ browser, next }).toDisplayRedbox(`
+       {
+         "count": 1,
+         "description": "  × Module build failed:",
+         "environmentLabel": null,
+         "label": "Build Error",
+         "source": "./index.js
+         × Module build failed:
+         ├─▶   ×
+         │     │   x Unexpected eof
+         │     │    ,-[<FIXME-project-root>/index.js:1:1]
+         │     │  1 | export default () => <div/
+         │     │    \`----
+         │     │
+         │
+         ╰─▶ Syntax Error
+       Import trace for requested module:
+       ./index.js
+       ./pages/index.js",
+         "stack": [],
+       }
+      `)
     } else {
       await expect(browser).toDisplayRedbox(`
        {
@@ -335,6 +358,35 @@ describe('pages/ error recovery', () => {
          "stack": [],
        }
       `)
+    } else if (process.env.NEXT_RSPACK) {
+      await expect({ browser, next }).toDisplayRedbox(`
+       {
+         "count": 1,
+         "description": "  × Module build failed:",
+         "environmentLabel": null,
+         "label": "Build Error",
+         "source": "./index.js
+         × Module build failed:
+         ├─▶   ×
+         │     │   x Expected '{', got 'return'
+         │     │    ,-[<FIXME-project-root>/index.js:5:1]
+         │     │  2 |
+         │     │  3 | class ClassDefault extends React.Component {
+         │     │  4 |   render()
+         │     │  5 |     return <h1>Default Export</h1>;
+         │     │    :     ^^^^^^
+         │     │  6 |   }
+         │     │  7 | }
+         │     │    \`----
+         │     │
+         │
+         ╰─▶ Syntax Error
+       Import trace for requested module:
+       ./index.js
+       ./pages/index.js",
+         "stack": [],
+       }
+      `)
     } else {
       await expect(browser).toDisplayRedbox(`
        {
@@ -394,8 +446,38 @@ describe('pages/ error recovery', () => {
          "stack": [],
        }
       `)
+    } else if (process.env.NEXT_RSPACK) {
+      await expect({ browser, next }).toDisplayRedbox(`
+       {
+         "count": 1,
+         "description": "  × Module build failed:",
+         "environmentLabel": null,
+         "label": "Build Error",
+         "source": "./index.js
+         × Module build failed:
+         ├─▶   ×
+         │     │   x Expected '{', got 'throw'
+         │     │    ,-[<FIXME-project-root>/index.js:5:1]
+         │     │  2 |
+         │     │  3 | class ClassDefault extends React.Component {
+         │     │  4 |   render()
+         │     │  5 |     throw new Error('nooo');
+         │     │    :     ^^^^^
+         │     │  6 |     return <h1>Default Export</h1>;
+         │     │  7 |   }
+         │     │  8 | }
+         │     │    \`----
+         │     │
+         │
+         ╰─▶ Syntax Error
+       Import trace for requested module:
+       ./index.js
+       ./pages/index.js",
+         "stack": [],
+       }
+      `)
     } else {
-      await expect(browser).toDisplayRedbox(`
+      await expect({ browser, next }).toDisplayRedbox(`
        {
          "count": 1,
          "description": "Error:   x Expected '{', got 'throw'",
@@ -465,23 +547,40 @@ describe('pages/ error recovery', () => {
        }
       `)
     } else {
-      await expect(browser).toDisplayRedbox(`
-       {
-         "count": 1,
-         "description": "Error: nooo",
-         "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
-         "source": "index.js (5:11) @ ClassDefault.render
-       > 5 |     throw new Error('nooo');
-           |           ^",
-         "stack": [
-           "ClassDefault.render index.js (5:11)",
-           "Set.forEach <anonymous> (0:0)",
-           "<FIXME-file-protocol>",
-           "<FIXME-file-protocol>",
-         ],
-       }
-      `)
+      if (process.env.NEXT_RSPACK) {
+        await expect(browser).toDisplayRedbox(`
+         {
+           "count": 1,
+           "description": "Error: nooo",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "index.js (5:11) @ ClassDefault.render
+         > 5 |     throw new Error('nooo');
+             |           ^",
+           "stack": [
+             "ClassDefault.render index.js (5:11)",
+           ],
+         }
+        `)
+      } else {
+        await expect(browser).toDisplayRedbox(`
+                {
+                  "count": 1,
+                  "description": "Error: nooo",
+                  "environmentLabel": null,
+                  "label": "Unhandled Runtime Error",
+                  "source": "index.js (5:11) @ ClassDefault.render
+                > 5 |     throw new Error('nooo');
+                    |           ^",
+                  "stack": [
+                    "ClassDefault.render index.js (5:11)",
+                    "Set.forEach <anonymous> (0:0)",
+                    "<FIXME-file-protocol>",
+                    "<FIXME-file-protocol>",
+                  ],
+                }
+              `)
+      }
     }
   })
 
@@ -616,20 +715,37 @@ describe('pages/ error recovery', () => {
     )
     await new Promise((resolve) => setTimeout(resolve, 1000))
 
-    await expect(browser).toDisplayRedbox(`
-     {
-       "count": 1,
-       "description": "Error: no 1",
-       "environmentLabel": null,
-       "label": "Unhandled Runtime Error",
-       "source": "index.js (5:9) @ eval
-     > 5 |   throw Error('no ' + i)
-         |         ^",
-       "stack": [
-         "eval index.js (5:9)",
-       ],
-     }
-    `)
+    if (process.env.NEXT_RSPACK) {
+      await expect(browser).toDisplayRedbox(`
+            {
+              "count": 1,
+              "description": "Error: no 1",
+              "environmentLabel": null,
+              "label": "Unhandled Runtime Error",
+              "source": "index.js (5:9) @ <unknown>
+            > 5 |   throw Error('no ' + i)
+                |         ^",
+              "stack": [
+                "<unknown> index.js (5:9)",
+              ],
+            }
+          `)
+    } else {
+      await expect(browser).toDisplayRedbox(`
+       {
+         "count": 1,
+         "description": "Error: no 1",
+         "environmentLabel": null,
+         "label": "Unhandled Runtime Error",
+         "source": "index.js (5:9) @ eval
+       > 5 |   throw Error('no ' + i)
+           |         ^",
+         "stack": [
+           "eval index.js (5:9)",
+         ],
+       }
+      `)
+    }
 
     // Make a syntax error.
     await session.patch(
@@ -659,6 +775,33 @@ describe('pages/ error recovery', () => {
        Parsing ecmascript source code failed
        > 7 | export default function FunctionNamed() {
            |                                         ^",
+         "stack": [],
+       }
+      `)
+    } else if (process.env.NEXT_RSPACK) {
+      await expect({ browser, next }).toDisplayRedbox(`
+       {
+         "count": 1,
+         "description": "  × Module build failed:",
+         "environmentLabel": null,
+         "label": "Build Error",
+         "source": "./index.js
+         × Module build failed:
+         ├─▶   ×
+         │     │   x Expected '}', got '<eof>'
+         │     │    ,-[<FIXME-project-root>/index.js:7:1]
+         │     │  4 |   i++
+         │     │  5 |   throw Error('no ' + i)
+         │     │  6 | }, 1000)
+         │     │  7 | export default function FunctionNamed() {
+         │     │    :                                         ^
+         │     │    \`----
+         │     │
+         │
+         ╰─▶ Syntax Error
+       Import trace for requested module:
+       ./index.js
+       ./pages/index.js",
          "stack": [],
        }
       `)
@@ -706,8 +849,35 @@ describe('pages/ error recovery', () => {
          "stack": [],
        }
       `)
+    } else if (process.env.NEXT_RSPACK) {
+      await expect({ browser, next }).toDisplayRedbox(`
+       {
+         "count": 1,
+         "description": "  × Module build failed:",
+         "environmentLabel": null,
+         "label": "Build Error",
+         "source": "./index.js
+         × Module build failed:
+         ├─▶   ×
+         │     │   x Expected '}', got '<eof>'
+         │     │    ,-[<FIXME-project-root>/index.js:7:1]
+         │     │  4 |   i++
+         │     │  5 |   throw Error('no ' + i)
+         │     │  6 | }, 1000)
+         │     │  7 | export default function FunctionNamed() {
+         │     │    :                                         ^
+         │     │    \`----
+         │     │
+         │
+         ╰─▶ Syntax Error
+       Import trace for requested module:
+       ./index.js
+       ./pages/index.js",
+         "stack": [],
+       }
+      `)
     } else {
-      await expect(browser).toDisplayRedbox(`
+      await expect({ browser, next }).toDisplayRedbox(`
        {
          "count": 1,
          "description": "Error:   x Expected '}', got '<eof>'",


### PR DESCRIPTION
Test Plan: `pnpm test-dev-rspack test/development/acceptance/error-recovery.test.ts`

Closes PACK-4037