### PR TITLE
Turbopack: unique node middleware layer name

### DIFF
--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -212,7 +212,7 @@ describe('middleware - development errors', () => {
         isTurbopack
           ? '\n ⨯ Error: booooom!' +
               // TODO(veil): Should be sourcemapped
-              '\n    at [project]/middleware.js [middleware] (ecmascript)'
+              '\n    at [project]/middleware.js [middleware-edge] (ecmascript)'
           : '\n ⨯ Error: booooom!' +
               // TODO: Should be anonymous method without a method name
               '\n    at <unknown> (middleware.js:3)' +


### PR DESCRIPTION
- In https://github.com/vercel/next.js/pull/76360, I missed that the two middleware asset contexts have the same layer name
- Furthermore, split out the creation of the two asset context into two separate functions for readability (just like for the existing two instrumentation contexts)

Closes PACK-4030