### PR TITLE
fix(rustdoc): Fix rustdoc warnings, block on rustdoc failures in CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -164,7 +164,7 @@ jobs:
       stepName: 'rust-check'
     secrets: inherit
 
-  rust-doc-check:
+  rustdoc-check:
     name: rustdoc check
     needs: ['changes', 'build-next']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
@@ -175,7 +175,7 @@ jobs:
       skipInstallBuild: 'yes'
       skipNativeBuild: 'yes'
       afterBuild: ./scripts/deploy-turbopack-docs.sh
-      stepName: 'rust-doc-check'
+      stepName: 'rustdoc-check'
     secrets: inherit
 
   ast-grep:
@@ -635,6 +635,7 @@ jobs:
         'test-ppr-integration',
         'test-cargo-unit',
         'rust-check',
+        'rustdoc-check',
         'test-next-swc-wasm',
         'test-turbopack-dev',
         'test-turbopack-integration',

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -1010,7 +1010,7 @@ pub fn project_hmr_identifiers_subscribe(
     )
 }
 
-enum UpdateMessage {
+pub enum UpdateMessage {
     Start,
     End(UpdateInfo),
 }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -495,8 +495,8 @@ impl ProjectContainer {
         self.project().hmr_identifiers()
     }
 
-    /// Gets a source map for a particular `file_path`. If `dev` mode is
-    /// disabled, this will always return [`OptionSourceMap::none`].
+    /// Gets a source map for a particular `file_path`. If `dev` mode is disabled, this will always
+    /// return [`OptionStringifiedSourceMap::none`].
     #[turbo_tasks::function]
     pub fn get_source_map(
         &self,

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -141,13 +141,12 @@ pub async fn foreign_code_context_condition(
     Ok(result)
 }
 
-/// Determines if the module is an internal asset (i.e overlay, fallback) coming
-/// from the embedded FS, don't apply user defined transforms.
-///
-/// [TODO] turbopack specific embed fs should be handled by internals of
-/// turbopack itself and user config should not try to leak this. However,
-/// currently we apply few transform options subject to next.js's configuration
-/// even if it's embedded assets.
+/// Determines if the module is an internal asset (i.e overlay, fallback) coming from the embedded
+/// FS, don't apply user defined transforms.
+//
+// TODO: Turbopack specific embed fs paths should be handled by internals of Turbopack itself and
+// user config should not try to leak this. However, currently we apply few transform options
+// subject to Next.js's configuration even if it's embedded assets.
 pub async fn internal_assets_conditions() -> Result<ContextCondition> {
     Ok(ContextCondition::any(vec![
         ContextCondition::InPath(next_js_fs().root().to_resolved().await?),


### PR DESCRIPTION
When we break rustdoc, it causes warnings on every PR, e.g:

![Screenshot 2025-02-24 at 1.38.28 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/a368e9a5-4ca6-4b3a-913e-df68aa038b7f.png)

...so we should either not check the rustdocs at all, or block on them. This makes them blocking.

Closes PACK-4041