### PR TITLE
chore(CI): Only update areweturboyet datasets for other bundlers from canary branch results

### DIFF
--- a/test/build-rspack-build-tests-manifest.js
+++ b/test/build-rspack-build-tests-manifest.js
@@ -91,10 +91,9 @@ async function fetchLatestTestArtifact() {
   const res = JSON.parse(stdout)
 
   for (const artifact of res.artifacts) {
-    // Temporarily allow other branches too
-    // if (artifact.expired || artifact.workflow_run.head_branch !== 'canary') {
-    //   continue
-    // }
+    if (artifact.expired || artifact.workflow_run.head_branch !== 'canary') {
+      continue
+    }
 
     return artifact
   }

--- a/test/build-rspack-dev-tests-manifest.js
+++ b/test/build-rspack-dev-tests-manifest.js
@@ -91,10 +91,9 @@ async function fetchLatestTestArtifact() {
   const res = JSON.parse(stdout)
 
   for (const artifact of res.artifacts) {
-    // Temporarily allow other branches too
-    // if (artifact.expired || artifact.workflow_run.head_branch !== 'canary') {
-    //   continue
-    // }
+    if (artifact.expired || artifact.workflow_run.head_branch !== 'canary') {
+      continue
+    }
 
     return artifact
   }


### PR DESCRIPTION
#76361 fixes areweturboyet runs for rspack on canary. We should just gather data from canary to avoid any confusion going forward.

Closes PACK-4036