### PR TITLE
docs: adjust Caching data with an ORM or Database section

### DIFF
--- a/docs/01-app/03-building-your-application/02-data-fetching/01-fetching.mdx
+++ b/docs/01-app/03-building-your-application/02-data-fetching/01-fetching.mdx
@@ -207,7 +207,7 @@ export function Posts() {
 
 ### Caching data with an ORM or Database
 
-You can use the `unstable_cache` API to cache the response to allow pages to be prerendered when running `next build`.
+You can use the `unstable_cache` API to cache the response when running `next build`.
 
 ```tsx filename="app/page.tsx" switcher
 import { unstable_cache } from 'next/cache'


### PR DESCRIPTION
## Why?

Adjust first sentence of [Caching with an ORM or Database](https://nextjs.org/docs/app/building-your-application/data-fetching/fetching#caching-data-with-an-orm-or-database) section to clarify that you don't need `unstable_cache` to prerender a page.

- Fixes https://github.com/vercel/next.js/issues/73808