### PR TITLE
[dev-overlay]: generalize ISR status functions for pages/app

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
@@ -340,7 +340,7 @@ function processMessage(
   }
 
   switch (obj.action) {
-    case HMR_ACTIONS_SENT_TO_BROWSER.APP_ISR_MANIFEST: {
+    case HMR_ACTIONS_SENT_TO_BROWSER.ISR_MANIFEST: {
       if (process.env.__NEXT_DEV_INDICATOR) {
         if (appIsrManifestRef) {
           appIsrManifestRef.current = obj.data

--- a/packages/next/src/client/dev/hot-middleware-client.ts
+++ b/packages/next/src/client/dev/hot-middleware-client.ts
@@ -90,7 +90,7 @@ export default (mode: 'webpack' | 'turbopack') => {
       }
       case 'serverError':
       case 'devPagesManifestUpdate':
-      case 'appIsrManifest':
+      case 'isrManifest':
       case 'building':
       case 'finishBuilding': {
         return

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1211,7 +1211,7 @@ async function renderToHTMLOrFlightImpl(
   if (process.env.NODE_ENV === 'development') {
     // reset isr status at start of request
     const { pathname } = new URL(req.url || '/', 'http://n')
-    renderOpts.setAppIsrStatus?.(pathname, null)
+    renderOpts.setIsrStatus?.(pathname, null)
   }
 
   if (
@@ -1473,19 +1473,19 @@ async function renderToHTMLOrFlightImpl(
 
     if (
       process.env.NODE_ENV === 'development' &&
-      renderOpts.setAppIsrStatus &&
+      renderOpts.setIsrStatus &&
       // The type check here ensures that `req` is correctly typed, and the
       // environment variable check provides dead code elimination.
       process.env.NEXT_RUNTIME !== 'edge' &&
       isNodeNextRequest(req) &&
       !isDevWarmupRequest
     ) {
-      const setAppIsrStatus = renderOpts.setAppIsrStatus
+      const setIsrStatus = renderOpts.setIsrStatus
       req.originalRequest.on('end', () => {
         if (!requestStore.usedDynamic && !workStore.forceDynamic) {
           // only node can be ISR so we only need to update the status here
           const { pathname } = new URL(req.url || '/', 'http://n')
-          setAppIsrStatus(pathname, true)
+          setIsrStatus(pathname, true)
         }
       })
     }

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -183,7 +183,7 @@ export interface RenderOptsPartial {
   cacheLifeProfiles?: {
     [profile: string]: import('../use-cache/cache-life').CacheLife
   }
-  setAppIsrStatus?: (key: string, value: boolean | null) => void
+  setIsrStatus?: (key: string, value: boolean | null) => void
   isRevalidate?: boolean
   nextExport?: boolean
   nextConfigOutput?: 'standalone' | 'export'

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2535,7 +2535,7 @@ export default abstract class Server<
         onClose: res.onClose.bind(res),
         onAfterTaskError: undefined,
         // only available in dev
-        setAppIsrStatus: (this as any).setAppIsrStatus,
+        setIsrStatus: (this as any).setIsrStatus,
       }
 
       if (isDebugStaticShell || isDebugDynamicAccesses) {

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -23,7 +23,7 @@ export const enum HMR_ACTIONS_SENT_TO_BROWSER {
   TURBOPACK_MESSAGE = 'turbopack-message',
   SERVER_ERROR = 'serverError',
   TURBOPACK_CONNECTED = 'turbopack-connected',
-  APP_ISR_MANIFEST = 'appIsrManifest',
+  ISR_MANIFEST = 'isrManifest',
 }
 
 interface ServerErrorAction {
@@ -112,7 +112,7 @@ export interface TurbopackConnectedAction {
 }
 
 export interface AppIsrManifestAction {
-  action: HMR_ACTIONS_SENT_TO_BROWSER.APP_ISR_MANIFEST
+  action: HMR_ACTIONS_SENT_TO_BROWSER.ISR_MANIFEST
   data: Record<string, boolean>
 }
 

--- a/packages/next/src/server/lib/dev-bundler-service.ts
+++ b/packages/next/src/server/lib/dev-bundler-service.ts
@@ -93,14 +93,14 @@ export class DevBundlerService {
     return serializableManifest
   }
 
-  public setAppIsrStatus(key: string, value: boolean | null) {
+  public setIsrStatus(key: string, value: boolean | null) {
     if (value === null) {
       this.appIsrManifestInner.remove(key)
     } else {
       this.appIsrManifestInner.set(key, value)
     }
     this.bundler?.hotReloader?.send({
-      action: HMR_ACTIONS_SENT_TO_BROWSER.APP_ISR_MANIFEST,
+      action: HMR_ACTIONS_SENT_TO_BROWSER.ISR_MANIFEST,
       data: this.appIsrManifest,
     })
   }

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -625,8 +625,7 @@ export async function initialize(opts: {
     server: opts.server,
     serverFields: {
       ...(developmentBundler?.serverFields || {}),
-      setAppIsrStatus:
-        devBundlerService?.setAppIsrStatus.bind(devBundlerService),
+      setIsrStatus: devBundlerService?.setIsrStatus.bind(devBundlerService),
     } satisfies ServerFields,
     experimentalTestProxy: !!config.experimental.testProxy,
     experimentalHttpsServer: !!opts.experimentalHttpsServer,
@@ -710,7 +709,7 @@ export async function initialize(opts: {
             (client) => {
               client.send(
                 JSON.stringify({
-                  action: HMR_ACTIONS_SENT_TO_BROWSER.APP_ISR_MANIFEST,
+                  action: HMR_ACTIONS_SENT_TO_BROWSER.ISR_MANIFEST,
                   data: devBundlerService?.appIsrManifest || {},
                 } satisfies AppIsrManifestAction)
               )

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -109,7 +109,7 @@ export type ServerFields = {
   interceptionRoutes?: ReturnType<
     typeof import('./filesystem').buildCustomRoute
   >[]
-  setAppIsrStatus?: (key: string, value: boolean) => void
+  setIsrStatus?: (key: string, value: boolean) => void
   resetFetch?: () => void
 }
 


### PR DESCRIPTION
This renames the functions associated with setting the ISR status (used for the static indicator in the error overlay) to be more generic, in preparation for it being used by pages router. 