### PR TITLE
[dev-overlay]: wire up ISR status for pages router

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/pages/client.ts
+++ b/packages/next/src/client/components/react-dev-overlay/pages/client.ts
@@ -10,6 +10,7 @@ import {
   ACTION_BUILD_ERROR,
   ACTION_BUILD_OK,
   ACTION_REFRESH,
+  ACTION_STATIC_INDICATOR,
   ACTION_UNHANDLED_ERROR,
   ACTION_UNHANDLED_REJECTION,
   ACTION_VERSION_INFO,
@@ -136,6 +137,10 @@ export function onBeforeRefresh() {
 
 export function onVersionInfo(versionInfo: VersionInfo) {
   Bus.emit({ type: ACTION_VERSION_INFO, versionInfo })
+}
+
+export function onStaticIndicator(isStatic: boolean) {
+  Bus.emit({ type: ACTION_STATIC_INDICATOR, staticIndicator: isStatic })
 }
 
 export { getErrorByType } from '../utils/get-error-by-type'

--- a/packages/next/src/client/components/react-dev-overlay/pages/hooks.ts
+++ b/packages/next/src/client/components/react-dev-overlay/pages/hooks.ts
@@ -1,13 +1,21 @@
 import React from 'react'
 import * as Bus from './bus'
 import { useErrorOverlayReducer } from '../shared'
+import { Router } from '../../../router'
 
 export const usePagesDevOverlay = () => {
   const [state, dispatch] = useErrorOverlayReducer()
 
   React.useEffect(() => {
     Bus.on(dispatch)
+
+    const { handleStaticIndicator } =
+      require('./hot-reloader-client') as typeof import('./hot-reloader-client')
+
+    Router.events.on('routeChangeComplete', handleStaticIndicator)
+
     return function () {
+      Router.events.off('routeChangeComplete', handleStaticIndicator)
       Bus.off(dispatch)
     }
   }, [dispatch])

--- a/packages/next/src/client/components/react-dev-overlay/pages/hot-reloader-client.ts
+++ b/packages/next/src/client/components/react-dev-overlay/pages/hot-reloader-client.ts
@@ -272,8 +272,20 @@ function handleAvailableHash(hash: string) {
 }
 
 export function handleStaticIndicator() {
-  if (process.env.__NEXT_DEV_INDICATOR && isrManifest) {
-    const isPageStatic = window.location.pathname in isrManifest
+  if (process.env.__NEXT_DEV_INDICATOR) {
+    const routeInfo = window.next.router.components[window.next.router.pathname]
+    const pageComponent = routeInfo?.Component
+    const appComponent = window.next.router.components['/_app']?.Component
+    const isDynamicPage =
+      Boolean(pageComponent?.getInitialProps) || Boolean(routeInfo.__N_SSP)
+    const hasAppGetInitialProps =
+      Boolean(appComponent?.getInitialProps) &&
+      appComponent?.getInitialProps !== appComponent?.origGetInitialProps
+
+    const isPageStatic =
+      window.location.pathname in isrManifest ||
+      (!isDynamicPage && !hasAppGetInitialProps)
+
     onStaticIndicator(isPageStatic)
   }
 }

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -257,6 +257,7 @@ export type RenderOptsPartial = {
   assetQueryString?: string
   resolvedUrl?: string
   resolvedAsPath?: string
+  setIsrStatus?: (key: string, value: boolean | null) => void
   clientReferenceManifest?: DeepReadonly<ClientReferenceManifest>
   nextFontManifest?: DeepReadonly<NextFontManifest>
   distDir?: string
@@ -652,6 +653,10 @@ export async function renderToHTMLImpl(
       throw new Error(
         `\`pages${pathname}\` ${STATIC_STATUS_PAGE_GET_INITIAL_PROPS_ERROR}`
       )
+    }
+
+    if (renderOpts?.setIsrStatus) {
+      renderOpts.setIsrStatus(asPath, isSSG || isAutoExport ? true : null)
     }
   }
 

--- a/test/development/app-dir/dev-indicator/route-type.test.ts
+++ b/test/development/app-dir/dev-indicator/route-type.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 import { getRouteTypeFromDevToolsIndicator, retry } from 'next-test-utils'
 
-describe('dev indicator - route type', () => {
+describe('app dir dev indicator - route type', () => {
   const { next } = nextTestSetup({
     files: __dirname,
   })

--- a/test/development/dev-indicator/dev-indicator.test.ts
+++ b/test/development/dev-indicator/dev-indicator.test.ts
@@ -6,11 +6,81 @@ describe('dev indicator - route type', () => {
     files: __dirname,
   })
 
-  it('should have route type as static by default for static page', async () => {
-    const browser = await next.browser('/')
+  describe('getServerSideProps', () => {
+    it('should update when going from dynamic -> static', async () => {
+      const browser = await next.browser('/gssp')
 
-    await retry(async () => {
-      expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Static')
+      await retry(async () => {
+        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Dynamic')
+      })
+
+      // validate static -> dynamic updates
+      await browser.elementByCss("[href='/']").click()
+
+      await retry(async () => {
+        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Static')
+      })
+    })
+
+    it('should update when going from static -> dynamic', async () => {
+      const browser = await next.browser('/')
+
+      await retry(async () => {
+        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Static')
+      })
+
+      // validate static -> dynamic updates
+      await browser.elementByCss("[href='/gssp']").click()
+
+      await retry(async () => {
+        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Dynamic')
+      })
+    })
+
+    it('should be marked dynamic on first load', async () => {
+      const browser = await next.browser('/gssp')
+
+      await retry(async () => {
+        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Dynamic')
+      })
+    })
+  })
+
+  describe('getInitialProps', () => {
+    it('should be marked dynamic on first load', async () => {
+      const browser = await next.browser('/gip')
+
+      await retry(async () => {
+        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Dynamic')
+      })
+    })
+
+    it('should update when going from dynamic -> static', async () => {
+      const browser = await next.browser('/gip')
+
+      await retry(async () => {
+        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Dynamic')
+      })
+
+      await browser.elementByCss("[href='/']").click()
+
+      await retry(async () => {
+        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Static')
+      })
+    })
+
+    it('should update when going from static -> dynamic', async () => {
+      const browser = await next.browser('/')
+
+      await retry(async () => {
+        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Static')
+      })
+
+      await browser.elementByCss("[href='/gip']").click()
+
+      await retry(async () => {
+        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Dynamic')
+      })
     })
   })
 
@@ -38,43 +108,11 @@ describe('dev indicator - route type', () => {
     })
   })
 
-  describe('getServerSideProps', () => {
-    it('should update when going from static -> dynamic', async () => {
-      const browser = await next.browser('/')
+  it('should have route type as static by default for static page', async () => {
+    const browser = await next.browser('/')
 
-      await retry(async () => {
-        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Static')
-      })
-
-      // validate static -> dynamic updates
-      await browser.elementByCss("[href='/gssp']").click()
-
-      await retry(async () => {
-        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Dynamic')
-      })
-    })
-
-    it('should update when going from dynamic -> static', async () => {
-      const browser = await next.browser('/gssp')
-
-      await retry(async () => {
-        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Dynamic')
-      })
-
-      // validate static -> dynamic updates
-      await browser.elementByCss("[href='/']").click()
-
-      await retry(async () => {
-        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Static')
-      })
-    })
-
-    it('should be marked dynamic on first load', async () => {
-      const browser = await next.browser('/gssp')
-
-      await retry(async () => {
-        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Dynamic')
-      })
+    await retry(async () => {
+      expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Static')
     })
   })
 })

--- a/test/development/dev-indicator/dev-indicator.test.ts
+++ b/test/development/dev-indicator/dev-indicator.test.ts
@@ -1,0 +1,80 @@
+import { nextTestSetup } from 'e2e-utils'
+import { getRouteTypeFromDevToolsIndicator, retry } from 'next-test-utils'
+
+describe('dev indicator - route type', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should have route type as static by default for static page', async () => {
+    const browser = await next.browser('/')
+
+    await retry(async () => {
+      expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Static')
+    })
+  })
+
+  describe('getStaticPaths', () => {
+    it('should be marked static on first load', async () => {
+      const browser = await next.browser('/pregenerated')
+
+      await retry(async () => {
+        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Static')
+      })
+    })
+
+    it('should update when going from dynamic -> static', async () => {
+      const browser = await next.browser('/gssp')
+
+      await retry(async () => {
+        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Dynamic')
+      })
+
+      await browser.elementByCss("[href='/pregenerated']").click()
+
+      await retry(async () => {
+        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Static')
+      })
+    })
+  })
+
+  describe('getServerSideProps', () => {
+    it('should update when going from static -> dynamic', async () => {
+      const browser = await next.browser('/')
+
+      await retry(async () => {
+        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Static')
+      })
+
+      // validate static -> dynamic updates
+      await browser.elementByCss("[href='/gssp']").click()
+
+      await retry(async () => {
+        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Dynamic')
+      })
+    })
+
+    it('should update when going from dynamic -> static', async () => {
+      const browser = await next.browser('/gssp')
+
+      await retry(async () => {
+        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Dynamic')
+      })
+
+      // validate static -> dynamic updates
+      await browser.elementByCss("[href='/']").click()
+
+      await retry(async () => {
+        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Static')
+      })
+    })
+
+    it('should be marked dynamic on first load', async () => {
+      const browser = await next.browser('/gssp')
+
+      await retry(async () => {
+        expect(await getRouteTypeFromDevToolsIndicator(browser)).toBe('Dynamic')
+      })
+    })
+  })
+})

--- a/test/development/dev-indicator/pages/[slug]/index.tsx
+++ b/test/development/dev-indicator/pages/[slug]/index.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link'
+
+export default function Page({ slug }: { slug: string }) {
+  return (
+    <p>
+      hello world {slug} <Link href="/gssp">to /gssp</Link>
+      <Link href="/">to /</Link>
+    </p>
+  )
+}
+
+export const getStaticPaths = async () => {
+  return {
+    paths: [
+      {
+        params: {
+          slug: 'pregenerated',
+        },
+      },
+    ],
+    fallback: true,
+  }
+}
+
+export const getStaticProps = async ({
+  params,
+}: {
+  params: { slug: string }
+}) => {
+  return {
+    props: {
+      slug: params.slug,
+    },
+  }
+}

--- a/test/development/dev-indicator/pages/gip.tsx
+++ b/test/development/dev-indicator/pages/gip.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <p>
+      hello world <Link href="/">to /</Link>
+    </p>
+  )
+}
+
+Page.getInitialProps = async () => {
+  return {
+    static: false,
+  }
+}

--- a/test/development/dev-indicator/pages/gssp.tsx
+++ b/test/development/dev-indicator/pages/gssp.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <p>
+      hello world <Link href="/pregenerated">to /pregenerated</Link>{' '}
+      <Link href="/">to /</Link>
+    </p>
+  )
+}
+
+export async function getServerSideProps() {
+  return {
+    props: {
+      static: false,
+    },
+  }
+}

--- a/test/development/dev-indicator/pages/index.tsx
+++ b/test/development/dev-indicator/pages/index.tsx
@@ -5,6 +5,7 @@ export default function Page() {
     <p>
       hello world <Link href="/gssp">to /gssp</Link>{' '}
       <Link href="/pregenerated">to /pregenerated</Link>
+      <Link href="/gip">to /gip</Link>
     </p>
   )
 }

--- a/test/development/dev-indicator/pages/index.tsx
+++ b/test/development/dev-indicator/pages/index.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <p>
+      hello world <Link href="/gssp">to /gssp</Link>{' '}
+      <Link href="/pregenerated">to /pregenerated</Link>
+    </p>
+  )
+}


### PR DESCRIPTION
The static indicator was added in the new dev overlay but wasn't hooked up to pages router. This wires that up so they're properly marked static/dynamic. 

Closes NDX-897