### PR TITLE
docs: adjust imageKitLoader example to comply with their URL structure

### DIFF
--- a/docs/01-app/04-api-reference/05-config/01-next-config-js/images.mdx
+++ b/docs/01-app/04-api-reference/05-config/01-next-config-js/images.mdx
@@ -249,7 +249,7 @@ export default function thumborLoader({ src, width, quality }) {
 // Docs: https://imagekit.io/docs/image-transformation
 export default function imageKitLoader({ src, width, quality }) {
   const params = [`w-${width}`, `q-${quality || 80}`]
-  return `https://ik.imagekit.io/your_imagekit_id/${src}?tr=${params.join(',')}`
+  return `https://ik.imagekit.io/your_imagekit_id/tr:${params.join(',')}/${src}`
 }
 ```
 


### PR DESCRIPTION
It seems the example for imageKitLoader uses a wrong URL structure.
After failing to use it myself i noticed their structure is slightly different and updated accordingly.

Link to URL structure
[https://imagekit.io/docs/image-transformation#basic-example](https://imagekit.io/docs/image-transformation#basic-example)