### PR TITLE
[dev-overlay]: fix inline docs to show correct info for given router

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/app/client-entry.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/client-entry.tsx
@@ -42,7 +42,11 @@ export function createRootLevelDevOverlayElement(reactEl: React.ReactElement) {
   return (
     <FallbackLayout>
       <AppDevOverlay
-        state={{ ...INITIAL_OVERLAY_STATE, rootLayoutMissingTags }}
+        state={{
+          ...INITIAL_OVERLAY_STATE,
+          rootLayoutMissingTags,
+          routerType: 'app',
+        }}
         globalError={[GlobalError, null]}
       >
         {reactEl}

--- a/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
@@ -541,7 +541,7 @@ export default function HotReload({
   children: ReactNode
   globalError: [GlobalErrorComponent, React.ReactNode]
 }) {
-  const [state, dispatch] = useErrorOverlayReducer()
+  const [state, dispatch] = useErrorOverlayReducer('app')
 
   const dispatcher = useMemo<Dispatcher>(() => {
     return {

--- a/packages/next/src/client/components/react-dev-overlay/pages/hooks.ts
+++ b/packages/next/src/client/components/react-dev-overlay/pages/hooks.ts
@@ -4,7 +4,7 @@ import { useErrorOverlayReducer } from '../shared'
 import { Router } from '../../../router'
 
 export const usePagesDevOverlay = () => {
-  const [state, dispatch] = useErrorOverlayReducer()
+  const [state, dispatch] = useErrorOverlayReducer('pages')
 
   React.useEffect(() => {
     Bus.on(dispatch)

--- a/packages/next/src/client/components/react-dev-overlay/shared.ts
+++ b/packages/next/src/client/components/react-dev-overlay/shared.ts
@@ -23,6 +23,7 @@ export interface OverlayState {
   staticIndicator: boolean
   disableDevIndicator: boolean
   debugInfo: DebugInfo
+  routerType: 'pages' | 'app'
 }
 
 export const ACTION_STATIC_INDICATOR = 'static-indicator'
@@ -101,7 +102,7 @@ function pushErrorFilterDuplicates(
   ]
 }
 
-export const INITIAL_OVERLAY_STATE: OverlayState = {
+export const INITIAL_OVERLAY_STATE: Omit<OverlayState, 'routerType'> = {
   nextId: 1,
   buildError: null,
   errors: [],
@@ -114,7 +115,16 @@ export const INITIAL_OVERLAY_STATE: OverlayState = {
   debugInfo: { devtoolsFrontendUrl: undefined },
 }
 
-export function useErrorOverlayReducer() {
+function getInitialState(
+  routerType: 'pages' | 'app'
+): OverlayState & { routerType: 'pages' | 'app' } {
+  return {
+    ...INITIAL_OVERLAY_STATE,
+    routerType,
+  }
+}
+
+export function useErrorOverlayReducer(routerType: 'pages' | 'app') {
   return useReducer((_state: OverlayState, action: BusEvent): OverlayState => {
     switch (action.type) {
       case ACTION_DEBUG_INFO: {
@@ -188,7 +198,7 @@ export function useErrorOverlayReducer() {
         return _state
       }
     }
-  }, INITIAL_OVERLAY_STATE)
+  }, getInitialState(routerType))
 }
 
 export const REACT_REFRESH_FULL_RELOAD_FROM_ERROR =

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.stories.tsx
@@ -51,6 +51,7 @@ const mockVersionInfo: VersionInfo = {
 }
 
 const state: OverlayState = {
+  routerType: 'app',
   nextId: 1,
   buildError: null,
   errors: [],

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -41,6 +41,7 @@ export function DevToolsIndicator({
 
   return (
     <DevToolsPopover
+      routerType={state.routerType}
       semver={state.versionInfo.installed}
       issueCount={errorCount}
       isStaticRoute={state.staticIndicator}
@@ -70,6 +71,7 @@ interface C {
 const Context = createContext({} as C)
 
 function DevToolsPopover({
+  routerType,
   disabled,
   issueCount,
   isStaticRoute,
@@ -79,6 +81,7 @@ function DevToolsPopover({
   hide,
   setIsErrorOverlayOpen,
 }: {
+  routerType: 'pages' | 'app'
   disabled: boolean
   issueCount: number
   isStaticRoute: boolean
@@ -283,6 +286,7 @@ function DevToolsPopover({
       {routeInfoMounted && (
         <RouteInfo
           ref={routeInfoRef}
+          routerType={routerType}
           routeType={isStaticRoute ? 'Static' : 'Dynamic'}
           isOpen={isRouteInfoOpen}
           setIsOpen={setIsRouteInfoOpen}

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/route-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/route-info.tsx
@@ -1,6 +1,6 @@
 import { DevToolsInfo } from './dev-tools-info'
 
-function StaticRouteContent() {
+function StaticRouteContent({ routerType }: { routerType: 'pages' | 'app' }) {
   return (
     <article className="dev-tools-info-article">
       <p className="dev-tools-info-paragraph">
@@ -14,7 +14,11 @@ function StaticRouteContent() {
         background after{' '}
         <a
           className="dev-tools-info-link"
-          href="https://nextjs.org/docs/app/building-your-application/data-fetching/incremental-static-regeneration"
+          href={
+            routerType === 'pages'
+              ? 'https://nextjs.org/docs/pages/building-your-application/data-fetching/incremental-static-regeneration'
+              : `https://nextjs.org/docs/app/building-your-application/data-fetching/incremental-static-regeneration`
+          }
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -31,7 +35,7 @@ function StaticRouteContent() {
   )
 }
 
-function DynamicRouteContent() {
+function DynamicRouteContent({ routerType }: { routerType: 'pages' | 'app' }) {
   return (
     <article className="dev-tools-info-article">
       <p className="dev-tools-info-paragraph">
@@ -45,42 +49,75 @@ function DynamicRouteContent() {
         to the user or has information that can only be known at request time,
         such as cookies or the URL's search params.
       </p>
-      <p className="dev-tools-info-paragraph">
-        During rendering, if a{' '}
-        <a
-          className="dev-tools-info-link"
-          href="https://nextjs.org/docs/app/building-your-application/rendering/server-components#dynamic-apis"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Dynamic API
-        </a>{' '}
-        or a{' '}
-        <a
-          className="dev-tools-info-link"
-          href="https://nextjs.org/docs/app/api-reference/functions/fetch"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          fetch
-        </a>{' '}
-        option of{' '}
-        <code className="dev-tools-info-code">{`{ cache: 'no-store' }`}</code>{' '}
-        is discovered, Next.js will switch to dynamically rendering the whole
-        route.
-      </p>
+      {routerType === 'pages' ? (
+        <p className="dev-tools-info-pagraph">
+          Exporting the{' '}
+          <a
+            className="dev-tools-info-link"
+            href="https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            getServerSideProps
+          </a>{' '}
+          function will opt the route into dynamic rendering. This function will
+          be called by the server on every request.
+        </p>
+      ) : (
+        <p className="dev-tools-info-paragraph">
+          During rendering, if a{' '}
+          <a
+            className="dev-tools-info-link"
+            href="https://nextjs.org/docs/app/building-your-application/rendering/server-components#dynamic-apis"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Dynamic API
+          </a>{' '}
+          or a{' '}
+          <a
+            className="dev-tools-info-link"
+            href="https://nextjs.org/docs/app/api-reference/functions/fetch"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            fetch
+          </a>{' '}
+          option of{' '}
+          <code className="dev-tools-info-code">{`{ cache: 'no-store' }`}</code>{' '}
+          is discovered, Next.js will switch to dynamically rendering the whole
+          route.
+        </p>
+      )}
     </article>
   )
 }
 
+const learnMoreLink = {
+  pages: {
+    static:
+      'https://nextjs.org/docs/pages/building-your-application/rendering/static-site-generation',
+    dynamic:
+      'https://nextjs.org/docs/pages/building-your-application/rendering/server-side-rendering',
+  },
+  app: {
+    static:
+      'https://nextjs.org/docs/app/building-your-application/rendering/server-components#static-rendering-default',
+    dynamic:
+      'https://nextjs.org/docs/app/building-your-application/rendering/server-components#dynamic-rendering',
+  },
+}
+
 export function RouteInfo({
   routeType,
+  routerType,
   isOpen,
   setIsOpen,
   setPreviousOpen,
   ...props
 }: {
   routeType: 'Static' | 'Dynamic'
+  routerType: 'pages' | 'app'
   isOpen: boolean
   setIsOpen: (isOpen: boolean) => void
   setPreviousOpen: (isOpen: boolean) => void
@@ -88,18 +125,23 @@ export function RouteInfo({
   ref?: React.RefObject<HTMLElement | null>
 }) {
   const isStaticRoute = routeType === 'Static'
-  const learnMoreLink = isStaticRoute
-    ? 'https://nextjs.org/docs/app/building-your-application/rendering/server-components#static-rendering-default'
-    : 'https://nextjs.org/docs/app/building-your-application/rendering/server-components#dynamic-rendering'
+
+  const learnMore = isStaticRoute
+    ? learnMoreLink[routerType].static
+    : learnMoreLink[routerType].dynamic
   return (
     <DevToolsInfo
       {...props}
       title={`${routeType} Route`}
-      learnMoreLink={learnMoreLink}
+      learnMoreLink={learnMore}
       setIsOpen={setIsOpen}
       setPreviousOpen={setPreviousOpen}
     >
-      {isStaticRoute ? <StaticRouteContent /> : <DynamicRouteContent />}
+      {isStaticRoute ? (
+        <StaticRouteContent routerType={routerType} />
+      ) : (
+        <DynamicRouteContent routerType={routerType} />
+      )}
     </DevToolsInfo>
   )
 }

--- a/packages/next/src/client/components/react-dev-overlay/ui/dev-overlay.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/dev-overlay.stories.tsx
@@ -17,6 +17,7 @@ type Story = StoryObj<typeof DevOverlay>
 
 const state: OverlayState = {
   nextId: 0,
+  routerType: 'app',
   buildError: null,
   disableDevIndicator: false,
   errors: [


### PR DESCRIPTION
The docs here differ depending on which router you're using. This wires the router type into overlay state so we can render different information in the popover. 