### PR TITLE
refactor(CI): Assign tests to groups round-robin instead of sequentially when we don't have timings

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -381,9 +381,9 @@ async function main() {
         Math.round(groupTimes[curGroupIdx]) + 's'
       )
     } else {
-      const numPerGroup = Math.ceil(tests.length / groupTotal)
-      let offset = (groupPos - 1) * numPerGroup
-      tests = tests.slice(offset, offset + numPerGroup)
+      // assign every nth test "round-robin" to the group, so that similar slow
+      // tests tend not to get clustered together
+      tests = tests.filter((_value, idx) => idx % groupTotal === groupPos - 1)
       console.log('Splitting without timings')
     }
   }


### PR DESCRIPTION
Our CI runs tests in parallel across multiple groups. We want test groups to all take similar amounts of time to decrease overall latency, and to reduce the chance of test group timeouts in CI.

There's logic here to assign intelligently to groups based on previous test timing information, but if there's no timing information for whatever reason (e.g. we don't currently use timings for rspack/turbopack integration tests), then we were assigning them to groups sequentially.

Because tests with similar paths tend to have similar performance characteristics, it's better to assign every nth test to each group, similar to round-robin assignment.

Closes PACK-4038