### PR TITLE
Ensure middleware layer is bundled

### DIFF
--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -182,6 +182,7 @@ const WEBPACK_LAYERS = {
       WEBPACK_LAYERS_NAMES.appPagesBrowser,
       WEBPACK_LAYERS_NAMES.shared,
       WEBPACK_LAYERS_NAMES.instrument,
+      WEBPACK_LAYERS_NAMES.middleware,
     ],
     appPages: [
       // app router pages and layouts


### PR DESCRIPTION
Optimization for node middleware bundling ensuring that we bundle all dependencies by default instead of externalizing like we do for pages routes. The `serverExternals` config is still applied for this configuration so if any packages need externalizing they still can be.  