### PR TITLE
[dev-overlay] style: make `<a>` tag in Terminal to stand out

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/code-frame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/code-frame.tsx
@@ -171,7 +171,7 @@ export const CODE_FRAME_STYLES = `
     background-color: var(--color-ansi-selection);
   }
 
-  [data-nextjs-codeframe] * {
+  [data-nextjs-codeframe] *:not(a) {
     color: inherit;
     background-color: transparent;
     font-family: var(--font-stack-monospace);

--- a/packages/next/src/client/components/react-dev-overlay/ui/styles/base.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/styles/base.tsx
@@ -137,6 +137,10 @@ export function Base() {
         }
 
         a {
+          color: var(--color-blue-900);
+          &:hover {
+            color: var(--color-blue-900);
+          }
           &:focus {
             outline: var(--focus-ring);
           }


### PR DESCRIPTION
### Why?

The color of a tag from the CSS reset has a bad color contrast with the background colors. Also, the hotlink text used in the Terminal component didn't stand out, which is easy to miss.

https://github.com/vercel/next.js/blob/265aba55ef048537ca5d69702b12c1231ec2d3b3/packages/next/src/client/components/react-dev-overlay/ui/styles/css-reset.tsx#L159-L168

| ------ | Before | After |
|--------|--------|--------|
| Light | ![CleanShot 2025-02-25 at 20 25 23](https://github.com/user-attachments/assets/b66fd782-7dbd-4846-9804-a069d9be75e1) | ![CleanShot 2025-02-25 at 20 25 16](https://github.com/user-attachments/assets/3213da7d-3c25-4a5e-a371-bb6827ce134d) |
| Dark | ![CleanShot 2025-02-25 at 20 25 29](https://github.com/user-attachments/assets/4a4409a8-f78e-4b82-948a-daf30c3da8e7) | ![CleanShot 2025-02-25 at 20 25 10](https://github.com/user-attachments/assets/c8f35fd1-7ac0-443c-816a-c34fd47e3be3) | 

Closes NDX-900