### PR TITLE
Only log unrecoverable SSR shell errors once

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -26,8 +26,6 @@ import { createInitialRouterState } from './components/router-reducer/create-ini
 import { MissingSlotContext } from '../shared/lib/app-router-context.shared-runtime'
 import { setAppBuildId } from './app-build-id'
 import { shouldRenderRootLevelErrorOverlay } from './lib/is-error-thrown-while-rendering-rsc'
-import { handleClientError } from './components/errors/use-error-handler'
-import { isNextRouterError } from './components/is-next-router-error'
 
 /// <reference types="react-dom/experimental" />
 
@@ -231,16 +229,6 @@ function Root({ children }: React.PropsWithChildren<{}>) {
     }, [])
   }
 
-  if (process.env.NODE_ENV !== 'production') {
-    const ssrError = devQueueSsrError()
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    React.useEffect(() => {
-      if (ssrError) {
-        handleClientError(ssrError, [])
-      }
-    }, [ssrError])
-  }
-
   return children
 }
 
@@ -293,28 +281,5 @@ export function hydrate() {
     const { linkGc } =
       require('./app-link-gc') as typeof import('./app-link-gc')
     linkGc()
-  }
-}
-
-function devQueueSsrError(): Error | undefined {
-  const ssrErrorTemplateTag = document.querySelector(
-    'template[data-next-error-message]'
-  )
-  if (ssrErrorTemplateTag) {
-    const message: string = ssrErrorTemplateTag.getAttribute(
-      'data-next-error-message'
-    )!
-    const stack = ssrErrorTemplateTag.getAttribute('data-next-error-stack')
-    const digest = ssrErrorTemplateTag.getAttribute('data-next-error-digest')
-    const error = new Error(message)
-    if (digest) {
-      ;(error as any).digest = digest
-    }
-    // Skip Next.js SSR'd internal errors that which will be handled by the error boundaries.
-    if (isNextRouterError(error)) {
-      return
-    }
-    error.stack = stack || ''
-    return error
   }
 }

--- a/packages/next/src/client/components/react-dev-overlay/app/app-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/app-dev-overlay.tsx
@@ -1,10 +1,62 @@
 import type { OverlayState } from '../shared'
 import type { GlobalErrorComponent } from '../../error-boundary'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { AppDevOverlayErrorBoundary } from './app-dev-overlay-error-boundary'
 import { FontStyles } from '../font/font-styles'
 import { DevOverlay } from '../ui/dev-overlay'
+import { handleClientError } from '../../errors/use-error-handler'
+import { isNextRouterError } from '../../is-next-router-error'
+
+function readSsrError(): Error | null {
+  if (typeof document === 'undefined') {
+    return null
+  }
+
+  const ssrErrorTemplateTag = document.querySelector(
+    'template[data-next-error-message]'
+  )
+  if (ssrErrorTemplateTag) {
+    const message: string = ssrErrorTemplateTag.getAttribute(
+      'data-next-error-message'
+    )!
+    const stack = ssrErrorTemplateTag.getAttribute('data-next-error-stack')
+    const digest = ssrErrorTemplateTag.getAttribute('data-next-error-digest')
+    const error = new Error(message)
+    if (digest) {
+      ;(error as any).digest = digest
+    }
+    // Skip Next.js SSR'd internal errors that which will be handled by the error boundaries.
+    if (isNextRouterError(error)) {
+      return null
+    }
+    error.stack = stack || ''
+    return error
+  }
+
+  return null
+}
+
+// Needs to be in the same error boundary as the shell.
+// If it commits, we know we recovered from an SSR error.
+// If it doesn't commit, we errored again and React will take care of error reporting.
+function ReplaySsrOnlyErrors() {
+  if (process.env.NODE_ENV !== 'production') {
+    // Need to read during render. The attributes will be gone after commit.
+    const ssrError = readSsrError()
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useEffect(() => {
+      if (ssrError !== null) {
+        // TODO(veil): Produces wrong Owner Stack
+        // TODO(veil): Mark as recoverable error
+        // TODO(veil): console.error
+        handleClientError(ssrError, [])
+      }
+    }, [ssrError])
+  }
+
+  return null
+}
 
 export function AppDevOverlay({
   state,
@@ -23,6 +75,7 @@ export function AppDevOverlay({
         globalError={globalError}
         onError={setIsErrorOverlayOpen}
       >
+        <ReplaySsrOnlyErrors />
         {children}
       </AppDevOverlayErrorBoundary>
 

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -90,7 +90,7 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 2,
+         "count": 1,
          "description": "Error: no",
          "environmentLabel": null,
          "label": "Unhandled Runtime Error",
@@ -106,7 +106,7 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 3,
+         "count": 2,
          "description": "Error: no",
          "environmentLabel": null,
          "label": "Unhandled Runtime Error",
@@ -363,7 +363,7 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 2,
+         "count": 1,
          "description": "Error: ",
          "environmentLabel": null,
          "label": "Unhandled Runtime Error",
@@ -1642,7 +1642,7 @@ export default function Home() {
       // FIXME: display the sourcemapped stack frames
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 2,
+         "count": 1,
          "description": "Error: utils error",
          "environmentLabel": null,
          "label": "Unhandled Runtime Error",
@@ -1659,7 +1659,7 @@ export default function Home() {
       // FIXME: Webpack stack frames are not source mapped
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 3,
+         "count": 2,
          "description": "Error: utils error",
          "environmentLabel": null,
          "label": "Unhandled Runtime Error",

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -217,6 +217,7 @@ describe('Error overlay for hydration errors in App router', () => {
            <HotReload assetPrefix="" globalError={[...]}>
              <AppDevOverlay state={{nextId:1, ...}} globalError={[...]}>
                <AppDevOverlayErrorBoundary globalError={[...]} onError={function bound dispatchSetState}>
+                 <ReplaySsrOnlyErrors>
                  <DevRootHTTPAccessFallbackBoundary>
                    <HTTPAccessFallbackBoundary notFound={<NotAllowedRootHTTPFallbackError>}>
                      <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<NotAllowedRootHTTPFallbackError>} ...>
@@ -240,6 +241,7 @@ describe('Error overlay for hydration errors in App router', () => {
            <HotReload assetPrefix="" globalError={[...]}>
              <AppDevOverlay state={{nextId:1, ...}} globalError={[...]}>
                <AppDevOverlayErrorBoundary globalError={[...]} onError={function bound dispatchSetState}>
+                 <ReplaySsrOnlyErrors>
                  <DevRootHTTPAccessFallbackBoundary>
                    <HTTPAccessFallbackBoundary notFound={<NotAllowedRootHTTPFallbackError>}>
                      <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<NotAllowedRootHTTPFallbackError>} ...>

--- a/test/development/app-dir/owner-stack/owner-stack.test.ts
+++ b/test/development/app-dir/owner-stack/owner-stack.test.ts
@@ -139,10 +139,9 @@ describe('app-dir - owner-stack', () => {
       },
     })
 
-    // TODO(veil): Should only display one error.
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 2,
+       "count": 1,
        "description": "Error: ssr error",
        "environmentLabel": null,
        "label": "Unhandled Runtime Error",

--- a/test/development/app-dir/ssr-only-error/app/page.tsx
+++ b/test/development/app-dir/ssr-only-error/app/page.tsx
@@ -1,8 +1,12 @@
 'use client'
 
-export default function Page() {
+function Component() {
   if (typeof window === 'undefined') {
     throw new Error('SSR only error')
   }
   return <p>hello world</p>
+}
+
+export default function Page() {
+  return <Component />
 }

--- a/test/development/app-dir/ssr-only-error/ssr-only-error.test.ts
+++ b/test/development/app-dir/ssr-only-error/ssr-only-error.test.ts
@@ -1,11 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import {
-  assertNoRedbox,
-  getRedboxDescription,
-  getRedboxSource,
-  hasErrorToast,
-  openRedbox,
-} from 'next-test-utils'
+import { assertNoRedbox, hasErrorToast } from 'next-test-utils'
 
 describe('ssr-only-error', () => {
   const { next } = nextTestSetup({
@@ -15,29 +9,19 @@ describe('ssr-only-error', () => {
   it('should show ssr only error in error overlay', async () => {
     const browser = await next.browser('/')
 
-    // Ensure it's not like server error that is shown by default
-    await hasErrorToast(browser)
-
-    await openRedbox(browser)
-
-    const description = await getRedboxDescription(browser)
-    const source = await getRedboxSource(browser)
-
-    expect({
-      description,
-      source,
-    }).toMatchInlineSnapshot(`
+    // TODO(veil): Missing Owner Stack
+    await expect(browser).toDisplayCollapsedRedbox(`
      {
+       "count": 1,
        "description": "Error: SSR only error",
-       "source": "app/page.tsx (5:11) @ Page
-
-       3 | export default function Page() {
-       4 |   if (typeof window === 'undefined') {
+       "environmentLabel": null,
+       "label": "Unhandled Runtime Error",
+       "source": "app/page.tsx (5:11) @ Component
      > 5 |     throw new Error('SSR only error')
-         |           ^
-       6 |   }
-       7 |   return <p>hello world</p>
-       8 | }",
+         |           ^",
+       "stack": [
+         "Component app/page.tsx (5:11)",
+       ],
      }
     `)
   })

--- a/test/e2e/next-link-errors/next-link-errors.test.ts
+++ b/test/e2e/next-link-errors/next-link-errors.test.ts
@@ -13,11 +13,10 @@ describe('next-link', () => {
     const browser = await webdriver(next.appPort, '/invalid-href')
 
     if (isNextDev) {
-      // TODO(veil): Should be a single error
       // TODO(veil): https://linear.app/vercel/issue/NDX-554/hide-the-anonymous-frames-which-are-between-2-ignored-frames
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 2,
+         "count": 1,
          "description": "Error: Failed prop type: The prop \`href\` expects a \`string\` or \`object\` in \`<Link>\`, but got \`undefined\` instead.
        Open your browser's console to view the Component stack trace.",
          "environmentLabel": null,
@@ -41,11 +40,10 @@ describe('next-link', () => {
     const browser = await webdriver(next.appPort, '/no-children')
 
     if (isNextDev) {
-      // TODO(veil): Should be a single error
       // TODO(veil): https://linear.app/vercel/issue/NDX-554/hide-the-anonymous-frames-which-are-between-2-ignored-frames
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 2,
+         "count": 1,
          "description": "Error: No children were passed to <Link> with \`href\` of \`/about\` but one child is required https://nextjs.org/docs/messages/link-no-children",
          "environmentLabel": null,
          "label": "Unhandled Runtime Error",
@@ -67,11 +65,10 @@ describe('next-link', () => {
     const browser = await webdriver(next.appPort, '/multiple-children')
 
     if (isNextDev) {
-      // TODO(veil): Should be a single error
       // TODO(veil): https://linear.app/vercel/issue/NDX-554/hide-the-anonymous-frames-which-are-between-2-ignored-frames
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 2,
+         "count": 1,
          "description": "Error: Multiple children were passed to <Link> with \`href\` of \`/\` but only one child is supported https://nextjs.org/docs/messages/link-multiple-children 
        Open your browser's console to view the Component stack trace.",
          "environmentLabel": null,


### PR DESCRIPTION
When we throw in the shell during SSR, Next.js will send the error to the Client and replay it. We couldn't rely on React because React only logs recoverable errors i.e. errors that no longer reproduce with `hydrateRoot`. However, if the shell errors, Next.js will render a fallback shell and then use `createRoot` on the Client instead.

This lead to double logging of SSR errors though. Once from React and once from Next.js.

By moving our custom replay mechanism into the same error boundary that also handles the shell, we ensure that we only replay if the shell recovered i.e. commits. If it errors again, `ReplaySsrOnlyErrors ` will not commit and React will take care of error handling.

```diff
-<ReplaySsrOnlyErrors />
 <RootErrorBoundary>
+  <ReplaySsrOnlyErrors />
   <UserCode />
 </ErrorBoundary>
```

Closes https://linear.app/vercel/issue/NDX-895/