### PR TITLE
[dev-overlay] style: improve error label background color contrast

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-type-label/error-type-label.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-type-label/error-type-label.tsx
@@ -26,7 +26,7 @@ export const styles = `
     margin: 0;
     /* used --size instead of --rounded because --rounded is missing 6px */
     border-radius: var(--size-1_5);
-    background: var(--color-red-300);
+    background: var(--color-red-100);
     font-weight: 600;
     font-size: var(--size-font-11);
     color: var(--color-red-900);


### PR DESCRIPTION
### Why?

The color contrast for the error label does not satisfy AAA of WCAG color contrast standards.
Even though it is AA, the text is small and is generally hard to read.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/e6b04d9b-3f4a-4641-ab86-d16f29163179) | ![CleanShot 2025-02-25 at 23 33 42](https://github.com/user-attachments/assets/78e0560b-e222-44f0-8f02-81c4da19629a) | 

| Before | After |
|--------|--------|
| ![CleanShot 2025-02-25 at 23 33 25](https://github.com/user-attachments/assets/c288eb22-5d85-4f08-a7e5-26a64481bdc5) | ![CleanShot 2025-02-25 at 23 33 25](https://github.com/user-attachments/assets/c288eb22-5d85-4f08-a7e5-26a64481bdc5) | 

---

EDIT 😂

| Before | After |
|--------|--------|
| ![CleanShot 2025-02-25 at 23 33 25](https://github.com/user-attachments/assets/c288eb22-5d85-4f08-a7e5-26a64481bdc5) | ![CleanShot 2025-02-26 at 00 42 22](https://github.com/user-attachments/assets/04f506b9-b013-4406-a53e-3c4d860cbf2e) | 

Closes NDX-901