### PR TITLE
[docs]: add --api option information

### DIFF
--- a/docs/01-app/04-api-reference/06-cli/create-next-app.mdx
+++ b/docs/01-app/04-api-reference/06-cli/create-next-app.mdx
@@ -27,6 +27,7 @@ The following options are available:
 | `--tailwind`                            | Initialize with Tailwind CSS config (default)                   |
 | `--eslint`                              | Initialize with ESLint config                                   |
 | `--app`                                 | Initialize as an App Router project                             |
+| `--api`                                 | Initialize a project with only route handlers                   |
 | `--src-dir`                             | Initialize inside a `src/` directory                            |
 | `--turbopack`                           | Enable Turbopack by default for development                     |
 | `--import-alias <alias-to-configure>`   | Specify import alias to use (default "@/\*")                    |


### PR DESCRIPTION
We added `--api` support to create-next-app via #68130. This documents that option.

Closes DOC-4221