### PR TITLE
refactor: clean up forked Form implementations

### DIFF
--- a/packages/next/src/client/app-dir/form.tsx
+++ b/packages/next/src/client/app-dir/form.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, type HTMLProps, type FormEvent, useContext } from 'react'
+import { useEffect, type FormEvent, useContext } from 'react'
 import { addBasePath } from '../add-base-path'
 import { useIntersection } from '../use-intersection'
 import { useMergedRef } from '../use-merged-ref'
@@ -9,56 +9,16 @@ import {
   type AppRouterInstance,
 } from '../../shared/lib/app-router-context.shared-runtime'
 import { PrefetchKind } from '../components/router-reducer/router-reducer-types'
-import { RouterContext } from '../../shared/lib/router-context.shared-runtime'
-import type { NextRouter } from '../router'
+import {
+  checkFormActionUrl,
+  createFormSubmitDestinationUrl,
+  DISALLOWED_FORM_PROPS,
+  hasReactClientActionAttributes,
+  hasUnsupportedSubmitterAttributes,
+  type FormProps,
+} from '../form-shared'
 
-const DISALLOWED_FORM_PROPS = ['method', 'encType', 'target'] as const
-
-type HTMLFormProps = HTMLProps<HTMLFormElement>
-type DisallowedFormProps = (typeof DISALLOWED_FORM_PROPS)[number]
-
-type InternalFormProps = {
-  /**
-   * `action` can be either a `string` or a function.
-   * - If `action` is a string, it will be interpreted as a path or URL to navigate to when the form is submitted.
-   *   The path will be prefetched when the form becomes visible.
-   * - If `action` is a function, it will be called when the form is submitted. See the [React docs](https://react.dev/reference/react-dom/components/form#props) for more.
-   */
-  action: NonNullable<HTMLFormProps['action']>
-  /**
-   * Controls how the route specified by `action` is prefetched.
-   * Any `<Form />` that is in the viewport (initially or through scroll) will be prefetched.
-   * Prefetch can be disabled by passing `prefetch={false}`. Prefetching is only enabled in production.
-   *
-   * Options:
-   * - `null` (default): For statically generated pages, this will prefetch the full React Server Component data. For dynamic pages, this will prefetch up to the nearest route segment with a [`loading.js`](https://nextjs.org/docs/app/api-reference/file-conventions/loading) file. If there is no loading file, it will not fetch the full tree to avoid fetching too much data.
-   * - `false`: This will not prefetch any data.
-   *
-   * In pages dir, prefetching is not supported, and passing this prop will emit a warning.
-   *
-   * @defaultValue `null`
-   */
-  prefetch?: false | null
-  /**
-   * Whether submitting the form should replace the current `history` state instead of adding a new url into the stack.
-   * Only valid if `action` is a string.
-   *
-   * @defaultValue `false`
-   */
-  replace?: boolean
-  /**
-   * Override the default scroll behavior when navigating.
-   * Only valid if `action` is a string.
-   *
-   * @defaultValue `true`
-   */
-  scroll?: boolean
-} & Omit<HTMLFormProps, 'action' | DisallowedFormProps>
-
-// `RouteInferType` is a stub here to avoid breaking `typedRoutes` when the type
-// isn't generated yet. It will be replaced when the webpack plugin runs.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type FormProps<RouteInferType = any> = InternalFormProps
+export type { FormProps }
 
 export default function Form({
   replace,
@@ -67,7 +27,7 @@ export default function Form({
   ref: externalRef,
   ...props
 }: FormProps) {
-  const router = useAppOrPagesRouter()
+  const router = useContext(AppRouterContext)
 
   const actionProp = props.action
   const isNavigatingForm = typeof actionProp === 'string'
@@ -75,7 +35,7 @@ export default function Form({
   // Validate `action`
   if (process.env.NODE_ENV === 'development') {
     if (isNavigatingForm) {
-      checkActionUrl(actionProp, 'action')
+      checkFormActionUrl(actionProp, 'action')
     }
   }
 
@@ -91,16 +51,10 @@ export default function Form({
       console.error('The `prefetch` prop of <Form> must be `false` or `null`')
     }
 
-    if (prefetchProp !== undefined) {
-      if (!isAppRouter(router)) {
-        console.error(
-          'Passing `prefetch` to a <Form> has no effect in the pages directory.'
-        )
-      } else if (!isNavigatingForm) {
-        console.error(
-          'Passing `prefetch` to a <Form> whose `action` is a function has no effect.'
-        )
-      }
+    if (prefetchProp !== undefined && !isNavigatingForm) {
+      console.error(
+        'Passing `prefetch` to a <Form> whose `action` is a function has no effect.'
+      )
     }
   }
 
@@ -136,11 +90,8 @@ export default function Form({
   }
 
   const isPrefetchEnabled =
-    // there is no notion of instant loading states in pages dir, so prefetching is pointless
-    isAppRouter(router) &&
-    // if we don't have an action path, we can't preload anything anyway.
-    isNavigatingForm &&
-    prefetch === null
+    // if we don't have an action path, we can't prefetch anything.
+    !!router && isNavigatingForm && prefetch === null
 
   const [setIntersectionRef, isVisible] = useIntersection({
     rootMargin: '200px',
@@ -202,7 +153,7 @@ function onFormSubmit(
     onSubmit: FormProps['onSubmit']
     replace: FormProps['replace']
     scroll: FormProps['scroll']
-    router: SomeRouter
+    router: AppRouterInstance | null
   }
 ) {
   if (typeof onSubmit === 'function') {
@@ -213,6 +164,12 @@ function onFormSubmit(
     if (event.defaultPrevented) {
       return
     }
+  }
+
+  if (!router) {
+    // Form was somehow used outside of the router (but not in pages, the implementation is forked!).
+    // We can't perform a soft navigation, so let the native submit handling do its thing.
+    return
   }
 
   const formElement = event.currentTarget
@@ -246,160 +203,20 @@ function onFormSubmit(
     const submitterFormAction = submitter.getAttribute('formAction')
     if (submitterFormAction !== null) {
       if (process.env.NODE_ENV === 'development') {
-        checkActionUrl(submitterFormAction, 'formAction')
+        checkFormActionUrl(submitterFormAction, 'formAction')
       }
       action = submitterFormAction
     }
   }
 
-  let targetUrl: URL
-  try {
-    // NOTE: It might be more correct to resolve URLs relative to `document.baseURI`,
-    // but we already do it relative to `location.href` elsewhere:
-    //  (see e.g. https://github.com/vercel/next.js/blob/bb0e6722f87ceb2d43015f5b8a413d0072f2badf/packages/next/src/client/components/app-router.tsx#L146)
-    // so it's better to stay consistent.
-    const base = window.location.href
-    targetUrl = new URL(action, base)
-  } catch (err) {
-    throw new Error(`Cannot parse form action "${action}" as a URL`, {
-      cause: err,
-    })
-  }
-  if (targetUrl.searchParams.size) {
-    // url-encoded HTML forms *overwrite* any search params in the `action` url:
-    //
-    //  "Let `query` be the result of running the application/x-www-form-urlencoded serializer [...]"
-    //  "Set parsed action's query component to `query`."
-    //   https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#submit-mutate-action
-    //
-    // We need to match that.
-    // (note that all other parts of the URL, like `hash`, are preserved)
-    targetUrl.search = ''
-  }
-
-  const formData = new FormData(formElement)
-
-  for (let [name, value] of formData) {
-    if (typeof value !== 'string') {
-      // For file inputs, the native browser behavior is to use the filename as the value instead:
-      //
-      //   "If entry's value is a File object, then let value be entry's value's name. Otherwise, let value be entry's value."
-      //   https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#converting-an-entry-list-to-a-list-of-name-value-pairs
-      //
-      if (process.env.NODE_ENV === 'development') {
-        console.warn(
-          `<Form> only supports file inputs if \`action\` is a function. File inputs cannot be used if \`action\` is a string, ` +
-            `because files cannot be encoded as search params.`
-        )
-      }
-      value = value.name
-    }
-
-    targetUrl.searchParams.append(name, value)
-  }
+  const targetUrl = createFormSubmitDestinationUrl(action, formElement)
 
   // Finally, no more reasons for bailing out.
   event.preventDefault()
 
   const method = replace ? 'replace' : 'push'
   const targetHref = targetUrl.href
-  if (isAppRouter(router)) {
-    router[method](targetHref, { scroll })
-  } else {
-    // TODO(form): Make this use a transition so that pending states work
-    //
-    // Unlike the app router, pages router doesn't use startTransition,
-    // and can't easily be wrapped in one because of implementation details
-    // (e.g. it doesn't use any react state)
-    // But it's important to have this wrapped in a transition because
-    // pending states from e.g. `useFormStatus` rely on that.
-    // So this needs some follow up work.
-    router[method](targetHref, undefined, { scroll })
-  }
-}
-
-type SomeRouter = AppRouterInstance | NextRouter
-
-function isAppRouter(router: SomeRouter): router is AppRouterInstance {
-  return !('asPath' in router)
-}
-
-function useAppOrPagesRouter(): SomeRouter {
-  const pagesRouter = useContext(RouterContext)
-  const appRouter = useContext(AppRouterContext)
-  if (pagesRouter) {
-    return pagesRouter
-  } else {
-    // We're in the app directory if there is no pages router.
-    return appRouter!
-  }
-}
-
-function checkActionUrl(action: string, source: 'action' | 'formAction') {
-  const aPropName = source === 'action' ? `an \`action\`` : `a \`formAction\``
-
-  let testUrl: URL
-  try {
-    testUrl = new URL(action, 'http://n')
-  } catch (err) {
-    console.error(
-      `<Form> received ${aPropName} that cannot be parsed as a URL: "${action}".`
-    )
-    return
-  }
-
-  // url-encoded HTML forms ignore any queryparams in the `action` url. We need to match that.
-  if (testUrl.searchParams.size) {
-    console.warn(
-      `<Form> received ${aPropName} that contains search params: "${action}". This is not supported, and they will be ignored. ` +
-        `If you need to pass in additional search params, use an \`<input type="hidden" />\` instead.`
-    )
-  }
-}
-
-const isSupportedEncType = (value: string) =>
-  value === 'application/x-www-form-urlencoded'
-const isSupportedMethod = (value: string) => value === 'get'
-const isSupportedTarget = (value: string) => value === '_self'
-
-function hasUnsupportedSubmitterAttributes(submitter: HTMLElement): boolean {
-  // A submitter can override `encType` for the form.
-  const formEncType = submitter.getAttribute('formEncType')
-  if (formEncType !== null && !isSupportedEncType(formEncType)) {
-    if (process.env.NODE_ENV === 'development') {
-      console.error(
-        `<Form>'s \`encType\` was set to an unsupported value via \`formEncType="${formEncType}"\`. ` +
-          `This will disable <Form>'s navigation functionality. If you need this, use a native <form> element instead.`
-      )
-    }
-    return true
-  }
-
-  // A submitter can override `method` for the form.
-  const formMethod = submitter.getAttribute('formMethod')
-  if (formMethod !== null && !isSupportedMethod(formMethod)) {
-    if (process.env.NODE_ENV === 'development') {
-      console.error(
-        `<Form>'s \`method\` was set to an unsupported value via \`formMethod="${formMethod}"\`. ` +
-          `This will disable <Form>'s navigation functionality. If you need this, use a native <form> element instead.`
-      )
-    }
-    return true
-  }
-
-  // A submitter can override `target` for the form.
-  const formTarget = submitter.getAttribute('formTarget')
-  if (formTarget !== null && !isSupportedTarget(formTarget)) {
-    if (process.env.NODE_ENV === 'development') {
-      console.error(
-        `<Form>'s \`target\` was set to an unsupported value via \`formTarget="${formTarget}"\`. ` +
-          `This will disable <Form>'s navigation functionality. If you need this, use a native <form> element instead.`
-      )
-    }
-    return true
-  }
-
-  return false
+  router[method](targetHref, { scroll })
 }
 
 function hasReactServerActionAttributes(submitter: HTMLElement) {
@@ -408,11 +225,4 @@ function hasReactServerActionAttributes(submitter: HTMLElement) {
   return (
     name && (name.startsWith('$ACTION_ID_') || name.startsWith('$ACTION_REF_'))
   )
-}
-
-function hasReactClientActionAttributes(submitter: HTMLElement) {
-  // CSR: https://github.com/facebook/react/blob/942eb80381b96f8410eab1bef1c539bed1ab0eb1/packages/react-dom-bindings/src/client/ReactDOMComponent.js#L482-L487
-  // SSR: https://github.com/facebook/react/blob/942eb80381b96f8410eab1bef1c539bed1ab0eb1/packages/react-dom-bindings/src/client/ReactDOMComponent.js#L2401
-  const action = submitter.getAttribute('formAction')
-  return action && /\s*javascript:/i.test(action)
 }

--- a/packages/next/src/client/form-shared.tsx
+++ b/packages/next/src/client/form-shared.tsx
@@ -1,0 +1,180 @@
+import type { HTMLProps } from 'react'
+
+export const DISALLOWED_FORM_PROPS = ['method', 'encType', 'target'] as const
+
+type HTMLFormProps = HTMLProps<HTMLFormElement>
+type DisallowedFormProps = (typeof DISALLOWED_FORM_PROPS)[number]
+
+type InternalFormProps = {
+  /**
+   * `action` can be either a `string` or a function.
+   * - If `action` is a string, it will be interpreted as a path or URL to navigate to when the form is submitted.
+   *   The path will be prefetched when the form becomes visible.
+   * - If `action` is a function, it will be called when the form is submitted. See the [React docs](https://react.dev/reference/react-dom/components/form#props) for more.
+   */
+  action: NonNullable<HTMLFormProps['action']>
+  /**
+   * Controls how the route specified by `action` is prefetched.
+   * Any `<Form />` that is in the viewport (initially or through scroll) will be prefetched.
+   * Prefetch can be disabled by passing `prefetch={false}`. Prefetching is only enabled in production.
+   *
+   * Options:
+   * - `null` (default): For statically generated pages, this will prefetch the full React Server Component data. For dynamic pages, this will prefetch up to the nearest route segment with a [`loading.js`](https://nextjs.org/docs/app/api-reference/file-conventions/loading) file. If there is no loading file, it will not fetch the full tree to avoid fetching too much data.
+   * - `false`: This will not prefetch any data.
+   *
+   * In pages dir, prefetching is not supported, and passing this prop will emit a warning.
+   *
+   * @defaultValue `null`
+   */
+  prefetch?: false | null
+  /**
+   * Whether submitting the form should replace the current `history` state instead of adding a new url into the stack.
+   * Only valid if `action` is a string.
+   *
+   * @defaultValue `false`
+   */
+  replace?: boolean
+  /**
+   * Override the default scroll behavior when navigating.
+   * Only valid if `action` is a string.
+   *
+   * @defaultValue `true`
+   */
+  scroll?: boolean
+} & Omit<HTMLFormProps, 'action' | DisallowedFormProps>
+
+// `RouteInferType` is a stub here to avoid breaking `typedRoutes` when the type
+// isn't generated yet. It will be replaced when the webpack plugin runs.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export type FormProps<RouteInferType = any> = InternalFormProps
+
+export function createFormSubmitDestinationUrl(
+  action: string,
+  formElement: HTMLFormElement
+) {
+  let targetUrl: URL
+  try {
+    // NOTE: It might be more correct to resolve URLs relative to `document.baseURI`,
+    // but we already do it relative to `location.href` elsewhere:
+    //  (see e.g. https://github.com/vercel/next.js/blob/bb0e6722f87ceb2d43015f5b8a413d0072f2badf/packages/next/src/client/components/app-router.tsx#L146)
+    // so it's better to stay consistent.
+    const base = window.location.href
+    targetUrl = new URL(action, base)
+  } catch (err) {
+    throw new Error(`Cannot parse form action "${action}" as a URL`, {
+      cause: err,
+    })
+  }
+  if (targetUrl.searchParams.size) {
+    // url-encoded HTML forms *overwrite* any search params in the `action` url:
+    //
+    //  "Let `query` be the result of running the application/x-www-form-urlencoded serializer [...]"
+    //  "Set parsed action's query component to `query`."
+    //   https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#submit-mutate-action
+    //
+    // We need to match that.
+    // (note that all other parts of the URL, like `hash`, are preserved)
+    targetUrl.search = ''
+  }
+
+  const formData = new FormData(formElement)
+
+  for (let [name, value] of formData) {
+    if (typeof value !== 'string') {
+      // For file inputs, the native browser behavior is to use the filename as the value instead:
+      //
+      //   "If entry's value is a File object, then let value be entry's value's name. Otherwise, let value be entry's value."
+      //   https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#converting-an-entry-list-to-a-list-of-name-value-pairs
+      //
+      if (process.env.NODE_ENV === 'development') {
+        console.warn(
+          `<Form> only supports file inputs if \`action\` is a function. File inputs cannot be used if \`action\` is a string, ` +
+            `because files cannot be encoded as search params.`
+        )
+      }
+      value = value.name
+    }
+
+    targetUrl.searchParams.append(name, value)
+  }
+  return targetUrl
+}
+
+export function checkFormActionUrl(
+  action: string,
+  source: 'action' | 'formAction'
+) {
+  const aPropName = source === 'action' ? `an \`action\`` : `a \`formAction\``
+
+  let testUrl: URL
+  try {
+    testUrl = new URL(action, 'http://n')
+  } catch (err) {
+    console.error(
+      `<Form> received ${aPropName} that cannot be parsed as a URL: "${action}".`
+    )
+    return
+  }
+
+  // url-encoded HTML forms ignore any queryparams in the `action` url. We need to match that.
+  if (testUrl.searchParams.size) {
+    console.warn(
+      `<Form> received ${aPropName} that contains search params: "${action}". This is not supported, and they will be ignored. ` +
+        `If you need to pass in additional search params, use an \`<input type="hidden" />\` instead.`
+    )
+  }
+}
+
+export const isSupportedFormEncType = (value: string) =>
+  value === 'application/x-www-form-urlencoded'
+export const isSupportedFormMethod = (value: string) => value === 'get'
+export const isSupportedFormTarget = (value: string) => value === '_self'
+
+export function hasUnsupportedSubmitterAttributes(
+  submitter: HTMLElement
+): boolean {
+  // A submitter can override `encType` for the form.
+  const formEncType = submitter.getAttribute('formEncType')
+  if (formEncType !== null && !isSupportedFormEncType(formEncType)) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error(
+        `<Form>'s \`encType\` was set to an unsupported value via \`formEncType="${formEncType}"\`. ` +
+          `This will disable <Form>'s navigation functionality. If you need this, use a native <form> element instead.`
+      )
+    }
+    return true
+  }
+
+  // A submitter can override `method` for the form.
+  const formMethod = submitter.getAttribute('formMethod')
+  if (formMethod !== null && !isSupportedFormMethod(formMethod)) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error(
+        `<Form>'s \`method\` was set to an unsupported value via \`formMethod="${formMethod}"\`. ` +
+          `This will disable <Form>'s navigation functionality. If you need this, use a native <form> element instead.`
+      )
+    }
+    return true
+  }
+
+  // A submitter can override `target` for the form.
+  const formTarget = submitter.getAttribute('formTarget')
+  if (formTarget !== null && !isSupportedFormTarget(formTarget)) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error(
+        `<Form>'s \`target\` was set to an unsupported value via \`formTarget="${formTarget}"\`. ` +
+          `This will disable <Form>'s navigation functionality. If you need this, use a native <form> element instead.`
+      )
+    }
+    return true
+  }
+
+  return false
+}
+
+export function hasReactClientActionAttributes(submitter: HTMLElement) {
+  // CSR: https://github.com/facebook/react/blob/942eb80381b96f8410eab1bef1c539bed1ab0eb1/packages/react-dom-bindings/src/client/ReactDOMComponent.js#L482-L487
+  // SSR: https://github.com/facebook/react/blob/942eb80381b96f8410eab1bef1c539bed1ab0eb1/packages/react-dom-bindings/src/client/ReactDOMComponent.js#L2401
+  const action = submitter.getAttribute('formAction')
+  return action && /\s*javascript:/i.test(action)
+}

--- a/packages/next/src/client/form.tsx
+++ b/packages/next/src/client/form.tsx
@@ -1,73 +1,25 @@
 'use client'
 
-import { useEffect, type HTMLProps, type FormEvent, useContext } from 'react'
+import { type FormEvent, useContext, forwardRef } from 'react'
 import { addBasePath } from './add-base-path'
-import { useIntersection } from './use-intersection'
-import { useMergedRef } from './use-merged-ref'
-import {
-  AppRouterContext,
-  type AppRouterInstance,
-} from '../shared/lib/app-router-context.shared-runtime'
-import { PrefetchKind } from './components/router-reducer/router-reducer-types'
 import { RouterContext } from '../shared/lib/router-context.shared-runtime'
 import type { NextRouter } from './router'
+import {
+  checkFormActionUrl,
+  createFormSubmitDestinationUrl,
+  DISALLOWED_FORM_PROPS,
+  hasReactClientActionAttributes,
+  hasUnsupportedSubmitterAttributes,
+  type FormProps,
+} from './form-shared'
 
-const DISALLOWED_FORM_PROPS = ['method', 'encType', 'target'] as const
+export type { FormProps }
 
-type HTMLFormProps = HTMLProps<HTMLFormElement>
-type DisallowedFormProps = (typeof DISALLOWED_FORM_PROPS)[number]
-
-type InternalFormProps = {
-  /**
-   * `action` can be either a `string` or a function.
-   * - If `action` is a string, it will be interpreted as a path or URL to navigate to when the form is submitted.
-   *   The path will be prefetched when the form becomes visible.
-   * - If `action` is a function, it will be called when the form is submitted. See the [React docs](https://react.dev/reference/react-dom/components/form#props) for more.
-   */
-  action: NonNullable<HTMLFormProps['action']>
-  /**
-   * Controls how the route specified by `action` is prefetched.
-   * Any `<Form />` that is in the viewport (initially or through scroll) will be prefetched.
-   * Prefetch can be disabled by passing `prefetch={false}`. Prefetching is only enabled in production.
-   *
-   * Options:
-   * - `null` (default): For statically generated pages, this will prefetch the full React Server Component data. For dynamic pages, this will prefetch up to the nearest route segment with a [`loading.js`](https://nextjs.org/docs/app/api-reference/file-conventions/loading) file. If there is no loading file, it will not fetch the full tree to avoid fetching too much data.
-   * - `false`: This will not prefetch any data.
-   *
-   * In pages dir, prefetching is not supported, and passing this prop will emit a warning.
-   *
-   * @defaultValue `null`
-   */
-  prefetch?: false | null
-  /**
-   * Whether submitting the form should replace the current `history` state instead of adding a new url into the stack.
-   * Only valid if `action` is a string.
-   *
-   * @defaultValue `false`
-   */
-  replace?: boolean
-  /**
-   * Override the default scroll behavior when navigating.
-   * Only valid if `action` is a string.
-   *
-   * @defaultValue `true`
-   */
-  scroll?: boolean
-} & Omit<HTMLFormProps, 'action' | DisallowedFormProps>
-
-// `RouteInferType` is a stub here to avoid breaking `typedRoutes` when the type
-// isn't generated yet. It will be replaced when the webpack plugin runs.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type FormProps<RouteInferType = any> = InternalFormProps
-
-export default function Form({
-  replace,
-  scroll,
-  prefetch: prefetchProp,
-  ref: externalRef,
-  ...props
-}: FormProps) {
-  const router = useAppOrPagesRouter()
+const Form = forwardRef<HTMLFormElement, FormProps>(function FormComponent(
+  { replace, scroll, prefetch: prefetchProp, ...props },
+  ref
+) {
+  const router = useContext(RouterContext)
 
   const actionProp = props.action
   const isNavigatingForm = typeof actionProp === 'string'
@@ -75,37 +27,18 @@ export default function Form({
   // Validate `action`
   if (process.env.NODE_ENV === 'development') {
     if (isNavigatingForm) {
-      checkActionUrl(actionProp, 'action')
+      checkFormActionUrl(actionProp, 'action')
     }
   }
 
   // Validate `prefetch`
   if (process.env.NODE_ENV === 'development') {
-    if (
-      !(
-        prefetchProp === undefined ||
-        prefetchProp === false ||
-        prefetchProp === null
-      )
-    ) {
-      console.error('The `prefetch` prop of <Form> must be `false` or `null`')
-    }
-
     if (prefetchProp !== undefined) {
-      if (!isAppRouter(router)) {
-        console.error(
-          'Passing `prefetch` to a <Form> has no effect in the pages directory.'
-        )
-      } else if (!isNavigatingForm) {
-        console.error(
-          'Passing `prefetch` to a <Form> whose `action` is a function has no effect.'
-        )
-      }
+      console.error(
+        'Passing `prefetch` to a <Form> has no effect in the pages directory.'
+      )
     }
   }
-
-  const prefetch =
-    prefetchProp === false || prefetchProp === null ? prefetchProp : null
 
   // Validate `scroll` and `replace`
   if (process.env.NODE_ENV === 'development') {
@@ -113,8 +46,7 @@ export default function Form({
       console.error(
         'Passing `replace` or `scroll` to a <Form> whose `action` is a function has no effect.\n' +
           'See the relevant docs to learn how to control this behavior for navigations triggered from actions:\n' +
-          '  `redirect()`       - https://nextjs.org/docs/app/api-reference/functions/redirect#parameters\n' +
-          '  `router.replace()` - https://nextjs.org/docs/app/api-reference/functions/use-router#userouter\n'
+          '  `router.replace()` - https://nextjs.org/docs/pages/api-reference/functions/use-router#routerreplace\n'
       )
     }
   }
@@ -123,50 +55,14 @@ export default function Form({
   for (const key of DISALLOWED_FORM_PROPS) {
     if (key in props) {
       if (process.env.NODE_ENV === 'development') {
-        console.error(
-          `<Form> does not support changing \`${key}\`. ` +
-            (isNavigatingForm
-              ? `If you'd like to use it to perform a mutation, consider making \`action\` a function instead.\n` +
-                `Learn more: https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations`
-              : '')
-        )
+        console.error(`<Form> does not support changing \`${key}\`.`)
       }
       delete (props as Record<string, unknown>)[key]
     }
   }
 
-  const isPrefetchEnabled =
-    // there is no notion of instant loading states in pages dir, so prefetching is pointless
-    isAppRouter(router) &&
-    // if we don't have an action path, we can't preload anything anyway.
-    isNavigatingForm &&
-    prefetch === null
-
-  const [setIntersectionRef, isVisible] = useIntersection({
-    rootMargin: '200px',
-    disabled: !isPrefetchEnabled,
-  })
-
-  const ownRef = useMergedRef<HTMLFormElement>(
-    setIntersectionRef,
-    externalRef ?? null
-  )
-
-  useEffect(() => {
-    if (!isVisible || !isPrefetchEnabled) {
-      return
-    }
-
-    try {
-      const prefetchKind = PrefetchKind.AUTO
-      router.prefetch(actionProp, { kind: prefetchKind })
-    } catch (err) {
-      console.error(err)
-    }
-  }, [isPrefetchEnabled, isVisible, actionProp, prefetch, router])
-
   if (!isNavigatingForm) {
-    return <form {...props} ref={ownRef} />
+    return <form {...props} ref={ref} />
   }
 
   const actionHref = addBasePath(actionProp)
@@ -174,7 +70,7 @@ export default function Form({
   return (
     <form
       {...props}
-      ref={ownRef}
+      ref={ref}
       action={actionHref}
       onSubmit={(event) =>
         onFormSubmit(event, {
@@ -187,7 +83,9 @@ export default function Form({
       }
     />
   )
-}
+})
+
+export default Form
 
 function onFormSubmit(
   event: FormEvent<HTMLFormElement>,
@@ -202,7 +100,7 @@ function onFormSubmit(
     onSubmit: FormProps['onSubmit']
     replace: FormProps['replace']
     scroll: FormProps['scroll']
-    router: SomeRouter
+    router: NextRouter | null
   }
 ) {
   if (typeof onSubmit === 'function') {
@@ -215,21 +113,20 @@ function onFormSubmit(
     }
   }
 
+  if (!router) {
+    // Form was somehow used outside of the router (but not in app/, the implementation is forked!).
+    // We can't perform a soft navigation, so let the native submit handling do its thing.
+    return
+  }
+
   const formElement = event.currentTarget
   const submitter = (event.nativeEvent as SubmitEvent).submitter
 
   let action = actionHref
 
   if (submitter) {
-    if (process.env.NODE_ENV === 'development') {
-      // the way server actions are encoded (e.g. `formMethod="post")
-      // causes some unnecessary dev-mode warnings from `hasUnsupportedSubmitterAttributes`.
-      // we'd bail out anyway, but we just do it silently.
-      if (hasReactServerActionAttributes(submitter)) {
-        return
-      }
-    }
-
+    // this is page-router-only, so we don't need to worry about false positives
+    // from the attributes that react adds for server actions.
     if (hasUnsupportedSubmitterAttributes(submitter)) {
       return
     }
@@ -246,173 +143,27 @@ function onFormSubmit(
     const submitterFormAction = submitter.getAttribute('formAction')
     if (submitterFormAction !== null) {
       if (process.env.NODE_ENV === 'development') {
-        checkActionUrl(submitterFormAction, 'formAction')
+        checkFormActionUrl(submitterFormAction, 'formAction')
       }
       action = submitterFormAction
     }
   }
 
-  let targetUrl: URL
-  try {
-    // NOTE: It might be more correct to resolve URLs relative to `document.baseURI`,
-    // but we already do it relative to `location.href` elsewhere:
-    //  (see e.g. https://github.com/vercel/next.js/blob/bb0e6722f87ceb2d43015f5b8a413d0072f2badf/packages/next/src/client/components/app-router.tsx#L146)
-    // so it's better to stay consistent.
-    const base = window.location.href
-    targetUrl = new URL(action, base)
-  } catch (err) {
-    throw new Error(`Cannot parse form action "${action}" as a URL`, {
-      cause: err,
-    })
-  }
-  if (targetUrl.searchParams.size) {
-    // url-encoded HTML forms *overwrite* any search params in the `action` url:
-    //
-    //  "Let `query` be the result of running the application/x-www-form-urlencoded serializer [...]"
-    //  "Set parsed action's query component to `query`."
-    //   https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#submit-mutate-action
-    //
-    // We need to match that.
-    // (note that all other parts of the URL, like `hash`, are preserved)
-    targetUrl.search = ''
-  }
-
-  const formData = new FormData(formElement)
-
-  for (let [name, value] of formData) {
-    if (typeof value !== 'string') {
-      // For file inputs, the native browser behavior is to use the filename as the value instead:
-      //
-      //   "If entry's value is a File object, then let value be entry's value's name. Otherwise, let value be entry's value."
-      //   https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#converting-an-entry-list-to-a-list-of-name-value-pairs
-      //
-      if (process.env.NODE_ENV === 'development') {
-        console.warn(
-          `<Form> only supports file inputs if \`action\` is a function. File inputs cannot be used if \`action\` is a string, ` +
-            `because files cannot be encoded as search params.`
-        )
-      }
-      value = value.name
-    }
-
-    targetUrl.searchParams.append(name, value)
-  }
+  const targetUrl = createFormSubmitDestinationUrl(action, formElement)
 
   // Finally, no more reasons for bailing out.
   event.preventDefault()
 
   const method = replace ? 'replace' : 'push'
-  const targetHref = targetUrl.href
-  if (isAppRouter(router)) {
-    router[method](targetHref, { scroll })
-  } else {
-    // TODO(form): Make this use a transition so that pending states work
-    //
-    // Unlike the app router, pages router doesn't use startTransition,
-    // and can't easily be wrapped in one because of implementation details
-    // (e.g. it doesn't use any react state)
-    // But it's important to have this wrapped in a transition because
-    // pending states from e.g. `useFormStatus` rely on that.
-    // So this needs some follow up work.
-    router[method](targetHref, undefined, { scroll })
-  }
-}
+  const targetHref = targetUrl.href // TODO: will pages router be happy about an absolute URL here?
 
-type SomeRouter = AppRouterInstance | NextRouter
-
-function isAppRouter(router: SomeRouter): router is AppRouterInstance {
-  return !('asPath' in router)
-}
-
-function useAppOrPagesRouter(): SomeRouter {
-  const pagesRouter = useContext(RouterContext)
-  const appRouter = useContext(AppRouterContext)
-  if (pagesRouter) {
-    return pagesRouter
-  } else {
-    // We're in the app directory if there is no pages router.
-    return appRouter!
-  }
-}
-
-function checkActionUrl(action: string, source: 'action' | 'formAction') {
-  const aPropName = source === 'action' ? `an \`action\`` : `a \`formAction\``
-
-  let testUrl: URL
-  try {
-    testUrl = new URL(action, 'http://n')
-  } catch (err) {
-    console.error(
-      `<Form> received ${aPropName} that cannot be parsed as a URL: "${action}".`
-    )
-    return
-  }
-
-  // url-encoded HTML forms ignore any queryparams in the `action` url. We need to match that.
-  if (testUrl.searchParams.size) {
-    console.warn(
-      `<Form> received ${aPropName} that contains search params: "${action}". This is not supported, and they will be ignored. ` +
-        `If you need to pass in additional search params, use an \`<input type="hidden" />\` instead.`
-    )
-  }
-}
-
-const isSupportedEncType = (value: string) =>
-  value === 'application/x-www-form-urlencoded'
-const isSupportedMethod = (value: string) => value === 'get'
-const isSupportedTarget = (value: string) => value === '_self'
-
-function hasUnsupportedSubmitterAttributes(submitter: HTMLElement): boolean {
-  // A submitter can override `encType` for the form.
-  const formEncType = submitter.getAttribute('formEncType')
-  if (formEncType !== null && !isSupportedEncType(formEncType)) {
-    if (process.env.NODE_ENV === 'development') {
-      console.error(
-        `<Form>'s \`encType\` was set to an unsupported value via \`formEncType="${formEncType}"\`. ` +
-          `This will disable <Form>'s navigation functionality. If you need this, use a native <form> element instead.`
-      )
-    }
-    return true
-  }
-
-  // A submitter can override `method` for the form.
-  const formMethod = submitter.getAttribute('formMethod')
-  if (formMethod !== null && !isSupportedMethod(formMethod)) {
-    if (process.env.NODE_ENV === 'development') {
-      console.error(
-        `<Form>'s \`method\` was set to an unsupported value via \`formMethod="${formMethod}"\`. ` +
-          `This will disable <Form>'s navigation functionality. If you need this, use a native <form> element instead.`
-      )
-    }
-    return true
-  }
-
-  // A submitter can override `target` for the form.
-  const formTarget = submitter.getAttribute('formTarget')
-  if (formTarget !== null && !isSupportedTarget(formTarget)) {
-    if (process.env.NODE_ENV === 'development') {
-      console.error(
-        `<Form>'s \`target\` was set to an unsupported value via \`formTarget="${formTarget}"\`. ` +
-          `This will disable <Form>'s navigation functionality. If you need this, use a native <form> element instead.`
-      )
-    }
-    return true
-  }
-
-  return false
-}
-
-function hasReactServerActionAttributes(submitter: HTMLElement) {
-  // https://github.com/facebook/react/blob/942eb80381b96f8410eab1bef1c539bed1ab0eb1/packages/react-client/src/ReactFlightReplyClient.js#L931-L934
-  const name = submitter.getAttribute('name')
-  return (
-    name && (name.startsWith('$ACTION_ID_') || name.startsWith('$ACTION_REF_'))
-  )
-}
-
-function hasReactClientActionAttributes(submitter: HTMLElement) {
-  // CSR: https://github.com/facebook/react/blob/942eb80381b96f8410eab1bef1c539bed1ab0eb1/packages/react-dom-bindings/src/client/ReactDOMComponent.js#L482-L487
-  // SSR: https://github.com/facebook/react/blob/942eb80381b96f8410eab1bef1c539bed1ab0eb1/packages/react-dom-bindings/src/client/ReactDOMComponent.js#L2401
-  const action = submitter.getAttribute('formAction')
-  return action && /\s*javascript:/i.test(action)
+  // TODO(form): Make this use a transition so that pending states work
+  //
+  // Unlike the app router, pages router doesn't use startTransition,
+  // and can't easily be wrapped in one because of implementation details
+  // (e.g. it doesn't use any react state)
+  // But it's important to have this wrapped in a transition because
+  // pending states from e.g. `useFormStatus` rely on that.
+  // So this needs some follow up work.
+  router[method](targetHref, undefined, { scroll })
 }


### PR DESCRIPTION
Split out of #76184 because it got a bit involved and i want to do it in isolation.

Removes dead code from the forked implementations of Form for app and pages dir. There's some shared utils but not much. Mostly involves removing code for prefetching and server actions from the pages implementation.

Also took this opportunity to fix some stuff for pages:
- improve error messages, previously they were linking to `/app/` docs
- use `React.forwardRef`: technically, you can use React <19 in pages, where `forwardRef` is still needed

