### PR TITLE
Remove `revalidate` property from incremental cache `ctx` for `FETCH` kind

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -649,5 +649,7 @@
   "648": "@rspack/plugin-react-refresh is not available. Please make sure `@next/plugin-rspack` is correctly installed.",
   "649": "Cache handlers not initialized",
   "650": "experimental.nodeMiddleware",
-  "651": "Unexpected module type %s"
+  "651": "Unexpected module type %s",
+  "652": "Expected cached value for cache key %s not to be a %s kind, got \"FETCH\" instead.",
+  "653": "Expected cached value for cache key %s to be a \"FETCH\" kind, got %s instead."
 }

--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -19,8 +19,8 @@ import {
   CachedRouteKind,
   type CachedImageValue,
   type IncrementalCacheEntry,
-  type IncrementalCacheItem,
   type IncrementalCacheValue,
+  type IncrementalResponseCacheEntry,
 } from './response-cache'
 import { sendEtagResponse } from './send-payload'
 import { getContentType, getExtension } from './serve-static'
@@ -390,7 +390,7 @@ export class ImageOptimizerCache {
     this.nextConfig = nextConfig
   }
 
-  async get(cacheKey: string): Promise<IncrementalCacheEntry | null> {
+  async get(cacheKey: string): Promise<IncrementalResponseCacheEntry | null> {
     try {
       const cacheDir = join(this.cacheDir, cacheKey)
       const files = await promises.readdir(cacheDir)
@@ -414,7 +414,7 @@ export class ImageOptimizerCache {
           revalidateAfter:
             Math.max(maxAge, this.nextConfig.images.minimumCacheTTL) * 1000 +
             Date.now(),
-          curRevalidate: maxAge,
+          revalidate: maxAge,
           isStale: now > expireAt,
           isFallback: false,
         }
@@ -508,7 +508,7 @@ export function getMaxAge(str: string | null | undefined): number {
 }
 export function getPreviouslyCachedImageOrNull(
   upstreamImage: ImageUpstream,
-  previousCacheEntry: IncrementalCacheItem | undefined
+  previousCacheEntry: IncrementalCacheEntry | null | undefined
 ): CachedImageValue | null {
   if (
     previousCacheEntry?.value?.kind === 'IMAGE' &&
@@ -678,7 +678,7 @@ export async function imageOptimizer(
   opts: {
     isDev?: boolean
     silent?: boolean
-    previousCacheEntry?: IncrementalCacheItem
+    previousCacheEntry?: IncrementalResponseCacheEntry | null
   }
 ): Promise<{
   buffer: Buffer
@@ -772,7 +772,7 @@ export async function imageOptimizer(
     return {
       buffer: previouslyCachedImage.buffer,
       contentType,
-      maxAge: opts?.previousCacheEntry?.curRevalidate || maxAge,
+      maxAge: opts?.previousCacheEntry?.revalidate || maxAge,
       etag: previouslyCachedImage.etag,
       upstreamEtag: previouslyCachedImage.upstreamEtag,
     }

--- a/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
@@ -5,6 +5,9 @@ import {
   CachedRouteKind,
   IncrementalCacheKind,
   type CachedFetchValue,
+  type IncrementalCacheValue,
+  type SetIncrementalFetchCacheContext,
+  type SetIncrementalResponseCacheContext,
 } from '../../response-cache'
 
 import { LRUCache } from '../lru-cache'
@@ -106,12 +109,16 @@ export default class FileSystemCache implements CacheHandler {
 
   public async get(...args: Parameters<CacheHandler['get']>) {
     const [key, ctx] = args
-    const { tags, softTags, kind, isRoutePPREnabled, isFallback } = ctx
+    const { kind } = ctx
 
     let data = memoryCache?.get(key)
 
     if (this.debug) {
-      console.log('get', key, tags, kind, !!data)
+      if (kind === IncrementalCacheKind.FETCH) {
+        console.log('get', key, ctx.tags, kind, !!data)
+      } else {
+        console.log('get', key, kind, !!data)
+      }
     }
 
     // let's check the disk for seed data
@@ -157,6 +164,8 @@ export default class FileSystemCache implements CacheHandler {
         const { mtime } = await this.fs.stat(filePath)
 
         if (kind === IncrementalCacheKind.FETCH) {
+          const { tags, fetchIdx, fetchUrl } = ctx
+
           if (!this.flushToDisk) return null
 
           const lastModified = mtime.getTime()
@@ -177,8 +186,10 @@ export default class FileSystemCache implements CacheHandler {
                 console.log('tags vs storedTags mismatch', tags, storedTags)
               }
               await this.set(key, data.value, {
+                fetchCache: true,
                 tags,
-                isRoutePPREnabled,
+                fetchIdx,
+                fetchUrl,
               })
             }
           }
@@ -226,10 +237,10 @@ export default class FileSystemCache implements CacheHandler {
           }
 
           let rscData: Buffer | undefined
-          if (!isFallback) {
+          if (!ctx.isFallback) {
             rscData = await this.fs.readFile(
               this.getFilePath(
-                `${key}${isRoutePPREnabled ? RSC_PREFETCH_SUFFIX : RSC_SUFFIX}`,
+                `${key}${ctx.isRoutePPREnabled ? RSC_PREFETCH_SUFFIX : RSC_SUFFIX}`,
                 IncrementalCacheKind.APP_PAGE
               )
             )
@@ -251,7 +262,7 @@ export default class FileSystemCache implements CacheHandler {
           let meta: RouteMetadata | undefined
           let pageData: string | object = {}
 
-          if (!isFallback) {
+          if (!ctx.isFallback) {
             pageData = JSON.parse(
               await this.fs.readFile(
                 this.getFilePath(
@@ -315,7 +326,10 @@ export default class FileSystemCache implements CacheHandler {
         }
       }
     } else if (data?.value?.kind === CachedRouteKind.FETCH) {
-      const combinedTags = [...(tags || []), ...(softTags || [])]
+      const combinedTags =
+        ctx.kind === IncrementalCacheKind.FETCH
+          ? [...(ctx.tags || []), ...(ctx.softTags || [])]
+          : []
 
       const wasRevalidated = combinedTags.some((tag) => {
         if (this.revalidatedTags.includes(tag)) {
@@ -338,9 +352,11 @@ export default class FileSystemCache implements CacheHandler {
     return data ?? null
   }
 
-  public async set(...args: Parameters<CacheHandler['set']>) {
-    const [key, data, ctx] = args
-    const { isFallback } = ctx
+  public async set(
+    key: string,
+    data: IncrementalCacheValue | null,
+    ctx: SetIncrementalFetchCacheContext | SetIncrementalResponseCacheContext
+  ) {
     memoryCache?.set(key, {
       value: data,
       lastModified: Date.now(),
@@ -388,7 +404,7 @@ export default class FileSystemCache implements CacheHandler {
       writer.append(htmlPath, data.html)
 
       // Fallbacks don't generate a data file.
-      if (!isFallback) {
+      if (!ctx.fetchCache && !ctx.isFallback) {
         writer.append(
           this.getFilePath(
             `${key}${
@@ -441,7 +457,7 @@ export default class FileSystemCache implements CacheHandler {
         filePath,
         JSON.stringify({
           ...data,
-          tags: ctx.tags,
+          tags: ctx.fetchCache ? ctx.tags : [],
         })
       )
     }

--- a/packages/next/src/server/lib/patch-fetch.test.ts
+++ b/packages/next/src/server/lib/patch-fetch.test.ts
@@ -86,7 +86,6 @@ describe('createPatchedFetcher', () => {
           fetchCache: true,
           fetchIdx: 1,
           fetchUrl: 'https://example.com/',
-          revalidate: false,
           tags: [],
         }
       )

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -635,8 +635,6 @@ export function createPatchedFetcher(
                   finalRevalidate >= INFINITE_CACHE
                     ? CACHE_ONE_YEAR
                     : finalRevalidate
-                const externalRevalidate =
-                  finalRevalidate >= INFINITE_CACHE ? false : finalRevalidate
 
                 if (workUnitStore && workUnitStore.type === 'prerender') {
                   // We are prerendering at build time or revalidate time with dynamicIO so we need to
@@ -660,13 +658,7 @@ export function createPatchedFetcher(
                       data: fetchedData,
                       revalidate: normalizedRevalidate,
                     },
-                    {
-                      fetchCache: true,
-                      revalidate: externalRevalidate,
-                      fetchUrl,
-                      fetchIdx,
-                      tags,
-                    }
+                    { fetchCache: true, fetchUrl, fetchIdx, tags }
                   )
                   await handleUnlock()
 
@@ -712,13 +704,7 @@ export function createPatchedFetcher(
                             data: fetchedData,
                             revalidate: normalizedRevalidate,
                           },
-                          {
-                            fetchCache: true,
-                            revalidate: externalRevalidate,
-                            fetchUrl,
-                            fetchIdx,
-                            tags,
-                          }
+                          { fetchCache: true, fetchUrl, fetchIdx, tags }
                         )
                       }
                     })
@@ -771,7 +757,6 @@ export function createPatchedFetcher(
                   fetchIdx,
                   tags,
                   softTags: implicitTags,
-                  isFallback: false,
                 })
 
             if (hasNoExplicitCacheConfig) {

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -77,7 +77,7 @@ import { getCloneableBody } from './body-streams'
 import { checkIsOnDemandRevalidate } from './api-utils'
 import ResponseCache, {
   CachedRouteKind,
-  type IncrementalCacheItem,
+  type IncrementalResponseCacheEntry,
 } from './response-cache'
 import { IncrementalCache } from './lib/incremental-cache'
 import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
@@ -665,7 +665,7 @@ export default class NextNodeServer extends BaseServer<
     req: NodeNextRequest,
     res: NodeNextResponse,
     paramsResult: import('./image-optimizer').ImageParamsResult,
-    previousCacheEntry?: IncrementalCacheItem
+    previousCacheEntry?: IncrementalResponseCacheEntry | null
   ): Promise<{
     buffer: Buffer
     contentType: string

--- a/packages/next/src/server/response-cache/types.ts
+++ b/packages/next/src/server/response-cache/types.ts
@@ -131,15 +131,32 @@ export interface IncrementalCachedPageValue {
   status: number | undefined
 }
 
-export type IncrementalCacheEntry = {
-  curRevalidate?: Revalidate
-  // milliseconds to revalidate after
-  revalidateAfter: Revalidate
-  // -1 here dictates a blocking revalidate should be used
+export interface IncrementalResponseCacheEntry {
+  revalidate?: Revalidate
+  /**
+   * timestamp in milliseconds to revalidate after
+   */
+  revalidateAfter?: Revalidate
+  /**
+   * `-1` here dictates a blocking revalidate should be used
+   */
   isStale?: boolean | -1
-  value: IncrementalCacheValue | null
+  isMiss?: boolean
   isFallback: boolean | undefined
+  value: Exclude<IncrementalCacheValue, CachedFetchValue> | null
 }
+
+export interface IncrementalFetchCacheEntry {
+  /**
+   * `-1` here dictates a blocking revalidate should be used
+   */
+  isStale?: boolean | -1
+  value: CachedFetchValue
+}
+
+export type IncrementalCacheEntry =
+  | IncrementalResponseCacheEntry
+  | IncrementalFetchCacheEntry
 
 export type IncrementalCacheValue =
   | CachedRedirectValue
@@ -170,19 +187,9 @@ export type ResponseCacheEntry = {
  */
 export type ResponseGenerator = (state: {
   hasResolved: boolean
-  previousCacheEntry?: IncrementalCacheItem
+  previousCacheEntry?: IncrementalResponseCacheEntry | null
   isRevalidating?: boolean
 }) => Promise<ResponseCacheEntry | null>
-
-export type IncrementalCacheItem = {
-  revalidateAfter?: number | false
-  curRevalidate?: number | false
-  revalidate?: number | false
-  value: IncrementalCacheValue | null
-  isStale?: boolean | -1
-  isMiss?: boolean
-  isFallback: boolean | undefined
-} | null
 
 export const enum IncrementalCacheKind {
   APP_PAGE = 'APP_PAGE',
@@ -192,38 +199,78 @@ export const enum IncrementalCacheKind {
   IMAGE = 'IMAGE',
 }
 
-export interface IncrementalCache {
-  get: (
+export interface GetIncrementalFetchCacheContext {
+  kind: IncrementalCacheKind.FETCH
+  revalidate?: Revalidate
+  fetchUrl?: string
+  fetchIdx?: number
+  tags?: string[]
+  softTags?: string[]
+}
+
+export interface GetIncrementalResponseCacheContext {
+  kind: Exclude<IncrementalCacheKind, IncrementalCacheKind.FETCH>
+  /**
+   * True if the route is enabled for PPR.
+   */
+  isRoutePPREnabled?: boolean
+
+  /**
+   * True if this is a fallback request.
+   */
+  isFallback: boolean
+}
+
+export interface SetIncrementalFetchCacheContext {
+  fetchCache: true
+  fetchUrl?: string
+  fetchIdx?: number
+  tags?: string[]
+}
+
+export interface SetIncrementalResponseCacheContext {
+  fetchCache?: false
+  revalidate?: Revalidate
+  /**
+   * True if the route is enabled for PPR.
+   */
+  isRoutePPREnabled?: boolean
+
+  /**
+   * True if this is a fallback request.
+   */
+  isFallback?: boolean
+}
+
+export interface IncrementalResponseCache {
+  get(
+    cacheKey: string,
+    ctx: GetIncrementalResponseCacheContext
+  ): Promise<IncrementalResponseCacheEntry | null>
+  set(
     key: string,
-    ctx: {
-      kind: IncrementalCacheKind
+    data: Exclude<IncrementalCacheValue, CachedFetchValue> | null,
+    ctx: SetIncrementalResponseCacheContext
+  ): Promise<void>
+}
 
-      /**
-       * True if the route is enabled for PPR.
-       */
-      isRoutePPREnabled?: boolean
-
-      /**
-       * True if this is a fallback request.
-       */
-      isFallback: boolean
-    }
-  ) => Promise<IncrementalCacheItem>
-  set: (
+export interface IncrementalCache extends IncrementalResponseCache {
+  get(
+    cacheKey: string,
+    ctx: GetIncrementalFetchCacheContext
+  ): Promise<IncrementalFetchCacheEntry | null>
+  get(
+    cacheKey: string,
+    ctx: GetIncrementalResponseCacheContext
+  ): Promise<IncrementalResponseCacheEntry | null>
+  set(
     key: string,
-    data: IncrementalCacheValue | null,
-    ctx: {
-      revalidate: Revalidate
-
-      /**
-       * True if the route is enabled for PPR.
-       */
-      isRoutePPREnabled?: boolean
-
-      /**
-       * True if this is a fallback request.
-       */
-      isFallback: boolean
-    }
-  ) => Promise<void>
+    data: CachedFetchValue | null,
+    ctx: SetIncrementalFetchCacheContext
+  ): Promise<void>
+  set(
+    key: string,
+    data: Exclude<IncrementalCacheValue, CachedFetchValue> | null,
+    ctx: SetIncrementalResponseCacheContext
+  ): Promise<void>
 }

--- a/packages/next/src/server/response-cache/utils.ts
+++ b/packages/next/src/server/response-cache/utils.ts
@@ -3,7 +3,7 @@ import {
   IncrementalCacheKind,
   type CachedAppPageValue,
   type CachedPageValue,
-  type IncrementalCacheItem,
+  type IncrementalResponseCacheEntry,
   type ResponseCacheEntry,
 } from './types'
 
@@ -12,7 +12,7 @@ import { RouteKind } from '../route-kind'
 
 export async function fromResponseCacheEntry(
   cacheEntry: ResponseCacheEntry
-): Promise<IncrementalCacheItem> {
+): Promise<IncrementalResponseCacheEntry> {
   return {
     ...cacheEntry,
     value:
@@ -39,15 +39,9 @@ export async function fromResponseCacheEntry(
 }
 
 export async function toResponseCacheEntry(
-  response: IncrementalCacheItem
+  response: IncrementalResponseCacheEntry | null
 ): Promise<ResponseCacheEntry | null> {
   if (!response) return null
-
-  if (response.value?.kind === CachedRouteKind.FETCH) {
-    throw new Error(
-      'Invariant: unexpected cachedResponse of kind fetch in response cache'
-    )
-  }
 
   return {
     isMiss: response.isMiss,
@@ -79,7 +73,7 @@ export async function toResponseCacheEntry(
 
 export function routeKindToIncrementalCacheKind(
   routeKind: RouteKind
-): IncrementalCacheKind {
+): Exclude<IncrementalCacheKind, IncrementalCacheKind.FETCH> {
   switch (routeKind) {
     case RouteKind.PAGES:
       return IncrementalCacheKind.PAGES

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -37,13 +37,7 @@ async function cacheNewResult<T>(
       } satisfies CachedFetchData,
       revalidate: typeof revalidate !== 'number' ? CACHE_ONE_YEAR : revalidate,
     },
-    {
-      revalidate,
-      fetchCache: true,
-      tags,
-      fetchIdx,
-      fetchUrl,
-    }
+    { fetchCache: true, tags, fetchIdx, fetchUrl }
   )
   return
 }
@@ -208,7 +202,6 @@ export function unstable_cache<T extends Callback>(
             softTags: implicitTags,
             fetchIdx,
             fetchUrl,
-            isFallback: false,
           })
 
           if (cacheEntry && cacheEntry.value) {
@@ -312,7 +305,6 @@ export function unstable_cache<T extends Callback>(
             fetchIdx,
             fetchUrl,
             softTags: implicitTags,
-            isFallback: false,
           })
 
           if (cacheEntry && cacheEntry.value) {

--- a/test/unit/image-optimizer/get-previously-cached-image-or-null.test.ts
+++ b/test/unit/image-optimizer/get-previously-cached-image-or-null.test.ts
@@ -5,7 +5,7 @@ import {
 } from 'next/dist/server/image-optimizer'
 import {
   CachedRouteKind,
-  IncrementalCacheItem,
+  IncrementalCacheEntry,
 } from 'next/dist/server/response-cache/types'
 import { readFile } from 'fs-extra'
 import { join } from 'path'
@@ -37,7 +37,7 @@ const getPreviousCacheEntry = async (
 ) => {
   const buffer = await readFile(join(__dirname, filepath))
   const upstreamEtag = getImageEtag(buffer)
-  const result: IncrementalCacheItem = {
+  const result: IncrementalCacheEntry = {
     ...baseCacheEntry,
     value: {
       kind: CachedRouteKind.IMAGE,
@@ -62,7 +62,7 @@ describe('shouldUsePreviouslyCachedEntry', () => {
   })
 
   it('should return null if previous cache entry value is not of kind IMAGE', async () => {
-    const nonImageCacheEntry: IncrementalCacheItem = {
+    const nonImageCacheEntry: IncrementalCacheEntry = {
       ...baseCacheEntry,
       value: { kind: CachedRouteKind.REDIRECT, props: {} },
     }

--- a/test/unit/incremental-cache/file-system-cache.test.ts
+++ b/test/unit/incremental-cache/file-system-cache.test.ts
@@ -79,7 +79,6 @@ describe('FileSystemCache (isrMemory 0)', () => {
       },
       {
         fetchCache: true,
-        revalidate: 30,
         fetchUrl: 'http://my-api.local',
         fetchIdx: 5,
         tags: ['server-time'],
@@ -89,7 +88,6 @@ describe('FileSystemCache (isrMemory 0)', () => {
     const res = await fsCache.get('fetch-cache', {
       tags: ['server-time'],
       kind: IncrementalCacheKind.FETCH,
-      isFallback: undefined,
     })
 
     expect(res?.value).toEqual({
@@ -113,13 +111,12 @@ describe('FileSystemCache (isrMemory 0)', () => {
         data: { headers: {}, body: '1700056381', status: 200, url: '' },
         revalidate: 30,
       },
-      { revalidate: 30, fetchCache: true, tags: ['server-time2'] }
+      { fetchCache: true, tags: ['server-time2'] }
     )
 
     const res = await fsCache.get('unstable-cache', {
       tags: ['server-time'],
       kind: IncrementalCacheKind.FETCH,
-      isFallback: undefined,
     })
 
     expect(res?.value).toEqual({


### PR DESCRIPTION
The `revalidate` property of the `ctx` object that is passed into the incremental cache by the patched `fetch` as well as `unstable_cache` is unused since it was introduced in #43659. It was just added because of how the method signature for `set()` was changed back then.

However, for those kinds of cache entries, the `revalidate` context property is never used, and instead the `revalidate` property of the passed-in `data` is used.

To avoid further confusion (e.g. in [this question](https://github.com/vercel/next.js/pull/76207#discussion_r1968478141)), this PR improves the method signatures and types of the incremental cache so that the different call-site use cases can be clearly discriminated, and superfluous context properties can be omitted.