### PR TITLE
[Segment Cache] handle errors in the prefetch stream

### DIFF
--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -313,7 +313,7 @@ function spawnPrefetchSubtask<T>(
       return null
     }
     // Wait for the connection to close before freeing up more bandwidth.
-    result.closed.then(onPrefetchConnectionClosed)
+    result.closed.then(onPrefetchConnectionClosed, onPrefetchConnectionClosed)
     return result.value
   })
 }


### PR DESCRIPTION
a manually `read()` stream without a `catch` makes me anxious -- [it can throw if the underlying stream errors](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultReader/read#return_value), and then the consumer would end up hanging forever, because we'd never call `onStreamClose`.

### TODO
- [ ] needs a test case, seems like a stream that gets interrupted would work