### PR TITLE
[ci]: PPR tests should run on development/acceptance-app

### DIFF
--- a/test/ppr-tests-manifest.json
+++ b/test/ppr-tests-manifest.json
@@ -79,7 +79,8 @@
       "test/e2e/**/*.test.{t,j}s{,x}",
       "test/integration/app-*/**/*.test.{t,j}s{,x}",
       "test/production/app-*/**/*.test.{t,j}s{,x}",
-      "test/development/app-*/**/*.test.{t,j}s{,x}"
+      "test/development/app-*/**/*.test.{t,j}s{,x}",
+      "test/development/acceptance-app/**/*.test.{t,j}s{,x}"
     ],
     "exclude": [
       "test/integration/app-dir-export/**/*",


### PR DESCRIPTION
Noticed this was not matched by the existing glob since it expects things to be in `app-/**`