### PR TITLE
[dev-overlay] Discriminate stack frame settled typed

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/call-stack-frame/call-stack-frame.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/call-stack-frame/call-stack-frame.stories.tsx
@@ -32,7 +32,7 @@ const frame = {
     lineNumber: 10,
     column: 5,
   },
-  error: false,
+  error: false as const,
   reason: null,
   external: false,
   ignored: false,

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/call-stack/call-stack.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/call-stack/call-stack.stories.tsx
@@ -33,7 +33,7 @@ const frame = {
     column: 5,
   },
   originalCodeFrame: 'export default function MyComponent() {',
-  error: false,
+  error: false as const,
   reason: null,
   external: false,
   ignored: false,


### PR DESCRIPTION
Adds two distinct types for the resolved and rejected case. Allows us to better reason about what ends up being displayed.