### PR TITLE
docs(errors): update suppressHydrationWarning section

### DIFF
--- a/errors/react-hydration-error.mdx
+++ b/errors/react-hydration-error.mdx
@@ -78,7 +78,7 @@ Sometimes content will inevitably differ between the server and client, such as 
 > **Good to know:**
 >
 > - This only works one level deep, and is intended to be an escape hatch. Don’t overuse it.
-> - React will **not** attempt to patch mismatched text content when `suppressHydrationWarning={true}`.
+> - React will **not** attempt to patch mismatched text content when `suppressHydrationWarning={true}` is set.
 
 ## Common iOS issues
 

--- a/errors/react-hydration-error.mdx
+++ b/errors/react-hydration-error.mdx
@@ -75,6 +75,11 @@ Sometimes content will inevitably differ between the server and client, such as 
 <time datetime="2016-10-25" suppressHydrationWarning />
 ```
 
+> **Good to know:**
+>
+> - This only works one level deep, and is intended to be an escape hatch. Don’t overuse it.
+> - React will **not** attempt to patch mismatched text content when `suppressHydrationWarning={true}`.
+
 ## Common iOS issues
 
 iOS attempts to detect phone numbers, email addresses, and other data in text content and convert them into links, leading to hydration mismatches.


### PR DESCRIPTION
## Why?

We should clarify that React will **not** attempt to patch mismatched text content when using `suppressHydrationWarning`.

- Related: https://github.com/reactjs/react.dev/pull/7651
- x-ref: https://github.com/vercel/next.js/discussions/75890