### PR TITLE
[dev-overlay]: remove background on custom select

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
@@ -253,6 +253,7 @@ export const DEV_TOOLS_INFO_USER_PREFERENCES_STYLES = css`
     padding: 0 6px 0 0;
     border-radius: 0;
     outline: none;
+    background: none;
   }
 
   :global(.icon) {


### PR DESCRIPTION
Forgot to remove this -- since the custom select hover state is styled by the parent, we don't want hover effects on the select itself.