### PR TITLE
[dev-overlay]: tweak system icon

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
@@ -6,6 +6,7 @@ import EyeIcon from '../../../../icons/eye-icon'
 import { STORAGE_KEY_POSITION, STORAGE_KEY_THEME } from '../../../../../shared'
 import LightIcon from '../../../../icons/light-icon'
 import DarkIcon from '../../../../icons/dark-icon'
+import SystemIcon from '../../../../icons/system-icon'
 
 function getInitialPreference() {
   if (typeof localStorage === 'undefined') {
@@ -147,14 +148,16 @@ export function UserPreferences({
 }
 
 function ThemeIcon({ theme }: { theme: 'dark' | 'light' | 'system' }) {
-  const activeTheme =
-    theme === 'system'
-      ? window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light'
-      : theme
-
-  return activeTheme === 'dark' ? <DarkIcon /> : <LightIcon />
+  switch (theme) {
+    case 'system':
+      return <SystemIcon />
+    case 'dark':
+      return <DarkIcon />
+    case 'light':
+      return <LightIcon />
+    default:
+      return null
+  }
 }
 
 export const DEV_TOOLS_INFO_USER_PREFERENCES_STYLES = css`

--- a/packages/next/src/client/components/react-dev-overlay/ui/icons/system-icon.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/icons/system-icon.tsx
@@ -1,0 +1,12 @@
+export default function SystemIcon() {
+  return (
+    <svg width="16" height="16" strokeLinejoin="round">
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M0 2a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v8.5a1 1 0 0 1-1 1H8.75v3h1.75V16h-5v-1.5h1.75v-3H1a1 1 0 0 1-1-1V2Zm1.5.5V10h13V2.5h-13Z"
+        clipRule="evenodd"
+      />
+    </svg>
+  )
+}


### PR DESCRIPTION
Uses a dedicated icon rather than showing the icon corresponding with the system value.

![CleanShot 2025-02-25 at 21 10 41@2x](https://github.com/user-attachments/assets/83f38eec-3267-4ff9-b83f-b6bf6caa1b7c)

![CleanShot 2025-02-25 at 21 10 30@2x](https://github.com/user-attachments/assets/e2655917-761c-49ac-ad08-31fa6450f04c)
