### PR TITLE
Handle duplex automatically for NextRequest

### DIFF
--- a/packages/next/src/server/web/spec-extension/adapters/next-request.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/next-request.ts
@@ -107,7 +107,6 @@ export class NextRequestAdapter {
     return new NextRequest(url, {
       method: request.method,
       headers: fromNodeOutgoingHttpHeaders(request.headers),
-      // @ts-expect-error - see https://github.com/whatwg/fetch/pull/1457
       duplex: 'half',
       signal,
       // geo
@@ -134,7 +133,6 @@ export class NextRequestAdapter {
     return new NextRequest(request.url, {
       method: request.method,
       headers: fromNodeOutgoingHttpHeaders(request.headers),
-      // @ts-expect-error - see https://github.com/whatwg/fetch/pull/1457
       duplex: 'half',
       signal: request.request.signal,
       // geo

--- a/test/unit/web-runtime/next-request-node.test.ts
+++ b/test/unit/web-runtime/next-request-node.test.ts
@@ -1,7 +1,5 @@
-/**
- * @jest-environment @edge-runtime/jest-environment
- */
-
+// this file must not use the edge-runtime env setup
+// so that we test node runtime properly
 import { expectTypeOf } from 'expect-type'
 import { NextRequest } from 'next/dist/server/web/spec-extension/request'
 


### PR DESCRIPTION
When configuring a body with `NextRequest` in node runtime without the `duplex: 'half'` option it can throw an error un-necessarily since it's an extension of the node `Request` instance. This auto-configures `duplex: 'half'` when using `NextRequest` for easier migration from edge -> node runtime for middleware. 

```sh
TypeError: RequestInit: duplex option is required when sending a body.
    at new Request (/opt/rust/undici-runtime.js:40:31096)
```

x-ref: [slack thread](https://vercel.slack.com/archives/C07LQPFERGF/p1740490607381379)