### PR TITLE
fix(turbopack): Temporarily disable prerender tests with turbopack

### DIFF
--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -7540,7 +7540,10 @@
       "runtimeError": false
     },
     "test/e2e/prerender.test.ts": {
-      "passed": [
+      "passed": [],
+      "failed": [],
+      "pending": [
+        "Prerender should reload page on failed data request, and retry",
         "Prerender outputs a prerender-manifest correctly",
         "Prerender outputs dataRoutes in routes-manifest correctly",
         "Prerender outputs prerendered files correctly",
@@ -7619,10 +7622,6 @@
         "Prerender should support prerendered catchall-explicit route (single)",
         "Prerender should use correct caching headers for a no-revalidate page",
         "Prerender should use correct caching headers for a revalidate page"
-      ],
-      "failed": [],
-      "pending": [
-        "Prerender should reload page on failed data request, and retry"
       ],
       "flakey": [],
       "runtimeError": false


### PR DESCRIPTION
https://vercel.slack.com/archives/C04KC8A53T7/p1740540566798769

It looks like these tests are sensitive to react version, and `build_and_test.yml` has some logic to force specific versions of react that we don't have when we run the tests for areweturboyet. My guess is that this is why this is passing in the baseline run and failing in the `build_and_test` workflow.

Closes PACK-4039