### PR TITLE
Move known failed test back into `failed` set in Turbopack manifest

### DIFF
--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -7560,7 +7560,6 @@
         "Prerender should automatically reset cache TTL when an error occurs and runtime cache was available",
         "Prerender should fetch /_next/data correctly with mismatched href and as",
         "Prerender should handle de-duping correctly",
-        "Prerender should handle fallback only page correctly HTML",
         "Prerender should handle fallback only page correctly data",
         "Prerender should handle on-demand revalidate for fallback: blocking",
         "Prerender should handle on-demand revalidate for fallback: false",
@@ -7620,7 +7619,7 @@
         "Prerender should use correct caching headers for a no-revalidate page",
         "Prerender should use correct caching headers for a revalidate page"
       ],
-      "failed": [],
+      "failed": ["Prerender should handle fallback only page correctly HTML"],
       "pending": [
         "Prerender should reload page on failed data request, and retry"
       ],


### PR DESCRIPTION
The test was moved out of `failed` in #76472, but still fails with Turbopack and React 18.3.1.

For posterity: Known failed tests are excluded [here](https://github.com/vercel/next.js/blob/91e61592a3137ad3bcc67f876f3e5eac8e51d7e9/test/get-test-filter.js#L81).

Running React 18 tests for the update PRs like #76472 is addressed in #76544.

closes #76535
