### PR TITLE
Run React 18 tests for automated update PRs

### DIFF
--- a/scripts/automated-update-workflow.js
+++ b/scripts/automated-update-workflow.js
@@ -66,6 +66,13 @@ async function main() {
     body: PR_BODY,
   })
 
+  await octokit.rest.issues.addLabels({
+    owner,
+    repo,
+    issue_number: pullRequest.number,
+    labels: ['run-react-18-tests'],
+  })
+
   console.log('Created pull request', pullRequest.url)
 
   const previousPullRequests = pullRequests.filter(({ title, user }) => {


### PR DESCRIPTION
This ensures that we don't marks tests as `passed` in the bundler test manifests if they would still fail when running them with React 18.

Those tests are usually only run on `canary`, unless a PR has the `run-react-18-tests` label, which we are now automatically adding for the update PRs.