### PR TITLE
Remove obsolete `sourcePackage` references

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/server/shared.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/shared.ts
@@ -2,8 +2,6 @@ import type { StackFrame } from 'stacktrace-parser'
 import { codeFrameColumns } from 'next/dist/compiled/babel/code-frame'
 import isInternal from '../../../../shared/lib/is-internal'
 
-export type SourcePackage = 'react' | 'next'
-
 export interface OriginalStackFramesRequest {
   frames: StackFrame[]
   isServer: boolean
@@ -19,8 +17,6 @@ export type OriginalStackFrameResponseResult =
 export interface OriginalStackFrameResponse {
   originalStackFrame?: (StackFrame & { ignored: boolean }) | null
   originalCodeFrame?: string | null
-  /** We use this to group frames in the error overlay */
-  sourcePackage?: SourcePackage | null
 }
 
 /**

--- a/packages/next/src/client/components/react-dev-overlay/utils/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/utils/stack-frame.ts
@@ -47,7 +47,6 @@ function getOriginalStackFrame(
       sourceStackFrame: source,
       originalStackFrame: body.originalStackFrame,
       originalCodeFrame: body.originalCodeFrame || null,
-      sourcePackage: body.sourcePackage,
       ignored: body.originalStackFrame?.ignored || false,
     }
   }
@@ -61,7 +60,6 @@ function getOriginalStackFrame(
       sourceStackFrame: source,
       originalStackFrame: null,
       originalCodeFrame: null,
-      sourcePackage: null,
       ignored: true,
     })
   }
@@ -74,7 +72,6 @@ function getOriginalStackFrame(
       sourceStackFrame: source,
       originalStackFrame: null,
       originalCodeFrame: null,
-      sourcePackage: null,
       ignored: false,
     })
   )


### PR DESCRIPTION
We used these to group frames by package.
We no longer do this and can remove the references.