### PR TITLE
[dev-overlay] control scrollbar by selected theme

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/dialog/styles.ts
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/dialog/styles.ts
@@ -1,3 +1,12 @@
+const darkTheme = `
+[data-nextjs-dialog]::-webkit-scrollbar-track {
+  background-color: #0a0a0a;
+}
+[data-nextjs-dialog]::-webkit-scrollbar-thumb {
+  background-color: #333;
+}
+`
+
 const styles = `
   [data-nextjs-dialog-root] {
     --next-dialog-radius: var(--rounded-xl);
@@ -47,15 +56,14 @@ const styles = `
     background-color: #ddd;
   }
 
+  :host(.dark) {
+    ${darkTheme}
+  }
   @media (prefers-color-scheme: dark) {
-    [data-nextjs-dialog]::-webkit-scrollbar-track {
-      background-color: #0a0a0a;
-    }
-    [data-nextjs-dialog]::-webkit-scrollbar-thumb {
-      background-color: #333;
+    :host(:not(.light)) {
+      ${darkTheme}  
     }
   }
-  
 
   ${
     '' /* Place overflow: hidden on this so we can break out from [data-nextjs-dialog] */

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/dialog/styles.ts
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/dialog/styles.ts
@@ -1,12 +1,3 @@
-const darkTheme = `
-[data-nextjs-dialog]::-webkit-scrollbar-track {
-  background-color: #0a0a0a;
-}
-[data-nextjs-dialog]::-webkit-scrollbar-thumb {
-  background-color: #333;
-}
-`
-
 const styles = `
   [data-nextjs-dialog-root] {
     --next-dialog-radius: var(--rounded-xl);
@@ -37,7 +28,7 @@ const styles = `
   [data-nextjs-dialog] {
     outline: none;
     overflow: hidden;
-  }  
+  }
   [data-nextjs-dialog]::-webkit-scrollbar {
     width: 6px;
     border-radius: 0 0 1rem 1rem;
@@ -46,23 +37,13 @@ const styles = `
   [data-nextjs-dialog]::-webkit-scrollbar-button {
     display: none;
   }
-  /* css variables not working in scrollbar pseudo element */ 
   [data-nextjs-dialog]::-webkit-scrollbar-track {
     border-radius: 0 0 1rem 1rem;
-    background-color: #fff;
+    background-color: var(--color-background-100);
   }
   [data-nextjs-dialog]::-webkit-scrollbar-thumb {
     border-radius: 1rem;
-    background-color: #ddd;
-  }
-
-  :host(.dark) {
-    ${darkTheme}
-  }
-  @media (prefers-color-scheme: dark) {
-    :host(:not(.light)) {
-      ${darkTheme}  
-    }
+    background-color: var(--color-gray-500);
   }
 
   ${


### PR DESCRIPTION
### What

Use css var to control the scrollbar theme, which was showing not defined in chrome devtool but actually works.
Since we introduced the light/dark theme selector, it needs to be controlled by the picked theme as well.