### PR TITLE
[dev-overlay] add disabled backround-color for toolbar buttons

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-toolbar/error-overlay-toolbar.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-toolbar/error-overlay-toolbar.tsx
@@ -62,6 +62,7 @@ export const styles = `
     }
 
     &:disabled {
+      background-color: var(--color-gray-100);
       cursor: not-allowed;
     }
   }


### PR DESCRIPTION
### Why?

The disabled button was hard to distinguish from clickable buttons before hovering.

| Light | Dark |
|--------|--------|
| ![CleanShot 2025-02-26 at 23 10 43@2x](https://github.com/user-attachments/assets/9c393c6a-979f-436d-be74-e275cc63bb20) | ![CleanShot 2025-02-26 at 23 08 51@2x](https://github.com/user-attachments/assets/97c86b6d-7c47-4ebb-8b3d-1101075dab44) | 

Closes NDX-917