### PR TITLE
Update mappings in `launch.json` to improve debugging in VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -45,11 +45,12 @@
         "webpack://_N_E/[.]/(.*)": "${workspaceFolder}/${input:appDirname}/.next/server/$1",
         "webpack-internal:///(ssr)/./*": "${workspaceFolder}/${input:appDirname}/*",
         "webpack://(?:_N_E)?/(?:../)*src/(.*)": "${workspaceFolder}/packages/next/src/$1",
-        "webpack://next/./dist/src/*": "${workspaceFolder}/packages/next/src/*",
-        "webpack://next/./dist/compiled/*": "${workspaceFolder}/packages/next/src/compiled/*",
+        "webpack:///./dist/src/*": "${workspaceFolder}/packages/next/src/*",
+        "webpack:///./dist/compiled/*": "${workspaceFolder}/packages/next/src/compiled/*",
         "webpack:///(?:../)*packages/next/dist/compiled/(.*)": "${workspaceFolder}/packages/next/src/compiled/$1",
-        "webpack://next/./src/*": "${workspaceFolder}/packages/next/src/*",
+        "webpack:///./src/*": "${workspaceFolder}/packages/next/src/*",
         "webpack-internal:///\\(rsc\\)/(?:../)*packages/next/dist/(.*)": "${workspaceFolder}/packages/next/src/$1",
+        "webpack-internal:///(react-server)/./dist/compiled/*": "${workspaceFolder}/packages/next/src/compiled/*",
         "turbopack:///[project]/*": "${workspaceFolder}/*"
       },
       "env": {
@@ -81,11 +82,12 @@
         "webpack://_N_E/[.]/(.*)": "${workspaceFolder}/${fileDirname}/.next/server/$1",
         "webpack-internal:///(ssr)/./*": "${workspaceFolder}/${fileDirname}/*",
         "webpack://(?:_N_E)?/(?:../)*src/(.*)": "${workspaceFolder}/packages/next/src/$1",
-        "webpack://next/./dist/src/*": "${workspaceFolder}/packages/next/src/*",
-        "webpack://next/./dist/compiled/*": "${workspaceFolder}/packages/next/src/compiled/*",
+        "webpack:///./dist/src/*": "${workspaceFolder}/packages/next/src/*",
+        "webpack:///./dist/compiled/*": "${workspaceFolder}/packages/next/src/compiled/*",
         "webpack:///(?:../)*packages/next/dist/compiled/(.*)": "${workspaceFolder}/packages/next/src/compiled/$1",
-        "webpack://next/./src/*": "${workspaceFolder}/packages/next/src/*",
+        "webpack:///./src/*": "${workspaceFolder}/packages/next/src/*",
         "webpack-internal:///\\(rsc\\)/(?:../)*packages/next/dist/(.*)": "${workspaceFolder}/packages/next/src/$1",
+        "webpack-internal:///(react-server)/./dist/compiled/*": "${workspaceFolder}/packages/next/src/compiled/*",
         "turbopack:///[project]/*": "${workspaceFolder}/*"
       },
       "env": {
@@ -109,11 +111,12 @@
         "webpack://_N_E/[.]/(.*)": "${workspaceFolder}/${fileDirname}/.next/server/$1",
         "webpack-internal:///(ssr)/./*": "${workspaceFolder}/${fileDirname}/*",
         "webpack://(?:_N_E)?/(?:../)*src/(.*)": "${workspaceFolder}/packages/next/src/$1",
-        "webpack://next/./dist/src/*": "${workspaceFolder}/packages/next/src/*",
-        "webpack://next/./dist/compiled/*": "${workspaceFolder}/packages/next/src/compiled/*",
+        "webpack:///./dist/src/*": "${workspaceFolder}/packages/next/src/*",
+        "webpack:///./dist/compiled/*": "${workspaceFolder}/packages/next/src/compiled/*",
         "webpack:///(?:../)*packages/next/dist/compiled/(.*)": "${workspaceFolder}/packages/next/src/compiled/$1",
-        "webpack://next/./src/*": "${workspaceFolder}/packages/next/src/*",
+        "webpack:///./src/*": "${workspaceFolder}/packages/next/src/*",
         "webpack-internal:///\\(rsc\\)/(?:../)*packages/next/dist/(.*)": "${workspaceFolder}/packages/next/src/$1",
+        "webpack-internal:///(react-server)/./dist/compiled/*": "${workspaceFolder}/packages/next/src/compiled/*",
         "turbopack:///[project]/*": "${workspaceFolder}/*"
       },
       "env": {


### PR DESCRIPTION
After recent changes to how we generate source maps, the source map overrides in `launch.json` became outdated.

With this update, setting breakpoints in VSCode when working in the Next.js repo should mostly work again. There's still some edge cases where breakpoints are not applied correctly. In this case `debugger` statements can be used as a last resort.

This also assumes that `pnpm dev` is running. See `contributing/core/vscode-debugger.md`.