### PR TITLE
Do not pass an empty string tag into `receiveExpiredTags`

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1443,7 +1443,7 @@ export default abstract class Server<
       // cache handlers.
       const handlers = getCacheHandlers()
       if (handlers) {
-        const header = req.headers[NEXT_CACHE_REVALIDATED_TAGS_HEADER] ?? ''
+        const header = req.headers[NEXT_CACHE_REVALIDATED_TAGS_HEADER]
         const expiredTags = typeof header === 'string' ? header.split(',') : []
 
         const promises: Promise<void>[] = []

--- a/test/production/app-dir/dynamic-io-cache-handlers/dynamic-io-cache-handlers.test.ts
+++ b/test/production/app-dir/dynamic-io-cache-handlers/dynamic-io-cache-handlers.test.ts
@@ -103,6 +103,15 @@ describe('dynamic-io-cache-handlers', () => {
     })
   })
 
+  it('should call receiveExpiredTags on global default cache handler without tags if none are provided', async () => {
+    const res = await fetchViaHTTP(appPort, '/', {})
+    expect(res.status).toBe(200)
+
+    await retry(async () => {
+      expect(output).toContain('symbol receiveExpiredTags []')
+    })
+  })
+
   it('should call receiveExpiredTags on global default cache handler', async () => {
     const res = await fetchViaHTTP(
       appPort,


### PR DESCRIPTION
Follow-up fix for #76130. This avoids unnecessary calls to the tags service when no tags are used.