### PR TITLE
exclude AppDevOverlayErrorBoundary from prod build

### DIFF
--- a/packages/next/src/client/react-client-callbacks/error-boundary-callbacks.ts
+++ b/packages/next/src/client/react-client-callbacks/error-boundary-callbacks.ts
@@ -7,7 +7,6 @@ import { isNextRouterError } from '../components/is-next-router-error'
 import { isBailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
 import { reportGlobalError } from './report-global-error'
 import { originConsoleError } from '../components/globals/intercept-console-error'
-import { AppDevOverlayErrorBoundary } from '../components/react-dev-overlay/app/app-dev-overlay-error-boundary'
 import {
   ErrorBoundaryHandler,
   GlobalError as DefaultErrorBoundary,
@@ -19,12 +18,22 @@ export function onCaughtError(
 ) {
   const errorBoundaryComponent = errorInfo.errorBoundary?.constructor
 
-  const isImplicitErrorBoundary =
-    (process.env.NODE_ENV !== 'production' &&
-      errorBoundaryComponent === AppDevOverlayErrorBoundary) ||
+  let isImplicitErrorBoundary
+
+  if (process.env.NODE_ENV !== 'production') {
+    const { AppDevOverlayErrorBoundary } =
+      require('../components/react-dev-overlay/app/app-dev-overlay-error-boundary') as typeof import('../components/react-dev-overlay/app/app-dev-overlay-error-boundary')
+
+    isImplicitErrorBoundary =
+      errorBoundaryComponent === AppDevOverlayErrorBoundary
+  }
+
+  isImplicitErrorBoundary =
+    isImplicitErrorBoundary ||
     (errorBoundaryComponent === ErrorBoundaryHandler &&
       (errorInfo.errorBoundary! as InstanceType<typeof ErrorBoundaryHandler>)
         .props.errorComponent === DefaultErrorBoundary)
+
   if (isImplicitErrorBoundary) {
     // We don't consider errors caught unless they're caught by an explicit error
     // boundary. The built-in ones are considered implicit.


### PR DESCRIPTION
**Test**


Generate a prod build, and search `AppDevOverlayErrorBoundary` in the build output.

---

Before the change, `main-app` has an occurrence of `AppDevOverlayErrorBoundary`.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/rKSEEwxbNzdFs9t0yyxN/85112448-fd0f-40f1-a948-79e69a97d4ff.png)

After the change, there should be 0 occurrences:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/rKSEEwxbNzdFs9t0yyxN/492605a8-3a23-459d-80a6-4f818ac8ef4d.png)

