### PR TITLE
[dev-overlay] allow force hide logo

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/next-logo.tsx
@@ -97,8 +97,8 @@ export const NextLogo = forwardRef(function NextLogo(
         {
           '--size': SIZE,
           '--duration-short': `${SHORT_DURATION_MS}ms`,
-          // if the indicator is disabled and there are no errors, hide the badge
-          display: disabled && !hasError ? 'none' : 'block',
+          // if the indicator is disabled, hide the badge
+          display: disabled ? 'none' : 'block',
         } as React.CSSProperties
       }
     >

--- a/test/development/client-dev-overlay/index.test.ts
+++ b/test/development/client-dev-overlay/index.test.ts
@@ -74,21 +74,7 @@ describe('client-dev-overlay', () => {
     )
   })
 
-  it('should keep the error indicator visible when there are errors', async () => {
-    await getMinimizeButton().click()
-    await getPopover().click()
-    await getPreferencesButton().click()
-    await getHideButton().click()
-
-    await retry(async () => {
-      const display = await browser.eval(
-        `getComputedStyle(document.querySelector('nextjs-portal').shadowRoot.querySelector('${selectors.indicator}')).display`
-      )
-      expect(display).toBe('block')
-    })
-  })
-
-  it('should be possible to hide the minimized overlay when there are no errors', async () => {
+  it('should be possible to hide the minimized overlay', async () => {
     const originalContent = await next.readFile('pages/index.js')
     try {
       await next.patchFile('pages/index.js', (content) => {


### PR DESCRIPTION
### What

When you force hide the indicator in the preference panel, logo should also be hidden no matter if there're errors.
This will allow you even hide it for build error, but since it's only in a session, it can still be recovered in another session.



https://github.com/user-attachments/assets/2322d93c-6d9d-48b1-a0b5-8ae4a90d30f7



