### PR TITLE
[dev-overlay] rephrase docs button title as link to related docs

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-toolbar/docs-link-button.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-toolbar/docs-link-button.tsx
@@ -33,8 +33,8 @@ export function DocsLinkButton({ errorMessage }: { errorMessage: string }) {
   if (!docsURL) {
     return (
       <button
-        title="No related Next.js docs found"
-        aria-label="No related Next.js docs found"
+        title="No related documentation found"
+        aria-label="No related documentation found"
         className="docs-link-button"
         disabled
       >
@@ -49,8 +49,8 @@ export function DocsLinkButton({ errorMessage }: { errorMessage: string }) {
 
   return (
     <a
-      title="Go to related Next.js docs"
-      aria-label="Go to related Next.js docs"
+      title="Go to related documentation"
+      aria-label="Go to related documentation"
       className="docs-link-button"
       href={docsURL}
       target="_blank"


### PR DESCRIPTION
### Why?

Since the docs button can link to related React docs, rephrase the title to "related documentation" instead of "related Next.js docs".