### PR TITLE
Update more global turbo CLI usage

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -304,7 +304,11 @@ jobs:
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
-      - run: corepack enable
+
+      - name: Setup corepack
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
 
       # we always want to run this to set environment variables
       - name: Install Rust
@@ -334,7 +338,7 @@ jobs:
       # issues with turbo caching
       - name: pull build cache
         if: ${{ matrix.settings.docker }}
-        run: npm i -g turbo@${{ env.TURBO_VERSION }} && node ./scripts/pull-turbo-cache.js ${{ matrix.settings.target }}
+        run: TURBO_VERSION=${TURBO_VERSION} node ./scripts/pull-turbo-cache.js ${{ matrix.settings.target }}
 
       - name: check build exists
         if: ${{ matrix.settings.docker }}
@@ -422,8 +426,6 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           targets: wasm32-unknown-unknown
-
-      - run: npm i -g turbo@${{ env.TURBO_VERSION }}
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/scripts/pull-turbo-cache.js
+++ b/scripts/pull-turbo-cache.js
@@ -7,11 +7,12 @@ const { spawn } = require('child_process')
   const target = process.argv[process.argv.length - 1]
 
   let turboResult = ''
+  const turboCommand = `pnpm dlx turbo@${process.env.TURBO_VERSION || 'latest'}`
 
   await new Promise((resolve, reject) => {
     const child = spawn(
       '/bin/bash',
-      ['-c', `pnpm turbo run cache-build-native --dry=json -- ${target}`],
+      ['-c', `${turboCommand} run cache-build-native --dry=json -- ${target}`],
       {
         stdio: 'pipe',
       }
@@ -51,7 +52,7 @@ const { spawn } = require('child_process')
     await new Promise((resolve, reject) => {
       const child = spawn(
         '/bin/bash',
-        ['-c', `pnpm turbo run cache-build-native -- ${target}`],
+        ['-c', `${turboCommand} run cache-build-native -- ${target}`],
         {
           stdio: 'inherit',
         }


### PR DESCRIPTION
Continues https://github.com/vercel/next.js/pull/76532 as it seems to be alleviating the `npm` failures so replaces some more usage of global `npm` installing the turbo CLI.

x-ref: https://github.com/vercel/next.js/actions/runs/13554859494/job/37886841090#step:15:25