### PR TITLE
Don’t use native built-ins for additional bundler

### DIFF
--- a/.github/workflows/rspack-nextjs-build-integration-tests.yml
+++ b/.github/workflows/rspack-nextjs-build-integration-tests.yml
@@ -14,11 +14,7 @@ jobs:
       name: rspack-production
       test_type: production
       run_before_test: |
-        export NEXT_RSPACK=1 \
-          NEXT_TEST_USE_RSPACK=1 \
-          BUILTIN_FLIGHT_CLIENT_ENTRY_PLUGIN=1 \
-          BUILTIN_APP_LOADER=1 \
-          BUILTIN_SWC_LOADER=1
+        export NEXT_RSPACK=1 NEXT_TEST_USE_RSPACK=1 \
       # Failing tests take longer (due to timeouts and retries). Since we have
       # many failing tests, we need smaller groups and longer timeouts, in case
       # a group gets stuck with a cluster of failing tests.

--- a/.github/workflows/rspack-nextjs-dev-integration-tests.yml
+++ b/.github/workflows/rspack-nextjs-dev-integration-tests.yml
@@ -14,11 +14,7 @@ jobs:
       name: rspack-development
       test_type: development
       run_before_test: |
-        export NEXT_RSPACK=1 \
-          NEXT_TEST_USE_RSPACK=1 \
-          BUILTIN_FLIGHT_CLIENT_ENTRY_PLUGIN=1 \
-          BUILTIN_APP_LOADER=1 \
-          BUILTIN_SWC_LOADER=1
+        export NEXT_RSPACK=1 NEXT_TEST_USE_RSPACK=1
       # Failing tests take longer (due to timeouts and retries). Since we have
       # many failing tests, we need smaller groups and longer timeouts, in case
       # a group gets stuck with a cluster of failing tests.

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "storybook": "turbo run storybook",
     "build-storybook": "turbo run build-storybook",
     "test-storybook": "turbo run test-storybook",
-    "with-rspack": "cross-env NEXT_RSPACK=1 NEXT_TEST_USE_RSPACK=1 BUILTIN_FLIGHT_CLIENT_ENTRY_PLUGIN=1 BUILTIN_APP_LOADER=1 BUILTIN_SWC_LOADER=1"
+    "with-rspack": "cross-env NEXT_RSPACK=1 NEXT_TEST_USE_RSPACK=1"
   },
   "devDependencies": {
     "@actions/core": "1.10.1",

--- a/packages/next-plugin-rspack/index.js
+++ b/packages/next-plugin-rspack/index.js
@@ -1,7 +1,5 @@
 module.exports = function withRspack(config) {
   process.env.NEXT_RSPACK = 'true'
-  process.env.BUILTIN_FLIGHT_CLIENT_ENTRY_PLUGIN = 'true'
-  process.env.BUILTIN_APP_LOADER = 'true'
-  process.env.BUILTIN_SWC_LOADER = 'true'
+  process.env.RSPACK_CONFIG_VALIDATE = 'loose-silent'
   return config
 }

--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -195,9 +195,7 @@ async function createNextInstall({
         // This is what the @next/plugin-rspack plugin does.
         // TODO: Load the plugin properly during test
         process.env.NEXT_RSPACK = 'true'
-        process.env.BUILTIN_FLIGHT_CLIENT_ENTRY_PLUGIN = 'true'
-        process.env.BUILTIN_APP_LOADER = 'true'
-        process.env.BUILTIN_SWC_LOADER = 'true'
+        process.env.RSPACK_CONFIG_VALIDATE = 'loose-silent'
       }
 
       return {


### PR DESCRIPTION
This opts us out of using the native built-in plugins for Rspack for now.

The existing swc plugin we use for webpack does additional work beyond just swc transformation, including validating RSC components to make sure they don’t use React APIs unavailable in that context.

In total, the native plugins result in a less than 20% performance gain which, while significant, isn’t necessary as we focus on correctness for now.

If we decide the maintenance cost of maintaining multiple plugins in parity is worth the performance gain in the future, we can selectively re-enable some or all of these plugins.

Test Plan: `pnpm test-dev-rspack test/development/acceptance/server-component-compiler-errors-in-pages.test.ts` no longer fails by missing the invalid React api messages.


Closes PACK-4046