### PR TITLE
perf: Reduce stack size

### DIFF
--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -172,11 +172,6 @@ export const lockfilePatchPromise: { cur?: Promise<void> } = {}
 export async function loadBindings(
   useWasmBinary: boolean = false
 ): Promise<Binding> {
-  // Increase Rust stack size as some npm packages being compiled need more than the default.
-  if (!process.env.RUST_MIN_STACK) {
-    process.env.RUST_MIN_STACK = '8388608'
-  }
-
   if (pendingBindings) {
     return pendingBindings
   }


### PR DESCRIPTION
### What?

Reduce the default stack size from 8MB to the OS default.

### Why?

8MB is too much for some of threads like tokio worker threads for blocking syscall APIs.

Closes PACK-4049