### PR TITLE
chore(cna): fix theme extend for tailwind v4

### DIFF
--- a/packages/create-next-app/templates/app-tw/js/app/globals.css
+++ b/packages/create-next-app/templates/app-tw/js/app/globals.css
@@ -1,13 +1,15 @@
 @import "tailwindcss";
 
-@theme {
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
 :root {
   --background: #ffffff;
   --foreground: #171717;
+}
+
+@theme {
+  --color-background: #ffffff;
+  --color-foreground: #171717;
+  --font-sans: var(--font-geist-sans);
+  --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -18,7 +20,7 @@
 }
 
 body {
-  color: var(--foreground);
   background: var(--background);
+  color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }

--- a/packages/create-next-app/templates/app-tw/js/app/globals.css
+++ b/packages/create-next-app/templates/app-tw/js/app/globals.css
@@ -6,8 +6,8 @@
 }
 
 @theme {
-  --color-background: #ffffff;
-  --color-foreground: #171717;
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }

--- a/packages/create-next-app/templates/app-tw/js/app/globals.css
+++ b/packages/create-next-app/templates/app-tw/js/app/globals.css
@@ -5,7 +5,7 @@
   --foreground: #171717;
 }
 
-@theme {
+@theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);

--- a/packages/create-next-app/templates/app-tw/ts/app/globals.css
+++ b/packages/create-next-app/templates/app-tw/ts/app/globals.css
@@ -1,13 +1,15 @@
 @import "tailwindcss";
 
-@theme {
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
 :root {
   --background: #ffffff;
   --foreground: #171717;
+}
+
+@theme {
+  --color-background: #ffffff;
+  --color-foreground: #171717;
+  --font-sans: var(--font-geist-sans);
+  --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -18,7 +20,7 @@
 }
 
 body {
-  color: var(--foreground);
   background: var(--background);
+  color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }

--- a/packages/create-next-app/templates/app-tw/ts/app/globals.css
+++ b/packages/create-next-app/templates/app-tw/ts/app/globals.css
@@ -6,8 +6,8 @@
 }
 
 @theme {
-  --color-background: #ffffff;
-  --color-foreground: #171717;
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }

--- a/packages/create-next-app/templates/app-tw/ts/app/globals.css
+++ b/packages/create-next-app/templates/app-tw/ts/app/globals.css
@@ -5,7 +5,7 @@
   --foreground: #171717;
 }
 
-@theme {
+@theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);

--- a/packages/create-next-app/templates/default-tw/js/styles/globals.css
+++ b/packages/create-next-app/templates/default-tw/js/styles/globals.css
@@ -1,13 +1,15 @@
 @import "tailwindcss";
 
-@theme {
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
 :root {
   --background: #ffffff;
   --foreground: #171717;
+}
+
+@theme {
+  --color-background: #ffffff;
+  --color-foreground: #171717;
+  --font-sans: var(--font-geist-sans);
+  --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -18,7 +20,7 @@
 }
 
 body {
-  color: var(--foreground);
   background: var(--background);
+  color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }

--- a/packages/create-next-app/templates/default-tw/js/styles/globals.css
+++ b/packages/create-next-app/templates/default-tw/js/styles/globals.css
@@ -6,8 +6,8 @@
 }
 
 @theme {
-  --color-background: #ffffff;
-  --color-foreground: #171717;
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }

--- a/packages/create-next-app/templates/default-tw/js/styles/globals.css
+++ b/packages/create-next-app/templates/default-tw/js/styles/globals.css
@@ -5,7 +5,7 @@
   --foreground: #171717;
 }
 
-@theme {
+@theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);

--- a/packages/create-next-app/templates/default-tw/ts/styles/globals.css
+++ b/packages/create-next-app/templates/default-tw/ts/styles/globals.css
@@ -1,13 +1,15 @@
 @import "tailwindcss";
 
-@theme {
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
 :root {
   --background: #ffffff;
   --foreground: #171717;
+}
+
+@theme {
+  --color-background: #ffffff;
+  --color-foreground: #171717;
+  --font-sans: var(--font-geist-sans);
+  --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -18,7 +20,7 @@
 }
 
 body {
-  color: var(--foreground);
   background: var(--background);
+  color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }

--- a/packages/create-next-app/templates/default-tw/ts/styles/globals.css
+++ b/packages/create-next-app/templates/default-tw/ts/styles/globals.css
@@ -6,8 +6,8 @@
 }
 
 @theme {
-  --color-background: #ffffff;
-  --color-foreground: #171717;
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }

--- a/packages/create-next-app/templates/default-tw/ts/styles/globals.css
+++ b/packages/create-next-app/templates/default-tw/ts/styles/globals.css
@@ -5,7 +5,7 @@
   --foreground: #171717;
 }
 
-@theme {
+@theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);


### PR DESCRIPTION
## Why?

We are not extending the tailwind theme for `--color-background` and `--color-foreground`.

(Before)

https://github.com/user-attachments/assets/d336dab3-a00f-46cb-9587-055a6c5272fa

(After)


https://github.com/user-attachments/assets/123e829d-aa7e-4b57-aa21-261fc05350f8

Follow-up fix for https://github.com/vercel/next.js/pull/75407.