### PR TITLE
[dev-overlay] change css var for terminal

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/styles/colors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/styles/colors.tsx
@@ -117,9 +117,9 @@ export function Colors() {
           /* cyan: keyword */
           --color-ansi-cyan: var(--color-syntax-keyword);
           /* yellow: capitalized, jsxIdentifier, punctuation */
-          --color-ansi-yellow: var(--color-syntax-punctuation);
+          --color-ansi-yellow: var(--color-syntax-function);
           /* magenta: number, regex */
-          --color-ansi-magenta: var(--color-syntax-number);
+          --color-ansi-magenta: var(--color-syntax-keyword);
           /* green: string */
           --color-ansi-green: var(--color-syntax-string);
           /* gray (bright black): comment, gutter */


### PR DESCRIPTION
### Why?

`--color-ansi-magenta` was mapped to `--color-syntax-number` which didn't existed. Replaced with `keyword`.
Also, the JSX Identifiers were mapped for `--color-syntax-punctuation`, but rather `--color-syntax-function` is more appropriate.

![CleanShot 2025-02-27 at 17 14 26@2x](https://github.com/user-attachments/assets/2d143632-95ed-4e8c-b5db-e901f6e8a162)

| Before | After |
|--------|--------|
| ![CleanShot 2025-02-27 at 17 13 04@2x](https://github.com/user-attachments/assets/ba135c98-a8f5-4974-99ff-8727d4068900) | ![CleanShot 2025-02-27 at 17 08 39@2x](https://github.com/user-attachments/assets/b21a5fc1-0f8d-41ba-9e32-ae18a6045764) |