### PR TITLE
Turbopack: prevent panic in swc issue emitter

### DIFF
--- a/turbopack/crates/turbopack-core/src/issue/analyze.rs
+++ b/turbopack/crates/turbopack-core/src/issue/analyze.rs
@@ -23,7 +23,7 @@ pub struct AnalyzeIssue {
 impl AnalyzeIssue {
     #[turbo_tasks::function]
     pub fn new(
-        severity: ResolvedVc<IssueSeverity>,
+        severity: IssueSeverity,
         source_ident: ResolvedVc<AssetIdent>,
         title: ResolvedVc<RcStr>,
         message: ResolvedVc<StyledString>,
@@ -31,7 +31,7 @@ impl AnalyzeIssue {
         source: Option<IssueSource>,
     ) -> Vc<Self> {
         Self {
-            severity,
+            severity: severity.resolved_cell(),
             source_ident,
             title,
             message,

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 
 #[turbo_tasks::value(shared)]
-#[derive(PartialOrd, Ord, Copy, Clone, Hash, Debug, DeterministicHash)]
+#[derive(PartialOrd, Ord, Copy, Clone, Hash, Debug, DeterministicHash, TaskInput)]
 #[serde(rename_all = "camelCase")]
 pub enum IssueSeverity {
     Bug,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -413,7 +413,7 @@ pub async fn expand_star_exports(
 
 async fn emit_star_exports_issue(source_ident: Vc<AssetIdent>, message: RcStr) -> Result<()> {
     AnalyzeIssue::new(
-        IssueSeverity::Warning.cell(),
+        IssueSeverity::Warning,
         source_ident,
         Vc::cell("unexpected export *".into()),
         StyledString::Text(message).cell(),

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -939,7 +939,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
             analysis.set_async_module(async_module);
         } else if let Some(span) = top_level_await_span {
             AnalyzeIssue::new(
-                IssueSeverity::Error.cell(),
+                IssueSeverity::Error,
                 source.ident(),
                 Vc::cell("unexpected top level await".into()),
                 StyledString::Text("top level await is only supported in ESM modules.".into())

--- a/turbopack/crates/turbopack-swc-utils/src/emitter.rs
+++ b/turbopack/crates/turbopack-swc-utils/src/emitter.rs
@@ -27,19 +27,46 @@ impl IssueCollector {
         };
 
         for issue in issues {
-            issue.to_resolved().await?.emit();
+            AnalyzeIssue::new(
+                issue.severity,
+                issue.source.ident(),
+                Vc::cell(issue.title),
+                issue.message.cell(),
+                issue.code,
+                issue.issue_source,
+            )
+            .to_resolved()
+            .await?
+            .emit();
         }
         Ok(())
     }
 
     pub fn last_emitted_issue(&self) -> Option<Vc<AnalyzeIssue>> {
         let inner = self.inner.lock();
-        inner.emitted_issues.last().copied()
+        inner.emitted_issues.last().map(|issue| {
+            AnalyzeIssue::new(
+                issue.severity,
+                issue.source.ident(),
+                Vc::cell(issue.title.clone()),
+                issue.message.clone().cell(),
+                issue.code.clone(),
+                issue.issue_source.clone(),
+            )
+        })
     }
 }
 
 struct IssueCollectorInner {
-    emitted_issues: Vec<Vc<AnalyzeIssue>>,
+    emitted_issues: Vec<PlainAnalyzeIssue>,
+}
+struct PlainAnalyzeIssue {
+    severity: IssueSeverity,
+    source: ResolvedVc<Box<dyn Source>>,
+    title: RcStr,
+    message: StyledString,
+    code: Option<RcStr>,
+    issue_source: Option<IssueSource>,
 }
 
 pub struct IssueEmitter {
@@ -88,7 +115,7 @@ impl Emitter for IssueEmitter {
             .as_ref()
             .is_some_and(|d| matches!(d, DiagnosticId::Lint(_)));
 
-        let severity = (if is_lint {
+        let severity = if is_lint {
             IssueSeverity::Suggestion
         } else {
             match level {
@@ -101,8 +128,7 @@ impl Emitter for IssueEmitter {
                 Level::Cancelled => IssueSeverity::Error,
                 Level::FailureNote => IssueSeverity::Note,
             }
-        })
-        .resolved_cell();
+        };
 
         let title;
         if let Some(t) = self.title.as_ref() {
@@ -118,14 +144,16 @@ impl Emitter for IssueEmitter {
         });
         // TODO add other primary and secondary spans with labels as sub_issues
 
-        let issue = AnalyzeIssue::new(
-            *severity,
-            self.source.ident(),
-            Vc::cell(title),
-            StyledString::Text(message.into()).cell(),
+        // This can be invoked by swc on different threads, so we cannot call any turbo-tasks or
+        // create cells here.
+        let issue = PlainAnalyzeIssue {
+            severity,
+            source: self.source,
+            title,
+            message: StyledString::Text(message.into()),
             code,
-            source,
-        );
+            issue_source: source,
+        };
 
         let mut inner = self.inner.lock();
         inner.emitted_issues.push(issue);


### PR DESCRIPTION
turbo-tasks has some `task_local!` ([from tokio](https://github.com/tokio-rs/tokio/discussions/6111)) state for getting the current task
so if you execute `.resolved_cell()` while not in that same tokio future, then it will be gone

Looks like https://github.com/vercel/next.js/pull/76414 can cause the issues to be emitted on different threads,  which breaks that thread-local

Alternative solution to https://github.com/vercel/next.js/pull/76596, which will take a bit more time because of some swc changes breaking other things



Closes PACK-4043