### PR TITLE
Omit unused segment cache client modules from main chunk

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -28,11 +28,10 @@ import {
 } from '../prefetch-cache-utils'
 import { clearCacheNodeDataForSegmentPath } from '../clear-cache-node-data-for-segment-path'
 import { handleAliasedPrefetchEntry } from '../aliased-prefetch-navigations'
-import {
-  navigate as navigateUsingSegmentCache,
-  NavigationResultTag,
-  type NavigationResult,
-} from '../../segment-cache/navigation'
+
+const segmentCacheNavigation = process.env.__NEXT_CLIENT_SEGMENT_CACHE
+  ? (require('../../segment-cache/navigation') as typeof import('../../segment-cache/navigation'))
+  : undefined
 
 export function handleExternalUrl(
   state: ReadonlyReducerState,
@@ -100,50 +99,6 @@ function triggerLazyFetchForLeafSegments(
   return appliedPatch
 }
 
-function handleNavigationResult(
-  state: ReadonlyReducerState,
-  mutable: Mutable,
-  pendingPush: boolean,
-  result: NavigationResult
-): ReducerState {
-  switch (result.tag) {
-    case NavigationResultTag.MPA: {
-      // Perform an MPA navigation.
-      const newUrl = result.data
-      return handleExternalUrl(state, mutable, newUrl, pendingPush)
-    }
-    case NavigationResultTag.NoOp:
-      // The server responded with no change to the current page.
-      return handleMutable(state, mutable)
-    case NavigationResultTag.Success: {
-      // Received a new result.
-      mutable.cache = result.data.cacheNode
-      mutable.patchedTree = result.data.flightRouterState
-      mutable.canonicalUrl = result.data.canonicalUrl
-      mutable.scrollableSegments = result.data.scrollableSegments
-      mutable.shouldScroll = result.data.shouldScroll
-      // TODO: Not yet implemented
-      // mutable.hashFragment = hash
-      return handleMutable(state, mutable)
-    }
-    case NavigationResultTag.Async: {
-      return result.data.then(
-        (asyncResult) =>
-          handleNavigationResult(state, mutable, pendingPush, asyncResult),
-        // If the navigation failed, return the current state.
-        // TODO: This matches the current behavior but we need to do something
-        // better here if the network fails.
-        () => {
-          return state
-        }
-      )
-    }
-    default:
-      const _exhaustiveCheck: never = result
-      return state
-  }
-}
-
 export function navigateReducer(
   state: ReadonlyReducerState,
   action: NavigateAction
@@ -170,7 +125,7 @@ export function navigateReducer(
     return handleExternalUrl(state, mutable, href, pendingPush)
   }
 
-  if (process.env.__NEXT_CLIENT_SEGMENT_CACHE) {
+  if (segmentCacheNavigation) {
     // (Very Early Experimental Feature) Segment Cache
     //
     // Bypass the normal prefetch cache and use the new per-segment cache
@@ -182,14 +137,20 @@ export function navigateReducer(
     // TODO: Currently this always returns an async result, but in the future
     // it will return a sync result if the navigation was prefetched. Hence
     // a result type that's more complicated than you might expect.
-    const result = navigateUsingSegmentCache(
+    const result = segmentCacheNavigation.navigate(
       url,
       state.cache,
       state.tree,
       state.nextUrl,
       shouldScroll
     )
-    return handleNavigationResult(state, mutable, pendingPush, result)
+
+    return segmentCacheNavigation.handleNavigationResult(
+      state,
+      mutable,
+      pendingPush,
+      result
+    )
   }
 
   const prefetchValues = getOrCreatePrefetchCacheEntry({

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -16,7 +16,12 @@ import { createEmptyCacheNode } from '../../app-router'
 import { handleSegmentMismatch } from '../handle-segment-mismatch'
 import { hasInterceptionRouteInCurrentTree } from './has-interception-route-in-current-tree'
 import { refreshInactiveParallelSegments } from '../refetch-inactive-parallel-segments'
-import { revalidateEntireCache } from '../../segment-cache/cache'
+
+const revalidateEntireCache = process.env.__NEXT_CLIENT_SEGMENT_CACHE
+  ? (
+      require('../../segment-cache/cache') as typeof import('../../segment-cache/cache')
+    ).revalidateEntireCache
+  : undefined
 
 export function refreshReducer(
   state: ReadonlyReducerState,
@@ -122,7 +127,7 @@ export function refreshReducer(
             head,
             undefined
           )
-          if (process.env.__NEXT_CLIENT_SEGMENT_CACHE) {
+          if (revalidateEntireCache) {
             revalidateEntireCache(state.nextUrl, newTree)
           } else {
             mutable.prefetchCache = new Map()

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -56,7 +56,6 @@ import {
   extractInfoFromServerReferenceId,
   omitUnusedArgs,
 } from '../../../../shared/lib/server-reference-info'
-import { revalidateEntireCache } from '../../segment-cache/cache'
 
 type FetchServerActionResult = {
   redirectLocation: URL | undefined
@@ -70,6 +69,12 @@ type FetchServerActionResult = {
     paths: string[]
   }
 }
+
+const revalidateEntireCache = process.env.__NEXT_CLIENT_SEGMENT_CACHE
+  ? (
+      require('../../segment-cache/cache') as typeof import('../../segment-cache/cache')
+    ).revalidateEntireCache
+  : undefined
 
 async function fetchServerAction(
   state: ReadonlyReducerState,
@@ -339,7 +344,7 @@ export function serverActionReducer(
           )
 
           mutable.cache = cache
-          if (process.env.__NEXT_CLIENT_SEGMENT_CACHE) {
+          if (revalidateEntireCache) {
             revalidateEntireCache(state.nextUrl, newTree)
           } else {
             mutable.prefetchCache = new Map()

--- a/test/e2e/app-dir/hello-world/next.config.js
+++ b/test/e2e/app-dir/hello-world/next.config.js
@@ -1,6 +1,8 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {}
+const nextConfig = {
+  productionBrowserSourceMaps: true,
+}
 
 module.exports = nextConfig


### PR DESCRIPTION
If `experimental.clientSegmentCache` is not enabled, we don't need to bundle the segment cache modules into the main client chunk. This reduces the main chunk's size for a hello world app from 59.4 kB to 53.1 kB.