### PR TITLE
refactor: remove unused variable in externals handling

### DIFF
--- a/packages/next/src/build/handle-externals.ts
+++ b/packages/next/src/build/handle-externals.ts
@@ -48,7 +48,6 @@ export async function resolveExternal(
   context: string,
   request: string,
   isEsmRequested: boolean,
-  _optOutBundlingPackages: string[],
   getResolve: (
     options: ResolveOptions
   ) => (
@@ -133,13 +132,11 @@ export async function resolveExternal(
 
 export function makeExternalHandler({
   config,
-  optOutBundlingPackages,
   optOutBundlingPackageRegex,
   transpiledPackages,
   dir,
 }: {
   config: NextConfigComplete
-  optOutBundlingPackages: string[]
   optOutBundlingPackageRegex: RegExp
   transpiledPackages: string[]
   dir: string
@@ -266,7 +263,6 @@ export function makeExternalHandler({
       context,
       request,
       isEsmRequested,
-      optOutBundlingPackages,
       getResolve,
       isLocal ? resolveNextExternal : undefined
     )
@@ -334,7 +330,6 @@ export function makeExternalHandler({
           context,
           pkg + '/package.json',
           isEsmRequested,
-          optOutBundlingPackages,
           getResolve,
           isLocal ? resolveNextExternal : undefined
         )

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -863,7 +863,6 @@ export default async function getBaseWebpackConfig(
 
   const handleExternals = makeExternalHandler({
     config,
-    optOutBundlingPackages,
     optOutBundlingPackageRegex,
     transpiledPackages: finalTranspilePackages,
     dir,
@@ -1927,7 +1926,6 @@ export default async function getBaseWebpackConfig(
             esmExternals: config.experimental.esmExternals,
             outputFileTracingRoot: config.outputFileTracingRoot,
             appDirEnabled: hasAppDir,
-            optOutBundlingPackages,
             traceIgnores: [],
             compilerType,
           }

--- a/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -131,7 +131,6 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
   private rootDir: string
   private appDir: string | undefined
   private pagesDir: string | undefined
-  private optOutBundlingPackages: string[]
   private appDirEnabled?: boolean
   private tracingRoot: string
   private entryTraces: Map<string, Map<string, { bundled: boolean }>>
@@ -144,7 +143,6 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
     appDir,
     pagesDir,
     compilerType,
-    optOutBundlingPackages,
     appDirEnabled,
     traceIgnores,
     esmExternals,
@@ -154,7 +152,6 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
     compilerType: CompilerNameValues
     appDir: string | undefined
     pagesDir: string | undefined
-    optOutBundlingPackages: string[]
     appDirEnabled?: boolean
     traceIgnores?: string[]
     outputFileTracingRoot?: string
@@ -168,7 +165,6 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
     this.appDirEnabled = appDirEnabled
     this.traceIgnores = traceIgnores || []
     this.tracingRoot = outputFileTracingRoot || rootDir
-    this.optOutBundlingPackages = optOutBundlingPackages
     this.compilerType = compilerType
   }
 
@@ -786,7 +782,6 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
             context,
             request,
             isEsmRequested,
-            this.optOutBundlingPackages,
             (options) => (_: string, resRequest: string) => {
               return getResolve(options)(parent, resRequest, job)
             },


### PR DESCRIPTION
### What

`_optOutBundlingPackages` was not used as there's already a optOutBundlingPackagesRegex, removing it from the `handleExternals`