### PR TITLE
Fix `octokit.rest.issues.addLabels` call

### DIFF
--- a/scripts/automated-update-workflow.js
+++ b/scripts/automated-update-workflow.js
@@ -69,7 +69,7 @@ async function main() {
   await octokit.rest.issues.addLabels({
     owner,
     repo,
-    issue_number: pullRequest.number,
+    issue_number: pullRequest.data.number,
     labels: ['run-react-18-tests'],
   })
 


### PR DESCRIPTION
Follow-up for #76544.

[Failed worflow run](https://github.com/vercel/next.js/actions/runs/13560755436/job/37903278074)

The PR number was incorrectly retrieved from the `octokit.rest.pulls.create` response.