### PR TITLE
15.2: Add version history for `devIndicators` and note on deprecated options

### DIFF
--- a/docs/01-app/04-api-reference/05-config/01-next-config-js/devIndicators.mdx
+++ b/docs/01-app/04-api-reference/05-config/01-next-config-js/devIndicators.mdx
@@ -49,3 +49,12 @@ Check your route for any of these conditions, and if you are not able to statica
 When exporting [`getServerSideProps`](/docs/pages/building-your-application/data-fetching/get-server-side-props) or [`getInitialProps`](/docs/pages/api-reference/functions/get-initial-props) from a page, it will be marked as dynamic.
 
 </PagesOnly>
+
+
+## Version History
+
+| Version   | Changes                                                                                       |
+| --------- | --------------------------------------------------------------------------------------------- |
+| `v15.2.0` |  Improved on-screen indicator with new `position` option. `appIsrStatus`, `buildActivity`, and `buildActivityPosition` options have been deprecated.                                                       |
+| `v15.0.0` |     Static on-screen indicator added with `appIsrStatus` option. |
+

--- a/docs/01-app/04-api-reference/05-config/01-next-config-js/devIndicators.mdx
+++ b/docs/01-app/04-api-reference/05-config/01-next-config-js/devIndicators.mdx
@@ -50,11 +50,9 @@ When exporting [`getServerSideProps`](/docs/pages/building-your-application/data
 
 </PagesOnly>
 
-
 ## Version History
 
-| Version   | Changes                                                                                       |
-| --------- | --------------------------------------------------------------------------------------------- |
-| `v15.2.0` |  Improved on-screen indicator with new `position` option. `appIsrStatus`, `buildActivity`, and `buildActivityPosition` options have been deprecated.                                                       |
-| `v15.0.0` |     Static on-screen indicator added with `appIsrStatus` option. |
-
+| Version   | Changes                                                                                                                                             |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `v15.2.0` | Improved on-screen indicator with new `position` option. `appIsrStatus`, `buildActivity`, and `buildActivityPosition` options have been deprecated. |
+| `v15.0.0` | Static on-screen indicator added with `appIsrStatus` option.                                                                                        |


### PR DESCRIPTION
We added a new option to `devIndicators` (`position`) and removed the previous options from the docs. This PR adds a version history with a note about the deprecated options. 