### PR TITLE
Pin pnpm in e2e tests

### DIFF
--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -153,6 +153,7 @@ async function createNextInstall({
             scripts,
             dependencies: combinedDependencies,
             private: true,
+            packageManager: 'pnpm@9.6.0',
             // Add resolutions if provided.
             ...(resolutions ? { resolutions } : {}),
           },


### PR DESCRIPTION
Some CI machines appear to use pnpm 10 as the global (default) version. This is fine for the Next.js repo itself, but the e2e isolated apps don't have a pinned `packageManager` package.json field

For example
https://github.com/vercel/next.js/actions/runs/13567087719/job/37922616070?pr=76601
vs its rerun:
https://github.com/vercel/next.js/actions/runs/13567087719/job/37926653739pr=76601

Closes PACK-4345