### PR TITLE
add title prop to YouTubeEmbed

### DIFF
--- a/docs/01-app/03-building-your-application/06-optimizing/12-third-party-libraries.mdx
+++ b/docs/01-app/03-building-your-application/06-optimizing/12-third-party-libraries.mdx
@@ -461,3 +461,4 @@ export default function Page() {
 | `playlabel` | Optional | A visually hidden label for the play button for accessibility.                                                                                                                                               |
 | `params`    | Optional | The video player params defined [here](https://developers.google.com/youtube/player_parameters#Parameters). <br/> Params are passed as a query param string. <br/> Eg: `params="controls=0&start=10&end=30"` |
 | `style`     | Optional | Used to apply styles to the video container.                                                                                                                                                                 |
+| `title`     | Optional | A title that will be displayed prior to loading the full embed.                                                                                                                                              |

--- a/packages/third-parties/src/types/google.ts
+++ b/packages/third-parties/src/types/google.ts
@@ -53,4 +53,5 @@ export type YouTubeEmbed = {
   playlabel?: string
   params?: string
   style?: string
+  title?: string
 }


### PR DESCRIPTION
I noticed that `lite-youtube-embed` accepts a `title` attribute for [displaying a title prior to the full embed loading](https://github.com/paulirish/lite-youtube-embed?tab=readme-ov-file#add-a-video-title). Turns out the [`YouTubeEmbed`  component](https://nextjs.org/docs/app/building-your-application/optimizing/third-party-libraries#youtube-embed) already passes this prop through to `lite-youtube-embed`, as can be seen in this [code sandbox](https://codesandbox.io/p/devbox/dreamy-thompson-jqt53x?workspaceId=ws_8QXhR31pB5m8nXC5jK4XeY). The problem is that if you're using TypeScript, it'll complain about the `title` prop not existing so this PR adds the `title` prop to the corresponding type and updates the doc.
