### PR TITLE
Fix test after CI switched to pnpm 10

### DIFF
--- a/test/e2e/app-dir/turbopack-reports/turbopack-reports.test.ts
+++ b/test/e2e/app-dir/turbopack-reports/turbopack-reports.test.ts
@@ -6,6 +6,11 @@ describe('turbopack-reports', () => {
     dependencies: {
       sqlite3: '5.1.7',
     },
+    packageJson: {
+      pnpm: {
+        onlyBuiltDependencies: ['sqlite3'],
+      },
+    },
   })
 
   it('should render page importing sqlite3', async () => {

--- a/test/e2e/prerender-native-module.test.ts
+++ b/test/e2e/prerender-native-module.test.ts
@@ -22,6 +22,11 @@ describe('prerender native module', () => {
         sqlite: '4.0.22',
         sqlite3: '5.0.2',
       },
+      packageJson: {
+        pnpm: {
+          onlyBuiltDependencies: ['sqlite3'],
+        },
+      },
     })
   })
   afterAll(() => next.destroy())

--- a/test/production/sharp-basic/sharp-basic.test.ts
+++ b/test/production/sharp-basic/sharp-basic.test.ts
@@ -6,6 +6,11 @@ describe('sharp support with hasNextSupport', () => {
     dependencies: {
       sharp: 'latest',
     },
+    packageJson: {
+      pnpm: {
+        onlyBuiltDependencies: ['sqlite3'],
+      },
+    },
     env: {
       NOW_BUILDER: '1',
     },


### PR DESCRIPTION
The proper fix would be https://github.com/vercel/next.js/pull/76613, but I don't exactly know how to get `packageManager: "pnpm@9.6.0"` in all the right places.

---

Some CI machines appear to use pnpm 10 as the global (default) version. This is fine for the Next.js repo itself, but the e2e isolated apps don't have a pinned `packageManager` package.json field

For example
https://github.com/vercel/next.js/actions/runs/13567087719/job/37922616070?pr=76601
vs its rerun:
https://github.com/vercel/next.js/actions/runs/13567087719/job/37926653739pr=76601

Closes PACK-4045