### PR TITLE
Turbopack: dedupe middleware-manifest entries

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1125,7 +1125,7 @@ impl AppEndpoint {
         let mut server_assets = fxindexset![];
         let mut client_assets = fxindexset![];
         // assets to add to the middleware manifest (to be loaded in the edge runtime).
-        let mut middleware_assets = vec![];
+        let mut middleware_assets = fxindexset![];
 
         let runtime = app_entry.config.await?.runtime.unwrap_or_default();
 
@@ -1314,7 +1314,6 @@ impl AppEndpoint {
                 .values()
             {
                 let ssr_chunks = ssr_chunks.await?;
-
                 middleware_assets.extend(ssr_chunks);
             }
         }
@@ -1387,7 +1386,7 @@ impl AppEndpoint {
                 .await?;
             server_assets.insert(entry_manifest);
             if runtime == NextRuntime::Edge {
-                middleware_assets.push(entry_manifest);
+                middleware_assets.insert(entry_manifest);
             }
             client_reference_manifest = Some(entry_manifest);
 
@@ -1411,13 +1410,13 @@ impl AppEndpoint {
                 // global variables defined in these files
                 //
                 // they are created in `setup-dev-bundler.ts`
-                let mut file_paths_from_root = vec![
+                let mut file_paths_from_root = fxindexset![
                     "server/server-reference-manifest.js".into(),
                     "server/middleware-build-manifest.js".into(),
                     "server/next-font-manifest.js".into(),
                     "server/interception-route-rewrite-manifest.js".into(),
                 ];
-                let mut wasm_paths_from_root = vec![];
+                let mut wasm_paths_from_root = fxindexset![];
 
                 let node_root_value = node_root.await?;
 
@@ -1476,8 +1475,8 @@ impl AppEndpoint {
                         ..Default::default()
                     };
                     let edge_function_definition = EdgeFunctionDefinition {
-                        files: file_paths_from_root,
-                        wasm: wasm_paths_to_bindings(wasm_paths_from_root),
+                        files: file_paths_from_root.into_iter().collect(),
+                        wasm: wasm_paths_to_bindings(wasm_paths_from_root.into_iter().collect()),
                         assets: paths_to_bindings(all_assets),
                         name: app_entry.pathname.clone(),
                         page: app_entry.original_name.clone(),

--- a/crates/next-api/src/paths.rs
+++ b/crates/next-api/src/paths.rs
@@ -78,11 +78,11 @@ pub async fn all_paths_in_root(
 
 pub(crate) async fn get_paths_from_root(
     root: &FileSystemPath,
-    output_assets: &[ResolvedVc<Box<dyn OutputAsset>>],
+    output_assets: impl IntoIterator<Item = &ResolvedVc<Box<dyn OutputAsset>>>,
     filter: impl FnOnce(&str) -> bool + Copy,
 ) -> Result<Vec<RcStr>> {
     output_assets
-        .iter()
+        .into_iter()
         .map(move |&file| async move {
             let path = &*file.path().await?;
             let Some(relative) = root.get_path_to(path) else {
@@ -101,21 +101,21 @@ pub(crate) async fn get_paths_from_root(
 
 pub(crate) async fn get_js_paths_from_root(
     root: &FileSystemPath,
-    output_assets: &[ResolvedVc<Box<dyn OutputAsset>>],
+    output_assets: impl IntoIterator<Item = &ResolvedVc<Box<dyn OutputAsset>>>,
 ) -> Result<Vec<RcStr>> {
     get_paths_from_root(root, output_assets, |path| path.ends_with(".js")).await
 }
 
 pub(crate) async fn get_wasm_paths_from_root(
     root: &FileSystemPath,
-    output_assets: &[ResolvedVc<Box<dyn OutputAsset>>],
+    output_assets: impl IntoIterator<Item = &ResolvedVc<Box<dyn OutputAsset>>>,
 ) -> Result<Vec<RcStr>> {
     get_paths_from_root(root, output_assets, |path| path.ends_with(".wasm")).await
 }
 
 pub(crate) async fn get_asset_paths_from_root(
     root: &FileSystemPath,
-    output_assets: &[ResolvedVc<Box<dyn OutputAsset>>],
+    output_assets: impl IntoIterator<Item = &ResolvedVc<Box<dyn OutputAsset>>>,
 ) -> Result<Vec<RcStr>> {
     get_paths_from_root(root, output_assets, |path| {
         !path.ends_with(".js") && !path.ends_with(".map") && !path.ends_with(".wasm")
@@ -125,7 +125,7 @@ pub(crate) async fn get_asset_paths_from_root(
 
 pub(crate) async fn get_font_paths_from_root(
     root: &FileSystemPath,
-    output_assets: &[ResolvedVc<Box<dyn OutputAsset>>],
+    output_assets: impl IntoIterator<Item = &ResolvedVc<Box<dyn OutputAsset>>>,
 ) -> Result<Vec<RcStr>> {
     get_paths_from_root(root, output_assets, |path| {
         path.ends_with(".woff")


### PR DESCRIPTION
The main source was that we walked through all client references and added all shared chunks again for each client reference.

Closes PACK-4050