### PR TITLE
Turbopack: avoid celling source maps before minify

### DIFF
--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -19,7 +19,6 @@ use turbopack_core::{
     reference_type::{CssReferenceSubType, ReferenceType},
     resolve::{origin::ResolveOrigin, parse::Request},
     source::Source,
-    source_map::OptionStringifiedSourceMap,
 };
 use turbopack_ecmascript::{
     chunk::{
@@ -436,12 +435,7 @@ async fn generate_minimal_source_map(filename: String, source: String) -> Result
     }
     let sm: Arc<SourceMap> = Default::default();
     sm.new_source_file(FileName::Custom(filename).into(), source);
-    let map = generate_js_source_map(
-        sm,
-        mappings,
-        OptionStringifiedSourceMap::none().to_resolved().await?,
-    )
-    .await?;
+    let map = generate_js_source_map(sm, mappings, None).await?;
     Ok(map)
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -966,8 +966,12 @@ async fn gen_content_with_code_gens(
 
             let source_map = if generate_source_map {
                 Some(
-                    generate_js_source_map(source_map.clone(), mappings, original_source_map)
-                        .await?,
+                    generate_js_source_map(
+                        source_map.clone(),
+                        mappings,
+                        original_source_map.await?.as_ref(),
+                    )
+                    .await?,
                 )
             } else {
                 None

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -30,7 +30,7 @@ use turbopack_core::{
     error::PrettyPrintError,
     issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
     source::Source,
-    source_map::{utils::add_default_ignore_list, OptionStringifiedSourceMap},
+    source_map::utils::add_default_ignore_list,
     SOURCE_URL_PROTOCOL,
 };
 use turbopack_swc_utils::emitter::IssueEmitter;
@@ -77,9 +77,9 @@ impl PartialEq for ParseResult {
 pub async fn generate_js_source_map(
     files_map: Arc<swc_core::common::SourceMap>,
     mappings: Vec<(BytePos, LineCol)>,
-    original_source_map: ResolvedVc<OptionStringifiedSourceMap>,
+    original_source_map: Option<&Rope>,
 ) -> Result<Rope> {
-    let input_map = if let Some(original_source_map) = &*original_source_map.await? {
+    let input_map = if let Some(original_source_map) = original_source_map {
         Some(match sourcemap::decode(original_source_map.read())? {
             sourcemap::DecodedMap::Regular(source_map) => source_map,
             // swc only accepts flattened sourcemaps as input


### PR DESCRIPTION
### What?

Avoid using a turbo-tasks function for generating the input source map so the source map is not persistently stored in a cell.

Closes PACK-4053