### PR TITLE
[test] Remove `describeVariants` helper

### DIFF
--- a/test/development/app-dir/basic/basic.test.ts
+++ b/test/development/app-dir/basic/basic.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
-import { describeVariants as describe, waitFor } from 'next-test-utils'
+import { waitFor } from 'next-test-utils'
 import { createSandbox, waitForHydration } from 'development-sandbox'
 
-describe.each(['default', 'turbo'])('basic app-dir tests', () => {
+describe('basic app-dir tests', () => {
   const { next } = nextTestSetup({
     files: __dirname,
   })

--- a/test/development/app-dir/experimental-lightningcss/experimental-lightningcss.test.ts
+++ b/test/development/app-dir/experimental-lightningcss/experimental-lightningcss.test.ts
@@ -1,53 +1,39 @@
 import { nextTestSetup } from 'e2e-utils'
-import { describeVariants } from 'next-test-utils'
 
-describeVariants.each(['turbo'])('experimental-lightningcss', () => {
-  const { next } = nextTestSetup({
-    files: __dirname,
-  })
+describe('experimental-lightningcss with default mode', () => {
+  describe('in dev server', () => {
+    const { isTurbopack, next } = nextTestSetup({
+      files: __dirname,
+      dependencies: { lightningcss: '^1.23.0' },
+      packageJson: {
+        browserslist: ['chrome 100'],
+      },
+    })
 
-  it('should support css modules', async () => {
-    // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
-    const $ = await next.render$('/')
-    expect($('p').text()).toBe('hello world')
-    // swc_css does not include `-module` in the class name, while lightningcss does.
-    expect($('p').attr('class')).toBe(
-      'search-keyword style-module__hlQ3RG__blue'
-    )
-  })
-})
+    it('should support css modules', async () => {
+      // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
+      const $ = await next.render$('/')
+      expect($('p').text()).toBe('hello world')
 
-// lightningcss produces different class names in turbo mode
-describeVariants.each(['default'])(
-  'experimental-lightningcss with default mode',
-  () => {
-    describe('in dev server', () => {
-      const { next } = nextTestSetup({
-        files: __dirname,
-        dependencies: { lightningcss: '^1.23.0' },
-        packageJson: {
-          browserslist: ['chrome 100'],
-        },
-      })
-
-      it('should support css modules', async () => {
-        // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
-        const $ = await next.render$('/')
-        expect($('p').text()).toBe('hello world')
+      // lightningcss produces different class names in turbo mode
+      if (isTurbopack) {
+        // swc_css does not include `-module` in the class name, while lightningcss does.
+        expect($('p').attr('class')).toBe(
+          'search-keyword style-module__hlQ3RG__blue'
+        )
+      } else {
         // We remove hash from the class name in test mode using env var because it is not deterministic.
         expect($('p').attr('class')).toBe('search-keyword style-module__blue')
-      })
-
-      it('should support browserslist', async () => {
-        const $ = await next.browser('/')
-
-        expect(await $.elementByCss('.nested').text()).toBe(
-          'Red due to nesting'
-        )
-        expect(await $.elementByCss('.nested').getComputedCss('color')).toBe(
-          'rgb(255, 0, 0)'
-        )
-      })
+      }
     })
-  }
-)
+
+    it('should support browserslist', async () => {
+      const $ = await next.browser('/')
+
+      expect(await $.elementByCss('.nested').text()).toBe('Red due to nesting')
+      expect(await $.elementByCss('.nested').getComputedCss('color')).toBe(
+        'rgb(255, 0, 0)'
+      )
+    })
+  })
+})

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1520,28 +1520,6 @@ export function getUrlFromBackgroundImage(backgroundImage: string) {
   return matches
 }
 
-/**
- * For better editor support, pass in the variants this should run on (`default` and/or `turbo`) as cases.
- *
- * This is necessary if separate snapshots are needed for next.js with webpack vs turbopack.
- */
-export const describeVariants = {
-  each(variants: TestVariants[]) {
-    return (name: string, fn: (variants: TestVariants) => any) => {
-      if (
-        !Array.isArray(variants) ||
-        !variants.every((val) => typeof val === 'string')
-      ) {
-        throw new Error('variants need to be an array of strings')
-      }
-
-      for (const variant of variants) {
-        getSnapshotTestDescribe(variant).each([variant])(name, fn)
-      }
-    }
-  },
-}
-
 export const getTitle = (browser: BrowserInterface) =>
   browser.elementByCss('title').text()
 


### PR DESCRIPTION
This is rarely used now and not needed. For `toMatchSnapshot`, you can just use `toMatchSnapshot(isTurbopack ? 'turbo' : 'default')`. There are way more dimensions nowadays anyway so let's cut down on testing API surface when it only has one-off use cases.