### PR TITLE
Revert "Run nightly bundler integration tests also with React 18"

### DIFF
--- a/.github/workflows/integration_tests_reusable.yml
+++ b/.github/workflows/integration_tests_reusable.yml
@@ -86,8 +86,6 @@ jobs:
       fail-fast: false
       matrix:
         group: ${{ fromJSON(needs.generate-matrices.outputs.e2e) }}
-        # Empty value uses default
-        react: ['', '18.3.1']
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: |
@@ -95,7 +93,6 @@ jobs:
 
         export NEXT_TEST_CONTINUE_ON_ERROR=TRUE
         export NEXT_E2E_TEST_TIMEOUT=240000
-        export NEXT_TEST_REACT_VERSION=${{ matrix.react }}
         export NEXT_TEST_MODE=${{
           inputs.test_type == 'development' && 'dev' || 'start'
         }}
@@ -122,8 +119,6 @@ jobs:
       fail-fast: false
       matrix:
         group: ${{ fromJSON(needs.generate-matrices.outputs.integration) }}
-        # Empty value uses default
-        react: ['', '18.3.1']
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 18.18.2
@@ -132,7 +127,6 @@ jobs:
 
         export NEXT_TEST_CONTINUE_ON_ERROR=TRUE
         export NEXT_E2E_TEST_TIMEOUT=240000
-        export NEXT_TEST_REACT_VERSION=${{ matrix.react }}
 
         # HACK: Despite the name, these environment variables are just used to
         # gate tests, so they're applicable to both turbopack and rspack tests


### PR DESCRIPTION
Reverts vercel/next.js#76606

Causes the nightly jobs to fail with:

```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

because we're running two `build_reusable` jobs with the same stepName. While I could fix this, we'd still have problems with either duplicating tests on areweturboyet, or we'd need some logic to merge test results across the matrix.

I like the idea of running the full matrix, but this type of thing is rare and maybe not worth solving for (aside from catching it when the PR goes up, which we now have logic for, thanks to @unstubbable).

Closes PACK-4048