### PR TITLE
[dev-overlay] fix: dev indicator navigation with keyboard arrow

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -149,27 +149,25 @@ function DevToolsPopover({
   // Features to make the menu accessible
   useFocusTrap(menuRef, triggerRef, isMenuOpen)
   useClickOutside(menuRef, triggerRef, isMenuOpen, closeMenu)
-  useFocusTrap(turbopackRef, triggerTurbopackRef, isTurbopackInfoOpen)
   useClickOutside(
     turbopackRef,
     triggerTurbopackRef,
     isTurbopackInfoOpen,
     closeTurbopackInfo
   )
-  useFocusTrap(routeInfoRef, triggerRouteInfoRef, isRouteInfoOpen)
   useClickOutside(
     routeInfoRef,
     triggerRouteInfoRef,
     isRouteInfoOpen,
     closeRouteInfo
   )
-  useFocusTrap(preferencesRef, triggerPreferencesRef, isPreferencesOpen)
   useClickOutside(
     preferencesRef,
     triggerPreferencesRef,
     isPreferencesOpen,
     closePreferences
   )
+
   function select(index: number | 'first' | 'last') {
     if (index === 'first') {
       const all = menuRef.current?.querySelectorAll('[role="menuitem"]')

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -538,20 +538,26 @@ function useFocusTrap(
   isMenuOpen: boolean
 ) {
   useEffect(() => {
-    if (isMenuOpen) {
-      menuRef.current?.focus()
-    } else {
-      const root = triggerRef.current?.getRootNode()
-      const activeElement =
-        root instanceof ShadowRoot ? (root?.activeElement as HTMLElement) : null
+    const timeoutId = setTimeout(() => {
+      if (isMenuOpen && menuRef.current) {
+        menuRef.current.focus()
+      } else {
+        const root = triggerRef.current?.getRootNode()
+        const activeElement =
+          root instanceof ShadowRoot
+            ? (root?.activeElement as HTMLElement)
+            : null
 
-      // Only restore focus if the focus was previously on the menu.
-      // This avoids us accidentally focusing on mount when the
-      // user could want to interact with their own app instead.
-      if (menuRef.current?.contains(activeElement)) {
-        triggerRef.current?.focus()
+        // Only restore focus if the focus was previously on the menu.
+        // This avoids us accidentally focusing on mount when the
+        // user could want to interact with their own app instead.
+        if (menuRef.current?.contains(activeElement)) {
+          triggerRef.current?.focus()
+        }
       }
-    }
+    })
+
+    return () => clearTimeout(timeoutId)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isMenuOpen])
 }


### PR DESCRIPTION
### Why?

The keyboard navigation didn't work since `menuRef.current` was null when `select()` was executed, resulting the `tab-index` of the indicator menu items to be always `-1` when tabbing.

Reverted regression from https://github.com/vercel/next.js/pull/75471 and applied minor refactors.

https://github.com/user-attachments/assets/dfbf6a6d-e2d9-45d1-bd01-c29268a0f8ce

Closes NDX-927