### PR TITLE
[dev-overlay] fix: env name label style was out of sync with error type label

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/environment-name-label/environment-name-label.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/environment-name-label/environment-name-label.tsx
@@ -10,13 +10,12 @@ export const ENVIRONMENT_NAME_LABEL_STYLES = `
   [data-nextjs-environment-name-label] {
     padding: 2px 6px;
     margin: 0;
-    /* used --size instead of --rounded because --rounded is missing 6px */
     border-radius: var(--rounded-md-2);
-    background: var(--color-gray-300);
+    background: var(--color-gray-100);
     font-weight: 600;
-    font-size: var(--size-11);
+    font-size: var(--size-12);
     color: var(--color-gray-900);
     font-family: var(--font-stack-monospace);
-    line-height: 1.25em; /* 20px in 16px font size */
+    line-height: var(--size-20);
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-type-label/error-type-label.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-type-label/error-type-label.tsx
@@ -24,7 +24,6 @@ export const styles = `
   .nextjs__container_errors_label {
     padding: 2px 6px;
     margin: 0;
-    /* used --size instead of --rounded because --rounded is missing 6px */
     border-radius: var(--rounded-md-2);
     background: var(--color-red-100);
     font-weight: 600;


### PR DESCRIPTION
### Why?

![image](https://github.com/user-attachments/assets/de7206bb-2027-4684-8311-1b44c6e58f3a)

The env name label style was different from the error type label. It is because during change of https://github.com/vercel/next.js/pull/76385, the env name label was omitted.

https://github.com/vercel/next.js/blob/e3878ca38f61ab50af46d342e770344076015b55/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-type-label/error-type-label.tsx#L23-L36

Closes NDX-930