### PR TITLE
[dev-overlay] fix dark theme missing close bracket

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/styles/dark-theme.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/styles/dark-theme.tsx
@@ -112,11 +112,13 @@ export function DarkTheme() {
       :host(.dark) {
         ${base}
         ${colors}
+      }
 
       @media (prefers-color-scheme: dark) {
         :host(:not(.light)) {
           ${base}
           ${colors}
+        }
       }
     `}</style>
   )


### PR DESCRIPTION
### Why?

The dark theme was broken due to invalid CSS syntax been shipped at https://github.com/vercel/next.js/issues/76528.

### Follow Up

Restore the removed VS Code Extension styled-components as recommended, and apply a real "noop" to CSS template literals so that it can leverage the extension.