### PR TITLE
Update use-cache-unknown-cache-kind.test.ts snapshot for alternate bundler

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -658,5 +658,6 @@
   "657": "revalidate must be a number for image-cache",
   "658": "Pass `Infinity` instead of `false` if you want to cache on the server forever without checking with the origin.",
   "659": "SSG should not return an image cache value",
-  "660": "Rspack support is only available in Next.js canary."
+  "660": "Rspack support is only available in Next.js canary.",
+  "661": "Build failed because of %s errors"
 }

--- a/packages/next/src/build/webpack-build/impl.ts
+++ b/packages/next/src/build/webpack-build/impl.ts
@@ -333,7 +333,9 @@ export async function webpackBuildImpl(
       err.code = 'INVALID_RESOLVE_ALIAS'
       throw err
     }
-    const err = new Error('Build failed because of webpack errors') as NextError
+    const err = new Error(
+      `Build failed because of ${process.env.NEXT_RSPACK ? 'rspack' : 'webpack'} errors`
+    ) as NextError
     err.code = 'WEBPACK_ERRORS'
     throw err
   } else {

--- a/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
+++ b/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
@@ -10,6 +10,8 @@ import {
 import stripAnsi from 'strip-ansi'
 import { createSandbox } from 'development-sandbox'
 
+const isRspack = process.env.NEXT_RSPACK
+
 const nextConfigWithCacheHandler: NextConfig = {
   experimental: {
     dynamicIO: true,
@@ -57,26 +59,49 @@ describe('use-cache-unknown-cache-kind', () => {
               at <unknown> (./app/page.tsx:1:1)
           "
         `)
+      } else if (isRspack) {
+        expect(buildOutput).toMatchInlineSnapshot(`
+         "
+         ./app/page.tsx
+           × Module build failed:
+           ╰─▶   × Error:   x Unknown cache kind "custom". Please configure a cache handler for this kind in the "experimental.cacheHandlers" object in your Next.js config.
+                 │   |
+                 │    ,-[1:1]
+                 │  1 | 'use cache: custom'
+                 │    : ^^^^^^^^^^^^^^^^^^^
+                 │  2 |
+                 │  3 | export default async function Page() {
+                 │  4 |   return <p>hello world</p>
+                 │    \`----
+                 │
+               
+         Import trace for requested module:
+         ./app/page.tsx
+
+
+         > Build failed because of rspack errors
+         "
+        `)
       } else {
         expect(buildOutput).toMatchInlineSnapshot(`
-          "
-          ./app/page.tsx
-          Error:   x Unknown cache kind "custom". Please configure a cache handler for this kind in the "experimental.cacheHandlers" object in your Next.js config.
-            | 
-             ,-[1:1]
-           1 | 'use cache: custom'
-             : ^^^^^^^^^^^^^^^^^^^
-           2 | 
-           3 | export default async function Page() {
-           4 |   return <p>hello world</p>
-             \`----
+         "
+         ./app/page.tsx
+         Error:   x Unknown cache kind "custom". Please configure a cache handler for this kind in the "experimental.cacheHandlers" object in your Next.js config.
+           | 
+            ,-[1:1]
+          1 | 'use cache: custom'
+            : ^^^^^^^^^^^^^^^^^^^
+          2 | 
+          3 | export default async function Page() {
+          4 |   return <p>hello world</p>
+            \`----
 
-          Import trace for requested module:
-          ./app/page.tsx
+         Import trace for requested module:
+         ./app/page.tsx
 
 
-          > Build failed because of webpack errors
-          "
+         > Build failed because of webpack errors
+         "
         `)
       }
     })
@@ -104,6 +129,10 @@ describe('use-cache-unknown-cache-kind', () => {
         expect(errorDescription).toMatchInlineSnapshot(
           `"Ecmascript file had an error"`
         )
+      } else if (isRspack) {
+        expect(errorDescription).toMatchInlineSnapshot(
+          `"  × Module build failed:"`
+        )
       } else {
         expect(errorDescription).toMatchInlineSnapshot(
           `"Error:   x Unknown cache kind "custom". Please configure a cache handler for this kind in the "experimental.cacheHandlers" object in your Next.js config."`
@@ -122,19 +151,34 @@ describe('use-cache-unknown-cache-kind', () => {
 
            Unknown cache kind "custom". Please configure a cache handler for this kind in the "experimental.cacheHandlers" object in your Next.js config."
           `)
+      } else if (isRspack) {
+        expect(errorSource).toMatchInlineSnapshot(`
+         "./app/page.tsx
+           × Module build failed:
+           ╰─▶   × Error:   x Unknown cache kind "custom". Please configure a cache handler for this kind in the "experimental.cacheHandlers" object in your Next.js config.
+                 │   |
+                 │    ,-[1:1]
+                 │  1 | 'use cache: custom'
+                 │    : ^^^^^^^^^^^^^^^^^^^
+                 │  2 |
+                 │  3 | export default async function Page() {
+                 │  4 |   return <p>hello world</p>
+                 │    \`----
+                 │"
+        `)
       } else {
         expect(errorSource).toMatchInlineSnapshot(`
-           "./app/page.tsx
-           Error:   x Unknown cache kind "custom". Please configure a cache handler for this kind in the "experimental.cacheHandlers" object in your Next.js config.
-             | 
-              ,-[1:1]
-            1 | 'use cache: custom'
-              : ^^^^^^^^^^^^^^^^^^^
-            2 | 
-            3 | export default async function Page() {
-            4 |   return <p>hello world</p>
-              \`----"
-          `)
+         "./app/page.tsx
+         Error:   x Unknown cache kind "custom". Please configure a cache handler for this kind in the "experimental.cacheHandlers" object in your Next.js config.
+           | 
+            ,-[1:1]
+          1 | 'use cache: custom'
+            : ^^^^^^^^^^^^^^^^^^^
+          2 | 
+          3 | export default async function Page() {
+          4 |   return <p>hello world</p>
+            \`----"
+        `)
       }
     })
 

--- a/test/integration/css-customization/test/index.test.js
+++ b/test/integration/css-customization/test/index.test.js
@@ -6,6 +6,7 @@ import { nextBuild } from 'next-test-utils'
 import escapeStringRegexp from 'escape-string-regexp'
 
 const fixturesDir = join(__dirname, '../..', 'css-fixtures')
+const BUILD_FAILURE_RE = /Build failed because of (webpack|rspack) errors/
 
 // Test checks webpack loaders and plugins.
 ;(process.env.TURBOPACK ? describe.skip : describe)('CSS Customization', () => {
@@ -266,7 +267,7 @@ const fixturesDir = join(__dirname, '../..', 'css-fixtures')
           expect(stderr).toMatch(
             /A PostCSS Plugin was passed as an array but did not provide its configuration \('postcss-trolling'\)/
           )
-          expect(stderr).toMatch(/Build failed because of webpack errors/)
+          expect(stderr).toMatch(BUILD_FAILURE_RE)
         })
       })
 
@@ -286,7 +287,7 @@ const fixturesDir = join(__dirname, '../..', 'css-fixtures')
           expect(stderr).toMatch(
             /To disable 'postcss-trolling', pass false, otherwise, pass true or a configuration object./
           )
-          expect(stderr).toMatch(/Build failed because of webpack errors/)
+          expect(stderr).toMatch(BUILD_FAILURE_RE)
         })
       })
 
@@ -303,7 +304,7 @@ const fixturesDir = join(__dirname, '../..', 'css-fixtures')
           expect(stderr).toMatch(
             /A PostCSS Plugin must be provided as a string. Instead, we got: '5'/
           )
-          expect(stderr).toMatch(/Build failed because of webpack errors/)
+          expect(stderr).toMatch(BUILD_FAILURE_RE)
         })
       })
 
@@ -318,7 +319,7 @@ const fixturesDir = join(__dirname, '../..', 'css-fixtures')
           const { stderr } = await nextBuild(appDir, [], { stderr: true })
 
           expect(stderr).toMatch(/An unknown PostCSS plugin was provided \(5\)/)
-          expect(stderr).toMatch(/Build failed because of webpack errors/)
+          expect(stderr).toMatch(BUILD_FAILURE_RE)
         })
       })
 
@@ -335,7 +336,7 @@ const fixturesDir = join(__dirname, '../..', 'css-fixtures')
           expect(stderr).toMatch(
             /Your custom PostCSS configuration must export a `plugins` key./
           )
-          expect(stderr).toMatch(/Build failed because of webpack errors/)
+          expect(stderr).toMatch(BUILD_FAILURE_RE)
         })
       })
 
@@ -352,7 +353,7 @@ const fixturesDir = join(__dirname, '../..', 'css-fixtures')
           expect(stderr).toMatch(
             /Your custom PostCSS configuration must export a `plugins` key./
           )
-          expect(stderr).toMatch(/Build failed because of webpack errors/)
+          expect(stderr).toMatch(BUILD_FAILURE_RE)
         })
       })
 
@@ -369,7 +370,7 @@ const fixturesDir = join(__dirname, '../..', 'css-fixtures')
           expect(stderr).toMatch(
             /A PostCSS Plugin was passed as an array but did not provide its configuration \('postcss-trolling'\)/
           )
-          expect(stderr).toMatch(/Build failed because of webpack errors/)
+          expect(stderr).toMatch(BUILD_FAILURE_RE)
         })
       })
 
@@ -386,7 +387,7 @@ const fixturesDir = join(__dirname, '../..', 'css-fixtures')
           expect(stderr).toMatch(
             /A PostCSS Plugin was passed as a function using require\(\), but it must be provided as a string/
           )
-          expect(stderr).toMatch(/Build failed because of webpack errors/)
+          expect(stderr).toMatch(BUILD_FAILURE_RE)
         })
       })
 
@@ -403,7 +404,7 @@ const fixturesDir = join(__dirname, '../..', 'css-fixtures')
           expect(stderr).toMatch(
             /Your custom PostCSS configuration may not export a function/
           )
-          expect(stderr).toMatch(/Build failed because of webpack errors/)
+          expect(stderr).toMatch(BUILD_FAILURE_RE)
         })
       })
     }


### PR DESCRIPTION
This adds a snapshot for rspack to this test. It also mentions rspack instead of webpack when failing with build errors.

Test Plan: `pnpm test-start-rspack test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts`


Closes PACK-4066