### PR TITLE
Update cache handler interface

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -664,5 +664,6 @@
   "663": "Invariant: client chunk changed but failed to detect hash %s",
   "664": "Missing 'next-action' header.",
   "665": "Failed to find Server Action \"%s\". This request might be from an older or newer deployment.\\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
-  "666": "Turbopack builds are only available in canary builds of Next.js."
+  "666": "Turbopack builds are only available in canary builds of Next.js.",
+  "667": "receiveExpiredTags is deprecated, and not expected to be called."
 }

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -336,6 +336,7 @@ export async function buildAppStaticPaths({
       onAfterTaskError: afterRunner.context.onTaskError,
     },
     buildId,
+    previouslyRevalidatedTags: [],
   })
 
   const routeParams = await ComponentMod.workAsyncStorage.run(

--- a/packages/next/src/server/after/after-context.test.ts
+++ b/packages/next/src/server/after/after-context.test.ts
@@ -542,7 +542,7 @@ const createMockWorkStore = (afterContext: AfterContext): WorkStore => {
     forceDynamic: false,
     dynamicShouldError: false,
     isStaticGeneration: false,
-    revalidatedTags: [],
+    pendingRevalidatedTags: [],
     pendingRevalidates: undefined,
     pendingRevalidateWrites: undefined,
     incrementalCache: undefined,

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -124,7 +124,9 @@ async function addRevalidationHeader(
   }
 ) {
   await Promise.all([
-    workStore.incrementalCache?.revalidateTag(workStore.revalidatedTags || []),
+    workStore.incrementalCache?.revalidateTag(
+      workStore.pendingRevalidatedTags || []
+    ),
     ...Object.values(workStore.pendingRevalidates || {}),
     ...(workStore.pendingRevalidateWrites || []),
   ])
@@ -142,7 +144,7 @@ async function addRevalidationHeader(
   // TODO-APP: Currently paths are treated as tags, so the second element of the tuple
   // is always empty.
 
-  const isTagRevalidated = workStore.revalidatedTags?.length ? 1 : 0
+  const isTagRevalidated = workStore.pendingRevalidatedTags?.length ? 1 : 0
   const isCookieRevalidated = getModifiedCookieValues(
     requestStore.mutableCookies
   ).length
@@ -320,10 +322,10 @@ async function createRedirectRenderResult(
       `${origin}${appRelativeRedirectUrl.pathname}${appRelativeRedirectUrl.search}`
     )
 
-    if (workStore.revalidatedTags) {
+    if (workStore.pendingRevalidatedTags) {
       forwardedHeaders.set(
         NEXT_CACHE_REVALIDATED_TAGS_HEADER,
-        workStore.revalidatedTags.join(',')
+        workStore.pendingRevalidatedTags.join(',')
       )
       forwardedHeaders.set(
         NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER,
@@ -569,7 +571,7 @@ export async function handleAction({
         res.statusCode = 500
         await Promise.all([
           workStore.incrementalCache?.revalidateTag(
-            workStore.revalidatedTags || []
+            workStore.pendingRevalidatedTags || []
           ),
           ...Object.values(workStore.pendingRevalidates || {}),
           ...(workStore.pendingRevalidateWrites || []),
@@ -1018,7 +1020,7 @@ export async function handleAction({
       res.statusCode = 500
       await Promise.all([
         workStore.incrementalCache?.revalidateTag(
-          workStore.revalidatedTags || []
+          workStore.pendingRevalidatedTags || []
         ),
         ...Object.values(workStore.pendingRevalidates || {}),
         ...(workStore.pendingRevalidateWrites || []),

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -175,11 +175,7 @@ import { getTracedMetadata } from '../lib/trace/utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
 import './clean-async-snapshot.external'
-import {
-  INFINITE_CACHE,
-  NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER,
-  NEXT_CACHE_REVALIDATED_TAGS_HEADER,
-} from '../../lib/constants'
+import { INFINITE_CACHE } from '../../lib/constants'
 import { createComponentStylesAndScripts } from './create-component-styles-and-scripts'
 import { parseLoaderTree } from './parse-loader-tree'
 import {
@@ -190,6 +186,7 @@ import type { MetadataErrorType } from '../../lib/metadata/resolve-metadata'
 import isError from '../../lib/is-error'
 import { isUseCacheTimeoutError } from '../use-cache/use-cache-errors'
 import { createServerInsertedMetadata } from './metadata-insertion/create-server-inserted-metadata'
+import { getPreviouslyRevalidatedTags } from '../server-utils'
 
 export type GetDynamicParamFromSegment = (
   // [slug] / [[slug]] / [...slug]
@@ -293,11 +290,10 @@ function parseRequestHeaders(
   const nonce =
     typeof csp === 'string' ? getScriptNonceFromHeader(csp) : undefined
 
-  const previouslyRevalidatedTags =
-    typeof headers[NEXT_CACHE_REVALIDATED_TAGS_HEADER] === 'string' &&
-    headers[NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER] === options.previewModeId
-      ? headers[NEXT_CACHE_REVALIDATED_TAGS_HEADER].split(',')
-      : []
+  const previouslyRevalidatedTags = getPreviouslyRevalidatedTags(
+    headers,
+    options.previewModeId
+  )
 
   return {
     flightRouterState,

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -54,7 +54,15 @@ export interface WorkStore {
   nextFetchId?: number
   pathWasRevalidated?: boolean
 
-  revalidatedTags?: string[]
+  // Tags that were revalidated during the current request. They need to be sent
+  // to cache handlers to propagate their revalidation.
+  pendingRevalidatedTags?: string[]
+
+  // Tags that were previously revalidated (e.g. by a redirecting server action)
+  // and have already been sent to cache handlers. Retrieved cache entries that
+  // include any of these tags must be discarded.
+  readonly previouslyRevalidatedTags: readonly string[]
+
   fetchMetrics?: FetchMetrics
 
   isDraftMode?: boolean

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -14,15 +14,17 @@ import type {
   PrerenderResumeDataCache,
 } from '../resume-data-cache/resume-data-cache'
 import type { Params } from '../request/params'
+import type { ImplicitTags } from '../lib/implicit-tags'
 
-type WorkUnitPhase = 'action' | 'render' | 'after'
+export type WorkUnitPhase = 'action' | 'render' | 'after'
 
-type PhasePartial = {
+export interface CommonWorkUnitStore {
   /** NOTE: Will be mutated as phases change */
   phase: WorkUnitPhase
+  readonly implicitTags: ImplicitTags | undefined
 }
 
-export type RequestStore = {
+export interface RequestStore extends CommonWorkUnitStore {
   type: 'request'
 
   /**
@@ -52,7 +54,6 @@ export type RequestStore = {
   readonly isHmrRefresh?: boolean
   readonly serverComponentsHmrCache?: ServerComponentsHmrCache
 
-  readonly implicitTags: string[]
   readonly rootParams: Params
 
   /**
@@ -63,7 +64,7 @@ export type RequestStore = {
   // DEV-only
   usedDynamic?: boolean
   prerenderPhase?: boolean
-} & PhasePartial
+}
 
 /**
  * The Prerender store is for tracking information related to prerenders.
@@ -75,9 +76,8 @@ export type RequestStore = {
  * only needs to happen during the RSC prerender when we are prospectively prerendering
  * to fill all caches.
  */
-export type PrerenderStoreModern = {
+export interface PrerenderStoreModern extends CommonWorkUnitStore {
   type: 'prerender'
-  readonly implicitTags: string[]
 
   /**
    * This signal is aborted when the React render is complete. (i.e. it is the same signal passed to react)
@@ -120,12 +120,11 @@ export type PrerenderStoreModern = {
   // not part of the primary render path and are just prerendering to produce
   // validation results
   validating?: boolean
-} & PhasePartial
+}
 
-export type PrerenderStorePPR = {
+export interface PrerenderStorePPR extends CommonWorkUnitStore {
   type: 'prerender-ppr'
   readonly rootParams: Params
-  readonly implicitTags: string[]
   readonly dynamicTracking: null | DynamicTrackingState
   // Collected revalidate times and tags for this document during the prerender.
   revalidate: number // in seconds. 0 means dynamic. INFINITE_CACHE and higher means never revalidate.
@@ -137,27 +136,25 @@ export type PrerenderStorePPR = {
    * The resume data cache for this prerender.
    */
   prerenderResumeDataCache: PrerenderResumeDataCache
-} & PhasePartial
+}
 
-export type PrerenderStoreLegacy = {
+export interface PrerenderStoreLegacy extends CommonWorkUnitStore {
   type: 'prerender-legacy'
   readonly rootParams: Params
-  readonly implicitTags: string[]
   // Collected revalidate times and tags for this document during the prerender.
   revalidate: number // in seconds. 0 means dynamic. INFINITE_CACHE and higher means never revalidate.
   expire: number // server expiration time
   stale: number // client expiration time
   tags: null | string[]
-} & PhasePartial
+}
 
 export type PrerenderStore =
   | PrerenderStoreLegacy
   | PrerenderStorePPR
   | PrerenderStoreModern
 
-export type UseCacheStore = {
+export interface UseCacheStore extends CommonWorkUnitStore {
   type: 'cache'
-  readonly implicitTags: string[]
   // Collected revalidate times and tags for this cache entry during the cache render.
   revalidate: number // implicit revalidate time from inner caches / fetches
   expire: number // server expiration time
@@ -170,11 +167,11 @@ export type UseCacheStore = {
   readonly isHmrRefresh: boolean
   readonly serverComponentsHmrCache: ServerComponentsHmrCache | undefined
   readonly forceRevalidate: boolean
-} & PhasePartial
+}
 
-export type UnstableCacheStore = {
+export interface UnstableCacheStore extends CommonWorkUnitStore {
   type: 'unstable-cache'
-} & PhasePartial
+}
 
 /**
  * The Cache store is for tracking information inside a "use cache" or unstable_cache context.

--- a/packages/next/src/server/async-storage/request-store.ts
+++ b/packages/next/src/server/async-storage/request-store.ts
@@ -23,6 +23,7 @@ import { splitCookiesString } from '../web/utils'
 import type { ServerComponentsHmrCache } from '../response-cache'
 import type { RenderResumeDataCache } from '../resume-data-cache/resume-data-cache'
 import type { Params } from '../request/params'
+import type { ImplicitTags } from '../lib/implicit-tags'
 
 function getHeaders(headers: Headers | IncomingHttpHeaders): ReadonlyHeaders {
   const cleaned = HeadersAdapter.from(headers)
@@ -67,7 +68,7 @@ type RequestContext = RequestResponsePair & {
   renderOpts?: WrapperRenderOpts
   isHmrRefresh?: boolean
   serverComponentsHmrCache?: ServerComponentsHmrCache
-  implicitTags?: string[] | undefined
+  implicitTags: ImplicitTags | undefined
 }
 
 type RequestResponsePair =
@@ -184,7 +185,7 @@ function createRequestStoreImpl(
   return {
     type: 'request',
     phase,
-    implicitTags: implicitTags ?? [],
+    implicitTags,
     // Rather than just using the whole `url` here, we pull the parts we want
     // to ensure we don't use parts of the URL that we shouldn't. This also
     // lets us avoid requiring an empty string for `search` in the type.

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -70,6 +70,10 @@ export type WorkStoreContext = {
    * The build ID of the current build.
    */
   buildId: string
+
+  // Tags that were previously revalidated (e.g. by a redirecting server action)
+  // and have already been sent to cache handlers.
+  previouslyRevalidatedTags: string[]
 }
 
 export function createWorkStore({
@@ -79,6 +83,7 @@ export function createWorkStore({
   requestEndedState,
   isPrefetchRequest,
   buildId,
+  previouslyRevalidatedTags,
 }: WorkStoreContext): WorkStore {
   /**
    * Rules of Static & Dynamic HTML:
@@ -129,6 +134,7 @@ export function createWorkStore({
     afterContext: createAfterContext(renderOpts),
     dynamicIOEnabled: renderOpts.experimental.dynamicIO,
     dev: renderOpts.dev ?? false,
+    previouslyRevalidatedTags,
   }
 
   // TODO: remove this when we resolve accessing the store outside the execution context

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1443,6 +1443,8 @@ export default abstract class Server<
 
         const promises: Promise<void>[] = []
         for (const handler of handlers) {
+          // TODO: Store expired tags in ALS and discard cache entries with
+          // these tags.
           promises.push(handler.receiveExpiredTags(...expiredTags))
         }
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -177,6 +177,7 @@ import {
 } from './lib/streaming-metadata'
 import { InvariantError } from '../shared/lib/invariant-error'
 import { decodeQueryPathParameter } from './lib/decode-query-path-parameter'
+import { getCacheHandlers } from './use-cache/handlers'
 
 export type FindComponentsResult = {
   components: LoadComponentsReturnType
@@ -1430,6 +1431,14 @@ export default abstract class Server<
         incrementalCache.resetRequestCache()
         addRequestMeta(req, 'incrementalCache', incrementalCache)
         ;(globalThis as any).__incrementalCache = incrementalCache
+      }
+
+      const cacheHandlers = getCacheHandlers()
+
+      if (cacheHandlers) {
+        await Promise.all(
+          [...cacheHandlers].map((cacheHandler) => cacheHandler.refreshTags())
+        )
       }
 
       // set server components HMR cache to request meta so it can be passed

--- a/packages/next/src/server/lib/cache-handlers/default.ts
+++ b/packages/next/src/server/lib/cache-handlers/default.ts
@@ -8,7 +8,7 @@
  */
 
 import { LRUCache } from '../lru-cache'
-import type { CacheEntry, CacheHandler } from './types'
+import type { CacheEntry, CacheHandlerV2 } from './types'
 import {
   isStale,
   tagsManifest,
@@ -41,7 +41,7 @@ const memoryCache = new LRUCache<PrivateCacheEntry>(
 )
 const pendingSets = new Map<string, Promise<void>>()
 
-const DefaultCacheHandler: CacheHandler = {
+const DefaultCacheHandler: CacheHandlerV2 = {
   async get(cacheKey) {
     await pendingSets.get(cacheKey)
 

--- a/packages/next/src/server/lib/cache-handlers/default.ts
+++ b/packages/next/src/server/lib/cache-handlers/default.ts
@@ -1,5 +1,5 @@
 /**
- * This is the default "use cache" handler it defaults to an in memory store.
+ * This is the default "use cache" handler it defaults to an in-memory store.
  * In-memory caches are fragile and should not use stale-while-revalidate
  * semantics on the caches because it's not worth warming up an entry that's
  * likely going to get evicted before we get to use it anyway. However, we also
@@ -13,7 +13,7 @@ import {
   isStale,
   tagsManifest,
 } from '../incremental-cache/tags-manifest.external'
-// import { InvariantError } from '../../../shared/lib/invariant-error'
+import { InvariantError } from '../../../shared/lib/invariant-error'
 
 type PrivateCacheEntry = {
   entry: CacheEntry
@@ -57,7 +57,7 @@ const DefaultCacheHandler: CacheHandler = {
       performance.timeOrigin + performance.now() >
       entry.timestamp + entry.revalidate * 1000
     ) {
-      // In memory caches should expire after revalidate time because it is
+      // In-memory caches should expire after revalidate time because it is
       // unlikely that a new entry will be able to be used before it is dropped
       // from the cache.
       return undefined
@@ -126,12 +126,10 @@ const DefaultCacheHandler: CacheHandler = {
     }
   },
 
-  async receiveExpiredTags(...tags) {
-    // TODO: Throw instead.
-    // throw new InvariantError(
-    //   'receiveExpiredTags is deprecated, and not expected to be called.'
-    // )
-    return this.expireTags(...tags)
+  async receiveExpiredTags() {
+    throw new InvariantError(
+      'receiveExpiredTags is deprecated, and not expected to be called.'
+    )
   },
 }
 

--- a/packages/next/src/server/lib/cache-handlers/default.ts
+++ b/packages/next/src/server/lib/cache-handlers/default.ts
@@ -13,7 +13,6 @@ import {
   isStale,
   tagsManifest,
 } from '../incremental-cache/tags-manifest.external'
-import { InvariantError } from '../../../shared/lib/invariant-error'
 
 type PrivateCacheEntry = {
   entry: CacheEntry
@@ -124,12 +123,6 @@ const DefaultCacheHandler: CacheHandler = {
       // TODO: update file-system-cache?
       tagsManifest.set(tag, timestamp)
     }
-  },
-
-  async receiveExpiredTags() {
-    throw new InvariantError(
-      'receiveExpiredTags is deprecated, and not expected to be called.'
-    )
   },
 }
 

--- a/packages/next/src/server/lib/cache-handlers/types.ts
+++ b/packages/next/src/server/lib/cache-handlers/types.ts
@@ -61,7 +61,7 @@ export interface CacheHandler {
    * communicate with the tags service to refresh the local tags manifest
    * accordingly.
    */
-  refreshTags?(): Promise<void>
+  refreshTags(): Promise<void>
 
   /**
    * Next.js will call this function for each set of soft tags that are relevant
@@ -69,7 +69,7 @@ export interface CacheHandler {
    * revalidate event for the tags. Returns `0` if none of the tags were ever
    * revalidated.
    */
-  getExpiration?(...tags: string[]): Promise<Timestamp>
+  getExpiration(...tags: string[]): Promise<Timestamp>
 
   /**
    * Next.js will call this function when `revalidateTag` or `revalidatePath()`

--- a/packages/next/src/server/lib/cache-handlers/types.ts
+++ b/packages/next/src/server/lib/cache-handlers/types.ts
@@ -61,7 +61,7 @@ export interface CacheHandler {
    * communicate with the tags service to refresh the local tags manifest
    * accordingly.
    */
-  refreshTags(): Promise<void>
+  refreshTags?(): Promise<void>
 
   /**
    * Next.js will call this function for each set of soft tags that are relevant
@@ -69,7 +69,7 @@ export interface CacheHandler {
    * revalidate event for the tags. Returns `0` if none of the tags were ever
    * revalidated.
    */
-  getExpiration(...tags: string[]): Promise<Timestamp>
+  getExpiration?(...tags: string[]): Promise<Timestamp>
 
   /**
    * Next.js will call this function when `revalidateTag` or `revalidatePath()`

--- a/packages/next/src/server/lib/cache-handlers/types.ts
+++ b/packages/next/src/server/lib/cache-handlers/types.ts
@@ -1,15 +1,13 @@
-// In-memory caches are fragile and should not use stale-while-revalidate
-// semantics on the caches because it's not worth warming up an entry that's
-// likely going to get evicted before we get to use it anyway. However,
-// we also don't want to reuse a stale entry for too long so stale entries
-// should be considered expired/missing in such CacheHandlers.
+/**
+ * A timestamp in milliseconds elapsed since the epoch
+ */
+export type Timestamp = number
 
-// This is the entry we store
 export interface CacheEntry {
   /**
-   * The ReadableStream can error and only have partial
-   * data so any cache handlers need to handle this case
-   * and decide to keep the partial cache around or not
+   * The ReadableStream can error and only have partial data so any cache
+   * handlers need to handle this case and decide to keep the partial cache
+   * around or not.
    */
   value: ReadableStream<Uint8Array>
 
@@ -19,40 +17,74 @@ export interface CacheEntry {
   tags: string[]
 
   /**
-   * This is for the client not used to calculate cache entry expiration
+   * This is for the client, not used to calculate cache entry expiration
+   * [duration in seconds]
    */
   stale: number
 
   /**
-   * When the cache entry was created
+   * When the cache entry was created [timestamp in milliseconds]
    */
-  timestamp: number
+  timestamp: Timestamp
 
   /**
-   * How long the entry can last (should be longer than revalidate)
+   * How long the entry is allowed to be used (should be longer than revalidate)
+   * [duration in seconds]
    */
   expire: number
 
   /**
-   * How long until the entry should revalidate
+   * How long until the entry should be revalidated [duration in seconds]
    */
   revalidate: number
 }
 
 export interface CacheHandler {
-  get(cacheKey: string, softTags: string[]): Promise<undefined | CacheEntry>
+  /**
+   * Retrieve a cache entry for the given cache key, if available.
+   */
+  get(cacheKey: string): Promise<undefined | CacheEntry>
 
-  set(cacheKey: string, entry: Promise<CacheEntry>): Promise<void>
+  /**
+   * Store a cache entry for the given cache key. When this is called, the entry
+   * may still be pending, i.e. its value stream may still be written to. So it
+   * needs to be awaited first. If a `get` for the same cache key is called in
+   * the before the pending entry is complete, the cache handler must wait for
+   * the `set` operation to finish, before returning the entry, instead of
+   * returning undefined.
+   */
+  set(cacheKey: string, pendingEntry: Promise<CacheEntry>): Promise<void>
 
-  // This is called when expireTags('') is called
-  // and should update tags manifest accordingly
+  /**
+   * Next.js will call this function periodically, but always before starting a
+   * new request. When working with a remote tags service, this method should
+   * communicate with the tags service to refresh the local tags manifest
+   * accordingly.
+   */
+  refreshTags(): Promise<void>
+
+  /**
+   * Next.js will call this function for each set of soft tags that are relevant
+   * at the start of a request. The result is the maximum timestamp of a
+   * revalidate event for the tags. Returns `0` if none of the tags were ever
+   * revalidated.
+   */
+  getExpiration(...tags: string[]): Promise<Timestamp>
+
+  /**
+   * Next.js will call this function when `revalidateTag` or `revalidatePath()`
+   * is called. It should update the tags manifest accordingly.
+   */
   expireTags(...tags: string[]): Promise<void>
 
-  // This is called when an action request sends
-  // NEXT_CACHE_REVALIDATED_TAGS_HEADER and tells
-  // us these tags are expired and the manifest
-  // should be updated this differs since in a multi
-  // instance environment you don't propagate these
-  // as they are request specific
+  /**
+   * This is called when a server action request sends
+   * `NEXT_CACHE_REVALIDATED_TAGS_HEADER` and tells us these tags are expired
+   * and the manifest should be updated. This differs from `expireTags` since in
+   * a multi-instance environment you don't propagate these as they are
+   * request-specific.
+   * @deprecated Use `refreshTags` or `expireTags` instead. Will be removed in a
+   * later canary version.
+   */
   receiveExpiredTags(...tags: string[]): Promise<void>
 }

--- a/packages/next/src/server/lib/cache-handlers/types.ts
+++ b/packages/next/src/server/lib/cache-handlers/types.ts
@@ -76,15 +76,4 @@ export interface CacheHandler {
    * is called. It should update the tags manifest accordingly.
    */
   expireTags(...tags: string[]): Promise<void>
-
-  /**
-   * This is called when a server action request sends
-   * `NEXT_CACHE_REVALIDATED_TAGS_HEADER` and tells us these tags are expired
-   * and the manifest should be updated. This differs from `expireTags` since in
-   * a multi-instance environment you don't propagate these as they are
-   * request-specific.
-   * @deprecated Use `refreshTags` or `expireTags` instead. Will be removed in a
-   * later canary version.
-   */
-  receiveExpiredTags(...tags: string[]): Promise<void>
 }

--- a/packages/next/src/server/lib/implicit-tags.ts
+++ b/packages/next/src/server/lib/implicit-tags.ts
@@ -50,7 +50,17 @@ async function getImplicitTagsExpiration(tags: string[]): Promise<number> {
 
   if (cacheHandlers) {
     const expirations = await Promise.all(
-      [...cacheHandlers].map((handler) => handler.getExpiration(...tags))
+      [...cacheHandlers].map(async (handler) => {
+        if ('getExpiration' in handler) {
+          return handler.getExpiration(...tags)
+        }
+
+        // Use 0 as fallback of legacy cache handlers. We don't need to track
+        // the expiration of implicit tags for those, because they're passed
+        // into the `get()` method and are checked internally by the cache
+        // handler.
+        return 0
+      })
     )
 
     // We use the most recent expiration from all cache handlers, i.e. the

--- a/packages/next/src/server/lib/implicit-tags.ts
+++ b/packages/next/src/server/lib/implicit-tags.ts
@@ -78,7 +78,8 @@ export async function getImplicitTags(
       [...cacheHandlers].map((handler) => handler.getExpiration(...tags))
     )
 
-    // We use the most recent expiration, i.e. the largest timestamp.
+    // We use the most recent expiration from all cache handlers, i.e. the
+    // largest timestamp. Semantically, they should all be the same though.
     expiration = Math.max(...expirations)
   }
 

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -277,13 +277,13 @@ export class IncrementalCache implements IncrementalCacheType {
       }
     }
 
+    await Promise.all(promises)
+
     const workUnitStore = workUnitAsyncStorage.getStore()
 
     if (workUnitStore?.implicitTags) {
-      promises.push(updateImplicitTagsExpiration(workUnitStore.implicitTags))
+      await updateImplicitTagsExpiration(workUnitStore.implicitTags)
     }
-
-    await Promise.all(promises)
   }
 
   // x-ref: https://github.com/facebook/react/blob/2655c9354d8e1c54ba888444220f63e836925caa/packages/react/src/ReactFetch.js#L23

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -1,4 +1,3 @@
-// TODO: Can we get previouslyRevalidatedTags from workStore here as well?
 import type { CacheFs } from '../../../shared/lib/utils'
 import type { PrerenderManifest } from '../../../build'
 import {

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -1,3 +1,4 @@
+// TODO: Can we get previouslyRevalidatedTags from workStore here as well?
 import type { CacheFs } from '../../../shared/lib/utils'
 import type { PrerenderManifest } from '../../../build'
 import {

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -21,8 +21,6 @@ import { normalizePagePath } from '../../../shared/lib/page-path/normalize-page-
 
 import {
   CACHE_ONE_YEAR,
-  NEXT_CACHE_REVALIDATED_TAGS_HEADER,
-  NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER,
   PRERENDER_REVALIDATE_HEADER,
 } from '../../../lib/constants'
 import { toRoute } from '../to-route'
@@ -36,6 +34,7 @@ import { getCacheHandlers } from '../../use-cache/handlers'
 import { InvariantError } from '../../../shared/lib/invariant-error'
 import type { Revalidate } from '../cache-control'
 import { updateImplicitTagsExpiration } from '../implicit-tags'
+import { getPreviouslyRevalidatedTags } from '../../server-utils'
 
 export interface CacheHandlerContext {
   fs?: CacheFs
@@ -182,14 +181,11 @@ export class IncrementalCache implements IncrementalCacheType {
       this.isOnDemandRevalidate = true
     }
 
-    if (
-      minimalMode &&
-      typeof requestHeaders[NEXT_CACHE_REVALIDATED_TAGS_HEADER] === 'string' &&
-      requestHeaders[NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER] ===
+    if (minimalMode) {
+      revalidatedTags = getPreviouslyRevalidatedTags(
+        requestHeaders,
         this.prerenderManifest?.preview?.previewModeId
-    ) {
-      revalidatedTags =
-        requestHeaders[NEXT_CACHE_REVALIDATED_TAGS_HEADER].split(',')
+      )
     }
 
     if (CurCacheHandler) {

--- a/packages/next/src/server/lib/incremental-cache/tags-manifest.external.ts
+++ b/packages/next/src/server/lib/incremental-cache/tags-manifest.external.ts
@@ -1,23 +1,17 @@
-type TagsManifest = {
-  items: { [tag: string]: { revalidatedAt?: number } }
-}
+import type { Timestamp } from '../cache-handlers/types'
 
-// we share tags manifest between "use cache" handlers and
-// previous file-system-cache
-export const tagsManifest: TagsManifest = {
-  items: {},
-}
+// We share the tags manifest between the "use cache" handlers and the previous
+// file-system cache.
+export const tagsManifest = new Map<string, number>()
 
-export const isTagStale = (tags: string[], timestamp: number) => {
+export const isStale = (tags: string[], timestamp: Timestamp) => {
   for (const tag of tags) {
-    const tagEntry = tagsManifest.items[tag]
-    if (
-      typeof tagEntry?.revalidatedAt === 'number' &&
-      // TODO: use performance.now and update file-system-cache?
-      tagEntry.revalidatedAt >= timestamp
-    ) {
+    const revalidatedAt = tagsManifest.get(tag)
+
+    if (typeof revalidatedAt === 'number' && revalidatedAt >= timestamp) {
       return true
     }
   }
+
   return false
 }

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -274,10 +274,7 @@ export function createPatchedFetcher(
           }
         }
 
-        const implicitTags =
-          !workUnitStore || workUnitStore.type === 'unstable-cache'
-            ? []
-            : workUnitStore.implicitTags
+        const implicitTags = workUnitStore?.implicitTags
 
         // Inside unstable-cache we treat it the same as force-no-store on the
         // page.
@@ -756,7 +753,7 @@ export function createPatchedFetcher(
                   fetchUrl,
                   fetchIdx,
                   tags,
-                  softTags: implicitTags,
+                  softTags: implicitTags?.tags,
                 })
 
             if (hasNoExplicitCacheConfig) {

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -18,7 +18,7 @@ import {
   type WorkStoreContext,
 } from '../../async-storage/work-store'
 import { type HTTP_METHOD, HTTP_METHODS, isHTTPMethod } from '../../web/http'
-import { getImplicitTags } from '../../lib/implicit-tags'
+import { getImplicitTags, type ImplicitTags } from '../../lib/implicit-tags'
 import { patchFetch } from '../../lib/patch-fetch'
 import { getTracer } from '../../lib/trace/tracer'
 import { AppRouteRouteHandlersSpan } from '../../lib/trace/constants'
@@ -300,7 +300,7 @@ export class AppRouteRouteModule extends RouteModule<
     // inside this function. Right now we get passed a RequestStore even when
     // we're going to do a prerender. We should probably just split do up into prexecute and execute
     requestStore: RequestStore,
-    implicitTags: string[],
+    implicitTags: ImplicitTags,
     request: NextRequest,
     context: AppRouteRouteHandlerContext
   ) {
@@ -367,7 +367,7 @@ export class AppRouteRouteModule extends RouteModule<
               // This replicates prior behavior where rootParams is empty in routes
               // TODO we need to make this have the proper rootParams for this route
               rootParams: {},
-              implicitTags: implicitTags,
+              implicitTags,
               renderSignal: prospectiveController.signal,
               controller: prospectiveController,
               cacheSignal,
@@ -377,7 +377,7 @@ export class AppRouteRouteModule extends RouteModule<
               revalidate: defaultRevalidate,
               expire: INFINITE_CACHE,
               stale: INFINITE_CACHE,
-              tags: [...implicitTags],
+              tags: [...implicitTags.tags],
               prerenderResumeDataCache: null,
             })
 
@@ -454,7 +454,7 @@ export class AppRouteRouteModule extends RouteModule<
             type: 'prerender',
             phase: 'action',
             rootParams: {},
-            implicitTags: implicitTags,
+            implicitTags,
             renderSignal: finalController.signal,
             controller: finalController,
             cacheSignal: null,
@@ -462,7 +462,7 @@ export class AppRouteRouteModule extends RouteModule<
             revalidate: defaultRevalidate,
             expire: INFINITE_CACHE,
             stale: INFINITE_CACHE,
-            tags: [...implicitTags],
+            tags: [...implicitTags.tags],
             prerenderResumeDataCache: null,
           })
 
@@ -534,11 +534,11 @@ export class AppRouteRouteModule extends RouteModule<
             type: 'prerender-legacy',
             phase: 'action',
             rootParams: {},
-            implicitTags: implicitTags,
+            implicitTags,
             revalidate: defaultRevalidate,
             expire: INFINITE_CACHE,
             stale: INFINITE_CACHE,
-            tags: [...implicitTags],
+            tags: [...implicitTags.tags],
           }
 
           res = await workUnitAsyncStorage.run(
@@ -666,7 +666,7 @@ export class AppRouteRouteModule extends RouteModule<
       isAction: getIsServerAction(req),
     }
 
-    const implicitTags = getImplicitTags(
+    const implicitTags = await getImplicitTags(
       this.definition.page,
       req.nextUrl,
       // App Routes don't support unknown route params.

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -604,7 +604,7 @@ export class AppRouteRouteModule extends RouteModule<
 
     context.renderOpts.pendingWaitUntil = Promise.all([
       workStore.incrementalCache?.revalidateTag(
-        workStore.revalidatedTags || []
+        workStore.pendingRevalidatedTags || []
       ),
       ...Object.values(workStore.pendingRevalidates || {}),
     ]).finally(() => {
@@ -655,6 +655,7 @@ export class AppRouteRouteModule extends RouteModule<
       page: this.definition.page,
       renderOpts: context.renderOpts,
       buildId: context.sharedContext.buildId,
+      previouslyRevalidatedTags: [],
     }
 
     // Add the fetchCache option to the renderOpts.

--- a/packages/next/src/server/server-utils.ts
+++ b/packages/next/src/server/server-utils.ts
@@ -17,10 +17,13 @@ import {
 import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-slash'
 import { normalizeRscURL } from '../shared/lib/router/utils/app-paths'
 import {
+  NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER,
+  NEXT_CACHE_REVALIDATED_TAGS_HEADER,
   NEXT_INTERCEPTION_MARKER_PREFIX,
   NEXT_QUERY_PARAM_PREFIX,
 } from '../lib/constants'
 import { normalizeNextQueryParam } from './web/utils'
+import type { IncomingHttpHeaders } from 'http'
 
 export function normalizeVercelUrl(
   req: BaseNextRequest,
@@ -394,4 +397,14 @@ export function getUtils({
       params: Record<string, undefined | string | string[]>
     ) => interpolateDynamicPath(pathname, params, defaultRouteRegex),
   }
+}
+
+export function getPreviouslyRevalidatedTags(
+  headers: IncomingHttpHeaders,
+  previewModeId: string | undefined
+): string[] {
+  return typeof headers[NEXT_CACHE_REVALIDATED_TAGS_HEADER] === 'string' &&
+    headers[NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER] === previewModeId
+    ? headers[NEXT_CACHE_REVALIDATED_TAGS_HEADER].split(',')
+    : []
 }

--- a/packages/next/src/server/use-cache/handlers.ts
+++ b/packages/next/src/server/use-cache/handlers.ts
@@ -1,5 +1,5 @@
 import DefaultCacheHandler from '../lib/cache-handlers/default'
-import type { CacheHandler } from '../lib/cache-handlers/types'
+import type { CacheHandlerCompat } from '../lib/cache-handlers/types'
 
 const debug = process.env.NEXT_PRIVATE_DEBUG_USE_CACHE
   ? (message: string, ...args: any[]) => {
@@ -18,11 +18,11 @@ const handlersSetSymbol = Symbol.for('@next/cache-handlers-set')
  */
 const reference: typeof globalThis & {
   [handlersSymbol]?: {
-    RemoteCache?: CacheHandler
-    DefaultCache?: CacheHandler
+    RemoteCache?: CacheHandlerCompat
+    DefaultCache?: CacheHandlerCompat
   }
-  [handlersMapSymbol]?: Map<string, CacheHandler>
-  [handlersSetSymbol]?: Set<CacheHandler>
+  [handlersMapSymbol]?: Map<string, CacheHandlerCompat>
+  [handlersSetSymbol]?: Set<CacheHandlerCompat>
 } = globalThis
 
 /**
@@ -37,11 +37,11 @@ export function initializeCacheHandlers(): boolean {
   }
 
   debug('initializing cache handlers')
-  reference[handlersMapSymbol] = new Map<string, CacheHandler>()
+  reference[handlersMapSymbol] = new Map<string, CacheHandlerCompat>()
 
   // Initialize the cache from the symbol contents first.
   if (reference[handlersSymbol]) {
-    let fallback: CacheHandler
+    let fallback: CacheHandlerCompat
     if (reference[handlersSymbol].DefaultCache) {
       debug('setting "default" cache handler from symbol')
       fallback = reference[handlersSymbol].DefaultCache
@@ -80,7 +80,7 @@ export function initializeCacheHandlers(): boolean {
  * @param kind - The kind of cache handler to get.
  * @returns The cache handler, or `undefined` if it is not initialized or does not exist.
  */
-export function getCacheHandler(kind: string): CacheHandler | undefined {
+export function getCacheHandler(kind: string): CacheHandlerCompat | undefined {
   // This should never be called before initializeCacheHandlers.
   if (!reference[handlersMapSymbol]) {
     throw new Error('Cache handlers not initialized')
@@ -93,7 +93,9 @@ export function getCacheHandler(kind: string): CacheHandler | undefined {
  * Get an iterator over the cache handlers.
  * @returns An iterator over the cache handlers, or `undefined` if they are not initialized.
  */
-export function getCacheHandlers(): SetIterator<CacheHandler> | undefined {
+export function getCacheHandlers():
+  | SetIterator<CacheHandlerCompat>
+  | undefined {
   if (!reference[handlersSetSymbol]) {
     return undefined
   }
@@ -108,7 +110,7 @@ export function getCacheHandlers(): SetIterator<CacheHandler> | undefined {
  */
 export function setCacheHandler(
   kind: string,
-  cacheHandler: CacheHandler
+  cacheHandler: CacheHandlerCompat
 ): void {
   // This should never be called before initializeCacheHandlers.
   if (!reference[handlersMapSymbol] || !reference[handlersSetSymbol]) {

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -688,7 +688,15 @@ export function cache(
 
         let entry = forceRevalidate
           ? undefined
-          : await cacheHandler.get(serializedCacheKey)
+          : 'getExpiration' in cacheHandler
+            ? await cacheHandler.get(serializedCacheKey)
+            : // Legacy cache handlers require implicit tags to be passed in,
+              // instead of checking their staleness here, as we do for modern
+              // cache handlers (see below).
+              await cacheHandler.get(
+                serializedCacheKey,
+                implicitTags?.tags ?? []
+              )
 
         if (
           entry &&

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -272,7 +272,7 @@ async function collectResult(
       ? innerCacheStore.explicitStale
       : innerCacheStore.stale
 
-  const entry = {
+  const entry: CacheEntry = {
     value: bufferStream,
     timestamp: startTime,
     revalidate: collectedRevalidate,
@@ -714,9 +714,8 @@ export function cache(
           } else {
             // TODO: Do this once at the start of the request (but for every
             // cache handler).
-            const implicitTagsExpiration = await cacheHandler.getExpiration(
-              ...implicitTags
-            )
+            const implicitTagsExpiration =
+              (await cacheHandler.getExpiration?.(...implicitTags)) ?? 0
 
             // If the cache entry was created before any of the implicit tags
             // were revalidated last, we need to discard it.

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -282,6 +282,7 @@ export async function adapter(
                 NEXT_ROUTER_PREFETCH_HEADER
               ),
               buildId: buildId ?? '',
+              previouslyRevalidatedTags: [],
             })
 
             return await workAsyncStorage.run(workStore, () =>

--- a/packages/next/src/server/web/spec-extension/revalidate.ts
+++ b/packages/next/src/server/web/spec-extension/revalidate.ts
@@ -145,13 +145,13 @@ function revalidate(tags: string[], expression: string) {
     }
   }
 
-  if (!store.revalidatedTags) {
-    store.revalidatedTags = []
+  if (!store.pendingRevalidatedTags) {
+    store.pendingRevalidatedTags = []
   }
 
   for (const tag of tags) {
-    if (!store.revalidatedTags.includes(tag)) {
-      store.revalidatedTags.push(tag)
+    if (!store.pendingRevalidatedTags.includes(tag)) {
+      store.pendingRevalidatedTags.push(tag)
     }
   }
 

--- a/test/e2e/app-dir/use-cache-custom-handler/app/legacy/page.tsx
+++ b/test/e2e/app-dir/use-cache-custom-handler/app/legacy/page.tsx
@@ -7,10 +7,10 @@ import {
 import { redirect } from 'next/navigation'
 
 async function getData() {
-  'use cache'
+  'use cache: legacy'
 
   cacheLife({ revalidate: 3 })
-  cacheTag('modern')
+  cacheTag('legacy')
 
   return new Date().toISOString()
 }
@@ -21,7 +21,7 @@ async function AsyncComp() {
   return <p id="data">{data}</p>
 }
 
-export default function Home() {
+export default function Legacy() {
   return (
     <main>
       <Suspense fallback={<p>Loading...</p>}>
@@ -31,8 +31,8 @@ export default function Home() {
         action={async () => {
           'use server'
 
-          revalidateTag('modern')
-          redirect('/')
+          revalidateTag('legacy')
+          redirect('/legacy')
         }}
       >
         <button id="revalidate">Revalidate Tag</button>

--- a/test/e2e/app-dir/use-cache-custom-handler/handler.js
+++ b/test/e2e/app-dir/use-cache-custom-handler/handler.js
@@ -1,17 +1,33 @@
-const cacheHandler =
+// @ts-check
+
+const defaultCacheHandler =
   require('next/dist/server/lib/cache-handlers/default').default
 
-module.exports = {
-  async get(cacheKey, softTags) {
-    console.log('CustomCacheHandler::Get', cacheKey, softTags)
-    return cacheHandler.get(cacheKey, softTags)
+/**
+ * @type {import('next/dist/server/lib/cache-handlers/types').CacheHandler}
+ */
+const cacheHandler = {
+  async get(cacheKey) {
+    console.log('CustomCacheHandler::get', cacheKey)
+    return defaultCacheHandler.get(cacheKey)
   },
 
   async set(cacheKey, pendingEntry) {
-    console.log('CustomCacheHandler::Set', cacheKey)
-    return cacheHandler.set(cacheKey, pendingEntry)
+    console.log('CustomCacheHandler::set', cacheKey)
+    return defaultCacheHandler.set(cacheKey, pendingEntry)
+  },
+
+  async refreshTags() {
+    console.log('CustomCacheHandler::refreshTags')
+    return defaultCacheHandler.refreshTags()
+  },
+
+  async getExpiration(...tags) {
+    console.log('CustomCacheHandler::getExpiration', tags)
+    return defaultCacheHandler.getExpiration(...tags)
   },
 
   async expireTags(...tags) {},
-  async receiveExpiredTags(...tags) {},
 }
+
+module.exports = cacheHandler

--- a/test/e2e/app-dir/use-cache-custom-handler/handler.js
+++ b/test/e2e/app-dir/use-cache-custom-handler/handler.js
@@ -4,7 +4,7 @@ const defaultCacheHandler =
   require('next/dist/server/lib/cache-handlers/default').default
 
 /**
- * @type {import('next/dist/server/lib/cache-handlers/types').CacheHandler}
+ * @type {import('next/dist/server/lib/cache-handlers/types').CacheHandlerV2}
  */
 const cacheHandler = {
   async get(cacheKey) {
@@ -23,11 +23,14 @@ const cacheHandler = {
   },
 
   async getExpiration(...tags) {
-    console.log('CustomCacheHandler::getExpiration', tags)
+    console.log('CustomCacheHandler::getExpiration', JSON.stringify(tags))
     return defaultCacheHandler.getExpiration(...tags)
   },
 
-  async expireTags(...tags) {},
+  async expireTags(...tags) {
+    console.log('CustomCacheHandler::expireTags', JSON.stringify(tags))
+    return defaultCacheHandler.expireTags(...tags)
+  },
 }
 
 module.exports = cacheHandler

--- a/test/e2e/app-dir/use-cache-custom-handler/legacy-handler.js
+++ b/test/e2e/app-dir/use-cache-custom-handler/legacy-handler.js
@@ -1,0 +1,37 @@
+// @ts-check
+
+const defaultCacheHandler =
+  require('next/dist/server/lib/cache-handlers/default').default
+
+/**
+ * @type {import('next/dist/server/lib/cache-handlers/types').CacheHandler}
+ */
+const cacheHandler = {
+  async get(cacheKey, softTags) {
+    console.log(
+      'LegacyCustomCacheHandler::get',
+      cacheKey,
+      JSON.stringify(softTags)
+    )
+    return defaultCacheHandler.get(cacheKey)
+  },
+
+  async set(cacheKey, pendingEntry) {
+    console.log('LegacyCustomCacheHandler::set', cacheKey)
+    return defaultCacheHandler.set(cacheKey, pendingEntry)
+  },
+
+  async expireTags(...tags) {
+    console.log('LegacyCustomCacheHandler::expireTags', JSON.stringify(tags))
+    return defaultCacheHandler.expireTags(...tags)
+  },
+
+  async receiveExpiredTags(...tags) {
+    console.log(
+      'LegacyCustomCacheHandler::receiveExpiredTags',
+      JSON.stringify(tags)
+    )
+  },
+}
+
+module.exports = cacheHandler

--- a/test/e2e/app-dir/use-cache-custom-handler/next.config.js
+++ b/test/e2e/app-dir/use-cache-custom-handler/next.config.js
@@ -6,6 +6,7 @@ const nextConfig = {
     dynamicIO: true,
     cacheHandlers: {
       default: require.resolve('./handler.js'),
+      legacy: require.resolve('./legacy-handler.js'),
     },
   },
 }

--- a/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
@@ -17,10 +17,16 @@ describe('use-cache-custom-handler', () => {
     expect(initialData).toMatch(/^\d+\.\d+$/)
 
     expect(next.cliOutput.slice(outputIndex)).toContain(
-      'CustomCacheHandler::Get'
+      'CustomCacheHandler::refreshTags'
     )
     expect(next.cliOutput.slice(outputIndex)).toContain(
-      'CustomCacheHandler::Set'
+      `CustomCacheHandler::getExpiration [ '_N_T_/layout', '_N_T_/page', '_N_T_/' ]`
+    )
+    expect(next.cliOutput.slice(outputIndex)).toContain(
+      'CustomCacheHandler::get'
+    )
+    expect(next.cliOutput.slice(outputIndex)).toContain(
+      'CustomCacheHandler::set'
     )
 
     await retry(async () => {

--- a/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
@@ -1,5 +1,7 @@
-import { nextTestSetup } from 'e2e-utils'
+import { isNextStart, nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
+
+const isoDateRegExp = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
 
 describe('use-cache-custom-handler', () => {
   const { next, skipped } = nextTestSetup({
@@ -10,30 +12,137 @@ describe('use-cache-custom-handler', () => {
 
   if (skipped) return
 
-  it('should use custom cache handler if provided', async () => {
+  it('should use a modern custom cache handler if provided', async () => {
     const outputIndex = next.cliOutput.length
     const browser = await next.browser(`/`)
+
+    if (isNextStart) {
+      // Refresh once to let it revalidate the prerendered page.
+      await browser.refresh()
+    }
+
     const initialData = await browser.elementById('data').text()
-    expect(initialData).toMatch(/^\d+\.\d+$/)
+    expect(initialData).toMatch(isoDateRegExp)
 
     expect(next.cliOutput.slice(outputIndex)).toContain(
       'CustomCacheHandler::refreshTags'
     )
+
     expect(next.cliOutput.slice(outputIndex)).toContain(
-      `CustomCacheHandler::getExpiration [ '_N_T_/layout', '_N_T_/page', '_N_T_/' ]`
+      `CustomCacheHandler::getExpiration ["_N_T_/layout","_N_T_/page","_N_T_/"]`
     )
-    expect(next.cliOutput.slice(outputIndex)).toContain(
-      'CustomCacheHandler::get'
+
+    expect(next.cliOutput.slice(outputIndex)).toMatch(
+      /CustomCacheHandler::get \["(development|[A-Za-z0-9_-]{21})","\$undefined","([0-9a-f]{2})+",\[\]\]/
     )
-    expect(next.cliOutput.slice(outputIndex)).toContain(
-      'CustomCacheHandler::set'
+
+    expect(next.cliOutput.slice(outputIndex)).toMatch(
+      /CustomCacheHandler::set \["(development|[A-Za-z0-9_-]{21})","\$undefined","([0-9a-f]{2})+",\[\]\]/
     )
+
+    // The data should be cached initially.
+
+    await browser.refresh()
+    let data = await browser.elementById('data').text()
+    expect(data).toMatch(isoDateRegExp)
+    expect(data).toEqual(initialData)
+
+    // Because we use a low `revalidate` value for the "use cache" function, new
+    // data should be returned eventually.
 
     await retry(async () => {
       await browser.refresh()
-      const data = await browser.elementById('data').text()
-      expect(data).toMatch(/^\d+\.\d+$/)
+      data = await browser.elementById('data').text()
+      expect(data).toMatch(isoDateRegExp)
       expect(data).not.toEqual(initialData)
-    })
+    }, 5000)
+  })
+
+  it('should use a legacy custom cache handler if provided', async () => {
+    const outputIndex = next.cliOutput.length
+    const browser = await next.browser(`/legacy`)
+
+    if (isNextStart) {
+      // Refresh once to let it revalidate the prerendered page.
+      await browser.refresh()
+    }
+
+    const initialData = await browser.elementById('data').text()
+    expect(initialData).toMatch(isoDateRegExp)
+
+    expect(next.cliOutput.slice(outputIndex)).toContain(
+      'LegacyCustomCacheHandler::receiveExpiredTags []'
+    )
+
+    expect(next.cliOutput.slice(outputIndex)).toMatch(
+      /LegacyCustomCacheHandler::get \["(development|[A-Za-z0-9_-]{21})","\$undefined","([0-9a-f]{2})+",\[\]\] \["_N_T_\/layout","_N_T_\/legacy\/layout","_N_T_\/legacy\/page","_N_T_\/legacy"\]/
+    )
+
+    expect(next.cliOutput.slice(outputIndex)).toMatch(
+      /LegacyCustomCacheHandler::set \["(development|[A-Za-z0-9_-]{21})","\$undefined","([0-9a-f]{2})+",\[\]\]/
+    )
+
+    // The data should be cached initially.
+
+    await browser.refresh()
+    let data = await browser.elementById('data').text()
+    expect(data).toMatch(isoDateRegExp)
+    expect(data).toEqual(initialData)
+
+    // Because we use a low `revalidate` value for the "use cache" function, new
+    // data should be returned eventually.
+
+    await retry(async () => {
+      await browser.refresh()
+      data = await browser.elementById('data').text()
+      expect(data).toMatch(isoDateRegExp)
+      expect(data).not.toEqual(initialData)
+    }, 5000)
+  })
+
+  it('should revalidate using a modern custom cache handler', async () => {
+    const outputIndex = next.cliOutput.length
+    const browser = await next.browser(`/`)
+    const initialData = await browser.elementById('data').text()
+    expect(initialData).toMatch(isoDateRegExp)
+
+    await browser.elementById('revalidate').click()
+
+    await retry(async () => {
+      expect(next.cliOutput.slice(outputIndex)).toContain(
+        'CustomCacheHandler::expireTags ["modern"]'
+      )
+
+      const data = await browser.elementById('data').text()
+      expect(data).toMatch(isoDateRegExp)
+      expect(data).not.toEqual(initialData)
+    }, 5000)
+  })
+
+  it('should revalidate using a legacy custom cache handler', async () => {
+    const outputIndex = next.cliOutput.length
+    const browser = await next.browser(`/legacy`)
+    const initialData = await browser.elementById('data').text()
+    expect(initialData).toMatch(isoDateRegExp)
+
+    expect(next.cliOutput.slice(outputIndex)).toContain(
+      'LegacyCustomCacheHandler::receiveExpiredTags []'
+    )
+
+    await browser.elementById('revalidate').click()
+
+    await retry(async () => {
+      expect(next.cliOutput.slice(outputIndex)).toContain(
+        'LegacyCustomCacheHandler::expireTags ["legacy"]'
+      )
+
+      expect(next.cliOutput.slice(outputIndex)).toContain(
+        'LegacyCustomCacheHandler::receiveExpiredTags ["legacy"]'
+      )
+
+      const data = await browser.elementById('data').text()
+      expect(data).toMatch(isoDateRegExp)
+      expect(data).not.toEqual(initialData)
+    }, 5000)
   })
 })

--- a/test/e2e/app-dir/use-cache/app/cache-tag/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/cache-tag/page.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { unstable_cacheTag as cacheTag } from 'next/cache'
 import { RevalidateButtons } from './buttons'
+import Link from 'next/link'
 
 async function getCachedWithTag({
   tag,
@@ -53,6 +54,11 @@ export default async function Page() {
       <p id="r1">[r, c] {r1}</p>
       <p id="r2">[-] {r2}</p>
       <RevalidateButtons />
+      <p>
+        <Link href="/revalidate-and-redirect">
+          Go to /revalidate-and-redirect
+        </Link>
+      </p>
     </div>
   )
 }

--- a/test/e2e/app-dir/use-cache/app/nested-in-unstable-cache/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/nested-in-unstable-cache/page.tsx
@@ -1,0 +1,24 @@
+import { revalidatePath, unstable_cache } from 'next/cache'
+
+async function inner() {
+  'use cache'
+  return Math.random()
+}
+
+const outer = unstable_cache(async () => {
+  return inner()
+})
+
+export default async function Page() {
+  return (
+    <form
+      action={async () => {
+        'use server'
+        revalidatePath('/nested-in-unstable-cache')
+      }}
+    >
+      <p>{await outer()}</p>
+      <button>Revalidate path</button>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/use-cache/app/revalidate-and-redirect/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/revalidate-and-redirect/page.tsx
@@ -1,0 +1,31 @@
+import { revalidatePath, revalidateTag } from 'next/cache'
+import { redirect } from 'next/navigation'
+
+export default function Page() {
+  return (
+    <form>
+      <button
+        id="revalidate-tag-redirect"
+        formAction={async () => {
+          'use server'
+
+          revalidateTag('a')
+          redirect('/cache-tag')
+        }}
+      >
+        Revalidate tag and redirect
+      </button>{' '}
+      <button
+        id="revalidate-path-redirect"
+        formAction={async () => {
+          'use server'
+
+          revalidatePath('/cache-tag')
+          redirect('/cache-tag')
+        }}
+      >
+        Revalidate path and redirect
+      </button>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/use-cache/app/with-server-action/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/with-server-action/page.tsx
@@ -1,5 +1,3 @@
-// TODO: This should not need the suspense boundary in the root layout, but
-// currently does with Turbopack.
 import { Form } from './form'
 
 async function action() {

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -393,6 +393,7 @@ describe('use-cache', () => {
         '/passed-to-client',
         '/react-cache',
         '/referential-equality',
+        '/revalidate-and-redirect',
         '/rsc-payload',
         '/static-class-method',
         '/use-action-state',

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -418,6 +418,7 @@ describe('use-cache', () => {
         '/imported-from-client',
         '/logs',
         '/method-props',
+        '/nested-in-unstable-cache',
         '/not-found',
         '/on-demand-revalidate',
         '/passed-to-client',

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -1,3 +1,4 @@
+// TODO: write a test for a nested "use cache" inside unstable_cache.
 import { nextTestSetup } from 'e2e-utils'
 import { retry, waitFor } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'

--- a/test/production/app-dir/dynamic-io-cache-handlers/dynamic-io-cache-handlers.test.ts
+++ b/test/production/app-dir/dynamic-io-cache-handlers/dynamic-io-cache-handlers.test.ts
@@ -39,12 +39,16 @@ describe('dynamic-io-cache-handlers', () => {
             console.log('symbol set', cacheKey)
           },
         
-          expireTags(...tags) {
-            console.log('symbol expireTags', tags)
+          refreshTags() {
+            console.log('symbol refreshTags')
+          },
+
+          getExpiration(...tags) {
+            console.log('symbol getExpiration', tags)
           },
         
-          receiveExpiredTags(...tags) {
-            console.log('symbol receiveExpiredTags', tags)
+          expireTags(...tags) {
+            console.log('symbol expireTags', tags)
           }
         }
       }
@@ -103,30 +107,12 @@ describe('dynamic-io-cache-handlers', () => {
     })
   })
 
-  it('should call receiveExpiredTags on global default cache handler without tags if none are provided', async () => {
+  it('should call refreshTags on global default cache handler', async () => {
     const res = await fetchViaHTTP(appPort, '/', {})
     expect(res.status).toBe(200)
 
     await retry(async () => {
-      expect(output).toContain('symbol receiveExpiredTags []')
-    })
-  })
-
-  it('should call receiveExpiredTags on global default cache handler', async () => {
-    const res = await fetchViaHTTP(
-      appPort,
-      '/',
-      {},
-      {
-        headers: {
-          'x-next-revalidated-tags': 'tag1',
-        },
-      }
-    )
-    expect(res.status).toBe(200)
-
-    await retry(async () => {
-      expect(output).toContain("symbol receiveExpiredTags [ 'tag1' ]")
+      expect(output).toContain('symbol refreshTags')
     })
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
   "include": [
     "test/**/*.test.ts",
     "test/**/*.test.tsx",
+    "test/e2e/app-dir/use-cache-custom-handler/*.js",
     "test/lib/**/*.ts",
     "turbo/**/*.ts"
   ]


### PR DESCRIPTION
With this PR, we're changing the experimental cache handler interface that's used for `"use cache"` cache handlers:

- A new method `refreshTags(): Promise<void>` has been added.
    - Next.js will call this function periodically, but always before starting a new request. When working with a remote tags service, this method should communicate with the tags service to refresh the local tags manifest accordingly.
- A new method `getExpiration(...tags: string[]): Promise<Timestamp>` has been added.
    - Next.js will call this function for each set of soft tags that are relevant at the start of a request. The result is the maximum timestamp of a revalidate event for the tags.
- The `get` method does not accept the soft tags anymore as its second arg: `get(cacheKey: string): Promise<undefined | CacheEntry>`
   - Checking the expiration of a cache entry via soft tags is now handled by Next.js.
- The `receiveExpiredTags` method has been removed.
    - This was used for two things:
        1. Refreshing the tags in the tags manifest. This was replaced by `refreshTags`.
        2. Setting the passed-in tags as expired in the tags manifest. This was used for redirecting server actions. Discarding cache entries based on these tags is now handled by Next.js internally.

To ease migration, the previous cache handler interface is still supported for now.

closes NAR-110