### PR TITLE
[metadata]: ensure metadata boundary is only rendered once on client nav

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
@@ -19,7 +19,30 @@ function findHeadInCacheImpl(
     // Returns the entire Cache Node of the segment whose head we will render.
     return [cache, keyPrefix]
   }
+
+  // First try the 'children' parallel route if it exists
+  // when starting from the "root", this corresponds with the main page component
+  if (parallelRoutes.children) {
+    const [segment, childParallelRoutes] = parallelRoutes.children
+    const childSegmentMap = cache.parallelRoutes.get('children')
+    if (childSegmentMap) {
+      const cacheKey = createRouterCacheKey(segment)
+      const cacheNode = childSegmentMap.get(cacheKey)
+      if (cacheNode) {
+        const item = findHeadInCacheImpl(
+          cacheNode,
+          childParallelRoutes,
+          keyPrefix + '/' + cacheKey
+        )
+        if (item) return item
+      }
+    }
+  }
+
+  // if we didn't find metadata in the page slot, check the other parallel routes
   for (const key in parallelRoutes) {
+    if (key === 'children') continue // already checked above
+
     const [segment, childParallelRoutes] = parallelRoutes[key]
     const childSegmentMap = cache.parallelRoutes.get(key)
     if (!childSegmentMap) {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -523,6 +523,7 @@ async function generateDynamicRSCPayload(
             {/* Adding requestId as react key to make metadata remount for each render */}
             <ViewportTree key={requestId} />
             {StreamingMetadata ? <StreamingMetadata /> : null}
+            {StreamingMetadataOutlet ? <StreamingMetadataOutlet /> : null}
             <StaticMetadata />
           </React.Fragment>
         ),
@@ -533,7 +534,6 @@ async function generateDynamicRSCPayload(
         getViewportReady,
         getMetadataReady,
         preloadCallbacks,
-        StreamingMetadataOutlet,
       })
     ).map((path) => path.slice(1)) // remove the '' (root) segment
   }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -522,6 +522,7 @@ async function generateDynamicRSCPayload(
             <NonIndex ctx={ctx} />
             {/* Adding requestId as react key to make metadata remount for each render */}
             <ViewportTree key={requestId} />
+            {StreamingMetadata ? <StreamingMetadata /> : null}
             <StaticMetadata />
           </React.Fragment>
         ),
@@ -532,7 +533,6 @@ async function generateDynamicRSCPayload(
         getViewportReady,
         getMetadataReady,
         preloadCallbacks,
-        StreamingMetadata,
         StreamingMetadataOutlet,
       })
     ).map((path) => path.slice(1)) // remove the '' (root) segment

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -523,7 +523,6 @@ async function generateDynamicRSCPayload(
             {/* Adding requestId as react key to make metadata remount for each render */}
             <ViewportTree key={requestId} />
             {StreamingMetadata ? <StreamingMetadata /> : null}
-            {StreamingMetadataOutlet ? <StreamingMetadataOutlet /> : null}
             <StaticMetadata />
           </React.Fragment>
         ),
@@ -534,6 +533,7 @@ async function generateDynamicRSCPayload(
         getViewportReady,
         getMetadataReady,
         preloadCallbacks,
+        StreamingMetadataOutlet,
       })
     ).map((path) => path.slice(1)) // remove the '' (root) segment
   }

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -41,7 +41,7 @@ export function createComponentTree(props: {
   preloadCallbacks: PreloadCallbacks
   authInterrupts: boolean
   StreamingMetadata: React.ComponentType<{}> | null
-  StreamingMetadataOutlet: React.ComponentType | null
+  StreamingMetadataOutlet: React.ComponentType
 }): Promise<CacheNodeSeedData> {
   return getTracer().trace(
     NextNodeServerSpan.createComponentTree,

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -41,7 +41,7 @@ export function createComponentTree(props: {
   preloadCallbacks: PreloadCallbacks
   authInterrupts: boolean
   StreamingMetadata: React.ComponentType<{}> | null
-  StreamingMetadataOutlet: React.ComponentType
+  StreamingMetadataOutlet: React.ComponentType | null
 }): Promise<CacheNodeSeedData> {
   return getTracer().trace(
     NextNodeServerSpan.createComponentTree,

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -40,7 +40,6 @@ export async function walkTreeWithFlightRouterState({
   getMetadataReady,
   ctx,
   preloadCallbacks,
-  StreamingMetadata,
   StreamingMetadataOutlet,
 }: {
   loaderTreeToFilter: LoaderTree
@@ -56,7 +55,6 @@ export async function walkTreeWithFlightRouterState({
   getViewportReady: () => Promise<void>
   ctx: AppRenderContext
   preloadCallbacks: PreloadCallbacks
-  StreamingMetadata: React.ComponentType<{}> | null
   StreamingMetadataOutlet: React.ComponentType<{}>
 }): Promise<FlightDataPath[]> {
   const {
@@ -206,7 +204,7 @@ export async function walkTreeWithFlightRouterState({
         getMetadataReady,
         preloadCallbacks,
         authInterrupts: experimental.authInterrupts,
-        StreamingMetadata,
+        StreamingMetadata: null,
         StreamingMetadataOutlet,
       }
     )
@@ -267,7 +265,6 @@ export async function walkTreeWithFlightRouterState({
       getViewportReady,
       getMetadataReady,
       preloadCallbacks,
-      StreamingMetadata,
       StreamingMetadataOutlet,
     })
 

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -40,6 +40,7 @@ export async function walkTreeWithFlightRouterState({
   getMetadataReady,
   ctx,
   preloadCallbacks,
+  StreamingMetadataOutlet,
 }: {
   loaderTreeToFilter: LoaderTree
   parentParams: { [key: string]: string | string[] }
@@ -54,6 +55,7 @@ export async function walkTreeWithFlightRouterState({
   getViewportReady: () => Promise<void>
   ctx: AppRenderContext
   preloadCallbacks: PreloadCallbacks
+  StreamingMetadataOutlet: React.ComponentType
 }): Promise<FlightDataPath[]> {
   const {
     renderOpts: { nextFontManifest, experimental },
@@ -203,7 +205,7 @@ export async function walkTreeWithFlightRouterState({
         preloadCallbacks,
         authInterrupts: experimental.authInterrupts,
         StreamingMetadata: null,
-        StreamingMetadataOutlet: null,
+        StreamingMetadataOutlet,
       }
     )
 
@@ -263,6 +265,7 @@ export async function walkTreeWithFlightRouterState({
       getViewportReady,
       getMetadataReady,
       preloadCallbacks,
+      StreamingMetadataOutlet,
     })
 
     for (const subPath of subPaths) {

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -40,7 +40,6 @@ export async function walkTreeWithFlightRouterState({
   getMetadataReady,
   ctx,
   preloadCallbacks,
-  StreamingMetadataOutlet,
 }: {
   loaderTreeToFilter: LoaderTree
   parentParams: { [key: string]: string | string[] }
@@ -55,7 +54,6 @@ export async function walkTreeWithFlightRouterState({
   getViewportReady: () => Promise<void>
   ctx: AppRenderContext
   preloadCallbacks: PreloadCallbacks
-  StreamingMetadataOutlet: React.ComponentType<{}>
 }): Promise<FlightDataPath[]> {
   const {
     renderOpts: { nextFontManifest, experimental },
@@ -205,7 +203,7 @@ export async function walkTreeWithFlightRouterState({
         preloadCallbacks,
         authInterrupts: experimental.authInterrupts,
         StreamingMetadata: null,
-        StreamingMetadataOutlet,
+        StreamingMetadataOutlet: null,
       }
     )
 
@@ -265,7 +263,6 @@ export async function walkTreeWithFlightRouterState({
       getViewportReady,
       getMetadataReady,
       preloadCallbacks,
-      StreamingMetadataOutlet,
     })
 
     for (const subPath of subPaths) {

--- a/test/e2e/app-dir/metadata-streaming/app/parallel-routes/@bar/test-page/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming/app/parallel-routes/@bar/test-page/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'test-page @bar'
+}

--- a/test/e2e/app-dir/metadata-streaming/app/parallel-routes/@foo/no-bar/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming/app/parallel-routes/@foo/no-bar/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'no-bar @foo'
+}

--- a/test/e2e/app-dir/metadata-streaming/app/parallel-routes/@foo/test-page/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming/app/parallel-routes/@foo/test-page/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'test-page @foo'
+}

--- a/test/e2e/app-dir/metadata-streaming/app/parallel-routes/no-bar/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming/app/parallel-routes/no-bar/page.tsx
@@ -1,0 +1,13 @@
+import { connection } from 'next/server'
+
+export default function TestPage() {
+  return 'test page'
+}
+
+export async function generateMetadata() {
+  await connection()
+  await new Promise((resolve) => setTimeout(resolve, 3000))
+  return {
+    title: `Dynamic api ${Math.random()}`,
+  }
+}

--- a/test/e2e/app-dir/metadata-streaming/app/parallel-routes/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming/app/parallel-routes/page.tsx
@@ -1,5 +1,14 @@
+import Link from 'next/link'
+
 export default function Page() {
-  return <div>Hello from Nested</div>
+  return (
+    <div>
+      Hello from Nested{' '}
+      <Link href="/parallel-routes/test-page">
+        To /parallel-routes/test-page
+      </Link>
+    </div>
+  )
 }
 
 export const metadata = {

--- a/test/e2e/app-dir/metadata-streaming/app/parallel-routes/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming/app/parallel-routes/page.tsx
@@ -7,6 +7,7 @@ export default function Page() {
       <Link href="/parallel-routes/test-page">
         To /parallel-routes/test-page
       </Link>
+      <Link href="/parallel-routes/no-bar">To /parallel-routes/no-bar</Link>
     </div>
   )
 }

--- a/test/e2e/app-dir/metadata-streaming/app/parallel-routes/test-page/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming/app/parallel-routes/test-page/page.tsx
@@ -1,0 +1,13 @@
+import { connection } from 'next/server'
+
+export default function TestPage() {
+  return 'test page'
+}
+
+export async function generateMetadata() {
+  await connection()
+  await new Promise((resolve) => setTimeout(resolve, 3000))
+  return {
+    title: `Dynamic api ${Math.random()}`,
+  }
+}

--- a/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
+++ b/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
@@ -88,7 +88,7 @@ describe('app-dir - metadata-streaming', () => {
     expect((await browser.elementsByCss('body meta')).length).toBe(9)
   })
 
-  it('should only insert metadata once for parallel routes', async () => {
+  it('should only insert metadata once for parallel routes when slots match', async () => {
     const browser = await next.browser('/parallel-routes')
 
     expect((await browser.elementsByCss('head title')).length).toBe(1)
@@ -99,6 +99,19 @@ describe('app-dir - metadata-streaming', () => {
 
     // validate behavior remains the same on client navigations
     await browser.elementByCss('[href="/parallel-routes/test-page"]').click()
+
+    await retry(async () => {
+      expect(await browser.elementByCss('title').text()).toContain(
+        'Dynamic api'
+      )
+    })
+
+    expect((await browser.elementsByCss('title')).length).toBe(1)
+  })
+
+  it('should only insert metadata once for parallel routes when there is a missing slot', async () => {
+    const browser = await next.browser('/parallel-routes')
+    await browser.elementByCss('[href="/parallel-routes/no-bar"]').click()
 
     await retry(async () => {
       expect(await browser.elementByCss('title').text()).toContain(

--- a/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
+++ b/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
@@ -96,6 +96,17 @@ describe('app-dir - metadata-streaming', () => {
 
     const $ = await next.render$('/parallel-routes')
     expect($('title').length).toBe(1)
+
+    // validate behavior remains the same on client navigations
+    await browser.elementByCss('[href="/parallel-routes/test-page"]').click()
+
+    await retry(async () => {
+      expect(await browser.elementByCss('title').text()).toContain(
+        'Dynamic api'
+      )
+    })
+
+    expect((await browser.elementsByCss('title')).length).toBe(1)
   })
 
   describe('dynamic api', () => {


### PR DESCRIPTION
On client navigations, rendering does not start at the root, it starts at the common layout down. As a result the existing heuristic to only render the `<StreamingMetadata />` component once won't work, as `children` will likely appear for parallel routes within the subtree. (In other words: `children` is only useful as a heuristic for root renders). 

As a result, metadata will get duplicated on client navigation if parallel routes match that page (this is because we iterate over all parallel routes, and conditionally render `<StreamingMetadata />` based on the flawed heuristic above)

Since the metadata tree is accumulated and only rendered once, ideally it should never be rendered in `createComponentTree`. Or if it is, we need to ensure it’s never rendered more than once, as it would contain the same contents twice. 

This PR:
- On client navs, ensures that we only render `<StreamingMetadata />` once as part of the `rscHead`, rather than per parallel route segment: [5e3686a](https://github.com/vercel/next.js/pull/76692/commits/5e3686ac55c0020ab843e8a2648f180ad9f33ca6)
- On the client, we make sure to prioritize the `head` node corresponding with the root page slot ("children"). Otherwise we might not render `<StreamingMetadata />` at all, since the current heuristic would have early-returned for a parallel route that _didn't_ change as part of the navigation (eg the case where a slot doesn't match, and keeps rendering the previous node): [7364e6e](https://github.com/vercel/next.js/pull/76692/commits/7364e6e008dfb99b454267ff6a7b4a080a9f3d08)