### PR TITLE
doc(fix):Document missing info about TURBOPACK env var

### DIFF
--- a/docs/01-app/04-api-reference/08-turbopack.mdx
+++ b/docs/01-app/04-api-reference/08-turbopack.mdx
@@ -7,7 +7,7 @@ description: Turbopack is an incremental bundler optimized for JavaScript and Ty
 
 [Turbopack](https://turbo.build/pack) is an incremental bundler optimized for JavaScript and TypeScript, written in Rust, and built into Next.js. Turbopack can be used in Next.js in both the `pages` and `app` directories for faster local development.
 
-To enable Turbopack, use the `--turbopack` flag when running the Next.js development server.
+To enable Turbopack, use the `--turbopack` flag or set the environment variable `TURBOPACK=1` when running the Next.js development server.
 
 ```json filename="package.json" highlight={3}
 {


### PR DESCRIPTION
I was searching the code on how to enable turbopack when using a custom file to instantiate next (without using `--turbopack`).

In order to do that, I found the env var `TURBOPACK=1` which I can use turbopack properly in my context:

```json filename="package.json" highlight={3}
{
  "scripts": {
    "dev": "TURBOPACK=1 npx tsx ./main.ts",
    "build": "next build",
    "start": "next start",
    "lint": "next lint"
  }
}
```