### PR TITLE
docs: fix reading `params` code blocks

### DIFF
--- a/docs/01-app/01-getting-started/08-error-handling.mdx
+++ b/docs/01-app/01-getting-started/08-error-handling.mdx
@@ -152,7 +152,8 @@ You can call the [`notFound`](/docs/app/api-reference/functions/not-found) funct
 import { getPostBySlug } from '@/lib/posts'
 
 export default async function Page({ params }: { params: { slug: string } }) {
-  const post = getPostBySlug((await params).slug)
+  const { slug } = await params
+  const post = getPostBySlug(slug)
 
   if (!post) {
     notFound()
@@ -166,7 +167,8 @@ export default async function Page({ params }: { params: { slug: string } }) {
 import { getPostBySlug } from '@/lib/posts'
 
 export default async function Page({ params }) {
-  const post = getPostBySlug((await params).slug)
+  const { slug } = await params
+  const post = getPostBySlug(slug)
 
   if (!post) {
     notFound()

--- a/docs/01-app/03-building-your-application/01-routing/04-linking-and-navigating.mdx
+++ b/docs/01-app/03-building-your-application/01-routing/04-linking-and-navigating.mdx
@@ -98,7 +98,7 @@ export default async function Profile({
 }: {
   params: Promise<{ id: string }>
 }) {
-  const id = (await params).id
+  const { id } = await params
   if (!id) {
     redirect('/login')
   }
@@ -122,7 +122,7 @@ async function fetchTeam(id) {
 }
 
 export default async function Profile({ params }) {
-  const id = (await params).id
+  const { id } = await params
   if (!id) {
     redirect('/login')
   }

--- a/docs/01-app/03-building-your-application/01-routing/10-dynamic-routes.mdx
+++ b/docs/01-app/03-building-your-application/01-routing/10-dynamic-routes.mdx
@@ -27,14 +27,14 @@ export default async function Page({
 }: {
   params: Promise<{ slug: string }>
 }) {
-  const slug = (await params).slug
+  const { slug } = await params
   return <div>My Post: {slug}</div>
 }
 ```
 
 ```jsx filename="app/blog/[slug]/page.js" switcher
 export default async function Page({ params }) {
-  const slug = (await params).slug
+  const { slug } = await params
   return <div>My Post: {slug}</div>
 }
 ```

--- a/docs/01-app/03-building-your-application/01-routing/13-route-handlers.mdx
+++ b/docs/01-app/03-building-your-application/01-routing/13-route-handlers.mdx
@@ -278,13 +278,13 @@ export async function GET(
   request: Request,
   { params }: { params: Promise<{ slug: string }> }
 ) {
-  const slug = (await params).slug // 'a', 'b', or 'c'
+  const { slug } = await params // 'a', 'b', or 'c'
 }
 ```
 
 ```js filename="app/items/[slug]/route.js" switcher
 export async function GET(request, { params }) {
-  const slug = (await params).slug // 'a', 'b', or 'c'
+  const { slug } = await params // 'a', 'b', or 'c'
 }
 ```
 

--- a/docs/01-app/03-building-your-application/01-routing/15-internationalization.mdx
+++ b/docs/01-app/03-building-your-application/01-routing/15-internationalization.mdx
@@ -77,7 +77,7 @@ export default async function Page({
 }: {
   params: Promise<{ lang: string }>
 }) {
-  const lang = (await params).lang;
+  const { lang } = await params
   return ...
 }
 ```
@@ -86,7 +86,7 @@ export default async function Page({
 // You now have access to the current locale
 // e.g. /en-US/products -> `lang` is "en-US"
 export default async function Page({ params }) {
-  const lang = (await params).lang;
+  const { lang } = await params
   return ...
 }
 ```
@@ -150,7 +150,7 @@ export default async function Page({
 }: {
   params: Promise<{ lang: 'en' | 'nl' }>
 }) {
-  const lang = (await params).lang
+  const { lang } = await params
   const dict = await getDictionary(lang) // en
   return <button>{dict.products.cart}</button> // Add to Cart
 }
@@ -160,7 +160,7 @@ export default async function Page({
 import { getDictionary } from './dictionaries'
 
 export default async function Page({ params }) {
-  const lang = (await params).lang
+  const { lang } = await params
   const dict = await getDictionary(lang) // en
   return <button>{dict.products.cart}</button> // Add to Cart
 }

--- a/docs/01-app/03-building-your-application/02-data-fetching/04-incremental-static-regeneration.mdx
+++ b/docs/01-app/03-building-your-application/02-data-fetching/04-incremental-static-regeneration.mdx
@@ -53,7 +53,7 @@ export default async function Page({
 }: {
   params: Promise<{ id: string }>
 }) {
-  const id = (await params).id
+  const { id } = await params
   const post: Post = await fetch(`https://api.vercel.app/blog/${id}`).then(
     (res) => res.json()
   )

--- a/docs/01-app/03-building-your-application/06-optimizing/04-metadata.mdx
+++ b/docs/01-app/03-building-your-application/06-optimizing/04-metadata.mdx
@@ -61,7 +61,7 @@ export async function generateMetadata(
   parent: ResolvingMetadata
 ): Promise<Metadata> {
   // read route params
-  const id = (await params).id
+  const { id } = await params
 
   // fetch data
   const product = await fetch(`https://.../${id}`).then((res) => res.json())
@@ -83,7 +83,7 @@ export default function Page({ params, searchParams }: Props) {}
 ```jsx filename="app/products/[id]/page.js" switcher
 export async function generateMetadata({ params, searchParams }, parent) {
   // read route params
-  const id = (await params).id
+  const { id } = await params
 
   // fetch data
   const product = await fetch(`https://.../${id}`).then((res) => res.json())
@@ -298,7 +298,8 @@ Our current recommendation for JSON-LD is to render structured data as a `<scrip
 
 ```tsx filename="app/products/[id]/page.tsx" switcher
 export default async function Page({ params }) {
-  const product = await getProduct((await params).id)
+  const { id } = await params
+  const product = await getProduct(id)
 
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -323,7 +324,8 @@ export default async function Page({ params }) {
 
 ```jsx filename="app/products/[id]/page.js" switcher
 export default async function Page({ params }) {
-  const product = await getProduct((await params).id)
+  const { id } = await params
+  const product = await getProduct(id)
 
   const jsonLd = {
     '@context': 'https://schema.org',

--- a/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
@@ -272,7 +272,7 @@ export default async function Page({
 }: {
   params: Promise<{ slug: string }>
 }) {
-  const slug = (await params).slug
+  const { slug } = await params
   const { default: Post } = await import(`@/content/${slug}.mdx`)
 
   return <Post />
@@ -287,7 +287,7 @@ export const dynamicParams = false
 
 ```jsx filename="app/blog/[slug]/page.js" switcher
 export default async function Page({ params }) {
-  const slug = (await params).slug
+  const { slug } = await params
   const { default: Post } = await import(`@/content/${slug}.mdx`)
 
   return <Post />

--- a/docs/01-app/04-api-reference/02-components/form.mdx
+++ b/docs/01-app/04-api-reference/02-components/form.mdx
@@ -17,7 +17,7 @@ import Form from 'next/form'
 export default function Page() {
   return (
     <Form action="/search">
-      {/* On submission, the input value will be appended to 
+      {/* On submission, the input value will be appended to
           the URL, e.g. /search?query=abc */}
       <input name="query" />
       <button type="submit">Submit</button>
@@ -32,7 +32,7 @@ import Form from 'next/form'
 export default function Search() {
   return (
     <Form action="/search">
-      {/* On submission, the input value will be appended to 
+      {/* On submission, the input value will be appended to
           the URL, e.g. /search?query=abc */}
       <input name="query" />
       <button type="submit">Submit</button>
@@ -51,7 +51,7 @@ import Form from 'next/form'
 export default function Page() {
   return (
     <Form action="/search">
-      {/* On submission, the input value will be appended to 
+      {/* On submission, the input value will be appended to
           the URL, e.g. /search?query=abc */}
       <input name="query" />
       <button type="submit">Submit</button>
@@ -66,7 +66,7 @@ import Form from 'next/form'
 export default function Search() {
   return (
     <Form action="/search">
-      {/* On submission, the input value will be appended to 
+      {/* On submission, the input value will be appended to
           the URL, e.g. /search?query=abc */}
       <input name="query" />
       <button type="submit">Submit</button>
@@ -373,7 +373,8 @@ export default async function PostPage({
 }: {
   params: Promise<{ id: string }>
 }) {
-  const data = await getPost((await params).id)
+  const { id } = await params
+  const data = await getPost(id)
 
   return (
     <div>
@@ -388,7 +389,8 @@ export default async function PostPage({
 import { getPost } from '@/posts/data'
 
 export default async function PostPage({ params }) {
-  const data = await getPost((await params).id)
+  const { id } = await params
+  const data = await getPost(id)
 
   return (
     <div>

--- a/docs/01-app/04-api-reference/03-file-conventions/default.mdx
+++ b/docs/01-app/04-api-reference/03-file-conventions/default.mdx
@@ -39,13 +39,13 @@ export default async function Default({
 }: {
   params: Promise<{ artist: string }>
 }) {
-  const artist = (await params).artist
+  const { artist } = await params
 }
 ```
 
 ```jsx filename="app/[artist]/@sidebar/default.js" switcher
 export default async function Default({ params }) {
-  const artist = (await params).artist
+  const { artist } = await params
 }
 ```
 

--- a/docs/01-app/04-api-reference/03-file-conventions/layout.mdx
+++ b/docs/01-app/04-api-reference/03-file-conventions/layout.mdx
@@ -65,13 +65,13 @@ export default async function Layout({
 }: {
   params: Promise<{ team: string }>
 }) {
-  const team = (await params).team
+  const { team } = await params
 }
 ```
 
 ```jsx filename="app/dashboard/[team]/layout.js" switcher
 export default async function Layout({ params }) {
-  const team = (await params).team
+  const { team } = await params
 }
 ```
 

--- a/docs/01-app/04-api-reference/03-file-conventions/page.mdx
+++ b/docs/01-app/04-api-reference/03-file-conventions/page.mdx
@@ -44,13 +44,13 @@ export default async function Page({
 }: {
   params: Promise<{ slug: string }>
 }) {
-  const slug = (await params).slug
+  const { slug } = await params
 }
 ```
 
 ```jsx filename="app/shop/[slug]/page.js" switcher
 export default async function Page({ params }) {
-  const slug = (await params).slug
+  const { slug } = await params
 }
 ```
 

--- a/docs/01-app/04-api-reference/03-file-conventions/route.mdx
+++ b/docs/01-app/04-api-reference/03-file-conventions/route.mdx
@@ -86,13 +86,13 @@ export async function GET(
   request: Request,
   { params }: { params: Promise<{ team: string }> }
 ) {
-  const team = (await params).team
+  const { team } = await params
 }
 ```
 
 ```js filename="app/dashboard/[team]/route.js" switcher
 export async function GET(request, { params }) {
-  const team = (await params).team
+  const { team } = await params
 }
 ```
 

--- a/docs/01-app/04-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/01-app/04-api-reference/04-functions/generate-metadata.mdx
@@ -90,7 +90,7 @@ export async function generateMetadata(
   parent: ResolvingMetadata
 ): Promise<Metadata> {
   // read route params
-  const id = (await params).id
+  const { id } = await params
 
   // fetch data
   const product = await fetch(`https://.../${id}`).then((res) => res.json())
@@ -112,7 +112,7 @@ export default function Page({ params, searchParams }: Props) {}
 ```jsx filename="app/products/[id]/page.js" switcher
 export async function generateMetadata({ params, searchParams }, parent) {
   // read route params
-  const id = (await params).id
+  const { id } = await params
 
   // fetch data
   const product = await fetch(`https://.../${id}`).then((res) => res.json())

--- a/docs/01-app/04-api-reference/04-functions/not-found.mdx
+++ b/docs/01-app/04-api-reference/04-functions/not-found.mdx
@@ -19,7 +19,8 @@ async function fetchUser(id) {
 }
 
 export default async function Profile({ params }) {
-  const user = await fetchUser((await params).id)
+  const { id } = await params
+  const user = await fetchUser(id)
 
   if (!user) {
     notFound()

--- a/docs/01-app/04-api-reference/04-functions/permanentRedirect.mdx
+++ b/docs/01-app/04-api-reference/04-functions/permanentRedirect.mdx
@@ -49,7 +49,8 @@ async function fetchTeam(id) {
 }
 
 export default async function Profile({ params }) {
-  const team = await fetchTeam((await params).id)
+  const { id } = await params
+  const team = await fetchTeam(id)
   if (!team) {
     permanentRedirect('/login')
   }

--- a/docs/01-app/04-api-reference/04-functions/unstable_cache.mdx
+++ b/docs/01-app/04-api-reference/04-functions/unstable_cache.mdx
@@ -55,7 +55,7 @@ export default async function Page({
 }: {
   params: Promise<{ userId: string }>
 }) {
-  const userId = (await params).userId
+  const { userId } = await params
   const getCachedUser = unstable_cache(
     async () => {
       return { id: userId }
@@ -75,7 +75,7 @@ export default async function Page({
 import { unstable_cache } from 'next/cache';
 
 export default async function Page({ params } }) {
-  const userId = (await params).userId
+  const { userId } = await params
   const getCachedUser = unstable_cache(
     async () => {
       return { id: userId };

--- a/examples/mdx-remote/app/[slug]/page.tsx
+++ b/examples/mdx-remote/app/[slug]/page.tsx
@@ -17,7 +17,7 @@ export default async function Blog({
 }: {
   params: Promise<{ slug: string }>;
 }) {
-  const slug = (await params).slug;
+  const { slug } = await params;
   const post = getPosts().find((post) => post.slug === slug);
 
   if (!post) {


### PR DESCRIPTION
These function the same, but the updated version looks cleaner.