### PR TITLE
[dev-overlay] fix: display version info for missing tags error

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/version-staleness-info/version-staleness-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/version-staleness-info/version-staleness-info.tsx
@@ -8,10 +8,28 @@ export function VersionStalenessInfo({
   versionInfo: VersionInfo
   isTurbopack?: boolean
 }) {
-  const { staleness } = versionInfo
-  let { text, indicatorClass, title } = getStaleness(versionInfo)
+  if (versionInfo.staleness === 'unknown') {
+    // This is only available for `__next_root_layout_missing_tags` error.
+    const versionInfoInit = window.__NEXT_VERSION_INFO_INIT
 
-  const shouldBeLink = staleness.startsWith('stale')
+    if (versionInfoInit) {
+      versionInfo = versionInfoInit
+    } else {
+      // This is attached during the initialization.
+      let installed = window.next.version
+
+      if (isTurbopack) {
+        // x.y.z-turbo -> x.y.z
+        installed = installed.split('-turbo')[0]
+      }
+
+      versionInfo.installed = installed
+    }
+  }
+
+  const { text, indicatorClass, title } = getStaleness(versionInfo)
+
+  const shouldBeLink = versionInfo.staleness.startsWith('stale')
   if (shouldBeLink) {
     return (
       <a

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -21,6 +21,7 @@ import findUp from 'next/dist/compiled/find-up'
 import { buildCustomRoute } from './filesystem'
 import * as Log from '../../../build/output/log'
 import HotReloaderWebpack from '../../dev/hot-reloader-webpack'
+import { getVersionInfo } from '../../dev/hot-reloader-webpack'
 import { setGlobal } from '../../../trace/shared'
 import type { Telemetry } from '../../../telemetry/storage'
 import type { IncomingMessage, ServerResponse } from 'http'
@@ -189,6 +190,10 @@ async function startWatcher(opts: SetupOpts) {
       })
 
   await hotReloader.start()
+
+  // This is expensive job including `fetch()` so don't await here
+  // but only if needed i.e. `__next_root_layout_missing_tags` error.
+  globalThis.__NEXT_VERSION_INFO_INIT_PROMISE = getVersionInfo()
 
   if (opts.nextConfig.experimental.nextScriptWorkers) {
     await verifyPartytownSetup(

--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -488,18 +488,20 @@ export function createRootLayoutValidatorStream(): TransformStream<
 
       controller.enqueue(chunk)
     },
-    flush(controller) {
+    async flush(controller) {
       const missingTags: typeof window.__next_root_layout_missing_tags = []
       if (!foundHtml) missingTags.push('html')
       if (!foundBody) missingTags.push('body')
 
       if (!missingTags.length) return
 
+      const versionInfo = await globalThis.__NEXT_VERSION_INFO_INIT_PROMISE
+
       controller.enqueue(
         encoder.encode(
           `<script>self.__next_root_layout_missing_tags=${JSON.stringify(
             missingTags
-          )}</script>`
+          )};self.__NEXT_VERSION_INFO_INIT=${JSON.stringify(versionInfo)};</script>`
         )
       )
     },

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -21,6 +21,7 @@ import type {
 import type { GetStaticPathsFallback } from './lib/fallback'
 
 import type { NextApiRequestCookies } from './server/api-utils'
+import type { VersionInfo } from './server/dev/parse-version-info'
 
 import next from './server/next'
 
@@ -319,6 +320,8 @@ declare global {
   var __NEXT_UNDICI_AGENT_SET: boolean
   var __NEXT_HTTP_AGENT: HttpAgent
   var __NEXT_HTTPS_AGENT: HttpsAgent
+  /** @internal development */
+  var __NEXT_VERSION_INFO_INIT_PROMISE: Promise<VersionInfo>
 }
 
 export default next

--- a/packages/next/types/global.d.ts
+++ b/packages/next/types/global.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="node" />
 
+import type { VersionInfo } from '../src/server/dev/parse-version-info'
+
 // Extend the NodeJS namespace with Next.js-defined properties
 declare namespace NodeJS {
   // only for rust, see https://github.com/napi-rs/napi-rs/issues/1630
@@ -42,18 +44,22 @@ declare module '*.module.scss' {
   export default classes
 }
 
-interface Window {
-  MSInputMethodContext?: unknown
-  /** @internal */
-  __NEXT_HMR_CB?: null | ((message?: string) => void)
-  /** @internal */
-  __next_root_layout_missing_tags?: ('html' | 'body')[]
-  /** @internal */
-  __NEXT_DEV_INDICATOR_POSITION?:
-    | 'top-left'
-    | 'top-right'
-    | 'bottom-left'
-    | 'bottom-right'
+declare global {
+  interface Window {
+    MSInputMethodContext?: unknown
+    /** @internal */
+    __NEXT_HMR_CB?: null | ((message?: string) => void)
+    /** @internal */
+    __next_root_layout_missing_tags?: ('html' | 'body')[]
+    /** @internal development */
+    __NEXT_VERSION_INFO_INIT?: VersionInfo
+    /** @internal */
+    __NEXT_DEV_INDICATOR_POSITION?:
+      | 'top-left'
+      | 'top-right'
+      | 'bottom-left'
+      | 'bottom-right'
+  }
 }
 
 interface NextFetchRequestConfig {

--- a/packages/next/types/global.d.ts
+++ b/packages/next/types/global.d.ts
@@ -1,7 +1,5 @@
 /// <reference types="node" />
 
-import type { VersionInfo } from '../src/server/dev/parse-version-info'
-
 // Extend the NodeJS namespace with Next.js-defined properties
 declare namespace NodeJS {
   // only for rust, see https://github.com/napi-rs/napi-rs/issues/1630
@@ -44,22 +42,31 @@ declare module '*.module.scss' {
   export default classes
 }
 
-declare global {
-  interface Window {
-    MSInputMethodContext?: unknown
-    /** @internal */
-    __NEXT_HMR_CB?: null | ((message?: string) => void)
-    /** @internal */
-    __next_root_layout_missing_tags?: ('html' | 'body')[]
-    /** @internal development */
-    __NEXT_VERSION_INFO_INIT?: VersionInfo
-    /** @internal */
-    __NEXT_DEV_INDICATOR_POSITION?:
-      | 'top-left'
-      | 'top-right'
-      | 'bottom-left'
-      | 'bottom-right'
+interface Window {
+  MSInputMethodContext?: unknown
+  /** @internal */
+  __NEXT_HMR_CB?: null | ((message?: string) => void)
+  /** @internal */
+  __next_root_layout_missing_tags?: ('html' | 'body')[]
+  /** @internal development */
+  __NEXT_VERSION_INFO_INIT?: {
+    installed: string
+    staleness:
+      | 'fresh'
+      | 'stale-patch'
+      | 'stale-minor'
+      | 'stale-major'
+      | 'stale-prerelease'
+      | 'newer-than-npm'
+      | 'unknown'
+    expected?: string
   }
+  /** @internal */
+  __NEXT_DEV_INDICATOR_POSITION?:
+    | 'top-left'
+    | 'top-right'
+    | 'bottom-left'
+    | 'bottom-right'
 }
 
 interface NextFetchRequestConfig {


### PR DESCRIPTION
### Why?

The missing tags error was missing version info. It is because this error occurs during render, but the `versionInfo` is fetched during HMR which comes later.

### How?

When initializing the dev bundler, set the `getVersionInfo()` promise to `globalThis`. Then resolve it if the missing tags error occurs and pass to the client along with the missing tags value.

As a fallback, use `window.next.version` to set the installed Next.js version. Note that this will still display as `(unknown)` for staleness.

| Before | After |
|--------|--------|
| ![CleanShot 2025-03-02 at 02 42 09](https://github.com/user-attachments/assets/f44c2913-7940-46d3-8d79-60010529f126) | ![CleanShot 2025-03-02 at 02 41 31](https://github.com/user-attachments/assets/5c9452ed-7f73-4ad2-8e79-5ae4b64a8037) |

Closes NDX-820