### PR TITLE
[metadata] clean up redudant options

### DIFF
--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -387,7 +387,6 @@ async function exportAppImpl(
     strictNextHead: nextConfig.experimental.strictNextHead ?? true,
     deploymentId: nextConfig.deploymentId,
     htmlLimitedBots: nextConfig.htmlLimitedBots.source,
-    streamingMetadata: true,
     experimental: {
       clientTraceMetadata: nextConfig.experimental.clientTraceMetadata,
       expireTime: nextConfig.expireTime,

--- a/packages/next/src/export/types.ts
+++ b/packages/next/src/export/types.ts
@@ -62,7 +62,6 @@ export interface ExportPageInput {
   nextConfigOutput?: NextConfigComplete['output']
   enableExperimentalReact?: boolean
   sriEnabled: boolean
-  streamingMetadata: boolean | undefined
 }
 
 export type ExportRouteResult =

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -256,9 +256,7 @@ async function exportPageImpl(
   // During the export phase in next build, if it's using PPR we can serve streaming metadata
   // when it's available. When we're building the PPR rendering result, we don't need to rely
   // on the user agent. The result can be determined to serve streaming on infrastructure level.
-  const serveStreamingMetadata = Boolean(
-    isRoutePPREnabled && input.streamingMetadata
-  )
+  const serveStreamingMetadata = !!isRoutePPREnabled
 
   const renderOpts: WorkerRenderOpts = {
     ...components,
@@ -425,7 +423,6 @@ export async function exportPages(
             enableExperimentalReact: needsExperimentalReact(nextConfig),
             sriEnabled: Boolean(nextConfig.experimental.sri?.algorithm),
             buildId: input.buildId,
-            streamingMetadata: true,
           }),
           // If exporting the page takes longer than the timeout, reject the promise.
           new Promise((_, reject) => {

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -204,7 +204,6 @@ export interface RenderOptsPartial {
   params?: ParsedUrlQuery
   isPrefetch?: boolean
   htmlLimitedBots: string | undefined
-  streamingMetadata: boolean
   experimental: {
     /**
      * When true, it indicates that the current page supports partial

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -600,7 +600,6 @@ export default abstract class Server<
       isExperimentalCompile: this.nextConfig.experimental.isExperimentalCompile,
       // `htmlLimitedBots` is passed to server as serialized config in string format
       htmlLimitedBots: this.nextConfig.htmlLimitedBots,
-      streamingMetadata: true,
       experimental: {
         expireTime: this.nextConfig.expireTime,
         clientTraceMetadata: this.nextConfig.experimental.clientTraceMetadata,
@@ -1761,10 +1760,10 @@ export default abstract class Server<
         ...this.renderOpts,
         supportsDynamicResponse: !isBotRequest,
         botType: getBotType(ua),
-        serveStreamingMetadata: shouldServeStreamingMetadata(ua, {
-          streamingMetadata: !!this.renderOpts.streamingMetadata,
-          htmlLimitedBots: this.nextConfig.htmlLimitedBots,
-        }),
+        serveStreamingMetadata: shouldServeStreamingMetadata(
+          ua,
+          this.nextConfig.htmlLimitedBots
+        ),
       },
     }
 

--- a/packages/next/src/server/lib/streaming-metadata.ts
+++ b/packages/next/src/server/lib/streaming-metadata.ts
@@ -6,18 +6,8 @@ import type { BaseNextRequest } from '../base-http'
 
 export function shouldServeStreamingMetadata(
   userAgent: string,
-  {
-    streamingMetadata,
-    htmlLimitedBots,
-  }: {
-    streamingMetadata: boolean
-    htmlLimitedBots: string | undefined
-  }
+  htmlLimitedBots: string | undefined
 ): boolean {
-  if (!streamingMetadata) {
-    return false
-  }
-
   const blockingMetadataUARegex = new RegExp(
     htmlLimitedBots || HTML_LIMITED_BOT_UA_RE_STRING,
     'i'


### PR DESCRIPTION
### What

streaming meatdata is fully enabled now, we don't need to pass down an extra flag through render options