### PR TITLE
Fix uniqueness detection for `generateStaticParams`

### DIFF
--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -38,7 +38,7 @@ function areParamValuesEqual(a: ParamValue, b: ParamValue) {
       return false
     }
 
-    return a.every((item) => b.includes(item))
+    return a.every((item, index) => item === b[index])
   }
 
   // Otherwise, they're not equal.

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -833,6 +833,10 @@ describe('app-dir static/dynamic handling', () => {
          "force-static/first.rsc",
          "force-static/second.html",
          "force-static/second.rsc",
+         "gen-params-catch-all-unique/foo/bar.html",
+         "gen-params-catch-all-unique/foo/bar.rsc",
+         "gen-params-catch-all-unique/foo/foo.html",
+         "gen-params-catch-all-unique/foo/foo.rsc",
          "gen-params-dynamic-revalidate/one.html",
          "gen-params-dynamic-revalidate/one.rsc",
          "hooks/use-pathname/slug.html",
@@ -1313,6 +1317,54 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialRevalidateSeconds": false,
            "srcRoute": "/force-static/[slug]",
+         },
+         "/gen-params-catch-all-unique/foo/bar": {
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token",
+           ],
+           "dataRoute": "/gen-params-catch-all-unique/foo/bar.rsc",
+           "experimentalBypassFor": [
+             {
+               "key": "Next-Action",
+               "type": "header",
+             },
+             {
+               "key": "content-type",
+               "type": "header",
+               "value": "multipart/form-data;.*",
+             },
+           ],
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/gen-params-catch-all-unique/[...slug]",
+         },
+         "/gen-params-catch-all-unique/foo/foo": {
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token",
+           ],
+           "dataRoute": "/gen-params-catch-all-unique/foo/foo.rsc",
+           "experimentalBypassFor": [
+             {
+               "key": "Next-Action",
+               "type": "header",
+             },
+             {
+               "key": "content-type",
+               "type": "header",
+               "value": "multipart/form-data;.*",
+             },
+           ],
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/gen-params-catch-all-unique/[...slug]",
          },
          "/gen-params-dynamic-revalidate/one": {
            "allowHeader": [
@@ -2429,6 +2481,31 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "fallback": null,
            "routeRegex": "^\\/force\\-static\\/([^\\/]+?)(?:\\/)?$",
+         },
+         "/gen-params-catch-all-unique/[...slug]": {
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token",
+           ],
+           "dataRoute": "/gen-params-catch-all-unique/[...slug].rsc",
+           "dataRouteRegex": "^\\/gen\\-params\\-catch\\-all\\-unique\\/(.+?)\\.rsc$",
+           "experimentalBypassFor": [
+             {
+               "key": "Next-Action",
+               "type": "header",
+             },
+             {
+               "key": "content-type",
+               "type": "header",
+               "value": "multipart/form-data;.*",
+             },
+           ],
+           "fallback": false,
+           "routeRegex": "^\\/gen\\-params\\-catch\\-all\\-unique\\/(.+?)(?:\\/)?$",
          },
          "/gen-params-dynamic-revalidate/[slug]": {
            "allowHeader": [
@@ -3678,6 +3755,13 @@ describe('app-dir static/dynamic handling', () => {
   })
 
   if (!process.env.CUSTOM_CACHE_HANDLER) {
+    it('should not filter out catch-all params with repeated segments in generateStaticParams', async () => {
+      const res1 = await next.fetch('/gen-params-catch-all-unique/foo/foo')
+      expect(res1.status).toBe(200)
+      const res2 = await next.fetch('/gen-params-catch-all-unique/foo/bar')
+      expect(res2.status).toBe(200)
+    })
+
     it('should honor dynamic = "force-static" correctly', async () => {
       const res = await next.fetch('/force-static/first')
       expect(res.status).toBe(200)

--- a/test/e2e/app-dir/app-static/app/gen-params-catch-all-unique/[...slug]/page.js
+++ b/test/e2e/app-dir/app-static/app/gen-params-catch-all-unique/[...slug]/page.js
@@ -1,0 +1,17 @@
+export const dynamicParams = false
+
+export default async function Page({ params }) {
+  const { slug } = await params
+  return <p>Test {slug.join('/')}</p>
+}
+
+export function generateStaticParams() {
+  return [
+    {
+      slug: ['foo', 'foo'],
+    },
+    {
+      slug: ['foo', 'bar'],
+    },
+  ]
+}


### PR DESCRIPTION
When for a catch-all route like `[...slug]` there is a page defined in `generateStaticParams` with repeated segments, e.g. `{slug: ['foo', 'foo']}`, other pages that contain the same segment but also other segments, e.g. `{slug: ['foo', 'bar']}`, must not be falsely regarded as duplicates, and should not be filtered out during prerendering.