### PR TITLE
document maxDuration value

### DIFF
--- a/docs/01-app/04-api-reference/03-file-conventions/route-segment-config.mdx
+++ b/docs/01-app/04-api-reference/03-file-conventions/route-segment-config.mdx
@@ -207,11 +207,15 @@ For example, on [Vercel](https://vercel.com/docs/functions/serverless-functions/
 
 ```tsx filename="layout.tsx | page.tsx | route.ts" switcher
 export const maxDuration = 5
+// number
 ```
 
 ```js filename="layout.js | page.js | route.js" switcher
 export const maxDuration = 5
+// number
 ```
+
+- **`number`**: (in seconds) Set the max duration of a layout, page, or route to `n` seconds.
 
 > **Good to know**:
 >


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

-->

### What?

Documents the value for `maxDuration` as being a `number` in seconds.

### Why?

It was not inherently clear what the `number` value for `maxDuration` represented.

### How?

Added markdown annotations for `maxDuration` matching the other annotations on the page.