### PR TITLE
Create static JSON config file for standalone server output

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1673,15 +1673,19 @@ export async function copyTracedFiles(
   }
 
   await handleTraceFiles(path.join(distDir, 'next-server.js.nft.json'))
-  const serverOutputPath = path.join(
-    outputPath,
-    path.relative(tracingRoot, dir),
-    'server.js'
+
+  const serverOutputDir = path.join(outputPath, path.relative(tracingRoot, dir))
+
+  await fs.mkdir(serverOutputDir, { recursive: true })
+
+  const NEXT_CONFIG_JSON = 'next.config.json'
+  await fs.writeFile(
+    path.join(serverOutputDir, NEXT_CONFIG_JSON),
+    JSON.stringify(nextConfig, undefined, 4)
   )
-  await fs.mkdir(path.dirname(serverOutputPath), { recursive: true })
 
   await fs.writeFile(
-    serverOutputPath,
+    path.join(serverOutputDir, 'server.js'),
     `${
       moduleType
         ? `performance.mark('next-start');
@@ -1703,7 +1707,7 @@ const currentPort = parseInt(process.env.PORT, 10) || 3000
 const hostname = process.env.HOSTNAME || '0.0.0.0'
 
 let keepAliveTimeout = parseInt(process.env.KEEP_ALIVE_TIMEOUT, 10)
-const nextConfig = ${JSON.stringify(nextConfig)}
+const nextConfig = require(path.join(dir, '${NEXT_CONFIG_JSON}'))
 
 process.env.__NEXT_PRIVATE_STANDALONE_CONFIG = JSON.stringify(nextConfig)
 

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -359,8 +359,11 @@ describe('required server files', () => {
 
   it('`compress` should be `false` in nextEnv', async () => {
     expect(
-      await fs.readFileSync(join(next.testDir, 'standalone/server.js'), 'utf8')
-    ).toContain('"compress":false')
+      await fs.readFile(
+        join(next.testDir, 'standalone/next.config.json'),
+        'utf8'
+      )
+    ).toContain('"compress": false')
   })
 
   it('`cacheHandler` should have correct path', async () => {
@@ -369,14 +372,20 @@ describe('required server files', () => {
     ).toBe(true)
 
     expect(
-      await fs.readFileSync(join(next.testDir, 'standalone/server.js'), 'utf8')
-    ).toContain('"cacheHandler":"../cache-handler.js"')
+      await fs.readFile(
+        join(next.testDir, 'standalone/next.config.json'),
+        'utf8'
+      )
+    ).toContain('"cacheHandler": "../cache-handler.js"')
   })
 
   it('`cacheMaxMemorySize` should be disabled by setting to 0', async () => {
     expect(
-      await fs.readFileSync(join(next.testDir, 'standalone/server.js'), 'utf8')
-    ).toContain('"cacheMaxMemorySize":0')
+      await fs.readFile(
+        join(next.testDir, 'standalone/next.config.json'),
+        'utf8'
+      )
+    ).toContain('"cacheMaxMemorySize": 0')
   })
 
   // TODO(mischnic) do these files even exist in turbopack?


### PR DESCRIPTION
### What?

Instead of inlining the build-time JSON config to the `server.js` file generated to the standalone output of Next.js build (with config option `output: 'standalone'`), this PR changes the build process to emit a separate JSON file which is `require`d into the `server.js` file.

### Why?

It's cleaner to separate the config into its own file, since it's static JSON anyway. This change also makes it easier for one to create their own `server.js` file.

### How?

Instead of inlining the `JSON.stringify(nextConfig)` content into the generated `server.js` file, write a separate file `next.config.json` next to it, and use the already-created `require` to load it. This should work with both CommonJS and ESM since the `createRequire` is already configured. The `require` automatically parses JSON.

I did not add new tests because this should not change existing behavior, and there's plenty of existing tests for the standalone build output; and if this was broken, hopefully some of them would fail.