### PR TITLE
[test] Add special placeholder if stackframes point into dist dir

### DIFF
--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -1496,10 +1496,10 @@ describe('ReactRefreshLogBox app', () => {
              |       ^",
            "stack": [
              "eval index.js (1:7)",
-             "<unknown> rsc)/./index.js (<FIXME-project-root>/.next/server/app/server/page.js (43:1)",
+             "<FIXME-next-dist-dir>",
              "<FIXME-file-protocol>",
              "eval ./app/server/page.js",
-             "<unknown> rsc)/./app/server/page.js (<FIXME-project-root>/.next/server/app/server/page.js (33:1)",
+             "<FIXME-next-dist-dir>",
              "<FIXME-file-protocol>",
            ],
          }

--- a/test/lib/add-redbox-matchers.ts
+++ b/test/lib/add-redbox-matchers.ts
@@ -31,6 +31,7 @@ declare global {
        * `<FIXME-internal-frame>` in the snapshot would be unintended.
        * `<FIXME-project-root>` in the snapshot would be unintended.
        * `<FIXME-file-protocol>` in the snapshot would be unintended.
+       * `<FIXME-next-dist-dir>` in the snapshot would be unintended.
        * Any node_modules in the snapshot would be unintended.
        * Differences in the snapshot between Turbopack and Webpack would be unintended.
        *
@@ -50,6 +51,7 @@ declare global {
        * `<FIXME-internal-frame>` in the snapshot would be unintended.
        * `<FIXME-project-root>` in the snapshot would be unintended.
        * `<FIXME-file-protocol>` in the snapshot would be unintended.
+       * `<FIXME-next-dist-dir>` in the snapshot would be unintended.
        * Any node_modules in the snapshot would be unintended.
        * Differences in the snapshot between Turbopack and Webpack would be unintended.
        *

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1456,6 +1456,8 @@ export async function getRedboxCallStack(
           foundInternalFrame = true
         } else if (frame.includes('file://')) {
           stack.push('<FIXME-file-protocol>')
+        } else if (frame.includes('.next/')) {
+          stack.push('<FIXME-next-dist-dir>')
         } else {
           stack.push(frame)
         }


### PR DESCRIPTION
Pointing into `.next` indicates a missing sourcemap or another sourcemap related bug. Now tests have a special marker for these kind of bugs.