### PR TITLE
[Dev Tools] Improve keyboard interactions for menu & overlays

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -144,15 +144,14 @@ function DevToolsPopover({
   useClickOutside(menuRef, triggerRef, isMenuOpen, closeMenu)
 
   useEffect(() => {
-    if (isMenuOpen) {
-      openRootMenu()
-      // Run on next tick because querying DOM after state change
-      setTimeout(() => {
-        select('first')
-      })
+    if (open === null) {
+      // Avoid flashing selected state
+      const id = setTimeout(() => {
+        setSelectedIndex(-1)
+      }, MENU_DURATION_MS)
+      return () => clearTimeout(id)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isMenuOpen])
+  }, [open])
 
   function select(index: number | 'first' | 'last') {
     if (index === 'first') {
@@ -180,6 +179,7 @@ function DevToolsPopover({
     const el = menuRef.current?.querySelector(
       `[data-index="${index}"]`
     ) as HTMLElement
+
     if (el) {
       setSelectedIndex(index)
       el?.focus()
@@ -221,7 +221,11 @@ function DevToolsPopover({
   }
 
   function openRootMenu() {
-    setOpen(OVERLAYS.Root)
+    setOpen((prevOpen) => {
+      console.log(prevOpen)
+      if (prevOpen === null) select('first')
+      return OVERLAYS.Root
+    })
   }
 
   function onTriggerClick() {
@@ -229,6 +233,9 @@ function DevToolsPopover({
       setOpen(null)
     } else {
       openRootMenu()
+      setTimeout(() => {
+        select('first')
+      })
     }
   }
 
@@ -241,10 +248,6 @@ function DevToolsPopover({
       }
       return prevOpen
     })
-    // Avoid flashing selected state
-    setTimeout(() => {
-      setSelectedIndex(-1)
-    }, MENU_DURATION_MS)
   }
 
   function handleHideDevtools() {

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -1,4 +1,4 @@
-import type { Dispatch, SetStateAction } from 'react'
+import type { CSSProperties, Dispatch, SetStateAction } from 'react'
 import { STORAGE_KEY_POSITION, type OverlayState } from '../../../../shared'
 
 import { useState, useEffect, useRef, createContext, useContext } from 'react'
@@ -11,6 +11,12 @@ import { TurbopackInfo } from './dev-tools-info/turbopack-info'
 import { RouteInfo } from './dev-tools-info/route-info'
 import GearIcon from '../../../icons/gear-icon'
 import { UserPreferences } from './dev-tools-info/user-preferences'
+import {
+  MENU_CURVE,
+  MENU_DURATION_MS,
+  useClickOutside,
+  useFocusTrap,
+} from './utils'
 
 // TODO: add E2E tests to cover different scenarios
 
@@ -59,9 +65,6 @@ export function DevToolsIndicator({
 
 //////////////////////////////////////////////////////////////////////////////////////
 
-const ANIMATE_OUT_DURATION_MS = 200
-const ANIMATE_OUT_TIMING_FUNCTION = 'cubic-bezier(0.175, 0.885, 0.32, 1.1)'
-
 interface C {
   closeMenu: () => void
   selectedIndex: number
@@ -82,6 +85,15 @@ function getInitialPosition() {
 
   return INDICATOR_POSITION
 }
+
+const OVERLAYS = {
+  Root: 'root',
+  Turbo: 'turbo',
+  Route: 'route',
+  Preferences: 'preferences',
+} as const
+
+export type Overlays = (typeof OVERLAYS)[keyof typeof OVERLAYS]
 
 function DevToolsPopover({
   routerType,
@@ -107,85 +119,61 @@ function DevToolsPopover({
 }) {
   const menuRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLButtonElement | null>(null)
-  const turbopackRef = useRef<HTMLElement>(null)
-  const triggerTurbopackRef = useRef<HTMLButtonElement | null>(null)
-  const routeInfoRef = useRef<HTMLElement>(null)
-  const triggerRouteInfoRef = useRef<HTMLButtonElement | null>(null)
-  const preferencesRef = useRef<HTMLElement>(null)
-  const triggerPreferencesRef = useRef<HTMLButtonElement | null>(null)
-  const [isMenuOpen, setIsMenuOpen] = useState(false)
-  const [isTurbopackInfoOpen, setIsTurbopackInfoOpen] = useState(false)
-  const [isRouteInfoOpen, setIsRouteInfoOpen] = useState(false)
-  const [isPreferencesOpen, setIsPreferencesOpen] = useState(false)
-  const [selectedIndex, setSelectedIndex] = useState(-1)
-  const [position, setPosition] = useState(getInitialPosition())
 
-  // This hook lets us do an exit animation before unmounting the component
+  const [open, setOpen] = useState<Overlays | null>(null)
+  const [position, setPosition] = useState(getInitialPosition())
+  const [selectedIndex, setSelectedIndex] = useState(-1)
+
+  const isMenuOpen = open === OVERLAYS.Root
+  const isTurbopackInfoOpen = open === OVERLAYS.Turbo
+  const isRouteInfoOpen = open === OVERLAYS.Route
+  const isPreferencesOpen = open === OVERLAYS.Preferences
+
   const { mounted: menuMounted, rendered: menuRendered } = useDelayedRender(
     isMenuOpen,
     {
       // Intentionally no fade in, makes the UI feel more immediate
       enterDelay: 0,
       // Graceful fade out to confirm that the UI did not break
-      exitDelay: ANIMATE_OUT_DURATION_MS,
+      exitDelay: MENU_DURATION_MS,
     }
   )
-  const { mounted: turbopackInfoMounted, rendered: turbopackInfoRendered } =
-    useDelayedRender(isTurbopackInfoOpen, {
-      enterDelay: 0,
-      exitDelay: ANIMATE_OUT_DURATION_MS,
-    })
-  const { mounted: routeInfoMounted, rendered: routeInfoRendered } =
-    useDelayedRender(isRouteInfoOpen, {
-      enterDelay: 0,
-      exitDelay: ANIMATE_OUT_DURATION_MS,
-    })
-  const { mounted: preferencesMounted, rendered: preferencesRendered } =
-    useDelayedRender(isPreferencesOpen, {
-      enterDelay: 0,
-      exitDelay: ANIMATE_OUT_DURATION_MS,
-    })
 
   // Features to make the menu accessible
   useFocusTrap(menuRef, triggerRef, isMenuOpen)
   useClickOutside(menuRef, triggerRef, isMenuOpen, closeMenu)
-  useFocusTrap(turbopackRef, triggerTurbopackRef, isTurbopackInfoOpen)
-  useClickOutside(
-    turbopackRef,
-    triggerTurbopackRef,
-    isTurbopackInfoOpen,
-    closeTurbopackInfo
-  )
-  useFocusTrap(routeInfoRef, triggerRouteInfoRef, isRouteInfoOpen)
-  useClickOutside(
-    routeInfoRef,
-    triggerRouteInfoRef,
-    isRouteInfoOpen,
-    closeRouteInfo
-  )
-  useFocusTrap(preferencesRef, triggerPreferencesRef, isPreferencesOpen)
-  useClickOutside(
-    preferencesRef,
-    triggerPreferencesRef,
-    isPreferencesOpen,
-    closePreferences
-  )
+
+  useEffect(() => {
+    if (isMenuOpen) {
+      openRootMenu()
+      // Run on next tick because querying DOM after state change
+      setTimeout(() => {
+        select('first')
+      })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isMenuOpen])
+
   function select(index: number | 'first' | 'last') {
     if (index === 'first') {
-      const all = menuRef.current?.querySelectorAll('[role="menuitem"]')
-      if (all) {
-        const firstIndex = all[0].getAttribute('data-index')
-        select(Number(firstIndex))
-      }
+      setTimeout(() => {
+        const all = menuRef.current?.querySelectorAll('[role="menuitem"]')
+        if (all) {
+          const firstIndex = all[0].getAttribute('data-index')
+          select(Number(firstIndex))
+        }
+      })
       return
     }
 
     if (index === 'last') {
-      const all = menuRef.current?.querySelectorAll('[role="menuitem"]')
-      if (all) {
-        const lastIndex = all.length - 1
-        select(lastIndex)
-      }
+      setTimeout(() => {
+        const all = menuRef.current?.querySelectorAll('[role="menuitem"]')
+        if (all) {
+          const lastIndex = all.length - 1
+          select(lastIndex)
+        }
+      })
       return
     }
 
@@ -221,33 +209,8 @@ function DevToolsPopover({
     }
   }
 
-  function onTriggerKeydown(e: React.KeyboardEvent<HTMLButtonElement>) {
-    if (isMenuOpen) {
-      return
-    }
-
-    // Open with first item focused
-    if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault()
-      setIsMenuOpen(true)
-      // Run on next tick because querying DOM after state change
-      setTimeout(() => {
-        select('first')
-      })
-    }
-
-    // Open with last item focused
-    if (e.key === 'ArrowUp') {
-      e.preventDefault()
-      setIsMenuOpen(true)
-      // Run on next tick because querying DOM after state change
-      setTimeout(() => {
-        select('last')
-      })
-    }
-  }
-
   function openErrorOverlay() {
+    setOpen(null)
     if (issueCount > 0) {
       setIsErrorOverlayOpen(true)
     }
@@ -257,50 +220,59 @@ function DevToolsPopover({
     setIsErrorOverlayOpen((prev) => !prev)
   }
 
+  function openRootMenu() {
+    setOpen(OVERLAYS.Root)
+  }
+
   function onTriggerClick() {
-    setIsMenuOpen((prev) => !prev)
+    if (open === OVERLAYS.Root) {
+      setOpen(null)
+    } else {
+      openRootMenu()
+    }
   }
 
   function closeMenu() {
-    setIsMenuOpen(false)
+    // Only close when we were on `Root`,
+    // otherwise it will close other overlays
+    setOpen((prevOpen) => {
+      if (prevOpen === OVERLAYS.Root) {
+        return null
+      }
+      return prevOpen
+    })
     // Avoid flashing selected state
     setTimeout(() => {
       setSelectedIndex(-1)
-    }, ANIMATE_OUT_DURATION_MS)
-  }
-
-  function closeTurbopackInfo() {
-    setIsTurbopackInfoOpen(false)
-  }
-
-  function closeRouteInfo() {
-    setIsRouteInfoOpen(false)
-  }
-
-  function closePreferences() {
-    setIsPreferencesOpen(false)
+    }, MENU_DURATION_MS)
   }
 
   function handleHideDevtools() {
-    closePreferences()
+    setOpen(null)
     hide()
   }
 
   const [vertical, horizontal] = position.split('-', 2)
+  const popover = { [vertical]: 'calc(100% + 8px)', [horizontal]: 0 }
 
   return (
     <Toast
       data-nextjs-toast
-      style={{
-        boxShadow: 'none',
-        zIndex: 2147483647,
-        // Reset the toast component's default positions.
-        bottom: 'initial',
-        left: 'initial',
-        [vertical]: '10px',
-        [horizontal]: '20px',
-      }}
+      style={
+        {
+          '--animate-out-duration-ms': `${MENU_DURATION_MS}ms`,
+          '--animate-out-timing-function': MENU_CURVE,
+          boxShadow: 'none',
+          zIndex: 2147483647,
+          // Reset the toast component's default positions.
+          bottom: 'initial',
+          left: 'initial',
+          [vertical]: '10px',
+          [horizontal]: '20px',
+        } as CSSProperties
+      }
     >
+      {/* Trigger */}
       <NextLogo
         ref={triggerRef}
         aria-haspopup="menu"
@@ -311,58 +283,42 @@ function DevToolsPopover({
         disabled={disabled}
         issueCount={issueCount}
         onTriggerClick={onTriggerClick}
-        onKeyDown={onTriggerKeydown}
         toggleErrorOverlay={toggleErrorOverlay}
         isDevBuilding={useIsDevBuilding()}
         isDevRendering={useIsDevRendering()}
         isBuildError={isBuildError}
       />
 
-      {routeInfoMounted && (
-        <RouteInfo
-          ref={routeInfoRef}
-          routerType={routerType}
-          routeType={isStaticRoute ? 'Static' : 'Dynamic'}
-          isOpen={isRouteInfoOpen}
-          setIsOpen={setIsRouteInfoOpen}
-          setPreviousOpen={setIsMenuOpen}
-          style={{
-            [vertical]: 'calc(100% + 8px)',
-            [horizontal]: 0,
-          }}
-          data-rendered={routeInfoRendered}
-        />
-      )}
+      {/* Route Info */}
+      <RouteInfo
+        isOpen={isRouteInfoOpen}
+        close={openRootMenu}
+        triggerRef={triggerRef}
+        style={popover}
+        routerType={routerType}
+        routeType={isStaticRoute ? 'Static' : 'Dynamic'}
+      />
 
-      {turbopackInfoMounted && (
-        <TurbopackInfo
-          ref={turbopackRef}
-          isOpen={isTurbopackInfoOpen}
-          setIsOpen={setIsTurbopackInfoOpen}
-          setPreviousOpen={setIsMenuOpen}
-          style={{
-            [vertical]: 'calc(100% + 8px)',
-            [horizontal]: 0,
-          }}
-          data-rendered={turbopackInfoRendered}
-        />
-      )}
+      {/* Turbopack Info */}
+      <TurbopackInfo
+        isOpen={isTurbopackInfoOpen}
+        close={openRootMenu}
+        triggerRef={triggerRef}
+        style={popover}
+      />
 
-      {preferencesMounted && (
-        <UserPreferences
-          ref={preferencesRef}
-          isOpen={isPreferencesOpen}
-          hide={handleHideDevtools}
-          setPosition={setPosition}
-          position={position}
-          style={{
-            [vertical]: 'calc(100% + 8px)',
-            [horizontal]: 0,
-          }}
-          data-rendered={preferencesRendered}
-        />
-      )}
+      {/* Preferences */}
+      <UserPreferences
+        isOpen={isPreferencesOpen}
+        close={openRootMenu}
+        triggerRef={triggerRef}
+        style={popover}
+        hide={handleHideDevtools}
+        setPosition={setPosition}
+        position={position}
+      />
 
+      {/* Dropdown Menu */}
       {menuMounted && (
         <div
           ref={menuRef}
@@ -375,14 +331,7 @@ function DevToolsPopover({
           className="dev-tools-indicator-menu"
           onKeyDown={onMenuKeydown}
           data-rendered={menuRendered}
-          style={
-            {
-              '--animate-out-duration-ms': `${ANIMATE_OUT_DURATION_MS}ms`,
-              '--animate-out-timing-function': ANIMATE_OUT_TIMING_FUNCTION,
-              [vertical]: 'calc(100% + 8px)',
-              [horizontal]: 0,
-            } as React.CSSProperties
-          }
+          style={popover}
         >
           <Context.Provider
             value={{
@@ -406,7 +355,7 @@ function DevToolsPopover({
                 label="Route"
                 index={1}
                 value={isStaticRoute ? 'Static' : 'Dynamic'}
-                onClick={() => setIsRouteInfoOpen(true)}
+                onClick={() => setOpen(OVERLAYS.Route)}
                 data-nextjs-route-type={isStaticRoute ? 'static' : 'dynamic'}
               />
               {isTurbopack ? (
@@ -421,7 +370,7 @@ function DevToolsPopover({
                   title="Learn about Turbopack and how to enable it in your application."
                   label="Try Turbopack"
                   value={<ChevronRight />}
-                  onClick={() => setIsTurbopackInfoOpen(true)}
+                  onClick={() => setOpen(OVERLAYS.Turbo)}
                 />
               )}
             </div>
@@ -431,7 +380,7 @@ function DevToolsPopover({
                 data-preferences
                 label="Preferences"
                 value={<GearIcon />}
-                onClick={() => setIsPreferencesOpen(true)}
+                onClick={() => setOpen(OVERLAYS.Preferences)}
                 index={isTurbopack ? 2 : 3}
               />
             </div>
@@ -530,84 +479,6 @@ function IssueCount({ children }: { children: number }) {
       {children}
     </span>
   )
-}
-
-//////////////////////////////////////////////////////////////////////////////////////
-
-function useFocusTrap(
-  menuRef: React.RefObject<HTMLElement | null>,
-  triggerRef: React.RefObject<HTMLButtonElement | null>,
-  isMenuOpen: boolean
-) {
-  useEffect(() => {
-    if (isMenuOpen) {
-      menuRef.current?.focus()
-    } else {
-      const root = triggerRef.current?.getRootNode()
-      const activeElement =
-        root instanceof ShadowRoot ? (root?.activeElement as HTMLElement) : null
-
-      // Only restore focus if the focus was previously on the menu.
-      // This avoids us accidentally focusing on mount when the
-      // user could want to interact with their own app instead.
-      if (menuRef.current?.contains(activeElement)) {
-        triggerRef.current?.focus()
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isMenuOpen])
-}
-
-//////////////////////////////////////////////////////////////////////////////////////
-
-function useClickOutside(
-  menuRef: React.RefObject<HTMLElement | null>,
-  triggerRef: React.RefObject<HTMLButtonElement | null>,
-  isMenuOpen: boolean,
-  closeMenu: () => void
-) {
-  useEffect(() => {
-    if (!isMenuOpen) {
-      return
-    }
-
-    // Close menu when clicking outside of it or its button
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        !(menuRef.current?.getBoundingClientRect()
-          ? event.clientX >= menuRef.current.getBoundingClientRect()!.left &&
-            event.clientX <= menuRef.current.getBoundingClientRect()!.right &&
-            event.clientY >= menuRef.current.getBoundingClientRect()!.top &&
-            event.clientY <= menuRef.current.getBoundingClientRect()!.bottom
-          : false) &&
-        !(triggerRef.current?.getBoundingClientRect()
-          ? event.clientX >= triggerRef.current.getBoundingClientRect()!.left &&
-            event.clientX <=
-              triggerRef.current.getBoundingClientRect()!.right &&
-            event.clientY >= triggerRef.current.getBoundingClientRect()!.top &&
-            event.clientY <= triggerRef.current.getBoundingClientRect()!.bottom
-          : false)
-      ) {
-        closeMenu()
-      }
-    }
-
-    // Close popover when pressing escape
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        closeMenu()
-      }
-    }
-
-    document.addEventListener('mousedown', handleClickOutside)
-    document.addEventListener('keydown', handleKeyDown)
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside)
-      document.removeEventListener('keydown', handleKeyDown)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isMenuOpen])
 }
 
 //////////////////////////////////////////////////////////////////////////////////////

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -222,7 +222,6 @@ function DevToolsPopover({
 
   function openRootMenu() {
     setOpen((prevOpen) => {
-      console.log(prevOpen)
       if (prevOpen === null) select('first')
       return OVERLAYS.Root
     })

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
@@ -156,8 +156,6 @@ export const DEV_TOOLS_INFO_STYLES = `
     background: var(--color-background-200);
   }
 
-  
-
   .dev-tools-info-close-button:hover {
     background: var(--color-gray-400);
   }

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
@@ -1,37 +1,69 @@
+import { useRef } from 'react'
+import { MENU_DURATION_MS, useClickOutside, useFocusTrap } from '../utils'
+import { useDelayedRender } from '../../../../hooks/use-delayed-render'
+
+export interface DevToolsInfoPropsCore {
+  isOpen: boolean
+  triggerRef: React.RefObject<HTMLButtonElement | null>
+  close: () => void
+}
+
+export interface DevToolsInfoProps extends DevToolsInfoPropsCore {
+  title: string
+  children: React.ReactNode
+  learnMoreLink?: string
+}
+
 export function DevToolsInfo({
   title,
   children,
   learnMoreLink,
-  setIsOpen,
-  setPreviousOpen,
+  isOpen,
+  triggerRef,
+  close,
   ...props
-}: {
-  title: string
-  children: React.ReactNode
-  learnMoreLink?: string
-  setIsOpen?: (isOpen: boolean) => void
-  setPreviousOpen?: (isOpen: boolean) => void
-}) {
-  const hasActionButtons = Boolean(
-    learnMoreLink && setIsOpen && setPreviousOpen
-  )
+}: DevToolsInfoProps) {
+  const ref = useRef<HTMLDivElement | null>(null)
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null)
+
+  const { mounted, rendered } = useDelayedRender(isOpen, {
+    // Intentionally no fade in, makes the UI feel more immediate
+    enterDelay: 0,
+    // Graceful fade out to confirm that the UI did not break
+    exitDelay: MENU_DURATION_MS,
+  })
+
+  useFocusTrap(ref, triggerRef, isOpen, () => {
+    // Bring focus to close button, so the user can easily close the overlay
+    closeButtonRef.current?.focus()
+  })
+  useClickOutside(ref, triggerRef, isOpen, close)
+
+  if (!mounted) {
+    return null
+  }
 
   return (
-    <div data-info-popover {...props}>
+    <div
+      tabIndex={-1}
+      role="dialog"
+      ref={ref}
+      data-info-popover
+      {...props}
+      data-rendered={rendered}
+    >
       <div className="dev-tools-info-container">
         <h1 className="dev-tools-info-title">{title}</h1>
         {children}
-        {hasActionButtons && (
-          <div className="dev-tools-info-button-container">
-            <button
-              className="dev-tools-info-close-button"
-              onClick={() => {
-                setIsOpen?.(false)
-                setPreviousOpen?.(true)
-              }}
-            >
-              Close
-            </button>
+        <div className="dev-tools-info-button-container">
+          <button
+            ref={closeButtonRef}
+            className="dev-tools-info-close-button"
+            onClick={close}
+          >
+            Close
+          </button>
+          {learnMoreLink && (
             <a
               className="dev-tools-info-learn-more-button"
               href={learnMoreLink}
@@ -40,8 +72,8 @@ export function DevToolsInfo({
             >
               Learn More
             </a>
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </div>
   )
@@ -71,6 +103,10 @@ export const DEV_TOOLS_INFO_STYLES = `
     &[data-rendered='true'] {
       opacity: 1;
       scale: 1;
+    }
+
+    button:focus-visible {
+      outline: var(--focus-ring);
     }
   }
 
@@ -120,6 +156,8 @@ export const DEV_TOOLS_INFO_STYLES = `
     background: var(--color-background-200);
   }
 
+  
+
   .dev-tools-info-close-button:hover {
     background: var(--color-gray-400);
   }
@@ -134,7 +172,6 @@ export const DEV_TOOLS_INFO_STYLES = `
     transition: background var(--duration-short) ease;
     color: var(--color-background-100);
     border-radius: var(--rounded-md-2);
-    border: 1px solid var(--color-gray-1000);
     background: var(--color-gray-1000);
   }
 

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/route-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/route-info.tsx
@@ -1,3 +1,5 @@
+import type { HTMLProps } from 'react'
+import type { DevToolsInfoProps } from './dev-tools-info'
 import { DevToolsInfo } from './dev-tools-info'
 
 function StaticRouteContent({ routerType }: { routerType: 'pages' | 'app' }) {
@@ -106,36 +108,27 @@ const learnMoreLink = {
     dynamic:
       'https://nextjs.org/docs/app/building-your-application/rendering/server-components#dynamic-rendering',
   },
-}
+} as const
 
 export function RouteInfo({
   routeType,
   routerType,
-  isOpen,
-  setIsOpen,
-  setPreviousOpen,
   ...props
 }: {
-  routeType: 'Static' | 'Dynamic'
   routerType: 'pages' | 'app'
-  isOpen: boolean
-  setIsOpen: (isOpen: boolean) => void
-  setPreviousOpen: (isOpen: boolean) => void
-  style?: React.CSSProperties
-  ref?: React.RefObject<HTMLElement | null>
-}) {
+} & DevToolsInfoProps &
+  HTMLProps<HTMLDivElement>) {
   const isStaticRoute = routeType === 'Static'
 
   const learnMore = isStaticRoute
     ? learnMoreLink[routerType].static
     : learnMoreLink[routerType].dynamic
+
   return (
     <DevToolsInfo
-      {...props}
       title={`${routeType} Route`}
       learnMoreLink={learnMore}
-      setIsOpen={setIsOpen}
-      setPreviousOpen={setPreviousOpen}
+      {...props}
     >
       {isStaticRoute ? (
         <StaticRouteContent routerType={routerType} />

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/route-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/route-info.tsx
@@ -1,5 +1,5 @@
 import type { HTMLProps } from 'react'
-import type { DevToolsInfoProps } from './dev-tools-info'
+import type { DevToolsInfoPropsCore } from './dev-tools-info'
 import { DevToolsInfo } from './dev-tools-info'
 
 function StaticRouteContent({ routerType }: { routerType: 'pages' | 'app' }) {
@@ -115,8 +115,9 @@ export function RouteInfo({
   routerType,
   ...props
 }: {
+  routeType: 'Static' | 'Dynamic'
   routerType: 'pages' | 'app'
-} & DevToolsInfoProps &
+} & DevToolsInfoPropsCore &
   HTMLProps<HTMLDivElement>) {
   const isStaticRoute = routeType === 'Static'
 

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/turbopack-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/turbopack-info.tsx
@@ -1,24 +1,14 @@
-import { DevToolsInfo } from './dev-tools-info'
+import { DevToolsInfo, type DevToolsInfoPropsCore } from './dev-tools-info'
 import { CopyButton } from '../../../copy-button'
+import type { HTMLProps } from 'react'
 
-export function TurbopackInfo({
-  isOpen,
-  setIsOpen,
-  setPreviousOpen,
-  ...props
-}: {
-  isOpen: boolean
-  setIsOpen: (isOpen: boolean) => void
-  setPreviousOpen: (isOpen: boolean) => void
-  style?: React.CSSProperties
-  ref?: React.RefObject<HTMLElement | null>
-}) {
+export function TurbopackInfo(
+  props: DevToolsInfoPropsCore & HTMLProps<HTMLDivElement>
+) {
   return (
     <DevToolsInfo
       title="Turbopack"
       learnMoreLink="https://nextjs.org/docs/app/api-reference/turbopack"
-      setIsOpen={setIsOpen}
-      setPreviousOpen={setPreviousOpen}
       {...props}
     >
       <article className="dev-tools-info-article">

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
@@ -1,12 +1,13 @@
-import { useState } from 'react'
-import { DevToolsInfo } from './dev-tools-info'
+import { useState, type HTMLProps } from 'react'
 import { css } from '../../../../../utils/css'
-import type { DevToolsIndicatorPosition } from '../dev-tools-indicator'
 import EyeIcon from '../../../../icons/eye-icon'
 import { STORAGE_KEY_POSITION, STORAGE_KEY_THEME } from '../../../../../shared'
 import LightIcon from '../../../../icons/light-icon'
 import DarkIcon from '../../../../icons/dark-icon'
 import SystemIcon from '../../../../icons/system-icon'
+import type { DevToolsInfoPropsCore } from './dev-tools-info'
+import { DevToolsInfo } from './dev-tools-info'
+import type { DevToolsIndicatorPosition } from '../dev-tools-indicator'
 
 function getInitialPreference() {
   if (typeof localStorage === 'undefined') {
@@ -18,19 +19,16 @@ function getInitialPreference() {
 }
 
 export function UserPreferences({
-  isOpen,
   setPosition,
   position,
   hide,
   ...props
 }: {
-  isOpen: boolean
   setPosition: (position: DevToolsIndicatorPosition) => void
   position: DevToolsIndicatorPosition
   hide: () => void
-  style?: React.CSSProperties
-  ref?: React.RefObject<HTMLElement | null>
-}) {
+} & DevToolsInfoPropsCore &
+  HTMLProps<HTMLDivElement>) {
   // derive initial theme from system preference
   const [theme, setTheme] = useState(getInitialPreference())
 

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
@@ -251,7 +251,7 @@ export const DEV_TOOLS_INFO_USER_PREFERENCES_STYLES = css`
     }
 
     &:focus-within {
-      outline: 5px auto -webkit-focus-ring-color;
+      outline: var(--focus-ring);
     }
   }
 

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/utils.ts
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/utils.ts
@@ -91,8 +91,7 @@ export function useClickOutside(
       return
     }
 
-    // Close content when clicking outside of it or its button
-    const handleClickOutside = (event: MouseEvent) => {
+    function handleClickOutside(event: MouseEvent) {
       if (
         !(rootRef.current?.getBoundingClientRect()
           ? event.clientX >= rootRef.current.getBoundingClientRect()!.left &&
@@ -112,7 +111,7 @@ export function useClickOutside(
       }
     }
 
-    const handleKeyDown = (event: KeyboardEvent) => {
+    function handleKeyDown(event: KeyboardEvent) {
       if (event.key === 'Escape') {
         close()
       }

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/utils.ts
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/utils.ts
@@ -128,5 +128,7 @@ export function useClickOutside(
   }, [active])
 }
 
+//////////////////////////////////////////////////////////////////////////////////////
+
 export const MENU_DURATION_MS = 200
 export const MENU_CURVE = 'cubic-bezier(0.175, 0.885, 0.32, 1.1)'

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/utils.ts
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/utils.ts
@@ -1,43 +1,89 @@
 import { useEffect } from 'react'
 
 export function useFocusTrap(
-  contentRef: React.RefObject<HTMLElement | null>,
+  rootRef: React.RefObject<HTMLElement | null>,
   triggerRef: React.RefObject<HTMLButtonElement | null>,
   active: boolean,
   onOpenFocus?: () => void
 ) {
   useEffect(() => {
-    setTimeout(() => {
+    let rootNode: HTMLElement | null = null
+
+    function onTab(e: KeyboardEvent) {
+      if (e.key !== 'Tab' || rootNode === null) {
+        return
+      }
+
+      const [firstFocusableNode, lastFocusableNode] =
+        getFocusableNodes(rootNode)
+      const activeElement = getActiveElement(rootNode)
+
+      if (e.shiftKey) {
+        if (activeElement === firstFocusableNode) {
+          lastFocusableNode?.focus()
+          e.preventDefault()
+        }
+      } else {
+        if (activeElement === lastFocusableNode) {
+          firstFocusableNode?.focus()
+          e.preventDefault()
+        }
+      }
+    }
+
+    const id = setTimeout(() => {
+      // Grab this on next tick to ensure the content is mounted
+      rootNode = rootRef.current
       if (active) {
         if (onOpenFocus) {
           onOpenFocus()
         } else {
-          contentRef.current?.focus()
+          rootNode?.focus()
         }
+        rootNode?.addEventListener('keydown', onTab)
       } else {
         // We only want to return back to the trigger
         // in case any other overlays aren't opened.
-        const root = triggerRef.current?.getRootNode()
-        const activeElement =
-          root instanceof ShadowRoot
-            ? (root?.activeElement as HTMLElement)
-            : null
+        const activeElement = getActiveElement(rootNode)
         // Only restore focus if the focus was previously on the content.
         // This avoids us accidentally focusing on mount when the
         // user could want to interact with their own app instead.
-        if (contentRef.current?.contains(activeElement)) {
+        if (rootNode?.contains(activeElement)) {
           triggerRef.current?.focus()
         }
       }
     })
+
+    return () => {
+      clearTimeout(id)
+      rootNode?.removeEventListener('keydown', onTab)
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active])
+}
+
+function getActiveElement(node: HTMLElement | null) {
+  const root = node?.getRootNode()
+  return root instanceof ShadowRoot
+    ? (root?.activeElement as HTMLElement)
+    : null
+}
+
+function getFocusableNodes(node: HTMLElement): [HTMLElement, HTMLElement] | [] {
+  const focusableElements = node.querySelectorAll(
+    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+  )
+  if (!focusableElements) return []
+  return [
+    focusableElements![0] as HTMLElement,
+    focusableElements![focusableElements!.length - 1] as HTMLElement,
+  ]
 }
 
 //////////////////////////////////////////////////////////////////////////////////////
 
 export function useClickOutside(
-  contentRef: React.RefObject<HTMLElement | null>,
+  rootRef: React.RefObject<HTMLElement | null>,
   triggerRef: React.RefObject<HTMLButtonElement | null>,
   active: boolean,
   closecontent: () => void
@@ -50,12 +96,11 @@ export function useClickOutside(
     // Close content when clicking outside of it or its button
     const handleClickOutside = (event: MouseEvent) => {
       if (
-        !(contentRef.current?.getBoundingClientRect()
-          ? event.clientX >= contentRef.current.getBoundingClientRect()!.left &&
-            event.clientX <=
-              contentRef.current.getBoundingClientRect()!.right &&
-            event.clientY >= contentRef.current.getBoundingClientRect()!.top &&
-            event.clientY <= contentRef.current.getBoundingClientRect()!.bottom
+        !(rootRef.current?.getBoundingClientRect()
+          ? event.clientX >= rootRef.current.getBoundingClientRect()!.left &&
+            event.clientX <= rootRef.current.getBoundingClientRect()!.right &&
+            event.clientY >= rootRef.current.getBoundingClientRect()!.top &&
+            event.clientY <= rootRef.current.getBoundingClientRect()!.bottom
           : false) &&
         !(triggerRef.current?.getBoundingClientRect()
           ? event.clientX >= triggerRef.current.getBoundingClientRect()!.left &&

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/utils.ts
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/utils.ts
@@ -1,0 +1,91 @@
+import { useEffect } from 'react'
+
+export function useFocusTrap(
+  contentRef: React.RefObject<HTMLElement | null>,
+  triggerRef: React.RefObject<HTMLButtonElement | null>,
+  active: boolean,
+  onOpenFocus?: () => void
+) {
+  useEffect(() => {
+    setTimeout(() => {
+      if (active) {
+        if (onOpenFocus) {
+          onOpenFocus()
+        } else {
+          contentRef.current?.focus()
+        }
+      } else {
+        // We only want to return back to the trigger
+        // in case any other overlays aren't opened.
+        const root = triggerRef.current?.getRootNode()
+        const activeElement =
+          root instanceof ShadowRoot
+            ? (root?.activeElement as HTMLElement)
+            : null
+        // Only restore focus if the focus was previously on the content.
+        // This avoids us accidentally focusing on mount when the
+        // user could want to interact with their own app instead.
+        if (contentRef.current?.contains(activeElement)) {
+          triggerRef.current?.focus()
+        }
+      }
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active])
+}
+
+//////////////////////////////////////////////////////////////////////////////////////
+
+export function useClickOutside(
+  contentRef: React.RefObject<HTMLElement | null>,
+  triggerRef: React.RefObject<HTMLButtonElement | null>,
+  active: boolean,
+  closecontent: () => void
+) {
+  useEffect(() => {
+    if (!active) {
+      return
+    }
+
+    // Close content when clicking outside of it or its button
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        !(contentRef.current?.getBoundingClientRect()
+          ? event.clientX >= contentRef.current.getBoundingClientRect()!.left &&
+            event.clientX <=
+              contentRef.current.getBoundingClientRect()!.right &&
+            event.clientY >= contentRef.current.getBoundingClientRect()!.top &&
+            event.clientY <= contentRef.current.getBoundingClientRect()!.bottom
+          : false) &&
+        !(triggerRef.current?.getBoundingClientRect()
+          ? event.clientX >= triggerRef.current.getBoundingClientRect()!.left &&
+            event.clientX <=
+              triggerRef.current.getBoundingClientRect()!.right &&
+            event.clientY >= triggerRef.current.getBoundingClientRect()!.top &&
+            event.clientY <= triggerRef.current.getBoundingClientRect()!.bottom
+          : false)
+      ) {
+        closecontent()
+      }
+    }
+
+    // Close popover when pressing escape
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closecontent()
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active])
+}
+
+export const MENU_DURATION_MS = 200
+export const MENU_CURVE = 'cubic-bezier(0.175, 0.885, 0.32, 1.1)'

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/utils.ts
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/utils.ts
@@ -42,8 +42,6 @@ export function useFocusTrap(
         }
         rootNode?.addEventListener('keydown', onTab)
       } else {
-        // We only want to return back to the trigger
-        // in case any other overlays aren't opened.
         const activeElement = getActiveElement(rootNode)
         // Only restore focus if the focus was previously on the content.
         // This avoids us accidentally focusing on mount when the
@@ -86,7 +84,7 @@ export function useClickOutside(
   rootRef: React.RefObject<HTMLElement | null>,
   triggerRef: React.RefObject<HTMLButtonElement | null>,
   active: boolean,
-  closecontent: () => void
+  close: () => void
 ) {
   useEffect(() => {
     if (!active) {
@@ -110,14 +108,13 @@ export function useClickOutside(
             event.clientY <= triggerRef.current.getBoundingClientRect()!.bottom
           : false)
       ) {
-        closecontent()
+        close()
       }
     }
 
-    // Close popover when pressing escape
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        closecontent()
+        close()
       }
     }
 


### PR DESCRIPTION
This PR implements robust keyboard navigation for the Dev Tools dropdown menu, and its nested overlays that appear.

Full list of changes:
- Use enum state `open` for making sure only one overlay can be open at a time
- Implement proper focus trapping through `useFocusTrap` to make sure focus can never leave the trap
- Fixed bugs related to focusing items in the menu
- Focused index in the menu is retained when closing a nested overlay
- Move all overlay-related logic to `DevToolsInfo`

_Note: We should follow up with an assessment of ARIA attributes on all these surfaces_

https://github.com/user-attachments/assets/66a36359-1265-40dd-82cc-1032dfdcff28

Closes NDX-927