### PR TITLE
Fix flaky Bun test

### DIFF
--- a/test/integration/create-next-app/package-manager/bun.test.ts
+++ b/test/integration/create-next-app/package-manager/bun.test.ts
@@ -1,3 +1,5 @@
+import execa from 'execa'
+import * as semver from 'semver'
 import {
   command,
   DEFAULT_FILES,
@@ -7,11 +9,9 @@ import {
   useTempDir,
 } from '../utils'
 
-const lockFile = 'bun.lockb'
-const files = [...DEFAULT_FILES, lockFile]
-
 describe('create-next-app with package manager bun', () => {
   let nextTgzFilename: string
+  let files: string[]
 
   beforeAll(async () => {
     if (!process.env.NEXT_TEST_PKG_PATHS) {
@@ -27,6 +27,12 @@ describe('create-next-app with package manager bun', () => {
     await command('bun', ['--version'])
       // install bun if not available
       .catch(() => command('npm', ['i', '-g', 'bun']))
+
+    const bunVersion = (await execa('bun', ['--version'])).stdout.trim()
+    // Some CI runners pre-install Bun.
+    // Locally, we don't pin Bun either.
+    const lockFile = semver.gte(bunVersion, '1.2.0') ? 'bun.lock' : 'bun.lockb'
+    files = [...DEFAULT_FILES, lockFile]
   })
 
   it('should use bun for --use-bun flag', async () => {


### PR DESCRIPTION
New default lockfile is `bun.lock`. This makes the test account for both defaults since some CI runners have different versions (e.g. https://github.com/vercel/next.js/actions/runs/13636552018/job/38117070221?pr=76760#step:33:336). We don't pin it locally either.