### PR TITLE
[dev-overlay] fix styling on overflow error messages, add button hover state

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-message/error-message.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-message/error-message.tsx
@@ -74,7 +74,7 @@ export const styles = `
     background: linear-gradient(
       180deg,
       rgba(250, 250, 250, 0) 0%,
-      var(--color-background-200) 100%
+      var(--color-background-100) 100%
     );
   }
 
@@ -96,5 +96,10 @@ export const styles = `
     cursor: pointer;
     color: var(--color-gray-900);
     font-weight: 500;
+    transition: background-color 0.2s ease;
+  }
+
+  .nextjs__container_errors_expand_button:hover {
+    background: var(--color-gray-100);
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/ui/styles/colors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/styles/colors.tsx
@@ -9,7 +9,7 @@ const darkTheme = css`
   --color-syntax-comment: #a0a0a0;
   --color-syntax-constant: #ededed;
   --color-syntax-function: #52a9ff;
-  --color-syntax-keyword: #f76e99;
+  --color-syntax-keyword: #f76191;
   --color-syntax-link: #0ac5b2;
   --color-syntax-parameter: #f1a10d;
   --color-syntax-punctuation: #ededed;
@@ -147,15 +147,15 @@ export function Colors() {
           --color-background-200: #fafafa;
 
           /* Syntax Light */
-          --color-syntax-comment: #545454;
+          --color-syntax-comment: #666666;
           --color-syntax-constant: #171717;
-          --color-syntax-function: #0054ad;
-          --color-syntax-keyword: #a51850;
-          --color-syntax-link: #066056;
-          --color-syntax-parameter: #8f3e00;
+          --color-syntax-function: #0068d6;
+          --color-syntax-keyword: #c01b5d;
+          --color-syntax-link: #067a6e;
+          --color-syntax-parameter: #ad4b00;
           --color-syntax-punctuation: #171717;
-          --color-syntax-string: #036157;
-          --color-syntax-string-expression: #066056;
+          --color-syntax-string: #067a6e;
+          --color-syntax-string-expression: #067a6e;
 
           /* Gray Scale Light */
           --color-gray-100: #f2f2f2;

--- a/packages/next/src/client/components/react-dev-overlay/ui/styles/colors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/styles/colors.tsx
@@ -9,7 +9,7 @@ const darkTheme = css`
   --color-syntax-comment: #a0a0a0;
   --color-syntax-constant: #ededed;
   --color-syntax-function: #52a9ff;
-  --color-syntax-keyword: #f76191;
+  --color-syntax-keyword: #f76e99;
   --color-syntax-link: #0ac5b2;
   --color-syntax-parameter: #f1a10d;
   --color-syntax-punctuation: #ededed;
@@ -147,15 +147,15 @@ export function Colors() {
           --color-background-200: #fafafa;
 
           /* Syntax Light */
-          --color-syntax-comment: #666666;
+          --color-syntax-comment: #545454;
           --color-syntax-constant: #171717;
-          --color-syntax-function: #0068d6;
-          --color-syntax-keyword: #c01b5d;
-          --color-syntax-link: #067a6e;
-          --color-syntax-parameter: #ad4b00;
+          --color-syntax-function: #0054ad;
+          --color-syntax-keyword: #a51850;
+          --color-syntax-link: #066056;
+          --color-syntax-parameter: #8f3e00;
           --color-syntax-punctuation: #171717;
-          --color-syntax-string: #067a6e;
-          --color-syntax-string-expression: #067a6e;
+          --color-syntax-string: #036157;
+          --color-syntax-string-expression: #066056;
 
           /* Gray Scale Light */
           --color-gray-100: #f2f2f2;


### PR DESCRIPTION
Small inconsistency between the overflow gradient on the overlay in production and in code. This should fix it :")

Before:
![CleanShot 2025-03-03 at 17 23 01@2x](https://github.com/user-attachments/assets/41033f5a-9cc2-4b2d-8af7-f4c39dd79e20)


After (normal):
![CleanShot 2025-03-03 at 17 17 51@2x](https://github.com/user-attachments/assets/713ecb32-940c-4c23-bd4e-a2b4a74ab64c)

After (hover):
![CleanShot 2025-03-03 at 17 22 50@2x](https://github.com/user-attachments/assets/47388845-25fb-411a-9366-b58aff86b163)


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
