### PR TITLE
fix(turbopack): Use vergen-git2 instead of shadow-rs for napi and next-api crates to fix stale git lock files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,7 +868,7 @@ dependencies = [
  "nom",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1018,7 +1018,21 @@ dependencies = [
  "semver 1.0.23",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.23",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1113,7 +1127,7 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "url",
@@ -1392,12 +1406,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "const_fn"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
 name = "const_format"
@@ -1838,12 +1846,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
- "darling_core 0.20.8",
- "darling_macro 0.20.8",
+ "darling_core 0.20.10",
+ "darling_macro 0.20.10",
 ]
 
 [[package]]
@@ -1862,15 +1870,15 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim 0.11.1",
  "syn 2.0.95",
 ]
 
@@ -1887,11 +1895,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
- "darling_core 0.20.8",
+ "darling_core 0.20.10",
  "quote",
  "syn 2.0.95",
 ]
@@ -1980,11 +1988,11 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd33f37ee6a119146a1781d3356a7c26028f83d779b2e04ecd45fdc75c76877b"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
 dependencies = [
- "derive_builder_macro 0.20.1",
+ "derive_builder_macro 0.20.2",
 ]
 
 [[package]]
@@ -2001,11 +2009,11 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_core"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7431fa049613920234f22c47fdc33e6cf3ee83067091ea4277a3f8c4587aae38"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling 0.20.8",
+ "darling 0.20.10",
  "proc-macro2",
  "quote",
  "syn 2.0.95",
@@ -2023,11 +2031,11 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abae7035bf79b9877b779505d8cf3749285b80c43941eda66604841889451dc"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
- "derive_builder_core 0.20.1",
+ "derive_builder_core 0.20.2",
  "syn 2.0.95",
 ]
 
@@ -2194,16 +2202,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
 dependencies = [
- "enum-iterator-derive 0.7.0",
-]
-
-[[package]]
-name = "enum-iterator"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7add3873b5dd076766ee79c8e406ad1a472c385476b9e38849f8eec24f1be689"
-dependencies = [
- "enum-iterator-derive 1.2.1",
+ "enum-iterator-derive",
 ]
 
 [[package]]
@@ -2215,17 +2214,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.95",
 ]
 
 [[package]]
@@ -2243,7 +2231,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08b6c6ab82d70f08844964ba10c7babb716de2ecaeab9be5717918a5177d3af"
 dependencies = [
- "darling 0.20.8",
+ "darling 0.20.10",
  "proc-macro2",
  "quote",
  "syn 2.0.95",
@@ -2604,18 +2592,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getset"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "gif"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2643,6 +2619,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
+dependencies = [
+ "bitflags 2.5.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,8 +2646,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2738,7 +2727,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3275,7 +3264,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.6",
+ "regex-automata 0.4.9",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -3307,7 +3296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6107a25f04af48ceeb4093eebc9b405ee5a1813a0bab5ecf1805d3eabb3337"
 dependencies = [
  "byteorder",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3395,7 +3384,7 @@ dependencies = [
  "dyn-clone",
  "lazy_static",
  "newline-converter",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -3484,12 +3473,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_debug"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ea828c9d6638a5bd3d8b14e37502b4d56cae910ccf8a5b7f51c7a0eb1d0508"
-
-[[package]]
 name = "isahc"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3560,7 +3543,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -3771,6 +3754,18 @@ dependencies = [
  "arbitrary",
  "cc",
  "once_cell",
+]
+
+[[package]]
+name = "libgit2-sys"
+version = "0.18.0+1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1a117465e7e1597e8febea8bb0c410f1c7fb93b1e1cddf34363f8390367ffec"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
 ]
 
 [[package]]
@@ -4163,7 +4158,7 @@ dependencies = [
  "miette-derive",
  "owo-colors 4.0.0",
  "textwrap",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-width",
 ]
 
@@ -4427,7 +4422,6 @@ dependencies = [
  "rustc-hash 2.1.0",
  "serde",
  "serde_json",
- "shadow-rs",
  "swc_core 16.0.0",
  "tracing",
  "turbo-rcstr",
@@ -4445,6 +4439,7 @@ dependencies = [
  "turbopack-env",
  "turbopack-node",
  "turbopack-nodejs",
+ "vergen",
 ]
 
 [[package]]
@@ -4454,7 +4449,6 @@ dependencies = [
  "next-core",
  "turbo-tasks-build",
  "turbopack-core",
- "vergen 7.5.1",
 ]
 
 [[package]]
@@ -4519,7 +4513,7 @@ dependencies = [
  "serde_json",
  "swc_core 16.0.0",
  "swc_relay",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "turbo-rcstr",
  "turbo-tasks",
@@ -4608,7 +4602,6 @@ dependencies = [
  "rustc-hash 2.1.0",
  "serde",
  "serde_json",
- "shadow-rs",
  "swc_core 16.0.0",
  "tokio",
  "tracing",
@@ -4629,6 +4622,7 @@ dependencies = [
  "turbopack-trace-utils",
  "url",
  "urlencoding",
+ "vergen-git2",
 ]
 
 [[package]]
@@ -5077,7 +5071,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.69",
  "ucd-trie",
 ]
 
@@ -5702,7 +5696,7 @@ dependencies = [
  "rand_chacha",
  "simd_helpers",
  "system-deps",
- "thiserror",
+ "thiserror 1.0.69",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -5805,14 +5799,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -5826,13 +5820,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -5843,9 +5837,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "region"
@@ -6210,9 +6204,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "rusty_pool"
@@ -6474,7 +6468,7 @@ checksum = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6"
 dependencies = [
  "percent-encoding",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6552,7 +6546,7 @@ version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
- "darling 0.20.8",
+ "darling 0.20.10",
  "proc-macro2",
  "quote",
  "syn 2.0.95",
@@ -6593,18 +6587,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
-]
-
-[[package]]
-name = "shadow-rs"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "974eb8222c62a8588bc0f02794dd1ba5b60b3ec88b58e050729d0907ed6af610"
-dependencies = [
- "const_format",
- "is_debug",
- "time",
- "tzdb",
 ]
 
 [[package]]
@@ -7239,7 +7221,7 @@ dependencies = [
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
  "swc_ecma_visit",
- "vergen 9.0.1",
+ "vergen",
 ]
 
 [[package]]
@@ -7276,7 +7258,7 @@ dependencies = [
  "swc_plugin_proxy",
  "swc_plugin_runner",
  "testing",
- "vergen 9.0.1",
+ "vergen",
 ]
 
 [[package]]
@@ -8318,7 +8300,7 @@ dependencies = [
  "swc_plugin_proxy",
  "tokio",
  "tracing",
- "vergen 9.0.1",
+ "vergen",
  "virtual-fs 0.19.0",
  "wasmer",
  "wasmer-cache",
@@ -8390,7 +8372,7 @@ dependencies = [
  "swc_ecma_ast",
  "swc_ecma_utils",
  "swc_ecma_visit",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8561,7 +8543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d32ddc0e2ebd072cbffe7424087267da990708a5bc3ae29e075904468450275"
 dependencies = [
  "ansi_term",
- "cargo_metadata",
+ "cargo_metadata 0.18.1",
  "difference",
  "once_cell",
  "pretty_assertions",
@@ -8609,7 +8591,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -8617,6 +8608,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.95",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8641,9 +8643,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
@@ -8664,9 +8666,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
@@ -9087,7 +9089,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "utf-8",
 ]
@@ -9106,7 +9108,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "utf-8",
 ]
@@ -9125,7 +9127,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "utf-8",
 ]
@@ -9216,7 +9218,7 @@ dependencies = [
  "serde_regex",
  "shrink-to-fit",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-util",
  "tracing",
@@ -10152,35 +10154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
-name = "tz-rs"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
-dependencies = [
- "const_fn",
-]
-
-[[package]]
-name = "tzdb"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b580f6b365fa89f5767cdb619a55d534d04a4e14c2d7e5b9a31e94598687fb1"
-dependencies = [
- "iana-time-zone",
- "tz-rs",
- "tzdb_data",
-]
-
-[[package]]
-name = "tzdb_data"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654c1ec546942ce0594e8d220e6b8e3899e0a0a8fe70ddd54d32a376dfefe3f8"
-dependencies = [
- "tz-rs",
-]
-
-[[package]]
 name = "ucd-trie"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10380,28 +10353,13 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "7.5.1"
+version = "9.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21b881cd6636ece9735721cf03c1fe1e774fe258683d084bb2812ab67435749"
+checksum = "e0d2f179f8075b805a43a2a21728a46f0cc2921b3c58695b28fa8817e103cd9a"
 dependencies = [
  "anyhow",
- "cfg-if",
- "enum-iterator 1.4.1",
- "getset",
- "rustversion",
- "thiserror",
- "time",
-]
-
-[[package]]
-name = "vergen"
-version = "9.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349ed9e45296a581f455bc18039878f409992999bc1d5da12a6800eb18c8752f"
-dependencies = [
- "anyhow",
- "cargo_metadata",
- "derive_builder 0.20.1",
+ "cargo_metadata 0.19.2",
+ "derive_builder 0.20.2",
  "regex",
  "rustversion",
  "time",
@@ -10409,13 +10367,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "vergen-lib"
-version = "0.1.4"
+name = "vergen-git2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229eaddb0050920816cf051e619affaf18caa3dd512de8de5839ccbc8e53abb0"
+checksum = "d86bae87104cb2790cdee615c2bb54729804d307191732ab27b1c5357ea6ddc5"
 dependencies = [
  "anyhow",
- "derive_builder 0.20.1",
+ "derive_builder 0.20.2",
+ "git2",
+ "rustversion",
+ "time",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
+dependencies = [
+ "anyhow",
+ "derive_builder 0.20.2",
  "rustversion",
 ]
 
@@ -10450,7 +10423,7 @@ dependencies = [
  "replace_with",
  "shared-buffer",
  "slab",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "wasmer-package 0.2.0",
@@ -10478,7 +10451,7 @@ dependencies = [
  "replace_with",
  "shared-buffer",
  "slab",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "wasmer-package 0.4.0",
@@ -10496,7 +10469,7 @@ dependencies = [
  "mio 1.0.3",
  "serde",
  "socket2 0.5.8",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -10519,7 +10492,7 @@ dependencies = [
  "rkyv 0.8.9",
  "serde",
  "smoltcp",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "virtual-mio",
@@ -10761,7 +10734,7 @@ dependencies = [
  "shared-buffer",
  "tar",
  "target-lexicon",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "ureq",
  "wasm-bindgen",
@@ -10782,7 +10755,7 @@ source = "git+https://github.com/kdy1/wasmer?branch=build-deps#afedc9315eb1c7fef
 dependencies = [
  "blake3",
  "hex",
- "thiserror",
+ "thiserror 1.0.69",
  "wasmer",
 ]
 
@@ -10794,7 +10767,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "cfg-if",
- "enum-iterator 0.7.0",
+ "enum-iterator",
  "enumset",
  "lazy_static",
  "leb128",
@@ -10808,7 +10781,7 @@ dependencies = [
  "shared-buffer",
  "smallvec",
  "target-lexicon",
- "thiserror",
+ "thiserror 1.0.69",
  "wasmer-types",
  "wasmer-vm",
  "wasmparser 0.216.0",
@@ -10852,7 +10825,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yml",
- "thiserror",
+ "thiserror 1.0.69",
  "toml 0.8.19",
  "url",
 ]
@@ -10873,7 +10846,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yml",
- "thiserror",
+ "thiserror 1.0.69",
  "toml 0.8.19",
  "url",
 ]
@@ -10906,7 +10879,7 @@ dependencies = [
  "rkyv 0.8.9",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "virtual-fs 0.21.0",
  "virtual-net",
@@ -10933,7 +10906,7 @@ dependencies = [
  "shared-buffer",
  "tar",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "toml 0.8.19",
  "url",
  "wasmer-config 0.10.0",
@@ -10958,7 +10931,7 @@ dependencies = [
  "shared-buffer",
  "tar",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "toml 0.8.19",
  "url",
  "wasmer-config 0.12.0",
@@ -10971,7 +10944,7 @@ version = "5.0.5-rc1"
 source = "git+https://github.com/kdy1/wasmer?branch=build-deps#afedc9315eb1c7fefddff7a3c6ada0235e78678a"
 dependencies = [
  "bytecheck 0.6.11",
- "enum-iterator 0.7.0",
+ "enum-iterator",
  "enumset",
  "getrandom",
  "hex",
@@ -10981,7 +10954,7 @@ dependencies = [
  "serde",
  "sha2",
  "target-lexicon",
- "thiserror",
+ "thiserror 1.0.69",
  "xxhash-rust",
 ]
 
@@ -10996,7 +10969,7 @@ dependencies = [
  "corosensei",
  "crossbeam-queue",
  "dashmap 6.1.0",
- "enum-iterator 0.7.0",
+ "enum-iterator",
  "fnv",
  "indexmap 2.7.1",
  "lazy_static",
@@ -11006,7 +10979,7 @@ dependencies = [
  "more-asserts",
  "region",
  "scopeguard",
- "thiserror",
+ "thiserror 1.0.69",
  "wasmer-types",
  "windows-sys 0.59.0",
 ]
@@ -11056,7 +11029,7 @@ dependencies = [
  "tempfile",
  "terminal_size",
  "termios",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "toml 0.8.19",
@@ -11201,7 +11174,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "shared-buffer",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -426,6 +426,8 @@ unicode-segmentation = "1.10.1"
 unsize = "1.1.0"
 url = "2.2.2"
 urlencoding = "2.1.2"
+vergen = { version = "9.0.4", features = ["cargo"] }
+vergen-git2 = { version = "1.0.5", features = ["cargo"] }
 webbrowser = "0.8.7"
 
 [patch.crates-io]

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -66,14 +66,13 @@ rand = { workspace = true }
 rustc-hash = { workspace = true }
 serde = "1"
 serde_json = "1"
-shadow-rs = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-chrome = "0.5.0"
 url = { workspace = true }
 urlencoding = { workspace = true }
 once_cell = { workspace = true }
-dashmap = "6.1.0"
+dashmap = { workspace = true }
 
 swc_core = { workspace = true, features = [
     "base_concurrent",
@@ -139,11 +138,11 @@ turbo-tasks-malloc = { workspace = true, default-features = false }
 tokio = { workspace = true, features = ["full"] }
 
 [build-dependencies]
+anyhow = { workspace = true }
 napi-build = "2"
 serde = { workspace = true }
 serde_json = { workspace = true }
-# It is not a mistake this dependency is specified in dep / build-dep both.
-shadow-rs = { workspace = true }
+vergen-git2 = { workspace = true }
 
 # build-dependencies for the native, non-wasm32 build
 [target.'cfg(not(target_arch = "wasm32"))'.build-dependencies]

--- a/crates/napi/build.rs
+++ b/crates/napi/build.rs
@@ -1,18 +1,52 @@
-use std::fs;
+use std::{env, process::Command, str};
 
 extern crate napi_build;
 
-fn main() {
+fn main() -> anyhow::Result<()> {
+    println!("cargo:rerun-if-env-changed=CI");
+    let is_ci = env::var("CI").is_ok_and(|value| !value.is_empty());
+
     // Generates, stores build-time information as static values.
     // There are some places relying on correct values for this (i.e telemetry),
     // So failing build if this fails.
-    shadow_rs::ShadowBuilder::builder()
-        .build()
-        .expect("Should able to generate build time information");
+    let cargo = vergen_git2::CargoBuilder::default()
+        .target_triple(true)
+        .build()?;
+    // We use the git dirty state to disable persistent caching (persistent caching relies on a
+    // commit hash to be safe). One tradeoff of this is that we must invalidate the rust build more
+    // often.
+    //
+    // This invalidates the build if any untracked files change. That's sufficient for the case
+    // where we transition from dirty to clean.
+    //
+    // There's an edge-case here where the repository could be newly dirty, but we can't know
+    // because our build hasn't been invalidated, since the untracked files weren't untracked last
+    // time we ran. That will cause us to incorrectly report ourselves as clean.
+    //
+    // However, in practice that shouldn't be much of an issue: If no other dependency of this
+    // top-level crate has changed (which would've triggered our rebuild), then the resulting binary
+    // must be equivalent to a clean build anyways. Therefore, persistent caching using the HEAD
+    // commit hash as a version is okay.
+    let git = vergen_git2::Git2Builder::default()
+        .dirty(/* include_untracked */ true)
+        .describe(
+            /* tags */ true,
+            /* dirty */ !is_ci, // suppress the dirty suffix in CI
+            /* matches */ Some("v[0-9]*"), // find the last version tag
+        )
+        .build()?;
+    vergen_git2::Emitter::default()
+        .add_instructions(&cargo)?
+        .add_instructions(&git)?
+        .fail_on_error()
+        .emit()?;
 
-    let git_head = fs::read_to_string("../../.git/HEAD").unwrap_or_default();
-    if !git_head.is_empty() && !git_head.starts_with("ref: ") {
-        println!("cargo:warning=git version {}", git_head);
+    match Command::new("git").args(["rev-parse", "HEAD"]).output() {
+        Ok(out) if out.status.success() => println!(
+            "cargo:warning=git HEAD: {}",
+            str::from_utf8(&out.stdout).unwrap()
+        ),
+        _ => println!("cargo:warning=`git rev-parse HEAD` failed"),
     }
 
     #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
@@ -36,4 +70,6 @@ fn main() {
 
     #[cfg(not(target_arch = "wasm32"))]
     turbo_tasks_build::generate_register();
+
+    Ok(())
 }

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -61,9 +61,6 @@ pub mod turbo_trace_server;
 pub mod turbopack;
 pub mod util;
 
-// Declare build-time information variables generated in build.rs
-shadow_rs::shadow!(build);
-
 #[cfg(not(any(feature = "__internal_dhat-heap", feature = "__internal_dhat-ad-hoc")))]
 #[global_allocator]
 static ALLOC: turbo_tasks_malloc::TurboMalloc = turbo_tasks_malloc::TurboMalloc;

--- a/crates/napi/src/util.rs
+++ b/crates/napi/src/util.rs
@@ -127,8 +127,8 @@ pub fn log_internal_error_and_inform(err_info: &str) {
 }
 
 #[napi]
-pub fn get_target_triple() -> String {
-    crate::build::BUILD_TARGET.to_string()
+pub fn get_target_triple() -> &'static str {
+    env!("VERGEN_CARGO_TARGET_TRIPLE")
 }
 
 pub trait MapErr<T>: Into<Result<T, anyhow::Error>> {

--- a/crates/next-api/Cargo.toml
+++ b/crates/next-api/Cargo.toml
@@ -24,7 +24,6 @@ regex = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-shadow-rs = { workspace = true }
 swc_core = { workspace = true }
 tracing = { workspace = true }
 turbo-rcstr = { workspace = true }
@@ -43,6 +42,6 @@ turbopack-node = { workspace = true }
 turbopack-nodejs = { workspace = true }
 
 [build-dependencies]
-# It is not a mistake this dependency is specified in dep / build-dep both.
-shadow-rs = { workspace = true }
+anyhow = { workspace = true }
 turbo-tasks-build = { workspace = true }
+vergen = { workspace = true }

--- a/crates/next-api/build.rs
+++ b/crates/next-api/build.rs
@@ -1,13 +1,18 @@
 use turbo_tasks_build::generate_register;
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     // Generates, stores build-time information as static values.
     // There are some places relying on correct values for this (i.e telemetry),
     // So failing build if this fails.
-    shadow_rs::ShadowBuilder::builder()
-        .build_pattern(shadow_rs::BuildPattern::Lazy)
-        .build()
-        .expect("Should able to generate build time information");
+    let cargo = vergen::CargoBuilder::default()
+        .target_triple(true)
+        .build()?;
+    vergen::Emitter::default()
+        .add_instructions(&cargo)?
+        .fail_on_error()
+        .emit()?;
 
     generate_register();
+
+    Ok(())
 }

--- a/crates/next-api/src/lib.rs
+++ b/crates/next-api/src/lib.rs
@@ -23,9 +23,6 @@ mod server_actions;
 mod versioned_content_map;
 mod webpack_stats;
 
-// Declare build-time information variables generated in build.rs
-shadow_rs::shadow!(build);
-
 pub fn register() {
     next_core::register();
     turbopack_nodejs::register();

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -68,7 +68,6 @@ use turbopack_nodejs::NodeJsChunkingContext;
 
 use crate::{
     app::{AppProject, OptionAppProject, ECMASCRIPT_CLIENT_TRANSITION_NAME},
-    build,
     empty::EmptyEndpoint,
     entrypoints::Entrypoints,
     instrumentation::InstrumentationEndpoint,
@@ -1068,7 +1067,7 @@ impl Project {
         // First, emit an event for the binary target triple.
         // This is different to webpack-config; when this is being called,
         // it is always using SWC so we don't check swc here.
-        emit_event(build::BUILD_TARGET, true);
+        emit_event(env!("VERGEN_CARGO_TARGET_TRIPLE"), true);
 
         // Go over jsconfig and report enabled features.
         let compiler_options = self.js_config().compiler_options().await?;

--- a/crates/next-build/Cargo.toml
+++ b/crates/next-build/Cargo.toml
@@ -16,25 +16,5 @@ workspace = true
 next-core = { workspace = true }
 turbopack-core = { workspace = true }
 
-#turbopack-binding = { workspace = true, features = [
-#  "__turbo_tasks",
-#  "__turbo_tasks_memory",
-#  "__turbo_tasks_env",
-#  "__turbo_tasks_fs",
-#  "__turbo_tasks_memory",
-#  "__turbopack",
-#  "__turbopack_nodejs",
-#  "__turbopack_core",
-#  "__turbopack_browser",
-#  "__turbopack_ecmascript",
-#  "__turbopack_ecmascript_runtime",
-#  "__turbopack_env",
-#  "__turbopack_node",
-#] }
-
 [build-dependencies]
 turbo-tasks-build = { workspace = true }
-vergen = { version = "7.3.2", default-features = false, features = [
-  "cargo",
-  "build",
-] }

--- a/crates/next-build/build.rs
+++ b/crates/next-build/build.rs
@@ -1,10 +1,5 @@
 use turbo_tasks_build::generate_register;
-use vergen::{vergen, Config};
 
 fn main() {
     generate_register();
-
-    // Attempt to collect some build time env values but will skip if there are any
-    // errors.
-    let _ = vergen(Config::default());
 }

--- a/turbopack/crates/turbo-tasks-backend/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/lib.rs
@@ -15,12 +15,13 @@ use std::path::Path;
 
 use anyhow::Result;
 
-pub use self::{
-    backend::{BackendOptions, StorageMode, TurboTasksBackend},
-    kv_backing_storage::KeyValueDatabaseBackingStorage,
-};
 use crate::database::{
     db_versioning::handle_db_versioning, noop_kv::NoopKvDb, turbo::TurboKeyValueDatabase,
+};
+pub use crate::{
+    backend::{BackendOptions, StorageMode, TurboTasksBackend},
+    database::db_versioning::GitVersionInfo,
+    kv_backing_storage::KeyValueDatabaseBackingStorage,
 };
 
 #[cfg(feature = "lmdb")]
@@ -35,7 +36,10 @@ pub type LmdbBackingStorage = KeyValueDatabaseBackingStorage<
 >;
 
 #[cfg(feature = "lmdb")]
-pub fn lmdb_backing_storage(path: &Path, version_info: &str) -> Result<LmdbBackingStorage> {
+pub fn lmdb_backing_storage(
+    path: &Path,
+    version_info: &GitVersionInfo,
+) -> Result<LmdbBackingStorage> {
     use crate::database::{
         fresh_db_optimization::{is_fresh, FreshDbOptimization},
         read_transaction_cache::ReadTransactionCache,
@@ -53,7 +57,10 @@ pub fn lmdb_backing_storage(path: &Path, version_info: &str) -> Result<LmdbBacki
 
 pub type TurboBackingStorage = KeyValueDatabaseBackingStorage<TurboKeyValueDatabase>;
 
-pub fn turbo_backing_storage(path: &Path, version_info: &str) -> Result<TurboBackingStorage> {
+pub fn turbo_backing_storage(
+    path: &Path,
+    version_info: &GitVersionInfo,
+) -> Result<TurboBackingStorage> {
     let path = handle_db_versioning(path, version_info)?;
     let database = TurboKeyValueDatabase::new(path)?;
     Ok(KeyValueDatabaseBackingStorage::new(database))
@@ -69,7 +76,10 @@ pub fn noop_backing_storage() -> NoopBackingStorage {
 pub type DefaultBackingStorage = LmdbBackingStorage;
 
 #[cfg(feature = "lmdb")]
-pub fn default_backing_storage(path: &Path, version_info: &str) -> Result<DefaultBackingStorage> {
+pub fn default_backing_storage(
+    path: &Path,
+    version_info: &GitVersionInfo,
+) -> Result<DefaultBackingStorage> {
     lmdb_backing_storage(path, version_info)
 }
 
@@ -77,6 +87,9 @@ pub fn default_backing_storage(path: &Path, version_info: &str) -> Result<Defaul
 pub type DefaultBackingStorage = TurboBackingStorage;
 
 #[cfg(not(feature = "lmdb"))]
-pub fn default_backing_storage(path: &Path, version_info: &str) -> Result<DefaultBackingStorage> {
+pub fn default_backing_storage(
+    path: &Path,
+    version_info: &GitVersionInfo,
+) -> Result<DefaultBackingStorage> {
     turbo_backing_storage(path, version_info)
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/test_config.trs
+++ b/turbopack/crates/turbo-tasks-backend/tests/test_config.trs
@@ -12,7 +12,10 @@
       turbo_tasks_backend::BackendOptions::default(),
       turbo_tasks_backend::default_backing_storage(
         path.as_path(),
-        "test"
+        &turbo_tasks_backend::GitVersionInfo {
+          describe: "test-unversioned",
+          dirty: false,
+        },
       ).unwrap()
     )
   )


### PR DESCRIPTION
Both `shadow-rs` and `vergen-gitcl` call out to the git CLI, which takes optional locks to update the index: https://git-scm.com/docs/git-status#_background_refresh

This is why we sometimes find ourselves with stale `.git/index.lock` files.

Using a lightly patched version of https://github.com/martinpitt/fatrace (to look up parent process names) shows this:

![Screenshot 2025-03-03 at 5.39.53 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/64a88f82-47bc-4d80-b49a-c5349e946411.png)

`shadow-rs` has a `git2` feature (enabled by default), but that doesn't prevent it from running the git CLI. Instead it runs *both* and overwrites some values.

`vergen-git2` only uses `libgit2` and does not invoke the CLI. This fixes things because `libgit2` disables `GIT_STATUS_OPT_UPDATE_INDEX` by default.

Additionally, after looking through both codebases, I've decided I like `vergen`'s implementation a bit more than `shadow-rs`'s.

Supposedly, `git`'s command-line should support a `GIT_OPTIONAL_LOCKS=0` environment variable to disable this behavior, but I'm still finding the lock written to when trying to use that. I'm still investigating if I can use something like this to contribute a proper fix upstream to these crates.

### Related Upstream PRs and Issues:

- PR to `vergen-gitcl` to work around the issue and add test coverage: https://github.com/rustyhorde/vergen/pull/406
- Issue reported to `shadow-rs` with suggestions on how to fix: https://github.com/baoyachi/shadow-rs/issues/221
- Patchset for git to add support for `--no-optional-locks` in more places: https://github.com/gitgitgadget/git/pull/1872

**EDIT:** Reverted in https://github.com/vercel/next.js/pull/76879 (due to build failures on some targets) and re-landed in https://github.com/vercel/next.js/pull/76889 (switching to a patched `vergen-gitcl` instead of `vergen-git2`)

Closes PACK-4081