### PR TITLE
[metadata] remove the duplicate metadata in the error boundary

### DIFF
--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -411,7 +411,6 @@ async function createComponentTreeInternal({
   const notFoundElement = NotFound ? (
     <>
       <NotFound />
-      {metadata}
       {notFoundStyles}
     </>
   ) : undefined
@@ -419,7 +418,6 @@ async function createComponentTreeInternal({
   const forbiddenElement = Forbidden ? (
     <>
       <Forbidden />
-      {metadata}
       {forbiddenStyles}
     </>
   ) : undefined
@@ -427,7 +425,6 @@ async function createComponentTreeInternal({
   const unauthorizedElement = Unauthorized ? (
     <>
       <Unauthorized />
-      {metadata}
       {unauthorizedStyles}
     </>
   ) : undefined
@@ -858,7 +855,6 @@ async function createComponentTreeInternal({
                     {notFoundStyles}
                     <NotFound />
                   </SegmentComponent>
-                  {metadata}
                 </>
               ) : undefined
             }

--- a/test/e2e/app-dir/parallel-routes-not-found/app/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-not-found/app/layout.tsx
@@ -6,11 +6,15 @@ export default function Layout({
   slot: React.ReactNode
 }) {
   return (
-    <html>
+    <html lang="en" className="layout">
       <body>
         {children}
         {slot}
       </body>
     </html>
   )
+}
+
+export const metadata = {
+  title: 'layout title',
 }

--- a/test/e2e/app-dir/parallel-routes-not-found/next.config.js
+++ b/test/e2e/app-dir/parallel-routes-not-found/next.config.js
@@ -1,8 +1,6 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {
-  pageExtensions: ['tsx', 'ts'],
-}
+const nextConfig = {}
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
+++ b/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
@@ -21,5 +21,8 @@ describe('parallel-routes-and-interception', () => {
 
     // we also check that the #children-slot id is not present
     expect(await browser.hasElementByCssSelector('#children-slot')).toBe(false)
+
+    const $ = await next.render$('/')
+    expect($('title').text()).toBe('layout title')
   })
 })

--- a/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
+++ b/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
@@ -28,7 +28,7 @@ describe('parallel-routes-and-interception', () => {
       let $ = await next.render$('/')
       expect($('title').text()).toBe('')
 
-      $ = await next.render$('/', {
+      $ = await next.render$('/', null, {
         headers: {
           'User-Agent': 'Discordbot',
         },

--- a/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
+++ b/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
@@ -27,6 +27,13 @@ describe('parallel-routes-and-interception', () => {
     if (isPPR && !isNextDev) {
       let $ = await next.render$('/')
       expect($('title').text()).toBe('')
+
+      $ = await next.render$('/', {
+        headers: {
+          'User-Agent': 'Discordbot',
+        },
+      })
+      expect($('title').text()).toBe('layout title')
     } else {
       const $ = await next.render$('/')
       expect($('title').text()).toBe('layout title')

--- a/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
+++ b/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
@@ -1,5 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
+const isPPR = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+
 describe('parallel-routes-and-interception', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
@@ -22,7 +24,20 @@ describe('parallel-routes-and-interception', () => {
     // we also check that the #children-slot id is not present
     expect(await browser.hasElementByCssSelector('#children-slot')).toBe(false)
 
-    const $ = await next.render$('/')
-    expect($('title').text()).toBe('layout title')
+    if (isPPR) {
+      let $ = await next.render$('/')
+      expect($('title').text()).toBe('layout title')
+    } else {
+      const $ = await next.render$('/')
+      expect($('title').text()).toBe('layout title')
+    }
+  })
+
+  it('should render the title once for the non-existed route', async () => {
+    const browser = await next.browser('/non-existed')
+    const titles = await browser.elementsByCss('title')
+
+    // FIXME: (metadata), the title should only be rendered once and using the not-found title
+    expect(titles).toHaveLength(3)
   })
 })

--- a/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
+++ b/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
@@ -3,7 +3,7 @@ import { nextTestSetup } from 'e2e-utils'
 const isPPR = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
 
 describe('parallel-routes-and-interception', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     // TODO: remove after deployment handling is updated
     skipDeployment: true,
@@ -24,9 +24,9 @@ describe('parallel-routes-and-interception', () => {
     // we also check that the #children-slot id is not present
     expect(await browser.hasElementByCssSelector('#children-slot')).toBe(false)
 
-    if (isPPR) {
+    if (isPPR && !isNextDev) {
       let $ = await next.render$('/')
-      expect($('title').text()).toBe('layout title')
+      expect($('title').text()).toBe('')
     } else {
       const $ = await next.render$('/')
       expect($('title').text()).toBe('layout title')

--- a/test/e2e/app-dir/parallel-routes-not-found/tsconfig.json
+++ b/test/e2e/app-dir/parallel-routes-not-found/tsconfig.json
@@ -21,5 +21,5 @@
     "target": "ES2017"
   },
   "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
 }


### PR DESCRIPTION
### What 

Those metadata were added into error boundaries but they're actually duplicated, we already have the actual metadata in the page and the metadata outlet can trigger the error boundary. The metadata element in the error boundary is not necessary.