### PR TITLE
chore(docs): update minimumCacheTTL example to 31 days

### DIFF
--- a/docs/01-app/04-api-reference/02-components/image.mdx
+++ b/docs/01-app/04-api-reference/02-components/image.mdx
@@ -753,6 +753,18 @@ The expiration (or rather Max Age) is defined by either the [`minimumCacheTTL`](
 
 You can configure the Time to Live (TTL) in seconds for cached optimized images. In many cases, it's better to use a [Static Image Import](/docs/app/building-your-application/optimizing/images#local-images) which will automatically hash the file contents and cache the image forever with a `Cache-Control` header of `immutable`.
 
+If no configuration is provided, the default below is used.
+
+```js filename="next.config.js"
+module.exports = {
+  images: {
+    minimumCacheTTL: 60, // 1 minute
+  },
+}
+```
+
+You can increase the TTL to reduce the number of revalidations and potentionally lower cost:
+
 ```js filename="next.config.js"
 module.exports = {
   images: {

--- a/docs/01-app/04-api-reference/02-components/image.mdx
+++ b/docs/01-app/04-api-reference/02-components/image.mdx
@@ -756,7 +756,7 @@ You can configure the Time to Live (TTL) in seconds for cached optimized images.
 ```js filename="next.config.js"
 module.exports = {
   images: {
-    minimumCacheTTL: 60,
+    minimumCacheTTL: 2678400, // 31 days
   },
 }
 ```

--- a/docs/02-pages/03-api-reference/01-components/image-legacy.mdx
+++ b/docs/02-pages/03-api-reference/01-components/image-legacy.mdx
@@ -550,6 +550,18 @@ The expiration (or rather Max Age) is defined by either the [`minimumCacheTTL`](
 
 You can configure the Time to Live (TTL) in seconds for cached optimized images. In many cases, it's better to use a [Static Image Import](/docs/pages/building-your-application/optimizing/images#local-images) which will automatically hash the file contents and cache the image forever with a `Cache-Control` header of `immutable`.
 
+If no configuration is provided, the default below is used.
+
+```js filename="next.config.js"
+module.exports = {
+  images: {
+    minimumCacheTTL: 60, // 1 minute
+  },
+}
+```
+
+You can increase the TTL to reduce the number of revalidations and potentionally lower cost:
+
 ```js filename="next.config.js"
 module.exports = {
   images: {

--- a/docs/02-pages/03-api-reference/01-components/image-legacy.mdx
+++ b/docs/02-pages/03-api-reference/01-components/image-legacy.mdx
@@ -553,7 +553,7 @@ You can configure the Time to Live (TTL) in seconds for cached optimized images.
 ```js filename="next.config.js"
 module.exports = {
   images: {
-    minimumCacheTTL: 60,
+    minimumCacheTTL: 2678400, // 31 days
   },
 }
 ```


### PR DESCRIPTION
The docs for `minimumCacheTTL` showed the default but didn't show an example of changing it.

Based on looking at many websites and the frequency those images change, I think 31 days is a good choice.