### PR TITLE
fix(form): polyfill submitter behavior for image inputs

### DIFF
--- a/packages/next/src/client/app-dir/form.tsx
+++ b/packages/next/src/client/app-dir/form.tsx
@@ -14,6 +14,7 @@ import {
   DISALLOWED_FORM_PROPS,
   hasReactClientActionAttributes,
   hasUnsupportedSubmitterAttributes,
+  useImageInputCoordsPolyfill,
   type FormProps,
 } from '../form-shared'
 import { mountLinkInstance, unmountLinkInstance } from '../components/links'
@@ -27,6 +28,8 @@ export default function Form({
   ref: externalRef,
   ...props
 }: FormProps) {
+  useImageInputCoordsPolyfill()
+
   const router = useContext(AppRouterContext)
 
   const actionProp = props.action

--- a/packages/next/src/client/form-data-submitter-polyfill.ts
+++ b/packages/next/src/client/form-data-submitter-polyfill.ts
@@ -1,3 +1,5 @@
+import { useLayoutEffect } from 'react'
+
 /**
  * A polyfill for the submitter param of `new FormData(form, submitter)` which is not supported everywhere yet
  * (~90% of users as of March 2025: https://caniuse.com/mdn-api_formdata_formdata_submitter)
@@ -55,30 +57,199 @@ function isFormDataSubmitterParamSupportedImpl(): boolean {
  * based on: https://github.com/facebook/react/blob/d4e24b349e6530a8e6c95d79ad40b32f93b47070/packages/react-dom-bindings/src/events/plugins/FormActionEventPlugin.js#L48-L70
  */
 function createFormDataWithSubmitter(
-  form: HTMLFormElement,
-  submitter: HTMLInputElement | HTMLButtonElement
-): FormData {
+  formElement: HTMLFormElement,
+  submitterElement: HTMLInputElement | HTMLButtonElement
+) {
+  if (isImageInputElement(submitterElement)) {
+    // `<input type="image">` is a special case.
+    // The formData should contain two fields, `${name}.x` and `${name}.y`,
+    // that hold the (relative) x and y coordinates of the click that initiated the submission.
+    let clickCoords = getPolyfilledClickCoordsFromImageInput(submitterElement)
+
+    if (!clickCoords) {
+      console.error(
+        'Failed to polyfill click coordinates for <input type="image">'
+      )
+      // For some reason, the click-tracking part of our polyfill didn't work.
+      // As a fallback, we can use dummy values of x: 0, y: 0 --
+      // That's what they'd be if the input is triggered using the keyboard
+      // or if the image failed to load, so it's a case that the consumer of the FormData has to handle anyway,
+      // and it's arguably less surprising than if we didn't include the params at all.
+      clickCoords = { clientX: 0, clientY: 0 }
+    }
+
+    const rect = submitterElement.getBoundingClientRect()
+    const x = Math.round(clickCoords.clientX - rect.left)
+    const y = Math.round(clickCoords.clientY - rect.top)
+
+    const name = submitterElement.getAttribute('name')
+    const nameX = name ? name + '.x' : 'x'
+    const nameY = name ? name + '.y' : 'y'
+    return createFormDataWithSubmitterValues(formElement, submitterElement, [
+      [nameX, x + ''],
+      [nameY, y + ''],
+    ])
+  } else {
+    // A regular input or button -- just add its name and value to the formData.
+    return createFormDataWithSubmitterValues(formElement, submitterElement, [
+      [submitterElement.name, submitterElement.value],
+    ])
+  }
+}
+
+function createFormDataWithSubmitterValues(
+  formElement: HTMLFormElement,
+  submitterElement: HTMLInputElement | HTMLButtonElement,
+  values: [name: string, value: string][]
+) {
   // The submitter's value should be included in the FormData.
   // It should be in the document order in the form.
   // Since the FormData constructor invokes the formdata event it also
   // needs to be available before that happens so after construction it's too
   // late. We use a temporary fake node for the duration of this event.
 
-  if (submitter.nodeName === 'INPUT' && submitter.type === 'image') {
-    // When a form is submitted via an `<input type="image">`, we should add the x and y coordinates of the click to the form data.
-    // (see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/image#using_the_x_and_y_data_points)
-    // A polyfill for this behavior is complicated, and will be handled in a follow up.
-    return new FormData(form)
+  const tempInputs: Element[] = []
+  for (const [name, value] of values) {
+    const temp = submitterElement.ownerDocument.createElement('input')
+    temp.type = 'hidden'
+    temp.name = name
+    temp.value = value
+    if (formElement.id) {
+      // If the `submitterElement` is outside the form,
+      // it had to be connected via id, so this will ensure that our
+      // dummy inputs are connected to it in the same way.
+      temp.setAttribute('form', formElement.id)
+    }
+    submitterElement.parentNode!.insertBefore(temp, submitterElement)
+    tempInputs.push(temp)
   }
 
-  const temp = submitter.ownerDocument.createElement('input')
-  temp.name = submitter.name
-  temp.value = submitter.value
-  if (form.id) {
-    temp.setAttribute('form', form.id)
+  const formData = new FormData(formElement)
+
+  for (const temp of tempInputs) {
+    temp.parentNode!.removeChild(temp)
   }
-  submitter.parentNode!.insertBefore(temp, submitter)
-  const formData = new FormData(form)
-  temp.parentNode!.removeChild(temp)
+
   return formData
+}
+
+//========================================================
+// click coordinates polyfill for `<input type="image">`
+//========================================================
+
+let mountedFormCount = 0
+export function useImageInputCoordsPolyfill() {
+  useLayoutEffect(() => {
+    // If `new FormData(formElement, submitterElement)` works,
+    // then `<input type="image">` click coords will be handled there,
+    // so we don't need the polyfill.
+    if (isFormDataSubmitterParamSupported()) {
+      return
+    }
+
+    // If we're the first <Form> on the page, set up the polyfill.
+    if (mountedFormCount === 0) {
+      setupImageInputClickPolyfill()
+    }
+    mountedFormCount++
+
+    return () => {
+      mountedFormCount--
+      // If we were the last <Form> on the page, the polyfill is no longer needed.
+      // Clean it up, but do it after a grace period to avoid repeatedly uninstalling and reinstalling.
+      // (e.g. when we have one form on the page and its react key changes)
+      if (mountedFormCount === 0) {
+        setTimeout(() => {
+          if (mountedFormCount === 0) {
+            cleanupImageInputCoordsPolyfill()
+          }
+        }, 100)
+      }
+    }
+  }, [])
+}
+
+type ImageInputPolyfillState =
+  | { isActive: false; cleanup: undefined }
+  | { isActive: true; cleanup: () => void }
+
+let polyfillState: ImageInputPolyfillState = {
+  isActive: false,
+  cleanup: undefined,
+}
+
+function setupImageInputClickPolyfill() {
+  if (polyfillState.isActive) {
+    return
+  }
+
+  const cleanupRaw = setupImageInputCoordsPolyfillImpl()
+  const cleanup = () => {
+    polyfillState = { isActive: false, cleanup: undefined }
+    cleanupRaw()
+  }
+  polyfillState = { isActive: true, cleanup }
+}
+
+function cleanupImageInputCoordsPolyfill() {
+  if (!polyfillState.isActive) {
+    return
+  }
+  polyfillState.cleanup()
+}
+
+function setupImageInputCoordsPolyfillImpl() {
+  // When we're in a submit event, we have no way of knowing where the `<input type="image">` was clicked.
+  // So we need to track clicks as they happen, and stash them on the element to be retrieved during the submit.
+  //
+  // Note that this will also get triggered when the input is submitted using the keyboard
+  // (with `{ clientX: 0, clientY: 0 }`, same as when `<input type="image">` is triggered via keyboard)
+  const onClick = (clickEvent: MouseEvent) => {
+    const target = clickEvent.target
+    if (
+      typeof target === 'object' &&
+      target &&
+      target instanceof HTMLElement &&
+      isImageInputElement(target)
+    ) {
+      const coords = {
+        clientX: clickEvent.clientX,
+        clientY: clickEvent.clientY,
+      }
+      target[LAST_CLICKED_COORDS] = coords
+      setTimeout(() => {
+        // this will last long enough to be usable in the submit event, and disappear after
+        // so that we're not accidentally left with a stale value
+        if (target[LAST_CLICKED_COORDS] === coords) {
+          target[LAST_CLICKED_COORDS] = undefined
+        }
+      })
+    }
+  }
+
+  window.addEventListener('click', onClick, /* passive */ true)
+  const cleanup = () => {
+    window.removeEventListener('click', onClick, /* passive */ true)
+  }
+  return cleanup
+}
+
+const LAST_CLICKED_COORDS = Symbol('LAST_CLICKED_COORDS')
+
+type InputImageElement = HTMLInputElement & {
+  type: 'image'
+  [LAST_CLICKED_COORDS]?: { clientX: number; clientY: number }
+}
+
+function isImageInputElement(
+  element: HTMLElement
+): element is InputImageElement {
+  return (
+    element.nodeName === 'INPUT' &&
+    (element as HTMLInputElement).type === 'image'
+  )
+}
+
+function getPolyfilledClickCoordsFromImageInput(element: InputImageElement) {
+  return element[LAST_CLICKED_COORDS]
 }

--- a/packages/next/src/client/form-shared.tsx
+++ b/packages/next/src/client/form-shared.tsx
@@ -1,5 +1,6 @@
 import type { HTMLProps } from 'react'
 import { createFormData } from './form-data-submitter-polyfill'
+export { useImageInputCoordsPolyfill } from './form-data-submitter-polyfill'
 
 export const DISALLOWED_FORM_PROPS = ['method', 'encType', 'target'] as const
 

--- a/packages/next/src/client/form.tsx
+++ b/packages/next/src/client/form.tsx
@@ -10,6 +10,7 @@ import {
   DISALLOWED_FORM_PROPS,
   hasReactClientActionAttributes,
   hasUnsupportedSubmitterAttributes,
+  useImageInputCoordsPolyfill,
   type FormProps,
 } from './form-shared'
 
@@ -19,6 +20,8 @@ const Form = forwardRef<HTMLFormElement, FormProps>(function FormComponent(
   { replace, scroll, prefetch: prefetchProp, ...props },
   ref
 ) {
+  useImageInputCoordsPolyfill()
+
   const router = useContext(RouterContext)
 
   const actionProp = props.action

--- a/test/e2e/app-dir/next-form/default/next-form.test.ts
+++ b/test/e2e/app-dir/next-form/default/next-form.test.ts
@@ -131,44 +131,37 @@ describe.each(['app', 'pages'])('%s dir - form', (type) => {
         }
       })
 
-      // TODO: fix submitter polyfill for image inputs
-      ;(forcePolyfill ? test.failing : test)(
-        '<input type="image">',
-        async () => {
-          const session = await next.browser(
-            pathPrefix + '/forms/submitter-value/input-type-image',
-            { beforePageLoad }
-          )
-          const navigationTracker = await trackMpaNavs(session)
+      test('<input type="image">', async () => {
+        const session = await next.browser(
+          pathPrefix + '/forms/submitter-value/input-type-image',
+          { beforePageLoad }
+        )
+        const navigationTracker = await trackMpaNavs(session)
 
-          const submitButtonOne = await session.elementById('submit-btn-one')
-          await submitButtonOne.click()
-          await session.waitForElementByCss('#search-results')
+        const submitButtonOne = await session.elementById('submit-btn-one')
+        await submitButtonOne.click()
+        await session.waitForElementByCss('#search-results')
 
-          // input type image sends `{name}.x` and `{name}.y` specifying the relative coordinates of the click
-          // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/image#using_the_x_and_y_data_points
-          // eslint-disable-next-line jest/no-standalone-expect
-          expect(new URL(await session.url()).search).toMatch(
-            /\?buttonOne\.x=\d+&buttonOne\.y=\d+/
-          )
+        // input type image sends `{name}.x` and `{name}.y` specifying the relative coordinates of the click
+        // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/image#using_the_x_and_y_data_points
+        expect(new URL(await session.url()).search).toMatch(
+          /\?buttonOne\.x=\d+&buttonOne\.y=\d+/
+        )
 
-          // eslint-disable-next-line jest/no-standalone-expect
-          expect(await navigationTracker.didMpaNavigate()).toBe(false)
+        expect(await navigationTracker.didMpaNavigate()).toBe(false)
 
-          await session.back()
+        await session.back()
 
-          const submitButtonTwo = await session.elementById('submit-btn-two')
-          await submitButtonTwo.click()
-          await session.waitForElementByCss('#search-results')
+        const submitButtonTwo = await session.elementById('submit-btn-two')
+        await submitButtonTwo.click()
+        await session.waitForElementByCss('#search-results')
 
-          // input type image sends `{name}.x` and `{name}.y` specifying the relative coordinates of the click
-          // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/image#using_the_x_and_y_data_points
-          // eslint-disable-next-line jest/no-standalone-expect
-          expect(new URL(await session.url()).search).toMatch(
-            /\?buttonTwo\.x=\d+&buttonTwo\.y=\d+/
-          )
-        }
-      )
+        // input type image sends `{name}.x` and `{name}.y` specifying the relative coordinates of the click
+        // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/image#using_the_x_and_y_data_points
+        expect(new URL(await session.url()).search).toMatch(
+          /\?buttonTwo\.x=\d+&buttonTwo\.y=\d+/
+        )
+      })
     })
   })
 


### PR DESCRIPTION
In #76524 we introduced a polyfill for `new FormData(form, submitter)` which is not supported by some old browsers. However, this polyfill wasn't handling `<input type="image">` -- when an image is used to submit a form, the form data should include the click coordinates.

This is not easy to polyfill because we don't have access to the click coordinates during the submit event. The approach chosen here is to track all clicks on image inputs, stash the coordinates on the element, and read them during the submit event. 
To reduce overhead, this click handler is installed lazily, when the first `Form` is rendered, and removed when the last Form is gone.

Note: React's form internals currently aren't handling this either, and we'll want to do an analogous fix there.