### PR TITLE
docs(errors): remove confusing good-to-know since global-errors.tsx also show in dev as of 15.2

### DIFF
--- a/docs/01-app/04-api-reference/03-file-conventions/error.mdx
+++ b/docs/01-app/04-api-reference/03-file-conventions/error.mdx
@@ -193,12 +193,10 @@ export default function GlobalError({ error, reset }) {
 }
 ```
 
-> **Good to know**: `global-error.js` is always displayed In development, error overlay will show instead.
-
 ## Version History
 
 | Version   | Changes                                     |
 | --------- | ------------------------------------------- |
-| `v15.2.0` | display `global-error` also in development. |
+| `v15.2.0` | Also display `global-error` in development. |
 | `v13.1.0` | `global-error` introduced.                  |
 | `v13.0.0` | `error` introduced.                         |


### PR DESCRIPTION
## Why?

The "Good to know" has a typo, and it is probably better not mentioned. The https://nextjs.org/docs/app/building-your-application/routing/error-handling#handling-global-errors page does not mention (the fact that `global-errors.tsx` now show in `next dev`) it either.