### PR TITLE
Turbopack: handle task cancelation

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -543,8 +543,8 @@ async fn project_on_exit_internal(project: &ProjectInstance) {
 pub async fn project_shutdown(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
 ) {
-    project_on_exit_internal(&project).await;
     project.turbo_tasks.stop_and_wait().await;
+    project_on_exit_internal(&project).await;
 }
 
 #[napi(object)]

--- a/packages/next/src/shared/lib/turbopack/manifest-loader.ts
+++ b/packages/next/src/shared/lib/turbopack/manifest-loader.ts
@@ -200,6 +200,16 @@ export class TurbopackManifestLoader {
       mergeActionIds(manifest.node, m.node)
       mergeActionIds(manifest.edge, m.edge)
     }
+    for (const key in manifest.node) {
+      const entry = manifest.node[key]
+      entry.workers = sortObjectByKey(entry.workers)
+      entry.layer = sortObjectByKey(entry.layer)
+    }
+    for (const key in manifest.edge) {
+      const entry = manifest.edge[key]
+      entry.workers = sortObjectByKey(entry.workers)
+      entry.layer = sortObjectByKey(entry.layer)
+    }
 
     return manifest
   }
@@ -247,6 +257,7 @@ export class TurbopackManifestLoader {
     for (const m of manifests) {
       Object.assign(manifest.pages, m.pages)
     }
+    manifest.pages = sortObjectByKey(manifest.pages)
     return manifest
   }
 
@@ -398,6 +409,7 @@ export class TurbopackManifestLoader {
       // polyfillFiles should always be the same, so we can overwrite instead of actually merging
       if (m.polyfillFiles.length) manifest.polyfillFiles = m.polyfillFiles
     }
+    manifest.pages = sortObjectByKey(manifest.pages) as BuildManifest['pages']
     return manifest
   }
 
@@ -550,6 +562,8 @@ export class TurbopackManifestLoader {
       manifest.pagesUsingSizeAdjust =
         manifest.pagesUsingSizeAdjust || m.pagesUsingSizeAdjust
     }
+    manifest.app = sortObjectByKey(manifest.app)
+    manifest.pages = sortObjectByKey(manifest.pages)
     return manifest
   }
 
@@ -620,6 +634,8 @@ export class TurbopackManifestLoader {
         instrumentation = m.instrumentation
       }
     }
+    manifest.functions = sortObjectByKey(manifest.functions)
+    manifest.middleware = sortObjectByKey(manifest.middleware)
     const updateFunctionDefinition = (
       fun: EdgeFunctionDefinition
     ): EdgeFunctionDefinition => {
@@ -696,7 +712,7 @@ export class TurbopackManifestLoader {
     for (const m of manifests) {
       Object.assign(manifest, m)
     }
-    return manifest
+    return sortObjectByKey(manifest)
   }
 
   private async writePagesManifest(): Promise<void> {
@@ -732,4 +748,16 @@ export class TurbopackManifestLoader {
       await this.writeWebpackStats()
     }
   }
+}
+
+function sortObjectByKey(obj: Record<string, any>) {
+  return Object.keys(obj)
+    .sort()
+    .reduce(
+      (acc, key) => {
+        acc[key] = obj[key]
+        return acc
+      },
+      {} as Record<string, any>
+    )
 }

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -320,6 +320,7 @@ pub struct InProgressStateInner {
 pub enum InProgressState {
     Scheduled { done_event: Event },
     InProgress(Box<InProgressStateInner>),
+    Canceled,
 }
 
 transient_traits!(InProgressState);

--- a/turbopack/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -395,6 +395,14 @@ impl Backend for MemoryBackend {
         }
     }
 
+    fn task_execution_canceled(
+        &self,
+        _task: TaskId,
+        _turbo_tasks: &dyn TurboTasksBackendApi<Self>,
+    ) {
+        todo!()
+    }
+
     fn try_start_task_execution<'a>(
         &'a self,
         task: TaskId,

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -453,6 +453,8 @@ pub trait Backend: Sync + Send {
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> Option<TaskExecutionSpec<'a>>;
 
+    fn task_execution_canceled(&self, task: TaskId, turbo_tasks: &dyn TurboTasksBackendApi<Self>);
+
     fn task_execution_result(
         &self,
         task: TaskId,

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -647,6 +647,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
                 )));
                 let single_execution_future = async {
                     if this.stopped.load(Ordering::Acquire) {
+                        this.backend.task_execution_canceled(task_id, &*this);
                         return false;
                     }
 


### PR DESCRIPTION
> After the compilation of next build has finished we call stop_and_wait on turbo tasks, which should wait for all tasks to finish. This should make sure any ongoing persisting will finish.
It will also prevent more tasks execution to be spawned. And exactly that caused the bug.
At this point all write_endpoint_to_disk calls have finished, but there might be still some ongoing tasks executing because of eventual consistency. We didn't need these tasks anymore, so write_endpoint_to_disk didn't wait on them.
On bad timing turbotasks might be stopped exactly after one of these tasks spawned another task. The task is not scheduled due to turbo tasks being stopped, but the parent task tries to read the task and waits forever...


### What?

* handle task cancelation
* wait for stopping turbo-tasks before running exit handlers
* sort all output manifests


Closes PACK-4073