### PR TITLE
Turbopack: don't use HashMap in manifests

### DIFF
--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -3,7 +3,6 @@
 pub mod client_reference_manifest;
 
 use anyhow::{Context, Result};
-use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
@@ -22,7 +21,7 @@ use crate::next_config::{CrossOriginConfig, Rewrites, RouteHas};
 #[derive(Serialize, Default, Debug)]
 pub struct PagesManifest {
     #[serde(flatten)]
-    pub pages: FxHashMap<RcStr, RcStr>,
+    pub pages: FxIndexMap<RcStr, RcStr>,
 }
 
 #[derive(Debug, Default)]
@@ -233,16 +232,16 @@ pub enum Regions {
 #[derive(Serialize, Default, Debug)]
 pub struct MiddlewaresManifestV2 {
     pub sorted_middleware: Vec<RcStr>,
-    pub middleware: FxHashMap<RcStr, EdgeFunctionDefinition>,
+    pub middleware: FxIndexMap<RcStr, EdgeFunctionDefinition>,
     pub instrumentation: Option<InstrumentationDefinition>,
-    pub functions: FxHashMap<RcStr, EdgeFunctionDefinition>,
+    pub functions: FxIndexMap<RcStr, EdgeFunctionDefinition>,
 }
 
 #[derive(Serialize, Default, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ReactLoadableManifest {
     #[serde(flatten)]
-    pub manifest: FxHashMap<RcStr, ReactLoadableManifestEntry>,
+    pub manifest: FxIndexMap<RcStr, ReactLoadableManifestEntry>,
 }
 
 #[derive(Serialize, Default, Debug)]
@@ -255,8 +254,8 @@ pub struct ReactLoadableManifestEntry {
 #[derive(Serialize, Default, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct NextFontManifest {
-    pub pages: FxHashMap<RcStr, Vec<RcStr>>,
-    pub app: FxHashMap<RcStr, Vec<RcStr>>,
+    pub pages: FxIndexMap<RcStr, Vec<RcStr>>,
+    pub app: FxIndexMap<RcStr, Vec<RcStr>>,
     pub app_using_size_adjust: bool,
     pub pages_using_size_adjust: bool,
 }
@@ -285,9 +284,9 @@ pub struct LoadableManifest {
 #[serde(rename_all = "camelCase")]
 pub struct ServerReferenceManifest<'a> {
     /// A map from hashed action name to the runtime module we that exports it.
-    pub node: FxHashMap<&'a str, ActionManifestEntry<'a>>,
+    pub node: FxIndexMap<&'a str, ActionManifestEntry<'a>>,
     /// A map from hashed action name to the runtime module we that exports it.
-    pub edge: FxHashMap<&'a str, ActionManifestEntry<'a>>,
+    pub edge: FxIndexMap<&'a str, ActionManifestEntry<'a>>,
 }
 
 #[derive(Serialize, Default, Debug)]
@@ -295,9 +294,9 @@ pub struct ServerReferenceManifest<'a> {
 pub struct ActionManifestEntry<'a> {
     /// A mapping from the page that uses the server action to the runtime
     /// module that exports it.
-    pub workers: FxHashMap<&'a str, ActionManifestWorkerEntry<'a>>,
+    pub workers: FxIndexMap<&'a str, ActionManifestWorkerEntry<'a>>,
 
-    pub layer: FxHashMap<&'a str, ActionLayer>,
+    pub layer: FxIndexMap<&'a str, ActionLayer>,
 }
 
 #[derive(Serialize, Debug)]
@@ -345,22 +344,22 @@ pub struct ClientReferenceManifest {
     pub client_modules: ManifestNode,
     /// Mapping of client module ID to corresponding SSR module ID and required
     /// SSR chunks.
-    pub ssr_module_mapping: FxHashMap<ModuleId, ManifestNode>,
+    pub ssr_module_mapping: FxIndexMap<ModuleId, ManifestNode>,
     /// Same as `ssr_module_mapping`, but for Edge SSR.
     #[serde(rename = "edgeSSRModuleMapping")]
-    pub edge_ssr_module_mapping: FxHashMap<ModuleId, ManifestNode>,
+    pub edge_ssr_module_mapping: FxIndexMap<ModuleId, ManifestNode>,
     /// Mapping of client module ID to corresponding RSC module ID and required
     /// RSC chunks.
-    pub rsc_module_mapping: FxHashMap<ModuleId, ManifestNode>,
+    pub rsc_module_mapping: FxIndexMap<ModuleId, ManifestNode>,
     /// Same as `rsc_module_mapping`, but for Edge RSC.
     #[serde(rename = "edgeRscModuleMapping")]
-    pub edge_rsc_module_mapping: FxHashMap<ModuleId, ManifestNode>,
+    pub edge_rsc_module_mapping: FxIndexMap<ModuleId, ManifestNode>,
     /// Mapping of server component path to required CSS client chunks.
     #[serde(rename = "entryCSSFiles")]
-    pub entry_css_files: FxHashMap<RcStr, FxIndexSet<CssResource>>,
+    pub entry_css_files: FxIndexMap<RcStr, FxIndexSet<CssResource>>,
     /// Mapping of server component path to required JS client chunks.
     #[serde(rename = "entryJSFiles")]
-    pub entry_js_files: FxHashMap<RcStr, FxIndexSet<RcStr>>,
+    pub entry_js_files: FxIndexMap<RcStr, FxIndexSet<RcStr>>,
 }
 
 #[derive(Serialize, Debug, Clone, Eq, Hash, PartialEq)]
@@ -383,7 +382,7 @@ pub struct ModuleLoading {
 pub struct ManifestNode {
     /// Mapping of export name to manifest node entry.
     #[serde(flatten)]
-    pub module_exports: FxHashMap<RcStr, ManifestNodeEntry>,
+    pub module_exports: FxIndexMap<RcStr, ManifestNodeEntry>,
 }
 
 #[derive(Serialize, Debug, Clone)]
@@ -490,7 +489,7 @@ pub struct ClientBuildManifest<'a> {
     pub sorted_pages: &'a [RcStr],
 
     #[serde(flatten)]
-    pub pages: FxHashMap<RcStr, Vec<&'a str>>,
+    pub pages: FxIndexMap<RcStr, Vec<&'a str>>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Should make the output more deterministic.
We could change these to instead use our own `SliceMap`, but these aren't stored anywhere.

Closes PACK-3309
Closes PACK-4068