### PR TITLE
fix: remove useless set-cookie in action-handler

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -30,10 +30,7 @@ import {
   filterReqHeaders,
   actionsForbiddenHeaders,
 } from '../lib/server-ipc/utils'
-import {
-  appendMutableCookies,
-  getModifiedCookieValues,
-} from '../web/spec-extension/adapters/request-cookies'
+import { getModifiedCookieValues } from '../web/spec-extension/adapters/request-cookies'
 
 import {
   NEXT_CACHE_REVALIDATED_TAGS_HEADER,
@@ -974,13 +971,6 @@ export async function handleAction({
             workStore
           ),
         }
-      }
-
-      // If there were mutable cookies set, we need to set them on the
-      // response.
-      const headers = new Headers()
-      if (appendMutableCookies(headers, requestStore.mutableCookies)) {
-        res.setHeader('set-cookie', Array.from(headers.values()))
       }
 
       res.setHeader('Location', redirectUrl)

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -175,6 +175,27 @@ describe('app-dir action handling', () => {
     })
   })
 
+  it.each([
+    { description: 'with javascript', disableJavaScript: false },
+    { description: 'no javascript', disableJavaScript: true },
+  ])(
+    'should support setting cookies when redirecting ($description)',
+    async ({ disableJavaScript }) => {
+      const browser = await next.browser('/mutate-cookie-with-redirect', {
+        disableJavaScript,
+      })
+      expect(await browser.elementByCss('#value').text()).toBe('')
+
+      await browser.elementByCss('#update-cookie').click()
+      await browser.elementByCss('#redirect-target')
+
+      expect(await browser.elementByCss('#value').text()).toMatch(/\d+/)
+      expect(await browser.eval('document.cookie')).toMatch(
+        /(?:^|(?:; ))testCookie=\d+/
+      )
+    }
+  )
+
   it('should push new route when redirecting', async () => {
     const browser = await next.browser('/header')
 

--- a/test/e2e/app-dir/actions/app/mutate-cookie-with-redirect/page.js
+++ b/test/e2e/app-dir/actions/app/mutate-cookie-with-redirect/page.js
@@ -1,0 +1,21 @@
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+async function updateCookieAndRedirect() {
+  'use server'
+  ;(await cookies()).set('testCookie', Date.now())
+  redirect('/mutate-cookie-with-redirect/redirect-target')
+}
+
+export default async function Page() {
+  return (
+    <>
+      <p id="value">{(await cookies()).get('testCookie')?.value ?? null}</p>
+      <form action={updateCookieAndRedirect}>
+        <button id="update-cookie" type="submit">
+          Update Cookie
+        </button>
+      </form>
+    </>
+  )
+}

--- a/test/e2e/app-dir/actions/app/mutate-cookie-with-redirect/redirect-target/page.js
+++ b/test/e2e/app-dir/actions/app/mutate-cookie-with-redirect/redirect-target/page.js
@@ -1,0 +1,9 @@
+import { cookies } from 'next/headers'
+
+export default async function Page() {
+  return (
+    <div id="redirect-target">
+      <p id="value">{(await cookies()).get('testCookie')?.value ?? null}</p>
+    </div>
+  )
+}


### PR DESCRIPTION
`handleAction` had a weird spot where it'd add a `set-cookie` header if a redirect was thrown during handling a no-js action. AFAICT, this is unnecessary -- we set the `set-cookie` header on the response as soon as `cookies().set()` is called, so there's no need to set the cookies again in that branch of the handler.

this is done through a combination of the patched setter from `RequestCookies`:
https://github.com/vercel/next.js/blob/0abd87717f19bced6c35af1255837628513cf772/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts#L160-L171
 and this cookie updating function from the request store (which `updateResponseCookies` above would invoke with the new cookies):
https://github.com/vercel/next.js/blob/0abd87717f19bced6c35af1255837628513cf772/packages/next/src/server/async-storage/request-store.ts#L170-L174

i've also added a test for this specific scenario to ensure that this wasn't actually doing anything useful.