### PR TITLE
refactor(actions): remove handling for urlencoded actions

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -50,15 +50,6 @@ import type { TemporaryReferenceSet } from 'react-server-dom-webpack/server.edge
 import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
-function formDataFromSearchQueryString(query: string) {
-  const searchParams = new URLSearchParams(query)
-  const formData = new FormData()
-  for (const [key, value] of searchParams) {
-    formData.append(key, value)
-  }
-  return formData
-}
-
 function nodeHeadersToRecord(
   headers: IncomingHttpHeaders | OutgoingHttpHeaders
 ) {
@@ -488,14 +479,13 @@ export async function handleAction({
 
   const {
     actionId,
-    isURLEncodedAction,
     isMultipartAction,
     isFetchAction,
     isPotentialServerAction,
   } = getServerActionRequestMetadata(req)
 
   // If it can't be a Server Action, skip handling.
-  // Note that this can be a false positive -- any multipart/urlencoded POST can get us here,
+  // Note that this can be a false positive -- any multipart POST can get us here,
   // But won't know if it's a no-js action or not until we call `decodeAction` below.
   if (!isPotentialServerAction) {
     return { type: 'not-an-action' }
@@ -739,21 +729,11 @@ export async function handleAction({
             }
 
             const actionData = Buffer.concat(chunks).toString('utf-8')
-
-            if (isURLEncodedAction) {
-              const formData = formDataFromSearchQueryString(actionData)
-              boundActionArguments = await decodeReply(
-                formData,
-                serverModuleMap,
-                { temporaryReferences }
-              )
-            } else {
-              boundActionArguments = await decodeReply(
-                actionData,
-                serverModuleMap,
-                { temporaryReferences }
-              )
-            }
+            boundActionArguments = await decodeReply(
+              actionData,
+              serverModuleMap,
+              { temporaryReferences }
+            )
           }
         } else if (
           // The type check here ensures that `req` is correctly typed, and the
@@ -904,20 +884,11 @@ export async function handleAction({
 
             const actionData = Buffer.concat(chunks).toString('utf-8')
 
-            if (isURLEncodedAction) {
-              const formData = formDataFromSearchQueryString(actionData)
-              boundActionArguments = await decodeReply(
-                formData,
-                serverModuleMap,
-                { temporaryReferences }
-              )
-            } else {
-              boundActionArguments = await decodeReply(
-                actionData,
-                serverModuleMap,
-                { temporaryReferences }
-              )
-            }
+            boundActionArguments = await decodeReply(
+              actionData,
+              serverModuleMap,
+              { temporaryReferences }
+            )
           }
         } else {
           throw new Error('Invariant: Unknown request type.')

--- a/packages/next/src/server/lib/server-action-request-meta.ts
+++ b/packages/next/src/server/lib/server-action-request-meta.ts
@@ -7,7 +7,6 @@ export function getServerActionRequestMetadata(
   req: IncomingMessage | BaseNextRequest | NextRequest
 ): {
   actionId: string | null
-  isURLEncodedAction: boolean
   isMultipartAction: boolean
   isFetchAction: boolean
   isPotentialServerAction: boolean
@@ -23,9 +22,6 @@ export function getServerActionRequestMetadata(
     contentType = req.headers['content-type'] ?? null
   }
 
-  const isURLEncodedAction = Boolean(
-    req.method === 'POST' && contentType === 'application/x-www-form-urlencoded'
-  )
   const isMultipartAction = Boolean(
     req.method === 'POST' && contentType?.startsWith('multipart/form-data')
   )
@@ -35,13 +31,10 @@ export function getServerActionRequestMetadata(
       req.method === 'POST'
   )
 
-  const isPotentialServerAction = Boolean(
-    isFetchAction || isURLEncodedAction || isMultipartAction
-  )
+  const isPotentialServerAction = isFetchAction || isMultipartAction
 
   return {
     actionId,
-    isURLEncodedAction,
     isMultipartAction,
     isFetchAction,
     isPotentialServerAction,

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -51,7 +51,6 @@ import {
   type ActionStore,
 } from '../../app-render/action-async-storage.external'
 import * as sharedModules from './shared-modules'
-import { getIsPotentialServerAction } from '../../lib/server-action-request-meta'
 import { RequestCookies } from 'next/dist/compiled/@edge-runtime/cookies'
 import { cleanURL } from './helpers/clean-url'
 import { StaticGenBailoutError } from '../../../client/components/static-generation-bailout'
@@ -294,7 +293,6 @@ export class AppRouteRouteModule extends RouteModule<
 
   private async do(
     handler: AppRouteHandlerFn,
-    actionStore: ActionStore,
     workStore: WorkStore,
     // @TODO refactor to not take this argument but instead construct the RequestStore
     // inside this function. Right now we get passed a RequestStore even when
@@ -575,14 +573,34 @@ export class AppRouteRouteModule extends RouteModule<
           appendMutableCookies(headers, requestStore.mutableCookies)
         }
 
+        // FIXME: We're forcing some redirects to use `RedirectStatusCode.SeeOther`
+        // but this behavior seems to be a bit accidental.
+        //
+        // This was introduced in https://github.com/vercel/next.js/pull/70769.
+        // We were checking if we this is a server action request (via `getServerActionRequestMetadata().isServerAction`)
+        // and if so, forcing the redirect to use `RedirectStatusCode.SeeOther`.
+        // That can't happen here (in a legitimate way), because this is a route handler, and action requests target pages.
+        // (and an action can't redirect to a route handler URL in a way where the POST would be retried, because actions always use 303).
+        //
+        // But incidentally, that `isServerAction` check was pretty loose, and would return `true`
+        // for any POST that was multipart, urlencoded, or had the Next-Action header.
+        // So in essence, a lot of POSTs to route handlers would have their `redirect()` calls result in a `RedirectStatusCode.SeeOther`.
+        // (requests that used `application/json` or `text/plain` for the body would be fine.)
+        //
+        // We should consider changing this, but it could cause breaking changes, so I'm going to keep it for now,
+        // except for checking for the `Next-Id` header, which no one should rely on.
+        const contentType = request.headers.get('content-type')
+        const forceSeeOther =
+          request.method === 'POST' &&
+          (!!contentType?.startsWith('multipart/form-data') ||
+            contentType === 'application/x-www-form-urlencoded')
+        const status = forceSeeOther
+          ? RedirectStatusCode.SeeOther
+          : getRedirectStatusCodeFromError(err)
+
         // Return the redirect response.
         return new Response(null, {
-          // If we're in an action, we want to use a 303 redirect as we don't
-          // want the POST request to follow the redirect, as it could result in
-          // erroneous re-submissions.
-          status: actionStore.isAction
-            ? RedirectStatusCode.SeeOther
-            : getRedirectStatusCodeFromError(err),
+          status,
           headers,
         })
       } else if (isHTTPAccessFallbackError(err)) {
@@ -662,7 +680,7 @@ export class AppRouteRouteModule extends RouteModule<
 
     const actionStore: ActionStore = {
       isAppRoute: true,
-      isAction: getIsPotentialServerAction(req),
+      isAction: false,
     }
 
     const implicitTags = getImplicitTags(
@@ -753,7 +771,6 @@ export class AppRouteRouteModule extends RouteModule<
               async () =>
                 this.do(
                   handler,
-                  actionStore,
                   workStore,
                   requestStore,
                   implicitTags,

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1633,72 +1633,126 @@ describe('app-dir action handling', () => {
   })
 
   describe('redirects', () => {
-    it('redirects properly when server action handler uses `redirect`', async () => {
-      const postRequests = []
-      const responseCodes = []
+    it.each([
+      {
+        name: 'plaintext POST request',
+        buttonId: 'submit-api-redirect-plaintext',
+        should303: false,
+      },
+      {
+        name: 'urlencoded POST request',
+        buttonId: 'submit-api-redirect-urlencoded',
+        should303: true, // special case. it's weird that we do this, but that's the current behavior
+      },
+      {
+        name: 'multipart POST request',
+        buttonId: 'submit-api-redirect-multipart',
+        should303: true, // special case. it's weird that we do this, but that's the current behavior
+      },
+    ])(
+      'redirects properly when route handler uses `redirect` - $name',
+      async ({ buttonId, should303 }) => {
+        const postRequests = []
+        const responseCodes = []
 
-      const browser = await next.browser('/redirects', {
-        beforePageLoad(page) {
-          page.on('request', (request: Request) => {
-            const url = new URL(request.url())
-            if (request.method() === 'POST') {
-              postRequests.push(url.pathname)
-            }
-          })
+        const browser = await next.browser('/redirects', {
+          beforePageLoad(page) {
+            page.on('request', (request: Request) => {
+              const url = new URL(request.url())
+              if (request.method() === 'POST') {
+                postRequests.push(url.pathname + url.search)
+              }
+            })
 
-          page.on('response', (response: Response) => {
-            const url = new URL(response.url())
-            const status = response.status()
+            page.on('response', (response: Response) => {
+              const url = new URL(response.url())
+              const status = response.status()
 
-            if (postRequests.includes(`${url.pathname}${url.search}`)) {
-              responseCodes.push(status)
-            }
-          })
-        },
-      })
-      await browser.elementById('submit-api-redirect').click()
-      // await check(() => browser.url(), /success=true/)
-      await retry(async () => {
-        expect(await browser.url()).toContain('success=true')
-      })
+              if (postRequests.includes(`${url.pathname}${url.search}`)) {
+                responseCodes.push(status)
+              }
+            })
+          },
+        })
+        await browser.elementById(buttonId).click()
+        // await check(() => browser.url(), /success=true/)
+        await retry(async () => {
+          expect(await browser.url()).toContain('success=true')
+        })
 
-      // verify that the POST request was only made to the action handler
-      expect(postRequests).toEqual(['/redirects/api-redirect'])
-      expect(responseCodes).toEqual([303])
-    })
+        if (should303) {
+          // verify that the POST request was only made to the route handler
+          expect(postRequests).toEqual(['/redirects/api-redirect'])
+          expect(responseCodes).toEqual([303])
+        } else {
+          expect(postRequests).toEqual([
+            '/redirects/api-redirect',
+            '/redirects?success=true',
+          ])
+          expect(responseCodes).toEqual([307, 200])
+        }
+      }
+    )
 
-    it('redirects properly when server action handler uses `permanentRedirect`', async () => {
-      const postRequests = []
-      const responseCodes = []
+    it.each([
+      {
+        name: 'plaintext POST request',
+        buttonId: 'submit-api-redirect-permanent-plaintext',
+        should303: false,
+      },
+      {
+        name: 'urlencoded POST request',
+        buttonId: 'submit-api-redirect-permanent-urlencoded',
+        should303: true, // special case. it's weird that we do this, but that's the current behavior
+      },
+      {
+        name: 'multipart POST request',
+        buttonId: 'submit-api-redirect-permanent-multipart',
+        should303: true, // special case. it's weird that we do this, but that's the current behavior
+      },
+    ])(
+      'redirects properly when route handler uses `permanentRedirect` - $name',
+      async ({ buttonId, should303 }) => {
+        const postRequests = []
+        const responseCodes = []
 
-      const browser = await next.browser('/redirects', {
-        beforePageLoad(page) {
-          page.on('request', (request: Request) => {
-            const url = new URL(request.url())
-            if (request.method() === 'POST') {
-              postRequests.push(url.pathname)
-            }
-          })
+        const browser = await next.browser('/redirects', {
+          beforePageLoad(page) {
+            page.on('request', (request: Request) => {
+              const url = new URL(request.url())
+              if (request.method() === 'POST') {
+                postRequests.push(url.pathname + url.search)
+              }
+            })
 
-          page.on('response', (response: Response) => {
-            const url = new URL(response.url())
-            const status = response.status()
+            page.on('response', (response: Response) => {
+              const url = new URL(response.url())
+              const status = response.status()
 
-            if (postRequests.includes(`${url.pathname}${url.search}`)) {
-              responseCodes.push(status)
-            }
-          })
-        },
-      })
+              if (postRequests.includes(`${url.pathname}${url.search}`)) {
+                responseCodes.push(status)
+              }
+            })
+          },
+        })
 
-      await browser.elementById('submit-api-redirect-permanent').click()
-      await retry(async () => {
-        expect(await browser.url()).toContain('success=true')
-      })
-      // verify that the POST request was only made to the action handler
-      expect(postRequests).toEqual(['/redirects/api-redirect-permanent'])
-      expect(responseCodes).toEqual([303])
-    })
+        await browser.elementById(buttonId).click()
+        await retry(async () => {
+          expect(await browser.url()).toContain('success=true')
+        })
+        if (should303) {
+          // verify that the POST request was only made to the route handler
+          expect(postRequests).toEqual(['/redirects/api-redirect-permanent'])
+          expect(responseCodes).toEqual([303])
+        } else {
+          expect(postRequests).toEqual([
+            '/redirects/api-redirect-permanent',
+            '/redirects?success=true',
+          ])
+          expect(responseCodes).toEqual([308, 200])
+        }
+      }
+    )
 
     it('displays searchParams correctly when redirecting with SearchParams', async () => {
       const browser = await next.browser('/redirects/action-redirect')

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -15,6 +15,8 @@ import { join } from 'path'
 const GENERIC_RSC_ERROR =
   'Error: An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
 
+const isPPREnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+
 describe('app-dir action handling', () => {
   const { next, isNextDev, isNextStart, isNextDeploy, isTurbopack } =
     nextTestSetup({
@@ -1689,7 +1691,12 @@ describe('app-dir action handling', () => {
             '/redirects/api-redirect',
             '/redirects?success=true',
           ])
-          expect(responseCodes).toEqual([307, 200])
+
+          expect(responseCodes).toEqual([
+            307,
+            // a POST to a route seems to always 405 when PPR is on.
+            isPPREnabled ? 405 : 200,
+          ])
         }
       }
     )
@@ -1749,7 +1756,11 @@ describe('app-dir action handling', () => {
             '/redirects/api-redirect-permanent',
             '/redirects?success=true',
           ])
-          expect(responseCodes).toEqual([308, 200])
+          expect(responseCodes).toEqual([
+            308,
+            // a POST to a page seems to always 405 when PPR is on.
+            isPPREnabled ? 405 : 200,
+          ])
         }
       }
     )

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -803,10 +803,10 @@ describe('app-dir action handling', () => {
       await next.fetch('/server', {
         method: 'POST',
         headers: {
-          'content-type': 'application/x-www-form-urlencoded',
+          'content-type': 'text/plain',
           'next-action': 'abc123',
         },
-        body: 'foo=bar',
+        body: '["foo","bar"]',
       })
 
       await retry(async () =>

--- a/test/e2e/app-dir/actions/app/redirects/api-redirect-permanent/route.js
+++ b/test/e2e/app-dir/actions/app/redirects/api-redirect-permanent/route.js
@@ -1,5 +1,5 @@
 import { permanentRedirect } from 'next/navigation'
 
 export function POST(request) {
-  permanentRedirect('/redirects/?success=true')
+  permanentRedirect('/redirects?success=true')
 }

--- a/test/e2e/app-dir/actions/app/redirects/api-redirect/route.js
+++ b/test/e2e/app-dir/actions/app/redirects/api-redirect/route.js
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation'
 
 export function POST(request) {
-  redirect('/redirects/?success=true')
+  redirect('/redirects?success=true')
 }

--- a/test/e2e/app-dir/actions/app/redirects/page.js
+++ b/test/e2e/app-dir/actions/app/redirects/page.js
@@ -5,18 +5,52 @@ export const dynamic = 'force-dynamic'
 export default function Home() {
   return (
     <main id="redirect-page">
-      <h1>POST /api-redirect (`redirect()`)</h1>
-      <form action="/redirects/api-redirect" method="POST">
-        <input type="submit" value="Submit" id="submit-api-redirect" />
-      </form>
-      <h1>POST /api-redirect-permanent (`permanentRedirect()`)</h1>
-      <form action="/redirects/api-redirect-permanent" method="POST">
-        <input
-          type="submit"
-          value="Submit"
-          id="submit-api-redirect-permanent"
-        />
-      </form>
+      <section>
+        <h1>POST /api-redirect (`redirect()`)</h1>
+        <form action="/redirects/api-redirect" method="POST">
+          <input
+            type="submit"
+            value="Submit - multipart"
+            id="submit-api-redirect-multipart"
+            formEncType="multipart/form-data"
+          />
+          <input
+            type="submit"
+            value="Submit - urlencoded"
+            id="submit-api-redirect-urlencoded"
+            formEncType="application/x-www-form-urlencoded"
+          />
+          <input
+            type="submit"
+            value="Submit - plaintext"
+            id="submit-api-redirect-plaintext"
+            formEncType="text/plain"
+          />
+        </form>
+      </section>
+      <section>
+        <h1>POST /api-redirect-permanent (`permanentRedirect()`)</h1>
+        <form action="/redirects/api-redirect-permanent" method="POST">
+          <input
+            type="submit"
+            value="Submit - multipart"
+            id="submit-api-redirect-permanent-multipart"
+            formEncType="multipart/form-data"
+          />
+          <input
+            type="submit"
+            value="Submit - urlencoded"
+            id="submit-api-redirect-permanent-urlencoded"
+            formEncType="application/x-www-form-urlencoded"
+          />
+          <input
+            type="submit"
+            value="Submit - plaintext"
+            id="submit-api-redirect-permanent-plaintext"
+            formEncType="text/plain"
+          />
+        </form>
+      </section>
       <h1>POST /api-reponse-redirect-307</h1>
       <form action="/redirects/api-redirect-307" method="POST">
         <input type="submit" value="Submit" id="submit-api-redirect-307" />

--- a/test/e2e/app-dir/app-routes-redirect/app-routes-redirect.test.ts
+++ b/test/e2e/app-dir/app-routes-redirect/app-routes-redirect.test.ts
@@ -1,0 +1,81 @@
+import type { RequestInit as NodeFetchRequestInit } from 'node-fetch'
+import { nextTestSetup } from 'e2e-utils'
+
+describe('route handlers - redirect handling', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  describe.each([
+    { name: 'redirect', status: 307, href: '/api-redirect' },
+    {
+      name: 'permanentRedirect',
+      status: 308,
+      href: '/api-redirect-permanent',
+    },
+  ])('route handlers - $name', ({ status: expectedStatus, href }) => {
+    const cases: {
+      name: string
+      options: NodeFetchRequestInit
+      expectedStatus: number
+    }[] = [
+      {
+        name: 'GET',
+        options: {},
+        expectedStatus,
+      },
+      {
+        name: 'POST json',
+        options: {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({}),
+        },
+        expectedStatus,
+      },
+      {
+        name: 'POST plaintext',
+        options: {
+          method: 'POST',
+          headers: { 'content-type': 'text/plain' },
+          body: 'hello',
+        },
+        expectedStatus,
+      },
+      {
+        name: 'POST multipart',
+        options: {
+          method: 'POST',
+          headers: { 'content-type': 'multipart/form-data' },
+          // @ts-expect-error: some bizarre type resolution issue, idk
+          body: new FormData(),
+        },
+        expectedStatus: 303, // special case. it's weird that we do this, but that's the current behavior
+      },
+      {
+        name: 'POST urlencoded',
+        options: {
+          method: 'POST',
+          headers: { 'content-type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({ foo: 'bar' }),
+        },
+        expectedStatus: 303, // special case. it's weird that we do this, but that's the current behavior
+      },
+    ]
+
+    it.each(cases)('$name', async ({ options, expectedStatus }) => {
+      const response = await next.fetch(href, {
+        redirect: 'manual',
+        ...options,
+      })
+      expect(response.status).toBe(expectedStatus)
+
+      const locationHeader = response.headers.get('location')
+      expect(locationHeader).toBeTruthy()
+      const redirectUrl = new URL(locationHeader!)
+      expect(redirectUrl.pathname + redirectUrl.search).toBe(
+        '/redirect-target?success=true'
+      )
+    })
+  })
+})

--- a/test/e2e/app-dir/app-routes-redirect/app/api-redirect-permanent/route.js
+++ b/test/e2e/app-dir/app-routes-redirect/app/api-redirect-permanent/route.js
@@ -1,0 +1,9 @@
+import { permanentRedirect } from 'next/navigation'
+
+export function GET(request) {
+  permanentRedirect('/redirect-target?success=true')
+}
+
+export function POST(request) {
+  permanentRedirect('/redirect-target?success=true')
+}

--- a/test/e2e/app-dir/app-routes-redirect/app/api-redirect/route.js
+++ b/test/e2e/app-dir/app-routes-redirect/app/api-redirect/route.js
@@ -1,0 +1,9 @@
+import { redirect } from 'next/navigation'
+
+export function GET(request) {
+  redirect('/redirect-target?success=true')
+}
+
+export function POST(request) {
+  redirect('/redirect-target?success=true')
+}

--- a/test/e2e/app-dir/app-routes-redirect/app/layout.js
+++ b/test/e2e/app-dir/app-routes-redirect/app/layout.js
@@ -1,0 +1,8 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <head />
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/app-routes-redirect/app/redirect-target/page.js
+++ b/test/e2e/app-dir/app-routes-redirect/app/redirect-target/page.js
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <main>Redirected!</main>
+}

--- a/test/e2e/app-dir/app-routes-redirect/next.config.mjs
+++ b/test/e2e/app-dir/app-routes-redirect/next.config.mjs
@@ -1,0 +1,1 @@
+export default {}


### PR DESCRIPTION
url-encoded server actions are currently not a thing that can happen, so i'm removing any handling related to them. if we need them, we can bring them back.

note that this includes commits from #76852, because there's good way to have two parent branches in graphite