### PR TITLE
fix duplicated noindex when server action is triggered

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -427,7 +427,8 @@ function NonIndex({ ctx }: { ctx: AppRenderContext }) {
   const isInvalidStatusCode =
     typeof ctx.res.statusCode === 'number' && ctx.res.statusCode > 400
 
-  if (is404Page || isInvalidStatusCode) {
+  // Only render noindex for page request, skip for server actions
+  if (!ctx.isAction && (is404Page || isInvalidStatusCode)) {
     return <meta name="robots" content="noindex" />
   }
   return null

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -359,9 +359,15 @@ describe('app-dir action handling', () => {
 
     await browser.elementByCss('#nowhere').click()
 
+    // Until not-found page is resolved
     await retry(async () => {
       expect(await browser.elementByCss('h1').text()).toBe('my-not-found')
     })
+
+    // Should have default noindex meta tag
+    expect(
+      await browser.elementByCss('meta[name="robots"]').getAttribute('content')
+    ).toBe('noindex')
   })
 
   it('should support uploading files', async () => {

--- a/test/e2e/app-dir/metadata-navigation/app/server-action/not-found/action.tsx
+++ b/test/e2e/app-dir/metadata-navigation/app/server-action/not-found/action.tsx
@@ -1,0 +1,7 @@
+'use server'
+
+import { notFound } from 'next/navigation'
+
+export async function actionNotFound() {
+  return notFound()
+}

--- a/test/e2e/app-dir/metadata-navigation/app/server-action/not-found/page-client.tsx
+++ b/test/e2e/app-dir/metadata-navigation/app/server-action/not-found/page-client.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { actionNotFound } from './action'
+
+export default function Page() {
+  return (
+    <button
+      id="trigger-not-found"
+      onClick={() => {
+        actionNotFound()
+      }}
+    >
+      trigger not found
+    </button>
+  )
+}

--- a/test/e2e/app-dir/metadata-navigation/app/server-action/not-found/page.tsx
+++ b/test/e2e/app-dir/metadata-navigation/app/server-action/not-found/page.tsx
@@ -1,0 +1,7 @@
+export { default } from './page-client'
+
+export async function generateMetadata() {
+  return {
+    robots: 'noindex, nofollow',
+  }
+}


### PR DESCRIPTION
### What

When client sends and Server Action request with `notFound()` inside, next-server will serve the RSC payload in response but we were also serving a fallback `robots=noindex` metadata for 404 requests. This will be a conflict for users custom metadata. The fallback `robots=noindex` for 404 response was for initially for pages rendering request.

Here we skip it for the dynamic RSC to avoid user's metadata being de-prioritized due to the fallback `robots=noindex` taking precedence.

We also add a test that it won't break form action, where when JS is disabled and notFound involked, the new page can still be served with fallback noindex

Fixes NDX-953