### PR TITLE
decouple route handler redirects from getIsServerAction

### DIFF
--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1633,72 +1633,126 @@ describe('app-dir action handling', () => {
   })
 
   describe('redirects', () => {
-    it('redirects properly when server action handler uses `redirect`', async () => {
-      const postRequests = []
-      const responseCodes = []
+    it.each([
+      {
+        name: 'plaintext POST request',
+        buttonId: 'submit-api-redirect-plaintext',
+        should303: false,
+      },
+      {
+        name: 'urlencoded POST request',
+        buttonId: 'submit-api-redirect-urlencoded',
+        should303: true, // special case. it's weird that we do this, but that's the current behavior
+      },
+      {
+        name: 'multipart POST request',
+        buttonId: 'submit-api-redirect-multipart',
+        should303: true, // special case. it's weird that we do this, but that's the current behavior
+      },
+    ])(
+      'redirects properly when route handler uses `redirect` - $name',
+      async ({ buttonId, should303 }) => {
+        const postRequests = []
+        const responseCodes = []
 
-      const browser = await next.browser('/redirects', {
-        beforePageLoad(page) {
-          page.on('request', (request: Request) => {
-            const url = new URL(request.url())
-            if (request.method() === 'POST') {
-              postRequests.push(url.pathname)
-            }
-          })
+        const browser = await next.browser('/redirects', {
+          beforePageLoad(page) {
+            page.on('request', (request: Request) => {
+              const url = new URL(request.url())
+              if (request.method() === 'POST') {
+                postRequests.push(url.pathname + url.search)
+              }
+            })
 
-          page.on('response', (response: Response) => {
-            const url = new URL(response.url())
-            const status = response.status()
+            page.on('response', (response: Response) => {
+              const url = new URL(response.url())
+              const status = response.status()
 
-            if (postRequests.includes(`${url.pathname}${url.search}`)) {
-              responseCodes.push(status)
-            }
-          })
-        },
-      })
-      await browser.elementById('submit-api-redirect').click()
-      // await check(() => browser.url(), /success=true/)
-      await retry(async () => {
-        expect(await browser.url()).toContain('success=true')
-      })
+              if (postRequests.includes(`${url.pathname}${url.search}`)) {
+                responseCodes.push(status)
+              }
+            })
+          },
+        })
+        await browser.elementById(buttonId).click()
+        // await check(() => browser.url(), /success=true/)
+        await retry(async () => {
+          expect(await browser.url()).toContain('success=true')
+        })
 
-      // verify that the POST request was only made to the action handler
-      expect(postRequests).toEqual(['/redirects/api-redirect'])
-      expect(responseCodes).toEqual([303])
-    })
+        if (should303) {
+          // verify that the POST request was only made to the route handler
+          expect(postRequests).toEqual(['/redirects/api-redirect'])
+          expect(responseCodes).toEqual([303])
+        } else {
+          expect(postRequests).toEqual([
+            '/redirects/api-redirect',
+            '/redirects?success=true',
+          ])
+          expect(responseCodes).toEqual([307, 200])
+        }
+      }
+    )
 
-    it('redirects properly when server action handler uses `permanentRedirect`', async () => {
-      const postRequests = []
-      const responseCodes = []
+    it.each([
+      {
+        name: 'plaintext POST request',
+        buttonId: 'submit-api-redirect-permanent-plaintext',
+        should303: false,
+      },
+      {
+        name: 'urlencoded POST request',
+        buttonId: 'submit-api-redirect-permanent-urlencoded',
+        should303: true, // special case. it's weird that we do this, but that's the current behavior
+      },
+      {
+        name: 'multipart POST request',
+        buttonId: 'submit-api-redirect-permanent-multipart',
+        should303: true, // special case. it's weird that we do this, but that's the current behavior
+      },
+    ])(
+      'redirects properly when route handler uses `permanentRedirect` - $name',
+      async ({ buttonId, should303 }) => {
+        const postRequests = []
+        const responseCodes = []
 
-      const browser = await next.browser('/redirects', {
-        beforePageLoad(page) {
-          page.on('request', (request: Request) => {
-            const url = new URL(request.url())
-            if (request.method() === 'POST') {
-              postRequests.push(url.pathname)
-            }
-          })
+        const browser = await next.browser('/redirects', {
+          beforePageLoad(page) {
+            page.on('request', (request: Request) => {
+              const url = new URL(request.url())
+              if (request.method() === 'POST') {
+                postRequests.push(url.pathname + url.search)
+              }
+            })
 
-          page.on('response', (response: Response) => {
-            const url = new URL(response.url())
-            const status = response.status()
+            page.on('response', (response: Response) => {
+              const url = new URL(response.url())
+              const status = response.status()
 
-            if (postRequests.includes(`${url.pathname}${url.search}`)) {
-              responseCodes.push(status)
-            }
-          })
-        },
-      })
+              if (postRequests.includes(`${url.pathname}${url.search}`)) {
+                responseCodes.push(status)
+              }
+            })
+          },
+        })
 
-      await browser.elementById('submit-api-redirect-permanent').click()
-      await retry(async () => {
-        expect(await browser.url()).toContain('success=true')
-      })
-      // verify that the POST request was only made to the action handler
-      expect(postRequests).toEqual(['/redirects/api-redirect-permanent'])
-      expect(responseCodes).toEqual([303])
-    })
+        await browser.elementById(buttonId).click()
+        await retry(async () => {
+          expect(await browser.url()).toContain('success=true')
+        })
+        if (should303) {
+          // verify that the POST request was only made to the route handler
+          expect(postRequests).toEqual(['/redirects/api-redirect-permanent'])
+          expect(responseCodes).toEqual([303])
+        } else {
+          expect(postRequests).toEqual([
+            '/redirects/api-redirect-permanent',
+            '/redirects?success=true',
+          ])
+          expect(responseCodes).toEqual([308, 200])
+        }
+      }
+    )
 
     it('displays searchParams correctly when redirecting with SearchParams', async () => {
       const browser = await next.browser('/redirects/action-redirect')

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -15,6 +15,8 @@ import { join } from 'path'
 const GENERIC_RSC_ERROR =
   'Error: An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
 
+const isPPREnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+
 describe('app-dir action handling', () => {
   const { next, isNextDev, isNextStart, isNextDeploy, isTurbopack } =
     nextTestSetup({
@@ -1689,7 +1691,12 @@ describe('app-dir action handling', () => {
             '/redirects/api-redirect',
             '/redirects?success=true',
           ])
-          expect(responseCodes).toEqual([307, 200])
+
+          expect(responseCodes).toEqual([
+            307,
+            // a POST to a route seems to always 405 when PPR is on.
+            isPPREnabled && !isNextDev ? 405 : 200,
+          ])
         }
       }
     )
@@ -1749,7 +1756,11 @@ describe('app-dir action handling', () => {
             '/redirects/api-redirect-permanent',
             '/redirects?success=true',
           ])
-          expect(responseCodes).toEqual([308, 200])
+          expect(responseCodes).toEqual([
+            308,
+            // a POST to a page seems to always 405 when PPR is on.
+            isPPREnabled && !isNextDev ? 405 : 200,
+          ])
         }
       }
     )

--- a/test/e2e/app-dir/actions/app/redirects/api-redirect-permanent/route.js
+++ b/test/e2e/app-dir/actions/app/redirects/api-redirect-permanent/route.js
@@ -1,5 +1,5 @@
 import { permanentRedirect } from 'next/navigation'
 
 export function POST(request) {
-  permanentRedirect('/redirects/?success=true')
+  permanentRedirect('/redirects?success=true')
 }

--- a/test/e2e/app-dir/actions/app/redirects/api-redirect/route.js
+++ b/test/e2e/app-dir/actions/app/redirects/api-redirect/route.js
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation'
 
 export function POST(request) {
-  redirect('/redirects/?success=true')
+  redirect('/redirects?success=true')
 }

--- a/test/e2e/app-dir/actions/app/redirects/page.js
+++ b/test/e2e/app-dir/actions/app/redirects/page.js
@@ -5,18 +5,52 @@ export const dynamic = 'force-dynamic'
 export default function Home() {
   return (
     <main id="redirect-page">
-      <h1>POST /api-redirect (`redirect()`)</h1>
-      <form action="/redirects/api-redirect" method="POST">
-        <input type="submit" value="Submit" id="submit-api-redirect" />
-      </form>
-      <h1>POST /api-redirect-permanent (`permanentRedirect()`)</h1>
-      <form action="/redirects/api-redirect-permanent" method="POST">
-        <input
-          type="submit"
-          value="Submit"
-          id="submit-api-redirect-permanent"
-        />
-      </form>
+      <section>
+        <h1>POST /api-redirect (`redirect()`)</h1>
+        <form action="/redirects/api-redirect" method="POST">
+          <input
+            type="submit"
+            value="Submit - multipart"
+            id="submit-api-redirect-multipart"
+            formEncType="multipart/form-data"
+          />
+          <input
+            type="submit"
+            value="Submit - urlencoded"
+            id="submit-api-redirect-urlencoded"
+            formEncType="application/x-www-form-urlencoded"
+          />
+          <input
+            type="submit"
+            value="Submit - plaintext"
+            id="submit-api-redirect-plaintext"
+            formEncType="text/plain"
+          />
+        </form>
+      </section>
+      <section>
+        <h1>POST /api-redirect-permanent (`permanentRedirect()`)</h1>
+        <form action="/redirects/api-redirect-permanent" method="POST">
+          <input
+            type="submit"
+            value="Submit - multipart"
+            id="submit-api-redirect-permanent-multipart"
+            formEncType="multipart/form-data"
+          />
+          <input
+            type="submit"
+            value="Submit - urlencoded"
+            id="submit-api-redirect-permanent-urlencoded"
+            formEncType="application/x-www-form-urlencoded"
+          />
+          <input
+            type="submit"
+            value="Submit - plaintext"
+            id="submit-api-redirect-permanent-plaintext"
+            formEncType="text/plain"
+          />
+        </form>
+      </section>
       <h1>POST /api-reponse-redirect-307</h1>
       <form action="/redirects/api-redirect-307" method="POST">
         <input type="submit" value="Submit" id="submit-api-redirect-307" />

--- a/test/e2e/app-dir/app-routes-redirect/app-routes-redirect.test.ts
+++ b/test/e2e/app-dir/app-routes-redirect/app-routes-redirect.test.ts
@@ -1,0 +1,81 @@
+import type { RequestInit as NodeFetchRequestInit } from 'node-fetch'
+import { nextTestSetup } from 'e2e-utils'
+
+describe('route handlers - redirect handling', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  describe.each([
+    { name: 'redirect', status: 307, href: '/api-redirect' },
+    {
+      name: 'permanentRedirect',
+      status: 308,
+      href: '/api-redirect-permanent',
+    },
+  ])('route handlers - $name', ({ status: expectedStatus, href }) => {
+    const cases: {
+      name: string
+      options: NodeFetchRequestInit
+      expectedStatus: number
+    }[] = [
+      {
+        name: 'GET',
+        options: {},
+        expectedStatus,
+      },
+      {
+        name: 'POST json',
+        options: {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({}),
+        },
+        expectedStatus,
+      },
+      {
+        name: 'POST plaintext',
+        options: {
+          method: 'POST',
+          headers: { 'content-type': 'text/plain' },
+          body: 'hello',
+        },
+        expectedStatus,
+      },
+      {
+        name: 'POST multipart',
+        options: {
+          method: 'POST',
+          headers: { 'content-type': 'multipart/form-data' },
+          // @ts-expect-error: some bizarre type resolution issue, idk
+          body: new FormData(),
+        },
+        expectedStatus: 303, // special case. it's weird that we do this, but that's the current behavior
+      },
+      {
+        name: 'POST urlencoded',
+        options: {
+          method: 'POST',
+          headers: { 'content-type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({ foo: 'bar' }),
+        },
+        expectedStatus: 303, // special case. it's weird that we do this, but that's the current behavior
+      },
+    ]
+
+    it.each(cases)('$name', async ({ options, expectedStatus }) => {
+      const response = await next.fetch(href, {
+        redirect: 'manual',
+        ...options,
+      })
+      expect(response.status).toBe(expectedStatus)
+
+      const locationHeader = response.headers.get('location')
+      expect(locationHeader).toBeTruthy()
+      const redirectUrl = new URL(locationHeader!)
+      expect(redirectUrl.pathname + redirectUrl.search).toBe(
+        '/redirect-target?success=true'
+      )
+    })
+  })
+})

--- a/test/e2e/app-dir/app-routes-redirect/app/api-redirect-permanent/route.js
+++ b/test/e2e/app-dir/app-routes-redirect/app/api-redirect-permanent/route.js
@@ -1,0 +1,9 @@
+import { permanentRedirect } from 'next/navigation'
+
+export function GET(request) {
+  permanentRedirect('/redirect-target?success=true')
+}
+
+export function POST(request) {
+  permanentRedirect('/redirect-target?success=true')
+}

--- a/test/e2e/app-dir/app-routes-redirect/app/api-redirect/route.js
+++ b/test/e2e/app-dir/app-routes-redirect/app/api-redirect/route.js
@@ -1,0 +1,9 @@
+import { redirect } from 'next/navigation'
+
+export function GET(request) {
+  redirect('/redirect-target?success=true')
+}
+
+export function POST(request) {
+  redirect('/redirect-target?success=true')
+}

--- a/test/e2e/app-dir/app-routes-redirect/app/layout.js
+++ b/test/e2e/app-dir/app-routes-redirect/app/layout.js
@@ -1,0 +1,8 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <head />
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/app-routes-redirect/app/redirect-target/page.js
+++ b/test/e2e/app-dir/app-routes-redirect/app/redirect-target/page.js
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <main>Redirected!</main>
+}

--- a/test/e2e/app-dir/app-routes-redirect/next.config.mjs
+++ b/test/e2e/app-dir/app-routes-redirect/next.config.mjs
@@ -1,0 +1,1 @@
+export default {}


### PR DESCRIPTION
Came up during #76844. After removing `application/x-www-form-urlencoded` from the allowed content types for server actions, some random redirect tests broke. Turns out that for some reason route handlers also check `isServerAction`, and vary redirect behavior based on that. I believe that this was an accident, although maybe i'm missing something.

This PR removes this coupling, but preserves the current behavior.

Feels like the sensible behavior for route handlers would be to make `redirect()` result in a 303 See Other for all POST requests (so that the request isn't retried by the client), but i don't know if we can fix that without breaking back-compat. But then again, if anybody's experiencing this, they had to switch to manually returning a 303 anyway, so maybe that's fine?