### PR TITLE
build: Update lightningcss to `v1.0.0-alpha.64`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3827,9 +3827,9 @@ dependencies = [
 
 [[package]]
 name = "lightningcss"
-version = "1.0.0-alpha.63"
+version = "1.0.0-alpha.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a75fcbcdbcc84fc1ae7c60c31f99337560b620757a9bfc1c9f84df3cff8ac24"
+checksum = "a296273515b1036d06fce6c1d6bfc11347083458e1765ae4a70d6288cdb15521"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -361,7 +361,7 @@ indoc = "2.0.0"
 itertools = "0.10.5"
 lazy_static = "1.4.0"
 log = "0.4.17"
-lightningcss = { version = "1.0.0-alpha.63", features = [
+lightningcss = { version = "1.0.0-alpha.64", features = [
   "serde",
   "visitor",
   "into_owned",


### PR DESCRIPTION
### What?

See release note: https://github.com/parcel-bundler/lightningcss/releases/tag/v1.29.2

### Why?

To keep in sync.

### How?



Closes PACK-4084