### PR TITLE
[dev-overlay] Dim ignore-listed callstack frames when shown

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/call-stack-frame/call-stack-frame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/call-stack-frame/call-stack-frame.tsx
@@ -46,10 +46,7 @@ export const CallStackFrame: React.FC<{
         } as React.CSSProperties
       }
     >
-      <div
-        data-nextjs-frame-expanded={!frame.ignored}
-        className="call-stack-frame-method-name"
-      >
+      <div className="call-stack-frame-method-name">
         <HotlinkedText text={formattedMethod} />
         {hasSource && (
           <button onClick={open} className="open-in-editor-button">

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/call-stack-frame/call-stack-frame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/call-stack-frame/call-stack-frame.tsx
@@ -39,7 +39,7 @@ export const CallStackFrame: React.FC<{
   return (
     <div
       data-nextjs-call-stack-frame
-      data-nextjs-call-stack-frame-ignored={!hasSource}
+      data-nextjs-call-stack-frame-no-source={!hasSource}
       style={
         {
           '--index': index,
@@ -77,14 +77,14 @@ export const CallStackFrame: React.FC<{
 }
 
 export const CALL_STACK_FRAME_STYLES = `
-  [data-nextjs-call-stack-frame-ignored] {
+  [data-nextjs-call-stack-frame-no-source] {
     padding: 6px 8px;
     margin-bottom: 4px;
 
     border-radius: var(--rounded-lg);
   }
 
-  [data-nextjs-call-stack-frame-ignored]:last-child {
+  [data-nextjs-call-stack-frame-no-source]:last-child {
     margin-bottom: 0;
   }
 

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/call-stack-frame/call-stack-frame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/call-stack-frame/call-stack-frame.tsx
@@ -40,6 +40,7 @@ export const CallStackFrame: React.FC<{
     <div
       data-nextjs-call-stack-frame
       data-nextjs-call-stack-frame-no-source={!hasSource}
+      data-nextjs-call-stack-frame-ignored={frame.ignored}
       style={
         {
           '--index': index,
@@ -83,6 +84,10 @@ export const CALL_STACK_FRAME_STYLES = `
 
   [data-nextjs-call-stack-frame-no-source]:last-child {
     margin-bottom: 0;
+  }
+
+  [data-nextjs-call-stack-frame-ignored="true"] {
+    opacity: 0.6;
   }
 
   [data-nextjs-call-stack-frame] {

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/call-stack-frame/call-stack-frame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/call-stack-frame/call-stack-frame.tsx
@@ -8,8 +8,7 @@ import { useOpenInEditor } from '../../utils/use-open-in-editor'
 
 export const CallStackFrame: React.FC<{
   frame: OriginalStackFrame
-  index: number
-}> = function CallStackFrame({ frame, index }) {
+}> = function CallStackFrame({ frame }) {
   // TODO: ability to expand resolved frames
 
   const f: StackFrame = frame.originalStackFrame ?? frame.sourceStackFrame
@@ -41,11 +40,6 @@ export const CallStackFrame: React.FC<{
       data-nextjs-call-stack-frame
       data-nextjs-call-stack-frame-no-source={!hasSource}
       data-nextjs-call-stack-frame-ignored={frame.ignored}
-      style={
-        {
-          '--index': index,
-        } as React.CSSProperties
-      }
     >
       <div className="call-stack-frame-method-name">
         <HotlinkedText text={formattedMethod} />

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/call-stack/call-stack.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/call-stack/call-stack.tsx
@@ -62,7 +62,7 @@ export function CallStack({ frames, dialogResizerRef }: CallStackProps) {
       </div>
       {frames.map((frame, frameIndex) => {
         return !frame.ignored || isIgnoreListOpen ? (
-          <CallStackFrame key={frameIndex} frame={frame} index={frameIndex} />
+          <CallStackFrame key={frameIndex} frame={frame} />
         ) : null
       })}
     </div>

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1676,7 +1676,7 @@ export async function getStackFramesContent(browser) {
   const stackFramesContent = (
     await Promise.all(
       stackFrameElements.map(async (frame) => {
-        const functionNameEl = await frame.$('[data-nextjs-frame-expanded]')
+        const functionNameEl = await frame.$('.call-stack-frame-method-name')
         const sourceEl = await frame.$('[data-has-source="true"]')
         const functionName = functionNameEl
           ? await functionNameEl.innerText()


### PR DESCRIPTION
Closes https://linear.app/vercel/issue/NDX-956

Includes some drive-by refactor that was confusing to deal with while working on this.

Dimming is done by applying 60% opacity. Chrome Devtools use the same mechanism. Checking in with desgin if there's some better way to do this.

![localhost_3000_rsc-error-log (3)](https://github.com/user-attachments/assets/8f0b5f70-da9e-4850-bb86-7e7d19849873)
![localhost_3000_rsc-error-log (2)](https://github.com/user-attachments/assets/e770ea1a-f7e6-4729-a999-cfa6c5a2eee5)
