### PR TITLE
Turbopack: side effect directive

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -23,6 +23,7 @@ use std::{borrow::Cow, collections::BTreeMap, future::Future, mem::take, ops::De
 use anyhow::{bail, Result};
 use constant_condition::{ConstantConditionCodeGen, ConstantConditionValue};
 use constant_value::ConstantValueCodeGen;
+use either::Either;
 use indexmap::map::Entry;
 use lazy_static::lazy_static;
 use num_traits::Zero;
@@ -42,6 +43,7 @@ use swc_core::{
     },
     ecma::{
         ast::*,
+        utils::IsDirective,
         visit::{
             fields::{AssignExprField, AssignTargetField, SimpleAssignTargetField},
             AstParentKind, AstParentNodeRef, VisitAstPath, VisitWithAstPath,
@@ -169,6 +171,7 @@ pub struct AnalyzeEcmascriptModuleResult {
     pub code_generation: ResolvedVc<CodeGens>,
     pub exports: ResolvedVc<EcmascriptExports>,
     pub async_module: ResolvedVc<OptionAsyncModule>,
+    pub has_side_effect_free_directive: bool,
     /// `true` when the analysis was successful.
     pub successful: bool,
     pub source_map: ResolvedVc<OptionStringifiedSourceMap>,
@@ -221,6 +224,7 @@ pub struct AnalyzeEcmascriptModuleResultBuilder {
     async_module: ResolvedVc<OptionAsyncModule>,
     successful: bool,
     source_map: Option<ResolvedVc<OptionStringifiedSourceMap>>,
+    has_side_effect_free_directive: bool,
 }
 
 impl AnalyzeEcmascriptModuleResultBuilder {
@@ -238,6 +242,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
             async_module: ResolvedVc::cell(None),
             successful: false,
             source_map: None,
+            has_side_effect_free_directive: false,
         }
     }
 
@@ -295,6 +300,11 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     /// Sets the analysis result ES export.
     pub fn set_async_module(&mut self, async_module: ResolvedVc<AsyncModule>) {
         self.async_module = ResolvedVc::cell(Some(async_module));
+    }
+
+    /// Set whether this module is side-efffect free according to a user-provided directive.
+    pub fn set_has_side_effect_free_directive(&mut self, value: bool) {
+        self.has_side_effect_free_directive = value;
     }
 
     /// Sets whether the analysis was successful.
@@ -411,6 +421,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
                 code_generation: ResolvedVc::cell(self.code_gens),
                 exports: self.exports.resolved_cell(),
                 async_module: self.async_module,
+                has_side_effect_free_directive: self.has_side_effect_free_directive,
                 successful: self.successful,
                 source_map,
             },
@@ -585,6 +596,33 @@ pub(crate) async fn analyse_ecmascript_module_internal(
     else {
         return analysis.build(Default::default(), false).await;
     };
+
+    let has_side_effect_free_directive = match program {
+        Program::Module(module) => Either::Left(
+            module
+                .body
+                .iter()
+                .take_while(|i| match i {
+                    ModuleItem::Stmt(stmt) => stmt.directive_continue(),
+                    ModuleItem::ModuleDecl(_) => false,
+                })
+                .filter_map(|i| i.as_stmt()),
+        ),
+        Program::Script(script) => Either::Right(
+            script
+                .body
+                .iter()
+                .take_while(|stmt| stmt.directive_continue()),
+        ),
+    }
+    .any(|f| match f {
+        Stmt::Expr(ExprStmt { expr, .. }) => match &**expr {
+            Expr::Lit(Lit::Str(Str { value, .. })) => value == "use turbopack no side effects",
+            _ => false,
+        },
+        _ => false,
+    });
+    analysis.set_has_side_effect_free_directive(has_side_effect_free_directive);
 
     let compile_time_info = compile_time_info_for_module_type(
         *raw_module.compile_time_info,

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/directive/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/directive/input/index.js
@@ -1,0 +1,10 @@
+import { foo } from './lib/index.js'
+
+it('should respect side effects directive', () => {
+  expect(foo).toBe(789)
+
+  const modules = Object.keys(__turbopack_modules__)
+  expect(modules).toContainEqual(expect.stringContaining('input/lib/foo'))
+  expect(modules).not.toContainEqual(expect.stringContaining('input/lib/index'))
+  expect(modules).not.toContainEqual(expect.stringContaining('input/lib/bar'))
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/directive/input/lib/bar.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/directive/input/lib/bar.js
@@ -1,0 +1,3 @@
+"use turbopack no side effects"
+
+export const bar = 123;

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/directive/input/lib/foo.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/directive/input/lib/foo.js
@@ -1,0 +1,3 @@
+"use turbopack no side effects"
+
+export const foo = 789;

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/directive/input/lib/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/directive/input/lib/index.js
@@ -1,0 +1,4 @@
+"use turbopack no side effects"
+
+export {foo} from "./foo";
+export {bar} from "./bar";

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/directive/options.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/directive/options.json
@@ -1,0 +1,3 @@
+{
+  "treeShakingMode": "reexports-only"
+}


### PR DESCRIPTION
This allows marking a module as side-effect free, but without having to modify `sideEffects` in package.json. This is especially useful for generated code (and this is going to be used for https://github.com/vercel/next.js/pull/76877 where next-custom-transforms is generating such side-effect free "virtual" modules and cannot modify package.json)

Any suggestions regarding the exact naming?

```
"use turbopack no side effects"

export const bar = 123;
```

Closes PACK-4095