### PR TITLE
Telemetry: include alternate bundler state in key events

### DIFF
--- a/packages/next/src/telemetry/events/build.ts
+++ b/packages/next/src/telemetry/events/build.ts
@@ -103,6 +103,7 @@ type EventBuildOptimized = {
   rewritesWithHasCount: number
   redirectsWithHasCount: number
   middlewareCount: number
+  isRspack: boolean
   totalAppPagesCount?: number
   staticAppPagesCount?: number
   serverAppPagesCount?: number
@@ -114,7 +115,7 @@ export function eventBuildOptimize(
   pagePaths: string[],
   event: Omit<
     EventBuildOptimized,
-    'totalPageCount' | 'hasDunderPages' | 'hasTestPages'
+    'totalPageCount' | 'hasDunderPages' | 'hasTestPages' | 'isRspack'
   >
 ): { eventName: string; payload: EventBuildOptimized } {
   return {
@@ -134,6 +135,7 @@ export function eventBuildOptimize(
       serverAppPagesCount: event.serverAppPagesCount,
       edgeRuntimeAppCount: event.edgeRuntimeAppCount,
       edgeRuntimePagesCount: event.edgeRuntimePagesCount,
+      isRspack: process.env.NEXT_RSPACK !== undefined,
     },
   }
 }

--- a/packages/next/src/telemetry/events/session-stopped.ts
+++ b/packages/next/src/telemetry/events/session-stopped.ts
@@ -8,10 +8,14 @@ export type EventCliSessionStopped = {
   durationMilliseconds?: number | null
   pagesDir?: boolean
   appDir?: boolean
+  isRspack: boolean
 }
 
 export function eventCliSessionStopped(
-  event: Omit<EventCliSessionStopped, 'nextVersion' | 'nodeVersion'>
+  event: Omit<
+    EventCliSessionStopped,
+    'nextVersion' | 'nodeVersion' | 'isRspack'
+  >
 ): { eventName: string; payload: EventCliSessionStopped }[] {
   // This should be an invariant, if it fails our build tooling is broken.
   if (typeof process.env.__NEXT_VERSION !== 'string') {
@@ -30,6 +34,7 @@ export function eventCliSessionStopped(
       : {}),
     pagesDir: event.pagesDir,
     appDir: event.appDir,
+    isRspack: process.env.NEXT_RSPACK !== undefined,
   }
   return [{ eventName: EVENT_VERSION, payload }]
 }

--- a/packages/next/src/telemetry/events/version.ts
+++ b/packages/next/src/telemetry/events/version.ts
@@ -33,6 +33,7 @@ type EventCliSessionStarted = {
   reactStrictMode: boolean
   webpackVersion: number | null
   turboFlag: boolean
+  isRspack: boolean
   appDir: boolean | null
   pagesDir: boolean | null
   staticStaleTime: number | null
@@ -93,6 +94,7 @@ export function eventCliSession(
     | 'reactCompiler'
     | 'reactCompilerCompilationMode'
     | 'reactCompilerPanicThreshold'
+    | 'isRspack'
   >
 ): { eventName: string; payload: EventCliSessionStarted }[] {
   // This should be an invariant, if it fails our build tooling is broken.
@@ -136,6 +138,7 @@ export function eventCliSession(
     reactStrictMode: !!nextConfig?.reactStrictMode,
     webpackVersion: event.webpackVersion || null,
     turboFlag: event.turboFlag || false,
+    isRspack: process.env.NEXT_RSPACK !== undefined,
     appDir: event.appDir,
     pagesDir: event.pagesDir,
     staticStaleTime: nextConfig.experimental.staleTimes?.static ?? null,


### PR DESCRIPTION
This includes `isRspack` in the following telemetry events, determining it with the presence of `process.env.NEXT_RSPACK`:

- `NEXT_CLI_SESSION_STARTED`
- `NEXT_CLI_SESSION_STOPPED`
- `NEXT_BUILD_OPTIMIZED`

Test Plan: Verify these are included with `NEXT_TELEMETRY_DEBUG=1` for both `next dev` and `next build`


Closes PACK-4093