### PR TITLE
build: Fix warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,6 @@ opt-level = 3
 [profile.release.package.lightningcss]
 opt-level = "s"
 
-[profile.release.package.std]
-opt-level = 3
-
 [profile.release.package.lightningcss-napi]
 opt-level = "s"
 


### PR DESCRIPTION
### What?

Fix warning like

<img width="909" alt="image" src="https://github.com/user-attachments/assets/f29a7a65-d032-4f95-ba39-480302ff566a" />


### Why?

I made a mistake in https://github.com/vercel/next.js/pull/76144

### How?


Closes PACK-4085