### PR TITLE
docs: fix create-next-app cli title

### DIFF
--- a/docs/02-pages/03-api-reference/05-cli/create-next-app.mdx
+++ b/docs/02-pages/03-api-reference/05-cli/create-next-app.mdx
@@ -1,5 +1,5 @@
 ---
-title: CLI
+title: create-next-app CLI
 description: Create Next.js apps using one command with the create-next-app CLI.
 source: app/api-reference/cli/create-next-app
 ---


### PR DESCRIPTION
This PR changes the title for the create-next-app cli page in order to make navigating the docs clearer, and consistent with [next cli](https://nextjs.org/docs/pages/api-reference/cli/next).

![Screenshot from 2025-03-07 16-53-46](https://github.com/user-attachments/assets/421ab7a1-fb60-4bbf-b91c-646d94afa421)
