### PR TITLE
Turbopack: ensure default layout is provided in default not-found entrypoint

### DIFF
--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1247,10 +1247,36 @@ async fn directory_tree_to_entrypoints_internal_untraced(
 
         let mut modules = directory_tree.modules.clone();
 
+        // fill in the default modules for the not-found entrypoint
         if modules.layout.is_none() {
             modules.layout = Some(
                 get_next_package(*app_dir)
                     .join("dist/client/components/default-layout.js".into())
+                    .to_resolved()
+                    .await?,
+            );
+        }
+
+        if modules.not_found.is_none() {
+            modules.not_found = Some(
+                get_next_package(*app_dir)
+                    .join("dist/client/components/not-found-error.js".into())
+                    .to_resolved()
+                    .await?,
+            );
+        }
+        if modules.forbidden.is_none() {
+            modules.forbidden = Some(
+                get_next_package(*app_dir)
+                    .join("dist/client/components/forbidden-error.js".into())
+                    .to_resolved()
+                    .await?,
+            );
+        }
+        if modules.unauthorized.is_none() {
+            modules.unauthorized = Some(
+                get_next_package(*app_dir)
+                    .join("dist/client/components/unauthorized-error.js".into())
                     .to_resolved()
                     .await?,
             );

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1245,6 +1245,17 @@ async fn directory_tree_to_entrypoints_internal_untraced(
             );
         }
 
+        let mut modules = directory_tree.modules.clone();
+
+        if modules.layout.is_none() {
+            modules.layout = Some(
+                get_next_package(*app_dir)
+                    .join("dist/client/components/default-layout.js".into())
+                    .to_resolved()
+                    .await?,
+            );
+        }
+
         // Next.js has this logic in "collect-app-paths", where the root not-found page
         // is considered as its own entry point.
         let not_found_tree = AppPageLoaderTree {

--- a/test/e2e/app-dir/app-root-params/simple.test.ts
+++ b/test/e2e/app-dir/app-root-params/simple.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import { assertNoRedbox } from 'next-test-utils'
 import { join } from 'path'
 
 describe('app-root-params - simple', () => {
@@ -15,6 +16,14 @@ describe('app-root-params - simple', () => {
     const $ = await next.render$('/en/us/other/1')
     expect($('#dynamic-params').text()).toBe('1')
     expect($('#root-params').text()).toBe('{"lang":"en","locale":"us"}')
+  })
+
+  it('should render the not found page without errors', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('h2').text()).toBe(
+      'This page could not be found.'
+    )
+    await assertNoRedbox(browser)
   })
 
   // `next-types-plugin` currently only runs in Webpack.


### PR DESCRIPTION
When Turbopack creates the default not-found entry, it does so without providing a default root layout in case one is missing. This works ok in Webpack since the `default-layout` is correctly added in [next-app-loader](https://github.com/vercel/next.js/blob/4518bc91641a0fd938664b781e12ae7c145f3396/packages/next/src/build/webpack/loaders/next-app-loader/index.ts#L339-L342).

Looking at the [original PR](https://github.com/vercel/next.js/pull/54199) that added `default-layout` it seems it was only really ever intended for the not-found entrypoint since in all other cases, a missing root layout means we create one for you in dev and in build it'd be a hard error.

This also includes the other defaults that are correctly added in other entries to match Webpack behavior. Though I'm not sure the presence of these makes a difference when rendering the not found page

Closes NDX-858