### PR TITLE
feat: support client-side instrumentation

### DIFF
--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -244,6 +244,7 @@ pub async fn get_next_client_import_map(
     }
 
     insert_turbopack_dev_alias(&mut import_map).await?;
+    insert_instrumentation_client_alias(&mut import_map, project_path).await?;
 
     Ok(import_map.cell())
 }
@@ -1140,6 +1141,26 @@ async fn insert_turbopack_dev_alias(import_map: &mut ImportMap) -> Result<()> {
             .to_resolved()
             .await?,
     );
+    Ok(())
+}
+
+/// Handles instrumentation-client.ts bundling logic
+async fn insert_instrumentation_client_alias(
+    import_map: &mut ImportMap,
+    project_path: ResolvedVc<FileSystemPath>,
+) -> Result<()> {
+    insert_alias_to_alternatives(
+        import_map,
+        "private-next-instrumentation-client",
+        vec![
+            request_to_import_mapping(project_path, "./src/instrumentation-client"),
+            request_to_import_mapping(project_path, "./src/instrumentation-client.ts"),
+            request_to_import_mapping(project_path, "./instrumentation-client"),
+            request_to_import_mapping(project_path, "./instrumentation-client.ts"),
+            ImportMapping::Ignore.resolved_cell(),
+        ],
+    );
+
     Ok(())
 }
 

--- a/packages/next/src/build/create-compiler-aliases.ts
+++ b/packages/next/src/build/create-compiler-aliases.ts
@@ -139,6 +139,19 @@ export function createWebpackAliases({
     ...(pagesDir ? { [PAGES_DIR_ALIAS]: pagesDir } : {}),
     ...(appDir ? { [APP_DIR_ALIAS]: appDir } : {}),
     [ROOT_DIR_ALIAS]: dir,
+    ...(isClient
+      ? {
+          'private-next-instrumentation-client': [
+            path.join(dir, 'src', 'instrumentation-client'),
+            path.join(dir, 'instrumentation-client'),
+            'private-next-empty-module',
+          ],
+
+          // disable typechecker, webpack5 allows aliases to be set to false to create a no-op module
+          'private-next-empty-module': false as any,
+        }
+      : {}),
+
     [DOT_NEXT_ALIAS]: distDir,
     ...(isClient || isEdgeServer ? getOptimizedModuleAliases() : {}),
     ...(reactProductionProfiling ? getReactProfilingInProduction() : {}),

--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -240,6 +240,9 @@ export function getDefineEnv({
     'process.env.__NEXT_TELEMETRY_DISABLED': Boolean(
       process.env.NEXT_TELEMETRY_DISABLED
     ),
+    'process.env.__NEXT_EXPERIMENTAL_CLIENT_INSTRUMENTATION_HOOK': Boolean(
+      config.experimental.clientInstrumentationHook
+    ),
     ...(isNodeOrEdgeCompilation
       ? {
           // Fix bad-actors in the npm ecosystem (e.g. `node-formidable`)

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -225,6 +225,7 @@ function Root({ children }: React.PropsWithChildren<{}>) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     React.useEffect(() => {
       window.__NEXT_HYDRATED = true
+      window.__NEXT_HYDRATED_AT = performance.now()
       window.__NEXT_HYDRATED_CB?.()
     }, [])
   }

--- a/packages/next/src/client/app-next-dev.ts
+++ b/packages/next/src/client/app-next-dev.ts
@@ -1,6 +1,7 @@
 // TODO-APP: hydration warning
 
 import './app-webpack'
+import '../lib/require-instrumentation-client'
 import { appBootstrap } from './app-bootstrap'
 import { initializeDevBuildIndicatorForAppRouter } from './dev/dev-build-indicator/initialize-for-app-router'
 

--- a/packages/next/src/client/app-next-turbopack.ts
+++ b/packages/next/src/client/app-next-turbopack.ts
@@ -1,5 +1,6 @@
 // TODO-APP: hydration warning
 
+import '../lib/require-instrumentation-client'
 import { appBootstrap } from './app-bootstrap'
 
 window.next.version += '-turbo'

--- a/packages/next/src/client/app-next.ts
+++ b/packages/next/src/client/app-next.ts
@@ -1,6 +1,7 @@
 // This import must go first because it needs to patch webpack chunk loading
 // before React patches chunk loading.
 import './app-webpack'
+import '../lib/require-instrumentation-client'
 import { appBootstrap } from './app-bootstrap'
 
 appBootstrap(() => {

--- a/packages/next/src/client/index.tsx
+++ b/packages/next/src/client/index.tsx
@@ -55,6 +55,7 @@ declare global {
   interface Window {
     /* test fns */
     __NEXT_HYDRATED?: boolean
+    __NEXT_HYDRATED_AT?: number
     __NEXT_HYDRATED_CB?: () => void
 
     /* prod */
@@ -612,6 +613,7 @@ function Root({
     // eslint-disable-next-line react-hooks/rules-of-hooks
     React.useEffect(() => {
       window.__NEXT_HYDRATED = true
+      window.__NEXT_HYDRATED_AT = performance.now()
 
       if (window.__NEXT_HYDRATED_CB) {
         window.__NEXT_HYDRATED_CB()

--- a/packages/next/src/client/next-turbopack.ts
+++ b/packages/next/src/client/next-turbopack.ts
@@ -1,6 +1,8 @@
 // A client-side entry point for Turbopack builds. Includes logic to load chunks,
 // but does not include development-time features like hot module reloading.
 
+import '../lib/require-instrumentation-client'
+
 // TODO: Remove use of `any` type.
 import { initialize, version, router, emitter, hydrate } from './'
 // TODO: This seems necessary, but is a module in the `dev` directory.

--- a/packages/next/src/client/next.ts
+++ b/packages/next/src/client/next.ts
@@ -1,4 +1,6 @@
 import './webpack'
+import '../lib/require-instrumentation-client'
+
 import { initialize, hydrate, version, router, emitter } from './'
 
 declare global {

--- a/packages/next/src/client/page-bootstrap.ts
+++ b/packages/next/src/client/page-bootstrap.ts
@@ -1,3 +1,4 @@
+import '../lib/require-instrumentation-client'
 import { hydrate, router } from './'
 import initOnDemandEntries from './dev/on-demand-entries-client'
 import { devBuildIndicator } from './dev/dev-build-indicator/internal/dev-build-indicator'

--- a/packages/next/src/lib/require-instrumentation-client.ts
+++ b/packages/next/src/lib/require-instrumentation-client.ts
@@ -1,0 +1,10 @@
+/**
+ * This module imports the client instrumentation hook from the project root.
+ *
+ * The `private-next-instrumentation-client` module is automatically aliased to
+ * the `instrumentation-client.ts` file in the project root by webpack or turbopack.
+ */
+
+if (process.env.__NEXT_EXPERIMENTAL_CLIENT_INSTRUMENTATION_HOOK) {
+  require('private-next-instrumentation-client')
+}

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -455,6 +455,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
             buildTimeThresholdMs: z.number().int(),
           })
           .optional(),
+        clientInstrumentationHook: z.boolean().optional(),
       })
       .optional(),
     exportPathMap: z

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -601,6 +601,15 @@ export interface ExperimentalConfig {
      */
     buildTimeThresholdMs: number
   }
+
+  /**
+   * Enables the client instrumentation hook.
+   * Loads the instrumentation-client.ts file from the project root
+   * and executes it on the client side before hydration.
+   *
+   * Note: Use with caution as this can negatively impact page loading performance.
+   */
+  clientInstrumentationHook?: boolean
 }
 
 export type ExportPathMap = {

--- a/test/e2e/instrumentation-client-hook/app-router/app/layout.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/layout.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/instrumentation-client-hook/app-router/app/page.tsx
+++ b/test/e2e/instrumentation-client-hook/app-router/app/page.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Page() {
+  return <h1>App</h1>
+}

--- a/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
+++ b/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
@@ -1,0 +1,1 @@
+;(window as any).__INSTRUMENTATION_CLIENT_EXECUTED_AT = performance.now()

--- a/test/e2e/instrumentation-client-hook/app-router/next.config.js
+++ b/test/e2e/instrumentation-client-hook/app-router/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    clientInstrumentationHook: true,
+  },
+}

--- a/test/e2e/instrumentation-client-hook/app-with-src/next.config.js
+++ b/test/e2e/instrumentation-client-hook/app-with-src/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    clientInstrumentationHook: true,
+  },
+}

--- a/test/e2e/instrumentation-client-hook/app-with-src/src/app/layout.tsx
+++ b/test/e2e/instrumentation-client-hook/app-with-src/src/app/layout.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/instrumentation-client-hook/app-with-src/src/app/page.tsx
+++ b/test/e2e/instrumentation-client-hook/app-with-src/src/app/page.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Page() {
+  return <h1>App with src folder</h1>
+}

--- a/test/e2e/instrumentation-client-hook/app-with-src/src/instrumentation-client.ts
+++ b/test/e2e/instrumentation-client-hook/app-with-src/src/instrumentation-client.ts
@@ -1,0 +1,1 @@
+;(window as any).__INSTRUMENTATION_CLIENT_EXECUTED_AT = performance.now()

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -1,0 +1,95 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import path from 'path'
+
+describe('Instrumentation Client Hook', () => {
+  const testCases = [
+    {
+      name: 'With src folder',
+      appDir: 'app-with-src',
+    },
+    {
+      name: 'App Router',
+      appDir: 'app-router',
+    },
+    {
+      name: 'Pages Router',
+      appDir: 'pages-router',
+    },
+  ]
+
+  testCases.forEach(({ name, appDir }) => {
+    describe(name, () => {
+      const { next } = nextTestSetup({
+        files: path.join(__dirname, appDir),
+      })
+
+      it(`should execute instrumentation-client from ${name.toLowerCase()} before hydration`, async () => {
+        const browser = await next.browser('/')
+
+        const instrumentationTime = await browser.eval(
+          `window.__INSTRUMENTATION_CLIENT_EXECUTED_AT`
+        )
+        const hydrationTime = await browser.eval(`window.__NEXT_HYDRATED_AT`)
+
+        expect(instrumentationTime).toBeDefined()
+        expect(hydrationTime).toBeDefined()
+        expect(instrumentationTime).toBeLessThan(hydrationTime)
+      })
+    })
+  })
+
+  describe('HMR in development mode', () => {
+    const { next, isNextDev } = nextTestSetup({
+      files: path.join(__dirname, 'app-router'),
+    })
+
+    if (isNextDev) {
+      it('should reload instrumentation-client when modified', async () => {
+        const browser = await next.browser('/')
+        const initialTime = await browser.eval(
+          `window.__INSTRUMENTATION_CLIENT_EXECUTED_AT`
+        )
+        expect(initialTime).toBeDefined()
+
+        // Modify the instrumentation-client.ts file
+        const instrumentationPath = 'instrumentation-client.ts'
+
+        const originalContent = await next.readFile(instrumentationPath)
+
+        await next.patchFile(
+          instrumentationPath,
+          `
+          window.__INSTRUMENTATION_CLIENT_EXECUTED_AT = Date.now();
+          window.__INSTRUMENTATION_CLIENT_UPDATED = true;
+          `
+        )
+
+        await retry(async () => {
+          // Check if the updated instrumentation client was executed
+          const updatedFlag = await browser.eval(
+            `window.__INSTRUMENTATION_CLIENT_UPDATED`
+          )
+          expect(updatedFlag).toBe(true)
+
+          // Verify new execution time
+          const newTime = await browser.eval(
+            `window.__INSTRUMENTATION_CLIENT_EXECUTED_AT`
+          )
+          expect(newTime).toBeDefined()
+          expect(newTime).toBeGreaterThan(initialTime)
+        })
+
+        // Restore the original file
+        await next.patchFile(instrumentationPath, originalContent)
+      })
+    } else {
+      // Add a dummy test when not in dev mode
+      it('skips tests in non-dev mode', () => {
+        console.log(
+          'Skipping instrumentation-client-hook tests in non-dev mode'
+        )
+      })
+    }
+  })
+})

--- a/test/e2e/instrumentation-client-hook/pages-router/instrumentation-client.ts
+++ b/test/e2e/instrumentation-client-hook/pages-router/instrumentation-client.ts
@@ -1,0 +1,1 @@
+;(window as any).__INSTRUMENTATION_CLIENT_EXECUTED_AT = performance.now()

--- a/test/e2e/instrumentation-client-hook/pages-router/next.config.js
+++ b/test/e2e/instrumentation-client-hook/pages-router/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    clientInstrumentationHook: true,
+  },
+}

--- a/test/e2e/instrumentation-client-hook/pages-router/pages/index.tsx
+++ b/test/e2e/instrumentation-client-hook/pages-router/pages/index.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Page() {
+  return <h1>Pages Router</h1>
+}


### PR DESCRIPTION
Some analytics APIs need to run before any Next.js code executes. Previously, we implemented `instrumentation.ts` to handle this on the server side. Now, we're introducing `instrumentation-client.ts` for client-side functionality. When placed at the project root, this script will be bundled into the initial JavaScript chunk and executed synchronously before hydration begins.

Closes NDX-934