### PR TITLE
fix(turbo-persistence): Update qfilter to 0.2.3 to fix CapacityExceeded panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5554,9 +5554,9 @@ dependencies = [
 
 [[package]]
 name = "qfilter"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b36883275f761fe4c69f0ba982d18b36208b72d647ad9d468afcad70fb08a4e"
+checksum = "67e8a816b53348c3700648b8b66c5d4b0e3913e85ba6e518e9e933510f32c42f"
 dependencies = [
  "serde",
  "serde_bytes",

--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -17,7 +17,7 @@ byteorder = "1.5.0"
 lzzzz = "1.1.0"
 memmap2 = "0.9.5"
 parking_lot = { workspace = true }
-qfilter = { version = "0.2.1", features = ["serde"] }
+qfilter = { version = "0.2.3", features = ["serde"] }
 quick_cache = { version = "0.6.9" }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }


### PR DESCRIPTION
User report: https://vercel.slack.com/archives/C046HAU4H7F/p1741216793060779
Appears to be fixed by: https://github.com/arthurprs/qfilter/pull/8

```
Panic: panicked at turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs:114:18:
AQMF insert failed: CapacityExceeded
Backtrace:    0: _napi_register_module_v1
   1: _napi_register_module_v1
   2: <unknown>
   3: _napi_register_module_v1
   4: _napi_register_module_v1
   5: _napi_register_module_v1
   6: _napi_register_module_v1
   7: _napi_register_module_v1
   8: _napi_register_module_v1
   9: <unknown>
  10: <unknown>
  11: <unknown>
  12: <unknown>
  13: <unknown>
  14: <unknown>
  15: <unknown>
  16: <unknown>
  17: <unknown>
  18: <unknown>
  19: <unknown>
  20: <unknown>
  21: <unknown>
  22: <unknown>
  23: <unknown>
  24: <unknown>
  25: <unknown>
  26: <unknown>
  27: <unknown>
  28: _napi_register_module_v1
  29: _napi_register_module_v1
  30: _napi_register_module_v1
  31: _napi_register_module_v1
  32: _napi_register_module_v1
  33: __pthread_deallocate
```

Closes PACK-4090