### PR TITLE
Set 'USER' at Dockerfile as numeric

### DIFF
--- a/examples/with-docker-compose/next-app/prod.Dockerfile
+++ b/examples/with-docker-compose/next-app/prod.Dockerfile
@@ -49,10 +49,12 @@ FROM base AS runner
 
 WORKDIR /app
 
+ENV APP_USER=1001
+
 # Don't run production as root
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
-USER nextjs
+RUN addgroup --system --gid ${APP_USER} nodejs
+RUN adduser --system --uid ${APP_USER} nextjs
+USER ${APP_USER}
 
 COPY --from=builder /app/public ./public
 

--- a/examples/with-docker-multi-env/docker/development/Dockerfile
+++ b/examples/with-docker-multi-env/docker/development/Dockerfile
@@ -32,9 +32,10 @@ FROM base AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
+ENV APP_USER=1001
 
-RUN addgroup -g 1001 -S nodejs
-RUN adduser -S nextjs -u 1001
+RUN addgroup -g ${APP_USER} -S nodejs
+RUN adduser -S nextjs -u ${APP_USER}
 
 COPY --from=builder /app/public ./public
 
@@ -43,8 +44,7 @@ COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
-
-USER nextjs
+USER ${APP_USER}
 
 EXPOSE 3000
 

--- a/examples/with-docker-multi-env/docker/production/Dockerfile
+++ b/examples/with-docker-multi-env/docker/production/Dockerfile
@@ -33,9 +33,10 @@ FROM base AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
+ENV APP_USER=1001
 
-RUN addgroup -g 1001 -S nodejs
-RUN adduser -S nextjs -u 1001
+RUN addgroup -g ${APP_USER} -S nodejs
+RUN adduser -S nextjs -u ${APP_USER}
 
 COPY --from=builder /app/public ./public
 
@@ -44,8 +45,7 @@ COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
-
-USER nextjs
+USER ${APP_USER}
 
 EXPOSE 3000
 

--- a/examples/with-docker-multi-env/docker/staging/Dockerfile
+++ b/examples/with-docker-multi-env/docker/staging/Dockerfile
@@ -33,9 +33,10 @@ FROM base AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
+ENV APP_USER=1001
 
-RUN addgroup -g 1001 -S nodejs
-RUN adduser -S nextjs -u 1001
+RUN addgroup -g ${APP_USER} -S nodejs
+RUN adduser -S nextjs -u ${APP_USER}
 
 COPY --from=builder /app/public ./public
 
@@ -44,8 +45,7 @@ COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
-
-USER nextjs
+USER ${APP_USER}
 
 EXPOSE 3000
 

--- a/examples/with-docker/Dockerfile
+++ b/examples/with-docker/Dockerfile
@@ -44,8 +44,10 @@ ENV NODE_ENV=production
 # Uncomment the following line in case you want to disable telemetry during runtime.
 # ENV NEXT_TELEMETRY_DISABLED=1
 
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
+ENV APP_USER=1001
+
+RUN addgroup --system --gid ${APP_USER} nodejs
+RUN adduser --system --uid ${APP_USER} nextjs
 
 COPY --from=builder /app/public ./public
 
@@ -54,7 +56,7 @@ COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
-USER nextjs
+USER ${APP_USER}
 
 EXPOSE 3000
 


### PR DESCRIPTION
Hi, it is recommended to use a numeric 'USER' since deploying a Next.js app in Kubernetes with the 'runAsNonRoot' option requires specifying a numeric user.