### PR TITLE
fix(turbopack): Fix the span of a magic comment

### DIFF
--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -438,12 +438,7 @@ impl<C: Comments> ServerActions<C> {
             .push((action_name.clone(), action_id.clone()));
 
         let register_action_expr = bind_args_to_ref_expr(
-            annotate_ident_as_server_reference(
-                action_ident.clone(),
-                action_id.clone(),
-                arrow.span,
-                &self.comments,
-            ),
+            annotate_ident_as_server_reference(action_ident.clone(), action_id.clone(), arrow.span),
             ids_from_closure
                 .iter()
                 .cloned()
@@ -451,6 +446,7 @@ impl<C: Comments> ServerActions<C> {
                 .collect(),
             action_id.clone(),
         );
+        add_turbopack_disable_export_merging_comment(action_ident.span, &self.comments);
 
         if let BlockStmtOrExpr::BlockStmt(block) = &mut *arrow.body {
             block.visit_mut_with(&mut ClosureReplacer {
@@ -573,7 +569,11 @@ impl<C: Comments> ServerActions<C> {
         new_params.append(&mut function.params);
 
         let action_name: Atom = self.gen_action_ident();
-        let action_ident = Ident::new(action_name.clone(), function.span, self.private_ctxt);
+        let mut action_ident = Ident::new(action_name.clone(), function.span, self.private_ctxt);
+        if action_ident.span.lo == self.start_pos {
+            action_ident.span = Span::dummy_with_cmt();
+        }
+
         let action_id = self.generate_server_reference_id(&action_name, false, Some(&new_params));
 
         self.has_action = true;
@@ -585,7 +585,6 @@ impl<C: Comments> ServerActions<C> {
                 action_ident.clone(),
                 action_id.clone(),
                 function.span,
-                &self.comments,
             ),
             ids_from_closure
                 .iter()
@@ -594,6 +593,7 @@ impl<C: Comments> ServerActions<C> {
                 .collect(),
             action_id.clone(),
         );
+        add_turbopack_disable_export_merging_comment(action_ident.span, &self.comments);
 
         function.body.visit_mut_with(&mut ClosureReplacer {
             used_ids: &ids_from_closure,
@@ -694,7 +694,7 @@ impl<C: Comments> ServerActions<C> {
         }
 
         let cache_name: Atom = self.gen_cache_ident();
-        let cache_ident = private_ident!(cache_name.clone());
+        let cache_ident = private_ident!(Span::dummy_with_cmt(), cache_name.clone());
         let export_name: Atom = cache_name;
 
         let reference_id = self.generate_server_reference_id(&export_name, true, Some(&new_params));
@@ -769,8 +769,8 @@ impl<C: Comments> ServerActions<C> {
             cache_ident.clone(),
             reference_id.clone(),
             arrow.span,
-            &self.comments,
         );
+        add_turbopack_disable_export_merging_comment(cache_ident.span, &self.comments);
 
         // If there're any bound args from the closure, we need to hoist the
         // register action expression to the top-level, and return the bind
@@ -829,7 +829,7 @@ impl<C: Comments> ServerActions<C> {
         }
 
         let cache_name: Atom = self.gen_cache_ident();
-        let cache_ident = private_ident!(cache_name.clone());
+        let cache_ident = private_ident!(Span::dummy_with_cmt(), cache_name.clone());
 
         let reference_id = self.generate_server_reference_id(&cache_name, true, Some(&new_params));
 
@@ -841,8 +841,8 @@ impl<C: Comments> ServerActions<C> {
             cache_ident.clone(),
             reference_id.clone(),
             function.span,
-            &self.comments,
         );
+        add_turbopack_disable_export_merging_comment(cache_ident.span, &self.comments);
 
         function.body.visit_mut_with(&mut ClosureReplacer {
             used_ids: &ids_from_closure,
@@ -1941,9 +1941,9 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                             ident.clone(),
                             ref_id.clone(),
                             ident.span,
-                            &self.comments,
                         )),
                     }));
+                    add_turbopack_disable_export_merging_comment(ident.span, &self.comments);
                 }
             }
 
@@ -2328,23 +2328,7 @@ fn assign_arrow_expr(ident: &Ident, expr: Expr) -> Expr {
     }
 }
 
-fn annotate_ident_as_server_reference(
-    ident: Ident,
-    action_id: Atom,
-    original_span: Span,
-    comments: &dyn Comments,
-) -> Expr {
-    if !original_span.lo.is_dummy() {
-        comments.add_leading(
-            original_span.lo,
-            Comment {
-                kind: CommentKind::Block,
-                span: original_span,
-                text: "#__TURBOPACK_DISABLE_EXPORT_MERGING__".into(),
-            },
-        );
-    }
-
+fn annotate_ident_as_server_reference(ident: Ident, action_id: Atom, original_span: Span) -> Expr {
     // registerServerReference(reference, id, null)
     Expr::Call(CallExpr {
         span: original_span,
@@ -2365,6 +2349,17 @@ fn annotate_ident_as_server_reference(
         ],
         ..Default::default()
     })
+}
+
+fn add_turbopack_disable_export_merging_comment(span: Span, comments: &dyn Comments) {
+    comments.add_leading(
+        span.lo,
+        Comment {
+            kind: CommentKind::Block,
+            span: DUMMY_SP,
+            text: "#__TURBOPACK_DISABLE_EXPORT_MERGING__".into(),
+        },
+    );
 }
 
 fn bind_args_to_ref_expr(expr: Expr, bound: Vec<Option<ExprOrSpread>>, action_id: Atom) -> Expr {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/27/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/27/output.js
@@ -1,9 +1,9 @@
 // Rules here:
 // 1. Each exported function should still be exported, but as a reference `registerServerReference(...)`.
 // 2. Actual action functions should be renamed to `$$ACTION_...` and got exported.
-/*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ /* __next_internal_action_entry_do_not_use__ {"001c36b06e398c97abe5d5d7ae8c672bfddf4e1b91":"$$RSC_SERVER_ACTION_2","006a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0","0090b5db271335765a4b0eab01f044b381b5ebd5cd":"$$RSC_SERVER_ACTION_1","009ed0cc47abc4e1c64320cf42b74ae60b58c40f00":"$$RSC_SERVER_ACTION_3","00a9b2939c1f39073a6bed227fd20233064c8b7869":"$$RSC_SERVER_ACTION_4"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+/* __next_internal_action_entry_do_not_use__ {"001c36b06e398c97abe5d5d7ae8c672bfddf4e1b91":"$$RSC_SERVER_ACTION_2","006a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0","0090b5db271335765a4b0eab01f044b381b5ebd5cd":"$$RSC_SERVER_ACTION_1","009ed0cc47abc4e1c64320cf42b74ae60b58c40f00":"$$RSC_SERVER_ACTION_3","00a9b2939c1f39073a6bed227fd20233064c8b7869":"$$RSC_SERVER_ACTION_4"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-export const $$RSC_SERVER_ACTION_0 = async function foo() {
+export const /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_ACTION_0 = async function foo() {
     console.log(1);
 };
 var foo = registerServerReference($$RSC_SERVER_ACTION_0, "006a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/46/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/46/output.js
@@ -1,9 +1,9 @@
 // This is for testing the "information byte" of Server Action / Cache IDs.
 // Should be 1 110000 0, which is "e0" in hex.
-/*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ /* __next_internal_action_entry_do_not_use__ {"6090b5db271335765a4b0eab01f044b381b5ebd5cd":"$$RSC_SERVER_ACTION_1","7c9ed0cc47abc4e1c64320cf42b74ae60b58c40f00":"$$RSC_SERVER_ACTION_3","7ea9b2939c1f39073a6bed227fd20233064c8b7869":"$$RSC_SERVER_ACTION_4","e03128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0","ff471a5eb0be1c31686dd4ba938a80328b80b1615d":"$$RSC_SERVER_CACHE_5","ff69348c79fce073bae2f70f139565a2fda1c74c74":"$$RSC_SERVER_CACHE_2"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+/* __next_internal_action_entry_do_not_use__ {"6090b5db271335765a4b0eab01f044b381b5ebd5cd":"$$RSC_SERVER_ACTION_1","7c9ed0cc47abc4e1c64320cf42b74ae60b58c40f00":"$$RSC_SERVER_ACTION_3","7ea9b2939c1f39073a6bed227fd20233064c8b7869":"$$RSC_SERVER_ACTION_4","e03128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0","ff471a5eb0be1c31686dd4ba938a80328b80b1615d":"$$RSC_SERVER_CACHE_5","ff69348c79fce073bae2f70f139565a2fda1c74c74":"$$RSC_SERVER_CACHE_2"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", 0, async function f1(a, b) {
+export var /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ $$RSC_SERVER_CACHE_0 = $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", 0, async function f1(a, b) {
     return [
         a,
         b

--- a/crates/next-custom-transforms/tests/fixture/source-maps/server-graph/use-cache/1/output.map
+++ b/crates/next-custom-transforms/tests/fixture/source-maps/server-graph/use-cache/1/output.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["input.js"],"sourcesContent":["'use cache'\n\nconst foo = async () => {\n  'use cache'\n}\n\nexport async function bar() {\n  return foo()\n}\n"],"names":[],"mappings":";;;WAEY,uCACC,GADD,+GAEZ;;;;;AAFA,MAAM,MAAM;WAIL,uCACO,GADP,6FAAA,eAAe;IACpB,OAAO;AACT;;;;;AAFA,WAAsB,MAAf"}
+{"version":3,"sources":["input.js"],"sourcesContent":["'use cache'\n\nconst foo = async () => {\n  'use cache'\n}\n\nexport async function bar() {\n  return foo()\n}\n"],"names":[],"mappings":";;;WAEY,yJAEZ;;;;;AAFA,MAAM,MAAM;WAIL,uIAAA,eAAe;IACpB,OAAO;AACT;;;;;AAFA,WAAsB,MAAf"}


### PR DESCRIPTION
### What?

Fix the span of the turbopack tree shaking magic comment.

### Why?

Previously it was printed on strange position.

### How?

Closes NAR-91

Closes PACK-4087