### PR TITLE
Don't mark ppr-errors Turbopack dev tests as failed

### DIFF
--- a/test/e2e/app-dir/ppr-errors/ppr-errors.test.ts
+++ b/test/e2e/app-dir/ppr-errors/ppr-errors.test.ts
@@ -1,8 +1,10 @@
 import { nextBuild } from 'next-test-utils'
+// In order for the global isNextStart to be set
+import 'e2e-utils'
 
 describe('ppr build errors', () => {
-  ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
-    'production mode',
+  ;(Boolean((global as any).isNextStart) ? describe : describe.skip)(
+    'production only',
     () => {
       let stderr: string
       let stdout: string

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -7339,12 +7339,12 @@
   },
   "test/e2e/app-dir/ppr-errors/ppr-errors.test.ts": {
     "passed": [],
-    "failed": [
+    "failed": [],
+    "pending": [
       "ppr build errors production mode outside of a suspense boundary should fail the build for uncaught errors",
       "ppr build errors production mode when a postpone call is caught and logged it should should include a message telling why",
       "ppr build errors production mode within a suspense boundary should fail the build for uncaught prerender errors"
     ],
-    "pending": [],
     "flakey": [],
     "runtimeError": false
   },

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -1888,10 +1888,9 @@
       "Error recovery app render error not shown right after syntax error",
       "Error recovery app server component can recover from a component error",
       "Error recovery app server component can recover from syntax error",
-      "Error recovery app stuck error",
-      "Error recovery app syntax > runtime error"
+      "Error recovery app stuck error"
     ],
-    "failed": [],
+    "failed": ["Error recovery app syntax > runtime error"],
     "pending": [],
     "flakey": [],
     "runtimeError": false

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -1888,9 +1888,10 @@
       "Error recovery app render error not shown right after syntax error",
       "Error recovery app server component can recover from a component error",
       "Error recovery app server component can recover from syntax error",
-      "Error recovery app stuck error"
+      "Error recovery app stuck error",
+      "Error recovery app syntax > runtime error"
     ],
-    "failed": ["Error recovery app syntax > runtime error"],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
Not sure what was going on here. And we don't really want to run the `production mode` tests in Webpack dev either?

To get a nicer result on the you-know-what-site.

Closes PACK-4157