### PR TITLE
[dev-overlay] remove text wrap for terminal

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/code-frame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/code-frame.tsx
@@ -145,10 +145,6 @@ export const CODE_FRAME_STYLES = `
     margin: auto 6px;
   }
 
-  .code-frame-pre {
-    white-space: pre-wrap;
-  }
-
   .code-frame-header {
     width: 100%;
     transition: background 100ms ease-out;


### PR DESCRIPTION
| Before | After |
|--------|--------|
| ![CleanShot 2025-03-10 at 18 51 16@2x](https://github.com/user-attachments/assets/2d39fcb5-072d-4ee0-a5bd-1df5e9c4b222) | ![CleanShot 2025-03-10 at 18 51 35@2x](https://github.com/user-attachments/assets/f0c21a0b-cca6-4606-b7a6-3ed8acc6e6c7) | 

Closes NDX-950