### PR TITLE
chore(HMR clients): Clean up and share code between app and pages router

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
@@ -86,15 +86,6 @@ export function waitForWebpackRuntimeHotUpdate() {
   return pendingHotUpdateWebpack
 }
 
-function handleBeforeHotUpdateWebpack(
-  dispatcher: Dispatcher,
-  hasUpdates: boolean
-) {
-  if (hasUpdates) {
-    dispatcher.onBeforeRefresh()
-  }
-}
-
 function handleSuccessfulHotUpdateWebpack(
   dispatcher: Dispatcher,
   sendMessage: (message: string) => void,
@@ -301,7 +292,9 @@ function processMessage(
     } else {
       tryApplyUpdates(
         function onBeforeHotUpdate(hasUpdates: boolean) {
-          handleBeforeHotUpdateWebpack(dispatcher, hasUpdates)
+          if (hasUpdates) {
+            dispatcher.onBeforeRefresh()
+          }
         },
         function onSuccessfulHotUpdate(webpackUpdatedModules: string[]) {
           // Only dismiss it when we're sure it's a hot update.

--- a/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
@@ -413,7 +413,6 @@ function processMessage(
       )
 
       if (obj.action === HMR_ACTIONS_SENT_TO_BROWSER.BUILT) {
-        // Handle hot updates
         handleHotUpdate()
       }
       return

--- a/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
@@ -22,6 +22,7 @@ import {
   ACTION_UNHANDLED_REJECTION,
   ACTION_VERSION_INFO,
   REACT_REFRESH_FULL_RELOAD,
+  reportInvalidHmrMessage,
   useErrorOverlayReducer,
 } from '../shared'
 import { parseStack } from '../utils/parse-stack'
@@ -666,13 +667,8 @@ export default function HotReload({
           appIsrManifestRef,
           pathnameRef
         )
-      } catch (err: any) {
-        console.warn(
-          '[HMR] Invalid message: ' +
-            JSON.stringify(event.data) +
-            '\n' +
-            (err?.stack ?? '')
-        )
+      } catch (err: unknown) {
+        reportInvalidHmrMessage(event, err)
       }
     }
 

--- a/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
@@ -21,6 +21,7 @@ import {
   ACTION_UNHANDLED_ERROR,
   ACTION_UNHANDLED_REJECTION,
   ACTION_VERSION_INFO,
+  REACT_REFRESH_FULL_RELOAD,
   useErrorOverlayReducer,
 } from '../shared'
 import { parseStack } from '../utils/parse-stack'
@@ -210,14 +211,7 @@ function tryApplyUpdates(
   function handleApplyUpdates(err: any, updatedModules: string[] | null) {
     if (err || RuntimeErrorHandler.hadRuntimeError || !updatedModules) {
       if (err) {
-        console.warn(
-          '[Fast Refresh] performing full reload\n\n' +
-            "Fast Refresh will perform a full reload when you edit a file that's imported by modules outside of the React rendering tree.\n" +
-            'You might have a file which exports a React component but also exports a value that is imported by a non-React component file.\n' +
-            'Consider migrating the non-React component export to a separate file and importing it into both files.\n\n' +
-            'It is also possible the parent component of the component you edited is a class component, which disables Fast Refresh.\n' +
-            'Fast Refresh requires at least one parent function component in your React tree.'
-        )
+        console.warn(REACT_REFRESH_FULL_RELOAD)
       } else if (RuntimeErrorHandler.hadRuntimeError) {
         console.warn(REACT_REFRESH_FULL_RELOAD_FROM_ERROR)
       }

--- a/packages/next/src/client/components/react-dev-overlay/pages/hot-reloader-client.ts
+++ b/packages/next/src/client/components/react-dev-overlay/pages/hot-reloader-client.ts
@@ -50,6 +50,7 @@ import { extractModulesFromTurbopackMessage } from '../../../../server/dev/extra
 import {
   REACT_REFRESH_FULL_RELOAD,
   REACT_REFRESH_FULL_RELOAD_FROM_ERROR,
+  reportInvalidHmrMessage,
 } from '../shared'
 import { RuntimeErrorHandler } from '../../errors/runtime-error-handler'
 import reportHmrLatency from '../utils/report-hmr-latency'
@@ -83,13 +84,8 @@ export default function connect() {
 
     try {
       processMessage(payload)
-    } catch (err: any) {
-      console.warn(
-        '[HMR] Invalid message: ' +
-          JSON.stringify(payload) +
-          '\n' +
-          (err?.stack ?? '')
-      )
+    } catch (err: unknown) {
+      reportInvalidHmrMessage(payload, err)
     }
   })
 

--- a/packages/next/src/client/components/react-dev-overlay/pages/hot-reloader-client.ts
+++ b/packages/next/src/client/components/react-dev-overlay/pages/hot-reloader-client.ts
@@ -260,7 +260,7 @@ export function handleStaticIndicator() {
     const pageComponent = routeInfo?.Component
     const appComponent = window.next.router.components['/_app']?.Component
     const isDynamicPage =
-      Boolean(pageComponent?.getInitialProps) || Boolean(routeInfo.__N_SSP)
+      Boolean(pageComponent?.getInitialProps) || Boolean(routeInfo?.__N_SSP)
     const hasAppGetInitialProps =
       Boolean(appComponent?.getInitialProps) &&
       appComponent?.getInitialProps !== appComponent?.origGetInitialProps

--- a/packages/next/src/client/components/react-dev-overlay/pages/hot-reloader-client.ts
+++ b/packages/next/src/client/components/react-dev-overlay/pages/hot-reloader-client.ts
@@ -73,9 +73,7 @@ window.__nextDevClientId = Math.round(Math.random() * 100 + Date.now())
 
 let customHmrEventHandler: any
 let turbopackMessageListeners: ((msg: TurbopackMsgToBrowser) => void)[] = []
-let MODE: 'webpack' | 'turbopack' = 'webpack'
-export default function connect(mode: 'webpack' | 'turbopack') {
-  MODE = mode
+export default function connect() {
   register()
 
   addMessageListener((payload) => {
@@ -132,7 +130,7 @@ function clearOutdatedErrors() {
 function handleSuccess() {
   clearOutdatedErrors()
 
-  if (MODE === 'webpack') {
+  if (!process.env.TURBOPACK) {
     const isHotUpdate =
       !isFirstCompilation ||
       (window.__NEXT_DATA__.page !== '/_error' && isUpdateAvailable())

--- a/packages/next/src/client/components/react-dev-overlay/pages/hot-reloader-client.ts
+++ b/packages/next/src/client/components/react-dev-overlay/pages/hot-reloader-client.ts
@@ -279,7 +279,6 @@ function processMessage(obj: HMR_ACTION_TYPES) {
     return
   }
 
-  // Use turbopack message for analytics, (still need built for webpack)
   switch (obj.action) {
     case HMR_ACTIONS_SENT_TO_BROWSER.ISR_MANIFEST: {
       isrManifest = obj.data

--- a/packages/next/src/client/components/react-dev-overlay/pages/hot-reloader-client.ts
+++ b/packages/next/src/client/components/react-dev-overlay/pages/hot-reloader-client.ts
@@ -130,7 +130,15 @@ function clearOutdatedErrors() {
 function handleSuccess() {
   clearOutdatedErrors()
 
-  if (!process.env.TURBOPACK) {
+  if (process.env.TURBOPACK) {
+    reportHmrLatency(
+      sendMessage,
+      [...turbopackUpdatedModules],
+      startLatency!,
+      turbopackLastUpdateLatency ?? Date.now()
+    )
+    onBuildOk()
+  } else {
     const isHotUpdate =
       !isFirstCompilation ||
       (window.__NEXT_DATA__.page !== '/_error' && isUpdateAvailable())
@@ -141,14 +149,6 @@ function handleSuccess() {
     if (isHotUpdate) {
       tryApplyUpdates(onBeforeFastRefresh, onFastRefresh)
     }
-  } else {
-    reportHmrLatency(
-      sendMessage,
-      [...turbopackUpdatedModules],
-      startLatency!,
-      turbopackLastUpdateLatency ?? Date.now()
-    )
-    onBuildOk()
   }
 }
 

--- a/packages/next/src/client/components/react-dev-overlay/pages/hot-reloader-client.ts
+++ b/packages/next/src/client/components/react-dev-overlay/pages/hot-reloader-client.ts
@@ -47,7 +47,10 @@ import type {
   TurbopackMsgToBrowser,
 } from '../../../../server/dev/hot-reloader-types'
 import { extractModulesFromTurbopackMessage } from '../../../../server/dev/extract-modules-from-turbopack-message'
-import { REACT_REFRESH_FULL_RELOAD_FROM_ERROR } from '../shared'
+import {
+  REACT_REFRESH_FULL_RELOAD,
+  REACT_REFRESH_FULL_RELOAD_FROM_ERROR,
+} from '../shared'
 import { RuntimeErrorHandler } from '../../errors/runtime-error-handler'
 // This alternative WebpackDevServer combines the functionality of:
 // https://github.com/webpack/webpack-dev-server/blob/webpack-1/client/index.js
@@ -458,18 +461,9 @@ function tryApplyUpdates(
   function handleApplyUpdates(err: any, updatedModules: string[] | null) {
     if (err || RuntimeErrorHandler.hadRuntimeError || !updatedModules) {
       if (err) {
-        console.warn(
-          '[Fast Refresh] performing full reload\n\n' +
-            "Fast Refresh will perform a full reload when you edit a file that's imported by modules outside of the React rendering tree.\n" +
-            'You might have a file which exports a React component but also exports a value that is imported by a non-React component file.\n' +
-            'Consider migrating the non-React component export to a separate file and importing it into both files.\n\n' +
-            'It is also possible the parent component of the component you edited is a class component, which disables Fast Refresh.\n' +
-            'Fast Refresh requires at least one parent function component in your React tree.'
-        )
+        console.warn(REACT_REFRESH_FULL_RELOAD)
       } else if (RuntimeErrorHandler.hadRuntimeError) {
-        console.warn(
-          '[Fast Refresh] performing full reload because your application had an unrecoverable error'
-        )
+        console.warn(REACT_REFRESH_FULL_RELOAD_FROM_ERROR)
       }
       performFullReload(err)
       return

--- a/packages/next/src/client/components/react-dev-overlay/shared.ts
+++ b/packages/next/src/client/components/react-dev-overlay/shared.ts
@@ -6,6 +6,7 @@ import type { SupportedErrorEvent } from './ui/container/runtime-error/render-er
 import type { ComponentStackFrame } from './utils/parse-component-stack'
 import type { DebugInfo } from './types'
 import type { DevIndicatorServerState } from '../../../server/dev/dev-indicator-server-state'
+import type { HMR_ACTION_TYPES } from '../../../server/dev/hot-reloader-types'
 
 type FastRefreshState =
   /** No refresh in progress. */
@@ -234,3 +235,15 @@ export const REACT_REFRESH_FULL_RELOAD =
 
 export const REACT_REFRESH_FULL_RELOAD_FROM_ERROR =
   '[Fast Refresh] performing full reload because your application had an unrecoverable error'
+
+export function reportInvalidHmrMessage(
+  message: HMR_ACTION_TYPES | MessageEvent<unknown>,
+  err: unknown
+) {
+  console.warn(
+    '[HMR] Invalid message: ' +
+      JSON.stringify(message) +
+      '\n' +
+      ((err instanceof Error && err?.stack) || '')
+  )
+}

--- a/packages/next/src/client/components/react-dev-overlay/shared.ts
+++ b/packages/next/src/client/components/react-dev-overlay/shared.ts
@@ -224,5 +224,13 @@ export function useErrorOverlayReducer(routerType: 'pages' | 'app') {
   }, getInitialState(routerType))
 }
 
+export const REACT_REFRESH_FULL_RELOAD =
+  '[Fast Refresh] performing full reload\n\n' +
+  "Fast Refresh will perform a full reload when you edit a file that's imported by modules outside of the React rendering tree.\n" +
+  'You might have a file which exports a React component but also exports a value that is imported by a non-React component file.\n' +
+  'Consider migrating the non-React component export to a separate file and importing it into both files.\n\n' +
+  'It is also possible the parent component of the component you edited is a class component, which disables Fast Refresh.\n' +
+  'Fast Refresh requires at least one parent function component in your React tree.'
+
 export const REACT_REFRESH_FULL_RELOAD_FROM_ERROR =
   '[Fast Refresh] performing full reload because your application had an unrecoverable error'

--- a/packages/next/src/client/components/react-dev-overlay/utils/report-hmr-latency.ts
+++ b/packages/next/src/client/components/react-dev-overlay/utils/report-hmr-latency.ts
@@ -1,0 +1,31 @@
+declare global {
+  interface Window {
+    __NEXT_HMR_LATENCY_CB: ((latencyMs: number) => void) | undefined
+  }
+}
+
+export default function reportHmrLatency(
+  sendMessage: (message: string) => void,
+  updatedModules: ReadonlyArray<string>,
+  startMsSinceEpoch: number,
+  endMsSinceEpoch: number
+) {
+  const latencyMs = endMsSinceEpoch - startMsSinceEpoch
+  console.log(`[Fast Refresh] done in ${latencyMs}ms`)
+  sendMessage(
+    JSON.stringify({
+      event: 'client-hmr-latency',
+      id: window.__nextDevClientId,
+      startTime: startMsSinceEpoch,
+      endTime: endMsSinceEpoch,
+      page: window.location.pathname,
+      updatedModules,
+      // Whether the page (tab) was hidden at the time the event occurred.
+      // This can impact the accuracy of the event's timing.
+      isPageHidden: document.visibilityState === 'hidden',
+    })
+  )
+  if (self.__NEXT_HMR_LATENCY_CB) {
+    self.__NEXT_HMR_LATENCY_CB(latencyMs)
+  }
+}

--- a/packages/next/src/client/components/react-dev-overlay/utils/use-websocket.ts
+++ b/packages/next/src/client/components/react-dev-overlay/utils/use-websocket.ts
@@ -3,12 +3,6 @@ import { GlobalLayoutRouterContext } from '../../../../shared/lib/app-router-con
 import { getSocketUrl } from './get-socket-url'
 import type { TurbopackMsgToBrowser } from '../../../../server/dev/hot-reloader-types'
 
-declare global {
-  interface Window {
-    __NEXT_HMR_LATENCY_CB: ((latencyMs: number) => void) | undefined
-  }
-}
-
 export function useWebsocket(assetPrefix: string) {
   const webSocketRef = useRef<WebSocket>(undefined)
 
@@ -120,30 +114,4 @@ export function useWebsocketPing(
     }, 2500)
     return () => clearInterval(interval)
   }, [tree, sendMessage])
-}
-
-export function reportHmrLatency(
-  sendMessage: (message: string) => void,
-  updatedModules: ReadonlyArray<string>,
-  startMsSinceEpoch: number,
-  endMsSinceEpoch: number
-) {
-  const latencyMs = endMsSinceEpoch - startMsSinceEpoch
-  console.log(`[Fast Refresh] done in ${latencyMs}ms`)
-  sendMessage(
-    JSON.stringify({
-      event: 'client-hmr-latency',
-      id: window.__nextDevClientId,
-      startTime: startMsSinceEpoch,
-      endTime: endMsSinceEpoch,
-      page: window.location.pathname,
-      updatedModules,
-      // Whether the page (tab) was hidden at the time the event occurred.
-      // This can impact the accuracy of the event's timing.
-      isPageHidden: document.visibilityState === 'hidden',
-    })
-  )
-  if (self.__NEXT_HMR_LATENCY_CB) {
-    self.__NEXT_HMR_LATENCY_CB(latencyMs)
-  }
 }

--- a/packages/next/src/client/components/react-dev-overlay/utils/use-websocket.ts
+++ b/packages/next/src/client/components/react-dev-overlay/utils/use-websocket.ts
@@ -3,6 +3,12 @@ import { GlobalLayoutRouterContext } from '../../../../shared/lib/app-router-con
 import { getSocketUrl } from './get-socket-url'
 import type { TurbopackMsgToBrowser } from '../../../../server/dev/hot-reloader-types'
 
+declare global {
+  interface Window {
+    __NEXT_HMR_LATENCY_CB: ((latencyMs: number) => void) | undefined
+  }
+}
+
 export function useWebsocket(assetPrefix: string) {
   const webSocketRef = useRef<WebSocket>(undefined)
 
@@ -114,4 +120,30 @@ export function useWebsocketPing(
     }, 2500)
     return () => clearInterval(interval)
   }, [tree, sendMessage])
+}
+
+export function reportHmrLatency(
+  sendMessage: (message: string) => void,
+  updatedModules: ReadonlyArray<string>,
+  startMsSinceEpoch: number,
+  endMsSinceEpoch: number
+) {
+  const latencyMs = endMsSinceEpoch - startMsSinceEpoch
+  console.log(`[Fast Refresh] done in ${latencyMs}ms`)
+  sendMessage(
+    JSON.stringify({
+      event: 'client-hmr-latency',
+      id: window.__nextDevClientId,
+      startTime: startMsSinceEpoch,
+      endTime: endMsSinceEpoch,
+      page: window.location.pathname,
+      updatedModules,
+      // Whether the page (tab) was hidden at the time the event occurred.
+      // This can impact the accuracy of the event's timing.
+      isPageHidden: document.visibilityState === 'hidden',
+    })
+  )
+  if (self.__NEXT_HMR_LATENCY_CB) {
+    self.__NEXT_HMR_LATENCY_CB(latencyMs)
+  }
 }

--- a/packages/next/src/client/dev/amp-dev.ts
+++ b/packages/next/src/client/dev/amp-dev.ts
@@ -6,6 +6,7 @@ import {
   connectHMR,
 } from '../components/react-dev-overlay/pages/websocket'
 import { HMR_ACTIONS_SENT_TO_BROWSER } from '../../server/dev/hot-reloader-types'
+import { reportInvalidHmrMessage } from '../components/react-dev-overlay/shared'
 
 declare global {
   const __webpack_runtime_id__: string
@@ -106,13 +107,8 @@ addMessageListener((message) => {
     } else if (message.action === HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE) {
       window.location.reload()
     }
-  } catch (err: any) {
-    console.warn(
-      '[HMR] Invalid message: ' +
-        JSON.stringify(message) +
-        '\n' +
-        (err?.stack ?? '')
-    )
+  } catch (err: unknown) {
+    reportInvalidHmrMessage(message, err)
   }
 })
 

--- a/packages/next/src/client/dev/hot-middleware-client.ts
+++ b/packages/next/src/client/dev/hot-middleware-client.ts
@@ -20,8 +20,8 @@ declare const window: NextWindow
 
 let reloading = false
 
-export default (mode: 'webpack' | 'turbopack') => {
-  const devClient = connect(mode)
+export default () => {
+  const devClient = connect()
 
   devClient.subscribeToHmrEvent((obj: any) => {
     if (reloading) return

--- a/packages/next/src/client/next-dev-turbopack.ts
+++ b/packages/next/src/client/next-dev-turbopack.ts
@@ -21,7 +21,7 @@ window.next = {
 // for the page loader
 declare let __turbopack_load__: any
 
-const devClient = initHMR('turbopack')
+const devClient = initHMR()
 initialize({
   devClient,
 })

--- a/packages/next/src/client/next-dev.ts
+++ b/packages/next/src/client/next-dev.ts
@@ -13,7 +13,7 @@ window.next = {
   emitter,
 }
 
-const devClient = initHMR('webpack')
+const devClient = initHMR()
 initialize({ devClient })
   .then(({ assetPrefix }) => {
     return pageBootstrap(assetPrefix)


### PR DESCRIPTION
# Do not review this PR in Graphite, review it one commit at a time: https://github.com/vercel/next.js/pull/76960/commits

This is a series of very small changes to the hot reloader clients in both app and pages router to share more code and unify some of the logic or behavior between the two.

This code is very fragile, so lots of small commits have been useful in bisecting test failures.

These changes are too small to be practical as separate stacked graphite PRs.

Closes PACK-4124