### PR TITLE
feat(styled-jsx): Allow legacy nesting syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6926,9 +6926,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.83.0"
+version = "0.83.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7991fd3e939e5093d5d58fca4f70821f5d4bb384a66c41e53f5c8e41c1e7ec89"
+checksum = "2ede6c96525315b1904d309fd66d69fad412e13efbb2801a98e61e92a25e814b"
 dependencies = [
  "anyhow",
  "lightningcss",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -308,7 +308,7 @@ miette = { version = "5.10.0", features = ["fancy"] }
 mdxjs = "0.3"
 modularize_imports = { version = "0.79.0" }
 styled_components = { version = "0.107.0" }
-styled_jsx = { version = "0.83.0" }
+styled_jsx = { version = "0.83.1" }
 swc_emotion = { version = "0.83.0" }
 swc_relay = { version = "0.53.0" }
 


### PR DESCRIPTION
### What?

Applies https://github.com/swc-project/plugins/pull/425

### Why?

To make it compatible with the babel version of styled-jsx, which supports the legacy nesting syntax.

Closes PACK-4151