### PR TITLE
[dev-overlay] Customize `<select>` styling for consistency

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
@@ -71,22 +71,17 @@ export function UserPreferences({
               Select your theme preference.
             </p>
           </div>
-          <div className="preference-control-select">
-            <div className="preference-icon">
-              <ThemeIcon theme={theme as 'dark' | 'light' | 'system'} />
-            </div>
-            <select
-              id="theme"
-              name="theme"
-              className="select-button"
-              value={theme}
-              onChange={handleThemeChange}
-            >
-              <option value="system">System</option>
-              <option value="light">Light</option>
-              <option value="dark">Dark</option>
-            </select>
-          </div>
+          <Select
+            id="theme"
+            name="theme"
+            prefix={<ThemeIcon theme={theme as 'dark' | 'light' | 'system'} />}
+            value={theme}
+            onChange={handleThemeChange}
+          >
+            <option value="system">System</option>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </Select>
         </div>
 
         <div className="preference-section">
@@ -96,20 +91,17 @@ export function UserPreferences({
               Adjust the placement of your dev tools.
             </p>
           </div>
-          <div className="preference-control-select">
-            <select
-              id="position"
-              name="position"
-              className="select-button"
-              value={position}
-              onChange={handlePositionChange}
-            >
-              <option value="bottom-left">Bottom Left</option>
-              <option value="bottom-right">Bottom Right</option>
-              <option value="top-left">Top Left</option>
-              <option value="top-right">Top Right</option>
-            </select>
-          </div>
+          <Select
+            id="position"
+            name="position"
+            value={position}
+            onChange={handlePositionChange}
+          >
+            <option value="bottom-left">Bottom Left</option>
+            <option value="bottom-right">Bottom Right</option>
+            <option value="top-left">Top Left</option>
+            <option value="top-right">Top Right</option>
+          </Select>
         </div>
 
         <div className="preference-section">
@@ -129,9 +121,7 @@ export function UserPreferences({
               className="action-button"
               onClick={hide}
             >
-              <div className="preference-icon">
-                <EyeIcon />
-              </div>
+              <EyeIcon />
               <span>Hide</span>
             </button>
           </div>
@@ -150,6 +140,16 @@ export function UserPreferences({
         </div>
       </div>
     </DevToolsInfo>
+  )
+}
+
+function Select({ children, prefix, ...props }) {
+  return (
+    <div className="select-button">
+      {prefix}
+      <select {...props}>{children}</select>
+      <ChevronDownIcon />
+    </div>
   )
 }
 
@@ -213,13 +213,6 @@ export const DEV_TOOLS_INFO_USER_PREFERENCES_STYLES = css`
     margin: 0;
   }
 
-  .preference-icon {
-    display: flex;
-    align-items: center;
-    width: 16px;
-    height: 16px;
-  }
-
   .select-button,
   .action-button {
     display: flex;
@@ -238,31 +231,14 @@ export const DEV_TOOLS_INFO_USER_PREFERENCES_STYLES = css`
     }
   }
 
-  .preference-control-select {
-    padding: 6px 8px;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    border-radius: var(--rounded-lg);
-    border: 1px solid var(--color-gray-400);
-
-    &:hover {
-      background: var(--color-gray-100);
-    }
-
+  .select-button {
     &:focus-within {
       outline: var(--focus-ring);
     }
-  }
 
-  .preference-control-select select {
-    font-size: var(--size-14);
-    font-weight: 400;
-    border: none;
-    padding: 0 6px 0 0;
-    border-radius: 0;
-    outline: none;
-    background: none;
+    select {
+      all: unset;
+    }
   }
 
   :global(.icon) {
@@ -271,3 +247,16 @@ export const DEV_TOOLS_INFO_USER_PREFERENCES_STYLES = css`
     color: #666;
   }
 `
+
+function ChevronDownIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M14.0607 5.49999L13.5303 6.03032L8.7071 10.8535C8.31658 11.2441 7.68341 11.2441 7.29289 10.8535L2.46966 6.03032L1.93933 5.49999L2.99999 4.43933L3.53032 4.96966L7.99999 9.43933L12.4697 4.96966L13 4.43933L14.0607 5.49999Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
@@ -143,7 +143,13 @@ export function UserPreferences({
   )
 }
 
-function Select({ children, prefix, ...props }) {
+function Select({
+  children,
+  prefix,
+  ...props
+}: {
+  prefix?: React.ReactNode
+} & React.HTMLProps<HTMLSelectElement>) {
   return (
     <div className="select-button">
       {prefix}

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
@@ -149,7 +149,7 @@ function Select({
   ...props
 }: {
   prefix?: React.ReactNode
-} & React.HTMLProps<HTMLSelectElement>) {
+} & Omit<React.HTMLProps<HTMLSelectElement>, 'prefix'>) {
   return (
     <div className="select-button">
       {prefix}


### PR DESCRIPTION
This PR applies `all: unset` to the `<select>` we use in Preferences for the Dev Overlay and adds a custom icon because we lose the chevron as soon as we apply this.

Why?

So the styling for the control would look more consistent, for example this is what it looks like in Safari now:

![CleanShot 2025-03-11 at 12 36 12@2x](https://github.com/user-attachments/assets/a6da93ce-2b89-4420-8165-c58d4ec8ba29)

And after the changes:

![CleanShot 2025-03-11 at 12 36 24@2x](https://github.com/user-attachments/assets/4f0f4c31-cc0f-436b-9575-e4434c783b4e)

---
Closes NDX-928