### PR TITLE
docs: fix typo for turbo env variable

### DIFF
--- a/docs/01-app/04-api-reference/08-turbopack.mdx
+++ b/docs/01-app/04-api-reference/08-turbopack.mdx
@@ -155,7 +155,7 @@ For more in-depth configuration examples, see the [Turbopack config documentatio
 
 ## Generating trace files for performance debugging
 
-If you encounter performance or memory issues and want to help the Next.js team diagnose them, you can generate a trace file by appending `NEXT_TURBOPACK_TRACING=1` to your dev command:
+If you encounter performance or memory issues and want to help the Next.js team diagnose them, you can generate a trace file by prepending `NEXT_TURBOPACK_TRACING=1` to your dev command:
 
 ```bash
 NEXT_TURBOPACK_TRACING=1 next dev --turbopack


### PR DESCRIPTION
Update wording to make sure the reader understands the variable needs to be prepended to the dev command
