### PR TITLE
[metadata]: add pinterest meta tag

### DIFF
--- a/packages/next/src/lib/metadata/default-metadata.tsx
+++ b/packages/next/src/lib/metadata/default-metadata.tsx
@@ -48,6 +48,7 @@ export function createDefaultMetadata(): ResolvedMetadata {
     formatDetection: null,
     itunes: null,
     facebook: null,
+    pinterest: null,
     abstract: null,
     appLinks: null,
     archives: null,

--- a/packages/next/src/lib/metadata/generate/basic.tsx
+++ b/packages/next/src/lib/metadata/generate/basic.tsx
@@ -157,6 +157,18 @@ export function FacebookMeta({
   ])
 }
 
+export function PinterestMeta({
+  pinterest,
+}: {
+  pinterest: ResolvedMetadata['pinterest']
+}) {
+  if (!pinterest || !pinterest.richPin) return null
+
+  const { richPin } = pinterest
+
+  return <meta property="pinterest-rich-pin" content={richPin.toString()} />
+}
+
 const formatDetectionKeys = [
   'telephone',
   'date',

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -12,6 +12,7 @@ import {
   ViewportMeta,
   VerificationMeta,
   FacebookMeta,
+  PinterestMeta,
 } from './generate/basic'
 import { AlternatesMetadata } from './generate/alternate'
 import {
@@ -392,6 +393,7 @@ function createMetadataElements(metadata: ResolvedMetadata) {
     AlternatesMetadata({ alternates: metadata.alternates }),
     ItunesMeta({ itunes: metadata.itunes }),
     FacebookMeta({ facebook: metadata.facebook }),
+    PinterestMeta({ pinterest: metadata.pinterest }),
     FormatDetectionMeta({ formatDetection: metadata.formatDetection }),
     VerificationMeta({ verification: metadata.verification }),
     AppleWebAppMeta({ appleWebApp: metadata.appleWebApp }),

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -215,7 +215,6 @@ function mergeMetadata({
       case 'facebook':
         target.facebook = resolveFacebook(source.facebook)
         break
-
       case 'verification':
         target.verification = resolveVerification(source.verification)
         break
@@ -272,6 +271,7 @@ function mergeMetadata({
       case 'referrer':
       case 'formatDetection':
       case 'manifest':
+      case 'pinterest':
         // @ts-ignore TODO: support inferring
         target[key] = source[key] || null
         break

--- a/packages/next/src/lib/metadata/types/extra-types.ts
+++ b/packages/next/src/lib/metadata/types/extra-types.ts
@@ -106,6 +106,15 @@ export type ResolvedFacebook = {
   admins?: string[] | undefined
 }
 
+export type Pinterest = PinterestRichPin
+export type PinterestRichPin = {
+  richPin: string | boolean
+}
+
+export type ResolvedPinterest = {
+  richPin?: string
+}
+
 // Format Detection
 // This is a poorly specified metadata export type that is supposed to
 // control whether the device attempts to conver text that matches

--- a/packages/next/src/lib/metadata/types/metadata-interface.ts
+++ b/packages/next/src/lib/metadata/types/metadata-interface.ts
@@ -372,13 +372,12 @@ interface Metadata extends DeprecatedMetadataFields {
   facebook?: null | Facebook | undefined
 
   /**
-   * The Pinterest metadata for the document.
-   * You can choose whether or not to opt out of rich pin data.
+   * The Pinterest metadata for the document to choose whether opt out of rich pin data.
    *
    * @example
    * ```tsx
-   *
-   * <meta name="pinterest-rich-pin" content="false" />
+   * pinterest: { richPin: true }
+   * // Renders <meta name="pinterest-rich-pin" content="true" />
    * ```
    */
   pinterest?: null | Pinterest

--- a/packages/next/src/lib/metadata/types/metadata-interface.ts
+++ b/packages/next/src/lib/metadata/types/metadata-interface.ts
@@ -23,9 +23,11 @@ import type {
   Facebook,
   FormatDetection,
   ItunesApp,
+  Pinterest,
   ResolvedAppleWebApp,
   ResolvedAppLinks,
   ResolvedFacebook,
+  ResolvedPinterest,
   ViewportLayout,
 } from './extra-types'
 import type {
@@ -370,6 +372,18 @@ interface Metadata extends DeprecatedMetadataFields {
   facebook?: null | Facebook | undefined
 
   /**
+   * The Pinterest metadata for the document.
+   * You can choose whether or not to opt out of rich pin data.
+   *
+   * @example
+   * ```tsx
+   *
+   * <meta name="pinterest-rich-pin" content="false" />
+   * ```
+   */
+  pinterest?: null | Pinterest
+
+  /**
    * The common verification tokens for the document.
    *
    * @example
@@ -605,6 +619,8 @@ interface ResolvedMetadata extends DeprecatedMetadataFields {
   twitter: null | ResolvedTwitterMetadata
 
   facebook: null | ResolvedFacebook
+
+  pinterest: null | ResolvedPinterest
 
   // common verification tokens
   verification: null | ResolvedVerification

--- a/test/e2e/app-dir/metadata/app/socials/page.tsx
+++ b/test/e2e/app-dir/metadata/app/socials/page.tsx
@@ -8,6 +8,9 @@ export async function generateMetadata() {
       appId: '12345678',
       admins: ['120', '122', '124'],
     },
+    pinterest: {
+      richPin: true,
+    },
   }
   return metadata
 }

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -162,22 +162,14 @@ describe('app dir - metadata', () => {
       )
     })
 
-    it('should support facebook related tags', async () => {
-      const browser = await next.browser('/facebook')
+    it('should support socials related tags like facebook and pinterest', async () => {
+      const browser = await next.browser('/socials')
       const matchMultiDom = createMultiDomMatcher(browser)
 
       await matchMultiDom('meta', 'property', 'content', {
         'fb:app_id': '12345678',
         'fb:admins': ['120', '122', '124'],
-      })
-    })
-
-    it('should support pinterest related tags', async () => {
-      const browser = await next.browser('/pinterest')
-      const matchDom = createDomMatcher(browser)
-
-      await matchDom('meta', 'property="pinterest-rich-pin"', {
-        content: 'true',
+        'pinterest-rich-pin': 'true',
       })
     })
 

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -172,6 +172,15 @@ describe('app dir - metadata', () => {
       })
     })
 
+    it('should support pinterest related tags', async () => {
+      const browser = await next.browser('/pinterest')
+      const matchDom = createDomMatcher(browser)
+
+      await matchDom('meta', 'property="pinterest-rich-pin"', {
+        content: 'true',
+      })
+    })
+
     it('should support alternate tags', async () => {
       const browser = await next.browser('/alternates')
       const matchDom = createDomMatcher(browser)


### PR DESCRIPTION
### What
Adds support for Pinterest's Rich Pin Data meta tag, while future-proofing for additional Pinterest tags.

This currently works like so

```js
pinterest: {
  richPin: true
}
  ```
 And would resolve to:
 
```html
 <meta property="pinterest-rich-pin" content="true" />
 ```

x-ref: https://help.pinterest.com/en/business/article/rich-pins

Closes #70873 