### PR TITLE
track persistent caching usage

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -206,6 +206,7 @@ import {
 } from '../server/lib/router-utils/build-prefetch-segment-data-route'
 
 import { turbopackBuild } from './turbopack-build'
+import { isPersistentCachingEnabled } from '../shared/lib/turbopack/utils'
 import { inlineStaticEnv, populateStaticEnv } from '../lib/inline-static-env'
 
 type Fallback = null | boolean | string
@@ -2475,6 +2476,10 @@ export default async function build(
         {
           featureName: 'experimental/ppr',
           invocationCount: config.experimental.ppr ? 1 : 0,
+        },
+        {
+          featureName: 'turbopackPersistentCaching',
+          invocationCount: isPersistentCachingEnabled(config) ? 1 : 0,
         },
       ]
       telemetry.record(

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -26,7 +26,10 @@ import type { Telemetry } from '../../../telemetry/storage'
 import type { IncomingMessage, ServerResponse } from 'http'
 import loadJsConfig from '../../../build/load-jsconfig'
 import { createValidFileMatcher } from '../find-page-file'
-import { eventCliSession } from '../../../telemetry/events'
+import {
+  EVENT_BUILD_FEATURE_USAGE,
+  eventCliSession,
+} from '../../../telemetry/events'
 import { getDefineEnv } from '../../../build/webpack/plugins/define-env-plugin'
 import { getSortedRoutes } from '../../../shared/lib/router/utils'
 import {
@@ -73,6 +76,7 @@ import { createEnvDefinitions } from '../experimental/create-env-definitions'
 import { JsConfigPathsPlugin } from '../../../build/webpack/plugins/jsconfig-paths-plugin'
 import { store as consoleStore } from '../../../build/output/store'
 import {
+  isPersistentCachingEnabled,
   ModuleBuildError,
   TurbopackInternalError,
 } from '../../../shared/lib/turbopack/utils'
@@ -996,6 +1000,16 @@ export async function setupDevBundler(opts: SetupOpts) {
       }
     )
   )
+
+  // Track build features for dev server here:
+  opts.telemetry.record({
+    eventName: EVENT_BUILD_FEATURE_USAGE,
+    payload: {
+      featureName: 'turbopackPersistentCaching',
+      invocationCount: isPersistentCachingEnabled(opts.nextConfig) ? 1 : 0,
+    },
+  })
+
   return result
 }
 

--- a/packages/next/src/telemetry/events/build.ts
+++ b/packages/next/src/telemetry/events/build.ts
@@ -178,6 +178,7 @@ export type EventBuildFeatureUsage = {
     | 'esmExternals'
     | 'webpackPlugins'
     | UseCacheTrackerKey
+    | 'turbopackPersistentCaching'
   invocationCount: number
 }
 export function eventBuildFeatureUsage(

--- a/test/integration/telemetry/next.config.persistent-cache
+++ b/test/integration/telemetry/next.config.persistent-cache
@@ -1,0 +1,7 @@
+module.exports = {
+  experimental: {
+    turbo: {
+      unstablePersistentCaching: true
+    }
+  }
+} 


### PR DESCRIPTION
Track the persistent caching usage at dev server start and at production build start.

Closes NDX-682