### PR TITLE
fix(CI): Correctly call test/update-bundler-manifest.js script

### DIFF
--- a/.github/workflows/rspack-update-tests-manifest.yml
+++ b/.github/workflows/rspack-update-tests-manifest.yml
@@ -45,7 +45,7 @@ jobs:
           # We don't currently have any CI running on every PR, so it's quite
           # possible for us to regress on tests. We need to skip the
           # only-promote-to-passing merge logic.
-          SCRIPT: test/update_build_manifest.js --bundler rspack --testSuite dev --override
+          SCRIPT: test/update-bundler-manifest.js --bundler rspack --test-suite dev --override
           PR_TITLE: Update bundler development test manifest
           PR_BODY: This auto-generated PR updates the development integration test manifest used when testing alternative bundlers.
   update_build_manifest:
@@ -81,6 +81,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           BRANCH_NAME: rspack-manifest
-          SCRIPT: test/update_build_manifest.js --bundler rspack --testSuite build --override
+          SCRIPT: test/update-bundler-manifest.js --bundler rspack --test-suite build --override
           PR_TITLE: Update bundler production test manifest
           PR_BODY: This auto-generated PR updates the production integration test manifest used when testing alternative bundlers.

--- a/.github/workflows/turbopack-update-tests-manifest.yml
+++ b/.github/workflows/turbopack-update-tests-manifest.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           BRANCH_NAME: turbopack-manifest
-          SCRIPT: test/update_build_manifest.js --bundler turbopack --testSuite dev
+          SCRIPT: test/update-bundler-manifest.js --bundler turbopack --test-suite dev
           PR_TITLE: Update Turbopack development test manifest
           PR_BODY: This auto-generated PR updates the development integration test manifest used when testing Turbopack.
   update_build_manifest:
@@ -77,6 +77,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           BRANCH_NAME: turbopack-manifest
-          SCRIPT: test/update_build_manifest.js --bundler turbopack --testSuite build
+          SCRIPT: test/update-bundler-manifest.js --bundler turbopack --test-suite build
           PR_TITLE: Update Turbopack production test manifest
           PR_BODY: This auto-generated PR updates the production integration test manifest used when testing Turbopack.


### PR DESCRIPTION
https://vercel.slack.com/archives/C03EWR7LGEN/p1741730241830569

> seems the manifest updating action is broken

Tested by manually triggering jobs on this branch:

- Turbopack Job: https://github.com/vercel/next.js/actions/runs/13799253102
- Rspack Job: https://github.com/vercel/next.js/actions/runs/13799251536

Closes PACK-4121