### PR TITLE
fix(styled-jsx): Pass `useLightningcss` option to `styled-jsx` correctly

### DIFF
--- a/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/crates/next-custom-transforms/src/chain_transforms.rs
@@ -170,7 +170,11 @@ where
                     &file.name,
                     &styled_jsx::visitor::Config {
                         use_lightningcss: config.use_lightningcss,
-                        browsers: *target_browsers,
+                        browsers: if !config.browsers.is_any_target() {
+                            config.browsers
+                        } else {
+                            *target_browsers
+                        },
                     },
                     &styled_jsx::visitor::NativeConfig { process_css: None },
                 ))

--- a/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/crates/next-custom-transforms/src/chain_transforms.rs
@@ -117,6 +117,9 @@ pub struct TransformOptions {
 
     #[serde(default)]
     pub lint_codemod_comments: bool,
+
+    #[serde(default)]
+    pub css_env: Option<swc_core::ecma::preset_env::Config>,
 }
 
 pub fn custom_before_pass<'a, C>(
@@ -151,30 +154,27 @@ where
         }
     };
 
-    let target_browsers = opts
-        .swc
-        .config
-        .env
-        .as_ref()
-        .map(|env| targets_to_versions(env.targets.clone()).expect("failed to parse env.targets"))
-        .unwrap_or_default();
-
     let styled_jsx = {
         let cm = cm.clone();
         let file = file.clone();
 
         fn_pass(move |program| {
             if let Some(config) = opts.styled_jsx.to_option() {
+                let target_browsers = opts
+                    .css_env
+                    .as_ref()
+                    .map(|env| {
+                        targets_to_versions(env.targets.clone())
+                            .expect("failed to parse env.targets")
+                    })
+                    .unwrap_or_default();
+
                 program.mutate(styled_jsx::visitor::styled_jsx(
                     cm.clone(),
                     &file.name,
                     &styled_jsx::visitor::Config {
                         use_lightningcss: config.use_lightningcss,
-                        browsers: if !config.browsers.is_any_target() {
-                            config.browsers
-                        } else {
-                            *target_browsers
-                        },
+                        browsers: *target_browsers,
                     },
                     &styled_jsx::visitor::NativeConfig { process_css: None },
                 ))

--- a/crates/next-custom-transforms/tests/full.rs
+++ b/crates/next-custom-transforms/tests/full.rs
@@ -81,6 +81,7 @@ fn test(input: &Path, minify: bool) {
                 optimize_server_react: None,
                 prefer_esm: false,
                 debug_function_name: false,
+                css_env: None,
             };
 
             let unresolved_mark = Mark::new();

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -197,7 +197,7 @@ function getBaseSWCOptions({
     relay: compilerOptions?.relay,
     // Always transform styled-jsx and error when `client-only` condition is triggered
     styledJsx: compilerOptions?.styledJsx ?? {
-      useLightningcss: jsConfig.experimental?.useLightningcss ?? false,
+      useLightningcss: jsConfig?.experimental?.useLightningcss ?? false,
     },
     // Disable css-in-js libs (without client-only integration) transform on server layer for server components
     ...(!isReactServerLayer && {

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -200,7 +200,6 @@ function getBaseSWCOptions({
     // Always transform styled-jsx and error when `client-only` condition is triggered
     styledJsx: compilerOptions?.styledJsx ?? {
       useLightningcss: jsConfig?.experimental?.useLightningcss ?? false,
-      browsers: supportedBrowsers,
     },
     // Disable css-in-js libs (without client-only integration) transform on server layer for server components
     ...(!isReactServerLayer && {
@@ -237,6 +236,14 @@ function getBaseSWCOptions({
     preferEsm: esm,
     lintCodemodComments: true,
     debugFunctionName: development,
+
+    ...(supportedBrowsers && supportedBrowsers.length > 0
+      ? {
+          cssEnv: {
+            targets: supportedBrowsers,
+          },
+        }
+      : {}),
   }
 }
 

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -196,7 +196,9 @@ function getBaseSWCOptions({
       : undefined,
     relay: compilerOptions?.relay,
     // Always transform styled-jsx and error when `client-only` condition is triggered
-    styledJsx: {},
+    styledJsx: compilerOptions?.styledJsx ?? {
+      useLightningcss: jsConfig.experimental?.useLightningcss ?? false,
+    },
     // Disable css-in-js libs (without client-only integration) transform on server layer for server components
     ...(!isReactServerLayer && {
       // eslint-disable-next-line @typescript-eslint/no-use-before-define

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -65,6 +65,7 @@ function getBaseSWCOptions({
   compilerOptions,
   resolvedBaseUrl,
   jsConfig,
+  supportedBrowsers,
   swcCacheDir,
   serverComponents,
   serverReferenceHashSalt,
@@ -84,6 +85,7 @@ function getBaseSWCOptions({
   swcPlugins: ExperimentalConfig['swcPlugins']
   resolvedBaseUrl?: ResolvedBaseUrl
   jsConfig: any
+  supportedBrowsers: string[] | undefined
   swcCacheDir?: string
   serverComponents?: boolean
   serverReferenceHashSalt: string
@@ -198,6 +200,7 @@ function getBaseSWCOptions({
     // Always transform styled-jsx and error when `client-only` condition is triggered
     styledJsx: compilerOptions?.styledJsx ?? {
       useLightningcss: jsConfig?.experimental?.useLightningcss ?? false,
+      browsers: supportedBrowsers,
     },
     // Disable css-in-js libs (without client-only integration) transform on server layer for server components
     ...(!isReactServerLayer && {
@@ -321,6 +324,7 @@ export function getJestSWCOptions({
     compilerOptions,
     jsConfig,
     resolvedBaseUrl,
+    supportedBrowsers: undefined,
     esm,
     // Don't apply server layer transformations for Jest
     // Disable server / client graph assertions for Jest
@@ -410,6 +414,7 @@ export function getLoaderSWCOptions({
     compilerOptions,
     jsConfig,
     // resolvedBaseUrl,
+    supportedBrowsers,
     swcCacheDir,
     bundleLayer,
     serverComponents,


### PR DESCRIPTION
### What?

Previously, `styled_jsx.useLightningcss` was not passed correctly. This PR fixes it.

### Why?

It's required to enable lightningcss mode for styled-jsx.


Closes PACK-4160