### PR TITLE
refactor: rename isAction to isPossibleServerAction

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -483,11 +483,13 @@ export async function handleAction({
     isURLEncodedAction,
     isMultipartAction,
     isFetchAction,
-    isServerAction,
+    isPossibleServerAction,
   } = getServerActionRequestMetadata(req)
 
-  // If it's not a Server Action, skip handling.
-  if (!isServerAction) {
+  // If it can't be a Server Action, skip handling.
+  // Note that this can be a false positive -- any multipart/urlencoded POST can get us here,
+  // But won't know if it's an MPA action or not until we call `decodeAction` below.
+  if (!isPossibleServerAction) {
     return
   }
 

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -31,7 +31,7 @@ export type WorkStoreContext = {
     incrementalCache?: IncrementalCache
     isOnDemandRevalidate?: boolean
     fetchCache?: AppSegmentConfig['fetchCache']
-    isServerAction?: boolean
+    isPossibleServerAction?: boolean
     pendingWaitUntil?: Promise<any>
     experimental: Pick<
       RenderOpts['experimental'],
@@ -108,7 +108,7 @@ export function createWorkStore({
     !renderOpts.shouldWaitOnAllReady &&
     !renderOpts.supportsDynamicResponse &&
     !renderOpts.isDraftMode &&
-    !renderOpts.isServerAction
+    !renderOpts.isPossibleServerAction
 
   const store: WorkStore = {
     isStaticGeneration,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -150,7 +150,7 @@ import {
 } from './route-modules/checks'
 import { PrefetchRSCPathnameNormalizer } from './normalizers/request/prefetch-rsc'
 import { NextDataPathnameNormalizer } from './normalizers/request/next-data'
-import { getIsServerAction } from './lib/server-action-request-meta'
+import { getIsPossibleServerAction } from './lib/server-action-request-meta'
 import { isInterceptionRouteAppPath } from '../shared/lib/router/utils/interception-routes'
 import { toRoute } from './lib/to-route'
 import type { DeepReadonly } from '../shared/lib/deep-readonly'
@@ -2019,7 +2019,7 @@ export default abstract class Server<
 
     const hasServerProps = !!components.getServerSideProps
     let hasGetStaticPaths = !!components.getStaticPaths
-    const isServerAction = getIsServerAction(req)
+    const isPossibleServerAction = getIsPossibleServerAction(req)
     const hasGetInitialProps = !!components.Component?.getInitialProps
     let isSSG = !!components.getStaticProps
 
@@ -2242,7 +2242,7 @@ export default abstract class Server<
 
     if (
       // Server actions can use non-GET/HEAD methods.
-      !isServerAction &&
+      !isPossibleServerAction &&
       // Resume can use non-GET/HEAD methods.
       !minimalPostponed &&
       !is404Page &&
@@ -2382,7 +2382,7 @@ export default abstract class Server<
       !isPreviewMode &&
       isSSG &&
       !opts.supportsDynamicResponse &&
-      !isServerAction &&
+      !isPossibleServerAction &&
       !minimalPostponed &&
       !isDynamicRSCRequest
     ) {
@@ -2528,7 +2528,7 @@ export default abstract class Server<
         shouldWaitOnAllReady,
         isOnDemandRevalidate,
         isDraftMode: isPreviewMode,
-        isServerAction,
+        isPossibleServerAction,
         postponed,
         waitUntil: this.getWaitUntil(),
         onClose: res.onClose.bind(res),
@@ -2768,7 +2768,7 @@ export default abstract class Server<
               this.nextConfig.experimental.dynamicIO &&
               this.renderOpts.dev &&
               !isPrefetchRSCRequest &&
-              !isServerAction
+              !isPossibleServerAction
             ) {
               const warmup = await module.warmup(req, res, context)
 

--- a/packages/next/src/server/lib/server-action-request-meta.ts
+++ b/packages/next/src/server/lib/server-action-request-meta.ts
@@ -10,7 +10,7 @@ export function getServerActionRequestMetadata(
   isURLEncodedAction: boolean
   isMultipartAction: boolean
   isFetchAction: boolean
-  isServerAction: boolean
+  isPossibleServerAction: boolean
 } {
   let actionId: string | null
   let contentType: string | null
@@ -35,7 +35,7 @@ export function getServerActionRequestMetadata(
       req.method === 'POST'
   )
 
-  const isServerAction = Boolean(
+  const isPossibleServerAction = Boolean(
     isFetchAction || isURLEncodedAction || isMultipartAction
   )
 
@@ -44,12 +44,12 @@ export function getServerActionRequestMetadata(
     isURLEncodedAction,
     isMultipartAction,
     isFetchAction,
-    isServerAction,
+    isPossibleServerAction,
   }
 }
 
-export function getIsServerAction(
+export function getIsPossibleServerAction(
   req: IncomingMessage | BaseNextRequest | NextRequest
 ): boolean {
-  return getServerActionRequestMetadata(req).isServerAction
+  return getServerActionRequestMetadata(req).isPossibleServerAction
 }

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -280,7 +280,7 @@ export type RenderOptsPartial = {
   largePageDataBytes?: number
   isOnDemandRevalidate?: boolean
   strictNextHead: boolean
-  isServerAction?: boolean
+  isPossibleServerAction?: boolean
   isExperimentalCompile?: boolean
   isPrefetch?: boolean
   expireTime?: number

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -51,7 +51,7 @@ import {
   type ActionStore,
 } from '../../app-render/action-async-storage.external'
 import * as sharedModules from './shared-modules'
-import { getIsServerAction } from '../../lib/server-action-request-meta'
+import { getIsPossibleServerAction } from '../../lib/server-action-request-meta'
 import { RequestCookies } from 'next/dist/compiled/@edge-runtime/cookies'
 import { cleanURL } from './helpers/clean-url'
 import { StaticGenBailoutError } from '../../../client/components/static-generation-bailout'
@@ -669,7 +669,7 @@ export class AppRouteRouteModule extends RouteModule<
 
     const actionStore: ActionStore = {
       isAppRoute: true,
-      isAction: getIsServerAction(req),
+      isAction: getIsPossibleServerAction(req),
     }
 
     const implicitTags = await getImplicitTags(


### PR DESCRIPTION
this is a pure rename, with no behavioral changes.

`getServerActionMetadata()` only checks if something:
- is definitely a fetch action (sent from the router, with a 'Next-Action' header set)
- is *potentially* a no-js action (a multipart POST where we need to run decodeAction to check)

so `isAction` is a bit misleading. I've renamed it to `isPossibleServerAction`, and updated related names in other places accordingly.