### PR TITLE
fix: respond with 404 for unrecognized action ids

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -712,5 +712,6 @@
   "711": "Can't resolve %s",
   "712": "`rspack.warnForEdgeRuntime` is not supported by the wasm bindings.",
   "713": "Unexpected error during process lookup",
-  "714": "cannot run loadNative when `NEXT_TEST_WASM` is set"
+  "714": "cannot run loadNative when `NEXT_TEST_WASM` is set",
+  "715": "Server Action \"%s\" was not found on the server. \\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action"
 }

--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -31,3 +31,4 @@ export const NEXT_DID_POSTPONE_HEADER = 'x-nextjs-postponed' as const
 export const NEXT_REWRITTEN_PATH_HEADER = 'x-nextjs-rewritten-path' as const
 export const NEXT_REWRITTEN_QUERY_HEADER = 'x-nextjs-rewritten-query' as const
 export const NEXT_IS_PRERENDER_HEADER = 'x-nextjs-prerender' as const
+export const NEXT_ACTION_NOT_FOUND_HEADER = 'x-nextjs-action-not-found' as const

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -6,6 +6,7 @@ import { callServer } from '../../../app-call-server'
 import { findSourceMapURL } from '../../../app-find-source-map-url'
 import {
   ACTION_HEADER,
+  NEXT_ACTION_NOT_FOUND_HEADER,
   NEXT_IS_PRERENDER_HEADER,
   NEXT_ROUTER_STATE_TREE_HEADER,
   NEXT_URL,
@@ -62,8 +63,8 @@ import { revalidateEntireCache } from '../../segment-cache'
 type FetchServerActionResult = {
   redirectLocation: URL | undefined
   redirectType: RedirectType | undefined
-  actionResult?: ActionResult
-  actionFlightData?: NormalizedFlightData[] | string
+  actionResult: ActionResult | undefined
+  actionFlightData: NormalizedFlightData[] | string | undefined
   isPrerender: boolean
   revalidatedParts: {
     tag: boolean
@@ -110,6 +111,14 @@ async function fetchServerAction(
     body,
   })
 
+  // Handle server actions that the server didn't recognize.
+  const unrecognizedActionHeader = res.headers.get(NEXT_ACTION_NOT_FOUND_HEADER)
+  if (unrecognizedActionHeader === '1') {
+    throw new Error(
+      `Server Action "${actionId}" was not found on the server. \nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action`
+    )
+  }
+
   const redirectHeader = res.headers.get('x-action-redirect')
   const [location, _redirectType] = redirectHeader?.split(';') || []
   let redirectType: RedirectType | undefined
@@ -136,11 +145,7 @@ async function fetchServerAction(
       cookie: revalidatedHeader[2],
     }
   } catch (e) {
-    revalidatedParts = {
-      paths: [],
-      tag: false,
-      cookie: false,
-    }
+    revalidatedParts = NO_REVALIDATED_PARTS
   }
 
   const redirectLocation = location
@@ -151,52 +156,54 @@ async function fetchServerAction(
     : undefined
 
   const contentType = res.headers.get('content-type')
+  const isRscResponse = !!(
+    contentType && contentType.startsWith(RSC_CONTENT_TYPE_HEADER)
+  )
 
-  if (contentType?.startsWith(RSC_CONTENT_TYPE_HEADER)) {
+  // Handle invalid server action responses.
+  // A valid response must have `content-type: text/x-component`, unless it's an external redirect.
+  // (external redirects have an 'x-action-redirect' header, but the body is an empty 'text/plain')
+  if (!isRscResponse && !redirectLocation) {
+    // The server can respond with a text/plain error message, but we'll fallback to something generic
+    // if there isn't one.
+    const message =
+      res.status >= 400 && contentType === 'text/plain'
+        ? await res.text()
+        : 'An unexpected response was received from the server.'
+
+    throw new Error(message)
+  }
+
+  let actionResult: FetchServerActionResult['actionResult']
+  let actionFlightData: FetchServerActionResult['actionFlightData']
+  if (isRscResponse) {
     const response: ActionFlightResponse = await createFromFetch(
       Promise.resolve(res),
       { callServer, findSourceMapURL, temporaryReferences }
     )
-
-    if (location) {
-      // if it was a redirection, then result is just a regular RSC payload
-      return {
-        actionFlightData: normalizeFlightData(response.f),
-        redirectLocation,
-        redirectType,
-        revalidatedParts,
-        isPrerender,
-      }
-    }
-
-    return {
-      actionResult: response.a,
-      actionFlightData: normalizeFlightData(response.f),
-      redirectLocation,
-      redirectType,
-      revalidatedParts,
-      isPrerender,
-    }
-  }
-
-  // Handle invalid server action responses
-  if (res.status >= 400) {
-    // The server can respond with a text/plain error message, but we'll fallback to something generic
-    // if there isn't one.
-    const error =
-      contentType === 'text/plain'
-        ? await res.text()
-        : 'An unexpected response was received from the server.'
-
-    throw new Error(error)
+    // An internal redirect can send an RSC response, but does not have a useful `actionResult`.
+    actionResult = redirectLocation ? undefined : response.a
+    actionFlightData = normalizeFlightData(response.f)
+  } else {
+    // An external redirect doesn't contain RSC data.
+    actionResult = undefined
+    actionFlightData = undefined
   }
 
   return {
+    actionResult,
+    actionFlightData,
     redirectLocation,
     redirectType,
     revalidatedParts,
     isPrerender,
   }
+}
+
+const NO_REVALIDATED_PARTS = {
+  paths: [],
+  tag: false,
+  cookie: false,
 }
 
 /*

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -10,6 +10,7 @@ import {
   RSC_CONTENT_TYPE_HEADER,
   NEXT_ROUTER_STATE_TREE_HEADER,
   ACTION_HEADER,
+  NEXT_ACTION_NOT_FOUND_HEADER,
 } from '../../client/components/app-router-headers'
 import {
   getAccessFallbackHTTPStatus,
@@ -370,7 +371,7 @@ async function createRedirectRenderResult(
     }
   }
 
-  return RenderResult.fromStatic('{}')
+  return RenderResult.fromStatic('')
 }
 
 // Used to compare Host header and Origin header.
@@ -448,6 +449,19 @@ type ServerActionsConfig = {
   allowedOrigins?: string[]
 }
 
+type HandleActionResult =
+  | {
+      /** An MPA action threw notFound(), and we need to render the appropriate HTML */
+      type: 'not-found'
+    }
+  | {
+      type: 'done'
+      result: RenderResult | undefined
+      formState?: any
+    }
+  /** The request turned out not to be a server action. */
+  | null
+
 export async function handleAction({
   req,
   res,
@@ -470,17 +484,7 @@ export async function handleAction({
   serverActions?: ServerActionsConfig
   ctx: AppRenderContext
   metadata: AppPageRenderResultMetadata
-}): Promise<
-  | undefined
-  | {
-      type: 'not-found'
-    }
-  | {
-      type: 'done'
-      result: RenderResult | undefined
-      formState?: any
-    }
-> {
+}): Promise<HandleActionResult> {
   const contentType = req.headers['content-type']
   const { serverActionsManifest, page } = ctx.renderOpts
 
@@ -496,7 +500,7 @@ export async function handleAction({
   // Note that this can be a false positive -- any multipart/urlencoded POST can get us here,
   // But won't know if it's an MPA action or not until we call `decodeAction` below.
   if (!isPossibleServerAction) {
-    return
+    return null
   }
 
   if (workStore.isStaticGeneration) {
@@ -592,13 +596,8 @@ export async function handleAction({
     'no-cache, no-store, max-age=0, must-revalidate'
   )
 
-  let boundActionArguments: unknown[] = []
-
   const { actionAsyncStorage } = ComponentMod
 
-  let actionResult: RenderResult | undefined
-  let formState: any | undefined
-  let actionModId: string | undefined
   const actionWasForwarded = Boolean(req.headers['x-action-forwarded'])
 
   if (actionId) {
@@ -624,331 +623,396 @@ export async function handleAction({
     }
   }
 
-  try {
-    await actionAsyncStorage.run({ isAction: true }, async () => {
-      if (
-        // The type check here ensures that `req` is correctly typed, and the
-        // environment variable check provides dead code elimination.
-        process.env.NEXT_RUNTIME === 'edge' &&
-        isWebNextRequest(req)
-      ) {
-        if (!req.body) {
-          throw new Error('invariant: Missing request body.')
-        }
+  const handleUnrecognizedFetchAction = (err: unknown): HandleActionResult => {
+    // If the deployment doesn't have skew protection, this is expected to occasionally happen,
+    // so we use a warning instead of an error.
+    console.warn(err)
 
-        // TODO: add body limit
-
-        // Use react-server-dom-webpack/server.edge
-        const {
-          createTemporaryReferenceSet,
-          decodeReply,
-          decodeAction,
-          decodeFormState,
-        } = ComponentMod
-
-        temporaryReferences = createTemporaryReferenceSet()
-
-        if (isMultipartAction) {
-          // TODO-APP: Add streaming support
-          const formData = await req.request.formData()
-          if (isFetchAction) {
-            boundActionArguments = await decodeReply(
-              formData,
-              serverModuleMap,
-              { temporaryReferences }
-            )
-          } else {
-            const action = await decodeAction(formData, serverModuleMap)
-            if (typeof action === 'function') {
-              // Only warn if it's a server action, otherwise skip for other post requests
-              warnBadServerActionRequest()
-
-              const actionReturnedState =
-                await executeActionAndPrepareForRender(
-                  action as () => Promise<unknown>,
-                  [],
-                  workStore,
-                  requestStore
-                )
-
-              formState = await decodeFormState(
-                actionReturnedState,
-                formData,
-                serverModuleMap
-              )
-            }
-
-            // Skip the fetch path
-            return
-          }
-        } else {
-          try {
-            actionModId = getActionModIdOrError(actionId, serverModuleMap)
-          } catch (err) {
-            if (actionId !== null) {
-              console.error(err)
-            }
-            return {
-              type: 'not-found',
-            }
-          }
-
-          const chunks: Buffer[] = []
-          const reader = req.body.getReader()
-          while (true) {
-            const { done, value } = await reader.read()
-            if (done) {
-              break
-            }
-
-            chunks.push(value)
-          }
-
-          const actionData = Buffer.concat(chunks).toString('utf-8')
-
-          if (isURLEncodedAction) {
-            const formData = formDataFromSearchQueryString(actionData)
-            boundActionArguments = await decodeReply(
-              formData,
-              serverModuleMap,
-              { temporaryReferences }
-            )
-          } else {
-            boundActionArguments = await decodeReply(
-              actionData,
-              serverModuleMap,
-              { temporaryReferences }
-            )
-          }
-        }
-      } else if (
-        // The type check here ensures that `req` is correctly typed, and the
-        // environment variable check provides dead code elimination.
-        process.env.NEXT_RUNTIME !== 'edge' &&
-        isNodeNextRequest(req)
-      ) {
-        // Use react-server-dom-webpack/server.node which supports streaming
-        const {
-          createTemporaryReferenceSet,
-          decodeReply,
-          decodeReplyFromBusboy,
-          decodeAction,
-          decodeFormState,
-        } = require(
-          `./react-server.node`
-        ) as typeof import('./react-server.node')
-
-        temporaryReferences = createTemporaryReferenceSet()
-
-        const { Transform, pipeline } =
-          require('node:stream') as typeof import('node:stream')
-
-        const defaultBodySizeLimit = '1 MB'
-        const bodySizeLimit =
-          serverActions?.bodySizeLimit ?? defaultBodySizeLimit
-        const bodySizeLimitBytes =
-          bodySizeLimit !== defaultBodySizeLimit
-            ? (
-                require('next/dist/compiled/bytes') as typeof import('next/dist/compiled/bytes')
-              ).parse(bodySizeLimit)
-            : 1024 * 1024 // 1 MB
-
-        let size = 0
-        const sizeLimitTransform = new Transform({
-          transform(chunk, encoding, callback) {
-            size += Buffer.byteLength(chunk, encoding)
-            if (size > bodySizeLimitBytes) {
-              const { ApiError } =
-                require('../api-utils') as typeof import('../api-utils')
-
-              callback(
-                new ApiError(
-                  413,
-                  `Body exceeded ${bodySizeLimit} limit.\n` +
-                    `To configure the body size limit for Server Actions, see: https://nextjs.org/docs/app/api-reference/next-config-js/serverActions#bodysizelimit`
-                )
-              )
-              return
-            }
-
-            callback(null, chunk)
-          },
-        })
-
-        const sizeLimitedBody = pipeline(
-          req.body,
-          sizeLimitTransform,
-          // Avoid unhandled errors from `pipeline()` by passing an empty completion callback.
-          // We'll propagate the errors properly when consuming the stream.
-          () => {}
-        )
-
-        if (isMultipartAction) {
-          if (isFetchAction) {
-            const busboy = (
-              require('next/dist/compiled/busboy') as typeof import('next/dist/compiled/busboy')
-            )({
-              defParamCharset: 'utf8',
-              headers: req.headers,
-              limits: { fieldSize: bodySizeLimitBytes },
-            })
-
-            // We need to use `pipeline(one, two)` instead of `one.pipe(two)` to propagate size limit errors correctly.
-            pipeline(
-              sizeLimitedBody,
-              busboy,
-              // Avoid unhandled errors from `pipeline()` by passing an empty completion callback.
-              // We'll propagate the errors properly when consuming the stream.
-              () => {}
-            )
-
-            boundActionArguments = await decodeReplyFromBusboy(
-              busboy,
-              serverModuleMap,
-              { temporaryReferences }
-            )
-          } else {
-            // React doesn't yet publish a busboy version of decodeAction
-            // so we polyfill the parsing of FormData.
-            const fakeRequest = new Request('http://localhost', {
-              method: 'POST',
-              // @ts-expect-error
-              headers: { 'Content-Type': contentType },
-              body: new ReadableStream({
-                start: (controller) => {
-                  sizeLimitedBody.on('data', (chunk) => {
-                    controller.enqueue(new Uint8Array(chunk))
-                  })
-                  sizeLimitedBody.on('end', () => {
-                    controller.close()
-                  })
-                  sizeLimitedBody.on('error', (err) => {
-                    controller.error(err)
-                  })
-                },
-              }),
-              duplex: 'half',
-            })
-            const formData = await fakeRequest.formData()
-            const action = await decodeAction(formData, serverModuleMap)
-            if (typeof action === 'function') {
-              // Only warn if it's a server action, otherwise skip for other post requests
-              warnBadServerActionRequest()
-
-              const actionReturnedState =
-                await executeActionAndPrepareForRender(
-                  action as () => Promise<unknown>,
-                  [],
-                  workStore,
-                  requestStore
-                )
-
-              formState = await decodeFormState(
-                actionReturnedState,
-                formData,
-                serverModuleMap
-              )
-            }
-
-            // Skip the fetch path
-            return
-          }
-        } else {
-          try {
-            actionModId = getActionModIdOrError(actionId, serverModuleMap)
-          } catch (err) {
-            if (actionId !== null) {
-              console.error(err)
-            }
-            return {
-              type: 'not-found',
-            }
-          }
-
-          const chunks: Buffer[] = []
-          for await (const chunk of sizeLimitedBody) {
-            chunks.push(Buffer.from(chunk))
-          }
-
-          const actionData = Buffer.concat(chunks).toString('utf-8')
-
-          if (isURLEncodedAction) {
-            const formData = formDataFromSearchQueryString(actionData)
-            boundActionArguments = await decodeReply(
-              formData,
-              serverModuleMap,
-              { temporaryReferences }
-            )
-          } else {
-            boundActionArguments = await decodeReply(
-              actionData,
-              serverModuleMap,
-              { temporaryReferences }
-            )
-          }
-        }
-      } else {
-        throw new Error('Invariant: Unknown request type.')
-      }
-
-      // actions.js
-      // app/page.js
-      //   action worker1
-      //     appRender1
-
-      // app/foo/page.js
-      //   action worker2
-      //     appRender
-
-      // / -> fire action -> POST / -> appRender1 -> modId for the action file
-      // /foo -> fire action -> POST /foo -> appRender2 -> modId for the action file
-
-      try {
-        actionModId =
-          actionModId ?? getActionModIdOrError(actionId, serverModuleMap)
-      } catch (err) {
-        if (actionId !== null) {
-          console.error(err)
-        }
-        return {
-          type: 'not-found',
-        }
-      }
-
-      const actionMod = (await ComponentMod.__next_app__.require(
-        actionModId
-      )) as Record<string, (...args: unknown[]) => Promise<unknown>>
-      const actionHandler =
-        actionMod[
-          // `actionId` must exist if we got here, as otherwise we would have thrown an error above
-          actionId!
-        ]
-
-      const returnVal = await executeActionAndPrepareForRender(
-        actionHandler,
-        boundActionArguments,
-        workStore,
-        requestStore
-      ).finally(() => {
-        addRevalidationHeader(res, { workStore, requestStore })
-      })
-
-      // For form actions, we need to continue rendering the page.
-      if (isFetchAction) {
-        actionResult = await generateFlight(req, ctx, requestStore, {
-          actionResult: Promise.resolve(returnVal),
-          // if the page was not revalidated, or if the action was forwarded from another worker, we can skip the rendering the flight tree
-          skipFlight: !workStore.pathWasRevalidated || actionWasForwarded,
-          temporaryReferences,
-        })
-      }
-    })
-
+    // Return an empty response with a header that the client router will interpret.
+    // We don't need to waste time encoding a flight response, and using a blank body + header
+    // means that unrecognized actions can also be handled at the infra level
+    // (i.e. without needing to invoke a lambda)
+    res.setHeader(NEXT_ACTION_NOT_FOUND_HEADER, '1')
+    res.setHeader('content-type', 'text/plain')
+    res.statusCode = 404
     return {
       type: 'done',
-      result: actionResult,
-      formState,
+      result: RenderResult.fromStatic('Server action not found.'),
     }
+  }
+
+  try {
+    return await actionAsyncStorage.run(
+      { isAction: true },
+      async (): Promise<HandleActionResult> => {
+        // We only use these for fetch actions -- MPA actions handle them inside `decodeAction`.
+        let actionModId: string | undefined
+        let boundActionArguments: unknown[] = []
+
+        if (
+          // The type check here ensures that `req` is correctly typed, and the
+          // environment variable check provides dead code elimination.
+          process.env.NEXT_RUNTIME === 'edge' &&
+          isWebNextRequest(req)
+        ) {
+          if (!req.body) {
+            throw new Error('invariant: Missing request body.')
+          }
+
+          // TODO: add body limit
+
+          // Use react-server-dom-webpack/server.edge
+          const {
+            createTemporaryReferenceSet,
+            decodeReply,
+            decodeAction,
+            decodeFormState,
+          } = ComponentMod
+
+          temporaryReferences = createTemporaryReferenceSet()
+
+          if (isMultipartAction) {
+            // TODO-APP: Add streaming support
+            const formData = await req.request.formData()
+            if (isFetchAction) {
+              // A fetch action with a multipart body.
+              boundActionArguments = await decodeReply(
+                formData,
+                serverModuleMap,
+                { temporaryReferences }
+              )
+            } else {
+              // Multipart POST, but not a fetch action.
+              // Potentially an MPA action, we have to try decoding it to check.
+              const action = await decodeAction(formData, serverModuleMap)
+              if (typeof action === 'function') {
+                // an MPA action.
+
+                // Only warn if it's a server action, otherwise skip for other post requests
+                warnBadServerActionRequest()
+
+                const actionReturnedState =
+                  await executeActionAndPrepareForRender(
+                    action as () => Promise<unknown>,
+                    [],
+                    workStore,
+                    requestStore
+                  )
+
+                const formState = await decodeFormState(
+                  actionReturnedState,
+                  formData,
+                  serverModuleMap
+                )
+
+                // Skip the fetch path.
+                // We need to render a full HTML version of the page for the response, we'll handle that in app-render.
+                return {
+                  type: 'done',
+                  result: undefined,
+                  formState,
+                }
+              } else {
+                // We couldn't decode an action, so this POST request turned out not to be a server action request.
+                return null
+              }
+            }
+          } else {
+            // POST with non-multipart body.
+
+            // If it's not multipart AND not a fetch action,
+            // then it can't be an action request.
+            if (!isFetchAction) {
+              return null
+            }
+
+            try {
+              actionModId = getActionModIdOrError(actionId, serverModuleMap)
+            } catch (err) {
+              return handleUnrecognizedFetchAction(err)
+            }
+
+            // A fetch action with a non-multipart body.
+            // In practice, this happens if `encodeReply` returned a string instead of FormData,
+            // which can happen for very simple JSON-like values that don't need multiple flight rows.
+
+            const chunks: Buffer[] = []
+            const reader = req.body.getReader()
+            while (true) {
+              const { done, value } = await reader.read()
+              if (done) {
+                break
+              }
+
+              chunks.push(value)
+            }
+
+            const actionData = Buffer.concat(chunks).toString('utf-8')
+
+            if (isURLEncodedAction) {
+              const formData = formDataFromSearchQueryString(actionData)
+              boundActionArguments = await decodeReply(
+                formData,
+                serverModuleMap,
+                { temporaryReferences }
+              )
+            } else {
+              boundActionArguments = await decodeReply(
+                actionData,
+                serverModuleMap,
+                { temporaryReferences }
+              )
+            }
+          }
+        } else if (
+          // The type check here ensures that `req` is correctly typed, and the
+          // environment variable check provides dead code elimination.
+          process.env.NEXT_RUNTIME !== 'edge' &&
+          isNodeNextRequest(req)
+        ) {
+          // Use react-server-dom-webpack/server.node which supports streaming
+          const {
+            createTemporaryReferenceSet,
+            decodeReply,
+            decodeReplyFromBusboy,
+            decodeAction,
+            decodeFormState,
+          } = require(
+            `./react-server.node`
+          ) as typeof import('./react-server.node')
+
+          temporaryReferences = createTemporaryReferenceSet()
+
+          const { Transform, pipeline } =
+            require('node:stream') as typeof import('node:stream')
+
+          const defaultBodySizeLimit = '1 MB'
+          const bodySizeLimit =
+            serverActions?.bodySizeLimit ?? defaultBodySizeLimit
+          const bodySizeLimitBytes =
+            bodySizeLimit !== defaultBodySizeLimit
+              ? (
+                  require('next/dist/compiled/bytes') as typeof import('next/dist/compiled/bytes')
+                ).parse(bodySizeLimit)
+              : 1024 * 1024 // 1 MB
+
+          let size = 0
+          const sizeLimitTransform = new Transform({
+            transform(chunk, encoding, callback) {
+              size += Buffer.byteLength(chunk, encoding)
+              if (size > bodySizeLimitBytes) {
+                const { ApiError } =
+                  require('../api-utils') as typeof import('../api-utils')
+
+                callback(
+                  new ApiError(
+                    413,
+                    `Body exceeded ${bodySizeLimit} limit.\n` +
+                      `To configure the body size limit for Server Actions, see: https://nextjs.org/docs/app/api-reference/next-config-js/serverActions#bodysizelimit`
+                  )
+                )
+                return
+              }
+
+              callback(null, chunk)
+            },
+          })
+
+          const sizeLimitedBody = pipeline(
+            req.body,
+            sizeLimitTransform,
+            // Avoid unhandled errors from `pipeline()` by passing an empty completion callback.
+            // We'll propagate the errors properly when consuming the stream.
+            () => {}
+          )
+
+          if (isMultipartAction) {
+            if (isFetchAction) {
+              // A fetch action with a multipart body.
+
+              const busboy = (
+                require('next/dist/compiled/busboy') as typeof import('next/dist/compiled/busboy')
+              )({
+                defParamCharset: 'utf8',
+                headers: req.headers,
+                limits: { fieldSize: bodySizeLimitBytes },
+              })
+
+              // We need to use `pipeline(one, two)` instead of `one.pipe(two)` to propagate size limit errors correctly.
+              pipeline(
+                sizeLimitedBody,
+                busboy,
+                // Avoid unhandled errors from `pipeline()` by passing an empty completion callback.
+                // We'll propagate the errors properly when consuming the stream.
+                () => {}
+              )
+
+              boundActionArguments = await decodeReplyFromBusboy(
+                busboy,
+                serverModuleMap,
+                { temporaryReferences }
+              )
+            } else {
+              // Multipart POST, but not a fetch action.
+              // Potentially an MPA action, we have to try decoding it to check.
+
+              // React doesn't yet publish a busboy version of decodeAction
+              // so we polyfill the parsing of FormData.
+              const fakeRequest = new Request('http://localhost', {
+                method: 'POST',
+                // @ts-expect-error
+                headers: { 'Content-Type': contentType },
+                body: new ReadableStream({
+                  start: (controller) => {
+                    sizeLimitedBody.on('data', (chunk) => {
+                      controller.enqueue(new Uint8Array(chunk))
+                    })
+                    sizeLimitedBody.on('end', () => {
+                      controller.close()
+                    })
+                    sizeLimitedBody.on('error', (err) => {
+                      controller.error(err)
+                    })
+                  },
+                }),
+                duplex: 'half',
+              })
+              const formData = await fakeRequest.formData()
+              const action = await decodeAction(formData, serverModuleMap)
+              if (typeof action === 'function') {
+                // an MPA action.
+
+                // Only warn if it's a server action, otherwise skip for other post requests
+                warnBadServerActionRequest()
+
+                const actionReturnedState =
+                  await executeActionAndPrepareForRender(
+                    action as () => Promise<unknown>,
+                    [],
+                    workStore,
+                    requestStore
+                  )
+
+                const formState = await decodeFormState(
+                  actionReturnedState,
+                  formData,
+                  serverModuleMap
+                )
+
+                // Skip the fetch path.
+                // We need to render a full HTML version of the page for the response, we'll handle that in app-render.
+                return {
+                  type: 'done',
+                  result: undefined,
+                  formState,
+                }
+              } else {
+                // We couldn't decode an action, so this POST request turned out not to be a server action request.
+                return null
+              }
+            }
+          } else {
+            // POST with non-multipart body.
+
+            // If it's not multipart AND not a fetch action,
+            // then it can't be an action request.
+            if (!isFetchAction) {
+              return null
+            }
+
+            try {
+              actionModId = getActionModIdOrError(actionId, serverModuleMap)
+            } catch (err) {
+              return handleUnrecognizedFetchAction(err)
+            }
+
+            // A fetch action with a non-multipart body.
+            // In practice, this happens if `encodeReply` returned a string instead of FormData,
+            // which can happen for very simple JSON-like values that don't need multiple flight rows.
+
+            const chunks: Buffer[] = []
+            for await (const chunk of sizeLimitedBody) {
+              chunks.push(Buffer.from(chunk))
+            }
+
+            const actionData = Buffer.concat(chunks).toString('utf-8')
+
+            if (isURLEncodedAction) {
+              const formData = formDataFromSearchQueryString(actionData)
+              boundActionArguments = await decodeReply(
+                formData,
+                serverModuleMap,
+                { temporaryReferences }
+              )
+            } else {
+              boundActionArguments = await decodeReply(
+                actionData,
+                serverModuleMap,
+                { temporaryReferences }
+              )
+            }
+          }
+        } else {
+          throw new Error('Invariant: Unknown request type.')
+        }
+
+        // actions.js
+        // app/page.js
+        //   action worker1
+        //     appRender1
+
+        // app/foo/page.js
+        //   action worker2
+        //     appRender
+
+        // / -> fire action -> POST / -> appRender1 -> modId for the action file
+        // /foo -> fire action -> POST /foo -> appRender2 -> modId for the action file
+
+        try {
+          actionModId =
+            actionModId ?? getActionModIdOrError(actionId, serverModuleMap)
+        } catch (err) {
+          return handleUnrecognizedFetchAction(err)
+        }
+
+        const actionMod = (await ComponentMod.__next_app__.require(
+          actionModId
+        )) as Record<string, (...args: unknown[]) => Promise<unknown>>
+        const actionHandler =
+          actionMod[
+            // `actionId` must exist if we got here, as otherwise we would have thrown an error above
+            actionId!
+          ]
+
+        const returnVal = await executeActionAndPrepareForRender(
+          actionHandler,
+          boundActionArguments,
+          workStore,
+          requestStore
+        ).finally(() => {
+          addRevalidationHeader(res, { workStore, requestStore })
+        })
+
+        // For form actions, we need to continue rendering the page.
+        if (isFetchAction) {
+          const actionResult = await generateFlight(req, ctx, requestStore, {
+            actionResult: Promise.resolve(returnVal),
+            // if the page was not revalidated, or if the action was forwarded from another worker, we can skip the rendering the flight tree
+            skipFlight: !workStore.pathWasRevalidated || actionWasForwarded,
+            temporaryReferences,
+          })
+
+          return {
+            type: 'done',
+            result: actionResult,
+          }
+        } else {
+          // TODO: this shouldn't be reachable, because all non-fetch codepaths return early.
+          // this will be handled in a follow-up refactor PR.
+          return null
+        }
+      }
+    )
   } catch (err) {
     if (isRedirectError(err)) {
       const redirectUrl = getURLFromRedirectError(err)
@@ -974,6 +1038,7 @@ export async function handleAction({
         }
       }
 
+      // For an MPA action, the redirect doesn't need a body, just a Location header.
       res.setHeader('Location', redirectUrl)
       return {
         type: 'done',
@@ -1003,10 +1068,15 @@ export async function handleAction({
           }),
         }
       }
+
+      // For an MPA action, we need to render a HTML response. We'll handle that in app-render.
       return {
         type: 'not-found',
       }
     }
+
+    // An error that didn't come from `redirect()` or `notFound()`, likely thrown from user code
+    // (but it could also be a bug in our code!)
 
     if (isFetchAction) {
       // TODO: consider checking if the error is an `ApiError` and change status code
@@ -1036,6 +1106,7 @@ export async function handleAction({
       }
     }
 
+    // For an MPA action, we need to render a HTML response. We'll rethrow the error and let it be handled above.
     throw err
   }
 }

--- a/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
+++ b/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
@@ -1,0 +1,220 @@
+/* eslint-disable jest/no-standalone-expect */
+import { nextTestSetup } from 'e2e-utils'
+import { createRequestTracker } from 'e2e-utils/request-tracker'
+import { retry } from 'next-test-utils'
+import { outdent } from 'outdent'
+
+describe('unrecognized server actions', () => {
+  const { next, isNextDeploy, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  let cliOutputPosition: number = 0
+  beforeEach(() => {
+    cliOutputPosition = next.cliOutput.length
+  })
+  const getLogs = () => {
+    return next.cliOutput.slice(cliOutputPosition)
+  }
+
+  // This is disabled when deployed because the 404 page will be served as a static route
+  // which will not support POST requests, and will return a 405 instead.
+  if (!isNextDeploy) {
+    it('should 404 when POSTing a non-server-action request to a nonexistent page', async () => {
+      const res = await next.fetch('/non-existent-route', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+        body: 'foo=bar',
+      })
+
+      const cliOutput = getLogs()
+      expect(cliOutput).not.toContain('TypeError')
+      expect(cliOutput).not.toContain(
+        'Missing `origin` header from a forwarded Server Actions request'
+      )
+      expect(res.status).toBe(404)
+    })
+
+    it.each([
+      {
+        // encodeReply encodes simple args as plaintext.
+        name: 'plaintext',
+        request: {
+          contentType: 'text/plain;charset=UTF-8',
+          body: '{}',
+        },
+      },
+      {
+        // encodeReply encodes complex args as FormData.
+        // this body is empty and wouldn't match how react encodes an action, but it should be rejected
+        // before we even get to parsing the FormData, so it doesn't really matter.
+        name: 'form-data/multipart',
+        request: {
+          body: new FormData(),
+        },
+      },
+      {
+        // we never use urlencoded actions, but we currently have codepaths for it in `handleAction`,
+        // so might as well test them.
+        name: 'urlencoded',
+        request: {
+          contentType: 'application/x-www-form-urlencoded',
+          body: 'foo=bar',
+        },
+      },
+    ])(
+      'should 404 when POSTing a server action with an unrecognized id to a nonexistent page: $name',
+      async ({ request: { contentType, body } }) => {
+        const res = await next.fetch('/non-existent-route', {
+          method: 'POST',
+          headers: {
+            'next-action': '123',
+            ...(contentType ? { 'content-type': contentType } : undefined),
+          },
+          // @ts-expect-error: node-fetch types don't seem to like FormData
+          body,
+        })
+
+        expect(res.status).toBe(404)
+
+        const cliOutput = getLogs()
+        expect(cliOutput).not.toContain('TypeError')
+        expect(cliOutput).not.toContain(
+          'Missing `origin` header from a forwarded Server Actions request'
+        )
+        expect(cliOutput).toInclude(outdent`
+          Failed to find Server Action "123". This request might be from an older or newer deployment.
+          Read more: https://nextjs.org/docs/messages/failed-to-find-server-action
+        `)
+      }
+    )
+  }
+
+  describe.each(['nodejs', 'edge'])(
+    'should error and log a warning when submitting a server action with an unrecognized ID - %s',
+    (runtime) => {
+      const testUnrecognizedActionSubmission = async ({
+        formId,
+        disableJavaScript,
+      }: {
+        formId: string
+        disableJavaScript: boolean
+      }) => {
+        const browser = await next.browser(`/${runtime}/unrecognized-action`, {
+          disableJavaScript,
+        })
+        const requestTracker = createRequestTracker(browser)
+
+        const [_, response] = await requestTracker.captureResponse(
+          async () =>
+            await browser
+              .elementByCss(`form#${formId} button[type="submit"]`)
+              .click(),
+          {
+            request: {
+              method: 'POST',
+              pathname: `/${runtime}/unrecognized-action`,
+            },
+          }
+        )
+
+        if (!disableJavaScript) {
+          // A fetch action, sent via the router.
+          expect(response.status()).toBe(404)
+          // NOTE: we cannot validate the response text, because playwright hangs on `response.text()` for some reason.
+          expect(response.headers()['content-type']).toStartWith('text/plain')
+
+          // The submission should throw and trigger our error boundary.
+          expect(await browser.elementByCss(`#error-boundary`).text()).toMatch(
+            /Error boundary: Server Action ".+?" was not found on the server\./
+          )
+
+          // We responded with a 404, but we shouldn't trigger a not-found (either a custom or a default one)
+          expect(await browser.elementByCss('body').text()).not.toContain(
+            'Not found'
+          )
+          expect(await browser.elementByCss('body').text()).not.toContain(
+            'my-not-found'
+          )
+
+          if (!isNextDeploy) {
+            await retry(async () =>
+              expect(getLogs()).toInclude(outdent`
+              Failed to find Server Action "decafc0ffeebad01". This request might be from an older or newer deployment.
+              Read more: https://nextjs.org/docs/messages/failed-to-find-server-action
+            `)
+            )
+          }
+        } else {
+          // An MPA action, sent without JS.
+
+          if (isNextDeploy) {
+            // FIXME: When deployed to vercel, the request is logged as a 500, but returns a 405.
+            // We also don't seem to display the error page correctly,
+            // and the response is inconsistent between nodejs and edge.
+            expect(response.status()).toBe(runtime === 'nodejs' ? 405 : 500)
+            expect(response.headers()['content-type']).toStartWith('text/html')
+          } else {
+            // FIXME: Currently, an unrecognized id in an MPA action results in a 500.
+            // This is not ideal, and ignores all nested `error.js` files, only showing the topmost one.
+            expect(response.status()).toBe(500)
+            expect(response.headers()['content-type']).toStartWith('text/html')
+            // In dev, the 500 page doesn't have any SSR'd html, so it won't show anything without JS.
+            if (!isNextDev) {
+              expect(await browser.elementByCss('body').text()).toContain(
+                'Internal Server Error'
+              )
+            }
+
+            if (!isNextDeploy) {
+              // FIXME: For an MPA action, the logs currently show the error thrown by React instead of our custom message with a link to a docs page.
+              await retry(async () =>
+                expect(getLogs()).toInclude(
+                  `Error: Could not find the module "decafc0ffeebad01" in the React Server Manifest. This is probably a bug in the React Server Components bundler`
+                )
+              )
+            }
+          }
+        }
+      }
+
+      it.each([
+        {
+          description: 'js enabled',
+          disableJavaScript: false,
+        },
+        {
+          description: 'js disabled',
+          disableJavaScript: true,
+        },
+      ])(
+        'server action invoked via form - $description',
+        async ({ disableJavaScript }) => {
+          await testUnrecognizedActionSubmission({
+            formId: 'form-direct',
+            disableJavaScript,
+          })
+        }
+      )
+
+      // these forms rely on client-side JS, so we can't test them with JS disabled
+      it.each([
+        {
+          description: 'with simple argument',
+          formId: 'form-simple-argument',
+        },
+        {
+          description: 'with complex argument',
+          formId: 'form-complex-argument',
+        },
+      ])('server action invoked from JS - $description', async ({ formId }) => {
+        await testUnrecognizedActionSubmission({
+          formId,
+          disableJavaScript: false,
+        })
+      })
+    }
+  )
+})

--- a/test/e2e/app-dir/actions-unrecognized/app/edge/unrecognized-action/page.tsx
+++ b/test/e2e/app-dir/actions-unrecognized/app/edge/unrecognized-action/page.tsx
@@ -1,0 +1,3 @@
+export const runtime = 'edge'
+
+export { default } from '../../nodejs/unrecognized-action/page'

--- a/test/e2e/app-dir/actions-unrecognized/app/layout.tsx
+++ b/test/e2e/app-dir/actions-unrecognized/app/layout.tsx
@@ -1,0 +1,8 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <head />
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/actions-unrecognized/app/nodejs/unrecognized-action/client.tsx
+++ b/test/e2e/app-dir/actions-unrecognized/app/nodejs/unrecognized-action/client.tsx
@@ -1,0 +1,61 @@
+'use client'
+import * as React from 'react'
+import { useActionState } from 'react'
+
+export function FormWithArg<T>({
+  action,
+  argument,
+  id,
+  children,
+}: {
+  action: (state: string, argument: T) => Promise<string>
+  argument: T
+  id: string
+  children?: React.ReactNode
+}) {
+  const [state, dispatch] = useActionState(
+    // don't use `bind()`, we want to explicitly avoid getting a FormData argument
+    // because that always results in a FormData request
+    (state) => action(state, argument),
+    'initial-state'
+  )
+  return (
+    <form id={id} action={dispatch}>
+      <button type="submit">{children}</button>
+      <span className="form-state">{`${state}`}</span>
+    </form>
+  )
+}
+
+export function Form({
+  action,
+}: {
+  action: (state: string, formData: FormData) => Promise<string>
+}) {
+  const [state, dispatch] = useActionState(action, 'initial-state')
+  return (
+    <form action={dispatch} id="form-direct">
+      <button type="submit">Submit server form</button>
+      <span className="form-state">{`${state}`}</span>
+    </form>
+  )
+}
+
+export class ErrorBoundary extends React.Component<{
+  children: React.ReactNode
+}> {
+  state = { error: null }
+  static getDerivedStateFromError(error) {
+    return { error }
+  }
+  render() {
+    if (this.state.error) {
+      return (
+        <div id="error-boundary">
+          Error boundary: {this.state.error.message}
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}

--- a/test/e2e/app-dir/actions-unrecognized/app/nodejs/unrecognized-action/page.tsx
+++ b/test/e2e/app-dir/actions-unrecognized/app/nodejs/unrecognized-action/page.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react'
+import { FormWithArg, Form, ErrorBoundary } from './client'
+
+const action = async (...args: any[]) => {
+  'use server'
+  console.log('hello from server', ...args)
+  return 'state-from-server'
+}
+
+// simulate client-side version skew by changing the action ID to something the server won't recognize
+setServerActionId(action, 'decafc0ffeebad01')
+
+export default function Page() {
+  return (
+    <div>
+      <div>
+        <ErrorBoundary>
+          <Form action={action} />
+        </ErrorBoundary>
+      </div>
+      <div>
+        <ErrorBoundary>
+          <FormWithArg
+            action={action}
+            id="form-simple-argument"
+            argument={{ foo: 'bar' }}
+          >
+            Submit client form with simple argument
+          </FormWithArg>
+        </ErrorBoundary>
+      </div>
+      <div>
+        <ErrorBoundary>
+          <FormWithArg
+            action={action}
+            id="form-complex-argument"
+            argument={new Map([['foo', Promise.resolve('bar')]])}
+          >
+            Submit client form with complex argument
+          </FormWithArg>
+        </ErrorBoundary>
+      </div>
+    </div>
+  )
+}
+
+function setServerActionId(action: (...args: any[]) => any, id: string) {
+  // React implementation detail: `registerServerReference(func, id)` sets `func.$$id = id`.
+  const actionWithMetadata = action as typeof action & { $$id?: string }
+  if (!actionWithMetadata.$$id) {
+    throw new Error(
+      `Expected to find server action metadata properties on ${action}`
+    )
+  }
+  Object.defineProperty(actionWithMetadata, '$$id', {
+    value: id,
+    configurable: true,
+  })
+}

--- a/test/e2e/app-dir/actions-unrecognized/app/not-found.tsx
+++ b/test/e2e/app-dir/actions-unrecognized/app/not-found.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1>my-not-found</h1>
+}

--- a/test/e2e/app-dir/actions-unrecognized/next.config.ts
+++ b/test/e2e/app-dir/actions-unrecognized/next.config.ts
@@ -1,0 +1,10 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  productionBrowserSourceMaps: true,
+  experimental: {
+    serverSourceMaps: true,
+  },
+}
+
+export default nextConfig

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -10,7 +10,6 @@ import {
 import type { Request, Response } from 'playwright'
 import fs from 'node:fs/promises'
 import { join } from 'node:path'
-import { outdent } from 'outdent'
 import { setTimeout } from 'node:timers/promises'
 
 const GENERIC_RSC_ERROR =
@@ -777,113 +776,6 @@ describe('app-dir action handling', () => {
       expect(requests.length).toBe(0)
     }
   })
-
-  // This is disabled when deployed because the 404 page will be served as a static route
-  // which will not support POST requests, and will return a 405 instead.
-  if (!isNextDeploy) {
-    it('should 404 when POSTing a non-server-action request to a nonexistent page', async () => {
-      const cliOutputPosition = next.cliOutput.length
-      const res = await next.fetch('/non-existent-route', {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/x-www-form-urlencoded',
-        },
-        body: 'foo=bar',
-      })
-
-      const cliOutput = next.cliOutput.slice(cliOutputPosition)
-
-      expect(cliOutput).not.toContain('TypeError')
-      expect(cliOutput).not.toContain(
-        'Missing `origin` header from a forwarded Server Actions request'
-      )
-      expect(res.status).toBe(404)
-    })
-
-    it.each([
-      {
-        // encodeReply encodes simple args as plaintext.
-        name: 'plaintext',
-        request: {
-          contentType: 'text/plain;charset=UTF-8',
-          body: '{}',
-        },
-      },
-      {
-        // we never use urlencoded actions, but we currently have codepaths for it in `handleAction`,
-        // so might as well test the,
-        name: 'urlencoded',
-        request: {
-          contentType: 'application/x-www-form-urlencoded',
-          body: 'foo=bar',
-        },
-      },
-    ])(
-      'should 404 when POSTing a server action with an unrecognized id a nonexistent page: $name',
-      async ({ request: { contentType, body } }) => {
-        const cliOutputPosition = next.cliOutput.length
-        const res = await next.fetch('/non-existent-route', {
-          method: 'POST',
-          headers: {
-            'next-action': '123',
-            'content-type': contentType,
-          },
-          body,
-        })
-
-        const cliOutput = next.cliOutput.slice(cliOutputPosition)
-
-        expect(cliOutput).not.toContain('TypeError')
-        expect(cliOutput).not.toContain(
-          'Missing `origin` header from a forwarded Server Actions request'
-        )
-        expect(res.status).toBe(404)
-      }
-    )
-  }
-
-  it.each([
-    {
-      // encodeReply encodes simple args as plaintext.
-      name: 'plaintext',
-      request: {
-        contentType: 'text/plain;charset=UTF-8',
-        body: '{}',
-      },
-    },
-    {
-      // we never use urlencoded actions, but we currently have codepaths for it in `handleAction`,
-      // so might as well test the,
-      name: 'urlencoded',
-      request: {
-        contentType: 'application/x-www-form-urlencoded',
-        body: 'foo=bar',
-      },
-    },
-  ])(
-    'should 404 and log a warning when a server action is not found but an id is provided: $name',
-    async ({ request: { body, contentType } }) => {
-      const response = await next.fetch('/server', {
-        method: 'POST',
-        headers: {
-          'next-action': 'abc123',
-          'content-type': contentType,
-        },
-        body,
-      })
-
-      expect(response.status).toBe(404)
-
-      if (!isNextDeploy) {
-        await retry(async () =>
-          expect(next.cliOutput).toInclude(outdent`
-            Failed to find Server Action "abc123". This request might be from an older or newer deployment.
-            Read more: https://nextjs.org/docs/messages/failed-to-find-server-action
-          `)
-        )
-      }
-    }
-  )
 
   it('should be possible to catch network errors', async () => {
     const browser = await next.browser('/catching-error', {

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -781,7 +781,7 @@ describe('app-dir action handling', () => {
   // This is disabled when deployed because the 404 page will be served as a static route
   // which will not support POST requests, and will return a 405 instead.
   if (!isNextDeploy) {
-    it('should 404 when POSTing an invalid server action', async () => {
+    it('should 404 when POSTing a non-server-action request to a nonexistent page', async () => {
       const cliOutputPosition = next.cliOutput.length
       const res = await next.fetch('/non-existent-route', {
         method: 'POST',
@@ -799,29 +799,91 @@ describe('app-dir action handling', () => {
       )
       expect(res.status).toBe(404)
     })
+
+    it.each([
+      {
+        // encodeReply encodes simple args as plaintext.
+        name: 'plaintext',
+        request: {
+          contentType: 'text/plain;charset=UTF-8',
+          body: '{}',
+        },
+      },
+      {
+        // we never use urlencoded actions, but we currently have codepaths for it in `handleAction`,
+        // so might as well test the,
+        name: 'urlencoded',
+        request: {
+          contentType: 'application/x-www-form-urlencoded',
+          body: 'foo=bar',
+        },
+      },
+    ])(
+      'should 404 when POSTing a server action with an unrecognized id a nonexistent page: $name',
+      async ({ request: { contentType, body } }) => {
+        const cliOutputPosition = next.cliOutput.length
+        const res = await next.fetch('/non-existent-route', {
+          method: 'POST',
+          headers: {
+            'next-action': '123',
+            'content-type': contentType,
+          },
+          body,
+        })
+
+        const cliOutput = next.cliOutput.slice(cliOutputPosition)
+
+        expect(cliOutput).not.toContain('TypeError')
+        expect(cliOutput).not.toContain(
+          'Missing `origin` header from a forwarded Server Actions request'
+        )
+        expect(res.status).toBe(404)
+      }
+    )
   }
 
-  // This is disabled when deployed because it relies on checking runtime logs,
-  // and only build time logs will be available.
-  if (!isNextDeploy) {
-    it('should log a warning when a server action is not found but an id is provided', async () => {
-      await next.fetch('/server', {
+  it.each([
+    {
+      // encodeReply encodes simple args as plaintext.
+      name: 'plaintext',
+      request: {
+        contentType: 'text/plain;charset=UTF-8',
+        body: '{}',
+      },
+    },
+    {
+      // we never use urlencoded actions, but we currently have codepaths for it in `handleAction`,
+      // so might as well test the,
+      name: 'urlencoded',
+      request: {
+        contentType: 'application/x-www-form-urlencoded',
+        body: 'foo=bar',
+      },
+    },
+  ])(
+    'should 404 and log a warning when a server action is not found but an id is provided: $name',
+    async ({ request: { body, contentType } }) => {
+      const response = await next.fetch('/server', {
         method: 'POST',
         headers: {
-          'content-type': 'application/x-www-form-urlencoded',
           'next-action': 'abc123',
+          'content-type': contentType,
         },
-        body: 'foo=bar',
+        body,
       })
 
-      await retry(async () =>
-        expect(next.cliOutput).toInclude(outdent`
-          Failed to find Server Action "abc123". This request might be from an older or newer deployment.
-          Read more: https://nextjs.org/docs/messages/failed-to-find-server-action
-        `)
-      )
-    })
-  }
+      expect(response.status).toBe(404)
+
+      if (!isNextDeploy) {
+        await retry(async () =>
+          expect(next.cliOutput).toInclude(outdent`
+            Failed to find Server Action "abc123". This request might be from an older or newer deployment.
+            Read more: https://nextjs.org/docs/messages/failed-to-find-server-action
+          `)
+        )
+      }
+    }
+  )
 
   it('should be possible to catch network errors', async () => {
     const browser = await next.browser('/catching-error', {
@@ -1656,7 +1718,7 @@ describe('app-dir action handling', () => {
   })
 
   describe('redirects', () => {
-    it('redirects properly when server action handler uses `redirect`', async () => {
+    it('redirects properly when route handler uses `redirect`', async () => {
       const postRequests = []
       const responseCodes = []
 
@@ -1685,12 +1747,12 @@ describe('app-dir action handling', () => {
         expect(await browser.url()).toContain('success=true')
       })
 
-      // verify that the POST request was only made to the action handler
+      // verify that the POST request was only made to the route handler
       expect(postRequests).toEqual(['/redirects/api-redirect'])
       expect(responseCodes).toEqual([303])
     })
 
-    it('redirects properly when server action handler uses `permanentRedirect`', async () => {
+    it('redirects properly when route handler uses `permanentRedirect`', async () => {
       const postRequests = []
       const responseCodes = []
 
@@ -1718,7 +1780,7 @@ describe('app-dir action handling', () => {
       await retry(async () => {
         expect(await browser.url()).toContain('success=true')
       })
-      // verify that the POST request was only made to the action handler
+      // verify that the POST request was only made to the route handler
       expect(postRequests).toEqual(['/redirects/api-redirect-permanent'])
       expect(responseCodes).toEqual([303])
     })
@@ -1783,7 +1845,7 @@ describe('app-dir action handling', () => {
     })
 
     it.each(['307', '308'])(
-      `redirects properly when server action handler redirects with a %s status code`,
+      `redirects properly when route handler redirects with a %s status code`,
       async (statusCode) => {
         const postRequests = []
         const responseCodes = []
@@ -1814,7 +1876,7 @@ describe('app-dir action handling', () => {
         })
         expect(await browser.elementById('redirect-page')).toBeTruthy()
 
-        // since a 307/308 status code follows the redirect, the POST request should be made to both the action handler and the redirect target
+        // since a 307/308 status code follows the redirect, the POST request should be made to both the route handler and the redirect target
         expect(postRequests).toEqual([
           `/redirects/api-redirect-${statusCode}`,
           `/redirects?success=true`,


### PR DESCRIPTION
> [!IMPORTANT]  
> view this diff with "hide whitespace changes", it's unreadable otherwise.

This is an alternative approach to #80613. We touch a lot of same areas but do different changes there, and i also have a bunch more changes stacked on top, so the plan is to just revert that and do this instead.

---

server action calls with an unrecognized action id (i.e. one not found in `serverModuleMap`) have been returning a 200 instead of a 404 for quite some time. and also rendering the page they were called on.

### The problem

this happened due to an unfortunate mistake. `handleAction` has a section like this:
```ts
await actionAsyncStorage.run(
  { isAction: true },
  // "the callback"
  async () => {
    ...
  }
);

return {
  type: 'done',
  result: actionResult,
  formState,
}
```

inside that callback, we have many places that validate the action id and try to bail out if it's not recognized:

```ts
try {
  actionModId = getActionModIdOrError(actionId);
} catch (err) {
  console.error(err);
  return { type: 'not-found '}
}
```

this was clearly intended to be an early return from `handleAction`. but it didn't work, because outside the callback we're doing
```ts
await actionAsyncStorage.run(...)
```
i.e. **discarding the callback's return value**. So instead of returning `'not-found'` as intended, we end up falling through to the `'done'` return right after, and returning `{ type: 'done', result: undefined, formState: undefined }`.

then, our caller,`renderToHTMLToFlightImpl` looks at that what we returned, and sees a 'done'
https://github.com/vercel/next.js/blob/768183c5ddbaa94c1f6004816a1fae282fa0ab04/packages/next/src/server/app-render/app-render.tsx#L1522-L1547
but because if there's no `result` or `formState`, it'll fall through the conditionals and do the same thing it'd do if we returned `null/undefined` (i.e. if `!actionRequestResult`). so we end up on the rendering path, render a page, and finally respond with a 200.

### The fix, part 1

This PR fixes this. we're now directly returning the value from the callback (`return await actionAsyncStorage.run(...)`) . i got rid of all the weird fallthroughs and made each of the branches return something explicitly. I've also changed `handleAction`'s return type to have a `... | null` instead of `... | undefined` (which is interpreted as "this was not an action request") so that it's not possible to fall off the end of the function without an explicit return.

### The fix, part 2

To make this more complicated, returning `'not-found'` for fetch actions was actually also incorrect! that value makes `renderToHTMLToFlightImpl` render an HTML 404 page, which is pretty useless as a (fetch) action response -- it's got the wrong content type!  (#80613 relied on this to make the action fail on the client-side, which isn't ideal, because the error message doesn't indicate what the problem is).

To solve this, `handleAction` now returns a custom 404 response tagged with a `x-nextjs-action-not-found` header (and uses `{ type: 'done' }` instead of `{ type: 'not-found' }` to bypass the aformentioned 404 handling). Then, on the client, `fetchServerAction` checks for this header, and throw a corresponding error. Other 404s will still throw a `An unexpected response was received from the server.` error instead, because they had to come from something else, like a bad proxy rewrite.