### PR TITLE
fix: improve error messages for unrecognized action ids

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -661,5 +661,6 @@
   "660": "Rspack support is only available in Next.js canary.",
   "661": "Build failed because of %s errors",
   "662": "Invariant failed to find webpack runtime chunk",
-  "663": "Invariant: client chunk changed but failed to detect hash %s"
+  "663": "Invariant: client chunk changed but failed to detect hash %s",
+  "664": "Failed to find Server Action \"%s\". This request might be from an older or newer deployment.%s\\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action"
 }

--- a/packages/next/src/server/app-render/action-utils.ts
+++ b/packages/next/src/server/app-render/action-utils.ts
@@ -20,7 +20,11 @@ export function createServerModuleMap({
         const workers =
           serverActionsManifest[
             process.env.NEXT_RUNTIME === 'edge' ? 'edge' : 'node'
-          ][id].workers
+          ][id]?.workers
+
+        if (!workers) {
+          return undefined
+        }
 
         const workStore = workAsyncStorage.getStore()
 


### PR DESCRIPTION
previously, most error messages about unrecognized action ids would look like this:

```
Failed to find Server Action "${actionId}". This request might be from an older or newer deployment.
Original Error: Cannot read properties of undefined (reading 'workers')
```

...because `createServerModuleMap` wasn't guarding against the id not being present in the manifest and just crashed.
I changed it to gracefully return `undefined` instead.

on the other hand, if the action id *was* present in the manifest, but not available in the current worker, we'd print

```
Failed to find Server Action "${actionId}". This request might be from an older or newer deployment.
Original Error: Invariant: Couldn't find action module ID from module map.
```

...because `getActionModIdOrError` was throwing that invariant error and immediately catching it.
this is "Invariant" messsage is redundant and doesn't help the user in any way.


after refactoring `getActionModIdOrError` to no longer throw that useless error if the manifest yielded undefined,
both of the above will now be just:

```
Failed to find Server Action "${actionId}". This request might be from an older or newer deployment.
```

and the "Original Error: ..." form should only occur in exceptional circumstances,
i.e. when `createServerModuleMap` throws something unexpected.

### TODO
- [ ] add tests