### PR TITLE
fix: check action id early for multipart fetch actions

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -646,8 +646,8 @@ export async function handleAction({
       { isAction: true },
       async (): Promise<HandleActionResult> => {
         // We only use these for fetch actions -- MPA actions handle them inside `decodeAction`.
-        let actionModId: string | undefined
-        let boundActionArguments: unknown[] = []
+        let actionModId: string
+        let boundActionArguments: unknown[]
 
         if (
           // The type check here ensures that `req` is correctly typed, and the
@@ -675,6 +675,12 @@ export async function handleAction({
             // TODO-APP: Add streaming support
             const formData = await req.request.formData()
             if (isFetchAction) {
+              try {
+                actionModId = getActionModIdOrError(actionId, serverModuleMap)
+              } catch (err) {
+                return handleUnrecognizedFetchAction(err)
+              }
+
               // A fetch action with a multipart body.
               boundActionArguments = await decodeReply(
                 formData,
@@ -835,6 +841,12 @@ export async function handleAction({
             if (isFetchAction) {
               // A fetch action with a multipart body.
 
+              try {
+                actionModId = getActionModIdOrError(actionId, serverModuleMap)
+              } catch (err) {
+                return handleUnrecognizedFetchAction(err)
+              }
+
               const busboy = (
                 require('next/dist/compiled/busboy') as typeof import('next/dist/compiled/busboy')
               )({
@@ -978,19 +990,12 @@ export async function handleAction({
         // / -> fire action -> POST / -> appRender1 -> modId for the action file
         // /foo -> fire action -> POST /foo -> appRender2 -> modId for the action file
 
-        try {
-          actionModId =
-            actionModId ?? getActionModIdOrError(actionId, serverModuleMap)
-        } catch (err) {
-          return handleUnrecognizedFetchAction(err)
-        }
-
         const actionMod = (await ComponentMod.__next_app__.require(
           actionModId
         )) as Record<string, (...args: unknown[]) => Promise<unknown>>
         const actionHandler =
           actionMod[
-            // `actionId` must exist if we got here, as otherwise we would have thrown an error above
+            // `actionId` must exist if we got here, as otherwise `getActionModIdOrError` would have thrown earlier
             actionId!
           ]
 


### PR DESCRIPTION
the branches of `handleAction` where "`isFetchAction`, but not `isMultipart`" all call `getActionModIdOrError` before doing anything else. i don't see a good reason why the `isMultipart` branches shouldn't do the same -- there's no point decoding the action arguments if we're going to later discover that the action id is invalid. so i've added the same check in those.

this also lets us turn `let actionModId: string | undefined` into just `let actionModId: string`, because typescript understands that all codepaths that reach \[the section that `require()`s the action module\] have already assigned a value to `actionModId`.

i don't think this is really sensibly testable -- the only case i can think of that would have an observable change would be an action request that

1. has an unrecognized action id
2. but also has args that cause a crash in `decodeReply`

previously, we'd hit `decodeAction` first and never get to validating the action id. and after this PR we'd print "Failed to find Server Action", because that check goes first now.