### PR TITLE
refactor: nicer return types in action handler

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -455,12 +455,19 @@ type HandleActionResult =
       type: 'not-found'
     }
   | {
-      type: 'done'
-      result: RenderResult | undefined
-      formState?: any
+      /** The request turned out to not be an action. */
+      type: 'not-an-action'
     }
-  /** The request turned out not to be a server action. */
-  | null
+  | {
+      /** We decoded a FormState, but haven't rendered anything yet. */
+      type: 'form-state'
+      formState: any
+    }
+  | {
+      /** A finished result. */
+      type: 'done'
+      result: RenderResult
+    }
 
 export async function handleAction({
   req,
@@ -500,7 +507,7 @@ export async function handleAction({
   // Note that this can be a false positive -- any multipart/urlencoded POST can get us here,
   // But won't know if it's an MPA action or not until we call `decodeAction` below.
   if (!isPossibleServerAction) {
-    return null
+    return { type: 'not-an-action' }
   }
 
   if (workStore.isStaticGeneration) {
@@ -696,36 +703,35 @@ export async function handleAction({
                 throwIfActionNotInModuleMap(serverModuleMap)
               )
 
-              if (typeof action === 'function') {
-                // an MPA action.
+              if (typeof action !== 'function') {
+                // We couldn't decode an action, so this POST request turned out not to be a server action request.
+                return { type: 'not-an-action' }
+              }
 
-                // Only warn if it's a server action, otherwise skip for other post requests
-                warnBadServerActionRequest()
+              // an MPA action.
 
-                const actionReturnedState =
-                  await executeActionAndPrepareForRender(
-                    action as () => Promise<unknown>,
-                    [],
-                    workStore,
-                    requestStore
-                  )
+              // Only warn if it's a server action, otherwise skip for other post requests
+              warnBadServerActionRequest()
 
-                const formState = await decodeFormState(
-                  actionReturnedState,
-                  formData,
-                  serverModuleMap
+              const actionReturnedState =
+                await executeActionAndPrepareForRender(
+                  action as () => Promise<unknown>,
+                  [],
+                  workStore,
+                  requestStore
                 )
 
-                // Skip the fetch path.
-                // We need to render a full HTML version of the page for the response, we'll handle that in app-render.
-                return {
-                  type: 'done',
-                  result: undefined,
-                  formState,
-                }
-              } else {
-                // We couldn't decode an action, so this POST request turned out not to be a server action request.
-                return null
+              const formState = await decodeFormState(
+                actionReturnedState,
+                formData,
+                serverModuleMap
+              )
+
+              // Skip the fetch path.
+              // We need to render a full HTML version of the page for the response, we'll handle that in app-render.
+              return {
+                type: 'form-state',
+                formState,
               }
             }
           } else {
@@ -734,7 +740,7 @@ export async function handleAction({
             // If it's not multipart AND not a fetch action,
             // then it can't be an action request.
             if (!isFetchAction) {
-              return null
+              return { type: 'not-an-action' }
             }
 
             try {
@@ -901,36 +907,35 @@ export async function handleAction({
                 throwIfActionNotInModuleMap(serverModuleMap)
               )
 
-              if (typeof action === 'function') {
-                // an MPA action.
+              if (typeof action !== 'function') {
+                // We couldn't decode an action, so this POST request turned out not to be a server action request.
+                return { type: 'not-an-action' }
+              }
 
-                // Only warn if it's a server action, otherwise skip for other post requests
-                warnBadServerActionRequest()
+              // an MPA action.
 
-                const actionReturnedState =
-                  await executeActionAndPrepareForRender(
-                    action as () => Promise<unknown>,
-                    [],
-                    workStore,
-                    requestStore
-                  )
+              // Only warn if it's a server action, otherwise skip for other post requests
+              warnBadServerActionRequest()
 
-                const formState = await decodeFormState(
-                  actionReturnedState,
-                  formData,
-                  serverModuleMap
+              const actionReturnedState =
+                await executeActionAndPrepareForRender(
+                  action as () => Promise<unknown>,
+                  [],
+                  workStore,
+                  requestStore
                 )
 
-                // Skip the fetch path.
-                // We need to render a full HTML version of the page for the response, we'll handle that in app-render.
-                return {
-                  type: 'done',
-                  result: undefined,
-                  formState,
-                }
-              } else {
-                // We couldn't decode an action, so this POST request turned out not to be a server action request.
-                return null
+              const formState = await decodeFormState(
+                actionReturnedState,
+                formData,
+                serverModuleMap
+              )
+
+              // Skip the fetch path.
+              // We need to render a full HTML version of the page for the response, we'll handle that in app-render.
+              return {
+                type: 'form-state',
+                formState,
               }
             }
           } else {
@@ -939,7 +944,7 @@ export async function handleAction({
             // If it's not multipart AND not a fetch action,
             // then it can't be an action request.
             if (!isFetchAction) {
-              return null
+              return { type: 'not-an-action' }
             }
 
             try {
@@ -978,6 +983,11 @@ export async function handleAction({
           throw new Error('Invariant: Unknown request type.')
         }
 
+        // Handle a fetch action.
+
+        // Ensure that non-fetch codepaths can't reach this part.
+        isFetchAction satisfies true
+
         // actions.js
         // app/page.js
         //   action worker1
@@ -993,6 +1003,7 @@ export async function handleAction({
         const actionMod = (await ComponentMod.__next_app__.require(
           actionModId
         )) as Record<string, (...args: unknown[]) => Promise<unknown>>
+
         const actionHandler = actionMod[actionId]
 
         const returnVal = await executeActionAndPrepareForRender(
@@ -1004,23 +1015,16 @@ export async function handleAction({
           addRevalidationHeader(res, { workStore, requestStore })
         })
 
-        // For form actions, we need to continue rendering the page.
-        if (isFetchAction) {
-          const actionResult = await generateFlight(req, ctx, requestStore, {
-            actionResult: Promise.resolve(returnVal),
-            // if the page was not revalidated, or if the action was forwarded from another worker, we can skip the rendering the flight tree
-            skipFlight: !workStore.pathWasRevalidated || actionWasForwarded,
-            temporaryReferences,
-          })
+        const actionResult = await generateFlight(req, ctx, requestStore, {
+          actionResult: Promise.resolve(returnVal),
+          // if the page was not revalidated, or if the action was forwarded from another worker, we can skip the rendering the flight tree
+          skipFlight: !workStore.pathWasRevalidated || actionWasForwarded,
+          temporaryReferences,
+        })
 
-          return {
-            type: 'done',
-            result: actionResult,
-          }
-        } else {
-          // TODO: this shouldn't be reachable, because all non-fetch codepaths return early.
-          // this will be handled in a follow-up refactor PR.
-          return null
+        return {
+          type: 'done',
+          result: actionResult,
         }
       }
     )

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -993,11 +993,7 @@ export async function handleAction({
         const actionMod = (await ComponentMod.__next_app__.require(
           actionModId
         )) as Record<string, (...args: unknown[]) => Promise<unknown>>
-        const actionHandler =
-          actionMod[
-            // `actionId` must exist if we got here, as otherwise `getActionModIdOrError` would have thrown earlier
-            actionId!
-          ]
+        const actionHandler = actionMod[actionId]
 
         const returnVal = await executeActionAndPrepareForRender(
           actionHandler,
@@ -1159,12 +1155,11 @@ async function executeActionAndPrepareForRender<
 }
 
 /**
- * Attempts to find the module ID for the action from the module map. When this fails, it could be a deployment skew where
- * the action came from a different deployment. It could also simply be an invalid POST request that is not a server action.
- * In either case, we'll throw an error to be handled by the caller.
+ * Attempts to find the module ID for the action from the module map.
+ * When this fails, it could be a deployment skew where the action came from a different deployment.
  */
 function getActionModIdOrError(
-  actionId: string | null,
+  actionId: string,
   serverModuleMap: ServerModuleMap
 ): string {
   // if we're missing the action ID header, we can't do any further processing

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1585,31 +1585,40 @@ async function renderToHTMLOrFlightImpl(
         metadata,
       })
 
-      if (actionRequestResult) {
-        if (actionRequestResult.type === 'not-found') {
-          const notFoundLoaderTree = createNotFoundLoaderTree(loaderTree)
-          res.statusCode = 404
-          metadata.statusCode = 404
-          const stream = await renderToStreamWithTracing(
-            requestStore,
-            req,
-            res,
-            ctx,
-            notFoundLoaderTree,
-            formState,
-            postponedState,
-            metadata
-          )
+      if (actionRequestResult.type === 'not-found') {
+        const notFoundLoaderTree = createNotFoundLoaderTree(loaderTree)
+        res.statusCode = 404
+        metadata.statusCode = 404
+        const stream = await renderToStreamWithTracing(
+          requestStore,
+          req,
+          res,
+          ctx,
+          workStore,
+          notFoundLoaderTree,
+          formState,
+          postponedState,
+          metadata
+        )
 
-          return new RenderResult(stream, { metadata })
-        } else if (actionRequestResult.type === 'done') {
-          if (actionRequestResult.result) {
-            actionRequestResult.result.assignMetadata(metadata)
-            return actionRequestResult.result
-          } else if (actionRequestResult.formState) {
-            formState = actionRequestResult.formState
-          }
-        }
+        return new RenderResult(stream, { metadata })
+      } else if (actionRequestResult.type === 'done') {
+        // We ran the action, and have a flight result. Nothing more to do here.
+        actionRequestResult.result.assignMetadata(metadata)
+        return actionRequestResult.result
+      } else if (actionRequestResult.type === 'form-state') {
+        // an MPA action. We ran the action, but haven't rendered anything yet, only decoded a form state.
+        // We need to produce an HTML response, so continue rendering below.
+        formState = actionRequestResult.formState
+      } else if (actionRequestResult.type === 'not-an-action') {
+        // This is likely a form submission request targetting a page. Generally, this can happen if:
+        // - the user did `<form action="/this-page">` using a vanilla HTML form
+        // - the user did `<form action="/router-handler">` using a vanilla HTML form,
+        //   and the route handler responded with a 307/308 to a page, so the browser retried the POST request at the new URL
+        // In both of these cases we should render the page to HTML as a response.
+        //
+        // TODO: we should consider disallowing these requests altogether, because they only work for dynamic pages,
+        // and would stop working if the page became static. (a POST to a static page will result in a 405).
       }
     }
 

--- a/packages/next/src/server/lib/server-action-request-meta.ts
+++ b/packages/next/src/server/lib/server-action-request-meta.ts
@@ -3,15 +3,25 @@ import type { BaseNextRequest } from '../base-http'
 import type { NextRequest } from '../web/exports'
 import { ACTION_HEADER } from '../../client/components/app-router-headers'
 
+export type ServerActionRequestMetadata =
+  | {
+      isFetchAction: true
+      actionId: string
+      isURLEncodedAction: boolean
+      isMultipartAction: boolean
+      isPossibleServerAction: true
+    }
+  | {
+      isFetchAction: false
+      actionId: null
+      isURLEncodedAction: boolean
+      isMultipartAction: boolean
+      isPossibleServerAction: boolean
+    }
+
 export function getServerActionRequestMetadata(
   req: IncomingMessage | BaseNextRequest | NextRequest
-): {
-  actionId: string | null
-  isURLEncodedAction: boolean
-  isMultipartAction: boolean
-  isFetchAction: boolean
-  isPossibleServerAction: boolean
-} {
+): ServerActionRequestMetadata {
   let actionId: string | null
   let contentType: string | null
 
@@ -29,21 +39,26 @@ export function getServerActionRequestMetadata(
   const isMultipartAction = Boolean(
     req.method === 'POST' && contentType?.startsWith('multipart/form-data')
   )
-  const isFetchAction = Boolean(
-    actionId !== undefined &&
-      typeof actionId === 'string' &&
-      req.method === 'POST'
-  )
+  if (actionId !== null && req.method === 'POST') {
+    return {
+      isFetchAction: true,
+      actionId,
+      isMultipartAction,
+      isURLEncodedAction,
+      isPossibleServerAction: true,
+    }
+  }
 
   const isPossibleServerAction = Boolean(
-    isFetchAction || isURLEncodedAction || isMultipartAction
+    isURLEncodedAction || isMultipartAction
   )
 
   return {
-    actionId,
+    isFetchAction: false,
+    // it may technically be non-null, but there's no use for it outside a fetch action.
+    actionId: null,
     isURLEncodedAction,
     isMultipartAction,
-    isFetchAction,
     isPossibleServerAction,
   }
 }


### PR DESCRIPTION
a follow-up to https://github.com/vercel/next.js/pull/77012. intended to be a pure refactor, with no behavioral changes.

**continue simplifying the control flow inside `handleAction`**
  - turn some conditionals into early returns
  - add an assertion that all non-fetch codepaths exit before we hit the part that loads + runs a fetch action
  - improve the types in `getServerActionRequestMetadata` to make typescript understand that if `isFetchAction`, then `actionId` is non-null

**clean up the return type of `handleAction`**
- `null` is now a more obvious `{ type: 'not-an-action' }`
- `type: 'done'` is split into two disjoint cases, where we either have a `result` or a `formState` (can't have both at once). 
