### PR TITLE
refactor: splitting up the action handler

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -714,5 +714,6 @@
   "713": "Unexpected error during process lookup",
   "714": "cannot run loadNative when `NEXT_TEST_WASM` is set",
   "715": "Server Action \"%s\" was not found on the server. \\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
-  "716": "`unstable_isUnrecognizedActionError` can only be used on the client."
+  "716": "`unstable_isUnrecognizedActionError` can only be used on the client.",
+  "717": "This function cannot be used in the edge runtime"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -715,5 +715,6 @@
   "714": "cannot run loadNative when `NEXT_TEST_WASM` is set",
   "715": "Server Action \"%s\" was not found on the server. \\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
   "716": "`unstable_isUnrecognizedActionError` can only be used on the client.",
-  "717": "This function cannot be used in the edge runtime"
+  "717": "This function cannot be used in the edge runtime",
+  "718": "Action handler not found in action module"
 }

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -649,12 +649,141 @@ export async function handleAction({
     }
   }
 
+  const handleNonFetchAction = async (): Promise<HandleActionResult> => {
+    // This might be an MPA action, but it might also be a random POST request.
+
+    if (!isMultipartAction) {
+      // Not a fetch action and not multipart.
+      // It can't be an action request.
+      return { type: 'not-an-action' }
+    }
+
+    if (
+      // The type check here ensures that `req` is correctly typed, and the
+      // environment variable check provides dead code elimination.
+      process.env.NEXT_RUNTIME === 'edge' &&
+      isWebNextRequest(req)
+    ) {
+      // Use react-server-dom-webpack/server.edge
+      const { decodeAction, decodeFormState } = ComponentMod
+
+      // TODO-APP: Add streaming support
+      const formData = await req.request.formData()
+
+      const action = await decodeAction(
+        formData,
+        throwIfActionNotInModuleMap(serverModuleMap)
+      )
+
+      if (typeof action !== 'function') {
+        // We couldn't decode an action, so this POST request turned out not to be a server action request.
+        return { type: 'not-an-action' }
+      }
+
+      // an MPA action.
+
+      // Only warn if it's a server action, otherwise skip for other post requests
+      warnBadServerActionRequest()
+
+      const actionReturnedState = await executeActionAndPrepareForRender(
+        action as () => Promise<unknown>,
+        [],
+        workStore,
+        requestStore
+      )
+
+      const formState = await decodeFormState(
+        actionReturnedState,
+        formData,
+        serverModuleMap
+      )
+
+      // We need to render a full HTML version of the page for the response, we'll handle that in app-render.
+      return {
+        type: 'form-state',
+        formState,
+      }
+    } else if (
+      // The type check here ensures that `req` is correctly typed, and the
+      // environment variable check provides dead code elimination.
+      process.env.NEXT_RUNTIME !== 'edge' &&
+      isNodeNextRequest(req)
+    ) {
+      // Use react-server-dom-webpack/server.node
+      const { decodeAction, decodeFormState } = require(
+        `./react-server.node`
+      ) as typeof import('./react-server.node')
+
+      const bodySizeLimit = resolveBodySizeLimitNode(serverActions)
+      const sizeLimitedBody = getSizeLimitedRequestBodyNode(req, bodySizeLimit)
+
+      // Multipart POST, but not a fetch action.
+      // Potentially an MPA action, we have to try decoding it to check.
+
+      // React doesn't yet publish a busboy version of decodeAction
+      // so we polyfill the parsing of FormData.
+      const formData = await parseBodyAsFormDataNode(
+        sizeLimitedBody,
+        req.headers['content-type']
+      )
+
+      const action = await decodeAction(
+        formData,
+        throwIfActionNotInModuleMap(serverModuleMap)
+      )
+
+      if (typeof action !== 'function') {
+        // We couldn't decode an action, so this POST request turned out not to be a server action request.
+        return { type: 'not-an-action' }
+      }
+
+      // an MPA action.
+
+      // Only warn if it's a server action, otherwise skip for other post requests
+      warnBadServerActionRequest()
+
+      const actionReturnedState = await executeActionAndPrepareForRender(
+        action as () => Promise<unknown>,
+        [],
+        workStore,
+        requestStore
+      )
+
+      const formState = await decodeFormState(
+        actionReturnedState,
+        formData,
+        serverModuleMap
+      )
+
+      // We need to render a full HTML version of the page for the response, we'll handle that in app-render.
+      return {
+        type: 'form-state',
+        formState,
+      }
+    } else {
+      throw new Error('Invariant: Unknown request type.')
+    }
+  }
+
   try {
     return await actionAsyncStorage.run(
       { isAction: true },
       async (): Promise<HandleActionResult> => {
-        // We only use these for fetch actions -- MPA actions handle them inside `decodeAction`.
+        if (!isFetchAction) {
+          return await handleNonFetchAction()
+        }
+
+        // A fetch action (initiated by the client router).
+
+        // Check the action id. if it's not valid, we can bail out immediately.
         let actionModId: string
+        try {
+          actionModId = getActionModIdOrError(actionId, serverModuleMap)
+        } catch (err) {
+          return handleUnrecognizedFetchAction(err)
+        }
+
+        // Parse the action arguments.
         let boundActionArguments: unknown[]
 
         if (
@@ -670,86 +799,21 @@ export async function handleAction({
           // TODO: add body limit
 
           // Use react-server-dom-webpack/server.edge
-          const {
-            createTemporaryReferenceSet,
-            decodeReply,
-            decodeAction,
-            decodeFormState,
-          } = ComponentMod
-
-          temporaryReferences = createTemporaryReferenceSet()
+          const { decodeReply } = ComponentMod
 
           if (isMultipartAction) {
             // TODO-APP: Add streaming support
             const formData = await req.request.formData()
-            if (isFetchAction) {
-              try {
-                actionModId = getActionModIdOrError(actionId, serverModuleMap)
-              } catch (err) {
-                return handleUnrecognizedFetchAction(err)
+            // A fetch action with a multipart body.
+
+            boundActionArguments = await decodeReply(
+              formData,
+              serverModuleMap,
+              {
+                temporaryReferences,
               }
-
-              // A fetch action with a multipart body.
-              boundActionArguments = await decodeReply(
-                formData,
-                serverModuleMap,
-                { temporaryReferences }
-              )
-            } else {
-              // Multipart POST, but not a fetch action.
-              // Potentially an MPA action, we have to try decoding it to check.
-
-              const action = await decodeAction(
-                formData,
-                throwIfActionNotInModuleMap(serverModuleMap)
-              )
-
-              if (typeof action !== 'function') {
-                // We couldn't decode an action, so this POST request turned out not to be a server action request.
-                return { type: 'not-an-action' }
-              }
-
-              // an MPA action.
-
-              // Only warn if it's a server action, otherwise skip for other post requests
-              warnBadServerActionRequest()
-
-              const actionReturnedState =
-                await executeActionAndPrepareForRender(
-                  action as () => Promise<unknown>,
-                  [],
-                  workStore,
-                  requestStore
-                )
-
-              const formState = await decodeFormState(
-                actionReturnedState,
-                formData,
-                serverModuleMap
-              )
-
-              // Skip the fetch path.
-              // We need to render a full HTML version of the page for the response, we'll handle that in app-render.
-              return {
-                type: 'form-state',
-                formState,
-              }
-            }
+            )
           } else {
-            // POST with non-multipart body.
-
-            // If it's not multipart AND not a fetch action,
-            // then it can't be an action request.
-            if (!isFetchAction) {
-              return { type: 'not-an-action' }
-            }
-
-            try {
-              actionModId = getActionModIdOrError(actionId, serverModuleMap)
-            } catch (err) {
-              return handleUnrecognizedFetchAction(err)
-            }
-
             // A fetch action with a non-multipart body.
             // In practice, this happens if `encodeReply` returned a string instead of FormData,
             // which can happen for very simple JSON-like values that don't need multiple flight rows.
@@ -761,10 +825,8 @@ export async function handleAction({
               if (done) {
                 break
               }
-
               chunks.push(value)
             }
-
             const actionData = Buffer.concat(chunks).toString('utf-8')
 
             if (isURLEncodedAction) {
@@ -772,13 +834,17 @@ export async function handleAction({
               boundActionArguments = await decodeReply(
                 formData,
                 serverModuleMap,
-                { temporaryReferences }
+                {
+                  temporaryReferences,
+                }
               )
             } else {
               boundActionArguments = await decodeReply(
                 actionData,
                 serverModuleMap,
-                { temporaryReferences }
+                {
+                  temporaryReferences,
+                }
               )
             }
           }
@@ -789,17 +855,9 @@ export async function handleAction({
           isNodeNextRequest(req)
         ) {
           // Use react-server-dom-webpack/server.node which supports streaming
-          const {
-            createTemporaryReferenceSet,
-            decodeReply,
-            decodeReplyFromBusboy,
-            decodeAction,
-            decodeFormState,
-          } = require(
+          const { decodeReply, decodeReplyFromBusboy } = require(
             `./react-server.node`
           ) as typeof import('./react-server.node')
-
-          temporaryReferences = createTemporaryReferenceSet()
 
           const bodySizeLimit = resolveBodySizeLimitNode(serverActions)
           const sizeLimitedBody = getSizeLimitedRequestBodyNode(
@@ -808,102 +866,36 @@ export async function handleAction({
           )
 
           if (isMultipartAction) {
-            if (isFetchAction) {
-              // A fetch action with a multipart body.
+            // A fetch action with a multipart body.
 
-              try {
-                actionModId = getActionModIdOrError(actionId, serverModuleMap)
-              } catch (err) {
-                return handleUnrecognizedFetchAction(err)
+            const { pipeline } =
+              require('node:stream') as typeof import('node:stream')
+
+            const busboy = (
+              require('next/dist/compiled/busboy') as typeof import('next/dist/compiled/busboy')
+            )({
+              defParamCharset: 'utf8',
+              headers: req.headers,
+              limits: { fieldSize: bodySizeLimit.byteLength },
+            })
+
+            // We need to use `pipeline(one, two)` instead of `one.pipe(two)` to propagate size limit errors correctly.
+            pipeline(
+              sizeLimitedBody,
+              busboy,
+              // Avoid unhandled errors from `pipeline()` by passing an empty completion callback.
+              // We'll propagate the errors properly when consuming the stream.
+              () => {}
+            )
+
+            boundActionArguments = await decodeReplyFromBusboy(
+              busboy,
+              serverModuleMap,
+              {
+                temporaryReferences,
               }
-
-              const { pipeline } =
-                require('node:stream') as typeof import('node:stream')
-
-              const busboy = (
-                require('next/dist/compiled/busboy') as typeof import('next/dist/compiled/busboy')
-              )({
-                defParamCharset: 'utf8',
-                headers: req.headers,
-                limits: { fieldSize: bodySizeLimit.byteLength },
-              })
-
-              // We need to use `pipeline(one, two)` instead of `one.pipe(two)` to propagate size limit errors correctly.
-              pipeline(
-                sizeLimitedBody,
-                busboy,
-                // Avoid unhandled errors from `pipeline()` by passing an empty completion callback.
-                // We'll propagate the errors properly when consuming the stream.
-                () => {}
-              )
-
-              boundActionArguments = await decodeReplyFromBusboy(
-                busboy,
-                serverModuleMap,
-                { temporaryReferences }
-              )
-            } else {
-              // Multipart POST, but not a fetch action.
-              // Potentially an MPA action, we have to try decoding it to check.
-
-              // React doesn't yet publish a busboy version of decodeAction
-              // so we polyfill the parsing of FormData.
-              const formData = await parseBodyAsFormDataNode(
-                sizeLimitedBody,
-                req.headers['content-type']
-              )
-
-              const action = await decodeAction(
-                formData,
-                throwIfActionNotInModuleMap(serverModuleMap)
-              )
-
-              if (typeof action !== 'function') {
-                // We couldn't decode an action, so this POST request turned out not to be a server action request.
-                return { type: 'not-an-action' }
-              }
-
-              // an MPA action.
-
-              // Only warn if it's a server action, otherwise skip for other post requests
-              warnBadServerActionRequest()
-
-              const actionReturnedState =
-                await executeActionAndPrepareForRender(
-                  action as () => Promise<unknown>,
-                  [],
-                  workStore,
-                  requestStore
-                )
-
-              const formState = await decodeFormState(
-                actionReturnedState,
-                formData,
-                serverModuleMap
-              )
-
-              // Skip the fetch path.
-              // We need to render a full HTML version of the page for the response, we'll handle that in app-render.
-              return {
-                type: 'form-state',
-                formState,
-              }
-            }
+            )
           } else {
-            // POST with non-multipart body.
-
-            // If it's not multipart AND not a fetch action,
-            // then it can't be an action request.
-            if (!isFetchAction) {
-              return { type: 'not-an-action' }
-            }
-
-            try {
-              actionModId = getActionModIdOrError(actionId, serverModuleMap)
-            } catch (err) {
-              return handleUnrecognizedFetchAction(err)
-            }
-
             // A fetch action with a non-multipart body.
             // In practice, this happens if `encodeReply` returned a string instead of FormData,
             // which can happen for very simple JSON-like values that don't need multiple flight rows.
@@ -912,7 +904,6 @@ export async function handleAction({
             for await (const chunk of sizeLimitedBody) {
               chunks.push(Buffer.from(chunk))
             }
-
             const actionData = Buffer.concat(chunks).toString('utf-8')
 
             if (isURLEncodedAction) {
@@ -934,10 +925,7 @@ export async function handleAction({
           throw new Error('Invariant: Unknown request type.')
         }
 
-        // Handle a fetch action.
-
-        // Ensure that non-fetch codepaths can't reach this part.
-        isFetchAction satisfies true
+        // Get the action function.
 
         // actions.js
         // app/page.js
@@ -1206,9 +1194,9 @@ function resolveBodySizeLimitNode(
     const bodySizeLimit = serverActions?.bodySizeLimit ?? defaultBodySizeLimit
     const byteLength =
       bodySizeLimit !== defaultBodySizeLimit
-        ? (require('next/dist/compiled/bytes') as typeof import('next/dist/compiled/bytes')).parse(
-            bodySizeLimit
-          )
+        ? (
+            require('next/dist/compiled/bytes') as typeof import('next/dist/compiled/bytes')
+          ).parse(bodySizeLimit)
         : 1024 * 1024 // 1 MB
     return {
       byteLength,
@@ -1234,7 +1222,6 @@ function getSizeLimitedRequestBodyNode(
         if (size > sizeLimit.byteLength) {
           const { ApiError } =
             require('../api-utils') as typeof import('../api-utils')
-
 
           callback(
             new ApiError(

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -765,6 +765,127 @@ export async function handleAction({
     }
   }
 
+  const parseFetchActionArguments = async (
+    // eslint-disable-next-line @typescript-eslint/no-shadow
+    temporaryReferences: TemporaryReferenceSet
+  ): Promise<unknown[]> => {
+    if (
+      // The type check here ensures that `req` is correctly typed, and the
+      // environment variable check provides dead code elimination.
+      process.env.NEXT_RUNTIME === 'edge' &&
+      isWebNextRequest(req)
+    ) {
+      if (!req.body) {
+        throw new Error('invariant: Missing request body.')
+      }
+
+      // TODO: add body limit
+
+      // Use react-server-dom-webpack/server.edge
+      const { decodeReply } = ComponentMod
+
+      if (isMultipartAction) {
+        // TODO-APP: Add streaming support
+        const formData = await req.request.formData()
+        // A fetch action with a multipart body.
+
+        return await decodeReply(formData, serverModuleMap, {
+          temporaryReferences,
+        })
+      } else {
+        // A fetch action with a non-multipart body.
+        // In practice, this happens if `encodeReply` returned a string instead of FormData,
+        // which can happen for very simple JSON-like values that don't need multiple flight rows.
+
+        const chunks: Buffer[] = []
+        const reader = req.body.getReader()
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) {
+            break
+          }
+          chunks.push(value)
+        }
+        const actionData = Buffer.concat(chunks).toString('utf-8')
+
+        if (isURLEncodedAction) {
+          const formData = formDataFromSearchQueryString(actionData)
+          return await decodeReply(formData, serverModuleMap, {
+            temporaryReferences,
+          })
+        } else {
+          return await decodeReply(actionData, serverModuleMap, {
+            temporaryReferences,
+          })
+        }
+      }
+    } else if (
+      // The type check here ensures that `req` is correctly typed, and the
+      // environment variable check provides dead code elimination.
+      process.env.NEXT_RUNTIME !== 'edge' &&
+      isNodeNextRequest(req)
+    ) {
+      // Use react-server-dom-webpack/server.node which supports streaming
+      const { decodeReply, decodeReplyFromBusboy } = require(
+        `./react-server.node`
+      ) as typeof import('./react-server.node')
+
+      const bodySizeLimit = resolveBodySizeLimitNode(serverActions)
+      const sizeLimitedBody = getSizeLimitedRequestBodyNode(req, bodySizeLimit)
+
+      if (isMultipartAction) {
+        // A fetch action with a multipart body.
+
+        const { pipeline } =
+          require('node:stream') as typeof import('node:stream')
+
+        const busboy = (
+          require('next/dist/compiled/busboy') as typeof import('next/dist/compiled/busboy')
+        )({
+          defParamCharset: 'utf8',
+          headers: req.headers,
+          limits: { fieldSize: bodySizeLimit.byteLength },
+        })
+
+        // We need to use `pipeline(one, two)` instead of `one.pipe(two)` to propagate size limit errors correctly.
+        pipeline(
+          sizeLimitedBody,
+          busboy,
+          // Avoid unhandled errors from `pipeline()` by passing an empty completion callback.
+          // We'll propagate the errors properly when consuming the stream.
+          () => {}
+        )
+
+        return await decodeReplyFromBusboy(busboy, serverModuleMap, {
+          temporaryReferences,
+        })
+      } else {
+        // A fetch action with a non-multipart body.
+        // In practice, this happens if `encodeReply` returned a string instead of FormData,
+        // which can happen for very simple JSON-like values that don't need multiple flight rows.
+
+        const chunks: Buffer[] = []
+        for await (const chunk of sizeLimitedBody) {
+          chunks.push(Buffer.from(chunk))
+        }
+        const actionData = Buffer.concat(chunks).toString('utf-8')
+
+        if (isURLEncodedAction) {
+          const formData = formDataFromSearchQueryString(actionData)
+          return await decodeReply(formData, serverModuleMap, {
+            temporaryReferences,
+          })
+        } else {
+          return await decodeReply(actionData, serverModuleMap, {
+            temporaryReferences,
+          })
+        }
+      }
+    } else {
+      throw new Error('Invariant: Unknown request type.')
+    }
+  }
+
   try {
     return await actionAsyncStorage.run(
       { isAction: true },
@@ -783,147 +904,23 @@ export async function handleAction({
           return handleUnrecognizedFetchAction(err)
         }
 
+        // The temporary reference set is used for parsing the arguments and in the catch handler,
+        // so we want to create it before any of the decoding logic has a chance to throw.
+        const createTemporaryReferenceSet =
+          process.env.NEXT_RUNTIME === 'edge'
+            ? // Use react-server-dom-webpack/server.edge
+              ComponentMod.createTemporaryReferenceSet
+            : // Use react-server-dom-webpack/server.node
+              (
+                require(
+                  `./react-server.node`
+                ) as typeof import('./react-server.node')
+              ).createTemporaryReferenceSet
+        temporaryReferences = createTemporaryReferenceSet()
+
         // Parse the action arguments.
-        let boundActionArguments: unknown[]
-
-        if (
-          // The type check here ensures that `req` is correctly typed, and the
-          // environment variable check provides dead code elimination.
-          process.env.NEXT_RUNTIME === 'edge' &&
-          isWebNextRequest(req)
-        ) {
-          if (!req.body) {
-            throw new Error('invariant: Missing request body.')
-          }
-
-          // TODO: add body limit
-
-          // Use react-server-dom-webpack/server.edge
-          const { decodeReply } = ComponentMod
-
-          if (isMultipartAction) {
-            // TODO-APP: Add streaming support
-            const formData = await req.request.formData()
-            // A fetch action with a multipart body.
-
-            boundActionArguments = await decodeReply(
-              formData,
-              serverModuleMap,
-              {
-                temporaryReferences,
-              }
-            )
-          } else {
-            // A fetch action with a non-multipart body.
-            // In practice, this happens if `encodeReply` returned a string instead of FormData,
-            // which can happen for very simple JSON-like values that don't need multiple flight rows.
-
-            const chunks: Buffer[] = []
-            const reader = req.body.getReader()
-            while (true) {
-              const { done, value } = await reader.read()
-              if (done) {
-                break
-              }
-              chunks.push(value)
-            }
-            const actionData = Buffer.concat(chunks).toString('utf-8')
-
-            if (isURLEncodedAction) {
-              const formData = formDataFromSearchQueryString(actionData)
-              boundActionArguments = await decodeReply(
-                formData,
-                serverModuleMap,
-                {
-                  temporaryReferences,
-                }
-              )
-            } else {
-              boundActionArguments = await decodeReply(
-                actionData,
-                serverModuleMap,
-                {
-                  temporaryReferences,
-                }
-              )
-            }
-          }
-        } else if (
-          // The type check here ensures that `req` is correctly typed, and the
-          // environment variable check provides dead code elimination.
-          process.env.NEXT_RUNTIME !== 'edge' &&
-          isNodeNextRequest(req)
-        ) {
-          // Use react-server-dom-webpack/server.node which supports streaming
-          const { decodeReply, decodeReplyFromBusboy } = require(
-            `./react-server.node`
-          ) as typeof import('./react-server.node')
-
-          const bodySizeLimit = resolveBodySizeLimitNode(serverActions)
-          const sizeLimitedBody = getSizeLimitedRequestBodyNode(
-            req,
-            bodySizeLimit
-          )
-
-          if (isMultipartAction) {
-            // A fetch action with a multipart body.
-
-            const { pipeline } =
-              require('node:stream') as typeof import('node:stream')
-
-            const busboy = (
-              require('next/dist/compiled/busboy') as typeof import('next/dist/compiled/busboy')
-            )({
-              defParamCharset: 'utf8',
-              headers: req.headers,
-              limits: { fieldSize: bodySizeLimit.byteLength },
-            })
-
-            // We need to use `pipeline(one, two)` instead of `one.pipe(two)` to propagate size limit errors correctly.
-            pipeline(
-              sizeLimitedBody,
-              busboy,
-              // Avoid unhandled errors from `pipeline()` by passing an empty completion callback.
-              // We'll propagate the errors properly when consuming the stream.
-              () => {}
-            )
-
-            boundActionArguments = await decodeReplyFromBusboy(
-              busboy,
-              serverModuleMap,
-              {
-                temporaryReferences,
-              }
-            )
-          } else {
-            // A fetch action with a non-multipart body.
-            // In practice, this happens if `encodeReply` returned a string instead of FormData,
-            // which can happen for very simple JSON-like values that don't need multiple flight rows.
-
-            const chunks: Buffer[] = []
-            for await (const chunk of sizeLimitedBody) {
-              chunks.push(Buffer.from(chunk))
-            }
-            const actionData = Buffer.concat(chunks).toString('utf-8')
-
-            if (isURLEncodedAction) {
-              const formData = formDataFromSearchQueryString(actionData)
-              boundActionArguments = await decodeReply(
-                formData,
-                serverModuleMap,
-                { temporaryReferences }
-              )
-            } else {
-              boundActionArguments = await decodeReply(
-                actionData,
-                serverModuleMap,
-                { temporaryReferences }
-              )
-            }
-          }
-        } else {
-          throw new Error('Invariant: Unknown request type.')
-        }
+        const actionArguments =
+          await parseFetchActionArguments(temporaryReferences)
 
         // Get the action function.
 
@@ -947,7 +944,7 @@ export async function handleAction({
 
         const returnVal = await executeActionAndPrepareForRender(
           actionHandler,
-          boundActionArguments,
+          actionArguments,
           workStore,
           requestStore
         ).finally(() => {

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -631,10 +631,10 @@ export async function handleAction({
     }
   }
 
-  const handleUnrecognizedFetchAction = (err: unknown): HandleActionResult => {
-    // If the deployment doesn't have skew protection, this is expected to occasionally happen,
-    // so we use a warning instead of an error.
-    console.warn(err)
+  const handleUnrecognizedFetchAction = (err?: unknown): HandleActionResult => {
+    if (err) {
+      console.warn(err)
+    }
 
     // Return an empty response with a header that the client router will interpret.
     // We don't need to waste time encoding a flight response, and using a blank body + header
@@ -886,6 +886,46 @@ export async function handleAction({
     }
   }
 
+  const getActionHandler = async (
+    // eslint-disable-next-line @typescript-eslint/no-shadow
+    actionId: string
+  ): Promise<((...args: unknown[]) => Promise<unknown>) | null> => {
+    // actions.js
+    // app/page.js
+    //   action worker1
+    //     appRender1
+
+    // app/foo/page.js
+    //   action worker2
+    //     appRender
+
+    // / -> fire action -> POST / -> appRender1 -> modId for the action file
+    // /foo -> fire action -> POST /foo -> appRender2 -> modId for the action file
+
+    //  Validate the actionId.
+    let actionModId: string
+    try {
+      actionModId = getActionModIdOrError(actionId, serverModuleMap)
+    } catch (err) {
+      // TODO: this is weirdly split with `handleUnrecognizedFetchAction`, should unify
+      console.error(err)
+      return null
+    }
+
+    const actionMod = (await ComponentMod.__next_app__.require(
+      actionModId
+    )) as Record<string, (...args: unknown[]) => Promise<unknown>>
+
+    const actionHandler = actionMod[actionId]
+    // if the `actionId` is valid, and resolved to a valid `actionModId`, but the module does not contain the action,
+    // then something went very wrong in the bundling process, and we should error.
+    if (!actionHandler) {
+      throw new InvariantError('Action handler not found in action module')
+    }
+
+    return actionHandler
+  }
+
   try {
     return await actionAsyncStorage.run(
       { isAction: true },
@@ -896,12 +936,11 @@ export async function handleAction({
 
         // A fetch action (initiated by the client router).
 
-        // Check the action id. if it's not valid, we can bail out immediately.
-        let actionModId: string
-        try {
-          actionModId = getActionModIdOrError(actionId, serverModuleMap)
-        } catch (err) {
-          return handleUnrecognizedFetchAction(err)
+        // Get the action function.
+        const actionHandler = await getActionHandler(actionId)
+        if (!actionHandler) {
+          // We didn't recognize the provided actionId, so we can't run the action.
+          return handleUnrecognizedFetchAction()
         }
 
         // The temporary reference set is used for parsing the arguments and in the catch handler,
@@ -922,26 +961,7 @@ export async function handleAction({
         const actionArguments =
           await parseFetchActionArguments(temporaryReferences)
 
-        // Get the action function.
-
-        // actions.js
-        // app/page.js
-        //   action worker1
-        //     appRender1
-
-        // app/foo/page.js
-        //   action worker2
-        //     appRender
-
-        // / -> fire action -> POST / -> appRender1 -> modId for the action file
-        // /foo -> fire action -> POST /foo -> appRender2 -> modId for the action file
-
-        const actionMod = (await ComponentMod.__next_app__.require(
-          actionModId
-        )) as Record<string, (...args: unknown[]) => Promise<unknown>>
-
-        const actionHandler = actionMod[actionId]
-
+        // Run the action.
         const returnVal = await executeActionAndPrepareForRender(
           actionHandler,
           actionArguments,


### PR DESCRIPTION
(this is a big PR that might get sliced up into smaller ones because i'm finding it hard to write a good description, but really it's just moving stuff around,. currently best viewed commit-by-commit)

the most important change is factoring out non-fetch action codepaths out into a `handleNonFetchAction`. the easiest way to think about it is that it's just switching the main thing we're branching on.
previously, we were doing something like this:
```ts
if (isMultiPart) {
  if (isFetchAction) {
    // fetch + multipart
    ...  // fallthrough to the end
  } else {
    // non-fetch + multipart
    return ...
  }
} else {
   if (isFetchAction) {
    // fetch + non-multipart
    ... // fallthrough to the end
  } else {
    // non-fetch + non-multipart
    return ...
  }
}
// finish fetch action
```
after this refactor, the flow is more like this:
```ts
function handleNonFetchAction() {
  if (isMultiPart) {
    // non-fetch + multipart
    return ...
  } else {
    // non-fetch + non-multipart
    return ...
  }
}

if (!isFetchAction) {
  return handleNonFetchAction()
}

if (isMultiPart) {
  // fetch + multipart
  ...
} else {
  // fetch + non-multipart
  ...
}
// finish fetch action
```
the branching is isomorphic, but because the fetch and non-fetch parts are similar, it ends up being easier to follow.