### PR TITLE
fix: wrong jsDoc link in resolveAlias of turbo opts

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -120,7 +120,7 @@ export interface ExperimentalTurboOptions {
   /**
    * (`next --turbopack` only) A mapping of aliased imports to modules to load in their place.
    *
-   * @see [Resolve Alias](https://nextjs.org/docs/app/api-reference/next-config-js/turbo#resolve-alias)
+   * @see [Resolve Alias](https://nextjs.org/docs/app/api-reference/config/next-config-js/turbo#resolving-aliases)
    */
   resolveAlias?: Record<
     string,


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors
### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

- resolveAlias in ExperimentalTurboOption has wrong jsDoc link. So I fix it. 
- Is this PR's category Docs?

## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

- Fixed links to follow to the appropriate location in the document.
- I think I can type it precisely, but I don't know turboPack very well. (I think it would be good if someone could document this in more detail)

### What?
- Fix wrong link

### Why?
- Go to right link and its section of Docs.

### How?
- Fix link in jsDocs.

Closes NEXT-
Fixes #

-->
