### PR TITLE
[dev-overlay] Add `size` setting to preferences

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/shared.ts
+++ b/packages/next/src/client/components/react-dev-overlay/shared.ts
@@ -40,6 +40,7 @@ export const ACTION_DEV_INDICATOR = 'dev-indicator'
 
 export const STORAGE_KEY_THEME = '__nextjs-dev-tools-theme'
 export const STORAGE_KEY_POSITION = '__nextjs-dev-tools-position'
+export const STORAGE_KEY_SCALE = '__nextjs-dev-tools-scale'
 
 interface StaticIndicatorAction {
   type: typeof ACTION_STATIC_INDICATOR

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties, Dispatch, SetStateAction } from 'react'
-import { STORAGE_KEY_POSITION, type OverlayState } from '../../../../shared'
+import type { OverlayState } from '../../../../shared'
 
 import { useState, useEffect, useRef, createContext, useContext } from 'react'
 import { Toast } from '../../toast'
@@ -17,21 +17,19 @@ import {
   useClickOutside,
   useFocusTrap,
 } from './utils'
+import {
+  getInitialPosition,
+  type DevToolsScale,
+} from './dev-tools-info/preferences'
 
 // TODO: add E2E tests to cover different scenarios
-
-const INDICATOR_POSITION =
-  (process.env
-    .__NEXT_DEV_INDICATOR_POSITION as typeof window.__NEXT_DEV_INDICATOR_POSITION) ||
-  'bottom-left'
-
-export type DevToolsIndicatorPosition = typeof INDICATOR_POSITION
 
 export function DevToolsIndicator({
   state,
   errorCount,
   isBuildError,
   setIsErrorOverlayOpen,
+  ...props
 }: {
   state: OverlayState
   errorCount: number
@@ -39,6 +37,8 @@ export function DevToolsIndicator({
   setIsErrorOverlayOpen: (
     isErrorOverlayOpen: boolean | ((prev: boolean) => boolean)
   ) => void
+  scale: DevToolsScale
+  setScale: (value: DevToolsScale) => void
 }) {
   const [isDevToolsIndicatorVisible, setIsDevToolsIndicatorVisible] =
     useState(true)
@@ -59,6 +59,7 @@ export function DevToolsIndicator({
       isTurbopack={!!process.env.TURBOPACK}
       disabled={state.disableDevIndicator || !isDevToolsIndicatorVisible}
       isBuildError={isBuildError}
+      {...props}
     />
   )
 }
@@ -72,19 +73,6 @@ interface C {
 }
 
 const Context = createContext({} as C)
-
-function getInitialPosition() {
-  if (
-    typeof localStorage !== 'undefined' &&
-    localStorage.getItem(STORAGE_KEY_POSITION)
-  ) {
-    return localStorage.getItem(
-      STORAGE_KEY_POSITION
-    ) as DevToolsIndicatorPosition
-  }
-
-  return INDICATOR_POSITION
-}
 
 const OVERLAYS = {
   Root: 'root',
@@ -104,6 +92,8 @@ function DevToolsPopover({
   isBuildError,
   hide,
   setIsErrorOverlayOpen,
+  scale,
+  setScale,
 }: {
   routerType: 'pages' | 'app'
   disabled: boolean
@@ -116,6 +106,8 @@ function DevToolsPopover({
   setIsErrorOverlayOpen: (
     isOverlayOpen: boolean | ((prev: boolean) => boolean)
   ) => void
+  scale: DevToolsScale
+  setScale: (value: DevToolsScale) => void
 }) {
   const menuRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLButtonElement | null>(null)
@@ -289,6 +281,7 @@ function DevToolsPopover({
         isDevBuilding={useIsDevBuilding()}
         isDevRendering={useIsDevRendering()}
         isBuildError={isBuildError}
+        scale={scale}
       />
 
       {/* Route Info */}
@@ -318,6 +311,8 @@ function DevToolsPopover({
         hide={handleHideDevtools}
         setPosition={setPosition}
         position={position}
+        scale={scale}
+        setScale={setScale}
       />
 
       {/* Dropdown Menu */}

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/preferences.ts
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/preferences.ts
@@ -1,0 +1,72 @@
+import { useState } from 'react'
+import {
+  STORAGE_KEY_POSITION,
+  STORAGE_KEY_SCALE,
+  STORAGE_KEY_THEME,
+} from '../../../../../shared'
+
+const INDICATOR_POSITION =
+  (process.env
+    .__NEXT_DEV_INDICATOR_POSITION as typeof window.__NEXT_DEV_INDICATOR_POSITION) ||
+  'bottom-left'
+
+export type DevToolsIndicatorPosition = typeof INDICATOR_POSITION
+
+export function getInitialPosition() {
+  if (
+    typeof localStorage !== 'undefined' &&
+    localStorage.getItem(STORAGE_KEY_POSITION)
+  ) {
+    return localStorage.getItem(
+      STORAGE_KEY_POSITION
+    ) as DevToolsIndicatorPosition
+  }
+  return INDICATOR_POSITION
+}
+
+//////////////////////////////////////////////////////////////////////////////////////
+
+const BASE_SIZE = 16
+
+export const NEXT_DEV_TOOLS_SCALE = {
+  Small: BASE_SIZE / 14,
+  Medium: BASE_SIZE / 16,
+  Large: BASE_SIZE / 18,
+} as const
+
+export type DevToolsScale =
+  (typeof NEXT_DEV_TOOLS_SCALE)[keyof typeof NEXT_DEV_TOOLS_SCALE]
+
+function getInitialScale() {
+  if (
+    typeof localStorage !== 'undefined' &&
+    localStorage.getItem(STORAGE_KEY_SCALE)
+  ) {
+    return Number(localStorage.getItem(STORAGE_KEY_SCALE)) as DevToolsScale
+  }
+  return NEXT_DEV_TOOLS_SCALE.Medium
+}
+
+export function useDevToolsScale(): [
+  DevToolsScale,
+  (value: DevToolsScale) => void,
+] {
+  const [scale, setScale] = useState<DevToolsScale>(getInitialScale())
+
+  function set(value: DevToolsScale) {
+    setScale(value)
+    localStorage.setItem(STORAGE_KEY_SCALE, String(value))
+  }
+
+  return [scale, set]
+}
+
+//////////////////////////////////////////////////////////////////////////////////////
+
+export function getInitialTheme() {
+  if (typeof localStorage === 'undefined') {
+    return 'system'
+  }
+  const theme = localStorage.getItem(STORAGE_KEY_THEME)
+  return theme === 'dark' || theme === 'light' ? theme : 'system'
+}

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
@@ -111,14 +111,14 @@ export function UserPreferences({
 
         <div className="preference-section">
           <div className="preference-header">
-            <label htmlFor="theme">Size</label>
+            <label htmlFor="size">Size</label>
             <p className="preference-description">
               Adjust the size of your dev tools.
             </p>
           </div>
           <Select
-            id="theme"
-            name="theme"
+            id="size"
+            name="size"
             value={scale}
             onChange={handleSizeChange}
           >

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
@@ -113,7 +113,7 @@ export function UserPreferences({
           <div className="preference-header">
             <label htmlFor="theme">Size</label>
             <p className="preference-description">
-              Adjust the size of the overlay.
+              Adjust the size of your dev tools.
             </p>
           </div>
           <Select

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
@@ -7,30 +7,30 @@ import DarkIcon from '../../../../icons/dark-icon'
 import SystemIcon from '../../../../icons/system-icon'
 import type { DevToolsInfoPropsCore } from './dev-tools-info'
 import { DevToolsInfo } from './dev-tools-info'
-import type { DevToolsIndicatorPosition } from '../dev-tools-indicator'
-
-function getInitialPreference() {
-  if (typeof localStorage === 'undefined') {
-    return 'system'
-  }
-
-  const theme = localStorage.getItem(STORAGE_KEY_THEME)
-  return theme === 'dark' || theme === 'light' ? theme : 'system'
-}
+import {
+  getInitialTheme,
+  NEXT_DEV_TOOLS_SCALE,
+  type DevToolsIndicatorPosition,
+  type DevToolsScale,
+} from './preferences'
 
 export function UserPreferences({
   setPosition,
   position,
   hide,
+  scale,
+  setScale,
   ...props
 }: {
   setPosition: (position: DevToolsIndicatorPosition) => void
   position: DevToolsIndicatorPosition
+  scale: DevToolsScale
+  setScale: (value: DevToolsScale) => void
   hide: () => void
 } & DevToolsInfoPropsCore &
-  HTMLProps<HTMLDivElement>) {
+  Omit<HTMLProps<HTMLDivElement>, 'size'>) {
   // derive initial theme from system preference
-  const [theme, setTheme] = useState(getInitialPreference())
+  const [theme, setTheme] = useState(getInitialTheme())
 
   const handleThemeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const portal = document.querySelector('nextjs-portal')
@@ -59,6 +59,11 @@ export function UserPreferences({
   function handlePositionChange(e: React.ChangeEvent<HTMLSelectElement>) {
     setPosition(e.target.value as DevToolsIndicatorPosition)
     localStorage.setItem(STORAGE_KEY_POSITION, e.target.value)
+  }
+
+  function handleSizeChange({ target }: React.ChangeEvent<HTMLSelectElement>) {
+    const value = Number(target.value) as DevToolsScale
+    setScale(value)
   }
 
   return (
@@ -101,6 +106,29 @@ export function UserPreferences({
             <option value="bottom-right">Bottom Right</option>
             <option value="top-left">Top Left</option>
             <option value="top-right">Top Right</option>
+          </Select>
+        </div>
+
+        <div className="preference-section">
+          <div className="preference-header">
+            <label htmlFor="theme">Size</label>
+            <p className="preference-description">
+              Adjust the size of the overlay.
+            </p>
+          </div>
+          <Select
+            id="theme"
+            name="theme"
+            value={scale}
+            onChange={handleSizeChange}
+          >
+            {Object.entries(NEXT_DEV_TOOLS_SCALE).map(([key, value]) => {
+              return (
+                <option value={value} key={key}>
+                  {key}
+                </option>
+              )
+            })}
           </Select>
         </div>
 

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/next-logo.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/next-logo.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useEffect, useMemo, useRef, useState } from 'react'
 import { css } from '../../../../utils/css'
 import mergeRefs from '../../../utils/merge-refs'
 import { useMinimumLoadingTimeMultiple } from './use-minimum-loading-time-multiple'
+import type { DevToolsScale } from './dev-tools-info/preferences'
 
 interface Props extends React.ComponentProps<'button'> {
   issueCount: number
@@ -10,9 +11,9 @@ interface Props extends React.ComponentProps<'button'> {
   isBuildError: boolean
   onTriggerClick: () => void
   toggleErrorOverlay: () => void
+  scale: DevToolsScale
 }
 
-const SIZE = 36
 const SHORT_DURATION_MS = 150
 
 export const NextLogo = forwardRef(function NextLogo(
@@ -24,10 +25,13 @@ export const NextLogo = forwardRef(function NextLogo(
     isBuildError,
     onTriggerClick,
     toggleErrorOverlay,
+    scale,
     ...props
   }: Props,
   propRef: React.Ref<HTMLButtonElement>
 ) {
+  const SIZE = 36 / scale
+
   const hasError = issueCount > 0
   const [isErrorExpanded, setIsErrorExpanded] = useState(hasError)
   const [dismissed, setDismissed] = useState(false)
@@ -50,7 +54,7 @@ export const NextLogo = forwardRef(function NextLogo(
     if (pristine && hasError) width = 'auto'
     // Default state, collapsed
     return { width }
-  }, [measuredWidth, pristine, hasError])
+  }, [measuredWidth, pristine, hasError, SIZE])
 
   useEffect(() => {
     setIsErrorExpanded(hasError)

--- a/packages/next/src/client/components/react-dev-overlay/ui/dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/dev-overlay.tsx
@@ -9,6 +9,7 @@ import { ErrorOverlay } from './components/errors/error-overlay/error-overlay'
 import { DevToolsIndicator } from './components/errors/dev-tools-indicator/dev-tools-indicator'
 import { RenderError } from './container/runtime-error/render-error'
 import { DarkTheme } from './styles/dark-theme'
+import { useDevToolsScale } from './components/errors/dev-tools-indicator/dev-tools-info/preferences'
 
 export function DevOverlay({
   state,
@@ -21,10 +22,11 @@ export function DevOverlay({
     isErrorOverlayOpen: boolean | ((prev: boolean) => boolean)
   ) => void
 }) {
+  const [scale, setScale] = useDevToolsScale()
   return (
     <ShadowPortal>
       <CssReset />
-      <Base />
+      <Base scale={scale} />
       <Colors />
       <ComponentStyles />
       <DarkTheme />
@@ -35,6 +37,8 @@ export function DevOverlay({
           return (
             <>
               <DevToolsIndicator
+                scale={scale}
+                setScale={setScale}
                 state={state}
                 errorCount={totalErrorCount}
                 isBuildError={isBuildError}

--- a/packages/next/src/client/components/react-dev-overlay/ui/styles/base.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/styles/base.tsx
@@ -1,6 +1,7 @@
 import { css } from '../../utils/css'
+import type { DevToolsScale } from '../components/errors/dev-tools-indicator/dev-tools-info/preferences'
 
-export function Base() {
+export function Base({ scale = 1 }: { scale?: DevToolsScale }) {
   return (
     <style>
       {css`
@@ -70,51 +71,44 @@ export function Base() {
           --rounded-full: 9999px;
 
           /* 
-            These used to be in rem units but we have realised
-            that using rem to style the Dev Overlays is not a
-            good idea because if the user sets their root font size
-            to something tiny, they will not have a great time using
-            the Overlays because they will appear unexpectedly tiny.
-
-            In the future, we want to use these variables to offer
-            a custom preference in the dropdown menu to alter the size
-            of the Overlays.
-
-            Ref: https://github.com/vercel/next.js/discussions/76812
+            This value gets set from the Dev Tools preferences,
+            and we use the following --size-* variables to 
+            scale the relevant elements.
           */
-          --size-1: 1px;
-          --size-2: 2px;
-          --size-3: 3px;
-          --size-4: 4px;
-          --size-5: 5px;
-          --size-6: 6px;
-          --size-7: 7px;
-          --size-8: 8px;
-          --size-9: 9px;
-          --size-10: 10px;
-          --size-11: 11px;
-          --size-12: 12px;
-          --size-13: 13px;
-          --size-14: 14px;
-          --size-15: 15px;
-          --size-16: 16px;
-          --size-17: 17px;
-          --size-18: 18px;
-          --size-20: 20px;
-          --size-22: 22px;
-          --size-24: 24px;
-          --size-26: 26px;
-          --size-28: 28px;
-          --size-30: 30px;
-          --size-32: 32px;
-          --size-34: 34px;
-          --size-36: 36px;
-          --size-38: 38px;
-          --size-40: 40px;
-          --size-42: 42px;
-          --size-44: 44px;
-          --size-46: 46px;
-          --size-48: 48px;
+          --nextjs-dev-tools-scale: ${String(scale)};
+          --size-1: calc(1px / var(--nextjs-dev-tools-scale));
+          --size-2: calc(2px / var(--nextjs-dev-tools-scale));
+          --size-3: calc(3px / var(--nextjs-dev-tools-scale));
+          --size-4: calc(4px / var(--nextjs-dev-tools-scale));
+          --size-5: calc(5px / var(--nextjs-dev-tools-scale));
+          --size-6: calc(6px / var(--nextjs-dev-tools-scale));
+          --size-7: calc(7px / var(--nextjs-dev-tools-scale));
+          --size-8: calc(8px / var(--nextjs-dev-tools-scale));
+          --size-9: calc(9px / var(--nextjs-dev-tools-scale));
+          --size-10: calc(10px / var(--nextjs-dev-tools-scale));
+          --size-11: calc(11px / var(--nextjs-dev-tools-scale));
+          --size-12: calc(12px / var(--nextjs-dev-tools-scale));
+          --size-13: calc(13px / var(--nextjs-dev-tools-scale));
+          --size-14: calc(14px / var(--nextjs-dev-tools-scale));
+          --size-15: calc(15px / var(--nextjs-dev-tools-scale));
+          --size-16: calc(16px / var(--nextjs-dev-tools-scale));
+          --size-17: calc(17px / var(--nextjs-dev-tools-scale));
+          --size-18: calc(18px / var(--nextjs-dev-tools-scale));
+          --size-20: calc(20px / var(--nextjs-dev-tools-scale));
+          --size-22: calc(22px / var(--nextjs-dev-tools-scale));
+          --size-24: calc(24px / var(--nextjs-dev-tools-scale));
+          --size-26: calc(26px / var(--nextjs-dev-tools-scale));
+          --size-28: calc(28px / var(--nextjs-dev-tools-scale));
+          --size-30: calc(30px / var(--nextjs-dev-tools-scale));
+          --size-32: calc(32px / var(--nextjs-dev-tools-scale));
+          --size-34: calc(34px / var(--nextjs-dev-tools-scale));
+          --size-36: calc(36px / var(--nextjs-dev-tools-scale));
+          --size-38: calc(38px / var(--nextjs-dev-tools-scale));
+          --size-40: calc(40px / var(--nextjs-dev-tools-scale));
+          --size-42: calc(42px / var(--nextjs-dev-tools-scale));
+          --size-44: calc(44px / var(--nextjs-dev-tools-scale));
+          --size-46: calc(46px / var(--nextjs-dev-tools-scale));
+          --size-48: calc(48px / var(--nextjs-dev-tools-scale));
 
           @media print {
             display: none;

--- a/packages/next/src/client/components/react-dev-overlay/ui/styles/base.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/styles/base.tsx
@@ -74,6 +74,13 @@ export function Base({ scale = 1 }: { scale?: DevToolsScale }) {
             This value gets set from the Dev Tools preferences,
             and we use the following --size-* variables to 
             scale the relevant elements.
+
+            The reason why we don't rely on rem values is because
+            if an app sets their root font size to something tiny, 
+            it feels unexpected to have the app root size leak 
+            into a Next.js surface.
+
+            https://github.com/vercel/next.js/discussions/76812
           */
           --nextjs-dev-tools-scale: ${String(scale)};
           --size-1: calc(1px / var(--nextjs-dev-tools-scale));


### PR DESCRIPTION
This PR is a follow up to https://github.com/vercel/next.js/pull/76969 and adds a size setting to the Dev Tools preferences. 

Right now the **Small**, **Medium** (default), and **Large** variants scale the UI as if the root font size were **14px**, **16px**, **18px**. We can tweak these values as a follow-up.

https://github.com/user-attachments/assets/43055cae-1e14-4e52-94cc-3ad1b8cae424

---
- Closes NDX-971