### PR TITLE
Turbopack: add test case for persistent caching

### DIFF
--- a/test/e2e/persistent-caching/app/client/page.tsx
+++ b/test/e2e/persistent-caching/app/client/page.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+export default function Page() {
+  return (
+    <>
+      <p>hello world</p>
+      <main suppressHydrationWarning>Timestamp</main>
+    </>
+  )
+}

--- a/test/e2e/persistent-caching/app/remove-me/page.tsx
+++ b/test/e2e/persistent-caching/app/remove-me/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <>
+      <p>hello world</p>
+      <main suppressHydrationWarning>Timestamp</main>
+    </>
+  )
+}

--- a/test/e2e/persistent-caching/next.config.js
+++ b/test/e2e/persistent-caching/next.config.js
@@ -2,9 +2,6 @@
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
-  // TODO workaround for missing content hashing on output static files
-  // Browser caching would break this test case, but we want to test persistent caching.
-  deploymentId: true,
   turbopack: {
     rules: {
       'app/page.tsx': {

--- a/test/e2e/persistent-caching/next.config.js
+++ b/test/e2e/persistent-caching/next.config.js
@@ -2,6 +2,9 @@
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
+  // TODO workaround for missing content hashing on output static files
+  // Browser caching would break this test case, but we want to test persistent caching.
+  deploymentId: true,
   turbopack: {
     rules: {
       'app/page.tsx': {

--- a/test/e2e/persistent-caching/persistent-caching.test.ts
+++ b/test/e2e/persistent-caching/persistent-caching.test.ts
@@ -2,6 +2,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 
 describe('persistent-caching', () => {
+  process.env.NEXT_DEPLOYMENT_ID = '' + Date.now()
   const { skipped, next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
@@ -26,7 +27,9 @@ describe('persistent-caching', () => {
 
   async function start() {
     if (!isNextDev) {
-      await next.build()
+      // TODO workaround for missing content hashing on output static files
+      // Browser caching would break this test case, but we want to test persistent caching.
+      process.env.NEXT_DEPLOYMENT_ID = '' + Date.now()
     }
     await next.start()
   }

--- a/test/e2e/persistent-caching/persistent-caching.test.ts
+++ b/test/e2e/persistent-caching/persistent-caching.test.ts
@@ -89,6 +89,11 @@ describe('persistent-caching', () => {
       expect(await browser.elementByCss('p').text()).toBe('hello world')
       await browser.close()
     }
+    {
+      const browser = await next.browser('/remove-me')
+      expect(await browser.elementByCss('p').text()).toBe('hello world')
+      await browser.close()
+    }
 
     await stop()
 
@@ -109,6 +114,14 @@ describe('persistent-caching', () => {
       }
       {
         const browser = await next.browser('/pages')
+        expect(await browser.elementByCss('p').text()).toBe(
+          'hello persistent caching'
+        )
+        await browser.close()
+      }
+
+      {
+        const browser = await next.browser('/add-me')
         expect(await browser.elementByCss('p').text()).toBe(
           'hello persistent caching'
         )
@@ -137,9 +150,14 @@ describe('persistent-caching', () => {
                 )
               },
               async () => {
-                await start()
-                await checkChanges()
-                await stop()
+                await next.renameFolder('app/remove-me', 'app/add-me')
+                try {
+                  await start()
+                  await checkChanges()
+                  await stop()
+                } finally {
+                  await next.renameFolder('app/add-me', 'app/remove-me')
+                }
               }
             )
           }

--- a/test/e2e/persistent-caching/persistent-caching.test.ts
+++ b/test/e2e/persistent-caching/persistent-caching.test.ts
@@ -122,9 +122,7 @@ describe('persistent-caching', () => {
 
       {
         const browser = await next.browser('/add-me')
-        expect(await browser.elementByCss('p').text()).toBe(
-          'hello persistent caching'
-        )
+        expect(await browser.elementByCss('p').text()).toBe('hello world')
         await browser.close()
       }
     }


### PR DESCRIPTION
### What?

Make the test case cover more cases by testing for add and removal of pages, client components, multiple noop builds and multiple change cycles.

Closes PACK-4381