### PR TITLE
Move static-env imports

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -207,7 +207,8 @@ import {
 
 import { turbopackBuild } from './turbopack-build'
 import { isPersistentCachingEnabled } from '../shared/lib/turbopack/utils'
-import { inlineStaticEnv, populateStaticEnv } from '../lib/inline-static-env'
+import { inlineStaticEnv } from '../lib/inline-static-env'
+import { populateStaticEnv } from '../lib/static-env'
 
 type Fallback = null | boolean | string
 

--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -6,17 +6,10 @@ import type { MiddlewareMatcher } from '../../analysis/get-page-static-info'
 import { webpack } from 'next/dist/compiled/webpack/webpack'
 import { needsExperimentalReact } from '../../../lib/needs-experimental-react'
 import { checkIsAppPPREnabled } from '../../../server/lib/experimental/ppr'
-
-function errorIfEnvConflicted(config: NextConfigComplete, key: string) {
-  const isPrivateKey = /^(?:NODE_.+)|^(?:__.+)$/i.test(key)
-  const hasNextRuntimeKey = key === 'NEXT_RUNTIME'
-
-  if (isPrivateKey || hasNextRuntimeKey) {
-    throw new Error(
-      `The key "${key}" under "env" in ${config.configFileName} is not allowed. https://nextjs.org/docs/messages/env-key-not-allowed`
-    )
-  }
-}
+import {
+  getNextConfigEnv,
+  getNextPublicEnvironmentVariables,
+} from '../../../lib/static-env'
 
 type BloomFilter = ReturnType<
   import('../../../shared/lib/bloom-filter').BloomFilter['export']
@@ -54,39 +47,6 @@ interface DefineEnv {
 
 interface SerializedDefineEnv {
   [key: string]: string
-}
-
-/**
- * Collects all environment variables that are using the `NEXT_PUBLIC_` prefix.
- */
-export function getNextPublicEnvironmentVariables(): DefineEnv {
-  const defineEnv: DefineEnv = {}
-  for (const key in process.env) {
-    if (key.startsWith('NEXT_PUBLIC_')) {
-      const value = process.env[key]
-      if (value != null) {
-        defineEnv[`process.env.${key}`] = value
-      }
-    }
-  }
-  return defineEnv
-}
-
-/**
- * Collects the `env` config value from the Next.js config.
- */
-export function getNextConfigEnv(config: NextConfigComplete): DefineEnv {
-  // Refactored code below to use for-of
-  const defineEnv: DefineEnv = {}
-  const env = config.env
-  for (const key in env) {
-    const value = env[key]
-    if (value != null) {
-      errorIfEnvConflicted(config, key)
-      defineEnv[`process.env.${key}`] = value
-    }
-  }
-  return defineEnv
 }
 
 /**

--- a/packages/next/src/lib/inline-static-env.ts
+++ b/packages/next/src/lib/inline-static-env.ts
@@ -3,37 +3,12 @@ import path from 'path'
 import crypto from 'crypto'
 import { promisify } from 'util'
 import globOriginal from 'next/dist/compiled/glob'
-import {
-  getNextConfigEnv,
-  getNextPublicEnvironmentVariables,
-} from '../build/webpack/plugins/define-env-plugin'
 import { Sema } from 'next/dist/compiled/async-sema'
 import type { NextConfigComplete } from '../server/config-shared'
 import { BUILD_MANIFEST } from '../shared/lib/constants'
+import { getNextConfigEnv, getStaticEnv } from './static-env'
 
 const glob = promisify(globOriginal)
-
-const getStaticEnv = (config: NextConfigComplete) => {
-  const staticEnv: Record<string, string | undefined> = {
-    ...getNextPublicEnvironmentVariables(),
-    ...getNextConfigEnv(config),
-    'process.env.NEXT_DEPLOYMENT_ID': config.deploymentId || '',
-  }
-  return staticEnv
-}
-
-export function populateStaticEnv(config: NextConfigComplete) {
-  // since inlining comes after static generation we need
-  // to ensure this value is assigned to process env so it
-  // can still be accessed
-  const staticEnv = getStaticEnv(config)
-  for (const key in staticEnv) {
-    const innerKey = key.split('.').pop() || ''
-    if (!process.env[innerKey]) {
-      process.env[innerKey] = staticEnv[key] || ''
-    }
-  }
-}
 
 export async function inlineStaticEnv({
   distDir,

--- a/packages/next/src/lib/static-env.ts
+++ b/packages/next/src/lib/static-env.ts
@@ -1,0 +1,67 @@
+import type { NextConfigComplete } from '../server/config-shared'
+
+function errorIfEnvConflicted(config: NextConfigComplete, key: string) {
+  const isPrivateKey = /^(?:NODE_.+)|^(?:__.+)$/i.test(key)
+  const hasNextRuntimeKey = key === 'NEXT_RUNTIME'
+
+  if (isPrivateKey || hasNextRuntimeKey) {
+    throw new Error(
+      `The key "${key}" under "env" in ${config.configFileName} is not allowed. https://nextjs.org/docs/messages/env-key-not-allowed`
+    )
+  }
+}
+
+/**
+ * Collects all environment variables that are using the `NEXT_PUBLIC_` prefix.
+ */
+export function getNextPublicEnvironmentVariables() {
+  const defineEnv: Record<string, string | undefined> = {}
+  for (const key in process.env) {
+    if (key.startsWith('NEXT_PUBLIC_')) {
+      const value = process.env[key]
+      if (value != null) {
+        defineEnv[`process.env.${key}`] = value
+      }
+    }
+  }
+  return defineEnv
+}
+
+/**
+ * Collects the `env` config value from the Next.js config.
+ */
+export function getNextConfigEnv(config: NextConfigComplete) {
+  // Refactored code below to use for-of
+  const defineEnv: Record<string, string | undefined> = {}
+  const env = config.env
+  for (const key in env) {
+    const value = env[key]
+    if (value != null) {
+      errorIfEnvConflicted(config, key)
+      defineEnv[`process.env.${key}`] = value
+    }
+  }
+  return defineEnv
+}
+
+export function getStaticEnv(config: NextConfigComplete) {
+  const staticEnv: Record<string, string | undefined> = {
+    ...getNextPublicEnvironmentVariables(),
+    ...getNextConfigEnv(config),
+    'process.env.NEXT_DEPLOYMENT_ID': config.deploymentId || '',
+  }
+  return staticEnv
+}
+
+export function populateStaticEnv(config: NextConfigComplete) {
+  // since inlining comes after static generation we need
+  // to ensure this value is assigned to process env so it
+  // can still be accessed
+  const staticEnv = getStaticEnv(config)
+  for (const key in staticEnv) {
+    const innerKey = key.split('.').pop() || ''
+    if (!process.env[innerKey]) {
+      process.env[innerKey] = staticEnv[key] || ''
+    }
+  }
+}

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -614,17 +614,6 @@ export default abstract class Server<
       reactMaxHeadersLength: this.nextConfig.reactMaxHeadersLength,
     }
 
-    if (process.env.NEXT_RUNTIME !== 'edge') {
-      const { populateStaticEnv } =
-        require('../lib/inline-static-env') as typeof import('../lib/inline-static-env')
-
-      // when using compile mode static env isn't inlined so we
-      // need to populate in normal runtime env
-      if (this.renderOpts.isExperimentalCompile) {
-        populateStaticEnv(this.nextConfig)
-      }
-    }
-
     // Initialize next/config with the environment configuration
     setConfig({
       serverRuntimeConfig,

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -111,6 +111,7 @@ import { AwaiterOnce } from './after/awaiter'
 import { AsyncCallbackSet } from './lib/async-callback-set'
 import { initializeCacheHandlers, setCacheHandler } from './use-cache/handlers'
 import type { UnwrapPromise } from '../lib/coalesced-function'
+import { populateStaticEnv } from '../lib/static-env'
 
 export * from './base-server'
 
@@ -278,6 +279,12 @@ export default class NextNodeServer extends BaseServer<
       this.prepare().catch((err) => {
         console.error('Failed to prepare server', err)
       })
+    }
+
+    // when using compile mode static env isn't inlined so we
+    // need to populate in normal runtime env
+    if (this.renderOpts.isExperimentalCompile) {
+      populateStaticEnv(this.nextConfig)
     }
   }
 


### PR DESCRIPTION
In https://github.com/vercel/next.js/pull/76990 we noticed that imports in `base-server`/`next-server` are being processed by turbopack which needs to be investigated further although for now this moves the imports to only import the necessary files in `next-server` to avoid bundling time regression. 