### PR TITLE
Add config for only generating static env

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2509,6 +2509,17 @@ export default async function build(
               buildId,
             })
           })
+
+        // users might only want to inline env during experimental generate
+        // instead of also prerendering e.g. for testmode so exit after
+        if (config.experimental.generateOnlyEnv) {
+          Log.info(
+            'Only inlining static env due to experimental.generateOnlyEnv'
+          )
+        }
+        await flushAllTraces()
+        teardownTraceSubscriber()
+        process.exit(0)
       }
 
       const middlewareManifest: MiddlewareManifest = await readManifest(

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -261,6 +261,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
     excludeDefaultMomentLocales: z.boolean().optional(),
     experimental: z
       .strictObject({
+        generateOnlyEnv: z.boolean().optional(),
         allowedDevOrigins: z.array(z.string()).optional(),
         nodeMiddleware: z.boolean().optional(),
         after: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -257,6 +257,7 @@ export interface LoggingConfig {
 }
 
 export interface ExperimentalConfig {
+  generateOnlyEnv?: boolean
   allowedDevOrigins?: string[]
   nodeMiddleware?: boolean
   cacheHandlers?: {
@@ -1135,6 +1136,7 @@ export const defaultConfig: NextConfig = {
   modularizeImports: undefined,
   outputFileTracingRoot: process.env.NEXT_PRIVATE_OUTPUT_TRACE_ROOT || '',
   experimental: {
+    generateOnlyEnv: false,
     allowedDevOrigins: [],
     nodeMiddleware: false,
     cacheLife: {


### PR DESCRIPTION
This adds a config for more granular handling for `--experimental-build-mode=generate` to allow only inlining the env variables since this was moved to the generate step and you might need these inlined without also running prerendering e.g. when using the experimental test mode server. 