### PR TITLE
unify allowed origin detection handling

### DIFF
--- a/docs/01-app/04-api-reference/05-config/01-next-config-js/allowedDevOrigins.mdx
+++ b/docs/01-app/04-api-reference/05-config/01-next-config-js/allowedDevOrigins.mdx
@@ -11,7 +11,7 @@ To configure a Next.js application to allow requests from origins other than the
 
 ```js filename="next.config.js"
 module.exports = {
-  allowedDevOrigins: ['local-origin.dev'],
+  allowedDevOrigins: ['local-origin.dev', '*.local-origin.dev'],
 }
 ```
 

--- a/packages/next/src/server/lib/router-utils/block-cross-site.ts
+++ b/packages/next/src/server/lib/router-utils/block-cross-site.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage, ServerResponse } from 'webpack-dev-server'
 import { parseUrl } from '../../../lib/url'
 import net from 'net'
 import { warnOnce } from '../../../build/output/log'
+import { isCsrfOriginAllowed } from '../../app-render/csrf-protection'
 
 export const blockCrossSite = (
   req: IncomingMessage,
@@ -25,7 +26,7 @@ export const blockCrossSite = (
     }
     res.end('Unauthorized')
     warnOnce(
-      `Blocked cross-origin request to /_next/*. To allow this, configure "allowedDevOrigins" in next.config\nRead more: https://nextjs.org/docs/app/api-reference/config/next-config-js/allowedDevOrigins`
+      `Blocked cross-origin request to /_next/*. Cross-site requests are blocked in "no-cors" mode.`
     )
     return true
   }
@@ -46,9 +47,7 @@ export const blockCrossSite = (
         // allow requests if direct IP and matching port and
         // allow if any of the allowed origins match
         !(isIpRequest && isMatchingPort) &&
-        !allowedOrigins.some(
-          (allowedOrigin) => allowedOrigin === originLowerCase
-        )
+        !isCsrfOriginAllowed(originLowerCase, allowedOrigins)
       ) {
         if ('statusCode' in res) {
           res.statusCode = 403


### PR DESCRIPTION
This unifies the CSRF origin detection to mirror what we do for server action origins, which supports things like wildcard matches (below the domain level)

Fixes #76999