### PR TITLE
Update rust toolchain to 2025-03-12

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-02-12"
+channel = "nightly-2025-03-12"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/turbopack/crates/turbo-tasks-auto-hash-map/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-auto-hash-map/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(hash_raw_entry)]
-#![feature(hash_extract_if)]
 
 pub mod map;
 pub mod set;

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -455,7 +455,6 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
         self.task_id
     }
 
-    #[must_use]
     fn add(&mut self, item: CachedDataItem) -> bool {
         self.check_access(item.category());
         if !self.backend.should_persist() || self.task_id.is_transient() || !item.is_persistent() {

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 #![feature(trivial_bounds)]
-#![feature(hash_extract_if)]
 #![feature(min_specialization)]
 #![feature(iter_advance_by)]
 #![feature(io_error_more)]

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_type.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_type.stderr
@@ -4,6 +4,15 @@ error: methods taking `self` are not supported with `operation`
 13 |     fn arbitrary_self_type(self: OperationVc<Self>) -> Vc<()> {
    |                            ^^^^^^^^^^^^^^^^^^^^^^^
 
+error[E0307]: invalid `self` parameter type: `OperationVc<Foobar>`
+  --> tests/function/fail_operation_method_self_type.rs:13:34
+   |
+13 |     fn arbitrary_self_type(self: OperationVc<Self>) -> Vc<()> {
+   |                                  ^^^^^^^^^^^^^^^^^
+   |
+   = note: type of `self` must be `Self` or some type implementing `Receiver`
+   = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
+
 error[E0277]: the trait bound `fn(...) -> ... {...::arbitrary_self_type_turbo_tasks_function_inline}: IntoTaskFnWithThis<_, _, _>` is not satisfied
   --> tests/function/fail_operation_method_self_type.rs:10:1
    |
@@ -22,12 +31,3 @@ note: required by a bound in `NativeFunction::new_method`
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `NativeFunction::new_method`
    = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the attribute macro `turbo_tasks::value_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0307]: invalid `self` parameter type: `OperationVc<Foobar>`
-  --> tests/function/fail_operation_method_self_type.rs:13:34
-   |
-13 |     fn arbitrary_self_type(self: OperationVc<Self>) -> Vc<()> {
-   |                                  ^^^^^^^^^^^^^^^^^
-   |
-   = note: type of `self` must be `Self` or some type implementing `Receiver`
-   = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`

--- a/turbopack/crates/turbo-tasks-memory/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(hash_extract_if)]
 #![feature(type_alias_impl_trait)]
 #![feature(box_patterns)]
 #![feature(int_roundings)]

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -29,7 +29,6 @@
 #![feature(trivial_bounds)]
 #![feature(min_specialization)]
 #![feature(try_trait_v2)]
-#![feature(hash_extract_if)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![feature(result_flattening)]
 #![feature(error_generic_member_access)]

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -113,6 +113,7 @@ impl StyleSheetLike<'_, '_> {
 pub struct UnresolvedUrlReferences(pub Vec<(String, ResolvedVc<UrlAssetReference>)>);
 
 #[turbo_tasks::value(shared, serialization = "none", eq = "manual", cell = "new")]
+#[allow(clippy::large_enum_variant)] // This is a turbo-tasks value
 pub enum ParseCssResult {
     Ok {
         code: ResolvedVc<FileContent>,

--- a/turbopack/crates/turbopack-dev-server/src/http.rs
+++ b/turbopack/crates/turbopack-dev-server/src/http.rs
@@ -1,4 +1,4 @@
-use std::io::{Error, ErrorKind};
+use std::io::Error;
 
 use anyhow::{anyhow, Result};
 use auto_hash_map::AutoSet;
@@ -177,10 +177,7 @@ pub async fn process_request_with_content_source(
                     header_map.insert(CONTENT_ENCODING, HeaderValue::from_static("gzip"));
 
                     // Grab ropereader stream, coerce anyhow::Error to std::io::Error
-                    let stream_ext = content
-                        .read()
-                        .into_stream()
-                        .map_err(|err| Error::new(ErrorKind::Other, err));
+                    let stream_ext = content.read().into_stream().map_err(Error::other);
 
                     let gzipped_stream =
                         ReaderStream::new(async_compression::tokio::bufread::GzipEncoder::new(

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -1509,10 +1509,9 @@ impl VisitAstPath for Analyzer<'_> {
         decl: &'ast FnDecl,
         ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
     ) {
-        let old = replace(
-            &mut self.cur_fn_return_values,
-            Some(get_fn_init_return_vals(decl.function.body.as_ref())),
-        );
+        let old = self
+            .cur_fn_return_values
+            .replace(get_fn_init_return_vals(decl.function.body.as_ref()));
         let old_ident = self.cur_fn_ident;
         self.cur_fn_ident = decl.function.span.lo.0;
         decl.visit_children_with_ast_path(self, ast_path);
@@ -1533,10 +1532,9 @@ impl VisitAstPath for Analyzer<'_> {
         expr: &'ast FnExpr,
         ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
     ) {
-        let old = replace(
-            &mut self.cur_fn_return_values,
-            Some(get_fn_init_return_vals(expr.function.body.as_ref())),
-        );
+        let old = self
+            .cur_fn_return_values
+            .replace(get_fn_init_return_vals(expr.function.body.as_ref()));
         let old_ident = self.cur_fn_ident;
         self.cur_fn_ident = expr.function.span.lo.0;
         expr.visit_children_with_ast_path(self, ast_path);

--- a/turbopack/crates/turbopack-ecmascript/src/swc_comments.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/swc_comments.rs
@@ -191,8 +191,8 @@ impl Comments for ImmutableComments {
 }
 
 pub struct CowComments<'a> {
-    leading: RefCell<FxHashMap<BytePos, Cow<'a, Vec<Comment>>>>,
-    trailing: RefCell<FxHashMap<BytePos, Cow<'a, Vec<Comment>>>>,
+    leading: RefCell<FxHashMap<BytePos, Cow<'a, [Comment]>>>,
+    trailing: RefCell<FxHashMap<BytePos, Cow<'a, [Comment]>>>,
 }
 
 impl<'a> CowComments<'a> {
@@ -202,14 +202,14 @@ impl<'a> CowComments<'a> {
                 comments
                     .leading
                     .iter()
-                    .map(|(&key, value)| (key, Cow::Borrowed(value)))
+                    .map(|(&key, value)| (key, Cow::Borrowed(&value[..])))
                     .collect(),
             ),
             trailing: RefCell::new(
                 comments
                     .trailing
                     .iter()
-                    .map(|(&key, value)| (key, Cow::Borrowed(value)))
+                    .map(|(&key, value)| (key, Cow::Borrowed(&value[..])))
                     .collect(),
             ),
         }
@@ -274,7 +274,7 @@ impl Comments for CowComments<'_> {
         &self,
         pos: swc_core::common::BytePos,
     ) -> Option<Vec<swc_core::common::comments::Comment>> {
-        self.leading.borrow().get(&pos).map(|v| (**v).clone())
+        self.leading.borrow().get(&pos).map(|v| (**v).to_vec())
     }
 
     fn add_trailing(
@@ -315,7 +315,7 @@ impl Comments for CowComments<'_> {
         &self,
         pos: swc_core::common::BytePos,
     ) -> Option<Vec<swc_core::common::comments::Comment>> {
-        self.trailing.borrow().get(&pos).map(|v| (**v).clone())
+        self.trailing.borrow().get(&pos).map(|v| (**v).to_vec())
     }
 
     fn add_pure_comment(&self, _pos: swc_core::common::BytePos) {

--- a/turbopack/crates/turbopack-ecmascript/src/utils.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/utils.rs
@@ -114,11 +114,8 @@ where
         impl std::io::Write for DisplayWriter<'_, '_> {
             fn write(&mut self, bytes: &[u8]) -> std::result::Result<usize, std::io::Error> {
                 self.f
-                    .write_str(
-                        std::str::from_utf8(bytes)
-                            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?,
-                    )
-                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                    .write_str(std::str::from_utf8(bytes).map_err(std::io::Error::other)?)
+                    .map_err(std::io::Error::other)?;
                 Ok(bytes.len())
             }
 

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -1,7 +1,6 @@
 #![feature(min_specialization)]
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
-#![feature(extract_if)]
 
 use std::{iter::once, thread::available_parallelism};
 

--- a/turbopack/crates/turbopack-trace-server/src/store.rs
+++ b/turbopack/crates/turbopack-trace-server/src/store.rs
@@ -1,7 +1,6 @@
 use std::{
     cmp::{max, min},
     env,
-    mem::replace,
     num::NonZeroUsize,
     sync::{atomic::AtomicU64, OnceLock},
 };
@@ -266,9 +265,9 @@ impl Store {
         outdated_spans.insert(span_index);
         let span = &mut self.spans[span_index.get()];
 
-        let old_parent = replace(&mut span.parent, Some(parent));
+        let old_parent = &mut span.parent.replace(parent);
         let old_parent = if let Some(parent) = old_parent {
-            outdated_spans.insert(parent);
+            outdated_spans.insert(*parent);
             &mut self.spans[parent.get()]
         } else {
             &mut self.spans[0]


### PR DESCRIPTION
- Removed `#![feature(extract_if)]`
- Removed `#![feature(hash_extract_if)]`
- Removed no-op `#[must_use]`
- Addressed new clippy violations


Closes PACK-4138