### PR TITLE
Alternate bundler: use built-in minifiers

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -93,7 +93,7 @@ import {
   NEXT_PROJECT_ROOT,
   NEXT_PROJECT_ROOT_DIST_CLIENT,
 } from './next-dir-paths'
-import { getRspackReactRefresh } from '../shared/lib/get-rspack'
+import { getRspackCore, getRspackReactRefresh } from '../shared/lib/get-rspack'
 import { RspackProfilingPlugin } from './webpack/plugins/rspack-profiling-plugin'
 
 type ExcludesFalse = <T>(x: T | false) => x is T
@@ -1173,12 +1173,10 @@ export default async function getBaseWebpackConfig(
           (isNodeServer && config.experimental.serverMinification)),
       minimizer: isRspack
         ? [
-            // @ts-expect-error
-            new webpack.SwcJsMinimizerRspackPlugin({
+            new (getRspackCore().SwcJsMinimizerRspackPlugin)({
               // JS minimizer configuration
             }),
-            // @ts-expect-error
-            new webpack.LightningCssMinimizerRspackPlugin({
+            new (getRspackCore().LightningCssMinimizerRspackPlugin)({
               // CSS minimizer configuration
             }),
           ]


### PR DESCRIPTION
Unlike other built-in plugins, we’re going to use the native minifiers. This was trying to use these exports from `webpack`, where they don’t exist. This updates them to be imported from `@rspack/core` instead.
    
Test Plan: Build the Rspack example (next PR in this stack)

Closes PACK-4137