### PR TITLE
Handle hash change in all files for static env

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2255,7 +2255,9 @@ export default async function build(
                 trustHostHeader: ciEnvironment.hasNextSupport,
 
                 // @ts-expect-error internal field TODO: fix this, should use a separate mechanism to pass the info.
-                isExperimentalCompile: isCompileMode,
+                isExperimentalCompile:
+                  isCompileMode ||
+                  (isGenerateMode && config.experimental.generateOnlyEnv),
               },
             },
             appDir: dir,
@@ -2513,7 +2515,7 @@ export default async function build(
         // instead of also prerendering e.g. for test mode so exit after
         if (config.experimental.generateOnlyEnv) {
           Log.info(
-            'Only inlining static env due to experimental.generateOnlyEnv'
+            'Inlined static env, exiting due to experimental.generateOnlyEnv'
           )
           await flushAllTraces()
           teardownTraceSubscriber()

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2506,7 +2506,6 @@ export default async function build(
             await inlineStaticEnv({
               distDir,
               config,
-              buildId,
             })
           })
 

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2510,15 +2510,15 @@ export default async function build(
           })
 
         // users might only want to inline env during experimental generate
-        // instead of also prerendering e.g. for testmode so exit after
+        // instead of also prerendering e.g. for test mode so exit after
         if (config.experimental.generateOnlyEnv) {
           Log.info(
             'Only inlining static env due to experimental.generateOnlyEnv'
           )
+          await flushAllTraces()
+          teardownTraceSubscriber()
+          process.exit(0)
         }
-        await flushAllTraces()
-        teardownTraceSubscriber()
-        process.exit(0)
       }
 
       const middlewareManifest: MiddlewareManifest = await readManifest(


### PR DESCRIPTION
Continuation of https://github.com/vercel/next.js/pull/77038 this ensures we replace hash changes in all assets so no stale hashes are left present and we don't have to keep a static list to update. This also ensures the server still treats the outputs as `compile` unless if only env `generate` is run. 

x-ref: [slack thread](https://vercel.slack.com/archives/C07BVA6HM17/p1741840160742479?thread_ts=1741722738.816639&cid=C07BVA6HM17)