### PR TITLE
docs: remove wrong tailwindcss type import from postcss config

### DIFF
--- a/docs/01-app/02-guides/tailwind-css.mdx
+++ b/docs/01-app/02-guides/tailwind-css.mdx
@@ -22,8 +22,7 @@ npm install -D tailwindcss @tailwindcss/postcss postcss
 
 Create a `postcss.config.mjs` file in the root of your project and add the `@tailwindcss/postcss` plugin to your PostCSS configuration:
 
-```js filename="postcss.config.mjs" highlight={4}
-/** @type {import('tailwindcss').Config} */
+```js filename="postcss.config.mjs" highlight={3}
 export default {
   plugins: {
     '@tailwindcss/postcss': {},


### PR DESCRIPTION
## What?

Delete `/** @type {import('tailwindcss').Config} */` line at `postcss.config.mjs` in [css](https://nextjs.org/docs/app/getting-started/css#configuring-tailwind) and [tailwind.css](https://nextjs.org/docs/app/building-your-application/styling/tailwind-css#configuring-tailwind) docs.

## Why?

`/** @type {import('tailwindcss').Config} */` is `tailwind.config.mjs` type.

```js
// tailwind.config.mjs

/** @type {import('tailwindcss').Config} */
module.exports = {
  content: [
    './pages/**/*.{js,ts,jsx,tsx}',
    './components/**/*.{js,ts,jsx,tsx}',
    './app/**/*.{js,ts,jsx,tsx}',
  ],
  theme: {
    extend: {
      fontFamily: {
        sans: ['var(--font-inter)'],
        mono: ['var(--font-roboto-mono)'],
      },
    },
  },
  plugins: [],
}
```

The appropriate type is `/** @type {import('postcss-load-config').Config} */`.

```js
// postcss.config.mjs

/** @type {import('postcss-load-config').Config} */
export default {
  plugins: {
    '@tailwindcss/postcss': {},
  },
}
```

Next, why delete `/** @type {import('postcss-load-config').Config} */`?

Because [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app) package removed the the types for postcss at #75407.

> **Note:** Removed the types for postcss added at https://github.com/vercel/next.js/pull/63380 since it requires additional [postcss-load-config](https://www.npmjs.com/package/postcss-load-config) dependency.

## How?

Adopt `create-next-app` template's [`postcss.config.mjs`](https://github.com/vercel/next.js/blob/canary/packages/create-next-app/templates/app-tw/ts/postcss.config.mjs).

```js
export default {
  plugins: {
    '@tailwindcss/postcss': {},
  },
}
```

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors


### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change


Closes NEXT-
Fixes #

-->
