### PR TITLE
[dev-overlay] highlight errored code line for runtime errors

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/code-frame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/code-frame.tsx
@@ -102,6 +102,8 @@ export function CodeFrame({ stackFrame, codeFrame }: CodeFrameProps) {
 
 export const CODE_FRAME_STYLES = `
   [data-nextjs-codeframe] {
+    --code-frame-padding: 12px;
+    --code-frame-line-height: var(--size-16);
     background-color: var(--color-background-200);
     overflow: hidden;
     color: var(--color-gray-1000);
@@ -110,7 +112,7 @@ export const CODE_FRAME_STYLES = `
     border-radius: 8px;
     font-family: var(--font-stack-monospace);
     font-size: var(--size-12);
-    line-height: var(--size-16);
+    line-height: var(--code-frame-line-height);
     margin: 8px 0;
 
     svg {
@@ -121,7 +123,7 @@ export const CODE_FRAME_STYLES = `
 
   .code-frame-link,
   .code-frame-pre {
-    padding: 12px;
+    padding: var(--code-frame-padding);
   }
 
   .code-frame-link svg {
@@ -171,6 +173,26 @@ export const CODE_FRAME_STYLES = `
     background-color: transparent;
     font-family: var(--font-stack-monospace);
   }
+
+  [data-nextjs-codeframe-line][data-nextjs-codeframe-line--errored="true"] {
+    position: relative;
+
+    > span { 
+      position: relative;
+      z-index: 1;
+    }
+
+    &::after {
+      content: "";
+      width: calc(100% + var(--code-frame-padding) * 2);
+      height: var(--code-frame-line-height);
+      left: calc(-1 * var(--code-frame-padding));
+      background: var(--color-red-200);
+      box-shadow: 2px 0 0 0 var(--color-red-900) inset;
+      position: absolute;
+    }
+  }
+
 
   [data-nextjs-codeframe] > * {
     margin: 0;

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/code-frame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/code-frame.tsx
@@ -1,55 +1,27 @@
 import type { StackFrame } from 'next/dist/compiled/stacktrace-parser'
-
-import Anser from 'next/dist/compiled/anser'
-import stripAnsi from 'next/dist/compiled/strip-ansi'
-
 import { useMemo } from 'react'
 import { HotlinkedText } from '../hot-linked-text'
 import { getFrameSource } from '../../../utils/stack-frame'
 import { useOpenInEditor } from '../../utils/use-open-in-editor'
 import { ExternalIcon } from '../../icons/external'
 import { FileIcon } from '../../icons/file'
+import {
+  formatCodeFrame,
+  groupCodeFrameLines,
+  parseLineNumberFromCodeFrameLine,
+} from './parse-code-frame'
 
 export type CodeFrameProps = { stackFrame: StackFrame; codeFrame: string }
 
 export function CodeFrame({ stackFrame, codeFrame }: CodeFrameProps) {
-  // Strip leading spaces out of the code frame:
-  const formattedFrame = useMemo<string>(() => {
-    const lines = codeFrame.split(/\r?\n/g)
-
-    // Find the minimum length of leading spaces after `|` in the code frame
-    const miniLeadingSpacesLength = lines
-      .map((line) =>
-        /^>? +\d+ +\| [ ]+/.exec(stripAnsi(line)) === null
-          ? null
-          : /^>? +\d+ +\| ( *)/.exec(stripAnsi(line))
-      )
-      .filter(Boolean)
-      .map((v) => v!.pop()!)
-      .reduce((c, n) => (isNaN(c) ? n.length : Math.min(c, n.length)), NaN)
-
-    // When the minimum length of leading spaces is greater than 1, remove them
-    // from the code frame to help the indentation looks better when there's a lot leading spaces.
-    if (miniLeadingSpacesLength > 1) {
-      return lines
-        .map((line, a) =>
-          ~(a = line.indexOf('|'))
-            ? line.substring(0, a) +
-              line.substring(a).replace(`^\\ {${miniLeadingSpacesLength}}`, '')
-            : line
-        )
-        .join('\n')
-    }
-    return lines.join('\n')
-  }, [codeFrame])
-
-  const decoded = useMemo(() => {
-    return Anser.ansiToJson(formattedFrame, {
-      json: true,
-      use_classes: true,
-      remove_empty: true,
-    })
-  }, [formattedFrame])
+  const formattedFrame = useMemo<string>(
+    () => formatCodeFrame(codeFrame),
+    [codeFrame]
+  )
+  const decodedLines = useMemo(
+    () => groupCodeFrameLines(formattedFrame),
+    [formattedFrame]
+  )
 
   const open = useOpenInEditor({
     file: stackFrame.file,
@@ -88,24 +60,41 @@ export function CodeFrame({ stackFrame, codeFrame }: CodeFrameProps) {
         </p>
       </div>
       <pre className="code-frame-pre">
-        {decoded.map((entry, index) => (
-          <span
-            key={`frame-${index}`}
-            style={{
-              color: entry.fg ? `var(--color-${entry.fg})` : undefined,
-              ...(entry.decoration === 'bold'
-                ? // TODO(jiwon): This used to be 800, but the symbols like `─┬─` are
-                  // having longer width than expected on Geist Mono font-weight
-                  // above 600, hence a temporary fix is to use 500 for bold.
-                  { fontWeight: 500 }
-                : entry.decoration === 'italic'
-                  ? { fontStyle: 'italic' }
-                  : undefined),
-            }}
-          >
-            {entry.content}
-          </span>
-        ))}
+        {decodedLines.map((line, lineIndex) => {
+          const { lineNumber, isErroredLine } =
+            parseLineNumberFromCodeFrameLine(line, stackFrame)
+
+          const lineNumberProps: Record<string, string | boolean> = {}
+          if (lineNumber) {
+            lineNumberProps['data-nextjs-codeframe-line'] = lineNumber
+          }
+          if (isErroredLine) {
+            lineNumberProps['data-nextjs-codeframe-line--errored'] = true
+          }
+
+          return (
+            <div key={`line-${lineIndex}`} {...lineNumberProps}>
+              {line.map((entry, entryIndex) => (
+                <span
+                  key={`frame-${entryIndex}`}
+                  style={{
+                    color: entry.fg ? `var(--color-${entry.fg})` : undefined,
+                    ...(entry.decoration === 'bold'
+                      ? // TODO(jiwon): This used to be 800, but the symbols like `─┬─` are
+                        // having longer width than expected on Geist Mono font-weight
+                        // above 600, hence a temporary fix is to use 500 for bold.
+                        { fontWeight: 500 }
+                      : entry.decoration === 'italic'
+                        ? { fontStyle: 'italic' }
+                        : undefined),
+                  }}
+                >
+                  {entry.content}
+                </span>
+              ))}
+            </div>
+          )
+        })}
       </pre>
     </div>
   )

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/parse-code-frame.test.ts
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/parse-code-frame.test.ts
@@ -1,0 +1,52 @@
+import {
+  formatCodeFrame,
+  groupCodeFrameLines,
+  parseLineNumberFromCodeFrameLine,
+} from './parse-code-frame'
+
+describe('parse line numbers', () => {
+  it('parse line numbers from code frame', () => {
+    const input = {
+      stackFrame: {
+        file: 'app/page.tsx',
+        lineNumber: 2,
+        column: 9,
+        methodName: 'Page',
+        arguments: [],
+        ignored: false,
+      },
+      //   1 | export default function Page() {
+      // > 2 |   throw new Error('test error')
+      //     |         ^
+      //   3 |   return <p>hello world</p>
+      //   4 | }
+      codeFrame:
+        "\u001b[0m \u001b[90m 1 |\u001b[39m \u001b[36mexport\u001b[39m \u001b[36mdefault\u001b[39m \u001b[36mfunction\u001b[39m \u001b[33mPage\u001b[39m() {\u001b[0m\n\u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 2 |\u001b[39m   \u001b[36mthrow\u001b[39m \u001b[36mnew\u001b[39m \u001b[33mError\u001b[39m(\u001b[32m'test error'\u001b[39m)\u001b[0m\n\u001b[0m \u001b[90m   |\u001b[39m         \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 3 |\u001b[39m   \u001b[36mreturn\u001b[39m \u001b[33m<\u001b[39m\u001b[33mp\u001b[39m\u001b[33m>\u001b[39mhello world\u001b[33m<\u001b[39m\u001b[33m/\u001b[39m\u001b[33mp\u001b[39m\u001b[33m>\u001b[39m\u001b[0m\n\u001b[0m \u001b[90m 4 |\u001b[39m }\u001b[0m\n\u001b[0m \u001b[90m 5 |\u001b[39m\u001b[0m",
+    }
+
+    const formattedFrame = formatCodeFrame(input.codeFrame)
+    const decodedLines = groupCodeFrameLines(formattedFrame)
+
+    expect(
+      parseLineNumberFromCodeFrameLine(decodedLines[0], input.stackFrame)
+    ).toEqual({
+      lineNumber: '1',
+      isErroredLine: false,
+    })
+
+    expect(
+      parseLineNumberFromCodeFrameLine(decodedLines[1], input.stackFrame)
+    ).toEqual({
+      lineNumber: '2',
+      isErroredLine: true,
+    })
+
+    // Line of ^ marker
+    expect(
+      parseLineNumberFromCodeFrameLine(decodedLines[2], input.stackFrame)
+    ).toEqual({
+      lineNumber: '',
+      isErroredLine: false,
+    })
+  })
+})

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/parse-code-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/parse-code-frame.ts
@@ -1,0 +1,81 @@
+import type { StackFrame } from 'next/dist/compiled/stacktrace-parser'
+import Anser, { type AnserJsonEntry } from 'next/dist/compiled/anser'
+import stripAnsi from 'next/dist/compiled/strip-ansi'
+
+// Strip leading spaces out of the code frame
+export function formatCodeFrame(codeFrame: string) {
+  const lines = codeFrame.split(/\r?\n/g)
+
+  // Find the minimum length of leading spaces after `|` in the code frame
+  const miniLeadingSpacesLength = lines
+    .map((line) =>
+      /^>? +\d+ +\| [ ]+/.exec(stripAnsi(line)) === null
+        ? null
+        : /^>? +\d+ +\| ( *)/.exec(stripAnsi(line))
+    )
+    .filter(Boolean)
+    .map((v) => v!.pop()!)
+    .reduce((c, n) => (isNaN(c) ? n.length : Math.min(c, n.length)), NaN)
+
+  // When the minimum length of leading spaces is greater than 1, remove them
+  // from the code frame to help the indentation looks better when there's a lot leading spaces.
+  if (miniLeadingSpacesLength > 1) {
+    return lines
+      .map((line, a) =>
+        ~(a = line.indexOf('|'))
+          ? line.substring(0, a) +
+            line.substring(a).replace(`^\\ {${miniLeadingSpacesLength}}`, '')
+          : line
+      )
+      .join('\n')
+  }
+  return lines.join('\n')
+}
+
+export function groupCodeFrameLines(formattedFrame: string) {
+  // Map the decoded lines to a format that can be rendered
+  const decoded = Anser.ansiToJson(formattedFrame, {
+    json: true,
+    use_classes: true,
+    remove_empty: true,
+  })
+  const lines: (typeof decoded)[] = []
+
+  let line: typeof decoded = []
+  for (const token of decoded) {
+    if (token.content === '\n') {
+      lines.push(line)
+      line = []
+    } else {
+      line.push(token)
+    }
+  }
+  if (line.length > 0) {
+    lines.push(line)
+  }
+
+  return lines
+}
+
+export function parseLineNumberFromCodeFrameLine(
+  line: AnserJsonEntry[],
+  stackFrame: StackFrame
+) {
+  let lineNumberToken: AnserJsonEntry | undefined
+  let lineNumber: string | undefined
+  // parse line number from line first 2 tokens
+  // e.g. ` > 1 | const foo = 'bar'` => `1`, first token is `1 |`
+  // e.g. `  2 | const foo = 'bar'` => `2`. first 2 tokens are ' ' and ' 2 |'
+  // console.log('line', line)
+  if (line[0]?.content === '>' || line[0]?.content === ' ') {
+    lineNumberToken = line[1]
+    lineNumber = lineNumberToken?.content?.replace('|', '')?.trim()
+  }
+
+  // When the line number is possibly undefined, it can be just the non-source code line
+  // e.g. the ^ sign can also take a line, we skip rendering line number for it
+  return {
+    lineNumber,
+    isErroredLine: lineNumber === stackFrame.lineNumber?.toString(),
+  }
+}

--- a/packages/next/src/client/components/react-dev-overlay/ui/container/runtime-error/component-stack-pseudo-html.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/container/runtime-error/component-stack-pseudo-html.tsx
@@ -20,6 +20,7 @@ export const PSEUDO_HTML_DIFF_STYLES = `
   }
   [data-nextjs-container-errors-pseudo-html--diff='error'] {
     background: var(--color-amber-100);
+    box-shadow: 2px 0 0 0 var(--color-amber-900) inset;
     font-weight: bold;
   }
   [data-nextjs-container-errors-pseudo-html-collapse-button] {


### PR DESCRIPTION
### What

In the runtime error code frame display, since there's usually a errored line we highlighted, we want to highlight the certain that line to give the better visibility.

We already know each token in the highlighted code frame but it lacks of the concept of "line". I now parse the code frame leading tokens and group them into lines, in order to apply the certain class name or attributes to that line for styling purpose.

This PR wraps each line of code in a `div`, it will have 1 - 2 new attributes.

* If it's a source code line, which is not just highlight mark like `^`, it will have `data-nextjs-codeframe-line="<line number>"`
* if it's the line that errored in stack frame, it will have `data-nextjs-codeframe-line--errored="true"`

And we apply the red background styling to the highlighted lines


| After | Before |
|:---|:--- |
| ![image](https://github.com/user-attachments/assets/45cc1bb5-f8e0-4448-8678-9133d4f11e00) |  ![image](https://github.com/user-attachments/assets/364c03e6-07a7-4259-b558-1ffbf0c37605) |


Closes NDX-975