### PR TITLE
NFT: Ignore all of Webpack

### DIFF
--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -201,7 +201,7 @@ export async function collectBuildTraces({
       const sharedIgnores = [
         '**/next/dist/compiled/next-server/**/*.dev.js',
         ...(isStandalone ? [] : ['**/next/dist/compiled/jest-worker/**/*']),
-        '**/next/dist/compiled/webpack/(bundle4|bundle5).js',
+        '**/next/dist/compiled/webpack/*',
         '**/node_modules/webpack5/**/*',
         '**/next/dist/server/lib/route-resolver*',
         'next/dist/compiled/semver/semver/**/*.js',


### PR DESCRIPTION
After https://github.com/vercel/next.js/pull/76990, `packages/next/dist/build/webpack/plugins/define-env-plugin.js` would pull in `compiled/webpack/webpack.js`, which was not on the ignore list. Resulting in 2100 files in the NFT result, instead of 971.

This leaves the more reasonable change of the following additional NFT results:
```
  'packages/next/dist/compiled/async-sema/index.js',
  'packages/next/dist/compiled/async-sema/package.json',
  'packages/next/dist/build/webpack/plugins/define-env-plugin.js',
  'packages/next/dist/compiled/glob/glob.js',
  'packages/next/dist/compiled/glob/package.json',
  'packages/next/dist/lib/inline-static-env.js',
  'packages/next/dist/lib/needs-experimental-react.js',
```

Closes PACK-4132