### PR TITLE
Fix JSDoc comment for `'seconds'` cache life profile

### DIFF
--- a/packages/next/cache.d.ts
+++ b/packages/next/cache.d.ts
@@ -30,11 +30,12 @@ export function unstable_cacheLife(profile: 'default'): void
  * ```
  *   stale:      0 seconds
  *   revalidate: 1 seconds
- *   expire:     1 seconds
+ *   expire:     1 minute
  * ```
  *
  * This cache may be stale on clients for 0 seconds before checking with the server.
- * This cache will expire after 1 seconds. The next request will recompute it.
+ * If the server receives a new request after 1 second, start revalidating new values in the background.
+ * If this entry has no traffic for 1 minute it will expire. The next request will recompute it.
  */
 export function unstable_cacheLife(profile: 'seconds'): void
 


### PR DESCRIPTION
The `expire` value for the `'seconds'` cache life profile is one minute, not one second.

[Source](https://github.com/vercel/next.js/blob/6b35981a80959db80e89a5dff27535c4094e3828/packages/next/src/server/config-shared.ts#L1152)