### PR TITLE
Turbopack: fewer manifests for static metadata

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1108,8 +1108,11 @@ impl AppEndpoint {
 
         #[derive(Debug, PartialEq, Eq)]
         enum EmitManifests {
+            /// Don't emit any manifests (needed for the RSC endpoints)
             None,
+            /// Emit the manifest for basic Next.js functionality (e.g. app-build-manifest.json)
             Minimal,
+            /// All manifests: `Minimal` plus client-references, next-dynamic, ...
             Full,
         }
         let (process_client_assets, process_ssr, emit_manifests) = match this.ty {

--- a/test/e2e/app-dir/use-cache-metadata-route-handler/use-cache-metadata-route-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-metadata-route-handler/use-cache-metadata-route-handler.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('use-cache-metadata-route-handler', () => {
-  const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isNextStart } = nextTestSetup({
     files: __dirname,
   })
 
@@ -132,7 +132,7 @@ describe('use-cache-metadata-route-handler', () => {
     }
   })
 
-  if (isNextStart && !isTurbopack) {
+  if (isNextStart) {
     it('should include the client reference manifest in the route.js.nft.json files of dynamic metadata routes', async () => {
       for (const filename of [
         'icon',
@@ -146,7 +146,9 @@ describe('use-cache-metadata-route-handler', () => {
           `/.next/server/app/${filename}/route.js.nft.json`
         )
 
-        expect(files).toInclude('route_client-reference-manifest.js')
+        expect(
+          files.find((e) => e.endsWith('route_client-reference-manifest.js'))
+        ).toBeString()
       }
     })
 
@@ -155,7 +157,9 @@ describe('use-cache-metadata-route-handler', () => {
         '/.next/server/app/favicon.ico/route.js.nft.json'
       )
 
-      expect(files).not.toInclude('route_client-reference-manifest.js')
+      expect(
+        files.find((e) => e.endsWith('route_client-reference-manifest.js'))
+      ).toBeUndefined()
     })
   }
 })

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -5498,7 +5498,9 @@
         "use-cache-metadata-route-handler should generate manifest.json with a metadata route handler that uses \"use cache\"",
         "use-cache-metadata-route-handler should generate multiple sitemaps with a metadata route handler that uses \"use cache\"",
         "use-cache-metadata-route-handler should generate robots.txt with a metadata route handler that uses \"use cache\"",
-        "use-cache-metadata-route-handler should generate sitemaps with a metadata route handler that uses \"use cache\""
+        "use-cache-metadata-route-handler should generate sitemaps with a metadata route handler that uses \"use cache\"",
+        "use-cache-metadata-route-handler should include the client reference manifest in the route.js.nft.json files of dynamic metadata routes",
+        "use-cache-metadata-route-handler should not include the client reference manifest in the route.js.nft.json files of static metadata routes"
       ],
       "failed": [],
       "pending": [],

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -8724,10 +8724,7 @@
       "use-cache-metadata-route-handler should generate sitemaps with a metadata route handler that uses \"use cache\""
     ],
     "failed": [],
-    "pending": [
-      "use-cache-metadata-route-handler should include the client reference manifest in the route.js.nft.json files of dynamic metadata routes",
-      "use-cache-metadata-route-handler should not include the client reference manifest in the route.js.nft.json files of static metadata routes"
-    ],
+    "pending": [],
     "flakey": [],
     "runtimeError": false
   },

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -8724,7 +8724,10 @@
       "use-cache-metadata-route-handler should generate sitemaps with a metadata route handler that uses \"use cache\""
     ],
     "failed": [],
-    "pending": [],
+    "pending": [
+      "use-cache-metadata-route-handler should include the client reference manifest in the route.js.nft.json files of dynamic metadata routes",
+      "use-cache-metadata-route-handler should not include the client reference manifest in the route.js.nft.json files of static metadata routes"
+    ],
     "flakey": [],
     "runtimeError": false
   },


### PR DESCRIPTION
Closes PACK-3731

This test was effectively already passing, except that we unnecessarily always emitted manifests.

No need to emit the various client reference, next dynamic, server actions, ... manifests for static metadata routes.
