### PR TITLE
Add experimental build mode flag for env

### DIFF
--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -135,7 +135,7 @@ program
       '--experimental-build-mode [mode]',
       'Uses an experimental build mode.'
     )
-      .choices(['compile', 'generate'])
+      .choices(['compile', 'generate', 'generate-env'])
       .default('default')
   )
   .option(

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -885,6 +885,10 @@ export default async function build(
       NextBuildContext.buildId = buildId
 
       if (experimentalBuildMode === 'generate-env') {
+        if (turboNextBuild) {
+          Log.warn('generate-env is not needed with turbopack')
+          process.exit(0)
+        }
         Log.info('Inlining static env ...')
         await nextBuildSpan
           .traceChild('inline-static-env')
@@ -2517,6 +2521,8 @@ export default async function build(
       // we don't need to inline for turbopack build as
       // it will handle it's own caching separate of compile
       if (isGenerateMode && !turboNextBuild) {
+        Log.info('Inlining static env ...')
+
         await nextBuildSpan
           .traceChild('inline-static-env')
           .traceAsyncFn(async () => {

--- a/packages/next/src/cli/next-build.ts
+++ b/packages/next/src/cli/next-build.ts
@@ -19,7 +19,7 @@ export type NextBuildOptions = {
   experimentalDebugMemoryUsage: boolean
   experimentalAppOnly?: boolean
   experimentalTurbo?: boolean
-  experimentalBuildMode: 'default' | 'compile' | 'generate'
+  experimentalBuildMode: 'default' | 'compile' | 'generate' | 'generate-env'
   experimentalUploadTrace?: string
 }
 

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -262,7 +262,6 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
     excludeDefaultMomentLocales: z.boolean().optional(),
     experimental: z
       .strictObject({
-        generateOnlyEnv: z.boolean().optional(),
         nodeMiddleware: z.boolean().optional(),
         after: z.boolean().optional(),
         appDocumentPreloading: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -257,7 +257,6 @@ export interface LoggingConfig {
 }
 
 export interface ExperimentalConfig {
-  generateOnlyEnv?: boolean
   nodeMiddleware?: boolean
   cacheHandlers?: {
     default?: string
@@ -1138,7 +1137,6 @@ export const defaultConfig: NextConfig = {
   outputFileTracingRoot: process.env.NEXT_PRIVATE_OUTPUT_TRACE_ROOT || '',
   allowedDevOrigins: [],
   experimental: {
-    generateOnlyEnv: false,
     nodeMiddleware: false,
     cacheLife: {
       default: {

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -13,8 +13,15 @@ describe('app dir - basic', () => {
     nextTestSetup({
       files: __dirname,
       buildCommand: process.env.NEXT_EXPERIMENTAL_COMPILE
-        ? `pnpm next build --experimental-build-mode=compile`
+        ? 'pnpm compile-mode'
         : undefined,
+      packageJson: {
+        scripts: {
+          'compile-mode': process.env.NEXT_EXPERIMENTAL_COMPILE
+            ? `next build --experimental-build-mode=compile && next build --experimental-build-mode=generate-env`
+            : undefined,
+        },
+      },
       dependencies: {
         nanoid: '4.0.1',
       },


### PR DESCRIPTION
This is an alternative to the `generateOnlyEnv` config which moves it to a build-mode flag instead for easier running. This also adds a log when running in compile mode to make it clear the build isn't finalized and saying next step since this is more important now that we don't inline env during compile by default. 