### PR TITLE
Make `revalidate*` work when followed by a redirect in a route handler

### DIFF
--- a/test/e2e/app-dir/use-cache/app/api/revalidate-redirect/route.ts
+++ b/test/e2e/app-dir/use-cache/app/api/revalidate-redirect/route.ts
@@ -1,0 +1,7 @@
+import { revalidateTag } from 'next/cache'
+import { redirect } from 'next/navigation'
+
+export async function GET() {
+  revalidateTag('api')
+  redirect('/api')
+}

--- a/test/e2e/app-dir/use-cache/app/api/route.ts
+++ b/test/e2e/app-dir/use-cache/app/api/route.ts
@@ -1,5 +1,9 @@
+import { unstable_cacheTag } from 'next/cache'
+
 async function getCachedRandom() {
   'use cache'
+  unstable_cacheTag('api')
+
   return Math.random()
 }
 
@@ -7,9 +11,5 @@ export async function GET() {
   const rand1 = await getCachedRandom()
   const rand2 = await getCachedRandom()
 
-  const response = JSON.stringify({ rand1, rand2 })
-
-  return new Response(response, {
-    headers: { 'content-type': 'application/json' },
-  })
+  return Response.json({ rand1, rand2 })
 }

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -158,44 +158,47 @@ describe('use-cache', () => {
     }
   })
 
-  it('should cache results in route handlers', async () => {
-    const response = await next.fetch('/api')
-    const { rand1, rand2 } = await response.json()
+  // TODO: Enable for deploy tests when upstream changes have been rolled out.
+  if (!isNextDeploy) {
+    it('should cache results in route handlers', async () => {
+      const response = await next.fetch('/api')
+      const { rand1, rand2 } = await response.json()
 
-    expect(rand1).toEqual(rand2)
-  })
+      expect(rand1).toEqual(rand2)
+    })
 
-  it('should revalidate before redirecting in a route handlers', async () => {
-    const initialValues = await next.fetch('/api').then((res) => res.json())
+    it('should revalidate before redirecting in a route handlers', async () => {
+      const initialValues = await next.fetch('/api').then((res) => res.json())
 
-    const values = await next
-      .fetch('/api/revalidate-redirect')
-      .then((res) => res.json())
+      const values = await next
+        .fetch('/api/revalidate-redirect')
+        .then((res) => res.json())
 
-    if (isNextDeploy) {
-      try {
+      if (isNextDeploy) {
+        try {
+          expect(values).not.toEqual(initialValues)
+        } catch {
+          // When deployed, we currently don't have a strong guarantee that the
+          // revalidations are propagated fully (as we do for redirecting server
+          // actions). This is because, for route handlers, the redirect occurs
+          // client-side, which prevents us from using the same technique as for
+          // server actions, which involves sending a revalidate token as a
+          // request header. This token must not leak to the client. However,
+          // eventually the revalidation will be propagated, and a refresh should
+          // show fresh data.
+          await retry(async () => {
+            const refreshedValues = await next
+              .fetch('/api')
+              .then((res) => res.json())
+
+            expect(refreshedValues).not.toEqual(initialValues)
+          })
+        }
+      } else {
         expect(values).not.toEqual(initialValues)
-      } catch {
-        // When deployed, we currently don't have a strong guarantee that the
-        // revalidations are propagated fully (as we do for redirecting server
-        // actions). This is because, for route handlers, the redirect occurs
-        // client-side, which prevents us from using the same technique as for
-        // server actions, which involves sending a revalidate token as a
-        // request header. This token must not leak to the client. However,
-        // eventually the revalidation will be propagated, and a refresh should
-        // show fresh data.
-        await retry(async () => {
-          const refreshedValues = await next
-            .fetch('/api')
-            .then((res) => res.json())
-
-          expect(refreshedValues).not.toEqual(initialValues)
-        })
       }
-    } else {
-      expect(values).not.toEqual(initialValues)
-    }
-  })
+    })
+  }
 
   it('should cache results for cached functions imported from client components', async () => {
     const browser = await next.browser('/imported-from-client')


### PR DESCRIPTION
When a route handler calls `revalidateTag` or `revalidatePath`, we need to make sure that these revalidations are executed before returning with the redirect response.

Note: When deployed, we currently don't have a strong guarantee that the revalidations are fully propagated before executing the redirect target route – as we do for redirecting server actions. This is because, for route handlers, the redirect occurs client-side, which prevents us from using the same technique as for server actions, which involves sending a revalidate token as a request header. This token must not leak to the client. However, eventually the revalidation will be propagated, and a refresh should show fresh data.

fixes #74757