### PR TITLE
Turbopack: fix graph layout segment optimization

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -860,7 +860,7 @@ impl AppProject {
                     // as part of rsc_entry
                     for module in server_component_entries
                         .iter()
-                        .take(server_component_entries.len() - 1)
+                        .take(server_component_entries.len().saturating_sub(1))
                     {
                         let graph = SingleModuleGraph::new_with_entries_visited_intern(
                             // This should really be ChunkGroupEntry::Shared(module.await?.module),

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -855,7 +855,13 @@ impl AppProject {
                     graphs.push(graph);
                     let mut visited_modules = VisitedModules::from_graph(graph);
 
-                    for module in server_component_entries.iter() {
+                    // Skip the last server component, which is the page itself, because that one
+                    // won't have it's visited modules added, and will be visited in the next step
+                    // as part of rsc_entry
+                    for module in server_component_entries
+                        .iter()
+                        .take(server_component_entries.len() - 1)
+                    {
                         let graph = SingleModuleGraph::new_with_entries_visited_intern(
                             // This should really be ChunkGroupEntry::Shared(module.await?.module),
                             // but that breaks everything for some reason.


### PR DESCRIPTION
The modules in the last layout segment (`server_component_entries`) were visited twice: as part of the last iteration of the for loop (which doesn't propagate its `visited_modules` because it's not a layout), and then again with `rsc_entry`.

We already do the right thing in another place:
https://github.com/vercel/next.js/blob/f42739d114695702922dab4c08d6c8223daafceb/crates/next-api/src/app.rs#L1740-L1748

Before:
![Bildschirmfoto 2025-03-17 um 11 39 41](https://github.com/user-attachments/assets/62adad85-043c-47f4-8c70-a8f5779e34a9)

After:
![Bildschirmfoto 2025-03-17 um 11 43 14](https://github.com/user-attachments/assets/62642bcf-8946-4bcd-ba16-cdd711cac383)


Closes PACK-4165