### PR TITLE
fix: fixes double encoded parameters when deployed to Vercel

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -178,6 +178,7 @@ import {
 } from './lib/streaming-metadata'
 import { getCacheHandlers } from './use-cache/handlers'
 import { InvariantError } from '../shared/lib/invariant-error'
+import { decodeQueryPathParameter } from './lib/decode-query-path-parameter'
 
 export type FindComponentsResult = {
   components: LoadComponentsReturnType
@@ -1218,7 +1219,10 @@ export default abstract class Server<
             delete parsedUrl.query[key]
 
             if (typeof value === 'undefined') continue
-            queryParams[normalizedKey] = value
+
+            queryParams[normalizedKey] = Array.isArray(value)
+              ? value.map((v) => decodeQueryPathParameter(v))
+              : decodeQueryPathParameter(value)
           }
 
           // interpolate dynamic params and normalize URL if needed

--- a/packages/next/src/server/lib/decode-query-path-parameter.ts
+++ b/packages/next/src/server/lib/decode-query-path-parameter.ts
@@ -1,0 +1,15 @@
+/**
+ * Decodes a query path parameter.
+ *
+ * @param value - The value to decode.
+ * @returns The decoded value.
+ */
+export function decodeQueryPathParameter(value: string) {
+  // When deployed to Vercel, the value may be encoded, so this attempts to
+  // decode it and returns the original value if it fails.
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}


### PR DESCRIPTION
When resolving routes during partial prerendering, the parameters that are added as query parameters can be double encoded. This fixes it so that the query parameters are decoded before being assigned to the `queryParams` object used for parsing the path parameters from.

Fixes #71005

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
