### PR TITLE
chore(github): add Not Found label

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -103,6 +103,7 @@ body:
         - 'Metadata'
         - 'Middleware'
         - 'Module Resolution'
+        - 'Not Found'
         - 'Output'
         - 'Pages Router'
         - 'Parallel & Intercepting Routes'


### PR DESCRIPTION
## Why?

Add the `Not Found` label for `not-found.tsx` file and `notFound()` function cases.