### PR TITLE
[ts-hint] fix vscode type hint plugin enabling

### DIFF
--- a/packages/next/src/server/typescript/index.ts
+++ b/packages/next/src/server/typescript/index.ts
@@ -28,10 +28,6 @@ import metadata from './rules/metadata'
 import errorEntry from './rules/error'
 import type tsModule from 'typescript/lib/tsserverlibrary'
 
-type NextTypePluginOptions = {
-  enabled?: boolean
-}
-
 export const createTSPlugin: tsModule.server.PluginModuleFactory = ({
   typescript: ts,
 }) => {
@@ -48,10 +44,14 @@ export const createTSPlugin: tsModule.server.PluginModuleFactory = ({
       proxy[k] = (...args: Array<{}>) => x.apply(info.languageService, args)
     }
 
-    const pluginOptions: NextTypePluginOptions = info.config ?? {
-      enabled: true,
-    }
-    if (!pluginOptions.enabled) {
+    // Get plugin options
+    // config is the plugin options from the user's tsconfig.json
+    // e.g. { "plugins": [{ "name": "next", "enabled": true }] }
+    // config will be { "name": "next", "enabled": true }
+    // The default user config is { "name": "next" }
+    const isPluginEnabled = info.config.enabled ?? true
+
+    if (!isPluginEnabled) {
       return proxy
     }
 


### PR DESCRIPTION
### What

Fix the enabling of ts hint plugin in vscode. This is a regression introduced in #76300, where we use the plugin config `{ "name": "next" }` to directly check if it has a `enabled` property, and determine if we should enable the plugin. This PR fixed the way of reading plugin config and keep it enabled by default.

Fixes #76980