### PR TITLE
Turbopack: move must_use to actually have an effect

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -366,6 +366,7 @@ where
 
 pub trait TaskGuard: Debug {
     fn id(&self) -> TaskId;
+    #[must_use]
     fn add(&mut self, item: CachedDataItem) -> bool;
     fn add_new(&mut self, item: CachedDataItem);
     fn insert(&mut self, item: CachedDataItem) -> Option<CachedDataItemValue>;
@@ -455,7 +456,6 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
         self.task_id
     }
 
-    #[must_use]
     fn add(&mut self, item: CachedDataItem) -> bool {
         self.check_access(item.category());
         if !self.backend.should_persist() || self.task_id.is_transient() || !item.is_persistent() {


### PR DESCRIPTION
It doesn't cause any warnings when declared on trait impls.

https://github.com/vercel/next.js/pull/77054#discussion_r1992412231

Closes PACK-4141