### PR TITLE
Turbopack: don't put server action loader at `.next-internal`

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1357,7 +1357,6 @@ impl AppEndpoint {
         let server_action_manifest = create_server_actions_manifest(
             *rsc_entry,
             actions,
-            project.project_path(),
             node_root,
             app_entry.original_name.clone(),
             runtime,
@@ -1984,8 +1983,6 @@ impl Endpoint for AppEndpoint {
         let server_actions_loader = ResolvedVc::upcast(
             build_server_actions_loader(
                 *rsc_entry,
-                this.app_project.project().project_path(),
-                app_entry.original_name.clone(),
                 actions,
                 match runtime {
                     NextRuntime::Edge => Vc::upcast(this.app_project.edge_rsc_module_context()),

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1355,6 +1355,7 @@ impl AppEndpoint {
         );
 
         let server_action_manifest = create_server_actions_manifest(
+            *rsc_entry,
             actions,
             project.project_path(),
             node_root,
@@ -1982,6 +1983,7 @@ impl Endpoint for AppEndpoint {
 
         let server_actions_loader = ResolvedVc::upcast(
             build_server_actions_loader(
+                *rsc_entry,
                 this.app_project.project().project_path(),
                 app_entry.original_name.clone(),
                 actions,

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -140,6 +140,7 @@ pub(crate) async fn build_server_actions_loader(
     let source = VirtualSource::new_with_ident(
         rsc_entry
             .ident()
+            .with_path(rsc_entry.ident().path().with_extension("js".into()))
             .with_modifier(server_actions_loader_modifier()),
         AssetContent::file(file.into()),
     );

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -26,7 +26,6 @@ use turbopack_core::{
     chunk::{ChunkItem, ChunkItemExt, ChunkableModule, ChunkingContext, EvaluatableAsset},
     context::AssetContext,
     file_source::FileSource,
-    ident::AssetIdent,
     module::Module,
     module_graph::{
         async_module_info::AsyncModulesInfo, ModuleGraph, SingleModuleGraph,
@@ -60,7 +59,6 @@ pub(crate) struct ServerActionsManifest {
 pub(crate) async fn create_server_actions_manifest(
     rsc_entry: Vc<Box<dyn Module>>,
     actions: Vc<AllActions>,
-    project_path: Vc<FileSystemPath>,
     node_root: Vc<FileSystemPath>,
     page_name: RcStr,
     runtime: NextRuntime,
@@ -68,13 +66,7 @@ pub(crate) async fn create_server_actions_manifest(
     module_graph: Vc<ModuleGraph>,
     chunking_context: Vc<Box<dyn ChunkingContext>>,
 ) -> Result<Vc<ServerActionsManifest>> {
-    let loader = build_server_actions_loader(
-        rsc_entry,
-        project_path,
-        page_name.clone(),
-        actions,
-        rsc_asset_context,
-    );
+    let loader = build_server_actions_loader(rsc_entry, actions, rsc_asset_context);
     let evaluable = Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(loader)
         .await?
         .context("loader module must be evaluatable")?
@@ -112,8 +104,6 @@ fn server_actions_loader_modifier() -> Vc<RcStr> {
 #[turbo_tasks::function]
 pub(crate) async fn build_server_actions_loader(
     rsc_entry: Vc<Box<dyn Module>>,
-    project_path: Vc<FileSystemPath>,
-    page_name: RcStr,
     actions: Vc<AllActions>,
     asset_context: Vc<Box<dyn AssetContext>>,
 ) -> Result<Vc<Box<dyn EcmascriptChunkPlaceable>>> {


### PR DESCRIPTION
Instead, its `ident` is now `rsc_entry.ident().with_modifier(some modifier)`.

The actual path is irrelevant, because all resolving happens via precomputed internal references anyway, but this saves us from creating a few more `ModuleContext`s in `.next-internal/.../.../...`.

So that might be then
`[project]/packages/next/dist/esm/build/templates/app-page.js?page=/css/css-conflict-layers/page { MODULE_0 => \"[project]/test/e2e/app-dir/app-css/app/layout.js [app-rsc] (ecmascript, Next.js server component)\", MODULE_1 => \"[project]/test/e2e/app-dir/app-css/app/not-found.js [app-rsc] (ecmascript, Next.js server component)\", MODULE_2 => \"[project]/packages/next/dist/client/components/forbidden-error.js [app-rsc] (ecmascript, Next.js server component)\", MODULE_3 => \"[project]/packages/next/dist/client/components/unauthorized-error.js [app-rsc] (ecmascript, Next.js server component)\", MODULE_4 => \"[project]/test/e2e/app-dir/app-css/app/css/layout.js [app-rsc] (ecmascript, Next.js server component)\", MODULE_5 => \"[project]/test/e2e/app-dir/app-css/app/css/css-conflict-layers/layout.js [app-rsc] (ecmascript, Next.js server component)\", MODULE_6 => \"[project]/test/e2e/app-dir/app-css/app/css/css-conflict-layers/page.js [app-rsc] (ecmascript, Next.js server component)\" } [app-rsc] (ecmascript, action loader)`

Closes PACK-4348