### PR TITLE
Add @phosphor-icons/react to the import optimization list

### DIFF
--- a/docs/01-app/04-api-reference/05-config/01-next-config-js/optimizePackageImports.mdx
+++ b/docs/01-app/04-api-reference/05-config/01-next-config-js/optimizePackageImports.mdx
@@ -19,28 +19,29 @@ module.exports = {
 
 The following libraries are optimized by default:
 
-- `lucide-react`
-- `date-fns`
-- `lodash-es`
-- `ramda`
-- `antd`
-- `react-bootstrap`
-- `ahooks`
 - `@ant-design/icons`
-- `@headlessui/react`
 - `@headlessui-float/react`
+- `@headlessui/react`
 - `@heroicons/react/20/solid`
-- `@heroicons/react/24/solid`
 - `@heroicons/react/24/outline`
-- `@visx/visx`
-- `@tremor/react`
-- `rxjs`
-- `@mui/material`
-- `@mui/icons-material`
-- `recharts`
-- `react-use`
+- `@heroicons/react/24/solid`
 - `@material-ui/core`
 - `@material-ui/icons`
+- `@mui/icons-material`
+- `@mui/material`
+- `@phosphor-icons/react`
 - `@tabler/icons-react`
+- `@tremor/react`
+- `@visx/visx`
+- `ahooks`
+- `antd`
+- `date-fns`
+- `lodash-es`
+- `lucide-react`
 - `mui-core`
+- `ramda`
+- `react-bootstrap`
 - `react-icons/*`
+- `react-use`
+- `recharts`
+- `rxjs`

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1013,6 +1013,7 @@ function assignDefaults(
       '@effect/opentelemetry',
       '@material-ui/core',
       '@material-ui/icons',
+      '@phosphor-icons/react',
       '@tabler/icons-react',
       'mui-core',
       // We don't support wildcard imports for these configs, e.g. `react-icons/*`

--- a/test/development/basic/barrel-optimization/barrel-optimization.test.ts
+++ b/test/development/basic/barrel-optimization/barrel-optimization.test.ts
@@ -16,6 +16,7 @@ import { nextTestSetup } from 'e2e-utils'
           '@heroicons/react': '2.0.18',
           '@visx/visx': '3.3.0',
           'recursive-barrel': '1.0.0',
+          '@phosphor-icons/react': '2.1.7',
         },
       })
 
@@ -113,6 +114,11 @@ import { nextTestSetup } from 'e2e-utils'
       it('should support visx', async () => {
         const html = await next.render('/visx')
         expect(html).toContain('<linearGradient')
+      })
+
+      it('should support @phosphor-icons/react', async () => {
+        const html = await next.render('/phosphor-icons')
+        expect(html).toContain('<svg xmlns="http://www.w3.org/2000/svg"')
       })
 
       it('should not break "use client" directive in optimized packages', async () => {

--- a/test/development/basic/barrel-optimization/fixture/pages/phosphor-icons.js
+++ b/test/development/basic/barrel-optimization/fixture/pages/phosphor-icons.js
@@ -1,0 +1,11 @@
+import { Horse, Heart, Cube } from '@phosphor-icons/react'
+
+export default function Page() {
+  return (
+    <>
+      <Horse />
+      <Heart color="#AE2983" weight="fill" size={32} />
+      <Cube color="teal" weight="duotone" />
+    </>
+  )
+}


### PR DESCRIPTION
Add @phosphor-icons/react to the import optimization list

I've been bitten by this in production one too many times. 

As you can see in this thread: https://github.com/phosphor-icons/react/issues/45 
This is a common issue with @phosphor-icons/react.

### What?
Add @phosphor-icons/react to the import optimization list
### Why?
@phophor-icons/react includes thousands of files and expects to be tree shaken when used. 
### How?
Fixes #52646


