### PR TITLE
Slightly improve error handling for unknown server actions

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -661,5 +661,7 @@
   "660": "Rspack support is only available in Next.js canary.",
   "661": "Build failed because of %s errors",
   "662": "Invariant failed to find webpack runtime chunk",
-  "663": "Invariant: client chunk changed but failed to detect hash %s"
+  "663": "Invariant: client chunk changed but failed to detect hash %s",
+  "664": "Missing 'next-action' header.",
+  "665": "Failed to find Server Action \"%s\". This request might be from an older or newer deployment.\\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action"
 }

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -48,6 +48,7 @@ import { RedirectStatusCode } from '../../client/components/redirect-status-code
 import { synchronizeMutableCookies } from '../async-storage/request-store'
 import type { TemporaryReferenceSet } from 'react-server-dom-webpack/server.edge'
 import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
+import { InvariantError } from '../../shared/lib/invariant-error'
 
 function formDataFromSearchQueryString(query: string) {
   const searchParams = new URLSearchParams(query)
@@ -1058,26 +1059,18 @@ function getActionModIdOrError(
   actionId: string | null,
   serverModuleMap: ServerModuleMap
 ): string {
-  try {
-    // if we're missing the action ID header, we can't do any further processing
-    if (!actionId) {
-      throw new Error("Invariant: Missing 'next-action' header.")
-    }
+  // if we're missing the action ID header, we can't do any further processing
+  if (!actionId) {
+    throw new InvariantError("Missing 'next-action' header.")
+  }
 
-    const actionModId = serverModuleMap?.[actionId]?.id
+  const actionModId = serverModuleMap[actionId]?.id
 
-    if (!actionModId) {
-      throw new Error(
-        "Invariant: Couldn't find action module ID from module map."
-      )
-    }
-
-    return actionModId
-  } catch (err) {
+  if (!actionModId) {
     throw new Error(
-      `Failed to find Server Action "${actionId}". This request might be from an older or newer deployment. ${
-        err instanceof Error ? `Original error: ${err.message}` : ''
-      }\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action`
+      `Failed to find Server Action "${actionId}". This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action`
     )
   }
+
+  return actionModId
 }

--- a/packages/next/src/server/app-render/action-utils.ts
+++ b/packages/next/src/server/app-render/action-utils.ts
@@ -20,7 +20,11 @@ export function createServerModuleMap({
         const workers =
           serverActionsManifest[
             process.env.NEXT_RUNTIME === 'edge' ? 'edge' : 'node'
-          ][id].workers
+          ]?.[id]?.workers
+
+        if (!workers) {
+          return undefined
+        }
 
         const workStore = workAsyncStorage.getStore()
 

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -11,6 +11,7 @@ import type { Page, Request, Response, Route } from 'playwright'
 import fs from 'fs-extra'
 import nodeFs from 'fs'
 import { join } from 'path'
+import { outdent } from 'outdent'
 
 const GENERIC_RSC_ERROR =
   'Error: An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
@@ -808,9 +809,10 @@ describe('app-dir action handling', () => {
       })
 
       await retry(async () =>
-        expect(next.cliOutput).toMatch(
-          /Failed to find Server Action "abc123". This request might be from an older or newer deployment./
-        )
+        expect(next.cliOutput).toInclude(outdent`
+          Failed to find Server Action "abc123". This request might be from an older or newer deployment.
+          Read more: https://nextjs.org/docs/messages/failed-to-find-server-action
+        `)
       )
     })
   }


### PR DESCRIPTION
This fixes the following error when retrieving a non-existent server action from the server reference manifest:
`Cannot read properties of undefined (reading 'workers')`.

We're also removing the original error from the error message with this PR, as there shouldn't be an original error anymore. The result will just be `undefined`.