### PR TITLE
docs(scripts): missing 'soon'

### DIFF
--- a/docs/01-app/04-api-reference/02-components/script.mdx
+++ b/docs/01-app/04-api-reference/02-components/script.mdx
@@ -82,7 +82,7 @@ Scripts denoted with this strategy are preloaded and fetched before any first-pa
 
 </PagesOnly>
 
-**This strategy should only be used for critical scripts that need to be fetched as as possible.**
+**This strategy should only be used for critical scripts that need to be fetched as soon as possible.**
 
 <AppOnly>
 


### PR DESCRIPTION
## Why?

Follow up to https://github.com/vercel/next.js/pull/77136