### PR TITLE
Bypass `"use cache"` caches when Draft Mode is enabled

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -504,7 +504,13 @@ export async function handleAction({
     // We want the render to see any cookie writes that we performed during the action,
     // so we need to update the immutable cookies to reflect the changes.
     synchronizeMutableCookies(requestStore)
+
+    // The server action might have toggled draft mode, so we need to reflect
+    // that in the work store to be up-to-date for subsequent rendering.
+    workStore.isDraftMode = requestStore.draftMode.isEnabled
+
     requestStore.phase = 'render'
+
     return generateFlight(...args)
   }
 

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -15,6 +15,7 @@ import type {
 } from '../resume-data-cache/resume-data-cache'
 import type { Params } from '../request/params'
 import type { ImplicitTags } from '../lib/implicit-tags'
+import type { WorkStore } from './work-async-storage.external'
 
 export type WorkUnitPhase = 'action' | 'render' | 'after'
 
@@ -174,6 +175,9 @@ export interface UseCacheStore extends CommonWorkUnitStore {
 
 export interface UnstableCacheStore extends CommonWorkUnitStore {
   type: 'unstable-cache'
+  // Draft mode is only available if the outer work unit store is a request
+  // store and draft mode is enabled.
+  readonly draftMode: DraftModeProvider | undefined
 }
 
 /**
@@ -272,4 +276,21 @@ export function getHmrRefreshHash(
     : workUnitStore.type === 'request'
       ? workUnitStore.cookies.get('__next_hmr_refresh_hash__')?.value
       : undefined
+}
+
+export function getDraftMode(
+  workStore: WorkStore,
+  workUnitStore: WorkUnitStore
+): DraftModeProvider | undefined {
+  if (workStore.isDraftMode) {
+    // eslint-disable-next-line default-case
+    switch (workUnitStore.type) {
+      case 'cache':
+      case 'unstable-cache':
+      case 'request':
+        return workUnitStore.draftMode
+    }
+  }
+
+  return undefined
 }

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -278,7 +278,10 @@ export function getHmrRefreshHash(
       : undefined
 }
 
-export function getDraftMode(
+/**
+ * Returns a draft mode provider only if draft mode is enabled.
+ */
+export function getDraftModeProviderForCacheScope(
   workStore: WorkStore,
   workUnitStore: WorkUnitStore
 ): DraftModeProvider | undefined {

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -286,12 +286,13 @@ export function getDraftModeProviderForCacheScope(
   workUnitStore: WorkUnitStore
 ): DraftModeProvider | undefined {
   if (workStore.isDraftMode) {
-    // eslint-disable-next-line default-case
     switch (workUnitStore.type) {
       case 'cache':
       case 'unstable-cache':
       case 'request':
         return workUnitStore.draftMode
+      default:
+        return undefined
     }
   }
 

--- a/packages/next/src/server/async-storage/draft-mode-provider.ts
+++ b/packages/next/src/server/async-storage/draft-mode-provider.ts
@@ -11,7 +11,7 @@ import {
 import type { __ApiPreviewProps } from '../api-utils'
 
 export class DraftModeProvider {
-  public readonly isEnabled: boolean
+  #isEnabled: boolean
 
   /**
    * @internal - this declaration is stripped via `tsc --stripInternal`
@@ -37,7 +37,7 @@ export class DraftModeProvider {
 
     const cookieValue = cookies.get(COOKIE_NAME_PRERENDER_BYPASS)?.value
 
-    this.isEnabled = Boolean(
+    this.#isEnabled = Boolean(
       !isOnDemandRevalidate &&
         cookieValue &&
         previewProps &&
@@ -49,6 +49,10 @@ export class DraftModeProvider {
 
     this._previewModeId = previewProps?.previewModeId
     this._mutableCookies = mutableCookies
+  }
+
+  get isEnabled() {
+    return this.#isEnabled
   }
 
   enable() {
@@ -66,6 +70,8 @@ export class DraftModeProvider {
       secure: process.env.NODE_ENV !== 'development',
       path: '/',
     })
+
+    this.#isEnabled = true
   }
 
   disable() {
@@ -81,5 +87,7 @@ export class DraftModeProvider {
       path: '/',
       expires: new Date(0),
     })
+
+    this.#isEnabled = false
   }
 }

--- a/packages/next/src/server/async-storage/draft-mode-provider.ts
+++ b/packages/next/src/server/async-storage/draft-mode-provider.ts
@@ -11,7 +11,10 @@ import {
 import type { __ApiPreviewProps } from '../api-utils'
 
 export class DraftModeProvider {
-  #isEnabled: boolean
+  /**
+   * @internal - this declaration is stripped via `tsc --stripInternal`
+   */
+  private _isEnabled: boolean
 
   /**
    * @internal - this declaration is stripped via `tsc --stripInternal`
@@ -37,7 +40,7 @@ export class DraftModeProvider {
 
     const cookieValue = cookies.get(COOKIE_NAME_PRERENDER_BYPASS)?.value
 
-    this.#isEnabled = Boolean(
+    this._isEnabled = Boolean(
       !isOnDemandRevalidate &&
         cookieValue &&
         previewProps &&
@@ -52,7 +55,7 @@ export class DraftModeProvider {
   }
 
   get isEnabled() {
-    return this.#isEnabled
+    return this._isEnabled
   }
 
   enable() {
@@ -71,7 +74,7 @@ export class DraftModeProvider {
       path: '/',
     })
 
-    this.#isEnabled = true
+    this._isEnabled = true
   }
 
   disable() {
@@ -88,6 +91,6 @@ export class DraftModeProvider {
       expires: new Date(0),
     })
 
-    this.#isEnabled = false
+    this._isEnabled = false
   }
 }

--- a/packages/next/src/server/request/draft-mode.ts
+++ b/packages/next/src/server/request/draft-mode.ts
@@ -56,6 +56,7 @@ export function draftMode(): Promise<DraftMode> {
       )
 
     case 'cache':
+    case 'unstable-cache':
       // Inside of "use cache" draft mode is available if the outer work unit
       // store is a request store and draft mode is enabled. Checking
       // `workStore.isDraftMode` here is just a double-safety measure. If it's
@@ -69,7 +70,6 @@ export function draftMode(): Promise<DraftMode> {
 
     // Otherwise, we fall through to providing an empty draft mode.
     // eslint-disable-next-line no-fallthrough
-    case 'unstable-cache': // TODO: unstable-cache should be the same as cache.
     case 'prerender':
     case 'prerender-ppr':
     case 'prerender-legacy':

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -165,6 +165,9 @@ function generateCacheEntryWithCacheContext(
     isHmrRefresh: useCacheOrRequestStore?.isHmrRefresh ?? false,
     serverComponentsHmrCache: useCacheOrRequestStore?.serverComponentsHmrCache,
     forceRevalidate: shouldForceRevalidate(workStore, outerWorkUnitStore),
+    draftMode: workStore?.isDraftMode
+      ? useCacheOrRequestStore?.draftMode
+      : undefined,
   }
 
   return workUnitAsyncStorage.run(
@@ -295,19 +298,14 @@ async function collectResult(
   return entry
 }
 
-async function generateStream(
+async function generateCacheEntryImpl(
   outerWorkUnitStore: WorkUnitStore | undefined,
+  innerCacheStore: UseCacheStore,
   clientReferenceManifest: DeepReadonly<ClientReferenceManifestForRsc>,
   encodedArguments: FormData | string,
   fn: (...args: unknown[]) => Promise<unknown>,
-  {
-    signal,
-    timeoutError,
-  }: {
-    signal: AbortSignal | undefined
-    timeoutError: UseCacheTimeoutError | undefined
-  }
-): Promise<{ stream: ReadableStream; errors: unknown[] }> {
+  timeoutError: UseCacheTimeoutError
+): Promise<[ReadableStream, Promise<CacheEntry>]> {
   const temporaryReferences = createServerTemporaryReferenceSet()
 
   const [, , , args] =
@@ -347,6 +345,9 @@ async function generateStream(
           { temporaryReferences }
         )
 
+  // Track the timestamp when we started computing the result.
+  const startTime = performance.timeOrigin + performance.now()
+
   // Invoke the inner function to load a new result. We delay the invocation
   // though, until React awaits the promise so that React's request store (ALS)
   // is available when the function is invoked. This allows us, for example, to
@@ -355,12 +356,23 @@ async function generateStream(
 
   let errors: Array<unknown> = []
 
+  let timer = undefined
+  const controller = new AbortController()
+  if (outerWorkUnitStore?.type === 'prerender') {
+    // If we're prerendering, we give you 50 seconds to fill a cache entry.
+    // Otherwise we assume you stalled on hanging input and de-opt. This needs
+    // to be lower than just the general timeout of 60 seconds.
+    timer = setTimeout(() => {
+      controller.abort(timeoutError)
+    }, 50000)
+  }
+
   const stream = renderToReadableStream(
     resultPromise,
     clientReferenceManifest.clientModules,
     {
       environmentName: 'Cache',
-      signal,
+      signal: controller.signal,
       temporaryReferences,
       // In the "Cache" environment, we only need to make sure that the error
       // digests are handled correctly. Error formatting and reporting is not
@@ -380,7 +392,7 @@ async function generateStream(
           console.error(error)
         }
 
-        if (timeoutError && error === timeoutError) {
+        if (error === timeoutError) {
           // The timeout error already aborted the whole stream. We don't need
           // to also push this error into the `errors` array.
           return timeoutError.digest
@@ -389,39 +401,6 @@ async function generateStream(
         errors.push(error)
       },
     }
-  )
-
-  return { stream, errors }
-}
-
-async function generateCacheEntryImpl(
-  outerWorkUnitStore: WorkUnitStore | undefined,
-  innerCacheStore: UseCacheStore,
-  clientReferenceManifest: DeepReadonly<ClientReferenceManifestForRsc>,
-  encodedArguments: FormData | string,
-  fn: (...args: unknown[]) => Promise<unknown>,
-  timeoutError: UseCacheTimeoutError
-): Promise<[ReadableStream, Promise<CacheEntry>]> {
-  // Track the timestamp when we started computing the result.
-  const startTime = performance.timeOrigin + performance.now()
-
-  let timer = undefined
-  const controller = new AbortController()
-  if (outerWorkUnitStore?.type === 'prerender') {
-    // If we're prerendering, we give you 50 seconds to fill a cache entry.
-    // Otherwise we assume you stalled on hanging input and de-opt. This needs
-    // to be lower than just the general timeout of 60 seconds.
-    timer = setTimeout(() => {
-      controller.abort(timeoutError)
-    }, 50000)
-  }
-
-  const { stream, errors } = await generateStream(
-    outerWorkUnitStore,
-    clientReferenceManifest,
-    encodedArguments,
-    fn,
-    { signal: controller.signal, timeoutError }
   )
 
   const [returnStream, savedStream] = stream.tee()
@@ -754,32 +733,27 @@ export function cache(
         ) {
           // Miss. Generate a new result.
 
-          // When draft mode is enabled, we're only generating the stream but no
-          // cache entry.
-          if (workStore.isDraftMode) {
-            ;({ stream } = await generateStream(
-              workUnitStore,
-              clientReferenceManifest,
-              encodedCacheKeyParts,
-              fn,
-              // In draft mode we're not prerendering, so we don't need to
-              // handle timeouts caused by hanging promises.
-              { signal: undefined, timeoutError: undefined }
-            ))
-          } else {
-            // If the cache entry is stale and we're prerendering, we don't want
-            // to use the stale entry since it would unnecessarily need to
-            // shorten the lifetime of the prerender. We're not time constrained
-            // here so we can re-generated it now.
-            const [newStream, pendingCacheEntry] = await generateCacheEntry(
-              workStore,
-              workUnitStore,
-              clientReferenceManifest,
-              encodedCacheKeyParts,
-              fn,
-              timeoutError
-            )
+          // If the cache entry is stale and we're prerendering, we don't want to use the
+          // stale entry since it would unnecessarily need to shorten the lifetime of the
+          // prerender. We're not time constrained here so we can re-generated it now.
 
+          // We need to run this inside a clean AsyncLocalStorage snapshot so that the cache
+          // generation cannot read anything from the context we're currently executing which
+          // might include request specific things like cookies() inside a React.cache().
+          // Note: It is important that we await at least once before this because it lets us
+          // pop out of any stack specific contexts as well - aka "Sync" Local Storage.
+
+          const [newStream, pendingCacheEntry] = await generateCacheEntry(
+            workStore,
+            workUnitStore,
+            clientReferenceManifest,
+            encodedCacheKeyParts,
+            fn,
+            timeoutError
+          )
+
+          // When draft mode is enabled, we must not save the cache entry.
+          if (!workStore.isDraftMode) {
             let savedCacheEntry
 
             if (prerenderResumeDataCache) {
@@ -801,9 +775,9 @@ export function cache(
 
             workStore.pendingRevalidateWrites ??= []
             workStore.pendingRevalidateWrites.push(promise)
-
-            stream = newStream
           }
+
+          stream = newStream
         } else {
           propagateCacheLifeAndTags(workUnitStore, entry)
 

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -600,6 +600,11 @@ export function cache(
         args.unshift(boundArgs)
       }
 
+      // When draft mode is enabled, we must bypass caching altogether.
+      if (workStore.isDraftMode) {
+        return fn.apply(null, args)
+      }
+
       const temporaryReferences = createClientTemporaryReferenceSet()
       const cacheKeyParts: CacheKeyParts = [buildId, hmrRefreshHash, id, args]
       const encodedCacheKeyParts: FormData | string = await encodeReply(

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -24,7 +24,7 @@ import {
   getRenderResumeDataCache,
   getPrerenderResumeDataCache,
   workUnitAsyncStorage,
-  getDraftMode,
+  getDraftModeProviderForCacheScope,
 } from '../app-render/work-unit-async-storage.external'
 import { runInCleanSnapshot } from '../app-render/clean-async-snapshot.external'
 
@@ -167,7 +167,8 @@ function generateCacheEntryWithCacheContext(
     serverComponentsHmrCache: useCacheOrRequestStore?.serverComponentsHmrCache,
     forceRevalidate: shouldForceRevalidate(workStore, outerWorkUnitStore),
     draftMode:
-      outerWorkUnitStore && getDraftMode(workStore, outerWorkUnitStore),
+      outerWorkUnitStore &&
+      getDraftModeProviderForCacheScope(workStore, outerWorkUnitStore),
   }
 
   return workUnitAsyncStorage.run(

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -24,6 +24,7 @@ import {
   getRenderResumeDataCache,
   getPrerenderResumeDataCache,
   workUnitAsyncStorage,
+  getDraftMode,
 } from '../app-render/work-unit-async-storage.external'
 import { runInCleanSnapshot } from '../app-render/clean-async-snapshot.external'
 
@@ -165,9 +166,8 @@ function generateCacheEntryWithCacheContext(
     isHmrRefresh: useCacheOrRequestStore?.isHmrRefresh ?? false,
     serverComponentsHmrCache: useCacheOrRequestStore?.serverComponentsHmrCache,
     forceRevalidate: shouldForceRevalidate(workStore, outerWorkUnitStore),
-    draftMode: workStore?.isDraftMode
-      ? useCacheOrRequestStore?.draftMode
-      : undefined,
+    draftMode:
+      outerWorkUnitStore && getDraftMode(workStore, outerWorkUnitStore),
   }
 
   return workUnitAsyncStorage.run(

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -3,7 +3,10 @@ import type { IncrementalCache } from '../../lib/incremental-cache'
 import { CACHE_ONE_YEAR } from '../../../lib/constants'
 import { validateRevalidate, validateTags } from '../../lib/patch-fetch'
 import { workAsyncStorage } from '../../app-render/work-async-storage.external'
-import { workUnitAsyncStorage } from '../../app-render/work-unit-async-storage.external'
+import {
+  getDraftMode,
+  workUnitAsyncStorage,
+} from '../../app-render/work-unit-async-storage.external'
 import {
   CachedRouteKind,
   IncrementalCacheKind,
@@ -228,6 +231,8 @@ export function unstable_cache<T extends Callback>(
                   type: 'unstable-cache',
                   phase: 'render',
                   implicitTags,
+                  draftMode:
+                    workUnitStore && getDraftMode(workStore, workUnitStore),
                 }
                 // We run the cache function asynchronously and save the result when it completes
                 workStore.pendingRevalidates[invocationKey] =
@@ -262,6 +267,7 @@ export function unstable_cache<T extends Callback>(
           type: 'unstable-cache',
           phase: 'render',
           implicitTags,
+          draftMode: workUnitStore && getDraftMode(workStore, workUnitStore),
         }
         // If we got this far then we had an invalid cache entry and need to generate a new one
         const result = await workUnitAsyncStorage.run(
@@ -324,6 +330,10 @@ export function unstable_cache<T extends Callback>(
           type: 'unstable-cache',
           phase: 'render',
           implicitTags,
+          draftMode:
+            workUnitStore &&
+            workStore &&
+            getDraftMode(workStore, workUnitStore),
         }
         // If we got this far then we had an invalid cache entry and need to generate a new one
         const result = await workUnitAsyncStorage.run(

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -4,7 +4,7 @@ import { CACHE_ONE_YEAR } from '../../../lib/constants'
 import { validateRevalidate, validateTags } from '../../lib/patch-fetch'
 import { workAsyncStorage } from '../../app-render/work-async-storage.external'
 import {
-  getDraftMode,
+  getDraftModeProviderForCacheScope,
   workUnitAsyncStorage,
 } from '../../app-render/work-unit-async-storage.external'
 import {
@@ -144,6 +144,16 @@ export function unstable_cache<T extends Callback>(
 
       const implicitTags = workUnitStore?.implicitTags
 
+      const innerCacheStore: UnstableCacheStore = {
+        type: 'unstable-cache',
+        phase: 'render',
+        implicitTags,
+        draftMode:
+          workUnitStore &&
+          workStore &&
+          getDraftModeProviderForCacheScope(workStore, workUnitStore),
+      }
+
       if (workStore) {
         workStore.nextFetchId = fetchIdx + 1
 
@@ -227,13 +237,7 @@ export function unstable_cache<T extends Callback>(
                 if (!workStore.pendingRevalidates) {
                   workStore.pendingRevalidates = {}
                 }
-                const innerCacheStore: UnstableCacheStore = {
-                  type: 'unstable-cache',
-                  phase: 'render',
-                  implicitTags,
-                  draftMode:
-                    workUnitStore && getDraftMode(workStore, workUnitStore),
-                }
+
                 // We run the cache function asynchronously and save the result when it completes
                 workStore.pendingRevalidates[invocationKey] =
                   workUnitAsyncStorage
@@ -263,12 +267,6 @@ export function unstable_cache<T extends Callback>(
           }
         }
 
-        const innerCacheStore: UnstableCacheStore = {
-          type: 'unstable-cache',
-          phase: 'render',
-          implicitTags,
-          draftMode: workUnitStore && getDraftMode(workStore, workUnitStore),
-        }
         // If we got this far then we had an invalid cache entry and need to generate a new one
         const result = await workUnitAsyncStorage.run(
           innerCacheStore,
@@ -326,15 +324,6 @@ export function unstable_cache<T extends Callback>(
           }
         }
 
-        const innerCacheStore: UnstableCacheStore = {
-          type: 'unstable-cache',
-          phase: 'render',
-          implicitTags,
-          draftMode:
-            workUnitStore &&
-            workStore &&
-            getDraftMode(workStore, workUnitStore),
-        }
         // If we got this far then we had an invalid cache entry and need to generate a new one
         const result = await workUnitAsyncStorage.run(
           innerCacheStore,

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -4236,6 +4236,21 @@ describe('app-dir static/dynamic handling', () => {
       expect(data).not.toEqual(data2)
     })
 
+    it('should be able to read the draft mode status', async () => {
+      let $ = await next.render$('/unstable-cache/dynamic')
+      expect($('#draft-mode-enabled').text()).toBe('draft mode enabled: false')
+
+      const draftRes = await next.fetch('/api/draft-mode?status=enable')
+      const setCookie = draftRes.headers.get('set-cookie')
+      const cookieHeader = { Cookie: setCookie?.split(';', 1)[0] }
+
+      $ = await next.render$('/unstable-cache/dynamic', undefined, {
+        headers: cookieHeader,
+      })
+
+      expect($('#draft-mode-enabled').text()).toBe('draft mode enabled: true')
+    })
+
     it('should not error when retrieving the value undefined', async () => {
       const res = await next.fetch('/unstable-cache/dynamic-undefined')
       const html = await res.text()

--- a/test/e2e/app-dir/app-static/app/unstable-cache/dynamic/page.tsx
+++ b/test/e2e/app-dir/app-static/app/unstable-cache/dynamic/page.tsx
@@ -1,3 +1,4 @@
+import { draftMode } from 'next/headers'
 import { unstable_expireTag, unstable_cache } from 'next/cache'
 import { RevalidateButton } from '../revalidate-button'
 
@@ -13,6 +14,7 @@ export default async function Page() {
     async () => {
       return {
         random: Math.random(),
+        draftModeEnabled: (await draftMode()).isEnabled,
       }
     },
     ['random-value'],
@@ -25,6 +27,9 @@ export default async function Page() {
     <div>
       <p>random: {Math.random()}</p>
       <p id="cached-data">cachedData: {cachedData.random}</p>
+      <p id="draft-mode-enabled">
+        draft mode enabled: {cachedData.draftModeEnabled.toString()}
+      </p>
       <RevalidateButton onClick={revalidate} />
     </div>
   )

--- a/test/e2e/app-dir/use-cache/app/draft-mode/button.tsx
+++ b/test/e2e/app-dir/use-cache/app/draft-mode/button.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import React from 'react'
+import { useFormStatus } from 'react-dom'
+
+export function Button({
+  children,
+  id,
+}: React.PropsWithChildren<{ id: string }>) {
+  const { pending } = useFormStatus()
+
+  return (
+    <button id={id} disabled={pending}>
+      {children}
+    </button>
+  )
+}

--- a/test/e2e/app-dir/use-cache/app/draft-mode/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/draft-mode/page.tsx
@@ -1,6 +1,6 @@
 'use cache'
 
-import { draftMode } from 'next/headers'
+import { cookies, draftMode } from 'next/headers'
 import { Button } from './button'
 
 async function getCachedValue(
@@ -34,6 +34,18 @@ export default async function Page() {
 
   const { isEnabled } = await draftMode()
 
+  // Accessing request-scoped data in "use cache" should not be allowed, even if
+  // draft mode is enabled. We expect the access to throw.
+  let isAccessingRequestScopedDataAllowedInUseCache = isEnabled
+
+  if (isAccessingRequestScopedDataAllowedInUseCache) {
+    try {
+      await cookies()
+    } catch {
+      isAccessingRequestScopedDataAllowedInUseCache = false
+    }
+  }
+
   const [cachedValue, passthroughFn] = await getCachedValue(
     {
       [Symbol.iterator]: function* () {
@@ -59,6 +71,9 @@ export default async function Page() {
     >
       <p id="top-level">{cachedValue}</p>
       <p id="closure">{await cachedClosure()}</p>
+      <p id="is-accessing-request-scoped-data-allowed-in-use-cache">
+        {isAccessingRequestScopedDataAllowedInUseCache.toString()}
+      </p>
       <p>{passthroughFn()}</p>
       <Button id="toggle">{isEnabled ? 'Disable' : 'Enable'} Draft Mode</Button>
     </form>

--- a/test/e2e/app-dir/use-cache/app/draft-mode/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/draft-mode/page.tsx
@@ -1,5 +1,6 @@
 import { draftMode } from 'next/headers'
 import { Button } from './button'
+import { connection } from 'next/server'
 
 async function getCachedValue(
   iterable: Iterable<number>,
@@ -23,6 +24,7 @@ async function getCachedValue(
 }
 
 export default async function Page() {
+  await connection()
   const offset = 1000
 
   const cachedClosure = async () => {

--- a/test/e2e/app-dir/use-cache/app/draft-mode/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/draft-mode/page.tsx
@@ -1,6 +1,7 @@
+'use cache'
+
 import { draftMode } from 'next/headers'
 import { Button } from './button'
-import { connection } from 'next/server'
 
 async function getCachedValue(
   iterable: Iterable<number>,
@@ -24,7 +25,6 @@ async function getCachedValue(
 }
 
 export default async function Page() {
-  await connection()
   const offset = 1000
 
   const cachedClosure = async () => {

--- a/test/e2e/app-dir/use-cache/app/draft-mode/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/draft-mode/page.tsx
@@ -1,0 +1,33 @@
+'use cache'
+
+import { draftMode } from 'next/headers'
+import { Button } from './button'
+
+export default async function Page() {
+  const offset = 1000
+
+  const cachedClosure = async () => {
+    'use cache'
+    return new Date(Date.now() + offset).toISOString()
+  }
+
+  const { isEnabled } = await draftMode()
+
+  return (
+    <form
+      action={async () => {
+        'use server'
+        const draft = await draftMode()
+        if (draft.isEnabled) {
+          draft.disable()
+        } else {
+          draft.enable()
+        }
+      }}
+    >
+      <p id="top-level">{new Date().toISOString()}</p>
+      <p id="closure">{await cachedClosure()}</p>
+      <Button id="toggle">{isEnabled ? 'Disable' : 'Enable'} Draft Mode</Button>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -741,6 +741,13 @@ describe('use-cache', () => {
   it('should not read nor write cached data when draft mode is enabled', async () => {
     const browser = await next.browser('/draft-mode')
 
+    if (isNextDeploy) {
+      // Sometimes the first request triggers a background revalidation, so we
+      // refresh once to make sure we capture the correct initial values for
+      // later comparison.
+      await browser.refresh()
+    }
+
     expect(await browser.elementByCss('button#toggle').text()).toBe(
       'Enable Draft Mode'
     )

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -785,6 +785,13 @@ describe('use-cache', () => {
         newClosureValue
       )
 
+      // Accessing request-scoped data should still not be allowed.
+      expect(
+        await browser
+          .elementById('is-accessing-request-scoped-data-allowed-in-use-cache')
+          .text()
+      ).toBe('false')
+
       await browser.elementByCss('button#toggle').click()
       await browser.waitForElementByCss('button#toggle:enabled')
 

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -503,6 +503,7 @@ describe('use-cache', () => {
         '/cache-fetch-no-store',
         '/cache-life',
         '/cache-tag',
+        '/draft-mode',
         '/form',
         '/imported-from-client',
         '/logs',
@@ -793,6 +794,8 @@ describe('use-cache', () => {
 
       // Draft mode is disabled again, the initially cached data should be
       // returned again.
+
+      await browser.refresh()
 
       expect(await browser.elementById('top-level').text()).toBe(
         initialTopLevelValue


### PR DESCRIPTION
When a request has Draft Mode enabled, all caches should be disabled. This is currently implemented for `fetch` caching and `unstable_cache`, but was omitted accidentally from the `"use cache"` implementation.

Specifically, when Draft Mode is enabled, we must skip looking up a cache entry, but we must also skip saving a cache entry. This is different from the force-revalidate logic we have in place, e.g. for on-demand revalidation, where saving a cache entry is expected.

With this PR we're also enabling toggling draft mode via server action, and then reading the result in the subsequent rendering. Previously, `draftMode` returned a stale value for `isEnabled` in this case.

fixes #76581
closes NAR-117