### PR TITLE
Alternate bundler: Add `react-refresh` as a dependency of plugin

### DIFF
--- a/packages/next-plugin-rspack/package.json
+++ b/packages/next-plugin-rspack/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@rspack/core": "npm:@rspack-canary/core@1.2.9-canary-c009cfc1-20250313053424",
-    "@rspack/plugin-react-refresh": "1.0.1"
+    "@rspack/plugin-react-refresh": "1.0.1",
+    "react-refresh": "0.12.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1651,6 +1651,9 @@ importers:
       '@rspack/plugin-react-refresh':
         specifier: 1.0.1
         version: 1.0.1(react-refresh@0.12.0)
+      react-refresh:
+        specifier: 0.12.0
+        version: 0.12.0
 
   packages/next-plugin-storybook: {}
 


### PR DESCRIPTION
`react-refresh` is a peer dependency of `@rspack/plugin-react-refresh`. It’s marked optional but is required when it’s loaded otherwise requiring throws.

Test Plan: In a test project, `require('@rspack/plugin-react-refresh')`


Closes PACK-4150