### PR TITLE
Alternate bundler: add index.d.ts types to plugin

### DIFF
--- a/packages/next-plugin-rspack/index.d.ts
+++ b/packages/next-plugin-rspack/index.d.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from 'next'
+
+declare function NextPluginRspack(config: NextConfig): NextConfig
+
+export = NextPluginRspack

--- a/packages/next-plugin-rspack/package.json
+++ b/packages/next-plugin-rspack/package.json
@@ -5,6 +5,7 @@
     "url": "vercel/next.js",
     "directory": "packages/next-plugin-rspack"
   },
+  "types": "index.d.ts",
   "dependencies": {
     "@rspack/core": "npm:@rspack-canary/core@1.2.9-canary-c009cfc1-20250313053424",
     "@rspack/plugin-react-refresh": "1.0.1"


### PR DESCRIPTION
This allows the plugin to be used with typescript next.config.ts configs.
    
Test Plan:
    
    import type { NextConfig } from 'next'
    import withRspack from '@next/plugin-rspack'
    
    const nextConfig: NextConfig = {
      experimental: {
        inlineCss: true,
        ppr: true,
        useLightningcss: true,
      },
      reactStrictMode: true,
    }
    
    export default withRspack(nextConfig)

Closes PACK-4149