### PR TITLE
Allow building node-pty in tests

### DIFF
--- a/test/production/build-spinners/index.test.ts
+++ b/test/production/build-spinners/index.test.ts
@@ -55,6 +55,11 @@ describe('build-spinners', () => {
       dependencies: {
         'node-pty': '0.10.1',
       },
+      packageJson: {
+        pnpm: {
+          onlyBuiltDependencies: ['node-pty'],
+        },
+      },
     })
   })
 


### PR DESCRIPTION
See #76615

Prevents failures like this one: https://github.com/vercel/next.js/actions/runs/13893521836/job/38869486683?pr=77183

```
╭ Warning ─────────────────────────────────────────────────────────────────────╮│                                                                              ││   Ignored build scripts: node-pty, sharp.                                    ││   Run "pnpm approve-builds" to pick which dependencies should be allowed     ││   to run scripts.                                                            ││                                                                              │╰──────────────────────────────────────────────────────────────────────────────╯

Done in 2.3s using pnpm v10.5.1
[Error: ENOENT: no such file or directory, lstat '/tmp/next-install-f1b51a9db51b727[335](https://github.com/vercel/next.js/actions/runs/13893521836/job/38869486683?pr=77183#step:33:338)132a63d491f5f34dbe98376b0a6a02f50106f2b0ef705b/.next/trace'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'lstat',
  path: '/tmp/next-install-f1b51a9db51b727335132a63d491f5f34dbe98376b0a6a02f50106f2b0ef705b/.next/trace'
}
destroyed next instance: 199.685ms
FAIL default test/production/build-spinners/index.test.ts
  build-spinners
    ✕ should handle build spinners correctly app dir - basic (8 ms)
    ✕ should handle build spinners correctly app dir - (compile workers) (4 ms)
    ✕ should handle build spinners correctly page dir (4 ms)
    ✕ should handle build spinners correctly page dir (compile workers) (3 ms)
    ✕ should handle build spinners correctly app and pages (3 ms)

  ● build-spinners › should handle build spinners correctly app dir - basic

    Cannot find module '../build/Release/pty.node' from '../../../../../../tmp/next-install-f1b51a9db51b7273[351](https://github.com/vercel/next.js/actions/runs/13893521836/job/38869486683?pr=77183#step:33:354)32a63d491f5f34dbe98376b0a6a02f50106f2b0ef705b/node_modules/.pnpm/node-pty@0.10.1/node_modules/node-pty/lib/unixTerminal.js'
```

Closes PACK-4156