### PR TITLE
feat: onNavigate for link

### DIFF
--- a/test/e2e/link-on-navigate-prop/app/app-router/layout.tsx
+++ b/test/e2e/link-on-navigate-prop/app/app-router/layout.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import React from 'react'
+import OnNavigate from '../../shared/OnNavigate'
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <OnNavigate rootPath="/app-router">{children}</OnNavigate>
+}

--- a/test/e2e/link-on-navigate-prop/app/app-router/page.tsx
+++ b/test/e2e/link-on-navigate-prop/app/app-router/page.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Home() {
+  return <div>Home</div>
+}

--- a/test/e2e/link-on-navigate-prop/app/app-router/subpage/page.tsx
+++ b/test/e2e/link-on-navigate-prop/app/app-router/subpage/page.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Subpage() {
+  return <div>Subpage</div>
+}

--- a/test/e2e/link-on-navigate-prop/app/layout.tsx
+++ b/test/e2e/link-on-navigate-prop/app/layout.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/link-on-navigate-prop/index.test.ts
+++ b/test/e2e/link-on-navigate-prop/index.test.ts
@@ -1,0 +1,185 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('<Link /> onNavigate prop', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  const routers = [
+    { name: 'App Router', path: '/app-router' },
+    { name: 'Pages Router', path: '/pages-router' },
+  ]
+
+  routers.forEach(({ name, path }) => {
+    describe(name, () => {
+      it('should trigger onClick but not onNavigate when using modifier key', async () => {
+        const browser = await next.browser(path)
+
+        // Check initial state
+        expect(await browser.elementById('is-clicked').text()).toBe(
+          'isClicked: false'
+        )
+        expect(await browser.elementById('is-navigated').text()).toBe(
+          'isNavigated: false'
+        )
+
+        // Click with modifier key based on OS to open in new window
+        const platform = process.platform
+        const modifierKey = platform === 'darwin' ? 'Meta' : 'Control'
+
+        // First press down the modifier key
+        await browser.keydown(modifierKey)
+
+        // Click the link while the modifier key is pressed
+        await browser.elementById('link-to-subpage').click()
+
+        // Release the modifier key
+        await browser.keyup(modifierKey)
+
+        await browser.waitForIdleNetwork()
+
+        // Should trigger onClick but not onNavigate
+        expect(await browser.elementById('is-clicked').text()).toBe(
+          'isClicked: true'
+        )
+        expect(await browser.elementById('is-navigated').text()).toBe(
+          'isNavigated: false'
+        )
+      })
+
+      it('should trigger both onClick and onNavigate for internal navigation', async () => {
+        const browser = await next.browser(path)
+
+        // Check initial state
+        expect(await browser.elementById('is-clicked').text()).toBe(
+          'isClicked: false'
+        )
+        expect(await browser.elementById('is-navigated').text()).toBe(
+          'isNavigated: false'
+        )
+
+        // Click internal link
+        await browser.elementById('link-to-subpage').click()
+        await browser.waitForIdleNetwork()
+
+        // Should trigger both onClick and onNavigate
+        expect(await browser.elementById('is-clicked').text()).toBe(
+          'isClicked: true'
+        )
+        expect(await browser.elementById('is-navigated').text()).toBe(
+          'isNavigated: true'
+        )
+      })
+
+      it('should prevent navigation when onNavigate calls preventDefault', async () => {
+        const browser = await next.browser(path)
+
+        // Check initial state
+        expect(await browser.elementById('is-locked').text()).toBe(
+          'isLocked: false'
+        )
+
+        // Lock navigation
+        await browser.elementById('toggle-lock').click()
+        expect(await browser.elementById('is-locked').text()).toBe(
+          'isLocked: true'
+        )
+
+        // Try to navigate
+        await browser.elementById('link-to-subpage').click()
+        await browser.waitForIdleNetwork()
+
+        // Should trigger onClick but not navigate or trigger onNavigate
+        expect(await browser.elementById('is-clicked').text()).toBe(
+          'isClicked: true'
+        )
+        expect(await browser.elementById('is-navigated').text()).toBe(
+          'isNavigated: false'
+        )
+
+        // Verify we're still on the same page
+        expect(await browser.url()).toContain(path)
+      })
+
+      it('should only trigger onClick for external links with target="_blank"', async () => {
+        const browser = await next.browser(path)
+
+        // Check initial state
+        expect(await browser.elementById('is-clicked').text()).toBe(
+          'isClicked: false'
+        )
+        expect(await browser.elementById('is-navigated').text()).toBe(
+          'isNavigated: false'
+        )
+
+        // We can't fully test the new window, but we can verify the events are triggered
+        await browser.elementById('external-link-with-target').click()
+        await browser.waitForIdleNetwork()
+
+        // Should only trigger onClick for external links with target
+        expect(await browser.elementById('is-clicked').text()).toBe(
+          'isClicked: true'
+        )
+        expect(await browser.elementById('is-navigated').text()).toBe(
+          'isNavigated: false'
+        )
+      })
+
+      it('should only trigger onClick for download links', async () => {
+        const browser = await next.browser(path)
+
+        // Check initial state
+        expect(await browser.elementById('is-clicked').text()).toBe(
+          'isClicked: false'
+        )
+        expect(await browser.elementById('is-navigated').text()).toBe(
+          'isNavigated: false'
+        )
+
+        // Click download link
+        await browser.elementById('download-link').click()
+        await browser.waitForIdleNetwork()
+
+        // Should trigger both onClick and onNavigate for download links
+        expect(await browser.elementById('is-clicked').text()).toBe(
+          'isClicked: true'
+        )
+        expect(await browser.elementById('is-navigated').text()).toBe(
+          'isNavigated: false'
+        )
+      })
+
+      it('should only trigger both onClick for external links', async () => {
+        const alerts: string[] = []
+        const browser = await next.browser(path, {
+          beforePageLoad(page) {
+            page.on('dialog', (dialog) => {
+              alerts.push(dialog.message())
+              dialog.dismiss()
+            })
+          },
+        })
+
+        await browser.elementById('external-link').click()
+        await browser.waitForIdleNetwork()
+
+        expect(alerts).toEqual(['onClick'])
+      })
+
+      it('should replace history state for external links with replace prop', async () => {
+        const browser = await next.browser(path)
+
+        // Get initial history length
+        const initialLength = await browser.eval('history.length')
+
+        // Click external link with replace
+        await browser.elementById('external-link-with-replace').click()
+        await browser.waitForIdleNetwork()
+
+        // Verify history length hasn't changed (replace instead of push)
+        const finalLength = await browser.eval('history.length')
+        expect(finalLength).toBe(initialLength)
+      })
+    })
+  })
+})

--- a/test/e2e/link-on-navigate-prop/pages/_app.tsx
+++ b/test/e2e/link-on-navigate-prop/pages/_app.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import type { AppProps } from 'next/app'
+import OnNavigate from '../shared/OnNavigate'
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+    <OnNavigate rootPath="/pages-router">
+      <Component {...pageProps} />
+    </OnNavigate>
+  )
+}

--- a/test/e2e/link-on-navigate-prop/pages/pages-router/index.tsx
+++ b/test/e2e/link-on-navigate-prop/pages/pages-router/index.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Home() {
+  return <div>Home</div>
+}

--- a/test/e2e/link-on-navigate-prop/pages/pages-router/subpage/index.tsx
+++ b/test/e2e/link-on-navigate-prop/pages/pages-router/subpage/index.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Subpage() {
+  return <div>Subpage</div>
+}

--- a/test/e2e/link-on-navigate-prop/public/zip.zip
+++ b/test/e2e/link-on-navigate-prop/public/zip.zip
@@ -1,0 +1,2 @@
+// This is a stub file to simulate a downloadable zip file
+// Used in download link tests to verify onClick/onNavigate behavior

--- a/test/e2e/link-on-navigate-prop/shared/OnNavigate.tsx
+++ b/test/e2e/link-on-navigate-prop/shared/OnNavigate.tsx
@@ -1,0 +1,116 @@
+import Link from 'next/link'
+import { useState } from 'react'
+import React from 'react'
+
+interface OnNavigateProps {
+  children: React.ReactNode
+  rootPath: string
+}
+
+export default function OnNavigate({ children, rootPath }: OnNavigateProps) {
+  const [isClicked, setIsClicked] = useState(false)
+  const [isNavigated, setIsNavigated] = useState(false)
+  const [isLocked, setIsLocked] = useState(false)
+
+  return (
+    <div>
+      <nav>
+        <div id="navigation-state">
+          <p id="is-clicked">isClicked: {isClicked ? 'true' : 'false'}</p>
+          <p id="is-navigated">isNavigated: {isNavigated ? 'true' : 'false'}</p>
+          <p id="is-locked">isLocked: {isLocked ? 'true' : 'false'}</p>
+        </div>
+        <button id="toggle-lock" onClick={() => setIsLocked(!isLocked)}>
+          {isLocked ? 'Unlock' : 'Lock'}
+        </button>
+
+        <div>
+          <Link
+            href={rootPath}
+            id="link-to-main"
+            onClick={() => setIsClicked(true)}
+            onNavigate={(e: any) => {
+              if (isLocked) {
+                e.preventDefault()
+              } else {
+                setIsNavigated(true)
+              }
+            }}
+          >
+            Client Side Navigation to Main Page
+          </Link>
+        </div>
+
+        <div>
+          <Link
+            href={`${rootPath}/subpage`}
+            id="link-to-subpage"
+            onClick={() => setIsClicked(true)}
+            onNavigate={(e: any) => {
+              if (isLocked) {
+                e.preventDefault()
+              } else {
+                setIsNavigated(true)
+              }
+            }}
+          >
+            Client Side Navigation to Subpage
+          </Link>
+        </div>
+
+        <div>
+          <Link
+            href="https://nextjs.org"
+            id="external-link-with-target"
+            onClick={() => setIsClicked(true)}
+            onNavigate={() => setIsNavigated(true)}
+            target="_blank"
+          >
+            External Link with Target
+          </Link>
+        </div>
+
+        <div>
+          <Link
+            href="https://nextjs.org"
+            id="external-link"
+            onClick={() => alert('onClick')}
+            onNavigate={() => alert('onNavigate')}
+          >
+            External Link
+          </Link>
+        </div>
+
+        <div>
+          <Link
+            href="https://nextjs.org"
+            id="external-link-with-replace"
+            onClick={() => alert('onClick')}
+            onNavigate={() => alert('onNavigate')}
+            replace
+          >
+            External Link with replace
+          </Link>
+        </div>
+
+        <div>
+          <Link
+            download
+            href="/zip.zip"
+            id="download-link"
+            onClick={() => setIsClicked(true)}
+            onNavigate={() => {
+              setIsNavigated(true)
+            }}
+          >
+            Download Link with download attribute
+          </Link>
+        </div>
+      </nav>
+
+      <div id="content" style={{ border: '1px solid red' }}>
+        {children}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
# onNavigate Event Handler for Next.js Link Component

```jsx
<Link
  onClick={(e) => {
    console.log("Executes on every click interaction");
  }}
  onNavigate={(e) => {
    console.log("Executes only when navigation is triggered");
    // You can prevent the navigation if needed
    // e.preventDefault();
  }}
  href="/home"
>
  Home
</Link>
```

The `onNavigate` prop allows you to execute code specifically when a SPA-like navigation is occurring, while `onClick` executes on any click regardless of navigation.

## Event Object and preventDefault

The event object (`e`) passed to the `onNavigate` handler includes a `preventDefault()` method that allows you to cancel the navigation when needed. This gives you control over whether the navigation should proceed based on certain conditions.

```jsx
<Link
  href="/dashboard"
  onNavigate={(e) => {
    // Example: Prevent navigation if user is not logged in
    if (!isUserLoggedIn) {
      e.preventDefault();
      showLoginPrompt();
    }
  }}
>
  Dashboard
</Link>
```

## Edge Cases Where onClick and onNavigate Differ

1. **Modified Click Events**: When a user clicks with modifier keys (Ctrl/Cmd+Click or Shift+Click), the `onClick` handler will execute, but `onNavigate` won't run because Next.js prevents the default navigation when the browser opens up a new tab.
2. **External URLs**: Navigation to external URLs will not invoke `onNavigate`, since we define `onNavigate` as a callback for SPA-like navigations.
3. **Download Link**: If a link has a download attribute, it should perform a default browser navigation instead of client-side navigation. In this case, `onClick` will be called but `onNavigate` will not, because download is technically not a SPA-like navigation.