### PR TITLE
Ensure deploymentId is used for CSS preloads

### DIFF
--- a/packages/next/src/shared/lib/lazy-dynamic/preload-chunks.tsx
+++ b/packages/next/src/shared/lib/lazy-dynamic/preload-chunks.tsx
@@ -37,10 +37,14 @@ export function PreloadChunks({
     return null
   }
 
+  const dplId = process.env.NEXT_DEPLOYMENT_ID
+    ? `?dpl=${process.env.NEXT_DEPLOYMENT_ID}`
+    : ''
+
   return (
     <>
       {allFiles.map((chunk) => {
-        const href = `${workStore.assetPrefix}/_next/${encodeURIPath(chunk)}`
+        const href = `${workStore.assetPrefix}/_next/${encodeURIPath(chunk)}${dplId}`
         const isCss = chunk.endsWith('.css')
         // If it's stylesheet we use `precedence` o help hoist with React Float.
         // For stylesheets we actually need to render the CSS because nothing else is going to do it so it needs to be part of the component tree.


### PR DESCRIPTION
This just ensures we use the deployment ID if configured for preload CSS links. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03S8ED1DKM/p1742146672858189)