### PR TITLE
with-polyfills example: only link to specific browsers

### DIFF
--- a/examples/with-polyfills/README.md
+++ b/examples/with-polyfills/README.md
@@ -1,6 +1,6 @@
 # With Polyfills
 
-Next.js supports IE11 and all modern browsers (Edge, Firefox, Chrome, Safari, Opera, et al) with no required configuration. It also adds [some polyfills](https://nextjs.org/docs/architecture/supported-browsers#polyfills) by default.
+Next.js supports [modern browsers](https://nextjs.org/docs/architecture/supported-browsers) with no required configuration. It also adds [some polyfills](https://nextjs.org/docs/architecture/supported-browsers#polyfills) by default.
 
 If your own code or any external npm dependencies require features not supported by your target browsers, you need to add polyfills yourself.
 


### PR DESCRIPTION
Previously, this example named specific browsers, including IE 11 which is no longer supported by default. This now links to the corresponding docs page that lists what’s currently supported.

I couldn’t find any other examples of this in the codebase.


Closes PACK-4175