### PR TITLE
Update default allowed origins list

### DIFF
--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -172,7 +172,11 @@ export async function initialize(opts: {
   ;(globalThis as any)[Symbol.for('@next/middleware-subrequest-id')] =
     middlewareSubrequestId
 
-  const allowedOrigins = ['localhost', ...(config.allowedDevOrigins || [])]
+  const allowedOrigins = [
+    '*.localhost',
+    'localhost',
+    ...(config.allowedDevOrigins || []),
+  ]
   if (opts.hostname) {
     allowedOrigins.push(opts.hostname)
   }


### PR DESCRIPTION
Per feedback in https://github.com/vercel/next.js/pull/76880 this ensures we ocnsider `*.localhost` as allowed by default for the dev origins list. 