### PR TITLE
devlow-bench: wait for complete ready for server startup event

### DIFF
--- a/scripts/devlow-bench.mjs
+++ b/scripts/devlow-bench.mjs
@@ -8,6 +8,8 @@ import { command } from '@vercel/devlow-bench/shell'
 import { waitForFile } from '@vercel/devlow-bench/file'
 
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url))
+const START_SERVER_REGEXP = /Ready in \d+/
+const URL_REGEXP = /Local:\s+(?<url>.+)\n/
 
 const GIT_SHA =
   process.env.GITHUB_SHA ??
@@ -101,10 +103,12 @@ const nextBuildWorkflow =
       cleanupTasks.push(killShell)
 
       // wait for server to be ready
-      const START_SERVER_REGEXP = /Local:\s+(?<url>.+)\n/
       const {
         groups: { url },
-      } = await shell.waitForOutput(START_SERVER_REGEXP)
+      } = await shell.waitForOutput(URL_REGEXP)
+
+      // wait for server to be ready
+      await shell.waitForOutput(START_SERVER_REGEXP)
       await measureTime('server startup', { props: { turbopack, page } })
       await shell.reportMemUsage('mem usage after startup', {
         props: { turbopack, page },
@@ -188,7 +192,7 @@ const nextBuildWorkflow =
       // wait for server to be ready
       const {
         groups: { url: url2 },
-      } = await shell.waitForOutput(START_SERVER_REGEXP)
+      } = await shell.waitForOutput(URL_REGEXP)
       await shell.reportMemUsage('mem usage after startup with cache')
 
       // open page
@@ -279,10 +283,12 @@ const nextDevWorkflow =
       cleanupTasks.push(killShell)
 
       // wait for server to be ready
-      const START_SERVER_REGEXP = /Local:\s+(?<url>.+)\n/
       const {
         groups: { url },
-      } = await shell.waitForOutput(START_SERVER_REGEXP)
+      } = await shell.waitForOutput(URL_REGEXP)
+
+      // wait for server to be ready
+      await shell.waitForOutput(START_SERVER_REGEXP)
       await measureTime('server startup', { props: { turbopack, page } })
       await shell.reportMemUsage('mem usage after startup', {
         props: { turbopack, page },
@@ -508,7 +514,7 @@ const nextDevWorkflow =
       // wait for server to be ready
       const {
         groups: { url: url2 },
-      } = await shell.waitForOutput(START_SERVER_REGEXP)
+      } = await shell.waitForOutput(URL_REGEXP)
       await shell.reportMemUsage('mem usage after startup with cache')
 
       // open page


### PR DESCRIPTION
Previously, we marked the server startup whenever a local url was shown in stdio. Next.js shows this url as soon as it can to make it actionable sooner, before the server is truly ready.

This changes makes the event record the time until the “Ready in Nms” message is shown instead.

Test Plan: `./node_modules/.bin/devlow-bench ./scripts/devlow-bench.mjs` and validate server startup is recorded.


Closes PACK-4184