### PR TITLE
chore(HMR clients): Clean up tryApplyUpdates, reduce differences between app/pages versions

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
@@ -81,23 +81,6 @@ export function waitForWebpackRuntimeHotUpdate() {
   return pendingHotUpdateWebpack
 }
 
-function handleSuccessfulHotUpdateWebpack(
-  dispatcher: Dispatcher,
-  sendMessage: (message: string) => void,
-  updatedModules: ReadonlyArray<string>
-) {
-  resolvePendingHotUpdateWebpack()
-  dispatcher.onBuildOk()
-  reportHmrLatency(
-    sendMessage,
-    updatedModules,
-    webpackStartMsSinceEpoch!,
-    Date.now()
-  )
-
-  dispatcher.onRefresh()
-}
-
 // There is a newer version of the code available.
 function handleAvailableHash(hash: string) {
   // Update last known compilation hash.
@@ -160,10 +143,8 @@ function performFullReload(err: any, sendMessage: any) {
 }
 
 // Attempt to update code on the fly, fall back to a hard reload.
-function tryApplyUpdates(
-  onBeforeUpdate: (hasUpdates: boolean) => void,
-  onHotUpdateSuccess: (updatedModules: string[]) => void,
-  sendMessage: any,
+function tryApplyUpdatesWebpack(
+  sendMessage: (message: string) => void,
   dispatcher: Dispatcher
 ) {
   if (!isUpdateAvailable() || !canApplyUpdates()) {
@@ -173,8 +154,11 @@ function tryApplyUpdates(
     return
   }
 
-  function handleApplyUpdates(err: any, updatedModules: string[] | null) {
-    if (err || RuntimeErrorHandler.hadRuntimeError || !updatedModules) {
+  function handleApplyUpdates(
+    err: any,
+    updatedModules: (string | number)[] | null
+  ) {
+    if (err || RuntimeErrorHandler.hadRuntimeError || updatedModules == null) {
       if (err) {
         console.warn(REACT_REFRESH_FULL_RELOAD)
       } else if (RuntimeErrorHandler.hadRuntimeError) {
@@ -184,50 +168,50 @@ function tryApplyUpdates(
       return
     }
 
-    const hasUpdates = Boolean(updatedModules.length)
-    if (typeof onHotUpdateSuccess === 'function') {
-      // Maybe we want to do something.
-      onHotUpdateSuccess(updatedModules)
-    }
+    dispatcher.onBuildOk()
 
     if (isUpdateAvailable()) {
       // While we were updating, there was a new update! Do it again.
-      tryApplyUpdates(
-        hasUpdates ? () => {} : onBeforeUpdate,
-        hasUpdates ? () => dispatcher.onBuildOk() : onHotUpdateSuccess,
-        sendMessage,
-        dispatcher
-      )
-    } else {
-      dispatcher.onBuildOk()
-      if (process.env.__NEXT_TEST_MODE) {
-        afterApplyUpdates(() => {
-          if (self.__NEXT_HMR_CB) {
-            self.__NEXT_HMR_CB()
-            self.__NEXT_HMR_CB = null
-          }
-        })
-      }
+      tryApplyUpdatesWebpack(sendMessage, dispatcher)
+      return
+    }
+
+    dispatcher.onRefresh()
+    resolvePendingHotUpdateWebpack()
+    reportHmrLatency(
+      sendMessage,
+      updatedModules,
+      webpackStartMsSinceEpoch!,
+      Date.now()
+    )
+
+    if (process.env.__NEXT_TEST_MODE) {
+      afterApplyUpdates(() => {
+        if (self.__NEXT_HMR_CB) {
+          self.__NEXT_HMR_CB()
+          self.__NEXT_HMR_CB = null
+        }
+      })
     }
   }
 
   // https://webpack.js.org/api/hot-module-replacement/#check
   module.hot
     .check(/* autoApply */ false)
-    .then((updatedModules: any[] | null) => {
-      if (!updatedModules) {
+    .then((updatedModules: (string | number)[] | null) => {
+      if (updatedModules == null) {
         return null
       }
 
-      if (typeof onBeforeUpdate === 'function') {
-        const hasUpdates = Boolean(updatedModules.length)
-        onBeforeUpdate(hasUpdates)
-      }
+      // We should always handle an update, even if updatedModules is empty (but
+      // non-null) for any reason. That's what webpack would normally do:
+      // https://github.com/webpack/webpack/blob/3aa6b6bc3a64/lib/hmr/HotModuleReplacement.runtime.js#L296-L298
+      dispatcher.onBeforeRefresh()
       // https://webpack.js.org/api/hot-module-replacement/#apply
       return module.hot.apply()
     })
     .then(
-      (updatedModules: any[] | null) => {
+      (updatedModules: (string | number)[] | null) => {
         handleApplyUpdates(null, updatedModules)
       },
       (err: any) => {
@@ -236,7 +220,7 @@ function tryApplyUpdates(
     )
 }
 
-/** Handles messages from the sevrer for the App Router. */
+/** Handles messages from the server for the App Router. */
 function processMessage(
   obj: HMR_ACTION_TYPES,
   sendMessage: (message: string) => void,
@@ -288,24 +272,7 @@ function processMessage(
       }
       dispatcher.onBuildOk()
     } else {
-      tryApplyUpdates(
-        function onBeforeHotUpdate(hasUpdates: boolean) {
-          if (hasUpdates) {
-            dispatcher.onBeforeRefresh()
-          }
-        },
-        function onSuccessfulHotUpdate(webpackUpdatedModules: string[]) {
-          // Only dismiss it when we're sure it's a hot update.
-          // Otherwise it would flicker right before the reload.
-          handleSuccessfulHotUpdateWebpack(
-            dispatcher,
-            sendMessage,
-            webpackUpdatedModules
-          )
-        },
-        sendMessage,
-        dispatcher
-      )
+      tryApplyUpdatesWebpack(sendMessage, dispatcher)
     }
   }
 

--- a/packages/next/src/client/components/react-dev-overlay/utils/report-hmr-latency.ts
+++ b/packages/next/src/client/components/react-dev-overlay/utils/report-hmr-latency.ts
@@ -6,7 +6,7 @@ declare global {
 
 export default function reportHmrLatency(
   sendMessage: (message: string) => void,
-  updatedModules: ReadonlyArray<string>,
+  updatedModules: ReadonlyArray<string | number>,
   startMsSinceEpoch: number,
   endMsSinceEpoch: number
 ) {

--- a/packages/next/src/client/components/react-dev-overlay/utils/turbopack-hot-reloader-common.ts
+++ b/packages/next/src/client/components/react-dev-overlay/utils/turbopack-hot-reloader-common.ts
@@ -48,7 +48,7 @@ export class TurbopackHmr {
   }
 }
 
-export function extractModulesFromTurbopackMessage(
+function extractModulesFromTurbopackMessage(
   data: TurbopackUpdate | TurbopackUpdate[]
 ): Set<string> {
   const updatedModules: Set<string> = new Set()


### PR DESCRIPTION
Various cleanup efforts in `tryApplyUpdates`:
- Code across pages and app are more similar.
- Inlined functions that were only called once.
- Less code overall, less branches.
- Better type signatures, less usage of `any`.

Closes PACK-4190