### PR TITLE
fix(test/e2e/prerender): Remove race condition in test

### DIFF
--- a/test/e2e/prerender/pages/fallback-only/[slug].js
+++ b/test/e2e/prerender/pages/fallback-only/[slug].js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import fs from 'node:fs/promises'
 
 export async function getStaticPaths() {
   return {
@@ -10,7 +11,13 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ params }) {
-  await new Promise((resolve) => setTimeout(resolve, 1000))
+  while (true) {
+    try {
+      await fs.stat('resolve-static-props')
+      break
+    } catch (e) {}
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
 
   return {
     props: {


### PR DESCRIPTION
Fixed `setTimeout`s in tests are bad for flakiness, as they introduce potential race conditions.

https://vercel.slack.com/archives/C07UCHRBWGK/p1742074798403739

Instead of using a fixed timeout, check for a special marker file in a loop every 100ms.

Closes PACK-4177