### PR TITLE
docs: update `create-next-app` cli documents

### DIFF
--- a/docs/01-app/03-api-reference/06-cli/create-next-app.mdx
+++ b/docs/01-app/03-api-reference/06-cli/create-next-app.mdx
@@ -17,35 +17,35 @@ npx create-next-app@latest [project-name] [options]
 
 The following options are available:
 
-| Options                                 | Description                                                           |
-| --------------------------------------- | --------------------------------------------------------------------- |
-| `-h` or `--help`                        | Show all available options                                            |
-| `-v` or `--version`                     | Output the version number                                             |
-| `--no-*`                                | Negate default options. E.g. `--no-ts`                                |
-| `--ts` or `--typescript`                | Initialize as a TypeScript project (default)                          |
-| `--js` or `--javascript`                | Initialize as a JavaScript project                                    |
-| `--tailwind`                            | Initialize with Tailwind CSS config (default)                         |
-| `--react-compiler`                      | Initialize with React Compiler enabled                                |
-| `--eslint`                              | Initialize with ESLint config                                         |
-| `--biome`                               | Initialize with Biome config                                          |
-| `--no-linter`                           | Skip linter configuration                                             |
-| `--app`                                 | Initialize as an App Router project                                   |
-| `--api`                                 | Initialize a project with only route handlers                         |
-| `--src-dir`                             | Initialize inside a `src/` directory                                  |
-| `--turbopack`                           | Force enable Turbopack in generated package.json (enabled by default) |
-| `--webpack`                             | Force enable Webpack in generated package.json                        |
-| `--import-alias <alias-to-configure>`   | Specify import alias to use (default "@/\*")                          |
-| `--empty`                               | Initialize an empty project                                           |
-| `--use-npm`                             | Explicitly tell the CLI to bootstrap the application using npm        |
-| `--use-pnpm`                            | Explicitly tell the CLI to bootstrap the application using pnpm       |
-| `--use-yarn`                            | Explicitly tell the CLI to bootstrap the application using Yarn       |
-| `--use-bun`                             | Explicitly tell the CLI to bootstrap the application using Bun        |
-| `-e` or `--example [name] [github-url]` | An example to bootstrap the app with                                  |
-| `--example-path <path-to-example>`      | Specify the path to the example separately                            |
-| `--reset-preferences`                   | Explicitly tell the CLI to reset any stored preferences               |
-| `--skip-install`                        | Explicitly tell the CLI to skip installing packages                   |
-| `--disable-git`                         | Explicitly tell the CLI to disable git initialization                 |
-| `--yes`                                 | Use previous preferences or defaults for all options                  |
+| Options                                       | Description                                                           |
+| --------------------------------------------- | --------------------------------------------------------------------- |
+| `-h` or `--help`                              | Show all available options                                            |
+| `-v` or `--version`                           | Output the version number                                             |
+| `--no-*`                                      | Negate default options. E.g. `--no-ts`, `--no-linter`                 |
+| `--ts` or `--typescript`                      | Initialize as a TypeScript project (default)                          |
+| `--js` or `--javascript`                      | Initialize as a JavaScript project                                    |
+| `--tailwind`                                  | Initialize with Tailwind CSS config (default)                         |
+| `--react-compiler`                            | Initialize with React Compiler enabled                                |
+| `--eslint`                                    | Initialize with ESLint config                                         |
+| `--biome`                                     | Initialize with Biome config                                          |
+| `--app`                                       | Initialize as an App Router project                                   |
+| `--api`                                       | Initialize a project with only route handlers                         |
+| `--src-dir`                                   | Initialize inside a `src/` directory                                  |
+| `--turbopack`                                 | Force enable Turbopack in generated package.json (enabled by default) |
+| `--webpack`                                   | Force enable Webpack in generated package.json                        |
+| `--rspack`                                    | Force enable Rspack in generated package.json                         |
+| `--import-alias <prefix/*>`                   | Specify import alias to use (default "@/\*")                          |
+| `--empty`                                     | Initialize an empty project                                           |
+| `--use-npm`                                   | Explicitly tell the CLI to bootstrap the application using npm        |
+| `--use-pnpm`                                  | Explicitly tell the CLI to bootstrap the application using pnpm       |
+| `--use-yarn`                                  | Explicitly tell the CLI to bootstrap the application using Yarn       |
+| `--use-bun`                                   | Explicitly tell the CLI to bootstrap the application using Bun        |
+| `-e` or `--example <example-name|github-url>` | An example to bootstrap the app with                                  |
+| `--example-path <path-to-example>`            | Specify the path to the example separately                            |
+| `--reset` or `--reset-preferences`            | Explicitly tell the CLI to reset any stored preferences               |
+| `--skip-install`                              | Explicitly tell the CLI to skip installing packages                   |
+| `--disable-git`                               | Explicitly tell the CLI to disable git initialization                 |
+| `--yes`                                       | Use previous preferences or defaults for all options                  |
 
 ## Examples
 

--- a/packages/create-next-app/README.md
+++ b/packages/create-next-app/README.md
@@ -31,67 +31,36 @@ You can also pass command line arguments to set up a new project
 non-interactively. See `create-next-app --help`:
 
 ```bash
-Usage: create-next-app [project-directory] [options]
+Usage: create-next-app [directory] [options]
 
 Options:
-  -V, --version                        output the version number
-  --ts, --typescript
-
-    Initialize as a TypeScript project. (default)
-
-  --js, --javascript
-
-    Initialize as a JavaScript project.
-
-  --tailwind
-
-    Initialize with Tailwind CSS config. (default)
-
-  --eslint
-
-    Initialize with ESLint config.
-
-  --app
-
-    Initialize as an App Router project.
-
-  --src-dir
-
-    Initialize inside a `src/` directory.
-
-  --turbopack
-
-    Enable Turbopack by default for development.
-
-  --import-alias <alias-to-configure>
-
-    Specify import alias to use (default "@/*").
-
-  --empty
-
-    Initialize an empty project.
-
-  --use-npm
-
-    Explicitly tell the CLI to bootstrap the application using npm
-
-  --use-pnpm
-
-    Explicitly tell the CLI to bootstrap the application using pnpm
-
-  --use-yarn
-
-    Explicitly tell the CLI to bootstrap the application using Yarn
-
-  --use-bun
-
-    Explicitly tell the CLI to bootstrap the application using Bun
-
-  -e, --example [name]|[github-url]
+  -v, --version                            Output the current version of create-next-app.
+  --ts, --typescript                       Initialize as a TypeScript project. (default)
+  --js, --javascript                       Initialize as a JavaScript project.
+  --tailwind                               Initialize with Tailwind CSS config. (default)
+  --react-compiler                         Initialize with React Compiler enabled.
+  --eslint                                 Initialize with ESLint config.
+  --biome                                  Initialize with Biome config.
+  --app                                    Initialize as an App Router project.
+  --src-dir                                Initialize inside a 'src/' directory.
+  --turbopack                              Enable Turbopack as the bundler.
+  --webpack                                Enable Webpack as the bundler.
+  --rspack                                 Enable Rspack as the bundler.
+  --import-alias <prefix/*>                Specify import alias to use (default "@/*").
+  --api                                    Initialize a headless API using the App Router.
+  --empty                                  Initialize an empty project.
+  --use-npm                                Explicitly tell the CLI to bootstrap the application using npm.
+  --use-pnpm                               Explicitly tell the CLI to bootstrap the application using pnpm.
+  --use-yarn                               Explicitly tell the CLI to bootstrap the application using Yarn.
+  --use-bun                                Explicitly tell the CLI to bootstrap the application using Bun.
+  --reset, --reset-preferences             Reset the preferences saved for create-next-app.
+  --skip-install                           Explicitly tell the CLI to skip installing packages.
+  --yes                                    Use saved preferences or defaults for unprovided options.
+  -e, --example <example-name|github-url>
 
     An example to bootstrap the app with. You can use an example name
-    from the official Next.js repo or a GitHub URL. The URL can use
-    any branch and/or subdirectory
+    from the official Next.js repo or a public GitHub URL. The URL can use
+    any branch and/or subdirectory.
 
   --example-path <path-to-example>
 
@@ -100,24 +69,8 @@ Options:
     In this case, you must specify the path to the example separately:
     --example-path foo/bar
 
-  --reset-preferences
-
-    Explicitly tell the CLI to reset any stored preferences
-
-  --skip-install
-
-    Explicitly tell the CLI to skip installing packages
-
-  --disable-git
-
-    Explicitly tell the CLI to skip initializing a git repository.
-
-  --yes
-
-    Use previous preferences or defaults for all options that were not
-    explicitly specified, without prompting.
-
-  -h, --help                           display help for command
+  --disable-git                            Skip initializing a git repository.
+  -h, --help                               Display this help message.
 ```
 
 ### Why use Create Next App?


### PR DESCRIPTION
# What?

This PR updates the two files.

## [create-next-app.mdx](https://github.com/vercel/next.js/blob/canary/docs/01-app/04-api-reference/06-cli/create-next-app.mdx)

1. Update `--import-alias` option to follow up #68225.

```diff
- | `--import-alias <alias-to-configure>`   | Specify import alias to use (default "@/\*")                    |
+ | `--import-alias <prefix/*>`           | Specify import alias to use (default "@/\*")                    |
```

2. `--no-linter` option is merged into `--no-*` option with example.

3. Add a missing `--rspack` option.

## [README.md](https://github.com/vercel/next.js/blob/canary/packages/create-next-app/README.md)

1. Update the outputs of `create-next-app --help` to follow up #68225.

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide